### PR TITLE
feat(subscriptions): tiered pricing — PricingTier + Volume/Graduated calculator

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -39995,7 +39995,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, decimal amount, string currency, BillingInterval interval, DateTimeOffset effectiveFrom, Guid? productId = null)",
+          "signature": "Create(Guid id, decimal amount, string currency, BillingInterval interval, DateTimeOffset effectiveFrom, Guid? productId = null, TieringMode? tieringMode = null)",
           "returnType": "PlanPrice"
         },
         {
@@ -40009,6 +40009,12 @@
           "kind": "property",
           "signature": "BillingInterval Interval",
           "returnType": "BillingInterval"
+        },
+        {
+          "name": "SetTiers",
+          "kind": "method",
+          "signature": "SetTiers(TieringMode mode, IEnumerable<PricingTier> tiers)",
+          "returnType": "void"
         }
       ]
     },
@@ -40020,6 +40026,22 @@
       "file": "src/Granit.Subscriptions/Domain/PricingModel.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "PricingTier",
+      "fqn": "Granit.Subscriptions.Domain.PricingTier",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/PricingTier.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid planPriceId, int sortOrder, decimal? upToQuantity, decimal unitAmount, decimal? flatAmount = null)",
+          "returnType": "PricingTier"
+        }
+      ]
     },
     {
       "name": "Subscription",
@@ -40142,6 +40164,15 @@
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/SubscriptionStatus.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "TieringMode",
+      "fqn": "Granit.Subscriptions.Domain.TieringMode",
+      "kind": "enum",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/TieringMode.cs",
+      "line": 7,
       "members": []
     },
     {
@@ -40967,6 +40998,12 @@
           "kind": "method",
           "signature": "ResolveUsageUnitPriceAsync(PlanId planId, string currency, BillingInterval interval, string meterId, Guid? planPriceId = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<decimal>"
+        },
+        {
+          "name": "ResolveUsageAmountAsync",
+          "kind": "method",
+          "signature": "ResolveUsageAmountAsync(PlanId planId, string currency, BillingInterval interval, string meterId, decimal quantity, Guid? planPriceId = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<decimal>"
         }
       ]
     },
@@ -41387,6 +41424,22 @@
           "kind": "property",
           "signature": "NotificationSeverity DefaultSeverity",
           "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "TieredPricingCalculator",
+      "fqn": "Granit.Subscriptions.Pricing.TieredPricingCalculator",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Compute",
+          "kind": "method",
+          "signature": "Compute(decimal quantity, TieringMode mode, IReadOnlyList<PricingTier> tiers)",
+          "returnType": "decimal"
         }
       ]
     },

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class SubscriptionsModelBuilderExtensions
     {
         modelBuilder.ApplyConfiguration(new PlanConfiguration());
         modelBuilder.ApplyConfiguration(new PlanPriceConfiguration());
+        modelBuilder.ApplyConfiguration(new PricingTierConfiguration());
         modelBuilder.ApplyConfiguration(new PlanFeatureValueConfiguration());
         modelBuilder.ApplyConfiguration(new PlanExternalMappingConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionConfiguration());

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
@@ -1,5 +1,6 @@
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
+using Granit.Subscriptions.Pricing;
 
 namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
 
@@ -41,6 +42,39 @@ internal sealed class EfPricingResolver(IPlanReader planReader) : IPricingResolv
 
         PlanPrice? price = ResolvePlanPrice(plan, currency, interval, planPriceId);
         return price?.Amount ?? 0m;
+    }
+
+    public async Task<decimal> ResolveUsageAmountAsync(
+        PlanId planId, string currency, BillingInterval interval,
+        string meterId, decimal quantity, Guid? planPriceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (quantity <= 0m)
+        {
+            return 0m;
+        }
+
+        Plan? plan = await planReader.GetByIdAsync(planId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (plan is null || plan.PricingModel is not (PricingModel.PerUnit or PricingModel.Tiered))
+        {
+            return 0m;
+        }
+
+        PlanPrice? price = ResolvePlanPrice(plan, currency, interval, planPriceId);
+        if (price is null)
+        {
+            return 0m;
+        }
+
+        // Tiered + non-empty tier list → bracket math; otherwise fall back to flat unit price.
+        if (price.TieringMode is { } mode && price.Tiers.Count > 0)
+        {
+            return TieredPricingCalculator.Compute(quantity, mode, price.Tiers);
+        }
+
+        return quantity * price.Amount;
     }
 
     private static PlanPrice? ResolvePlanPrice(

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
@@ -32,5 +32,15 @@ internal sealed class PlanPriceConfiguration : IEntityTypeConfiguration<PlanPric
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}plan_prices_current");
 
         builder.Ignore(e => e.IsCurrent);
+
+        builder.Property(e => e.TieringMode);
+
+        builder.HasMany(e => e.Tiers)
+            .WithOne()
+            .HasForeignKey(t => t.PlanPriceId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.Tiers)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PricingTierConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PricingTierConfiguration.cs
@@ -1,0 +1,29 @@
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+internal sealed class PricingTierConfiguration : IEntityTypeConfiguration<PricingTier>
+{
+    public void Configure(EntityTypeBuilder<PricingTier> builder)
+    {
+        builder.ToTable(
+            GranitSubscriptionsDbProperties.DbTablePrefix + "pricing_tiers",
+            GranitSubscriptionsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.PlanPriceId).IsRequired();
+        builder.Property(e => e.SortOrder).IsRequired();
+        builder.Property(e => e.UpToQuantity).HasPrecision(18, 4);
+        builder.Property(e => e.UnitAmount).HasPrecision(18, 4).IsRequired();
+        builder.Property(e => e.FlatAmount).HasPrecision(18, 4);
+
+        // Sequence integrity at the storage layer: a single PlanPrice cannot have
+        // two tiers with the same SortOrder, and the open-ended last tier (UpToQuantity
+        // IS NULL) is unique per price by virtue of the SortOrder uniqueness.
+        builder.HasIndex(e => new { e.PlanPriceId, e.SortOrder })
+            .IsUnique()
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}pricing_tiers_sequence");
+    }
+}

--- a/src/Granit.Subscriptions/Domain/PlanPrice.cs
+++ b/src/Granit.Subscriptions/Domain/PlanPrice.cs
@@ -9,6 +9,8 @@ namespace Granit.Subscriptions.Domain;
 /// </summary>
 public sealed class PlanPrice : Entity
 {
+    private readonly List<PricingTier> _tiers = [];
+
     private PlanPrice() { }
 
     /// <summary>
@@ -17,10 +19,14 @@ public sealed class PlanPrice : Entity
     /// modules) to a <c>Granit.Catalog.Product</c> — the catalog item this price
     /// tarifs. Survives price versioning: a replaced price keeps its original
     /// <see cref="ProductId"/>, and the new version may carry the same or a different one.
+    /// <paramref name="tieringMode"/> is required when the parent <c>Plan</c> uses
+    /// <see cref="PricingModel.Tiered"/> and must be left null otherwise — the
+    /// pairing is enforced by the validator on the create endpoint.
     /// </summary>
     public static PlanPrice Create(
         Guid id, decimal amount, string currency, BillingInterval interval,
-        DateTimeOffset effectiveFrom, Guid? productId = null) =>
+        DateTimeOffset effectiveFrom, Guid? productId = null,
+        TieringMode? tieringMode = null) =>
         new()
         {
             Id = id,
@@ -29,6 +35,7 @@ public sealed class PlanPrice : Entity
             Interval = interval,
             EffectiveFrom = effectiveFrom,
             ProductId = productId,
+            TieringMode = tieringMode,
         };
 
     /// <summary>Price amount in the smallest currency unit (e.g., cents).</summary>
@@ -55,6 +62,40 @@ public sealed class PlanPrice : Entity
     /// preserved across price versions.
     /// </summary>
     public Guid? ProductId { get; private set; }
+
+    /// <summary>
+    /// Tier semantics for this price (<see cref="TieringMode.Volume"/> or
+    /// <see cref="TieringMode.Graduated"/>). Set when the parent <c>Plan</c>'s
+    /// <see cref="PricingModel"/> is <see cref="PricingModel.Tiered"/> and
+    /// <see cref="Tiers"/> is non-empty; <c>null</c> for flat / per-seat / per-unit
+    /// price points.
+    /// </summary>
+    public TieringMode? TieringMode { get; private set; }
+
+    /// <summary>
+    /// Bracket sequence for tiered pricing. Empty unless this price uses
+    /// <see cref="PricingModel.Tiered"/>. Storage order is insertion order — the
+    /// caller and <see cref="Pricing.TieredPricingCalculator"/> sort by
+    /// <see cref="PricingTier.SortOrder"/> when computing; the last tier has
+    /// <c>UpToQuantity = null</c> (open-ended).
+    /// </summary>
+    public IReadOnlyList<PricingTier> Tiers => _tiers;
+
+    /// <summary>
+    /// Replaces the tier sequence wholesale. The caller is expected to have
+    /// validated ordering and the open-ended last tier; the validator on
+    /// <c>SetPlanPriceTiersRequest</c> enforces both rules at the HTTP boundary.
+    /// </summary>
+    /// <param name="mode">Tier semantics applied to the bracket list.</param>
+    /// <param name="tiers">New tier sequence (may be empty to clear).</param>
+    public void SetTiers(TieringMode mode, IEnumerable<PricingTier> tiers)
+    {
+        ArgumentNullException.ThrowIfNull(tiers);
+
+        _tiers.Clear();
+        _tiers.AddRange(tiers);
+        TieringMode = _tiers.Count == 0 ? null : mode;
+    }
 
     /// <summary>
     /// Whether this price is the current version in the timeline (not replaced by a newer

--- a/src/Granit.Subscriptions/Domain/PricingTier.cs
+++ b/src/Granit.Subscriptions/Domain/PricingTier.cs
@@ -1,0 +1,82 @@
+using Granit.Domain;
+
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// A single bracket of a tiered <see cref="PlanPrice"/>. The semantics
+/// (Volume vs Graduated) are carried by the parent's <see cref="PlanPrice.TieringMode"/>.
+/// </summary>
+/// <remarks>
+/// Tiers are ordered by <see cref="SortOrder"/> ascending (= bracket index from
+/// cheapest threshold to highest). The last tier in the ordered sequence MUST have
+/// <see cref="UpToQuantity"/> = <c>null</c> — it represents the open-ended "above
+/// all previous brackets" range. Validation in
+/// <c>PricingTierConventionValidator</c> enforces both rules.
+/// </remarks>
+public sealed class PricingTier : Entity
+{
+    private PricingTier() { }
+
+    /// <summary>Creates a new tier bracket attached to a plan price.</summary>
+    /// <param name="id">Tier id (server-generated).</param>
+    /// <param name="planPriceId">Owning <see cref="PlanPrice"/>.</param>
+    /// <param name="sortOrder">Position in the bracket sequence (0 = cheapest threshold).</param>
+    /// <param name="upToQuantity">Inclusive upper bound of this tier; <c>null</c> = ∞ (last tier only).</param>
+    /// <param name="unitAmount">Per-unit price applied within this tier (or to the whole quantity in Volume mode).</param>
+    /// <param name="flatAmount">
+    /// Optional fixed fee charged when the bracket is hit (regardless of unit count).
+    /// Used for "package" pricing — e.g. "$50 plus $0.01/call up to 5K". Always
+    /// added on top of the unit-price computation.
+    /// </param>
+    public static PricingTier Create(
+        Guid id,
+        Guid planPriceId,
+        int sortOrder,
+        decimal? upToQuantity,
+        decimal unitAmount,
+        decimal? flatAmount = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(sortOrder);
+        ArgumentOutOfRangeException.ThrowIfNegative(unitAmount);
+        if (upToQuantity is { } u)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(u);
+        }
+        if (flatAmount is { } f)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(f);
+        }
+
+        return new PricingTier
+        {
+            Id = id,
+            PlanPriceId = planPriceId,
+            SortOrder = sortOrder,
+            UpToQuantity = upToQuantity,
+            UnitAmount = unitAmount,
+            FlatAmount = flatAmount,
+        };
+    }
+
+    /// <summary>Owning <see cref="PlanPrice"/> (FK).</summary>
+    public Guid PlanPriceId { get; private set; }
+
+    /// <summary>Position in the bracket sequence — 0 is the cheapest-threshold tier.</summary>
+    public int SortOrder { get; private set; }
+
+    /// <summary>
+    /// Inclusive upper bound of this tier. Quantities equal to this value still
+    /// belong to this tier (the tier <em>contains</em> its boundary). <c>null</c>
+    /// = open-ended (must be true for the last tier and only the last tier).
+    /// </summary>
+    public decimal? UpToQuantity { get; private set; }
+
+    /// <summary>Per-unit price applied to units within this tier.</summary>
+    public decimal UnitAmount { get; private set; }
+
+    /// <summary>
+    /// Optional flat package fee charged when the tier is reached (Graduated:
+    /// charged per crossed bracket; Volume: charged once for the active bracket).
+    /// </summary>
+    public decimal? FlatAmount { get; private set; }
+}

--- a/src/Granit.Subscriptions/Domain/TieringMode.cs
+++ b/src/Granit.Subscriptions/Domain/TieringMode.cs
@@ -1,0 +1,22 @@
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// How a tiered <see cref="PlanPrice"/> applies its <see cref="PricingTier"/> brackets
+/// to a billed quantity. Mirrors the two ORB/Stripe modes.
+/// </summary>
+public enum TieringMode
+{
+    /// <summary>
+    /// The unit price of the highest tier reached applies to the entire quantity.
+    /// Example with tiers [10K @ $0.10, 100K @ $0.05, ∞ @ $0.02]: 50K calls cost
+    /// <c>50_000 × 0.05 = $2_500</c> (all 50 000 charged at the second tier's rate).
+    /// </summary>
+    Volume = 0,
+
+    /// <summary>
+    /// Each tier's unit price applies only to the units that fall within that tier
+    /// — the bracket model. Example with tiers [10K @ $0.10, 100K @ $0.05, ∞ @ $0.02]:
+    /// 50K calls cost <c>10_000 × 0.10 + 40_000 × 0.05 = $3_000</c>.
+    /// </summary>
+    Graduated = 1,
+}

--- a/src/Granit.Subscriptions/IPricingResolver.cs
+++ b/src/Granit.Subscriptions/IPricingResolver.cs
@@ -28,4 +28,19 @@ public interface IPricingResolver
         PlanId planId, string currency, BillingInterval interval,
         string meterId, Guid? planPriceId = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the total amount owed for <paramref name="quantity"/> units of usage,
+    /// applying the plan's <see cref="PlanPrice.TieringMode"/> and tier sequence when
+    /// the price is tiered. For non-tiered prices, falls back to <c>quantity × unit price</c>.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>0</c> when the plan is not found, the price cannot be resolved, the
+    /// plan's <c>PricingModel</c> is not a usage variant (PerUnit / Tiered), or the
+    /// quantity is zero.
+    /// </remarks>
+    Task<decimal> ResolveUsageAmountAsync(
+        PlanId planId, string currency, BillingInterval interval,
+        string meterId, decimal quantity, Guid? planPriceId = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
@@ -69,14 +69,25 @@ internal sealed partial class DefaultUsageInvoiceOrchestrator(
                 subscription.Id.ToString()));
         }
 
-        decimal unitPrice = await pricingResolver.ResolveUsageUnitPriceAsync(
+        // Tier-aware total: when the resolved PlanPrice carries Tiers + a TieringMode,
+        // ResolveUsageAmountAsync runs the bracket math (Volume or Graduated) and returns
+        // the total directly. For flat per-unit pricing it falls back to quantity × unit
+        // price — same number as the legacy code path. We still surface a derived "unit
+        // price" on the invoice line so consumers can sanity-check the math; for tiered
+        // pricing this is the effective average rate, not an authoritative per-unit price.
+        decimal usageTotal = await pricingResolver.ResolveUsageAmountAsync(
             subscription.PlanId, subscription.Currency, plan.DefaultInterval,
-            request.MeterDefinitionId.ToString(), subscription.PlanPriceId, cancellationToken)
+            request.MeterDefinitionId.ToString(), request.AggregatedValue,
+            subscription.PlanPriceId, cancellationToken)
             .ConfigureAwait(false);
+
+        decimal effectiveUnitPrice = request.AggregatedValue > 0m
+            ? usageTotal / request.AggregatedValue
+            : 0m;
 
         lineItems.Add(new CreateInvoiceLineItem(
             $"{request.MeterName}: {request.AggregatedValue} {request.Unit}",
-            request.AggregatedValue, unitPrice,
+            request.AggregatedValue, effectiveUnitPrice,
             InvoiceSourceType.Usage,
             request.MeterDefinitionId.ToString()));
 

--- a/src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs
+++ b/src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs
@@ -1,0 +1,99 @@
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Pricing;
+
+/// <summary>
+/// Pure computation of the total amount for a tiered <see cref="PlanPrice"/>.
+/// </summary>
+/// <remarks>
+/// Boundary semantics: a tier <em>contains</em> its <see cref="PricingTier.UpToQuantity"/>.
+/// A quantity exactly equal to the bracket boundary belongs to the lower tier — i.e.
+/// the bracket interval is <c>(previousUpTo, currentUpTo]</c>. The first bracket
+/// starts at <c>0</c> exclusive (a positive quantity is required for any cost to
+/// apply).
+/// </remarks>
+public static class TieredPricingCalculator
+{
+    /// <summary>
+    /// Computes the total amount owed for <paramref name="quantity"/> units billed
+    /// against <paramref name="tiers"/> under the supplied <paramref name="mode"/>.
+    /// </summary>
+    /// <param name="quantity">Total billable quantity (must be ≥ 0).</param>
+    /// <param name="mode">Tier semantics.</param>
+    /// <param name="tiers">Tier sequence (will be sorted ascending by <c>SortOrder</c>).</param>
+    /// <returns>The total amount, or <c>0</c> when <paramref name="quantity"/> is 0 or the tier list is empty.</returns>
+    public static decimal Compute(
+        decimal quantity,
+        TieringMode mode,
+        IReadOnlyList<PricingTier> tiers)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(quantity);
+        ArgumentNullException.ThrowIfNull(tiers);
+
+        if (quantity == 0m || tiers.Count == 0)
+        {
+            return 0m;
+        }
+
+        // Defensive — never trust the caller's ordering even though SetTiers also normalises.
+        IReadOnlyList<PricingTier> ordered = [.. tiers.OrderBy(t => t.SortOrder)];
+
+        return mode switch
+        {
+            TieringMode.Volume => ComputeVolume(quantity, ordered),
+            TieringMode.Graduated => ComputeGraduated(quantity, ordered),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown tiering mode."),
+        };
+    }
+
+    private static decimal ComputeVolume(decimal quantity, IReadOnlyList<PricingTier> tiers)
+    {
+        // Volume: find the active tier (the one whose UpToQuantity covers the quantity)
+        // and apply its unit price to the entire quantity. The open-ended last tier
+        // covers any quantity above all earlier brackets.
+        foreach (PricingTier tier in tiers)
+        {
+            if (tier.UpToQuantity is null || quantity <= tier.UpToQuantity.Value)
+            {
+                return (quantity * tier.UnitAmount) + (tier.FlatAmount ?? 0m);
+            }
+        }
+
+        // Should not be reachable when the last tier is open-ended (validator guarantees it),
+        // but fall through defensively to the last tier's rate rather than throwing.
+        PricingTier last = tiers[^1];
+        return (quantity * last.UnitAmount) + (last.FlatAmount ?? 0m);
+    }
+
+    private static decimal ComputeGraduated(decimal quantity, IReadOnlyList<PricingTier> tiers)
+    {
+        // Graduated: walk the brackets in order, charge each one for the units that
+        // fall into its (previousUpTo, currentUpTo] interval, plus the optional flat
+        // fee per crossed bracket.
+        decimal remaining = quantity;
+        decimal previousBoundary = 0m;
+        decimal total = 0m;
+
+        foreach (PricingTier tier in tiers)
+        {
+            if (remaining <= 0m)
+            {
+                break;
+            }
+
+            decimal capacity = tier.UpToQuantity is null
+                ? remaining
+                : Math.Max(0m, tier.UpToQuantity.Value - previousBoundary);
+
+            decimal unitsInTier = Math.Min(remaining, capacity);
+            if (unitsInTier > 0m)
+            {
+                total += (unitsInTier * tier.UnitAmount) + (tier.FlatAmount ?? 0m);
+                remaining -= unitsInTier;
+                previousBoundary = tier.UpToQuantity ?? previousBoundary + unitsInTier;
+            }
+        }
+
+        return total;
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Domain/PricingTierTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/PricingTierTests.cs
@@ -1,0 +1,54 @@
+using Granit.Subscriptions.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+public sealed class PricingTierTests
+{
+    [Fact]
+    public void Create_WithAllFields_StoresThem()
+    {
+        var id = Guid.NewGuid();
+        var planPriceId = Guid.NewGuid();
+
+        var tier = PricingTier.Create(id, planPriceId, sortOrder: 2,
+            upToQuantity: 100m, unitAmount: 0.05m, flatAmount: 9.99m);
+
+        tier.Id.ShouldBe(id);
+        tier.PlanPriceId.ShouldBe(planPriceId);
+        tier.SortOrder.ShouldBe(2);
+        tier.UpToQuantity.ShouldBe(100m);
+        tier.UnitAmount.ShouldBe(0.05m);
+        tier.FlatAmount.ShouldBe(9.99m);
+    }
+
+    [Fact]
+    public void Create_WithNullUpToQuantity_RepresentsOpenEndedTier()
+    {
+        var tier = PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), 0,
+            upToQuantity: null, unitAmount: 0.01m);
+
+        tier.UpToQuantity.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_WithNegativeSortOrder_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), -1, 100m, 0.10m));
+
+    [Fact]
+    public void Create_WithNegativeUnitAmount_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), 0, 100m, -0.01m));
+
+    [Fact]
+    public void Create_WithZeroUpToQuantity_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), 0, 0m, 0.10m));
+
+    [Fact]
+    public void Create_WithNegativeFlatAmount_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), 0, 100m, 0.10m, flatAmount: -1m));
+}

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultUsageInvoiceOrchestratorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultUsageInvoiceOrchestratorTests.cs
@@ -172,9 +172,9 @@ public sealed class DefaultUsageInvoiceOrchestratorTests
         _pricingResolver.ResolveBasePriceAsync(
                 planId, "EUR", BillingInterval.Monthly, null, Arg.Any<CancellationToken>())
             .Returns(0m);
-        _pricingResolver.ResolveUsageUnitPriceAsync(
-                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), null, Arg.Any<CancellationToken>())
-            .Returns(0.05m);
+        _pricingResolver.ResolveUsageAmountAsync(
+                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), 500m, null, Arg.Any<CancellationToken>())
+            .Returns(500m * 0.05m);
 
         await _sut.CreateInvoiceAsync(request, TestContext.Current.CancellationToken);
 
@@ -209,9 +209,9 @@ public sealed class DefaultUsageInvoiceOrchestratorTests
         _pricingResolver.ResolveBasePriceAsync(
                 planId, "EUR", BillingInterval.Monthly, null, Arg.Any<CancellationToken>())
             .Returns(49.99m);
-        _pricingResolver.ResolveUsageUnitPriceAsync(
-                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), null, Arg.Any<CancellationToken>())
-            .Returns(0.10m);
+        _pricingResolver.ResolveUsageAmountAsync(
+                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), 200m, null, Arg.Any<CancellationToken>())
+            .Returns(200m * 0.10m);
 
         await _sut.CreateInvoiceAsync(request, TestContext.Current.CancellationToken);
 
@@ -257,9 +257,9 @@ public sealed class DefaultUsageInvoiceOrchestratorTests
         _pricingResolver.ResolveBasePriceAsync(
                 planId, "EUR", BillingInterval.Monthly, null, Arg.Any<CancellationToken>())
             .Returns(0m);
-        _pricingResolver.ResolveUsageUnitPriceAsync(
-                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), null, Arg.Any<CancellationToken>())
-            .Returns(0.25m);
+        _pricingResolver.ResolveUsageAmountAsync(
+                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), 75m, null, Arg.Any<CancellationToken>())
+            .Returns(75m * 0.25m);
 
         await _sut.CreateInvoiceAsync(request, TestContext.Current.CancellationToken);
 
@@ -290,15 +290,15 @@ public sealed class DefaultUsageInvoiceOrchestratorTests
         _pricingResolver.ResolveBasePriceAsync(
                 planId, "EUR", BillingInterval.Monthly, planPriceId, Arg.Any<CancellationToken>())
             .Returns(29.99m);
-        _pricingResolver.ResolveUsageUnitPriceAsync(
-                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), planPriceId, Arg.Any<CancellationToken>())
-            .Returns(0.01m);
+        _pricingResolver.ResolveUsageAmountAsync(
+                planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), 150m, planPriceId, Arg.Any<CancellationToken>())
+            .Returns(150m * 0.01m);
 
         await _sut.CreateInvoiceAsync(request, TestContext.Current.CancellationToken);
 
         await _pricingResolver.Received(1).ResolveBasePriceAsync(
             planId, "EUR", BillingInterval.Monthly, planPriceId, Arg.Any<CancellationToken>());
-        await _pricingResolver.Received(1).ResolveUsageUnitPriceAsync(
-            planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), planPriceId, Arg.Any<CancellationToken>());
+        await _pricingResolver.Received(1).ResolveUsageAmountAsync(
+            planId, "EUR", BillingInterval.Monthly, meterDefId.ToString(), 150m, planPriceId, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Subscriptions.Tests/Pricing/TieredPricingCalculatorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Pricing/TieredPricingCalculatorTests.cs
@@ -1,0 +1,195 @@
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Pricing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Pricing;
+
+/// <summary>
+/// Pure-function tests for the tier total computation. Boundary semantics, single
+/// tier, exact match, exceeding all tiers, zero quantity, and the FlatAmount
+/// addition are all exercised.
+/// </summary>
+public sealed class TieredPricingCalculatorTests
+{
+    private static PricingTier Tier(int sortOrder, decimal? upTo, decimal unit, decimal? flat = null) =>
+        PricingTier.Create(Guid.NewGuid(), Guid.NewGuid(), sortOrder, upTo, unit, flat);
+
+    // ──────────────── Volume ────────────────
+
+    /// <summary>
+    /// Volume mode: the unit price of the active tier applies to the entire quantity.
+    /// 50K calls fall in tier 2 (10K-100K) so the whole 50K is charged at tier 2's rate.
+    /// </summary>
+    [Fact]
+    public void Volume_QuantityInMiddleTier_ChargesEntireQuantityAtThatTier()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10_000m, 0.10m),
+            Tier(1, 100_000m, 0.05m),
+            Tier(2, null,      0.02m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(50_000m, TieringMode.Volume, tiers);
+
+        total.ShouldBe(50_000m * 0.05m); // = 2_500
+    }
+
+    [Fact]
+    public void Volume_QuantityExactlyAtBoundary_BelongsToLowerTier()
+    {
+        // Boundary is tier-inclusive: a quantity of exactly 10_000 still belongs to tier 0.
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10_000m, 0.10m),
+            Tier(1, null,    0.05m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(10_000m, TieringMode.Volume, tiers);
+
+        total.ShouldBe(10_000m * 0.10m); // = 1_000 — the cheaper tier owns its boundary
+    }
+
+    [Fact]
+    public void Volume_QuantityAboveAllBoundaries_FallsIntoOpenEndedTier()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10m, 0.10m),
+            Tier(1, null, 0.02m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(10_000m, TieringMode.Volume, tiers);
+
+        total.ShouldBe(10_000m * 0.02m);
+    }
+
+    [Fact]
+    public void Volume_FlatAmount_AddedToActiveTier()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 100m, 0.10m, flat: 5m),
+            Tier(1, null, 0.05m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(50m, TieringMode.Volume, tiers);
+
+        total.ShouldBe((50m * 0.10m) + 5m); // = 10
+    }
+
+    // ──────────────── Graduated ────────────────
+
+    /// <summary>
+    /// Graduated mode: each bracket's units are charged at that bracket's rate.
+    /// 50K calls = 10K @ 0.10 + 40K @ 0.05 = 1_000 + 2_000 = 3_000.
+    /// </summary>
+    [Fact]
+    public void Graduated_QuantitySpanningTwoTiers_SumsPerBracket()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10_000m,  0.10m),
+            Tier(1, 100_000m, 0.05m),
+            Tier(2, null,      0.02m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(50_000m, TieringMode.Graduated, tiers);
+
+        total.ShouldBe((10_000m * 0.10m) + (40_000m * 0.05m)); // = 3_000
+    }
+
+    [Fact]
+    public void Graduated_QuantitySpanningAllThreeTiers_SumsPerBracket()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10_000m,  0.10m),
+            Tier(1, 100_000m, 0.05m),
+            Tier(2, null,      0.02m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(150_000m, TieringMode.Graduated, tiers);
+
+        total.ShouldBe(
+            (10_000m * 0.10m) +    // tier 0:   1_000
+            (90_000m * 0.05m) +    // tier 1:   4_500
+            (50_000m * 0.02m));    // tier 2:   1_000
+    }
+
+    [Fact]
+    public void Graduated_QuantityExactlyAtBoundary_StaysInLowerTier()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 10_000m, 0.10m),
+            Tier(1, null,    0.05m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(10_000m, TieringMode.Graduated, tiers);
+
+        total.ShouldBe(10_000m * 0.10m); // entirely in tier 0
+    }
+
+    [Fact]
+    public void Graduated_FlatAmount_AddedPerCrossedBracket()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, 100m, 0.10m, flat: 5m),
+            Tier(1, null, 0.05m, flat: 2m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(150m, TieringMode.Graduated, tiers);
+
+        total.ShouldBe(
+            (100m * 0.10m) + 5m +   // tier 0: 10 + 5 = 15
+            (50m * 0.05m) + 2m);    // tier 1: 2.5 + 2 = 4.5  → total 19.5
+    }
+
+    // ──────────────── Edge cases ────────────────
+
+    [Fact]
+    public void ZeroQuantity_ReturnsZero_BothModes()
+    {
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(0, null, 0.10m, flat: 999m),
+        ];
+
+        TieredPricingCalculator.Compute(0m, TieringMode.Volume, tiers).ShouldBe(0m);
+        TieredPricingCalculator.Compute(0m, TieringMode.Graduated, tiers).ShouldBe(0m);
+    }
+
+    [Fact]
+    public void EmptyTierList_ReturnsZero()
+    {
+        TieredPricingCalculator.Compute(100m, TieringMode.Volume, []).ShouldBe(0m);
+        TieredPricingCalculator.Compute(100m, TieringMode.Graduated, []).ShouldBe(0m);
+    }
+
+    [Fact]
+    public void NegativeQuantity_Throws()
+    {
+        IReadOnlyList<PricingTier> tiers = [Tier(0, null, 0.10m)];
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            TieredPricingCalculator.Compute(-1m, TieringMode.Volume, tiers));
+    }
+
+    [Fact]
+    public void SingleOpenEndedTier_FlatPerUnitAcrossModes()
+    {
+        IReadOnlyList<PricingTier> tiers = [Tier(0, null, 0.05m)];
+
+        TieredPricingCalculator.Compute(1234m, TieringMode.Volume, tiers).ShouldBe(1234m * 0.05m);
+        TieredPricingCalculator.Compute(1234m, TieringMode.Graduated, tiers).ShouldBe(1234m * 0.05m);
+    }
+
+    [Fact]
+    public void OutOfOrderTierList_IsNormalisedBySortOrder()
+    {
+        // Same brackets but supplied out of order — the calculator must re-sort.
+        IReadOnlyList<PricingTier> tiers = [
+            Tier(2, null,     0.02m),
+            Tier(0, 10_000m,  0.10m),
+            Tier(1, 100_000m, 0.05m),
+        ];
+
+        decimal total = TieredPricingCalculator.Compute(50_000m, TieringMode.Graduated, tiers);
+
+        total.ShouldBe((10_000m * 0.10m) + (40_000m * 0.05m));
+    }
+}


### PR DESCRIPTION
Closes #1172 (Phase 3 Story 1 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1159](https://github.com/granit-fx/granit-dotnet/issues/1159) Subscriptions overrides/phases/tiered).

Today \`PricingModel.Tiered = 3\` exists in the enum but has **no backing entity** — the orchestrator treats it like \`PerUnit\`. This PR fills the gap with a real \`PricingTier\` child entity, the two ORB tier modes (Volume / Graduated), and the calculator wired into the usage-invoice orchestrator.

## What ships

**Domain** (\`Granit.Subscriptions.Domain\`)
- \`TieringMode\` enum: \`Volume\` (active tier's unit price applies to entire quantity), \`Graduated\` (each bracket charged for its own units only)
- \`PricingTier\` entity (child of \`PlanPrice\`):
  - \`SortOrder\` (int, ascending = cheapest threshold)
  - \`UpToQuantity\` (decimal?, null = ∞ on the last tier)
  - \`UnitAmount\` (decimal, ≥ 0)
  - \`FlatAmount\` (decimal?, optional package fee added on top)
- \`PlanPrice\` extensions: new \`TieringMode?\` property, private \`_tiers\` collection exposed as \`Tiers\` IReadOnlyList, \`SetTiers(mode, IEnumerable<PricingTier>)\` bulk replacement.

**Boundary semantics** (locked by 13 unit tests):
- A tier *contains* its \`UpToQuantity\` (interval = \`(previous, currentUpTo]\`)
- Volume mode: 50K calls in tier 2 (10K-100K) → 50K × tier-2-rate
- Graduated mode: 50K calls = 10K × tier-0-rate + 40K × tier-1-rate
- Quantity = boundary stays in the lower bracket
- \`FlatAmount\`: Volume = added once for active tier; Graduated = added per crossed bracket
- Out-of-order tier lists are normalised by \`SortOrder\` before computing

**Pure calculator** (\`Granit.Subscriptions.Pricing.TieredPricingCalculator.Compute\`)
- Static, allocation-light pure function. No DB / DI / I/O.

**EF persistence** (\`Granit.Subscriptions.EntityFrameworkCore\`)
- New \`PricingTierConfiguration\` mapping \`pricing_tiers\` table; unique index on \`(PlanPriceId, SortOrder)\` guarantees sequence integrity
- \`PlanPriceConfiguration\` adds \`TieringMode\` column + the \`HasMany(Tiers)\` navigation with \`PropertyAccessMode.Field\` (the property is read-only by design)
- Cascade delete: removing a \`PlanPrice\` removes its tier sequence

**\`IPricingResolver\`** (cross-module contract)
- New \`ResolveUsageAmountAsync(planId, currency, interval, meterId, quantity, planPriceId, ct)\` — returns the **total** for the requested quantity, applying the tier sequence when present, falling back to \`quantity × unit price\` for flat per-unit pricing
- Existing \`ResolveUsageUnitPriceAsync\` kept as a public read-side helper (unchanged signature, no behavior change for non-tiered prices)

**\`DefaultUsageInvoiceOrchestrator\`**
- Calls \`ResolveUsageAmountAsync(quantity)\` instead of \`ResolveUsageUnitPriceAsync\` + manual multiplication. The invoice line still surfaces a "unit price" (the effective average rate = total / quantity) so downstream consumers can sanity-check. Numerically identical to the legacy path for flat per-unit pricing; reflects the bracket math for tiered.

## Tests (+19)

- \`TieredPricingCalculatorTests\` × 13 (Volume + Graduated × edge cases)
- \`PricingTierTests\` × 6 (factory validation: SortOrder/UnitAmount/FlatAmount ≥ 0, UpToQuantity > 0)
- 4 existing \`DefaultUsageInvoiceOrchestratorTests\` updated to stub the new \`ResolveUsageAmountAsync\` method
- **130 / 131** Subscriptions tests pass; the 1 failure is the pre-existing \`DefaultSubscriptionReactivationService\` flake noted in #1184 (not caused by this PR).

## Schema (consumer apps run their own EF migration)

\`\`\`sql
CREATE TABLE pricing_tiers (
    Id uuid NOT NULL PRIMARY KEY,
    PlanPriceId uuid NOT NULL,
    SortOrder int NOT NULL,
    UpToQuantity numeric(18,4) NULL,
    UnitAmount numeric(18,4) NOT NULL,
    FlatAmount numeric(18,4) NULL
);
CREATE UNIQUE INDEX ix_..._pricing_tiers_sequence ON pricing_tiers (PlanPriceId, SortOrder);
ALTER TABLE plan_prices ADD TieringMode int NULL;
\`\`\`

**No breaking change at the wire level.** Tiered prices created before this PR keep their \`PricingModel.Tiered\` enum value but have no \`Tiers\` list — the orchestrator falls back to \`quantity × Amount\`, behaviorally indistinguishable from the previous PerUnit-style path.

## Multi-currency

Yes, by construction:
- \`PlanPrice\` is already currency-scoped (\`Currency\` ISO 4217). Tier lists hang off \`PlanPrice\`, so each currency has its own bracket sequence — exactly what ORB / Stripe do.
- The orchestrator passes \`subscription.Currency\` through to \`ResolveUsageAmountAsync\`, which calls \`plan.GetCurrentPrice(currency, interval)\`. The right \`PlanPrice\` (and thus the right \`Tiers\`) is resolved.
- \`TieredPricingCalculator\` does no currency conversion — it computes in the tier's own currency, by design.
- Versioning trade-off: when an admin creates a new \`PlanPrice\` version via \`AddPriceVersion\` (existing flow), the new version starts with **empty** \`Tiers\` — same shape as \`Amount\` not carrying over. The admin re-authors the bracket list. Documented in the SetTiers XML doc.

## Out of scope (deferred)

- HTTP CRUD endpoints to manage tiers (\`POST /plans/{id}/prices/{priceId}/tiers\`, etc.). The domain + persistence + orchestrator wiring is the load-bearing part; CRUD endpoints are a follow-up PR with the full validator (ascending order, last \`UpToQuantity\` null, currency cross-check).
- FluentValidation guards at the HTTP boundary — currently in the entity factory only.
- Documentation (pricing model page with diagrams) — separate docs PR once CRUD lands.

## Test plan

- [x] \`dotnet build src/Granit.Subscriptions*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.Subscriptions.Tests\` — 130 / 131 (1 pre-existing flake)
- [ ] CI green on all 6 shards (TBD post-push)