### PR TITLE
fix(metering): align Recompute.Exceptions namespace with folder structure

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -25003,6 +25003,31 @@
       ]
     },
     {
+      "name": "MeterEventNotFoundException",
+      "fqn": "Granit.Metering.Recompute.Exceptions.MeterEventNotFoundException",
+      "kind": "class",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "UsageRecomputeRejectedException",
+      "fqn": "Granit.Metering.Recompute.Exceptions.UsageRecomputeRejectedException",
+      "kind": "class",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/Exceptions/UsageRecomputeRejectedException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ReasonCode",
+          "kind": "property",
+          "signature": "string ReasonCode",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "IMeterEventDeprecationService",
       "fqn": "Granit.Metering.Recompute.IMeterEventDeprecationService",
       "kind": "interface",
@@ -25040,7 +25065,7 @@
       "kind": "interface",
       "project": "Granit.Metering",
       "file": "src/Granit.Metering/Recompute/IUsageRecomputeService.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "RecomputeAsync",
@@ -25060,15 +25085,6 @@
       "members": []
     },
     {
-      "name": "MeterEventNotFoundException",
-      "fqn": "Granit.Metering.Recompute.MeterEventNotFoundException",
-      "kind": "class",
-      "project": "Granit.Metering",
-      "file": "src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs",
-      "line": 4,
-      "members": []
-    },
-    {
       "name": "UsageBackfillResult",
       "fqn": "Granit.Metering.Recompute.UsageBackfillResult",
       "kind": "record",
@@ -25076,22 +25092,6 @@
       "file": "src/Granit.Metering/Recompute/IUsageBackfillService.cs",
       "line": 30,
       "members": []
-    },
-    {
-      "name": "UsageRecomputeRejectedException",
-      "fqn": "Granit.Metering.Recompute.UsageRecomputeRejectedException",
-      "kind": "class",
-      "project": "Granit.Metering",
-      "file": "src/Granit.Metering/Recompute/Exceptions/UsageRecomputeRejectedException.cs",
-      "line": 7,
-      "members": [
-        {
-          "name": "ReasonCode",
-          "kind": "property",
-          "signature": "string ReasonCode",
-          "returnType": "string"
-        }
-      ]
     },
     {
       "name": "UsageRecomputeRequest",

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -6,6 +6,7 @@ using Granit.Metering.Domain.ValueObjects;
 using Granit.Metering.Endpoints.Dtos;
 using Granit.Metering.Endpoints.Permissions;
 using Granit.Metering.Recompute;
+using Granit.Metering.Recompute.Exceptions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -6,6 +6,7 @@ using Granit.Metering.Dtos;
 using Granit.Metering.Endpoints.Dtos;
 using Granit.Metering.Endpoints.Permissions;
 using Granit.Metering.Recompute;
+using Granit.Metering.Recompute.Exceptions;
 using Granit.MultiTenancy;
 using Granit.Workflow.Domain;
 using Microsoft.AspNetCore.Builder;

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterEventDeprecationService.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterEventDeprecationService.cs
@@ -3,6 +3,7 @@ using Granit.Domain;
 using Granit.Metering.Diagnostics;
 using Granit.Metering.Domain;
 using Granit.Metering.Recompute;
+using Granit.Metering.Recompute.Exceptions;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
@@ -5,6 +5,7 @@ using Granit.Guids;
 using Granit.Metering.Diagnostics;
 using Granit.Metering.Domain;
 using Granit.Metering.Recompute;
+using Granit.Metering.Recompute.Exceptions;
 using Granit.Persistence.EntityFrameworkCore.ExceptionHandling;
 using Granit.Timing;
 using Granit.Workflow.Domain;

--- a/src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs
+++ b/src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Metering.Recompute;
+namespace Granit.Metering.Recompute.Exceptions;
 
 /// <summary>Raised when a deprecation targets a non-existent <see cref="Domain.MeterEvent"/>.</summary>
 public sealed class MeterEventNotFoundException(Guid eventId)

--- a/src/Granit.Metering/Recompute/Exceptions/UsageRecomputeRejectedException.cs
+++ b/src/Granit.Metering/Recompute/Exceptions/UsageRecomputeRejectedException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Metering.Recompute;
+namespace Granit.Metering.Recompute.Exceptions;
 
 /// <summary>
 /// Raised when a recompute is rejected at the domain layer (unknown meter,

--- a/src/Granit.Metering/Recompute/IUsageRecomputeService.cs
+++ b/src/Granit.Metering/Recompute/IUsageRecomputeService.cs
@@ -1,3 +1,5 @@
+using Granit.Metering.Recompute.Exceptions;
+
 namespace Granit.Metering.Recompute;
 
 /// <summary>

--- a/tests/Granit.Metering.Tests/Recompute/UsageRecomputeContractsTests.cs
+++ b/tests/Granit.Metering.Tests/Recompute/UsageRecomputeContractsTests.cs
@@ -1,4 +1,5 @@
 using Granit.Metering.Recompute;
+using Granit.Metering.Recompute.Exceptions;
 using Shouldly;
 using Xunit;
 


### PR DESCRIPTION
The architecture test \`SourceCodeAntiPatternTests.Namespace_should_match_folder_structure_in_src\` broke on \`develop\` after #1193 + #1196 moved the two exception classes into \`Recompute/Exceptions/\` without updating their namespace declarations.

Two architecture rules together require BOTH:
- \`*.cs\` files ending in \`Exception\` must live in an \`Exceptions/\` subfolder (\`FileOrganizationTests.Exception_classes_should_reside_in_Exceptions_folder\`)
- namespace must match folder structure (\`SourceCodeAntiPatternTests.Namespace_should_match_folder_structure_in_src\`)

## Changes

- \`Recompute/Exceptions/UsageRecomputeRejectedException.cs\` namespace → \`Granit.Metering.Recompute.Exceptions\`
- \`Recompute/Exceptions/MeterEventNotFoundException.cs\` namespace → \`Granit.Metering.Recompute.Exceptions\`
- 6 consumers (3 src + 1 Endpoints + 1 EF + 1 test) get an additional \`using Granit.Metering.Recompute.Exceptions;\` directive

No public API change at the type level — both types remain public; only the namespace they live in changes. Downstream consumers of the package would need a using update (additive, not source-breaking on the wire).

## Test plan

- [x] \`dotnet test tests/Granit.ArchitectureTests --filter "Namespace_should_match_folder|Exception_classes"\` — 4 / 4
- [x] \`dotnet test tests/Granit.Metering.Tests\` — 58 / 58
- [x] \`dotnet build src/Granit.Metering*\` — 0 errors, 0 warnings