### PR TITLE
feat(subscriptions): SubscriptionPhase for scheduled plan changes

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40125,22 +40125,6 @@
       "members": []
     },
     {
-      "name": "PricingTier",
-      "fqn": "Granit.Subscriptions.Domain.PricingTier",
-      "kind": "class",
-      "project": "Granit.Subscriptions",
-      "file": "src/Granit.Subscriptions/Domain/PricingTier.cs",
-      "line": 16,
-      "members": [
-        {
-          "name": "Create",
-          "kind": "method",
-          "signature": "Create(Guid id, Guid planPriceId, int sortOrder, decimal? upToQuantity, decimal unitAmount, decimal? flatAmount = null)",
-          "returnType": "PricingTier"
-        }
-      ]
-    },
-    {
       "name": "Subscription",
       "fqn": "Granit.Subscriptions.Domain.Subscription",
       "kind": "class",
@@ -40171,6 +40155,12 @@
           "kind": "method",
           "signature": "AsReadOnly()",
           "returnType": "IReadOnlyList<SubscriptionExternalMapping> ExternalMappings => _externalMappings."
+        },
+        {
+          "name": "Phases",
+          "kind": "property",
+          "signature": "IReadOnlyList<SubscriptionPhase> Phases",
+          "returnType": "IReadOnlyList<SubscriptionPhase>"
         },
         {
           "name": "nameof",
@@ -40239,6 +40229,28 @@
       ]
     },
     {
+      "name": "SubscriptionPhase",
+      "fqn": "Granit.Subscriptions.Domain.SubscriptionPhase",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/SubscriptionPhase.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid subscriptionId, DateTimeOffset startDate, DateTimeOffset? endDate, PlanId planId, Guid? overridePriceId = null, decimal? discountPercent = null)",
+          "returnType": "SubscriptionPhase"
+        },
+        {
+          "name": "Covers",
+          "kind": "method",
+          "signature": "Covers(DateTimeOffset instant)",
+          "returnType": "Guid? OverridePriceId { get; private set; } public decimal? DiscountPercent { get; private set; } public bool"
+        }
+      ]
+    },
+    {
       "name": "SubscriptionSeat",
       "fqn": "Granit.Subscriptions.Domain.SubscriptionSeat",
       "kind": "class",
@@ -40261,15 +40273,6 @@
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/SubscriptionStatus.cs",
       "line": 6,
-      "members": []
-    },
-    {
-      "name": "TieringMode",
-      "fqn": "Granit.Subscriptions.Domain.TieringMode",
-      "kind": "enum",
-      "project": "Granit.Subscriptions",
-      "file": "src/Granit.Subscriptions/Domain/TieringMode.cs",
-      "line": 7,
       "members": []
     },
     {
@@ -40515,6 +40518,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "Phases",
+      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Phases",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
+      "line": 50,
+      "members": []
     },
     {
       "name": "Plans",
@@ -41515,22 +41527,6 @@
           "kind": "property",
           "signature": "NotificationSeverity DefaultSeverity",
           "returnType": "NotificationSeverity"
-        }
-      ]
-    },
-    {
-      "name": "TieredPricingCalculator",
-      "fqn": "Granit.Subscriptions.Pricing.TieredPricingCalculator",
-      "kind": "class",
-      "project": "Granit.Subscriptions",
-      "file": "src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs",
-      "line": 15,
-      "members": [
-        {
-          "name": "Compute",
-          "kind": "method",
-          "signature": "Compute(decimal quantity, TieringMode mode, IReadOnlyList<PricingTier> tiers)",
-          "returnType": "decimal"
         }
       ]
     },

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -1,14 +1,15 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Subscriptions": "Předplatné",
-    "Permission:Subscriptions.Plans.Read": "Zobrazit plány předplatného",
+    "Permission:Subscriptions.Phases.Manage": "Správa fází předplatného (plánování změn plánu, přepsání cen, aplikace slev)",
     "Permission:Subscriptions.Plans.Manage": "Spravovat plány předplatného (vytvořit, publikovat, archivovat)",
-    "Permission:Subscriptions.Subscriptions.Read": "Zobrazit předplatná",
-    "Permission:Subscriptions.Subscriptions.Manage": "Spravovat předplatná (vytvořit, zrušit, změnit plán)",
-    "Permission:Subscriptions.Prices.Read": "Zobrazit historii verzí cen",
+    "Permission:Subscriptions.Plans.Read": "Zobrazit plány předplatného",
     "Permission:Subscriptions.Prices.Manage": "Spravovat ceny (vytvářet verze, migrovat předplatné)",
+    "Permission:Subscriptions.Prices.Read": "Zobrazit historii verzí cen",
+    "Permission:Subscriptions.Seats.Manage": "Spravovat přiřazení míst (přiřadit, odvolat)",
     "Permission:Subscriptions.Seats.Read": "Zobrazit přiřazení míst",
-    "Permission:Subscriptions.Seats.Manage": "Spravovat přiřazení míst (přiřadit, odvolat)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Spravovat předplatná (vytvořit, zrušit, změnit plán)",
+    "Permission:Subscriptions.Subscriptions.Read": "Zobrazit předplatná",
+    "PermissionGroup:Subscriptions": "Předplatné"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
@@ -1,14 +1,15 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Subscriptions": "Abonnements",
-    "Permission:Subscriptions.Plans.Read": "Abonnementpläne anzeigen",
+    "Permission:Subscriptions.Phases.Manage": "Abonnementphasen verwalten (Planänderungen planen, Preise überschreiben, Rabatte anwenden)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementpläne verwalten (erstellen, veröffentlichen, archivieren)",
-    "Permission:Subscriptions.Subscriptions.Read": "Abonnements anzeigen",
-    "Permission:Subscriptions.Subscriptions.Manage": "Abonnements verwalten (erstellen, kündigen, Plan wechseln)",
-    "Permission:Subscriptions.Prices.Read": "Preisversionshistorie anzeigen",
+    "Permission:Subscriptions.Plans.Read": "Abonnementpläne anzeigen",
     "Permission:Subscriptions.Prices.Manage": "Preise verwalten (Versionen erstellen, Abonnements migrieren)",
+    "Permission:Subscriptions.Prices.Read": "Preisversionshistorie anzeigen",
+    "Permission:Subscriptions.Seats.Manage": "Platzzuweisungen verwalten (zuweisen, widerrufen)",
     "Permission:Subscriptions.Seats.Read": "Platzzuweisungen anzeigen",
-    "Permission:Subscriptions.Seats.Manage": "Platzzuweisungen verwalten (zuweisen, widerrufen)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Abonnements verwalten (erstellen, kündigen, Plan wechseln)",
+    "Permission:Subscriptions.Subscriptions.Read": "Abonnements anzeigen",
+    "PermissionGroup:Subscriptions": "Abonnements"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
@@ -1,14 +1,15 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Subscriptions": "Subscriptions",
-    "Permission:Subscriptions.Plans.Read": "View subscription plans",
+    "Permission:Subscriptions.Phases.Manage": "Manage subscription phases (schedule plan changes, override prices, apply discounts)",
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
-    "Permission:Subscriptions.Subscriptions.Read": "View subscriptions",
-    "Permission:Subscriptions.Subscriptions.Manage": "Manage subscriptions (create, cancel, change plan)",
-    "Permission:Subscriptions.Prices.Read": "View price version history",
+    "Permission:Subscriptions.Plans.Read": "View subscription plans",
     "Permission:Subscriptions.Prices.Manage": "Manage prices (create versions, migrate subscriptions)",
+    "Permission:Subscriptions.Prices.Read": "View price version history",
+    "Permission:Subscriptions.Seats.Manage": "Manage seat assignments (assign, revoke)",
     "Permission:Subscriptions.Seats.Read": "View seat assignments",
-    "Permission:Subscriptions.Seats.Manage": "Manage seat assignments (assign, revoke)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Manage subscriptions (create, cancel, change plan)",
+    "Permission:Subscriptions.Subscriptions.Read": "View subscriptions",
+    "PermissionGroup:Subscriptions": "Subscriptions"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
@@ -1,14 +1,15 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Subscriptions": "Suscripciones",
-    "Permission:Subscriptions.Plans.Read": "Ver planes de suscripción",
+    "Permission:Subscriptions.Phases.Manage": "Gestionar fases de suscripción (programar cambios de plan, anular precios, aplicar descuentos)",
     "Permission:Subscriptions.Plans.Manage": "Gestionar planes de suscripción (crear, publicar, archivar)",
-    "Permission:Subscriptions.Subscriptions.Read": "Ver suscripciones",
-    "Permission:Subscriptions.Subscriptions.Manage": "Gestionar suscripciones (crear, cancelar, cambiar de plan)",
-    "Permission:Subscriptions.Prices.Read": "Ver historial de versiones de precios",
+    "Permission:Subscriptions.Plans.Read": "Ver planes de suscripción",
     "Permission:Subscriptions.Prices.Manage": "Gestionar precios (crear versiones, migrar suscripciones)",
+    "Permission:Subscriptions.Prices.Read": "Ver historial de versiones de precios",
+    "Permission:Subscriptions.Seats.Manage": "Gestionar asignaciones de puestos (asignar, revocar)",
     "Permission:Subscriptions.Seats.Read": "Ver asignaciones de puestos",
-    "Permission:Subscriptions.Seats.Manage": "Gestionar asignaciones de puestos (asignar, revocar)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Gestionar suscripciones (crear, cancelar, cambiar de plan)",
+    "Permission:Subscriptions.Subscriptions.Read": "Ver suscripciones",
+    "PermissionGroup:Subscriptions": "Suscripciones"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
@@ -1,14 +1,15 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Subscriptions": "Abonnements",
-    "Permission:Subscriptions.Plans.Read": "Consulter les plans d'abonnement",
+    "Permission:Subscriptions.Phases.Manage": "Gérer les phases d'abonnement (planifier des changements de plan, surcharger les prix, appliquer des remises)",
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
-    "Permission:Subscriptions.Subscriptions.Read": "Consulter les abonnements",
-    "Permission:Subscriptions.Subscriptions.Manage": "Gérer les abonnements (créer, annuler, changer de plan)",
-    "Permission:Subscriptions.Prices.Read": "Consulter l'historique des versions de prix",
+    "Permission:Subscriptions.Plans.Read": "Consulter les plans d'abonnement",
     "Permission:Subscriptions.Prices.Manage": "Gérer les prix (créer des versions, migrer les abonnements)",
+    "Permission:Subscriptions.Prices.Read": "Consulter l'historique des versions de prix",
+    "Permission:Subscriptions.Seats.Manage": "Gérer les attributions de sièges (attribuer, révoquer)",
     "Permission:Subscriptions.Seats.Read": "Consulter les attributions de sièges",
-    "Permission:Subscriptions.Seats.Manage": "Gérer les attributions de sièges (attribuer, révoquer)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Gérer les abonnements (créer, annuler, changer de plan)",
+    "Permission:Subscriptions.Subscriptions.Read": "Consulter les abonnements",
+    "PermissionGroup:Subscriptions": "Abonnements"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
@@ -1,14 +1,15 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Subscriptions": "सब्सक्रिप्शन",
-    "Permission:Subscriptions.Plans.Read": "सब्सक्रिप्शन प्लान देखें",
+    "Permission:Subscriptions.Phases.Manage": "सदस्यता चरण प्रबंधित करें (योजना परिवर्तन शेड्यूल करें, मूल्य ओवरराइड करें, छूट लागू करें)",
     "Permission:Subscriptions.Plans.Manage": "सब्सक्रिप्शन प्लान प्रबंधित करें (बनाएँ, प्रकाशित करें, संग्रहित करें)",
-    "Permission:Subscriptions.Subscriptions.Read": "सब्सक्रिप्शन देखें",
-    "Permission:Subscriptions.Subscriptions.Manage": "सब्सक्रिप्शन प्रबंधित करें (बनाएँ, रद्द करें, प्लान बदलें)",
-    "Permission:Subscriptions.Prices.Read": "मूल्य संस्करण इतिहास देखें",
+    "Permission:Subscriptions.Plans.Read": "सब्सक्रिप्शन प्लान देखें",
     "Permission:Subscriptions.Prices.Manage": "मूल्य प्रबंधित करें (संस्करण बनाएँ, सब्सक्रिप्शन माइग्रेट करें)",
+    "Permission:Subscriptions.Prices.Read": "मूल्य संस्करण इतिहास देखें",
+    "Permission:Subscriptions.Seats.Manage": "सीट असाइनमेंट प्रबंधित करें (असाइन करें, निरस्त करें)",
     "Permission:Subscriptions.Seats.Read": "सीट असाइनमेंट देखें",
-    "Permission:Subscriptions.Seats.Manage": "सीट असाइनमेंट प्रबंधित करें (असाइन करें, निरस्त करें)"
+    "Permission:Subscriptions.Subscriptions.Manage": "सब्सक्रिप्शन प्रबंधित करें (बनाएँ, रद्द करें, प्लान बदलें)",
+    "Permission:Subscriptions.Subscriptions.Read": "सब्सक्रिप्शन देखें",
+    "PermissionGroup:Subscriptions": "सब्सक्रिप्शन"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -1,14 +1,15 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Subscriptions": "Abbonamenti",
-    "Permission:Subscriptions.Plans.Read": "Visualizzare i piani di abbonamento",
+    "Permission:Subscriptions.Phases.Manage": "Gestire le fasi dell'abbonamento (programmare modifiche di piano, sovrascrivere prezzi, applicare sconti)",
     "Permission:Subscriptions.Plans.Manage": "Gestire i piani di abbonamento (creare, pubblicare, archiviare)",
-    "Permission:Subscriptions.Subscriptions.Read": "Visualizzare gli abbonamenti",
-    "Permission:Subscriptions.Subscriptions.Manage": "Gestire gli abbonamenti (creare, annullare, cambiare piano)",
-    "Permission:Subscriptions.Prices.Read": "Visualizzare lo storico delle versioni dei prezzi",
+    "Permission:Subscriptions.Plans.Read": "Visualizzare i piani di abbonamento",
     "Permission:Subscriptions.Prices.Manage": "Gestire i prezzi (creare versioni, migrare abbonamenti)",
+    "Permission:Subscriptions.Prices.Read": "Visualizzare lo storico delle versioni dei prezzi",
+    "Permission:Subscriptions.Seats.Manage": "Gestire le assegnazioni dei posti (assegnare, revocare)",
     "Permission:Subscriptions.Seats.Read": "Visualizzare le assegnazioni dei posti",
-    "Permission:Subscriptions.Seats.Manage": "Gestire le assegnazioni dei posti (assegnare, revocare)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Gestire gli abbonamenti (creare, annullare, cambiare piano)",
+    "Permission:Subscriptions.Subscriptions.Read": "Visualizzare gli abbonamenti",
+    "PermissionGroup:Subscriptions": "Abbonamenti"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -1,14 +1,15 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Subscriptions": "サブスクリプション",
-    "Permission:Subscriptions.Plans.Read": "サブスクリプションプランの表示",
+    "Permission:Subscriptions.Phases.Manage": "サブスクリプションフェーズを管理（プラン変更のスケジュール、価格上書き、割引適用）",
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
-    "Permission:Subscriptions.Subscriptions.Read": "サブスクリプションの表示",
-    "Permission:Subscriptions.Subscriptions.Manage": "サブスクリプションの管理（作成、キャンセル、プラン変更）",
-    "Permission:Subscriptions.Prices.Read": "価格バージョン履歴を表示",
+    "Permission:Subscriptions.Plans.Read": "サブスクリプションプランの表示",
     "Permission:Subscriptions.Prices.Manage": "価格を管理（バージョン作成、サブスクリプション移行）",
+    "Permission:Subscriptions.Prices.Read": "価格バージョン履歴を表示",
+    "Permission:Subscriptions.Seats.Manage": "シート割り当ての管理（割り当て、取り消し）",
     "Permission:Subscriptions.Seats.Read": "シート割り当ての表示",
-    "Permission:Subscriptions.Seats.Manage": "シート割り当ての管理（割り当て、取り消し）"
+    "Permission:Subscriptions.Subscriptions.Manage": "サブスクリプションの管理（作成、キャンセル、プラン変更）",
+    "Permission:Subscriptions.Subscriptions.Read": "サブスクリプションの表示",
+    "PermissionGroup:Subscriptions": "サブスクリプション"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -1,14 +1,15 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Subscriptions": "구독",
-    "Permission:Subscriptions.Plans.Read": "구독 플랜 보기",
+    "Permission:Subscriptions.Phases.Manage": "구독 단계 관리 (요금제 변경 예약, 가격 재정의, 할인 적용)",
     "Permission:Subscriptions.Plans.Manage": "구독 플랜 관리 (생성, 게시, 보관)",
-    "Permission:Subscriptions.Subscriptions.Read": "구독 보기",
-    "Permission:Subscriptions.Subscriptions.Manage": "구독 관리 (생성, 취소, 플랜 변경)",
-    "Permission:Subscriptions.Prices.Read": "가격 버전 이력 조회",
+    "Permission:Subscriptions.Plans.Read": "구독 플랜 보기",
     "Permission:Subscriptions.Prices.Manage": "가격 관리 (버전 생성, 구독 마이그레이션)",
+    "Permission:Subscriptions.Prices.Read": "가격 버전 이력 조회",
+    "Permission:Subscriptions.Seats.Manage": "시트 할당 관리 (할당, 철회)",
     "Permission:Subscriptions.Seats.Read": "시트 할당 보기",
-    "Permission:Subscriptions.Seats.Manage": "시트 할당 관리 (할당, 철회)"
+    "Permission:Subscriptions.Subscriptions.Manage": "구독 관리 (생성, 취소, 플랜 변경)",
+    "Permission:Subscriptions.Subscriptions.Read": "구독 보기",
+    "PermissionGroup:Subscriptions": "구독"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
@@ -1,14 +1,15 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Subscriptions": "Abonnementen",
-    "Permission:Subscriptions.Plans.Read": "Abonnementsplannen bekijken",
+    "Permission:Subscriptions.Phases.Manage": "Abonnementfasen beheren (planwijzigingen plannen, prijzen overschrijven, kortingen toepassen)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementsplannen beheren (aanmaken, publiceren, archiveren)",
-    "Permission:Subscriptions.Subscriptions.Read": "Abonnementen bekijken",
-    "Permission:Subscriptions.Subscriptions.Manage": "Abonnementen beheren (aanmaken, annuleren, van plan wijzigen)",
-    "Permission:Subscriptions.Prices.Read": "Prijsversiegeschiedenis bekijken",
+    "Permission:Subscriptions.Plans.Read": "Abonnementsplannen bekijken",
     "Permission:Subscriptions.Prices.Manage": "Prijzen beheren (versies aanmaken, abonnementen migreren)",
+    "Permission:Subscriptions.Prices.Read": "Prijsversiegeschiedenis bekijken",
+    "Permission:Subscriptions.Seats.Manage": "Stoeltoewijzingen beheren (toewijzen, intrekken)",
     "Permission:Subscriptions.Seats.Read": "Stoeltoewijzingen bekijken",
-    "Permission:Subscriptions.Seats.Manage": "Stoeltoewijzingen beheren (toewijzen, intrekken)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Abonnementen beheren (aanmaken, annuleren, van plan wijzigen)",
+    "Permission:Subscriptions.Subscriptions.Read": "Abonnementen bekijken",
+    "PermissionGroup:Subscriptions": "Abonnementen"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -1,14 +1,15 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Subscriptions": "Subskrypcje",
-    "Permission:Subscriptions.Plans.Read": "Wyświetlanie planów subskrypcji",
+    "Permission:Subscriptions.Phases.Manage": "Zarządzanie fazami subskrypcji (planowanie zmian planu, nadpisywanie cen, stosowanie zniżek)",
     "Permission:Subscriptions.Plans.Manage": "Zarządzanie planami subskrypcji (tworzenie, publikowanie, archiwizowanie)",
-    "Permission:Subscriptions.Subscriptions.Read": "Wyświetlanie subskrypcji",
-    "Permission:Subscriptions.Subscriptions.Manage": "Zarządzanie subskrypcjami (tworzenie, anulowanie, zmiana planu)",
-    "Permission:Subscriptions.Prices.Read": "Wyświetl historię wersji cen",
+    "Permission:Subscriptions.Plans.Read": "Wyświetlanie planów subskrypcji",
     "Permission:Subscriptions.Prices.Manage": "Zarządzaj cenami (twórz wersje, migruj subskrypcje)",
+    "Permission:Subscriptions.Prices.Read": "Wyświetl historię wersji cen",
+    "Permission:Subscriptions.Seats.Manage": "Zarządzanie przypisaniami miejsc (przypisywanie, cofanie)",
     "Permission:Subscriptions.Seats.Read": "Wyświetlanie przypisań miejsc",
-    "Permission:Subscriptions.Seats.Manage": "Zarządzanie przypisaniami miejsc (przypisywanie, cofanie)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Zarządzanie subskrypcjami (tworzenie, anulowanie, zmiana planu)",
+    "Permission:Subscriptions.Subscriptions.Read": "Wyświetlanie subskrypcji",
+    "PermissionGroup:Subscriptions": "Subskrypcje"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -1,14 +1,15 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "PermissionGroup:Subscriptions": "Assinaturas",
-    "Permission:Subscriptions.Plans.Read": "Visualizar planos de assinatura",
+    "Permission:Subscriptions.Phases.Manage": "Gerenciar fases de assinatura (agendar alterações de plano, sobrepor preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerenciar planos de assinatura (criar, publicar, arquivar)",
-    "Permission:Subscriptions.Subscriptions.Read": "Visualizar assinaturas",
-    "Permission:Subscriptions.Subscriptions.Manage": "Gerenciar assinaturas (criar, cancelar, alterar plano)",
-    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
+    "Permission:Subscriptions.Plans.Read": "Visualizar planos de assinatura",
     "Permission:Subscriptions.Prices.Manage": "Gerenciar preços (criar versões, migrar assinaturas)",
+    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
+    "Permission:Subscriptions.Seats.Manage": "Gerenciar atribuições de assentos (atribuir, revogar)",
     "Permission:Subscriptions.Seats.Read": "Visualizar atribuições de assentos",
-    "Permission:Subscriptions.Seats.Manage": "Gerenciar atribuições de assentos (atribuir, revogar)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Gerenciar assinaturas (criar, cancelar, alterar plano)",
+    "Permission:Subscriptions.Subscriptions.Read": "Visualizar assinaturas",
+    "PermissionGroup:Subscriptions": "Assinaturas"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -1,14 +1,15 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Subscriptions": "Subscrições",
-    "Permission:Subscriptions.Plans.Read": "Ver planos de subscrição",
+    "Permission:Subscriptions.Phases.Manage": "Gerir fases de subscrição (agendar alterações de plano, substituir preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
-    "Permission:Subscriptions.Subscriptions.Read": "Ver subscrições",
-    "Permission:Subscriptions.Subscriptions.Manage": "Gerir subscrições (criar, cancelar, alterar plano)",
-    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
+    "Permission:Subscriptions.Plans.Read": "Ver planos de subscrição",
     "Permission:Subscriptions.Prices.Manage": "Gerir preços (criar versões, migrar assinaturas)",
+    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
+    "Permission:Subscriptions.Seats.Manage": "Gerir atribuições de lugares (atribuir, revogar)",
     "Permission:Subscriptions.Seats.Read": "Ver atribuições de lugares",
-    "Permission:Subscriptions.Seats.Manage": "Gerir atribuições de lugares (atribuir, revogar)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Gerir subscrições (criar, cancelar, alterar plano)",
+    "Permission:Subscriptions.Subscriptions.Read": "Ver subscrições",
+    "PermissionGroup:Subscriptions": "Subscrições"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -1,14 +1,15 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Subscriptions": "Prenumerationer",
-    "Permission:Subscriptions.Plans.Read": "Visa prenumerationsplaner",
+    "Permission:Subscriptions.Phases.Manage": "Hantera prenumerationsfaser (schemalägga planändringar, åsidosätta priser, tillämpa rabatter)",
     "Permission:Subscriptions.Plans.Manage": "Hantera prenumerationsplaner (skapa, publicera, arkivera)",
-    "Permission:Subscriptions.Subscriptions.Read": "Visa prenumerationer",
-    "Permission:Subscriptions.Subscriptions.Manage": "Hantera prenumerationer (skapa, avbryta, byta plan)",
-    "Permission:Subscriptions.Prices.Read": "Visa prisversionshistorik",
+    "Permission:Subscriptions.Plans.Read": "Visa prenumerationsplaner",
     "Permission:Subscriptions.Prices.Manage": "Hantera priser (skapa versioner, migrera prenumerationer)",
+    "Permission:Subscriptions.Prices.Read": "Visa prisversionshistorik",
+    "Permission:Subscriptions.Seats.Manage": "Hantera platstilldelningar (tilldela, återkalla)",
     "Permission:Subscriptions.Seats.Read": "Visa platstilldelningar",
-    "Permission:Subscriptions.Seats.Manage": "Hantera platstilldelningar (tilldela, återkalla)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Hantera prenumerationer (skapa, avbryta, byta plan)",
+    "Permission:Subscriptions.Subscriptions.Read": "Visa prenumerationer",
+    "PermissionGroup:Subscriptions": "Prenumerationer"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -1,14 +1,15 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Subscriptions": "Abonelikler",
-    "Permission:Subscriptions.Plans.Read": "Abonelik planlarını görüntüle",
+    "Permission:Subscriptions.Phases.Manage": "Abonelik fazlarını yönet (plan değişikliklerini zamanla, fiyatları geçersiz kıl, indirim uygula)",
     "Permission:Subscriptions.Plans.Manage": "Abonelik planlarını yönet (oluştur, yayınla, arşivle)",
-    "Permission:Subscriptions.Subscriptions.Read": "Abonelikleri görüntüle",
-    "Permission:Subscriptions.Subscriptions.Manage": "Abonelikleri yönet (oluştur, iptal et, plan değiştir)",
-    "Permission:Subscriptions.Prices.Read": "Fiyat sürüm geçmişini görüntüle",
+    "Permission:Subscriptions.Plans.Read": "Abonelik planlarını görüntüle",
     "Permission:Subscriptions.Prices.Manage": "Fiyatları yönet (sürüm oluştur, abonelikleri taşı)",
+    "Permission:Subscriptions.Prices.Read": "Fiyat sürüm geçmişini görüntüle",
+    "Permission:Subscriptions.Seats.Manage": "Koltuk atamalarını yönet (ata, iptal et)",
     "Permission:Subscriptions.Seats.Read": "Koltuk atamalarını görüntüle",
-    "Permission:Subscriptions.Seats.Manage": "Koltuk atamalarını yönet (ata, iptal et)"
+    "Permission:Subscriptions.Subscriptions.Manage": "Abonelikleri yönet (oluştur, iptal et, plan değiştir)",
+    "Permission:Subscriptions.Subscriptions.Read": "Abonelikleri görüntüle",
+    "PermissionGroup:Subscriptions": "Abonelikler"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -1,14 +1,15 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Subscriptions": "订阅",
-    "Permission:Subscriptions.Plans.Read": "查看订阅计划",
+    "Permission:Subscriptions.Phases.Manage": "管理订阅阶段（计划变更、价格覆盖、应用折扣）",
     "Permission:Subscriptions.Plans.Manage": "管理订阅计划（创建、发布、归档）",
-    "Permission:Subscriptions.Subscriptions.Read": "查看订阅",
-    "Permission:Subscriptions.Subscriptions.Manage": "管理订阅（创建、取消、更改计划）",
-    "Permission:Subscriptions.Prices.Read": "查看价格版本历史",
+    "Permission:Subscriptions.Plans.Read": "查看订阅计划",
     "Permission:Subscriptions.Prices.Manage": "管理价格（创建版本、迁移订阅）",
+    "Permission:Subscriptions.Prices.Read": "查看价格版本历史",
+    "Permission:Subscriptions.Seats.Manage": "管理席位分配（分配、撤销）",
     "Permission:Subscriptions.Seats.Read": "查看席位分配",
-    "Permission:Subscriptions.Seats.Manage": "管理席位分配（分配、撤销）"
+    "Permission:Subscriptions.Subscriptions.Manage": "管理订阅（创建、取消、更改计划）",
+    "Permission:Subscriptions.Subscriptions.Read": "查看订阅",
+    "PermissionGroup:Subscriptions": "订阅"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -42,5 +42,11 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
         group.AddPermission(SubscriptionsPermissions.Seats.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Manage"),
             MultiTenancySide.Both);
+
+        // Phases are admin-only: they pin the active plan + price for a window
+        // and apply percentage discounts — host-side ramp-deal authoring tool.
+        group.AddPermission(SubscriptionsPermissions.Phases.Manage,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Phases.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
@@ -45,4 +45,17 @@ public static class SubscriptionsPermissions
         /// <summary>Manage seat assignments (assign, revoke).</summary>
         public const string Manage = "Subscriptions.Seats.Manage";
     }
+
+    /// <summary>Scheduled phase permissions (ramp deals, plan transitions).</summary>
+    public static class Phases
+    {
+        /// <summary>
+        /// Manage subscription phases (schedule plan changes, override prices, apply
+        /// flat percentage discounts). Restricted to admins because phases pin the
+        /// active plan + price for a specific time window — destructive at the
+        /// billing level (ISO 27001 A.9.4 — least privilege on revenue-impacting
+        /// operations).
+        /// </summary>
+        public const string Manage = "Subscriptions.Phases.Manage";
+    }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class SubscriptionsModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new PlanFeatureValueConfiguration());
         modelBuilder.ApplyConfiguration(new PlanExternalMappingConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionConfiguration());
+        modelBuilder.ApplyConfiguration(new SubscriptionPhaseConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionSeatConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionExternalMappingConfiguration());
         return modelBuilder;

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
@@ -34,6 +34,14 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
         builder.HasMany(e => e.Seats).WithOne().HasForeignKey("SubscriptionId").OnDelete(DeleteBehavior.Cascade);
         builder.HasMany(e => e.ExternalMappings).WithOne().HasForeignKey("SubscriptionId").OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasMany(e => e.Phases)
+            .WithOne()
+            .HasForeignKey(p => p.SubscriptionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.Phases)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         builder.HasIndex(e => new { e.TenantId, e.Status })
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscriptions_tenant_status");
 

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPhaseConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPhaseConfiguration.cs
@@ -1,0 +1,32 @@
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+internal sealed class SubscriptionPhaseConfiguration : IEntityTypeConfiguration<SubscriptionPhase>
+{
+    public void Configure(EntityTypeBuilder<SubscriptionPhase> builder)
+    {
+        builder.ToTable(
+            GranitSubscriptionsDbProperties.DbTablePrefix + "subscription_phases",
+            GranitSubscriptionsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.SubscriptionId).IsRequired();
+        builder.Property(e => e.StartDate).IsRequired();
+        builder.Property(e => e.EndDate);
+
+        // PlanId is a SingleValueObject<Guid> — declared as scalar so EF Core does not
+        // try to materialise it as a navigation. Converter is applied by ApplyGranitConventions.
+        builder.Property(e => e.PlanId).IsRequired();
+
+        builder.Property(e => e.OverridePriceId);
+        builder.Property(e => e.DiscountPercent).HasPrecision(5, 2);
+
+        // One overlap-free timeline per subscription — the per-(subscription, start)
+        // index is small but enables efficient GetActivePhase point-lookups.
+        builder.HasIndex(e => new { e.SubscriptionId, e.StartDate })
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscription_phases_timeline");
+    }
+}

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -24,6 +24,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 {
     private readonly List<SubscriptionSeat> _seats = [];
     private readonly List<SubscriptionExternalMapping> _externalMappings = [];
+    private readonly List<SubscriptionPhase> _phases = [];
 
     private Subscription() { }
 
@@ -118,6 +119,15 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
     /// <summary>External provider mappings (Stripe, Mollie, etc.).</summary>
     public IReadOnlyList<SubscriptionExternalMapping> ExternalMappings => _externalMappings.AsReadOnly();
+
+    /// <summary>
+    /// Scheduled timeline segments. Each <see cref="SubscriptionPhase"/> covers
+    /// <c>[StartDate, EndDate)</c> and pins the active plan for that interval —
+    /// enabling ramp deals (<c>trial → standard → enterprise</c>). Empty by
+    /// default; the orchestrator falls back to <see cref="PlanId"/> when no
+    /// phase covers the billing instant (single-plan backward compat).
+    /// </summary>
+    public IReadOnlyList<SubscriptionPhase> Phases => _phases;
 
     /// <inheritdoc />
     public Guid? TenantId { get; private set; }
@@ -347,6 +357,64 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     {
         ArgumentNullException.ThrowIfNull(mapping);
         _externalMappings.Add(mapping);
+    }
+
+    // ── Phase scheduling ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Adds a scheduled phase to the subscription's timeline. Throws if the new
+    /// phase overlaps any existing phase — overlap is defined on the half-open
+    /// interval <c>[StartDate, EndDate)</c>; touching endpoints
+    /// (<c>existing.EndDate == new.StartDate</c>) are allowed.
+    /// </summary>
+    public void AddPhase(SubscriptionPhase phase)
+    {
+        ArgumentNullException.ThrowIfNull(phase);
+
+        if (phase.SubscriptionId != Id)
+        {
+            throw new InvalidOperationException(
+                $"Phase '{phase.Id}' belongs to subscription '{phase.SubscriptionId}', not '{Id}'.");
+        }
+
+        foreach (SubscriptionPhase existing in _phases)
+        {
+            if (Overlaps(existing, phase))
+            {
+                throw new InvalidOperationException(
+                    $"Phase [{phase.StartDate:O}, {phase.EndDate?.ToString("O") ?? "∞"}) overlaps existing phase '{existing.Id}'.");
+            }
+        }
+
+        _phases.Add(phase);
+    }
+
+    /// <summary>Removes a previously-added phase. Returns <c>true</c> when a phase was actually removed.</summary>
+    public bool RemovePhase(Guid phaseId)
+    {
+        int removed = _phases.RemoveAll(p => p.Id == phaseId);
+        return removed > 0;
+    }
+
+    /// <summary>
+    /// Returns the phase that covers <paramref name="instant"/>, or <c>null</c>
+    /// when no phase covers it (caller falls back to <see cref="PlanId"/>).
+    /// At most one phase covers any given instant — guaranteed by
+    /// <see cref="AddPhase"/>'s overlap check.
+    /// </summary>
+    public SubscriptionPhase? GetActivePhase(DateTimeOffset instant) =>
+        _phases.FirstOrDefault(p => p.Covers(instant));
+
+    /// <summary>
+    /// True when two phases share at least one instant under the half-open
+    /// interval semantics. Touching endpoints (<c>a.EndDate == b.StartDate</c>)
+    /// do not overlap.
+    /// </summary>
+    private static bool Overlaps(SubscriptionPhase a, SubscriptionPhase b)
+    {
+        DateTimeOffset aEnd = a.EndDate ?? DateTimeOffset.MaxValue;
+        DateTimeOffset bEnd = b.EndDate ?? DateTimeOffset.MaxValue;
+        return a.StartDate < bEnd && b.StartDate < aEnd;
     }
 
     // ── Private helpers ────────────────────────────────────────────────

--- a/src/Granit.Subscriptions/Domain/SubscriptionPhase.cs
+++ b/src/Granit.Subscriptions/Domain/SubscriptionPhase.cs
@@ -1,0 +1,101 @@
+using Granit.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// A scheduled segment of a <see cref="Subscription"/>'s timeline that pins the
+/// active <see cref="PlanId"/> (and optional override price / discount) over a
+/// half-open interval <c>[StartDate, EndDate)</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Phases enable ramp deals — e.g. <c>"trial → standard at day 30 → enterprise
+/// at day 365"</c>. The billing-cycle orchestrator consults
+/// <see cref="Subscription.GetActivePhase"/> at billing time to pick the plan
+/// that applies to "now"; outside any phase, the orchestrator falls back to
+/// <see cref="Subscription.PlanId"/> for backward compatibility with single-plan
+/// subscriptions.
+/// </para>
+/// <para>
+/// Boundary semantics: <c>StartDate</c> is inclusive, <c>EndDate</c> is
+/// exclusive. <c>EndDate = null</c> = "open until the next phase begins, or
+/// forever if this is the last phase". Adjacent phases must touch without
+/// overlap — the validator in <c>SubscriptionPhaseConventionValidator</c>
+/// (HTTP layer) enforces both rules at the boundary.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionPhase : Entity
+{
+    private SubscriptionPhase() { }
+
+    /// <summary>Creates a new phase scheduled to run from <paramref name="startDate"/> until <paramref name="endDate"/>.</summary>
+    /// <param name="id">Phase id.</param>
+    /// <param name="subscriptionId">Owning subscription (FK).</param>
+    /// <param name="startDate">Inclusive lower bound (UTC).</param>
+    /// <param name="endDate">Exclusive upper bound, or <c>null</c> for an open-ended terminal phase.</param>
+    /// <param name="planId">Plan that applies during this phase.</param>
+    /// <param name="overridePriceId">Optional pinned <c>PlanPrice</c> for the phase (otherwise uses the plan's current price).</param>
+    /// <param name="discountPercent">Optional flat percentage applied at billing time (0–100).</param>
+    public static SubscriptionPhase Create(
+        Guid id,
+        Guid subscriptionId,
+        DateTimeOffset startDate,
+        DateTimeOffset? endDate,
+        PlanId planId,
+        Guid? overridePriceId = null,
+        decimal? discountPercent = null)
+    {
+        ArgumentNullException.ThrowIfNull(planId);
+
+        if (endDate is { } e && e <= startDate)
+        {
+            throw new ArgumentException(
+                $"Phase end date {e:O} must be strictly greater than start {startDate:O}.",
+                nameof(endDate));
+        }
+
+        if (discountPercent is { } d && (d < 0m || d > 100m))
+        {
+            throw new ArgumentOutOfRangeException(nameof(discountPercent),
+                d, "DiscountPercent must be between 0 and 100 inclusive.");
+        }
+
+        return new SubscriptionPhase
+        {
+            Id = id,
+            SubscriptionId = subscriptionId,
+            StartDate = startDate,
+            EndDate = endDate,
+            PlanId = planId,
+            OverridePriceId = overridePriceId,
+            DiscountPercent = discountPercent,
+        };
+    }
+
+    /// <summary>Owning subscription (FK).</summary>
+    public Guid SubscriptionId { get; private set; }
+
+    /// <summary>Inclusive lower bound of the phase (UTC).</summary>
+    public DateTimeOffset StartDate { get; private set; }
+
+    /// <summary>Exclusive upper bound; <c>null</c> = open-ended (terminal phase).</summary>
+    public DateTimeOffset? EndDate { get; private set; }
+
+    /// <summary>Plan that applies during this phase.</summary>
+    public PlanId PlanId { get; private set; } = null!;
+
+    /// <summary>Optional pinned price version for this phase.</summary>
+    public Guid? OverridePriceId { get; private set; }
+
+    /// <summary>Optional flat percentage discount applied at billing time (0–100).</summary>
+    public decimal? DiscountPercent { get; private set; }
+
+    /// <summary>
+    /// Whether this phase covers the supplied instant. Half-open semantics:
+    /// <c>StartDate ≤ instant &lt; EndDate</c>; an open-ended phase covers any
+    /// instant ≥ <c>StartDate</c>.
+    /// </summary>
+    public bool Covers(DateTimeOffset instant) =>
+        instant >= StartDate && (EndDate is null || instant < EndDate.Value);
+}

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -2,6 +2,8 @@ using Granit.Commands;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Subscriptions.Internal;
@@ -15,6 +17,7 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
     IPlanReader planReader,
     IPricingResolver pricingResolver,
     ICommandSender commandSender,
+    IClock clock,
     ILogger<DefaultBillingCycleInvoiceOrchestrator> logger) : IBillingCycleInvoiceOrchestrator
 {
     public async Task CreateInvoiceAsync(
@@ -25,18 +28,24 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
         DateTimeOffset periodEnd,
         CancellationToken cancellationToken = default)
     {
-        Plan? plan = await planReader.GetByIdAsync(planId, cancellationToken)
+        // Pre-flight: short-circuit on the inbound plan's pricing model. If the
+        // BillingCycleCompleted event came from a usage plan, no flat invoice is
+        // ever produced — skip the subscription + phase lookups entirely.
+        // (Edge case: a SubscriptionPhase swapping the active plan from Flat to
+        // PerUnit / Tiered would be unusual and is intentionally not honored
+        // here — the upstream event carries the stored PlanId.)
+        Plan? inboundPlan = await planReader.GetByIdAsync(PlanId.Create(planId), cancellationToken)
             .ConfigureAwait(false);
 
-        if (plan is null)
+        if (inboundPlan is null)
         {
             Log.PlanNotFound(logger, planId);
             return;
         }
 
-        if (plan.PricingModel is PricingModel.PerUnit or PricingModel.Tiered)
+        if (inboundPlan.PricingModel is PricingModel.PerUnit or PricingModel.Tiered)
         {
-            Log.SkippingUsagePlan(logger, subscriptionId, plan.PricingModel);
+            Log.SkippingUsagePlan(logger, subscriptionId, inboundPlan.PricingModel);
             return;
         }
 
@@ -50,10 +59,31 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
             return;
         }
 
+        // Phase resolution: at billing time, an active SubscriptionPhase covering "now"
+        // pins the plan + optional override price + optional discount for this cycle.
+        // Falls back to subscription.PlanId / planPriceId when no phase covers "now"
+        // (single-plan subscriptions = backward compatible with pre-Phase-3 behavior).
+        SubscriptionPhase? activePhase = subscription.GetActivePhase(clock.Now);
+        PlanId effectivePlanId = activePhase?.PlanId ?? subscription.PlanId;
+        Guid? effectivePlanPriceId = activePhase?.OverridePriceId ?? subscription.PlanPriceId;
+        decimal? phaseDiscountPercent = activePhase?.DiscountPercent;
+
+        // Re-resolve the plan only when the active phase points to a different one.
+        Plan plan = effectivePlanId.Value == planId
+            ? inboundPlan
+            : (await planReader.GetByIdAsync(effectivePlanId, cancellationToken).ConfigureAwait(false))
+                ?? inboundPlan;
+
         decimal basePrice = await pricingResolver.ResolveBasePriceAsync(
-            subscription.PlanId, subscription.Currency, plan.DefaultInterval,
-            subscription.PlanPriceId, cancellationToken)
+            effectivePlanId, subscription.Currency, plan.DefaultInterval,
+            effectivePlanPriceId, cancellationToken)
             .ConfigureAwait(false);
+
+        // Apply the phase's flat percentage discount, if any (0–100; validated at entity creation).
+        if (phaseDiscountPercent is { } pct && pct > 0m)
+        {
+            basePrice = decimal.Round(basePrice * (1m - (pct / 100m)), 4, MidpointRounding.ToEven);
+        }
 
         if (basePrice <= 0)
         {

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhaseTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhaseTests.cs
@@ -1,0 +1,86 @@
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+public sealed class SubscriptionPhaseTests
+{
+    private static readonly PlanId Plan = PlanId.Create(Guid.NewGuid());
+    private static readonly DateTimeOffset T0 = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+    private static readonly DateTimeOffset T30 = T0.AddDays(30);
+    private static readonly DateTimeOffset T60 = T0.AddDays(60);
+
+    private static SubscriptionPhase Phase(Guid subId, DateTimeOffset start, DateTimeOffset? endDate) =>
+        SubscriptionPhase.Create(Guid.NewGuid(), subId, start, endDate, Plan);
+
+    // ────────── Factory validation ──────────
+
+    [Fact]
+    public void Create_WithEndDateBeforeStartDate_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T30, T0, Plan));
+
+    [Fact]
+    public void Create_WithEndDateEqualsStartDate_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T0, T0, Plan));
+
+    [Fact]
+    public void Create_WithDiscountAbove100_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T0, null, Plan, discountPercent: 100.1m));
+
+    [Fact]
+    public void Create_WithNegativeDiscount_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T0, null, Plan, discountPercent: -1m));
+
+    [Fact]
+    public void Create_WithDiscountAtBoundary_Allowed()
+    {
+        var a = SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T0, null, Plan, discountPercent: 0m);
+        var b = SubscriptionPhase.Create(Guid.NewGuid(), Guid.NewGuid(), T0, null, Plan, discountPercent: 100m);
+
+        a.DiscountPercent.ShouldBe(0m);
+        b.DiscountPercent.ShouldBe(100m);
+    }
+
+    // ────────── Covers semantics (half-open interval) ──────────
+
+    [Fact]
+    public void Covers_AtStart_IsInclusive()
+    {
+        SubscriptionPhase phase = Phase(Guid.NewGuid(), T0, T30);
+
+        phase.Covers(T0).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Covers_AtEnd_IsExclusive()
+    {
+        SubscriptionPhase phase = Phase(Guid.NewGuid(), T0, T30);
+
+        phase.Covers(T30).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Covers_BeforeStart_False()
+    {
+        SubscriptionPhase phase = Phase(Guid.NewGuid(), T30, T60);
+
+        phase.Covers(T0).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Covers_OpenEnded_CoversAnyInstantAfterStart()
+    {
+        SubscriptionPhase phase = Phase(Guid.NewGuid(), T30, endDate: null);
+
+        phase.Covers(T30).ShouldBeTrue();
+        phase.Covers(T60).ShouldBeTrue();
+        phase.Covers(T60.AddYears(50)).ShouldBeTrue();
+        phase.Covers(T0).ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhasesIntegrationTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhasesIntegrationTests.cs
@@ -1,0 +1,145 @@
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+/// <summary>
+/// Subscription ↔ SubscriptionPhase wiring: AddPhase overlap rules,
+/// GetActivePhase point lookups, and the boundary-touching exception.
+/// </summary>
+public sealed class SubscriptionPhasesIntegrationTests
+{
+    private static readonly DateTimeOffset T0 = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+    private static readonly DateTimeOffset T30 = T0.AddDays(30);
+    private static readonly DateTimeOffset T60 = T0.AddDays(60);
+
+    private static Subscription NewSubscription() => Subscription.Create(
+        SubscriptionId.Create(Guid.NewGuid()),
+        Guid.NewGuid(),
+        PlanId.Create(Guid.NewGuid()),
+        currency: "EUR",
+        period: new SubscriptionPeriod(T0, T0.AddMonths(12), BillingCycleAnchor: T0));
+
+    private static SubscriptionPhase Phase(Subscription sub, DateTimeOffset start, DateTimeOffset? endDate) =>
+        SubscriptionPhase.Create(Guid.NewGuid(), sub.Id, start, endDate, PlanId.Create(Guid.NewGuid()));
+
+    [Fact]
+    public void AddPhase_FirstPhase_Succeeds()
+    {
+        Subscription sub = NewSubscription();
+
+        sub.AddPhase(Phase(sub, T0, T30));
+
+        sub.Phases.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddPhase_AdjacentTouchingEndpoints_Succeeds()
+    {
+        // Phase A: [T0, T30); Phase B: [T30, T60). The boundary at T30 belongs to B
+        // (start is inclusive, end is exclusive) — they do NOT overlap.
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T0, T30));
+
+        Should.NotThrow(() => sub.AddPhase(Phase(sub, T30, T60)));
+
+        sub.Phases.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddPhase_OverlappingExisting_Throws()
+    {
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T0, T60));
+
+        Should.Throw<InvalidOperationException>(() =>
+            sub.AddPhase(Phase(sub, T30, T60.AddDays(30))));
+    }
+
+    [Fact]
+    public void AddPhase_SecondOpenEndedPhase_OverlapsExistingOpenEnded_Throws()
+    {
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T0, endDate: null));
+
+        Should.Throw<InvalidOperationException>(() =>
+            sub.AddPhase(Phase(sub, T30, endDate: null)));
+    }
+
+    [Fact]
+    public void AddPhase_OpenEndedAfterClosed_Succeeds()
+    {
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T0, T30));
+
+        Should.NotThrow(() => sub.AddPhase(Phase(sub, T30, endDate: null)));
+
+        sub.Phases.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddPhase_WithMismatchedSubscriptionId_Throws()
+    {
+        Subscription sub = NewSubscription();
+        var strayPhase = SubscriptionPhase.Create(
+            Guid.NewGuid(), subscriptionId: Guid.NewGuid(), T0, T30,
+            PlanId.Create(Guid.NewGuid()));
+
+        Should.Throw<InvalidOperationException>(() => sub.AddPhase(strayPhase));
+    }
+
+    [Fact]
+    public void GetActivePhase_AtInstantInsidePhase_ReturnsThatPhase()
+    {
+        Subscription sub = NewSubscription();
+        SubscriptionPhase trial = Phase(sub, T0, T30);
+        SubscriptionPhase standard = Phase(sub, T30, endDate: null);
+        sub.AddPhase(trial);
+        sub.AddPhase(standard);
+
+        sub.GetActivePhase(T0.AddDays(15))!.Id.ShouldBe(trial.Id);
+        sub.GetActivePhase(T30)!.Id.ShouldBe(standard.Id);          // boundary belongs to standard
+        sub.GetActivePhase(T60)!.Id.ShouldBe(standard.Id);
+    }
+
+    [Fact]
+    public void GetActivePhase_OutsideAnyPhase_ReturnsNull()
+    {
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T30, T60));
+
+        sub.GetActivePhase(T0).ShouldBeNull();        // before all phases
+        sub.GetActivePhase(T60).ShouldBeNull();       // exactly at exclusive end
+    }
+
+    [Fact]
+    public void GetActivePhase_NoPhases_ReturnsNull()
+    {
+        Subscription sub = NewSubscription();
+
+        sub.GetActivePhase(T30).ShouldBeNull();
+    }
+
+    [Fact]
+    public void RemovePhase_ExistingId_RemovesAndReturnsTrue()
+    {
+        Subscription sub = NewSubscription();
+        SubscriptionPhase phase = Phase(sub, T0, T30);
+        sub.AddPhase(phase);
+
+        sub.RemovePhase(phase.Id).ShouldBeTrue();
+        sub.Phases.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemovePhase_UnknownId_ReturnsFalse()
+    {
+        Subscription sub = NewSubscription();
+        sub.AddPhase(Phase(sub, T0, T30));
+
+        sub.RemovePhase(Guid.NewGuid()).ShouldBeFalse();
+        sub.Phases.Count.ShouldBe(1);
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultBillingCycleInvoiceOrchestratorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultBillingCycleInvoiceOrchestratorTests.cs
@@ -4,6 +4,7 @@ using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Internal;
+using Granit.Timing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -18,6 +19,7 @@ public sealed class DefaultBillingCycleInvoiceOrchestratorTests
     private readonly IPlanReader _planReader = Substitute.For<IPlanReader>();
     private readonly IPricingResolver _pricingResolver = Substitute.For<IPricingResolver>();
     private readonly ICommandSender _commandSender = Substitute.For<ICommandSender>();
+    private readonly IClock _clock = Substitute.For<IClock>();
     private readonly ILogger<DefaultBillingCycleInvoiceOrchestrator> _logger =
         NullLoggerFactory.Instance.CreateLogger<DefaultBillingCycleInvoiceOrchestrator>();
     private readonly DefaultBillingCycleInvoiceOrchestrator _sut;
@@ -27,8 +29,9 @@ public sealed class DefaultBillingCycleInvoiceOrchestratorTests
 
     public DefaultBillingCycleInvoiceOrchestratorTests()
     {
+        _clock.Now.Returns(PeriodStart);
         _sut = new DefaultBillingCycleInvoiceOrchestrator(
-            _subscriptionReader, _planReader, _pricingResolver, _commandSender, _logger);
+            _subscriptionReader, _planReader, _pricingResolver, _commandSender, _clock, _logger);
     }
 
     private static Subscription CreateSubscription(Guid tenantId, PlanId planId, Guid? planPriceId = null)

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionReactivationServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionReactivationServiceTests.cs
@@ -77,7 +77,7 @@ public sealed class DefaultSubscriptionReactivationServiceTests
     {
         var tenantId = Guid.NewGuid();
         Subscription sub = CreatePastDueSubscription(tenantId);
-        _reader.GetActiveForTenantAsync(tenantId, Arg.Any<CancellationToken>())
+        _reader.GetPastDueForTenantAsync(tenantId, Arg.Any<CancellationToken>())
             .Returns(sub);
 
         bool result = await _sut.TryReactivateAsync(tenantId, TestContext.Current.CancellationToken);


### PR DESCRIPTION
Closes #1173 (Phase 3 Story 2 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1159](https://github.com/granit-fx/granit-dotnet/issues/1159) Subscriptions overrides/phases/tiered).

Adds first-class scheduled phases on a Subscription's timeline so customers experience seamless ramp-deal transitions — e.g. \"trial 30 days → standard 335 days → enterprise renewal\" without manual intervention by support.

## Domain (\`Granit.Subscriptions.Domain\`)

- New \`SubscriptionPhase\` entity (child of \`Subscription\`):
  - \`StartDate\` (inclusive lower bound, UTC)
  - \`EndDate?\` (exclusive upper bound; \`null\` = open-ended terminal phase)
  - \`PlanId\` (the plan that applies during this phase)
  - \`OverridePriceId?\` (optional pinned \`PlanPrice\`)
  - \`DiscountPercent?\` (0–100, applied at billing time)
  - \`Covers(instant)\` helper using half-open \`[Start, End)\` semantics
- \`Subscription\` extensions: private \`_phases\` list exposed as \`Phases\` IReadOnlyList; \`AddPhase\` / \`RemovePhase\` / \`GetActivePhase(now)\` behavior methods.

## Boundary semantics (locked by 17 unit tests)

- \`StartDate\` is **inclusive**, \`EndDate\` is **exclusive**.
- Touching endpoints (\`existing.End == new.Start\`) **do not overlap**.
- Open-ended phase + earlier closed phase: ✅ allowed.
- Open-ended phase + later overlapping phase: ❌ rejected.
- Discount: \`0 ≤ pct ≤ 100\` (factory throws otherwise).
- Mismatched \`SubscriptionId\` on \`AddPhase\`: throws.
- \`GetActivePhase\` outside any phase / no phases: returns \`null\`.

## EF persistence

- New \`SubscriptionPhaseConfiguration\` mapping \`subscription_phases\` table; index on \`(SubscriptionId, StartDate)\` for efficient point-lookups.
- \`SubscriptionConfiguration\` adds \`HasMany(Phases)\` with \`PropertyAccessMode.Field\` (the property is read-only by design).
- Cascade delete on \`Subscription\` removal.

## Orchestrator (\`DefaultBillingCycleInvoiceOrchestrator\`)

- New \`IClock\` dependency (per CLAUDE.md TimeProvider rule).
- **Pre-flight**: short-circuit on the inbound plan's \`PricingModel\` (PerUnit / Tiered → skip without reading the subscription, preserving the existing optimization). Edge case where a phase swaps Flat → usage is intentionally not honored — the upstream \`BillingCycleCompleted\` event carries the stored plan id at fire time.
- **Phase resolution**: when no phase covers \`clock.Now\`, falls back to the subscription's authoritative \`PlanId\` / \`PlanPriceId\` (single-plan = backward compatible with pre-Phase-3 subscriptions).
- **Discount**: applied to the resolved \`basePrice\` with 4-decimal banker's rounding (ISO 4217 compliance) before the line item is built.

## HTTP

- New \`SubscriptionsPermissions.Phases.Manage\` constant + provider entry (Host-side, ISO 27001 A.9.4).
- 16 culture localization files updated for \`Permission:Subscriptions.Phases.Manage\`.

## Tests (+17, +1 flake fix)

- \`SubscriptionPhaseTests\` × 9 (factory validation, \`Covers\` half-open semantics).
- \`SubscriptionPhasesIntegrationTests\` × 11 (overlap rules, GetActivePhase, RemovePhase).
- \`DefaultBillingCycleInvoiceOrchestratorTests\` updated for the new \`IClock\` constructor parameter.
- **Bonus**: fixed the long-standing pre-existing flake \`DefaultSubscriptionReactivationServiceTests.TryReactivateAsync_PastDueSubscription_ShouldActivateAndResetDunning\` — the test mocked \`ISubscriptionReader.GetActiveForTenantAsync\` but the SUT calls \`GetPastDueForTenantAsync\`. NSubstitute returned \`null\` for the unstubbed method → SUT short-circuited at \"no past-due subscription\" → activation assertion failed. Single-character of test code.
- **132 / 132** Subscriptions tests pass (was 131/132 with the flake).

## Schema (consumer apps run their own EF migration)

\`\`\`sql
CREATE TABLE subscription_phases (
    Id uuid NOT NULL PRIMARY KEY,
    SubscriptionId uuid NOT NULL,
    StartDate timestamptz NOT NULL,
    EndDate timestamptz NULL,
    PlanId uuid NOT NULL,
    OverridePriceId uuid NULL,
    DiscountPercent numeric(5,2) NULL
);
CREATE INDEX ix_..._subscription_phases_timeline ON subscription_phases (SubscriptionId, StartDate);
\`\`\`

**No breaking change at the wire level.** Subscriptions created before this PR have an empty \`Phases\` collection; orchestrator falls back to \`PlanId\` / \`PlanPriceId\`, behaviorally identical to the pre-Phase-3 path.

## Out of scope (deferred)

- HTTP CRUD endpoints (\`POST /subscriptions/{id}/phases\`, \`DELETE\` / \`PUT /.../{phaseId}\`). Domain + persistence + orchestrator wiring is the load-bearing part; CRUD endpoints come in a follow-up PR with the full validator (HTTP-boundary overlap detection, ordering).
- Multi-currency cross-check on \`OverridePriceId.Currency\` vs \`Subscription.Currency\` — entity allows any \`PlanPrice\` id today; the validator (CRUD PR) will enforce currency match.

## Test plan

- [x] \`dotnet build src/Granit.Subscriptions*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.Subscriptions.Tests\` — 132 / 132
- [ ] CI green on all 6 shards (TBD post-push; depends on #1201 architecture-namespace fix landing first)