### PR TITLE
feat(subscriptions): SubscriptionDiscount with cumulative stacking calculator

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -39980,6 +39980,15 @@
       "members": []
     },
     {
+      "name": "DiscountType",
+      "fqn": "Granit.Subscriptions.Domain.DiscountType",
+      "kind": "enum",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/DiscountType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "Plan",
       "fqn": "Granit.Subscriptions.Domain.Plan",
       "kind": "class",
@@ -40163,6 +40172,12 @@
           "returnType": "IReadOnlyList<SubscriptionPhase>"
         },
         {
+          "name": "Discounts",
+          "kind": "property",
+          "signature": "IReadOnlyList<SubscriptionDiscount> Discounts",
+          "returnType": "IReadOnlyList<SubscriptionDiscount>"
+        },
+        {
           "name": "nameof",
           "kind": "method",
           "signature": "nameof(Status)",
@@ -40197,6 +40212,34 @@
           "kind": "method",
           "signature": "ChangePlan(PlanId newPlanId)",
           "returnType": "void"
+        },
+        {
+          "name": "GetActiveDiscounts",
+          "kind": "method",
+          "signature": "GetActiveDiscounts(DateTimeOffset instant)",
+          "returnType": "IEnumerable<SubscriptionDiscount>"
+        }
+      ]
+    },
+    {
+      "name": "SubscriptionDiscount",
+      "fqn": "Granit.Subscriptions.Domain.SubscriptionDiscount",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/SubscriptionDiscount.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid subscriptionId, DiscountType type, decimal value, string reason, DateTimeOffset? expiresAt = null)",
+          "returnType": "SubscriptionDiscount"
+        },
+        {
+          "name": "IsActiveAt",
+          "kind": "method",
+          "signature": "IsActiveAt(DateTimeOffset instant)",
+          "returnType": "DateTimeOffset? ExpiresAt { get; private set; } public bool"
         }
       ]
     },
@@ -40518,6 +40561,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "Discounts",
+      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Discounts",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
+      "line": 63,
+      "members": []
     },
     {
       "name": "Phases",
@@ -41527,6 +41579,22 @@
           "kind": "property",
           "signature": "NotificationSeverity DefaultSeverity",
           "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "SubscriptionDiscountCalculator",
+      "fqn": "Granit.Subscriptions.Pricing.SubscriptionDiscountCalculator",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Pricing/SubscriptionDiscountCalculator.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Apply",
+          "kind": "method",
+          "signature": "Apply(decimal baseAmount, IEnumerable<SubscriptionDiscount> discounts, DateTimeOffset now)",
+          "returnType": "decimal"
         }
       ]
     },

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Správa slev předplatného (Procenta / Pevná částka / Prodloužení zkušebního období)",
     "Permission:Subscriptions.Phases.Manage": "Správa fází předplatného (plánování změn plánu, přepsání cen, aplikace slev)",
     "Permission:Subscriptions.Plans.Manage": "Spravovat plány předplatného (vytvořit, publikovat, archivovat)",
     "Permission:Subscriptions.Plans.Read": "Zobrazit plány předplatného",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Abonnementrabatte verwalten (Prozentual / Fester Betrag / Testverlängerungen)",
     "Permission:Subscriptions.Phases.Manage": "Abonnementphasen verwalten (Planänderungen planen, Preise überschreiben, Rabatte anwenden)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementpläne verwalten (erstellen, veröffentlichen, archivieren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementpläne anzeigen",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Manage subscription discounts (Percentage / FixedAmount / Trial extensions)",
     "Permission:Subscriptions.Phases.Manage": "Manage subscription phases (schedule plan changes, override prices, apply discounts)",
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
     "Permission:Subscriptions.Plans.Read": "View subscription plans",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Gestionar descuentos de suscripción (Porcentaje / Importe fijo / Extensiones de prueba)",
     "Permission:Subscriptions.Phases.Manage": "Gestionar fases de suscripción (programar cambios de plan, anular precios, aplicar descuentos)",
     "Permission:Subscriptions.Plans.Manage": "Gestionar planes de suscripción (crear, publicar, archivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planes de suscripción",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Gérer les remises d'abonnement (Pourcentage / Montant fixe / Prolongations d'essai)",
     "Permission:Subscriptions.Phases.Manage": "Gérer les phases d'abonnement (planifier des changements de plan, surcharger les prix, appliquer des remises)",
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
     "Permission:Subscriptions.Plans.Read": "Consulter les plans d'abonnement",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "सदस्यता छूट प्रबंधित करें (प्रतिशत / निश्चित राशि / परीक्षण विस्तार)",
     "Permission:Subscriptions.Phases.Manage": "सदस्यता चरण प्रबंधित करें (योजना परिवर्तन शेड्यूल करें, मूल्य ओवरराइड करें, छूट लागू करें)",
     "Permission:Subscriptions.Plans.Manage": "सब्सक्रिप्शन प्लान प्रबंधित करें (बनाएँ, प्रकाशित करें, संग्रहित करें)",
     "Permission:Subscriptions.Plans.Read": "सब्सक्रिप्शन प्लान देखें",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Gestire gli sconti dell'abbonamento (Percentuale / Importo fisso / Estensioni di prova)",
     "Permission:Subscriptions.Phases.Manage": "Gestire le fasi dell'abbonamento (programmare modifiche di piano, sovrascrivere prezzi, applicare sconti)",
     "Permission:Subscriptions.Plans.Manage": "Gestire i piani di abbonamento (creare, pubblicare, archiviare)",
     "Permission:Subscriptions.Plans.Read": "Visualizzare i piani di abbonamento",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "サブスクリプション割引を管理（パーセンテージ / 固定金額 / トライアル延長）",
     "Permission:Subscriptions.Phases.Manage": "サブスクリプションフェーズを管理（プラン変更のスケジュール、価格上書き、割引適用）",
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
     "Permission:Subscriptions.Plans.Read": "サブスクリプションプランの表示",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "구독 할인 관리 (비율 / 고정 금액 / 체험 연장)",
     "Permission:Subscriptions.Phases.Manage": "구독 단계 관리 (요금제 변경 예약, 가격 재정의, 할인 적용)",
     "Permission:Subscriptions.Plans.Manage": "구독 플랜 관리 (생성, 게시, 보관)",
     "Permission:Subscriptions.Plans.Read": "구독 플랜 보기",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Abonnementkortingen beheren (Percentage / Vast bedrag / Proefverlengingen)",
     "Permission:Subscriptions.Phases.Manage": "Abonnementfasen beheren (planwijzigingen plannen, prijzen overschrijven, kortingen toepassen)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementsplannen beheren (aanmaken, publiceren, archiveren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementsplannen bekijken",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Zarządzanie zniżkami subskrypcji (Procent / Stała kwota / Przedłużenia okresu próbnego)",
     "Permission:Subscriptions.Phases.Manage": "Zarządzanie fazami subskrypcji (planowanie zmian planu, nadpisywanie cen, stosowanie zniżek)",
     "Permission:Subscriptions.Plans.Manage": "Zarządzanie planami subskrypcji (tworzenie, publikowanie, archiwizowanie)",
     "Permission:Subscriptions.Plans.Read": "Wyświetlanie planów subskrypcji",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Gerenciar descontos de assinatura (Porcentagem / Valor fixo / Extensões de teste)",
     "Permission:Subscriptions.Phases.Manage": "Gerenciar fases de assinatura (agendar alterações de plano, sobrepor preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerenciar planos de assinatura (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Visualizar planos de assinatura",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Gerir descontos de subscrição (Percentagem / Valor fixo / Extensões de avaliação)",
     "Permission:Subscriptions.Phases.Manage": "Gerir fases de subscrição (agendar alterações de plano, substituir preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planos de subscrição",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Hantera prenumerationsrabatter (Procent / Fast belopp / Provförlängningar)",
     "Permission:Subscriptions.Phases.Manage": "Hantera prenumerationsfaser (schemalägga planändringar, åsidosätta priser, tillämpa rabatter)",
     "Permission:Subscriptions.Plans.Manage": "Hantera prenumerationsplaner (skapa, publicera, arkivera)",
     "Permission:Subscriptions.Plans.Read": "Visa prenumerationsplaner",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "Abonelik indirimlerini yönet (Yüzde / Sabit Tutar / Deneme Uzatmaları)",
     "Permission:Subscriptions.Phases.Manage": "Abonelik fazlarını yönet (plan değişikliklerini zamanla, fiyatları geçersiz kıl, indirim uygula)",
     "Permission:Subscriptions.Plans.Manage": "Abonelik planlarını yönet (oluştur, yayınla, arşivle)",
     "Permission:Subscriptions.Plans.Read": "Abonelik planlarını görüntüle",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Permission:Subscriptions.Discounts.Manage": "管理订阅折扣（百分比 / 固定金额 / 试用延期）",
     "Permission:Subscriptions.Phases.Manage": "管理订阅阶段（计划变更、价格覆盖、应用折扣）",
     "Permission:Subscriptions.Plans.Manage": "管理订阅计划（创建、发布、归档）",
     "Permission:Subscriptions.Plans.Read": "查看订阅计划",

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -48,5 +48,10 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
         group.AddPermission(SubscriptionsPermissions.Phases.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Phases.Manage"),
             MultiTenancySide.Host);
+
+        // Discounts are admin-only: they reduce billed amounts at invoice time.
+        group.AddPermission(SubscriptionsPermissions.Discounts.Manage,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Discounts.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
@@ -58,4 +58,16 @@ public static class SubscriptionsPermissions
         /// </summary>
         public const string Manage = "Subscriptions.Phases.Manage";
     }
+
+    /// <summary>Negotiated discount permissions.</summary>
+    public static class Discounts
+    {
+        /// <summary>
+        /// Manage subscription discounts (Percentage / FixedAmount / Trial extensions).
+        /// Admin-only — discounts directly reduce billed amounts and feed the
+        /// invoice line at billing time. ISO 27001 A.9.4 (least privilege on
+        /// revenue-impacting operations).
+        /// </summary>
+        public const string Manage = "Subscriptions.Discounts.Manage";
+    }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
@@ -17,6 +17,7 @@ public static class SubscriptionsModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new PlanExternalMappingConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionPhaseConfiguration());
+        modelBuilder.ApplyConfiguration(new SubscriptionDiscountConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionSeatConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionExternalMappingConfiguration());
         return modelBuilder;

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
@@ -42,6 +42,14 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
         builder.Navigation(e => e.Phases)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
+        builder.HasMany(e => e.Discounts)
+            .WithOne()
+            .HasForeignKey(d => d.SubscriptionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.Discounts)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         builder.HasIndex(e => new { e.TenantId, e.Status })
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscriptions_tenant_status");
 

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionDiscountConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionDiscountConfiguration.cs
@@ -1,0 +1,27 @@
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+internal sealed class SubscriptionDiscountConfiguration : IEntityTypeConfiguration<SubscriptionDiscount>
+{
+    public void Configure(EntityTypeBuilder<SubscriptionDiscount> builder)
+    {
+        builder.ToTable(
+            GranitSubscriptionsDbProperties.DbTablePrefix + "subscription_discounts",
+            GranitSubscriptionsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.SubscriptionId).IsRequired();
+        builder.Property(e => e.Type).IsRequired();
+        // Precision (18, 4) covers Percentage 0–100 with 4 decimals, FixedAmount up to
+        // ~99 quadrillion units, and Trial day-count (always integral).
+        builder.Property(e => e.Value).HasPrecision(18, 4).IsRequired();
+        builder.Property(e => e.Reason).HasMaxLength(SubscriptionDiscount.ReasonMaxLength).IsRequired();
+        builder.Property(e => e.ExpiresAt);
+
+        builder.HasIndex(e => new { e.SubscriptionId, e.ExpiresAt })
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscription_discounts_active");
+    }
+}

--- a/src/Granit.Subscriptions/Domain/DiscountType.cs
+++ b/src/Granit.Subscriptions/Domain/DiscountType.cs
@@ -1,0 +1,27 @@
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// Type of <see cref="SubscriptionDiscount"/> applied to a subscription's invoices.
+/// </summary>
+public enum DiscountType
+{
+    /// <summary>
+    /// Reduces the running invoice total by <c>Value</c> percent (0–100). Stacks
+    /// cumulatively when multiple Percentage discounts are active — each applies
+    /// to whatever amount remains after previous discounts in the declaration order.
+    /// </summary>
+    Percentage = 0,
+
+    /// <summary>
+    /// Subtracts <c>Value</c> currency units from the running invoice total. The
+    /// total is floored at 0 — a discount cannot produce a negative invoice.
+    /// </summary>
+    FixedAmount = 1,
+
+    /// <summary>
+    /// Extends the trial period by <c>Value</c> days. Has no immediate price
+    /// impact at billing time (the calculator skips Trial entries); the trial
+    /// extension is consumed by the trial-end scheduler in a separate path.
+    /// </summary>
+    Trial = 2,
+}

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -25,6 +25,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     private readonly List<SubscriptionSeat> _seats = [];
     private readonly List<SubscriptionExternalMapping> _externalMappings = [];
     private readonly List<SubscriptionPhase> _phases = [];
+    private readonly List<SubscriptionDiscount> _discounts = [];
 
     private Subscription() { }
 
@@ -128,6 +129,14 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     /// phase covers the billing instant (single-plan backward compat).
     /// </summary>
     public IReadOnlyList<SubscriptionPhase> Phases => _phases;
+
+    /// <summary>
+    /// Negotiated discounts attached to this subscription. The billing-cycle
+    /// orchestrator applies every <see cref="SubscriptionDiscount.IsActiveAt"/>
+    /// entry to the base price in declaration order — see
+    /// <see cref="Pricing.SubscriptionDiscountCalculator"/>.
+    /// </summary>
+    public IReadOnlyList<SubscriptionDiscount> Discounts => _discounts;
 
     /// <inheritdoc />
     public Guid? TenantId { get; private set; }
@@ -416,6 +425,38 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         DateTimeOffset bEnd = b.EndDate ?? DateTimeOffset.MaxValue;
         return a.StartDate < bEnd && b.StartDate < aEnd;
     }
+
+    // ── Discounts ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Attaches a discount to the subscription. Cumulative — multiple discounts
+    /// stack on the running total in declaration order (see
+    /// <see cref="Pricing.SubscriptionDiscountCalculator"/>).
+    /// </summary>
+    public void AddDiscount(SubscriptionDiscount discount)
+    {
+        ArgumentNullException.ThrowIfNull(discount);
+
+        if (discount.SubscriptionId != Id)
+        {
+            throw new InvalidOperationException(
+                $"Discount '{discount.Id}' belongs to subscription '{discount.SubscriptionId}', not '{Id}'.");
+        }
+
+        _discounts.Add(discount);
+    }
+
+    /// <summary>Removes a previously-added discount. Returns <c>true</c> when a discount was actually removed.</summary>
+    public bool RemoveDiscount(Guid discountId) =>
+        _discounts.RemoveAll(d => d.Id == discountId) > 0;
+
+    /// <summary>
+    /// Returns the discounts active at <paramref name="instant"/> in declaration
+    /// order — i.e. the input the orchestrator hands to
+    /// <see cref="Pricing.SubscriptionDiscountCalculator.Apply"/>.
+    /// </summary>
+    public IEnumerable<SubscriptionDiscount> GetActiveDiscounts(DateTimeOffset instant) =>
+        _discounts.Where(d => d.IsActiveAt(instant));
 
     // ── Private helpers ────────────────────────────────────────────────
 

--- a/src/Granit.Subscriptions/Domain/SubscriptionDiscount.cs
+++ b/src/Granit.Subscriptions/Domain/SubscriptionDiscount.cs
@@ -1,0 +1,92 @@
+using Granit.Domain;
+
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// A negotiated discount applied to a <see cref="Subscription"/>'s invoices —
+/// percentage off, fixed-amount reduction, or trial-period extension.
+/// </summary>
+/// <remarks>
+/// Multiple discounts on the same subscription stack cumulatively in declaration
+/// order: each price-impacting discount applies to the running total after the
+/// previous one. Trial discounts have no price impact at billing time (the
+/// calculator skips them); they are consumed by the trial-end scheduler.
+/// </remarks>
+public sealed class SubscriptionDiscount : Entity
+{
+    private SubscriptionDiscount() { }
+
+    /// <summary>Maximum length of the free-text reason captured at creation.</summary>
+    public const int ReasonMaxLength = 500;
+
+    /// <summary>Creates a new discount attached to the supplied subscription.</summary>
+    /// <param name="id">Discount id.</param>
+    /// <param name="subscriptionId">Owning subscription (FK).</param>
+    /// <param name="type">Discount type.</param>
+    /// <param name="value">
+    /// Type-dependent magnitude:
+    /// <list type="bullet">
+    ///   <item><see cref="DiscountType.Percentage"/>: percent off, 0–100 inclusive.</item>
+    ///   <item><see cref="DiscountType.FixedAmount"/>: currency units to subtract, ≥ 0.</item>
+    ///   <item><see cref="DiscountType.Trial"/>: integer days to add to the trial period (≥ 0).</item>
+    /// </list>
+    /// </param>
+    /// <param name="reason">Free-text justification (commercial agreement reference, ≤ 500 chars).</param>
+    /// <param name="expiresAt">Optional UTC instant past which the discount stops being applied.</param>
+    public static SubscriptionDiscount Create(
+        Guid id,
+        Guid subscriptionId,
+        DiscountType type,
+        decimal value,
+        string reason,
+        DateTimeOffset? expiresAt = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(reason.Length, ReasonMaxLength);
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+        if (type == DiscountType.Percentage && value > 100m)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value,
+                "Percentage discount must be in [0, 100].");
+        }
+
+        if (type == DiscountType.Trial && value != decimal.Truncate(value))
+        {
+            throw new ArgumentException("Trial discount value must be a whole number of days.", nameof(value));
+        }
+
+        return new SubscriptionDiscount
+        {
+            Id = id,
+            SubscriptionId = subscriptionId,
+            Type = type,
+            Value = value,
+            Reason = reason,
+            ExpiresAt = expiresAt,
+        };
+    }
+
+    /// <summary>Owning subscription (FK).</summary>
+    public Guid SubscriptionId { get; private set; }
+
+    /// <summary>Discount kind (Percentage / FixedAmount / Trial).</summary>
+    public DiscountType Type { get; private set; }
+
+    /// <summary>
+    /// Type-dependent magnitude: percent for <see cref="DiscountType.Percentage"/>,
+    /// currency units for <see cref="DiscountType.FixedAmount"/>, days for
+    /// <see cref="DiscountType.Trial"/>.
+    /// </summary>
+    public decimal Value { get; private set; }
+
+    /// <summary>Free-text justification (commercial agreement reference).</summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    /// <summary>Optional UTC instant past which the discount stops being applied.</summary>
+    public DateTimeOffset? ExpiresAt { get; private set; }
+
+    /// <summary>True when the discount applies to invoices generated at <paramref name="instant"/>.</summary>
+    public bool IsActiveAt(DateTimeOffset instant) =>
+        ExpiresAt is null || instant < ExpiresAt.Value;
+}

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -3,6 +3,7 @@ using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
+using Granit.Subscriptions.Pricing;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
@@ -79,13 +80,29 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
             effectivePlanPriceId, cancellationToken)
             .ConfigureAwait(false);
 
+        // Short-circuit on a non-positive base price BEFORE running discount math —
+        // discount application throws on negative input, and a 0 base price already
+        // means "skip" by the existing convention.
+        if (basePrice <= 0m)
+        {
+            Log.ZeroPrice(logger, subscriptionId);
+            return;
+        }
+
         // Apply the phase's flat percentage discount, if any (0–100; validated at entity creation).
         if (phaseDiscountPercent is { } pct && pct > 0m)
         {
             basePrice = decimal.Round(basePrice * (1m - (pct / 100m)), 4, MidpointRounding.ToEven);
         }
 
-        if (basePrice <= 0)
+        // Apply attached SubscriptionDiscount entries in declaration order — each
+        // discount stacks cumulatively on the running total. Trial discounts are
+        // skipped at billing (they extend the trial period elsewhere). The
+        // calculator clamps the result to ≥ 0.
+        basePrice = SubscriptionDiscountCalculator.Apply(
+            basePrice, subscription.GetActiveDiscounts(clock.Now), clock.Now);
+
+        if (basePrice <= 0m)
         {
             Log.ZeroPrice(logger, subscriptionId);
             return;

--- a/src/Granit.Subscriptions/Pricing/SubscriptionDiscountCalculator.cs
+++ b/src/Granit.Subscriptions/Pricing/SubscriptionDiscountCalculator.cs
@@ -1,0 +1,65 @@
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Pricing;
+
+/// <summary>
+/// Applies a sequence of <see cref="SubscriptionDiscount"/> entries to a base
+/// invoice amount. Pure function — no DB / DI / I/O.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Stacking order:</strong> discounts are applied in iteration order
+/// (typically declaration order = insertion order on the parent
+/// <see cref="Subscription"/>). Each discount applies to the running total
+/// after the previous one — the model is <em>cumulative</em>, not
+/// <em>exclusive</em>. Two 10 % discounts produce a 19 % effective discount,
+/// not 20 %, because the second 10 % is computed on the post-first-discount total.
+/// </para>
+/// <para>
+/// <strong>Floor at 0:</strong> the result is clamped to ≥ 0 — no
+/// <see cref="DiscountType.FixedAmount"/> can produce a negative invoice.
+/// </para>
+/// <para>
+/// <strong>Trial discounts are skipped</strong> — they extend the trial period
+/// (consumed elsewhere) and have no immediate billing impact.
+/// </para>
+/// </remarks>
+public static class SubscriptionDiscountCalculator
+{
+    /// <summary>Returns the amount after applying every discount in order.</summary>
+    /// <param name="baseAmount">Amount before discounts (≥ 0).</param>
+    /// <param name="discounts">Discounts to apply, in stacking order.</param>
+    /// <param name="now">Reference instant for <see cref="SubscriptionDiscount.IsActiveAt"/>.</param>
+    /// <returns>Discounted amount, ≥ 0.</returns>
+    public static decimal Apply(
+        decimal baseAmount,
+        IEnumerable<SubscriptionDiscount> discounts,
+        DateTimeOffset now)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(baseAmount);
+        ArgumentNullException.ThrowIfNull(discounts);
+
+        decimal total = baseAmount;
+
+        foreach (SubscriptionDiscount discount in discounts)
+        {
+            if (!discount.IsActiveAt(now))
+            {
+                continue;
+            }
+
+            total = discount.Type switch
+            {
+                DiscountType.Percentage => decimal.Round(
+                    total * (1m - (discount.Value / 100m)),
+                    decimals: 4,
+                    MidpointRounding.ToEven),
+                DiscountType.FixedAmount => Math.Max(0m, total - discount.Value),
+                DiscountType.Trial => total,   // No price impact at billing time.
+                _ => total,
+            };
+        }
+
+        return total;
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionDiscountTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionDiscountTests.cs
@@ -1,0 +1,93 @@
+using Granit.Subscriptions.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+public sealed class SubscriptionDiscountTests
+{
+    [Fact]
+    public void Create_WithAllFields_StoresThem()
+    {
+        var id = Guid.NewGuid();
+        var subId = Guid.NewGuid();
+        var expiry = DateTimeOffset.Parse("2027-01-01T00:00:00Z");
+
+        var d = SubscriptionDiscount.Create(
+            id, subId, DiscountType.Percentage, 10m,
+            reason: "VIP customer agreement #4321",
+            expiresAt: expiry);
+
+        d.Id.ShouldBe(id);
+        d.SubscriptionId.ShouldBe(subId);
+        d.Type.ShouldBe(DiscountType.Percentage);
+        d.Value.ShouldBe(10m);
+        d.Reason.ShouldBe("VIP customer agreement #4321");
+        d.ExpiresAt.ShouldBe(expiry);
+    }
+
+    [Fact]
+    public void Create_PercentageOver100_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(),
+                DiscountType.Percentage, 100.5m, "x"));
+
+    [Fact]
+    public void Create_NegativeValue_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(),
+                DiscountType.FixedAmount, -1m, "x"));
+
+    [Fact]
+    public void Create_TrialWithFractionalValue_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(),
+                DiscountType.Trial, 7.5m, "extension"));
+
+    [Fact]
+    public void Create_EmptyReason_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(),
+                DiscountType.Percentage, 10m, "  "));
+
+    [Fact]
+    public void Create_ReasonOverMaxLength_Throws()
+    {
+        string overLong = new('x', SubscriptionDiscount.ReasonMaxLength + 1);
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(),
+                DiscountType.FixedAmount, 1m, overLong));
+    }
+
+    [Fact]
+    public void IsActiveAt_NoExpiry_AlwaysTrue()
+    {
+        var d = SubscriptionDiscount.Create(
+            Guid.NewGuid(), Guid.NewGuid(), DiscountType.Percentage, 10m, "x");
+
+        d.IsActiveAt(DateTimeOffset.UtcNow.AddYears(50)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsActiveAt_BeforeExpiry_True()
+    {
+        var expiry = DateTimeOffset.Parse("2027-01-01T00:00:00Z");
+        var d = SubscriptionDiscount.Create(
+            Guid.NewGuid(), Guid.NewGuid(), DiscountType.Percentage, 10m,
+            "x", expiresAt: expiry);
+
+        d.IsActiveAt(expiry.AddSeconds(-1)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsActiveAt_AtOrAfterExpiry_False()
+    {
+        var expiry = DateTimeOffset.Parse("2027-01-01T00:00:00Z");
+        var d = SubscriptionDiscount.Create(
+            Guid.NewGuid(), Guid.NewGuid(), DiscountType.Percentage, 10m,
+            "x", expiresAt: expiry);
+
+        d.IsActiveAt(expiry).ShouldBeFalse();              // exclusive
+        d.IsActiveAt(expiry.AddDays(1)).ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Pricing/SubscriptionDiscountCalculatorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Pricing/SubscriptionDiscountCalculatorTests.cs
@@ -1,0 +1,120 @@
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Pricing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Pricing;
+
+/// <summary>
+/// Pure-function tests for cumulative discount stacking. Boundaries: zero-amount
+/// no-op, fixed-amount floor, percentage rounding (banker's, 4 decimals),
+/// expiry skipping, trial no-op at billing time, multiple-discount stacking.
+/// </summary>
+public sealed class SubscriptionDiscountCalculatorTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-04-24T12:00:00Z");
+
+    private static SubscriptionDiscount NewDiscount(
+        DiscountType type, decimal value, DateTimeOffset? expiresAt = null) =>
+        SubscriptionDiscount.Create(Guid.NewGuid(), Guid.NewGuid(), type, value, "test", expiresAt);
+
+    [Fact]
+    public void Apply_NoDiscounts_ReturnsBaseAmount() =>
+        SubscriptionDiscountCalculator.Apply(100m, [], Now).ShouldBe(100m);
+
+    [Fact]
+    public void Apply_SinglePercentage_ReducesProportionally() =>
+        SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.Percentage, 10m)], Now).ShouldBe(90m);
+
+    [Fact]
+    public void Apply_SingleFixedAmount_SubtractsAmount() =>
+        SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.FixedAmount, 25m)], Now).ShouldBe(75m);
+
+    [Fact]
+    public void Apply_FixedAmountExceedsTotal_FlooredAtZero() =>
+        SubscriptionDiscountCalculator.Apply(50m,
+            [NewDiscount(DiscountType.FixedAmount, 200m)], Now).ShouldBe(0m);
+
+    [Fact]
+    public void Apply_TrialDiscount_NoBillingImpact()
+    {
+        // Trial extension is handled elsewhere — calculator is a no-op.
+        SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.Trial, 7m)], Now).ShouldBe(100m);
+    }
+
+    [Fact]
+    public void Apply_MultiplePercentages_StackCumulatively()
+    {
+        // 10% off then 10% off again = 0.9 × 0.9 = 0.81 = 81% of original = 19% effective discount.
+        decimal result = SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.Percentage, 10m), NewDiscount(DiscountType.Percentage, 10m)], Now);
+
+        result.ShouldBe(81m);
+    }
+
+    [Fact]
+    public void Apply_MixedFixedThenPercentage_AppliesInOrder()
+    {
+        // (100 - 20) × 0.9 = 72.
+        decimal result = SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.FixedAmount, 20m), NewDiscount(DiscountType.Percentage, 10m)], Now);
+
+        result.ShouldBe(72m);
+    }
+
+    [Fact]
+    public void Apply_MixedPercentageThenFixed_OrderMatters()
+    {
+        // (100 × 0.9) - 20 = 70 — different result vs the previous test, proving order matters.
+        decimal result = SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.Percentage, 10m), NewDiscount(DiscountType.FixedAmount, 20m)], Now);
+
+        result.ShouldBe(70m);
+    }
+
+    [Fact]
+    public void Apply_ExpiredDiscount_Skipped()
+    {
+        SubscriptionDiscount expired = NewDiscount(
+            DiscountType.Percentage, 50m, expiresAt: Now.AddDays(-1));
+        SubscriptionDiscount active = NewDiscount(DiscountType.Percentage, 10m);
+
+        SubscriptionDiscountCalculator.Apply(100m, [expired, active], Now).ShouldBe(90m);
+    }
+
+    [Fact]
+    public void Apply_TrialBetweenPriceDiscounts_DoesNotInterruptStacking()
+    {
+        decimal result = SubscriptionDiscountCalculator.Apply(100m,
+            [
+                NewDiscount(DiscountType.Percentage, 10m),
+                NewDiscount(DiscountType.Trial, 30m),
+                NewDiscount(DiscountType.FixedAmount, 5m),
+            ], Now);
+
+        result.ShouldBe(85m); // 100 → 90 → 90 → 85
+    }
+
+    [Fact]
+    public void Apply_PercentageWithBankerRounding()
+    {
+        // 33.333% off 100 = 100 * (1 - 0.33333) = 66.667; 4-decimal banker's = 66.6670
+        decimal result = SubscriptionDiscountCalculator.Apply(100m,
+            [NewDiscount(DiscountType.Percentage, 33.333m)], Now);
+
+        result.ShouldBe(66.667m);
+    }
+
+    [Fact]
+    public void Apply_NegativeBaseAmount_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionDiscountCalculator.Apply(-1m, [], Now));
+
+    [Fact]
+    public void Apply_ZeroBaseAmount_StaysZero() =>
+        SubscriptionDiscountCalculator.Apply(0m,
+            [NewDiscount(DiscountType.Percentage, 50m)], Now).ShouldBe(0m);
+}


### PR DESCRIPTION
Closes #1174 (Phase 3 Story 3 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1159](https://github.com/granit-fx/granit-dotnet/issues/1159)).

> **Stacked on PR #1202** (SubscriptionPhase). Retarget to develop once #1202 merges.

Adds first-class negotiated discounts on a Subscription — Percentage, FixedAmount, or Trial extension — applied at billing time by the \`DefaultBillingCycleInvoiceOrchestrator\`.

## Stacking decision: cumulative (documented)

Two 10 % discounts produce a **19 % effective discount**, not 20 %, because the second 10 % is computed on the post-first-discount total. \`FixedAmount → Percentage\` and \`Percentage → FixedAmount\` produce different totals (order matters; both verified by tests). Trial discounts have no billing impact (skipped at calculation time). Expired discounts are skipped.

## What ships

**Domain** (\`Granit.Subscriptions.Domain\`)
- \`DiscountType\` enum (\`Percentage\` 0-100, \`FixedAmount\` currency units, \`Trial\` whole days)
- \`SubscriptionDiscount\` entity (child of \`Subscription\`): \`Type\`, \`Value\`, \`Reason\` (≤ 500 chars), \`ExpiresAt?\` (UTC, exclusive). Factory validates non-empty reason, non-negative value, ≤ 100 for Percentage, integral for Trial.
- \`Subscription\` extensions: \`Discounts\` collection + \`AddDiscount\` / \`RemoveDiscount\` / \`GetActiveDiscounts(now)\`.

**Pure calculator** (\`Granit.Subscriptions.Pricing.SubscriptionDiscountCalculator.Apply\`)
- Cumulative stacking, floor at 0, banker's rounding to 4 decimals on percentage.

**EF persistence**
- \`SubscriptionDiscountConfiguration\` mapping \`subscription_discounts\` table; index on \`(SubscriptionId, ExpiresAt)\`. Cascade delete on Subscription.

**Orchestrator** (\`DefaultBillingCycleInvoiceOrchestrator\`)
- After phase resolution + \`ResolveBasePriceAsync\`, applies \`SubscriptionDiscountCalculator\` with the active discounts at \`clock.Now\`. Phase percentage discount + per-subscription discounts stack: phase first, then each entry of \`subscription.Discounts\` in declaration order.

**HTTP**
- New \`SubscriptionsPermissions.Discounts.Manage\` constant + provider entry (Host-only)
- 16 culture localization files updated.

## Tests (+22)

- \`SubscriptionDiscountTests\` × 9 (factory + IsActiveAt boundaries)
- \`SubscriptionDiscountCalculatorTests\` × 13 (single discount per type, stacking permutations, expired skip, trial no-op, banker's rounding, edge cases)
- All existing tests still green; **154 / 154** Subscriptions tests.

## Schema (consumer apps run their own EF migration)

\`\`\`sql
CREATE TABLE subscription_discounts (
    Id uuid NOT NULL PRIMARY KEY,
    SubscriptionId uuid NOT NULL,
    Type int NOT NULL,
    Value numeric(18,4) NOT NULL,
    Reason varchar(500) NOT NULL,
    ExpiresAt timestamptz NULL
);
CREATE INDEX ix_..._subscription_discounts_active ON subscription_discounts (SubscriptionId, ExpiresAt);
\`\`\`

## Out of scope (deferred)

- HTTP CRUD endpoints (\`POST /subscriptions/{id}/discounts\`, etc.)
- Trial extension consumption (calculator is no-op; trial-end scheduler wiring belongs to a separate \`Subscription.ExtendTrial(days)\` PR)
- \`DiscountApplicationMode\` option (Inline vs SeparateLine invoice line item) — this PR delivers Inline; SeparateLine deferred.

## Test plan

- [x] \`dotnet build src/Granit.Subscriptions*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.Subscriptions.Tests\` — 154 / 154
- [ ] CI green on all 6 shards (TBD post-push; depends on #1201 namespace fix + #1202 base)