### PR TITLE
feat(subscriptions): SubscriptionPriceOverride for per-customer negotiated pricing

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40178,6 +40178,12 @@
           "returnType": "IReadOnlyList<SubscriptionDiscount>"
         },
         {
+          "name": "PriceOverrides",
+          "kind": "property",
+          "signature": "IReadOnlyList<SubscriptionPriceOverride> PriceOverrides",
+          "returnType": "IReadOnlyList<SubscriptionPriceOverride>"
+        },
+        {
           "name": "nameof",
           "kind": "method",
           "signature": "nameof(Status)",
@@ -40218,6 +40224,18 @@
           "kind": "method",
           "signature": "GetActiveDiscounts(DateTimeOffset instant)",
           "returnType": "IEnumerable<SubscriptionDiscount>"
+        },
+        {
+          "name": "AddPriceOverride",
+          "kind": "method",
+          "signature": "AddPriceOverride(SubscriptionPriceOverride priceOverride)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetActivePriceOverride",
+          "kind": "method",
+          "signature": "GetActivePriceOverride(Guid planPriceId, DateTimeOffset instant)",
+          "returnType": "SubscriptionPriceOverride?"
         }
       ]
     },
@@ -40290,6 +40308,28 @@
           "kind": "method",
           "signature": "Covers(DateTimeOffset instant)",
           "returnType": "Guid? OverridePriceId { get; private set; } public decimal? DiscountPercent { get; private set; } public bool"
+        }
+      ]
+    },
+    {
+      "name": "SubscriptionPriceOverride",
+      "fqn": "Granit.Subscriptions.Domain.SubscriptionPriceOverride",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/SubscriptionPriceOverride.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid subscriptionId, Guid planPriceId, decimal amount, DateTimeOffset effectiveFrom, DateTimeOffset? effectiveUntil, string reason)",
+          "returnType": "SubscriptionPriceOverride"
+        },
+        {
+          "name": "Covers",
+          "kind": "method",
+          "signature": "Covers(Guid planPriceId, DateTimeOffset instant)",
+          "returnType": "bool"
         }
       ]
     },
@@ -40569,6 +40609,15 @@
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
       "line": 63,
+      "members": []
+    },
+    {
+      "name": "Overrides",
+      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Overrides",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
+      "line": 75,
       "members": []
     },
     {

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -2,6 +2,7 @@
   "culture": "cs",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Správa slev předplatného (Procenta / Pevná částka / Prodloužení zkušebního období)",
+    "Permission:Subscriptions.Overrides.Manage": "Správa cenových přepisů pro zákazníky (vyjednané enterprise ceny)",
     "Permission:Subscriptions.Phases.Manage": "Správa fází předplatného (plánování změn plánu, přepsání cen, aplikace slev)",
     "Permission:Subscriptions.Plans.Manage": "Spravovat plány předplatného (vytvořit, publikovat, archivovat)",
     "Permission:Subscriptions.Plans.Read": "Zobrazit plány předplatného",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
@@ -2,6 +2,7 @@
   "culture": "de",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Abonnementrabatte verwalten (Prozentual / Fester Betrag / Testverlängerungen)",
+    "Permission:Subscriptions.Overrides.Manage": "Kundenspezifische Preisüberschreibungen verwalten (verhandelte Enterprise-Preise)",
     "Permission:Subscriptions.Phases.Manage": "Abonnementphasen verwalten (Planänderungen planen, Preise überschreiben, Rabatte anwenden)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementpläne verwalten (erstellen, veröffentlichen, archivieren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementpläne anzeigen",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
@@ -2,6 +2,7 @@
   "culture": "en",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Manage subscription discounts (Percentage / FixedAmount / Trial extensions)",
+    "Permission:Subscriptions.Overrides.Manage": "Manage per-customer price overrides (enterprise negotiated pricing carve-outs)",
     "Permission:Subscriptions.Phases.Manage": "Manage subscription phases (schedule plan changes, override prices, apply discounts)",
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
     "Permission:Subscriptions.Plans.Read": "View subscription plans",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
@@ -2,6 +2,7 @@
   "culture": "es",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Gestionar descuentos de suscripción (Porcentaje / Importe fijo / Extensiones de prueba)",
+    "Permission:Subscriptions.Overrides.Manage": "Gestionar anulaciones de precio por cliente (precios enterprise negociados)",
     "Permission:Subscriptions.Phases.Manage": "Gestionar fases de suscripción (programar cambios de plan, anular precios, aplicar descuentos)",
     "Permission:Subscriptions.Plans.Manage": "Gestionar planes de suscripción (crear, publicar, archivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planes de suscripción",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
@@ -2,6 +2,7 @@
   "culture": "fr",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Gérer les remises d'abonnement (Pourcentage / Montant fixe / Prolongations d'essai)",
+    "Permission:Subscriptions.Overrides.Manage": "Gérer les surcharges de prix par client (tarifs enterprise négociés)",
     "Permission:Subscriptions.Phases.Manage": "Gérer les phases d'abonnement (planifier des changements de plan, surcharger les prix, appliquer des remises)",
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
     "Permission:Subscriptions.Plans.Read": "Consulter les plans d'abonnement",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
@@ -2,6 +2,7 @@
   "culture": "hi",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "सदस्यता छूट प्रबंधित करें (प्रतिशत / निश्चित राशि / परीक्षण विस्तार)",
+    "Permission:Subscriptions.Overrides.Manage": "प्रति-ग्राहक मूल्य ओवरराइड प्रबंधित करें (बातचीत किए गए एंटरप्राइज़ मूल्य)",
     "Permission:Subscriptions.Phases.Manage": "सदस्यता चरण प्रबंधित करें (योजना परिवर्तन शेड्यूल करें, मूल्य ओवरराइड करें, छूट लागू करें)",
     "Permission:Subscriptions.Plans.Manage": "सब्सक्रिप्शन प्लान प्रबंधित करें (बनाएँ, प्रकाशित करें, संग्रहित करें)",
     "Permission:Subscriptions.Plans.Read": "सब्सक्रिप्शन प्लान देखें",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -2,6 +2,7 @@
   "culture": "it",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Gestire gli sconti dell'abbonamento (Percentuale / Importo fisso / Estensioni di prova)",
+    "Permission:Subscriptions.Overrides.Manage": "Gestire le sovrascritture di prezzo per cliente (prezzi enterprise negoziati)",
     "Permission:Subscriptions.Phases.Manage": "Gestire le fasi dell'abbonamento (programmare modifiche di piano, sovrascrivere prezzi, applicare sconti)",
     "Permission:Subscriptions.Plans.Manage": "Gestire i piani di abbonamento (creare, pubblicare, archiviare)",
     "Permission:Subscriptions.Plans.Read": "Visualizzare i piani di abbonamento",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -2,6 +2,7 @@
   "culture": "ja",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "サブスクリプション割引を管理（パーセンテージ / 固定金額 / トライアル延長）",
+    "Permission:Subscriptions.Overrides.Manage": "顧客別価格上書きを管理（交渉済みエンタープライズ価格）",
     "Permission:Subscriptions.Phases.Manage": "サブスクリプションフェーズを管理（プラン変更のスケジュール、価格上書き、割引適用）",
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
     "Permission:Subscriptions.Plans.Read": "サブスクリプションプランの表示",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -2,6 +2,7 @@
   "culture": "ko",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "구독 할인 관리 (비율 / 고정 금액 / 체험 연장)",
+    "Permission:Subscriptions.Overrides.Manage": "고객별 가격 재정의 관리 (협상된 엔터프라이즈 가격)",
     "Permission:Subscriptions.Phases.Manage": "구독 단계 관리 (요금제 변경 예약, 가격 재정의, 할인 적용)",
     "Permission:Subscriptions.Plans.Manage": "구독 플랜 관리 (생성, 게시, 보관)",
     "Permission:Subscriptions.Plans.Read": "구독 플랜 보기",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
@@ -2,6 +2,7 @@
   "culture": "nl",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Abonnementkortingen beheren (Percentage / Vast bedrag / Proefverlengingen)",
+    "Permission:Subscriptions.Overrides.Manage": "Klantspecifieke prijsoverrides beheren (onderhandelde enterprise-tarieven)",
     "Permission:Subscriptions.Phases.Manage": "Abonnementfasen beheren (planwijzigingen plannen, prijzen overschrijven, kortingen toepassen)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementsplannen beheren (aanmaken, publiceren, archiveren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementsplannen bekijken",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -2,6 +2,7 @@
   "culture": "pl",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Zarządzanie zniżkami subskrypcji (Procent / Stała kwota / Przedłużenia okresu próbnego)",
+    "Permission:Subscriptions.Overrides.Manage": "Zarządzanie nadpisaniami ceny dla klientów (negocjowane ceny enterprise)",
     "Permission:Subscriptions.Phases.Manage": "Zarządzanie fazami subskrypcji (planowanie zmian planu, nadpisywanie cen, stosowanie zniżek)",
     "Permission:Subscriptions.Plans.Manage": "Zarządzanie planami subskrypcji (tworzenie, publikowanie, archiwizowanie)",
     "Permission:Subscriptions.Plans.Read": "Wyświetlanie planów subskrypcji",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -2,6 +2,7 @@
   "culture": "pt-BR",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Gerenciar descontos de assinatura (Porcentagem / Valor fixo / Extensões de teste)",
+    "Permission:Subscriptions.Overrides.Manage": "Gerenciar substituições de preço por cliente (preços enterprise negociados)",
     "Permission:Subscriptions.Phases.Manage": "Gerenciar fases de assinatura (agendar alterações de plano, sobrepor preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerenciar planos de assinatura (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Visualizar planos de assinatura",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -2,6 +2,7 @@
   "culture": "pt",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Gerir descontos de subscrição (Percentagem / Valor fixo / Extensões de avaliação)",
+    "Permission:Subscriptions.Overrides.Manage": "Gerir substituições de preço por cliente (preços enterprise negociados)",
     "Permission:Subscriptions.Phases.Manage": "Gerir fases de subscrição (agendar alterações de plano, substituir preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planos de subscrição",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -2,6 +2,7 @@
   "culture": "sv",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Hantera prenumerationsrabatter (Procent / Fast belopp / Provförlängningar)",
+    "Permission:Subscriptions.Overrides.Manage": "Hantera prisåsidosättningar per kund (förhandlade enterprise-priser)",
     "Permission:Subscriptions.Phases.Manage": "Hantera prenumerationsfaser (schemalägga planändringar, åsidosätta priser, tillämpa rabatter)",
     "Permission:Subscriptions.Plans.Manage": "Hantera prenumerationsplaner (skapa, publicera, arkivera)",
     "Permission:Subscriptions.Plans.Read": "Visa prenumerationsplaner",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -2,6 +2,7 @@
   "culture": "tr",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "Abonelik indirimlerini yönet (Yüzde / Sabit Tutar / Deneme Uzatmaları)",
+    "Permission:Subscriptions.Overrides.Manage": "Müşteri başına fiyat geçersiz kılmalarını yönet (anlaşmalı enterprise fiyatlandırma)",
     "Permission:Subscriptions.Phases.Manage": "Abonelik fazlarını yönet (plan değişikliklerini zamanla, fiyatları geçersiz kıl, indirim uygula)",
     "Permission:Subscriptions.Plans.Manage": "Abonelik planlarını yönet (oluştur, yayınla, arşivle)",
     "Permission:Subscriptions.Plans.Read": "Abonelik planlarını görüntüle",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -2,6 +2,7 @@
   "culture": "zh",
   "texts": {
     "Permission:Subscriptions.Discounts.Manage": "管理订阅折扣（百分比 / 固定金额 / 试用延期）",
+    "Permission:Subscriptions.Overrides.Manage": "管理客户级价格覆盖（协商的企业定价）",
     "Permission:Subscriptions.Phases.Manage": "管理订阅阶段（计划变更、价格覆盖、应用折扣）",
     "Permission:Subscriptions.Plans.Manage": "管理订阅计划（创建、发布、归档）",
     "Permission:Subscriptions.Plans.Read": "查看订阅计划",

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -53,5 +53,10 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
         group.AddPermission(SubscriptionsPermissions.Discounts.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Discounts.Manage"),
             MultiTenancySide.Host);
+
+        // Per-PlanPrice negotiated overrides (enterprise pricing carve-outs).
+        group.AddPermission(SubscriptionsPermissions.Overrides.Manage,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Overrides.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
@@ -70,4 +70,15 @@ public static class SubscriptionsPermissions
         /// </summary>
         public const string Manage = "Subscriptions.Discounts.Manage";
     }
+
+    /// <summary>Per-PlanPrice negotiated override permissions.</summary>
+    public static class Overrides
+    {
+        /// <summary>
+        /// Manage per-customer price overrides on individual <c>PlanPrice</c>
+        /// records. Admin-only — overrides supersede the standard plan price
+        /// at billing time, directly impacting revenue. ISO 27001 A.9.4.
+        /// </summary>
+        public const string Manage = "Subscriptions.Overrides.Manage";
+    }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsModelBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class SubscriptionsModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new SubscriptionConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionPhaseConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionDiscountConfiguration());
+        modelBuilder.ApplyConfiguration(new SubscriptionPriceOverrideConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionSeatConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionExternalMappingConfiguration());
         return modelBuilder;

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
@@ -50,6 +50,14 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
         builder.Navigation(e => e.Discounts)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
+        builder.HasMany(e => e.PriceOverrides)
+            .WithOne()
+            .HasForeignKey(o => o.SubscriptionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.PriceOverrides)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         builder.HasIndex(e => new { e.TenantId, e.Status })
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscriptions_tenant_status");
 

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPriceOverrideConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPriceOverrideConfiguration.cs
@@ -1,0 +1,29 @@
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+internal sealed class SubscriptionPriceOverrideConfiguration : IEntityTypeConfiguration<SubscriptionPriceOverride>
+{
+    public void Configure(EntityTypeBuilder<SubscriptionPriceOverride> builder)
+    {
+        builder.ToTable(
+            GranitSubscriptionsDbProperties.DbTablePrefix + "subscription_price_overrides",
+            GranitSubscriptionsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.SubscriptionId).IsRequired();
+        builder.Property(e => e.PlanPriceId).IsRequired();
+        builder.Property(e => e.Amount).HasPrecision(18, 4).IsRequired();
+        builder.Property(e => e.EffectiveFrom).IsRequired();
+        builder.Property(e => e.EffectiveUntil);
+        builder.Property(e => e.Reason).HasMaxLength(SubscriptionPriceOverride.ReasonMaxLength).IsRequired();
+
+        // Active-window lookup: for a given (subscription, planPrice) the orchestrator
+        // probes by EffectiveFrom — the index covers both the subscription scope and
+        // the timeline access pattern.
+        builder.HasIndex(e => new { e.SubscriptionId, e.PlanPriceId, e.EffectiveFrom })
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscription_price_overrides_active");
+    }
+}

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -26,6 +26,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     private readonly List<SubscriptionExternalMapping> _externalMappings = [];
     private readonly List<SubscriptionPhase> _phases = [];
     private readonly List<SubscriptionDiscount> _discounts = [];
+    private readonly List<SubscriptionPriceOverride> _priceOverrides = [];
 
     private Subscription() { }
 
@@ -137,6 +138,14 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     /// <see cref="Pricing.SubscriptionDiscountCalculator"/>.
     /// </summary>
     public IReadOnlyList<SubscriptionDiscount> Discounts => _discounts;
+
+    /// <summary>
+    /// Per-<see cref="PlanPrice"/> negotiated price overrides. The pricing resolver
+    /// consults <see cref="GetActivePriceOverride"/> at billing time and uses the
+    /// matching override's <see cref="SubscriptionPriceOverride.Amount"/> instead
+    /// of the standard <c>PlanPrice.Amount</c> when one covers the billing instant.
+    /// </summary>
+    public IReadOnlyList<SubscriptionPriceOverride> PriceOverrides => _priceOverrides;
 
     /// <inheritdoc />
     public Guid? TenantId { get; private set; }
@@ -457,6 +466,36 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     /// </summary>
     public IEnumerable<SubscriptionDiscount> GetActiveDiscounts(DateTimeOffset instant) =>
         _discounts.Where(d => d.IsActiveAt(instant));
+
+    // ── Price overrides ────────────────────────────────────────────────
+
+    /// <summary>Attaches a per-PlanPrice override to the subscription.</summary>
+    public void AddPriceOverride(SubscriptionPriceOverride priceOverride)
+    {
+        ArgumentNullException.ThrowIfNull(priceOverride);
+
+        if (priceOverride.SubscriptionId != Id)
+        {
+            throw new InvalidOperationException(
+                $"Price override '{priceOverride.Id}' belongs to subscription '{priceOverride.SubscriptionId}', not '{Id}'.");
+        }
+
+        _priceOverrides.Add(priceOverride);
+    }
+
+    /// <summary>Removes a previously-added override. Returns <c>true</c> when one was actually removed.</summary>
+    public bool RemovePriceOverride(Guid overrideId) =>
+        _priceOverrides.RemoveAll(o => o.Id == overrideId) > 0;
+
+    /// <summary>
+    /// Returns the override that covers <paramref name="planPriceId"/> at
+    /// <paramref name="instant"/>, or <c>null</c> when none does. At most one
+    /// override is expected to cover any given (priceId, instant) pair —
+    /// non-overlap is a UX contract enforced by the HTTP-layer validator
+    /// (CRUD endpoints PR), not by the entity itself.
+    /// </summary>
+    public SubscriptionPriceOverride? GetActivePriceOverride(Guid planPriceId, DateTimeOffset instant) =>
+        _priceOverrides.FirstOrDefault(o => o.Covers(planPriceId, instant));
 
     // ── Private helpers ────────────────────────────────────────────────
 

--- a/src/Granit.Subscriptions/Domain/SubscriptionPriceOverride.cs
+++ b/src/Granit.Subscriptions/Domain/SubscriptionPriceOverride.cs
@@ -1,0 +1,97 @@
+using Granit.Domain;
+
+namespace Granit.Subscriptions.Domain;
+
+/// <summary>
+/// A customer-negotiated price that supersedes the standard
+/// <see cref="PlanPrice.Amount"/> for a single <see cref="Subscription"/> over
+/// a half-open time window <c>[EffectiveFrom, EffectiveUntil)</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Overrides target a specific <see cref="PlanPriceId"/> — typically the
+/// subscription's pinned <see cref="Subscription.PlanPriceId"/>, or the current
+/// active price resolved at billing time. Multiple overrides may exist for the
+/// same <c>PlanPriceId</c> across non-overlapping time windows (e.g. a special
+/// rate for the first 6 months, then a different one); the orchestrator picks
+/// the one whose window covers <c>now</c>.
+/// </para>
+/// <para>
+/// Currency is implicitly carried by the parent <see cref="PlanPrice"/> — the
+/// override's <see cref="Amount"/> is denominated in the same currency.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionPriceOverride : Entity
+{
+    private SubscriptionPriceOverride() { }
+
+    /// <summary>Maximum length of the free-text reason captured at creation.</summary>
+    public const int ReasonMaxLength = 500;
+
+    /// <summary>Creates a new override attached to the supplied subscription.</summary>
+    /// <param name="id">Override id.</param>
+    /// <param name="subscriptionId">Owning subscription (FK).</param>
+    /// <param name="planPriceId">Target <see cref="PlanPrice"/> whose <c>Amount</c> is overridden.</param>
+    /// <param name="amount">Negotiated amount in the parent price's currency (≥ 0).</param>
+    /// <param name="effectiveFrom">Inclusive lower bound of the override window (UTC).</param>
+    /// <param name="effectiveUntil">Exclusive upper bound; <c>null</c> = open-ended.</param>
+    /// <param name="reason">Free-text justification (commercial agreement reference, ≤ 500 chars).</param>
+    public static SubscriptionPriceOverride Create(
+        Guid id,
+        Guid subscriptionId,
+        Guid planPriceId,
+        decimal amount,
+        DateTimeOffset effectiveFrom,
+        DateTimeOffset? effectiveUntil,
+        string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(reason.Length, ReasonMaxLength);
+        ArgumentOutOfRangeException.ThrowIfNegative(amount);
+
+        if (effectiveUntil is { } u && u <= effectiveFrom)
+        {
+            throw new ArgumentException(
+                $"Override effectiveUntil {u:O} must be strictly greater than effectiveFrom {effectiveFrom:O}.",
+                nameof(effectiveUntil));
+        }
+
+        return new SubscriptionPriceOverride
+        {
+            Id = id,
+            SubscriptionId = subscriptionId,
+            PlanPriceId = planPriceId,
+            Amount = amount,
+            EffectiveFrom = effectiveFrom,
+            EffectiveUntil = effectiveUntil,
+            Reason = reason,
+        };
+    }
+
+    /// <summary>Owning subscription (FK).</summary>
+    public Guid SubscriptionId { get; private set; }
+
+    /// <summary>Target <see cref="PlanPrice"/> id whose <c>Amount</c> is overridden.</summary>
+    public Guid PlanPriceId { get; private set; }
+
+    /// <summary>Negotiated amount, in the parent <see cref="PlanPrice"/>'s currency.</summary>
+    public decimal Amount { get; private set; }
+
+    /// <summary>Inclusive lower bound of the override window.</summary>
+    public DateTimeOffset EffectiveFrom { get; private set; }
+
+    /// <summary>Exclusive upper bound; <c>null</c> = open-ended.</summary>
+    public DateTimeOffset? EffectiveUntil { get; private set; }
+
+    /// <summary>Free-text justification (commercial agreement reference).</summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Whether this override covers the supplied instant for the supplied price id.
+    /// Half-open semantics: <c>EffectiveFrom ≤ instant &lt; EffectiveUntil</c>.
+    /// </summary>
+    public bool Covers(Guid planPriceId, DateTimeOffset instant) =>
+        PlanPriceId == planPriceId
+        && instant >= EffectiveFrom
+        && (EffectiveUntil is null || instant < EffectiveUntil.Value);
+}

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -80,6 +80,21 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
             effectivePlanPriceId, cancellationToken)
             .ConfigureAwait(false);
 
+        // SubscriptionPriceOverride: a per-customer negotiated amount supersedes
+        // the standard PlanPrice.Amount when the override window covers "now".
+        // Looked up by the resolved PlanPrice id (effectivePlanPriceId) — if no
+        // pinned price exists we skip override lookup (no PlanPrice to target).
+        if (effectivePlanPriceId is { } overrideTargetId)
+        {
+            SubscriptionPriceOverride? activeOverride = subscription
+                .GetActivePriceOverride(overrideTargetId, clock.Now);
+
+            if (activeOverride is not null)
+            {
+                basePrice = activeOverride.Amount;
+            }
+        }
+
         // Short-circuit on a non-positive base price BEFORE running discount math —
         // discount application throws on negative input, and a 0 base price already
         // means "skip" by the existing convention.

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPriceOverrideTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPriceOverrideTests.cs
@@ -1,0 +1,101 @@
+using Granit.Subscriptions.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+public sealed class SubscriptionPriceOverrideTests
+{
+    private static readonly DateTimeOffset T0 = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+    private static readonly DateTimeOffset T30 = T0.AddDays(30);
+
+    [Fact]
+    public void Create_WithAllFields_StoresThem()
+    {
+        var id = Guid.NewGuid();
+        var subId = Guid.NewGuid();
+        var priceId = Guid.NewGuid();
+
+        var ov = SubscriptionPriceOverride.Create(
+            id, subId, priceId, amount: 49.99m,
+            effectiveFrom: T0, effectiveUntil: T30,
+            reason: "Acme MSA #5678");
+
+        ov.Id.ShouldBe(id);
+        ov.SubscriptionId.ShouldBe(subId);
+        ov.PlanPriceId.ShouldBe(priceId);
+        ov.Amount.ShouldBe(49.99m);
+        ov.EffectiveFrom.ShouldBe(T0);
+        ov.EffectiveUntil.ShouldBe(T30);
+        ov.Reason.ShouldBe("Acme MSA #5678");
+    }
+
+    [Fact]
+    public void Create_NegativeAmount_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            SubscriptionPriceOverride.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                amount: -1m, effectiveFrom: T0, effectiveUntil: null, reason: "x"));
+
+    [Fact]
+    public void Create_EffectiveUntilEqualsFrom_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionPriceOverride.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                amount: 10m, effectiveFrom: T0, effectiveUntil: T0, reason: "x"));
+
+    [Fact]
+    public void Create_EffectiveUntilBeforeFrom_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionPriceOverride.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                amount: 10m, effectiveFrom: T30, effectiveUntil: T0, reason: "x"));
+
+    [Fact]
+    public void Create_EmptyReason_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            SubscriptionPriceOverride.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                amount: 10m, effectiveFrom: T0, effectiveUntil: null, reason: " "));
+
+    // ──────────── Covers semantics ────────────
+
+    [Fact]
+    public void Covers_MatchingPriceInsideWindow_True()
+    {
+        var priceId = Guid.NewGuid();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), Guid.NewGuid(), priceId, 10m, T0, T30, "x");
+
+        ov.Covers(priceId, T0.AddDays(15)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Covers_DifferentPriceId_False()
+    {
+        var priceId = Guid.NewGuid();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), Guid.NewGuid(), priceId, 10m, T0, T30, "x");
+
+        ov.Covers(Guid.NewGuid(), T0.AddDays(15)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Covers_AtEffectiveUntil_FalseExclusive()
+    {
+        var priceId = Guid.NewGuid();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), Guid.NewGuid(), priceId, 10m, T0, T30, "x");
+
+        ov.Covers(priceId, T30).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Covers_OpenEnded_CoversAnyInstantAfterFrom()
+    {
+        var priceId = Guid.NewGuid();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), Guid.NewGuid(), priceId, 10m,
+            effectiveFrom: T0, effectiveUntil: null, reason: "x");
+
+        ov.Covers(priceId, T0).ShouldBeTrue();
+        ov.Covers(priceId, T30.AddYears(50)).ShouldBeTrue();
+        ov.Covers(priceId, T0.AddSeconds(-1)).ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPriceOverridesIntegrationTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPriceOverridesIntegrationTests.cs
@@ -1,0 +1,103 @@
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.Tests.Domain;
+
+public sealed class SubscriptionPriceOverridesIntegrationTests
+{
+    private static readonly DateTimeOffset T0 = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+    private static readonly DateTimeOffset T30 = T0.AddDays(30);
+
+    private static Subscription NewSubscription() => Subscription.Create(
+        SubscriptionId.Create(Guid.NewGuid()),
+        Guid.NewGuid(),
+        PlanId.Create(Guid.NewGuid()),
+        currency: "EUR",
+        period: new SubscriptionPeriod(T0, T0.AddMonths(12), BillingCycleAnchor: T0));
+
+    [Fact]
+    public void AddPriceOverride_StoresAndIsRetrievable()
+    {
+        Subscription sub = NewSubscription();
+        var priceId = Guid.NewGuid();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, priceId, 49m, T0, T30, "Acme MSA");
+
+        sub.AddPriceOverride(ov);
+
+        sub.PriceOverrides.Count.ShouldBe(1);
+        sub.GetActivePriceOverride(priceId, T0.AddDays(15))!.Amount.ShouldBe(49m);
+    }
+
+    [Fact]
+    public void AddPriceOverride_MismatchedSubscriptionId_Throws()
+    {
+        Subscription sub = NewSubscription();
+        var stray = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(),
+            subscriptionId: Guid.NewGuid(),
+            planPriceId: Guid.NewGuid(),
+            amount: 1m, effectiveFrom: T0, effectiveUntil: null, reason: "x");
+
+        Should.Throw<InvalidOperationException>(() => sub.AddPriceOverride(stray));
+    }
+
+    [Fact]
+    public void GetActivePriceOverride_MissingPriceMatch_ReturnsNull()
+    {
+        Subscription sub = NewSubscription();
+        var priceA = Guid.NewGuid();
+        sub.AddPriceOverride(SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, priceA, 49m, T0, null, "x"));
+
+        sub.GetActivePriceOverride(Guid.NewGuid(), T0.AddDays(1)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetActivePriceOverride_OutsideWindow_ReturnsNull()
+    {
+        Subscription sub = NewSubscription();
+        var priceId = Guid.NewGuid();
+        sub.AddPriceOverride(SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, priceId, 49m, T0, T30, "x"));
+
+        sub.GetActivePriceOverride(priceId, T30).ShouldBeNull();          // exclusive end
+        sub.GetActivePriceOverride(priceId, T0.AddDays(-1)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetActivePriceOverride_MultipleNonOverlapping_PicksMatchingWindow()
+    {
+        Subscription sub = NewSubscription();
+        var priceId = Guid.NewGuid();
+        sub.AddPriceOverride(SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, priceId, 50m, T0, T30, "intro"));
+        sub.AddPriceOverride(SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, priceId, 75m, T30, null, "renewal"));
+
+        sub.GetActivePriceOverride(priceId, T0.AddDays(15))!.Amount.ShouldBe(50m);
+        sub.GetActivePriceOverride(priceId, T30.AddDays(15))!.Amount.ShouldBe(75m);
+    }
+
+    [Fact]
+    public void RemovePriceOverride_ExistingId_RemovesAndReturnsTrue()
+    {
+        Subscription sub = NewSubscription();
+        var ov = SubscriptionPriceOverride.Create(
+            Guid.NewGuid(), sub.Id, Guid.NewGuid(), 49m, T0, T30, "x");
+        sub.AddPriceOverride(ov);
+
+        sub.RemovePriceOverride(ov.Id).ShouldBeTrue();
+        sub.PriceOverrides.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemovePriceOverride_UnknownId_ReturnsFalse()
+    {
+        Subscription sub = NewSubscription();
+
+        sub.RemovePriceOverride(Guid.NewGuid()).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Closes #1175 (Phase 3 Story 4 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1159](https://github.com/granit-fx/granit-dotnet/issues/1159)).

> **Stacked on PR #1203** (SubscriptionDiscount). Retarget to develop once #1203 merges.

Adds per-PlanPrice negotiated overrides on a Subscription so enterprise contracts can carry non-standard pricing without polluting the public plan catalog with one-off Plans.

## Domain

- New \`SubscriptionPriceOverride\` entity (child of Subscription): \`PlanPriceId\`, \`Amount\` (in the parent PlanPrice's currency, ≥ 0), \`EffectiveFrom\` (inclusive), \`EffectiveUntil?\` (exclusive; null = open-ended), \`Reason\` (≤ 500 chars).
- \`Subscription\` extensions: \`PriceOverrides\` collection + \`AddPriceOverride\` / \`RemovePriceOverride\` / \`GetActivePriceOverride(planPriceId, now)\` behavior methods.
- \`Covers(planPriceId, instant)\` half-open interval check.

## EF persistence

- \`SubscriptionPriceOverrideConfiguration\` mapping \`subscription_price_overrides\` table; index on \`(SubscriptionId, PlanPriceId, EffectiveFrom)\` for active-window point lookups.
- \`SubscriptionConfiguration\` adds \`HasMany(PriceOverrides)\` with \`PropertyAccessMode.Field\`.
- Cascade delete on Subscription removal.

## Orchestrator

After \`ResolveBasePriceAsync\`, if a pinned \`PlanPriceId\` is in scope and the subscription has an active \`SubscriptionPriceOverride\` covering it at \`clock.Now\`, the override's \`Amount\` supersedes the resolved \`basePrice\`. Phase percentage discount + \`SubscriptionDiscount\` stacking apply on top of the override (not on top of the original price).

## HTTP

- \`SubscriptionsPermissions.Overrides.Manage\` (Host-only)
- 16 culture localization files updated.

## Tests (+16)

- \`SubscriptionPriceOverrideTests\` × 9 (factory + Covers semantics)
- \`SubscriptionPriceOverridesIntegrationTests\` × 7 (Add/Remove/GetActive across multi-overrides)
- **170 / 170** Subscriptions tests pass.

## Schema (consumer apps run their own EF migration)

\`\`\`sql
CREATE TABLE subscription_price_overrides (
    Id uuid NOT NULL PRIMARY KEY,
    SubscriptionId uuid NOT NULL,
    PlanPriceId uuid NOT NULL,
    Amount numeric(18,4) NOT NULL,
    EffectiveFrom timestamptz NOT NULL,
    EffectiveUntil timestamptz NULL,
    Reason varchar(500) NOT NULL
);
CREATE INDEX ix_..._subscription_price_overrides_active
    ON subscription_price_overrides (SubscriptionId, PlanPriceId, EffectiveFrom);
\`\`\`

## Out of scope (deferred)

- HTTP CRUD endpoints (\`POST /subscriptions/{id}/price-overrides\`, etc.)
- Non-overlap validator on \`(SubscriptionId, PlanPriceId)\` windows (entity allows overlap today; orchestrator picks \`FirstOrDefault\`, validator deferred to CRUD PR)
- Currency cross-check (override.PlanPriceId.Currency vs Subscription.Currency) — entity allows any \`PlanPrice\` id today; validator deferred.

## Test plan

- [x] \`dotnet build src/Granit.Subscriptions*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.Subscriptions.Tests\` — 170 / 170
- [ ] CI green on all 6 shards (TBD post-push; depends on the #1201 namespace fix and the #1202 + #1203 stack)