### PR TITLE
feat(customer-balance): admin debit endpoint for manual drawdown

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10495,6 +10495,15 @@
       "members": []
     },
     {
+      "name": "AdminDebitRequest",
+      "fqn": "Granit.CustomerBalance.Endpoints.Dtos.AdminDebitRequest",
+      "kind": "record",
+      "project": "Granit.CustomerBalance.Endpoints",
+      "file": "src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "BalanceTransactionResponse",
       "fqn": "Granit.CustomerBalance.Endpoints.Dtos.BalanceTransactionResponse",
       "kind": "record",
@@ -10780,6 +10789,22 @@
           "name": "ApplyAsync",
           "kind": "method",
           "signature": "ApplyAsync(Guid tenantId, decimal amount, string currency, TransactionSource source, string reason, DateTimeOffset? expiresAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BalanceAccount>"
+        }
+      ]
+    },
+    {
+      "name": "IAdminDebitService",
+      "fqn": "Granit.CustomerBalance.IAdminDebitService",
+      "kind": "interface",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/IAdminDebitService.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DebitAsync",
+          "kind": "method",
+          "signature": "DebitAsync(Guid tenantId, decimal amount, string currency, string reason, Guid? referenceId = null, string? referenceType = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount>"
         }
       ]
@@ -40131,6 +40156,22 @@
       "members": []
     },
     {
+      "name": "PricingTier",
+      "fqn": "Granit.Subscriptions.Domain.PricingTier",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/PricingTier.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid planPriceId, int sortOrder, decimal? upToQuantity, decimal unitAmount, decimal? flatAmount = null)",
+          "returnType": "PricingTier"
+        }
+      ]
+    },
+    {
       "name": "Subscription",
       "fqn": "Granit.Subscriptions.Domain.Subscription",
       "kind": "class",
@@ -40279,6 +40320,15 @@
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/SubscriptionStatus.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "TieringMode",
+      "fqn": "Granit.Subscriptions.Domain.TieringMode",
+      "kind": "enum",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/TieringMode.cs",
+      "line": 7,
       "members": []
     },
     {
@@ -41539,6 +41589,22 @@
           "kind": "property",
           "signature": "NotificationSeverity DefaultSeverity",
           "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "TieredPricingCalculator",
+      "fqn": "Granit.Subscriptions.Pricing.TieredPricingCalculator",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Compute",
+          "kind": "method",
+          "signature": "Compute(decimal quantity, TieringMode mode, IReadOnlyList<PricingTier> tiers)",
+          "returnType": "decimal"
         }
       ]
     },

--- a/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
@@ -1,0 +1,21 @@
+namespace Granit.CustomerBalance.Endpoints.Dtos;
+
+/// <summary>
+/// Request to debit a tenant's <c>BalanceAccount</c> manually — admin tooling
+/// for corrections, scheduled drawdowns, and non-invoice adjustments.
+/// </summary>
+/// <param name="Amount">Amount to debit (must be > 0).</param>
+/// <param name="Currency">ISO 4217 currency code identifying the target balance account.</param>
+/// <param name="Reason">Free-text justification (audit trail; ≤ 500 chars; no PII per GDPR).</param>
+/// <param name="ReferenceId">
+/// Optional external document reference. When present, a previous debit with the
+/// same <c>(ReferenceId, Source = ManualAdjustment)</c> short-circuits the call —
+/// admin retries are safe.
+/// </param>
+/// <param name="ReferenceType">Type of the referenced document (e.g. <c>"AdminAdjustment"</c>).</param>
+public sealed record AdminDebitRequest(
+    decimal Amount,
+    string Currency,
+    string Reason,
+    Guid? ReferenceId = null,
+    string? ReferenceType = null);

--- a/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
@@ -62,6 +62,23 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
             .RequireAuthorization(CustomerBalancePermissions.Credits.Manage)
             .AllowHostAccess();
 
+        group.MapPost("/balance/debit", AdminDebitEndpoint.HandleAsync)
+            .WithName("ApplyAdminDebit")
+            .WithSummary("Debits the tenant's balance manually (admin tooling).")
+            .WithDescription(
+                "Creates a ManualAdjustment debit transaction on the tenant's balance account — "
+                + "for corrections, scheduled drawdowns, and non-invoice adjustments. "
+                + "Returns 404 when no account exists for the (tenant, currency); 422 when the balance "
+                + "is insufficient. Idempotent at the application level when the same ReferenceId is "
+                + "supplied — replays return the original outcome without double-debiting.")
+            .Produces<CustomerBalanceResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .RequireAuthorization(CustomerBalancePermissions.Credits.Manage)
+            .AllowHostAccess();
+
         return group;
     }
 }

--- a/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
@@ -1,0 +1,59 @@
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Endpoints.Dtos;
+using Granit.CustomerBalance.Exceptions;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Granit.CustomerBalance.Endpoints.Internal;
+
+internal static class AdminDebitEndpoint
+{
+    internal static async Task<Results<Ok<CustomerBalanceResponse>, ProblemHttpResult>> HandleAsync(
+        AdminDebitRequest request,
+        [FromServices] IAdminDebitService debitService,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        Guid tenantId = currentTenant.Id!.Value;
+        string currency = request.Currency.ToUpperInvariant();
+
+        try
+        {
+            BalanceAccount account = await debitService
+                .DebitAsync(
+                    tenantId,
+                    request.Amount,
+                    currency,
+                    request.Reason,
+                    request.ReferenceId,
+                    request.ReferenceType,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Ok(new CustomerBalanceResponse(
+                account.Id, account.Currency, account.Balance, account.ModifiedAt));
+        }
+        catch (InsufficientBalanceException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                title: "Granit:CustomerBalance:InsufficientBalance",
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // No account exists for the (tenant, currency) — distinct from insufficient balance.
+            return TypedResults.Problem(
+                detail: ex.Message,
+                title: "Granit:CustomerBalance:AccountNotFound",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+}

--- a/src/Granit.CustomerBalance.Endpoints/Validators/AdminDebitRequestValidator.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Validators/AdminDebitRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using Granit.CustomerBalance.Endpoints.Dtos;
+
+namespace Granit.CustomerBalance.Endpoints.Validators;
+
+internal sealed class AdminDebitRequestValidator : AbstractValidator<AdminDebitRequest>
+{
+    public AdminDebitRequestValidator()
+    {
+        RuleFor(x => x.Amount).GreaterThan(0);
+        RuleFor(x => x.Currency).NotEmpty().Length(3);
+        RuleFor(x => x.Reason).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.ReferenceType).MaximumLength(64).When(x => x.ReferenceType is not null);
+    }
+}

--- a/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class CustomerBalanceHostApplicationBuilderExtensions
         builder.Services.TryAddSingleton<CustomerBalanceMetrics>();
         builder.Services.TryAddTransient<ICreditExpirationService, DefaultCreditExpirationService>();
         builder.Services.TryAddTransient<IAdminCreditService, DefaultAdminCreditService>();
+        builder.Services.TryAddTransient<IAdminDebitService, DefaultAdminDebitService>();
         builder.Services.TryAddTransient<IOverpaymentCreditService, DefaultOverpaymentCreditService>();
 
         // Replace default pre-payment processor to deduct available credit before PSP charges.

--- a/src/Granit.CustomerBalance/IAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/IAdminDebitService.cs
@@ -1,0 +1,42 @@
+using Granit.CustomerBalance.Domain;
+
+namespace Granit.CustomerBalance;
+
+/// <summary>
+/// Admin-only debit on a tenant's <see cref="BalanceAccount"/>. Used for manual
+/// corrections, scheduled drawdowns, or non-invoice adjustments — operations that
+/// the standard <c>CustomerBalancePrePaymentProcessor</c> (invoice flow) cannot
+/// cover.
+/// </summary>
+/// <remarks>
+/// Idempotency: when <paramref name="referenceId"/> is supplied, a previous
+/// <see cref="BalanceTransaction"/> with the same <c>(ReferenceId, Source)</c>
+/// pair short-circuits the operation — replaying the same admin action returns
+/// the original outcome without double-debiting. The same pattern is used by
+/// <c>CustomerBalancePrePaymentProcessor</c>, so the dedup story is uniform.
+/// </remarks>
+public interface IAdminDebitService
+{
+    /// <summary>
+    /// Debits the supplied amount from the tenant's <see cref="BalanceAccount"/>
+    /// for the given currency.
+    /// </summary>
+    /// <param name="tenantId">Tenant whose balance account is debited.</param>
+    /// <param name="amount">Amount to debit (must be positive).</param>
+    /// <param name="currency">ISO 4217 currency code.</param>
+    /// <param name="reason">Human-readable description (audit trail).</param>
+    /// <param name="referenceId">Optional external document reference for idempotency.</param>
+    /// <param name="referenceType">Type of the referenced document (e.g. <c>"AdminAdjustment"</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated <see cref="BalanceAccount"/>.</returns>
+    /// <exception cref="System.InvalidOperationException">Thrown when no account exists for the tenant/currency.</exception>
+    /// <exception cref="Exceptions.InsufficientBalanceException">Thrown when the balance is insufficient.</exception>
+    Task<BalanceAccount> DebitAsync(
+        Guid tenantId,
+        decimal amount,
+        string currency,
+        string reason,
+        Guid? referenceId = null,
+        string? referenceType = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.Guids;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.CustomerBalance.Internal;
+
+/// <summary>Default implementation of <see cref="IAdminDebitService"/>.</summary>
+internal sealed partial class DefaultAdminDebitService(
+    IBalanceAccountReader accountReader,
+    IBalanceAccountWriter accountWriter,
+    IGuidGenerator guidGenerator,
+    IClock clock,
+    CustomerBalanceMetrics metrics,
+    ILogger<DefaultAdminDebitService> logger) : IAdminDebitService
+{
+    public async Task<BalanceAccount> DebitAsync(
+        Guid tenantId,
+        decimal amount,
+        string currency,
+        string reason,
+        Guid? referenceId = null,
+        string? referenceType = null,
+        CancellationToken cancellationToken = default)
+    {
+        using Activity? activity = CustomerBalanceActivitySource.Source
+            .StartActivity(CustomerBalanceActivitySource.DebitBalance);
+
+        BalanceAccount? account = await accountReader
+            .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"No balance account exists for tenant '{tenantId}' in currency '{currency}'.");
+
+        // Idempotency: if a previous ManualAdjustment debit with the same
+        // referenceId already landed, return the account unchanged. Mirrors the
+        // (ReferenceId, Source) lookup used by CustomerBalancePrePaymentProcessor.
+        if (referenceId is { } refId)
+        {
+            BalanceTransaction? existing = account.Transactions
+                .FirstOrDefault(t =>
+                    t.Type == TransactionType.Debit
+                    && t.Source == TransactionSource.ManualAdjustment
+                    && t.ReferenceId == refId);
+
+            if (existing is not null)
+            {
+                Log.IdempotentDebitSkipped(logger, refId, existing.Amount);
+                return account;
+            }
+        }
+
+        // Domain throws InsufficientBalanceException on under-balance; let it bubble.
+        account.Debit(
+            amount,
+            TransactionSource.ManualAdjustment,
+            reason,
+            clock.Now,
+            guidGenerator.Create(),
+            referenceId: referenceId,
+            referenceType: referenceType);
+
+        await accountWriter.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
+        metrics.RecordDebited(tenantId.ToString(), currency, TransactionSource.ManualAdjustment.ToString());
+        Log.AdminDebited(logger, amount, account.Balance);
+
+        return account;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Admin debit (ManualAdjustment) of {Amount} applied, new balance: {NewBalance}")]
+        public static partial void AdminDebited(ILogger logger, decimal amount, decimal newBalance);
+
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Admin debit skipped (idempotent) for reference {ReferenceId}, original amount: {Amount}")]
+        public static partial void IdempotentDebitSkipped(ILogger logger, Guid referenceId, decimal amount);
+    }
+}

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics.Metrics;
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Exceptions;
+using Granit.CustomerBalance.Internal;
+using Granit.Guids;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.CustomerBalance.Tests.Internal;
+
+public sealed class DefaultAdminDebitServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IBalanceAccountReader _accountReader = Substitute.For<IBalanceAccountReader>();
+    private readonly IBalanceAccountWriter _accountWriter = Substitute.For<IBalanceAccountWriter>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly Meter _meter = new("test");
+    private readonly CustomerBalanceMetrics _metrics;
+    private readonly DefaultAdminDebitService _sut;
+
+    public DefaultAdminDebitServiceTests()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(_meter);
+        _metrics = new CustomerBalanceMetrics(meterFactory);
+
+        _clock.Now.Returns(Now);
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+
+        _sut = new DefaultAdminDebitService(
+            _accountReader,
+            _accountWriter,
+            _guidGenerator,
+            _clock,
+            _metrics,
+            NullLogger<DefaultAdminDebitService>.Instance);
+    }
+
+    public void Dispose() => _meter.Dispose();
+
+    private BalanceAccount AccountWithBalance(Guid tenantId, string currency, decimal balance)
+    {
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, currency);
+        if (balance > 0m)
+        {
+            account.Credit(
+                balance, TransactionSource.ManualAdjustment, "seed",
+                Now.AddDays(-1), Guid.NewGuid());
+        }
+
+        _accountReader.GetByTenantAndCurrencyAsync(tenantId, currency, Arg.Any<CancellationToken>())
+            .Returns(account);
+        return account;
+    }
+
+    [Fact]
+    public async Task DebitAsync_HappyPath_ReducesBalanceAndPersists()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+
+        BalanceAccount result = await _sut.DebitAsync(
+            tenantId, 30m, "EUR", "Manual correction", referenceId: null, referenceType: null, ct);
+
+        result.Balance.ShouldBe(70m);
+        result.Transactions.Count.ShouldBe(2);   // seed credit + this debit
+        result.Transactions[^1].Type.ShouldBe(TransactionType.Debit);
+        result.Transactions[^1].Source.ShouldBe(TransactionSource.ManualAdjustment);
+        result.Transactions[^1].Reason.ShouldBe("Manual correction");
+        await _accountWriter.Received(1).UpdateAsync(account, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DebitAsync_NoAccount_Throws()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+            .Returns((BalanceAccount?)null);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            _sut.DebitAsync(tenantId, 10m, "EUR", "x", null, null, ct));
+
+        await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
+    }
+
+    [Fact]
+    public async Task DebitAsync_InsufficientBalance_ThrowsAndDoesNotWrite()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        AccountWithBalance(tenantId, "EUR", balance: 20m);
+
+        await Should.ThrowAsync<InsufficientBalanceException>(() =>
+            _sut.DebitAsync(tenantId, 50m, "EUR", "x", null, null, ct));
+
+        await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
+    }
+
+    [Fact]
+    public async Task DebitAsync_SameReferenceId_IsIdempotent_NoDoubleDebit()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        var refId = Guid.NewGuid();
+        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+
+        // First call: real debit
+        await _sut.DebitAsync(tenantId, 30m, "EUR", "first", referenceId: refId, "AdminAdjustment", ct);
+        account.Balance.ShouldBe(70m);
+
+        // Second call with the same refId: short-circuited, no second debit
+        BalanceAccount second = await _sut.DebitAsync(
+            tenantId, 30m, "EUR", "retry", referenceId: refId, "AdminAdjustment", ct);
+
+        second.Balance.ShouldBe(70m);                          // unchanged
+        account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(1);
+        await _accountWriter.Received(1).UpdateAsync(account, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DebitAsync_DifferentReferenceIds_AppliesEach()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+
+        await _sut.DebitAsync(tenantId, 20m, "EUR", "a", referenceId: Guid.NewGuid(), "x", ct);
+        await _sut.DebitAsync(tenantId, 30m, "EUR", "b", referenceId: Guid.NewGuid(), "x", ct);
+
+        account.Balance.ShouldBe(50m);
+        account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task DebitAsync_NullReferenceId_AlwaysAppliesEvenOnRepeat()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+
+        // No idempotency without referenceId — both debits land.
+        await _sut.DebitAsync(tenantId, 10m, "EUR", "first", null, null, ct);
+        await _sut.DebitAsync(tenantId, 10m, "EUR", "second", null, null, ct);
+
+        account.Balance.ShouldBe(80m);
+    }
+}


### PR DESCRIPTION
Closes #1176 (Phase 4 Story 1 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1160](https://github.com/granit-fx/granit-dotnet/issues/1160)).

Adds \`POST /api/granit/customer-balance/balance/debit\` so admins can perform corrections, scheduled drawdowns, and non-invoice adjustments — operations the standard \`CustomerBalancePrePaymentProcessor\` (invoice flow) cannot cover.

## What ships

**Domain abstraction** (\`Granit.CustomerBalance\`)
- \`IAdminDebitService.DebitAsync(tenantId, amount, currency, reason, referenceId?, referenceType?, ct)\`
- Idempotency contract: when \`referenceId\` is supplied, a previous debit with the same \`(ReferenceId, Source = ManualAdjustment)\` short-circuits the call. Same pattern as \`CustomerBalancePrePaymentProcessor\` — uniform dedup story.

**Implementation** (\`Internal.DefaultAdminDebitService\`)
- Loads the account; throws \`InvalidOperationException\` if missing (caller maps to **404**)
- Idempotency probe: returns the unchanged account if a previous matching debit exists
- Calls \`account.Debit(...)\` with \`TransactionSource.ManualAdjustment\` — bubbles \`InsufficientBalanceException\` for the caller to map to **422**
- Records \`granit.customer_balance.debited\` metric + structured log
- Registered \`TryAddTransient<IAdminDebitService, DefaultAdminDebitService>\`

**HTTP** (\`Granit.CustomerBalance.Endpoints\`)
- \`AdminDebitRequest\` DTO (\`Amount\`, \`Currency\`, \`Reason\`, \`ReferenceId?\`, \`ReferenceType?\`) + validator
- \`AdminDebitEndpoint\` maps:
  - happy path → 200 with \`CustomerBalanceResponse\`
  - insufficient balance → **422** with title \`Granit:CustomerBalance:InsufficientBalance\`
  - no account for (tenant, currency) → **404** with title \`Granit:CustomerBalance:AccountNotFound\`
- Permission: **reuses existing \`CustomerBalance.Credits.Manage\`** (decision per issue context — adding a separate \`Debits.Manage\` would split the admin permission surface unnecessarily; both credit and debit are revenue-impacting admin ops gated together for the same operator role).
- Mounted on the existing \`/api/granit/customer-balance\` group with \`AllowHostAccess()\`.

## Tests (+7)

- Happy path: balance reduces, transaction recorded, writer called once
- No account → throws (mapped to 404)
- Insufficient balance → throws (mapped to 422)
- Same \`referenceId\` twice → idempotent (only one debit, balance unchanged on retry)
- Different \`referenceId\` values → each applied independently
- Null \`referenceId\` → no idempotency (repeated calls each apply)
- **51 / 51** Granit.CustomerBalance.Tests pass

## Out of scope (deferred)

- Localization keys for the two ProblemDetails titles — current responses use title as a stable code (clients map by code, not display string); adding 18 culture entries is a docs/i18n PR.
- Separate \`Debits.Manage\` permission scope — not warranted today; can be split later if a consumer needs finer-grained role boundaries.

## Test plan

- [x] \`dotnet build src/Granit.CustomerBalance*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.CustomerBalance.Tests\` — 51 / 51
- [ ] CI green on all 6 shards (TBD post-push)