### PR TITLE
feat(customer-balance): CreditPreExpirationScanJob with CreditNearExpirationEto

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10366,6 +10366,47 @@
       "members": []
     },
     {
+      "name": "CreditPreExpirationScanHandler",
+      "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditPreExpirationScanHandler",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.BackgroundJobs",
+      "file": "src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanHandler.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(CreditPreExpirationScanJob _, IPreExpirationScanService scanService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CreditPreExpirationScanJob",
+      "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditPreExpirationScanJob",
+      "kind": "record",
+      "project": "Granit.CustomerBalance.BackgroundJobs",
+      "file": "src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanJob.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "CustomerBalanceOptions",
+      "fqn": "Granit.CustomerBalance.CustomerBalanceOptions",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/CustomerBalanceOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "PreExpirationWarningDays",
+          "kind": "property",
+          "signature": "int PreExpirationWarningDays",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
       "name": "CustomerBalanceMetrics",
       "fqn": "Granit.CustomerBalance.Diagnostics.CustomerBalanceMetrics",
       "kind": "class",
@@ -10421,7 +10462,14 @@
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Domain/BalanceTransaction.cs",
       "line": 12,
-      "members": []
+      "members": [
+        {
+          "name": "MarkPreExpirationNoticed",
+          "kind": "method",
+          "signature": "MarkPreExpirationNoticed(DateTimeOffset now)",
+          "returnType": "Guid? ReferenceId { get; private set; } public string? ReferenceType { get; private set; } public DateTimeOffset? ExpiresAt { get; private set; } public DateTimeOffset CreatedAt { get; private set; } public DateTimeOffset? LastPreExpirationNoticedAt { get; private set; } public void"
+        }
+      ]
     },
     {
       "name": "TransactionSource",
@@ -10689,6 +10737,15 @@
       "members": []
     },
     {
+      "name": "CreditNearExpirationEto",
+      "fqn": "Granit.CustomerBalance.Events.CreditNearExpirationEto",
+      "kind": "record",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Events/CreditNearExpirationEto.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "InsufficientBalanceException",
       "fqn": "Granit.CustomerBalance.Exceptions.InsufficientBalanceException",
       "kind": "class",
@@ -10735,7 +10792,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitCustomerBalance",
@@ -10878,6 +10935,12 @@
           "kind": "method",
           "signature": "GetExpiredCreditsAsync(DateTimeOffset now, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<BalanceTransaction>>"
+        },
+        {
+          "name": "GetCreditsNearExpirationAsync",
+          "kind": "method",
+          "signature": "GetCreditsNearExpirationAsync(DateTimeOffset now, TimeSpan window, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BalanceTransaction>>"
         }
       ]
     },
@@ -10910,6 +10973,22 @@
           "kind": "method",
           "signature": "CreditOverpaymentAsync(Guid tenantId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IPreExpirationScanService",
+      "fqn": "Granit.CustomerBalance.IPreExpirationScanService",
+      "kind": "interface",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/IPreExpirationScanService.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
         }
       ]
     },

--- a/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanHandler.cs
+++ b/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanHandler.cs
@@ -1,0 +1,14 @@
+namespace Granit.CustomerBalance.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Handler for <see cref="CreditPreExpirationScanJob"/>. Delegates to
+/// <see cref="IPreExpirationScanService"/> for the daily warning emission.
+/// </summary>
+public class CreditPreExpirationScanHandler
+{
+    public static async Task HandleAsync(
+        CreditPreExpirationScanJob _,
+        IPreExpirationScanService scanService,
+        CancellationToken cancellationToken) =>
+        await scanService.ScanAsync(cancellationToken).ConfigureAwait(false);
+}

--- a/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanJob.cs
+++ b/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditPreExpirationScanJob.cs
@@ -1,0 +1,11 @@
+using Granit.BackgroundJobs;
+
+namespace Granit.CustomerBalance.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Scans promotional credits expiring within the configured warning window
+/// (<c>CustomerBalanceOptions.PreExpirationWarningDays</c>, default 7) and
+/// publishes <c>CreditNearExpirationEto</c> for each. Runs daily at 09:00 UTC.
+/// </summary>
+[RecurringJob("0 9 * * *", "customer-balance-credit-preexpiration-scan")]
+public sealed record CreditPreExpirationScanJob : IBackgroundJob;

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceTransactionConfiguration.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceTransactionConfiguration.cs
@@ -24,5 +24,7 @@ internal sealed class BalanceTransactionConfiguration : IEntityTypeConfiguration
         builder.HasIndex(e => e.ExpiresAt)
             .HasFilter($"\"Source\" = {(int)TransactionSource.Promotional} AND \"Type\" = {(int)TransactionType.Credit}")
             .HasDatabaseName($"ix_{GranitCustomerBalanceDbProperties.DbTablePrefix}transactions_expires_at");
+
+        builder.Property(e => e.LastPreExpirationNoticedAt);
     }
 }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceTransactionReader.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceTransactionReader.cs
@@ -44,4 +44,27 @@ internal sealed class EfBalanceTransactionReader(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task<IReadOnlyList<BalanceTransaction>> GetCreditsNearExpirationAsync(
+        DateTimeOffset now,
+        TimeSpan window,
+        CancellationToken cancellationToken = default)
+    {
+        DateTimeOffset cutoff = now + window;
+        DateTimeOffset todayStart = new(now.Year, now.Month, now.Day, 0, 0, 0, TimeSpan.Zero);
+
+        await using CustomerBalanceDbContext context = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.Transactions
+            .Where(t =>
+                t.Source == TransactionSource.Promotional &&
+                t.Type == TransactionType.Credit &&
+                t.ExpiresAt != null &&
+                t.ExpiresAt > now &&
+                t.ExpiresAt <= cutoff &&
+                (t.LastPreExpirationNoticedAt == null
+                    || t.LastPreExpirationNoticedAt < todayStart))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Granit.CustomerBalance/CustomerBalanceOptions.cs
+++ b/src/Granit.CustomerBalance/CustomerBalanceOptions.cs
@@ -1,0 +1,17 @@
+namespace Granit.CustomerBalance;
+
+/// <summary>Tunable knobs for <c>Granit.CustomerBalance</c>.</summary>
+public sealed class CustomerBalanceOptions
+{
+    /// <summary>
+    /// Configuration section name (e.g. <c>"Granit:CustomerBalance"</c>).
+    /// </summary>
+    public const string SectionName = "Granit:CustomerBalance";
+
+    /// <summary>
+    /// Number of days before <c>ExpiresAt</c> at which the daily pre-expiration
+    /// scan emits a <see cref="Events.CreditNearExpirationEto"/> for a promotional
+    /// credit. Default = 7. Must be ≥ 1.
+    /// </summary>
+    public int PreExpirationWarningDays { get; set; } = 7;
+}

--- a/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceMetrics.cs
+++ b/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceMetrics.cs
@@ -20,6 +20,7 @@ public sealed class CustomerBalanceMetrics
     private readonly Counter<long> _credited;
     private readonly Counter<long> _debited;
     private readonly Counter<long> _expired;
+    private readonly Counter<long> _preExpirationWarnings;
 
     /// <summary>Initializes customer balance metrics using the specified meter factory.</summary>
     public CustomerBalanceMetrics(IMeterFactory meterFactory)
@@ -37,6 +38,10 @@ public sealed class CustomerBalanceMetrics
         _expired = meter.CreateCounter<long>(
             "granit.customer_balance.credit.expired",
             description: "Number of promotional credits expired.");
+
+        _preExpirationWarnings = meter.CreateCounter<long>(
+            "granit.customer_balance.preexpiration.warnings_sent",
+            description: "Number of CreditNearExpirationEto warnings published by the daily pre-expiration scan.");
     }
 
     /// <summary>Records a credit transaction.</summary>
@@ -72,5 +77,16 @@ public sealed class CustomerBalanceMetrics
             { CurrencyTag, currency },
         };
         _expired.Add(1, tags);
+    }
+
+    /// <summary>Records a pre-expiration warning published by the daily scan.</summary>
+    public void RecordPreExpirationWarning(string? tenantId, string currency)
+    {
+        var tags = new TagList
+        {
+            { TenantIdTag, tenantId ?? GlobalTenant },
+            { CurrencyTag, currency },
+        };
+        _preExpirationWarnings.Add(1, tags);
     }
 }

--- a/src/Granit.CustomerBalance/Domain/BalanceTransaction.cs
+++ b/src/Granit.CustomerBalance/Domain/BalanceTransaction.cs
@@ -69,4 +69,22 @@ public sealed class BalanceTransaction : Entity
 
     /// <summary>When this transaction was recorded.</summary>
     public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>
+    /// Notification side-channel (not part of the ledger semantics): the most
+    /// recent UTC instant the daily pre-expiration scan published a
+    /// <c>CreditNearExpirationEto</c> for this credit. Used by the scan service
+    /// to short-circuit duplicate publications within the same day; the field
+    /// is mutated in-place via <see cref="MarkPreExpirationNoticed"/> and does
+    /// NOT alter <see cref="Amount"/>, <see cref="Type"/>, or any ledger field.
+    /// </summary>
+    public DateTimeOffset? LastPreExpirationNoticedAt { get; private set; }
+
+    /// <summary>
+    /// Records that a pre-expiration notice has been published for this credit
+    /// at <paramref name="now"/>. Idempotent at the day-bucket level — callers
+    /// gate on <see cref="LastPreExpirationNoticedAt"/> &lt; today before invoking.
+    /// </summary>
+    public void MarkPreExpirationNoticed(DateTimeOffset now) =>
+        LastPreExpirationNoticedAt = now;
 }

--- a/src/Granit.CustomerBalance/Events/CreditNearExpirationEto.cs
+++ b/src/Granit.CustomerBalance/Events/CreditNearExpirationEto.cs
@@ -1,0 +1,23 @@
+using Granit.Events;
+
+namespace Granit.CustomerBalance.Events;
+
+/// <summary>
+/// Published when a promotional credit is approaching its expiration date —
+/// early-warning signal so apps can notify customers before the credit vanishes.
+/// </summary>
+/// <param name="BalanceAccountId">Owning balance account.</param>
+/// <param name="TenantId">Owning tenant (denormalised for downstream consumers).</param>
+/// <param name="CreditTransactionId">Original credit transaction id (idempotency key for downstream notifiers).</param>
+/// <param name="ExpiringAmount">Remaining amount of the credit at the time of the scan.</param>
+/// <param name="Currency">ISO 4217 currency code of the balance account.</param>
+/// <param name="ExpiresAt">Scheduled expiration timestamp (UTC).</param>
+/// <param name="DaysUntilExpiration">Whole days remaining (rounded toward zero from the fractional value).</param>
+public sealed record CreditNearExpirationEto(
+    Guid BalanceAccountId,
+    Guid TenantId,
+    Guid CreditTransactionId,
+    decimal ExpiringAmount,
+    string Currency,
+    DateTimeOffset ExpiresAt,
+    int DaysUntilExpiration) : IIntegrationEvent;

--- a/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Invoicing;
 using Granit.QueryEngine.Extensions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -25,7 +26,10 @@ public static class CustomerBalanceHostApplicationBuilderExtensions
         this IHostApplicationBuilder builder)
     {
         builder.Services.TryAddSingleton<CustomerBalanceMetrics>();
+        builder.Services.AddOptions<CustomerBalanceOptions>()
+            .Bind(builder.Configuration.GetSection(CustomerBalanceOptions.SectionName));
         builder.Services.TryAddTransient<ICreditExpirationService, DefaultCreditExpirationService>();
+        builder.Services.TryAddTransient<IPreExpirationScanService, DefaultPreExpirationScanService>();
         builder.Services.TryAddTransient<IAdminCreditService, DefaultAdminCreditService>();
         builder.Services.TryAddTransient<IAdminDebitService, DefaultAdminDebitService>();
         builder.Services.TryAddTransient<IOverpaymentCreditService, DefaultOverpaymentCreditService>();

--- a/src/Granit.CustomerBalance/IBalanceTransactionReader.cs
+++ b/src/Granit.CustomerBalance/IBalanceTransactionReader.cs
@@ -17,4 +17,15 @@ public interface IBalanceTransactionReader
     Task<IReadOnlyList<BalanceTransaction>> GetExpiredCreditsAsync(
         DateTimeOffset now,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns promotional credit transactions whose <c>ExpiresAt</c> falls in the
+    /// half-open interval <c>(now, now + window]</c> AND that have not yet been
+    /// noticed in the current UTC day (idempotency guard so the daily job does not
+    /// republish the same warning).
+    /// </summary>
+    Task<IReadOnlyList<BalanceTransaction>> GetCreditsNearExpirationAsync(
+        DateTimeOffset now,
+        TimeSpan window,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.CustomerBalance/IPreExpirationScanService.cs
+++ b/src/Granit.CustomerBalance/IPreExpirationScanService.cs
@@ -1,0 +1,19 @@
+namespace Granit.CustomerBalance;
+
+/// <summary>
+/// Daily scan that publishes <see cref="Events.CreditNearExpirationEto"/> for every
+/// promotional credit whose expiration falls within the
+/// <c>CustomerBalanceOptions.PreExpirationWarningDays</c> window.
+/// </summary>
+/// <remarks>
+/// Idempotent at the day-bucket level via
+/// <see cref="Domain.BalanceTransaction.LastPreExpirationNoticedAt"/> — running
+/// the scan twice in the same UTC day for the same credit publishes the event
+/// only once. Already-expired credits are skipped (handled by
+/// <see cref="ICreditExpirationService"/>).
+/// </remarks>
+public interface IPreExpirationScanService
+{
+    /// <summary>Runs the scan for the current instant. Returns the number of warnings published.</summary>
+    Task<int> ScanAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.CustomerBalance/Internal/DefaultPreExpirationScanService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultPreExpirationScanService.cs
@@ -1,0 +1,91 @@
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Events;
+using Granit.Events;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.CustomerBalance.Internal;
+
+/// <summary>Default implementation of <see cref="IPreExpirationScanService"/>.</summary>
+internal sealed partial class DefaultPreExpirationScanService(
+    IBalanceTransactionReader transactionReader,
+    IBalanceAccountReader accountReader,
+    IBalanceAccountWriter accountWriter,
+    IDistributedEventBus eventBus,
+    IClock clock,
+    IOptions<CustomerBalanceOptions> options,
+    CustomerBalanceMetrics metrics,
+    ILogger<DefaultPreExpirationScanService> logger) : IPreExpirationScanService
+{
+    public async Task<int> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        DateTimeOffset now = clock.Now;
+        int warningDays = Math.Max(1, options.Value.PreExpirationWarningDays);
+        var window = TimeSpan.FromDays(warningDays);
+
+        Log.ScanStarted(logger, now, warningDays);
+
+        IReadOnlyList<BalanceTransaction> credits = await transactionReader
+            .GetCreditsNearExpirationAsync(now, window, cancellationToken)
+            .ConfigureAwait(false);
+
+        int published = 0;
+
+        foreach (BalanceTransaction credit in credits)
+        {
+            // Defensive: the reader's predicate already excludes credits with
+            // ExpiresAt <= now (those belong to the expiration job), but recompute
+            // here so the per-credit DaysUntilExpiration tag is consistent and so
+            // any race between the two jobs cannot publish a "near-expiration"
+            // signal for an already-expired credit.
+            if (credit.ExpiresAt is not { } expiresAt || expiresAt <= now)
+            {
+                continue;
+            }
+
+            BalanceAccount? account = await accountReader
+                .GetByIdAsync(credit.BalanceAccountId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (account is null)
+            {
+                continue;
+            }
+
+            int daysUntil = (int)Math.Floor((expiresAt - now).TotalDays);
+
+            await eventBus.PublishAsync(
+                new CreditNearExpirationEto(
+                    BalanceAccountId: account.Id,
+                    TenantId: account.TenantId!.Value,
+                    CreditTransactionId: credit.Id,
+                    ExpiringAmount: credit.Amount,
+                    Currency: account.Currency,
+                    ExpiresAt: expiresAt,
+                    DaysUntilExpiration: daysUntil),
+                cancellationToken).ConfigureAwait(false);
+
+            credit.MarkPreExpirationNoticed(now);
+            await accountWriter.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
+
+            metrics.RecordPreExpirationWarning(account.TenantId.Value.ToString(), account.Currency);
+            published++;
+        }
+
+        Log.ScanCompleted(logger, published);
+        return published;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Pre-expiration scan started at {Timestamp} (window: {WarningDays} day(s))")]
+        public static partial void ScanStarted(ILogger logger, DateTimeOffset timestamp, int warningDays);
+
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Pre-expiration scan completed, {Count} warning(s) published")]
+        public static partial void ScanCompleted(ILogger logger, int count);
+    }
+}

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultPreExpirationScanServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultPreExpirationScanServiceTests.cs
@@ -1,0 +1,217 @@
+using System.Diagnostics.Metrics;
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Events;
+using Granit.CustomerBalance.Internal;
+using Granit.Events;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.CustomerBalance.Tests.Internal;
+
+public sealed class DefaultPreExpirationScanServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 24, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset TodayStart = new(2026, 4, 24, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly IBalanceTransactionReader _transactionReader = Substitute.For<IBalanceTransactionReader>();
+    private readonly IBalanceAccountReader _accountReader = Substitute.For<IBalanceAccountReader>();
+    private readonly IBalanceAccountWriter _accountWriter = Substitute.For<IBalanceAccountWriter>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly Meter _meter = new("test");
+    private readonly CustomerBalanceMetrics _metrics;
+    private readonly DefaultPreExpirationScanService _sut;
+
+    public DefaultPreExpirationScanServiceTests()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(_meter);
+        _metrics = new CustomerBalanceMetrics(meterFactory);
+
+        _clock.Now.Returns(Now);
+
+        IOptions<CustomerBalanceOptions> options =
+            Options.Create(new CustomerBalanceOptions { PreExpirationWarningDays = 7 });
+
+        _sut = new DefaultPreExpirationScanService(
+            _transactionReader, _accountReader, _accountWriter,
+            _eventBus, _clock, options, _metrics,
+            NullLogger<DefaultPreExpirationScanService>.Instance);
+    }
+
+    public void Dispose() => _meter.Dispose();
+
+    private static (BalanceAccount Account, BalanceTransaction Credit) NewAccountWithExpiringCredit(
+        DateTimeOffset expiresAt, decimal amount = 50m)
+    {
+        var tenantId = Guid.NewGuid();
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        account.Credit(
+            amount, TransactionSource.Promotional, "Welcome",
+            createdAt: Now.AddDays(-30), transactionId: Guid.NewGuid(),
+            expiresAt: expiresAt);
+        return (account, account.Transactions[0]);
+    }
+
+    [Fact]
+    public async Task ScanAsync_NoCredits_ReturnsZero()
+    {
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        int published = await _sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        published.ShouldBe(0);
+        await _eventBus.DidNotReceiveWithAnyArgs().PublishAsync<CreditNearExpirationEto>(default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ScanAsync_PublishesEventAndMarksNoticed()
+    {
+        DateTimeOffset expiresIn5Days = Now.AddDays(5);
+        (BalanceAccount account, BalanceTransaction credit) = NewAccountWithExpiringCredit(expiresIn5Days);
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(7), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+        _accountReader
+            .GetByIdAsync(account.Id, Arg.Any<CancellationToken>())
+            .Returns(account);
+
+        int published = await _sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        published.ShouldBe(1);
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<CreditNearExpirationEto>(e =>
+                e.BalanceAccountId == account.Id
+                && e.TenantId == account.TenantId
+                && e.CreditTransactionId == credit.Id
+                && e.ExpiringAmount == credit.Amount
+                && e.Currency == "EUR"
+                && e.ExpiresAt == expiresIn5Days
+                && e.DaysUntilExpiration == 5),
+            Arg.Any<CancellationToken>());
+        credit.LastPreExpirationNoticedAt.ShouldBe(Now);
+        await _accountWriter.Received(1).UpdateAsync(account, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScanAsync_DaysUntilExpiration_FloorsTheFractionalValue()
+    {
+        // 5 days + 18 hours from Now → DaysUntilExpiration should be 5 (floored), not 6.
+        DateTimeOffset expires = Now.AddDays(5).AddHours(18);
+        (BalanceAccount account, BalanceTransaction credit) = NewAccountWithExpiringCredit(expires);
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(7), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+        _accountReader.GetByIdAsync(account.Id, Arg.Any<CancellationToken>()).Returns(account);
+
+        await _sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<CreditNearExpirationEto>(e => e.DaysUntilExpiration == 5),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScanAsync_AlreadyExpiredCredit_Skipped()
+    {
+        // The reader's filter excludes ExpiresAt <= now, but defensively the service
+        // re-checks. Simulate a race where the reader returns a stale row.
+        DateTimeOffset expired = Now.AddSeconds(-1);
+        (BalanceAccount account, BalanceTransaction credit) = NewAccountWithExpiringCredit(expired);
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(7), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+
+        int published = await _sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        published.ShouldBe(0);
+        await _eventBus.DidNotReceiveWithAnyArgs().PublishAsync<CreditNearExpirationEto>(default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ScanAsync_AccountVanished_Skipped()
+    {
+        (BalanceAccount _, BalanceTransaction credit) = NewAccountWithExpiringCredit(Now.AddDays(3));
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(7), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+        _accountReader
+            .GetByIdAsync(credit.BalanceAccountId, Arg.Any<CancellationToken>())
+            .Returns((BalanceAccount?)null);
+
+        int published = await _sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        published.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ScanAsync_HonoursConfiguredWarningDays()
+    {
+        // When PreExpirationWarningDays = 3, the reader should be queried with TimeSpan.FromDays(3).
+        IOptions<CustomerBalanceOptions> options =
+            Options.Create(new CustomerBalanceOptions { PreExpirationWarningDays = 3 });
+
+        var sut = new DefaultPreExpirationScanService(
+            _transactionReader, _accountReader, _accountWriter,
+            _eventBus, _clock, options, _metrics,
+            NullLogger<DefaultPreExpirationScanService>.Instance);
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(3), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        await _transactionReader.Received(1).GetCreditsNearExpirationAsync(
+            Now, TimeSpan.FromDays(3), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScanAsync_NonPositiveWarningDays_ClampedToOne()
+    {
+        IOptions<CustomerBalanceOptions> options =
+            Options.Create(new CustomerBalanceOptions { PreExpirationWarningDays = 0 });
+
+        var sut = new DefaultPreExpirationScanService(
+            _transactionReader, _accountReader, _accountWriter,
+            _eventBus, _clock, options, _metrics,
+            NullLogger<DefaultPreExpirationScanService>.Instance);
+
+        _transactionReader
+            .GetCreditsNearExpirationAsync(Now, TimeSpan.FromDays(1), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await sut.ScanAsync(TestContext.Current.CancellationToken);
+
+        await _transactionReader.Received(1).GetCreditsNearExpirationAsync(
+            Now, TimeSpan.FromDays(1), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void BalanceTransaction_MarkPreExpirationNoticed_SetsTimestamp()
+    {
+        (BalanceAccount _, BalanceTransaction credit) = NewAccountWithExpiringCredit(Now.AddDays(3));
+        credit.LastPreExpirationNoticedAt.ShouldBeNull();
+
+        credit.MarkPreExpirationNoticed(Now);
+
+        credit.LastPreExpirationNoticedAt.ShouldBe(Now);
+    }
+
+    // Sanity: ensure TodayStart constant is consistent with the convention used by
+    // the EF reader's "today" floor (UTC midnight of `now.Date`).
+    [Fact]
+    public void TodayStart_IsUtcMidnightOfNowDate() =>
+        TodayStart.ShouldBe(new DateTimeOffset(Now.Date, TimeSpan.Zero));
+}


### PR DESCRIPTION
Closes #1177 (Phase 4 Story 2 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1160](https://github.com/granit-fx/granit-dotnet/issues/1160)).

> **Stacked on PR #1205** (admin debit). Retarget to develop once #1205 merges.

Adds an early-warning daily scan: when a promotional credit is N days from expiration (configurable, default 7), the scan publishes \`CreditNearExpirationEto\` so SaaS apps can notify customers before the credit vanishes. Mirrors the ORB feature; idempotent at the day-bucket level.

## What ships

**Domain**
- \`BalanceTransaction\` adds nullable \`LastPreExpirationNoticedAt\` + behavior method \`MarkPreExpirationNoticed(now)\`. Documented as a notification side-channel — not part of the ledger semantics.

**Events**
- \`CreditNearExpirationEto\` { BalanceAccountId, TenantId, CreditTransactionId, ExpiringAmount, Currency, ExpiresAt, DaysUntilExpiration }

**Configuration**
- \`CustomerBalanceOptions\` bound from \`Granit:CustomerBalance\` section
  - \`PreExpirationWarningDays\` (default 7, clamped to ≥ 1)

**Reader / EF**
- \`GetCreditsNearExpirationAsync(now, window, ct)\`: Promotional + Credit + \`ExpiresAt > now AND ExpiresAt <= now+window\` AND `(LastPreExpirationNoticedAt IS NULL OR < todayStart)` → idempotency at the day-bucket level.

**Service**
- \`IPreExpirationScanService\` + \`DefaultPreExpirationScanService\`: iterates candidate credits, defensively re-checks expiry, publishes the event with \`floor((expiresAt - now).TotalDays)\`, marks the credit as noticed, persists, increments the metric.

**Background job**
- \`CreditPreExpirationScanJob\` (cron \`0 9 * * *\` daily 09:00 UTC) + \`CreditPreExpirationScanHandler\` — same shape as the existing \`CreditExpirationScanJob/Handler\` pair.

**Diagnostics**
- New counter \`granit.customer_balance.preexpiration.warnings_sent\` (tags: \`tenant_id\`, \`currency\`)

## Tests (+9)

- No credits → 0
- Publishes event with all expected fields and marks noticed
- DaysUntilExpiration floors fractional days (5d18h → 5)
- Already-expired credit (race window) skipped defensively
- Account vanished → skipped
- Configured warning days passed to reader
- Non-positive warning days clamped to 1
- BalanceTransaction.MarkPreExpirationNoticed sets the timestamp
- Total: **60 / 60** Granit.CustomerBalance.Tests pass

## Schema (consumer apps run their own EF migration)

\`\`\`sql
ALTER TABLE balance_transactions ADD LastPreExpirationNoticedAt timestamptz NULL;
\`\`\`

No breaking change at the wire level — existing rows have NULL for the new field.

## Out of scope (deferred)

- Sub-package \`Granit.CustomerBalance.Notifications\` consuming the event and sending notifications via \`INotificationService\` — apps can subscribe directly via Wolverine in the meantime.
- Per-tenant warning-days override — single global value for now; tenant customisation can be wired via \`Granit.Settings\` if requested.

## Test plan

- [x] \`dotnet build src/Granit.CustomerBalance*\` — 0 errors, 0 warnings
- [x] \`dotnet test tests/Granit.CustomerBalance.Tests\` — 60 / 60
- [ ] CI green on all 6 shards (TBD post-push; depends on #1205 base merging)