### PR TITLE
feat(invoicing): typed source convention + ProductId on line items (ADR-036)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -21946,7 +21946,7 @@
       "kind": "record",
       "project": "Granit.Invoicing.Abstractions",
       "file": "src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs",
-      "line": 33,
+      "line": 44,
       "members": []
     },
     {
@@ -22178,7 +22178,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, string description, decimal quantity, decimal unitPrice, LineItemSource source, decimal? taxRate = null, BillingPeriod? period = null)",
+          "signature": "Create(Guid id, string description, decimal quantity, decimal unitPrice, LineItemSource source, decimal? taxRate = null, BillingPeriod? period = null, Guid? productId = null)",
           "returnType": "InvoiceLineItem"
         }
       ]
@@ -41368,7 +41368,7 @@
       "kind": "interface",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "CreateInvoiceAsync",

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -35,7 +35,6 @@ export default defineConfig({
   redirects: {
     // The Vault documentation was split into a dedicated `vault/` folder.
     // Preserve external and in-repo links that still point at the old URL.
-    "/dotnet/data/vault-encryption": "/dotnet/data/vault/",
     "/dotnet/data/vault-encryption/": "/dotnet/data/vault/",
     "/dotnet/data/vault-encryption/#key-rotation": "/dotnet/data/vault/encryption/",
 

--- a/docs-site/src/content/docs/dotnet/architecture/adr/036-invoicing-line-source-convention.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/036-invoicing-line-source-convention.md
@@ -1,0 +1,148 @@
+---
+title: "ADR-036: Invoicing line item source + product convention"
+description: "Formalize InvoiceLineItem.SourceType → SourceId as a typed audit chain (Guid for Usage/Subscription) and add an optional ProductId carried from MeterDefinition.ProductId / PlanPrice.ProductId so invoice lines stay attributable to a Granit.Catalog.Product across renames and price versioning."
+sidebar:
+  order: 36
+  label: "036 - Invoicing Line Source"
+---
+
+> **Date:** 2026-04-25
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Invoicing`, `Granit.Invoicing.Abstractions`,
+> `Granit.Invoicing.EntityFrameworkCore`, `Granit.Subscriptions`
+> (orchestrators), `Granit.Metering` (UsageSummaryReadyEto)
+
+## Context
+
+`Granit.Invoicing.InvoiceLineItem` already carried a `SourceType`
+(`Subscription` / `Usage` / `OneShot` / `Credit`) and an optional `SourceId`
+(`string?`). In practice the field had no formal contract:
+
+- The `Subscription` orchestrators stored the **subscription id** as a Guid
+  string when generating recurring lines, but nothing prevented a future
+  caller from putting a plan price id, an external Stripe id, or free text.
+- The `Usage` lines emitted by `DefaultUsageInvoiceOrchestrator` stored the
+  **meter definition id** — again as a Guid string by convention only.
+- One-shot e-commerce purchases and manual credit lines were free-form by
+  design (SKU codes, refund references, etc.).
+
+Two consequences:
+
+1. **Audit chain was broken in practice.** ADR-032 declared the
+   `event → metric → product → invoice line` chain as a goal, but with no
+   typed contract on `(SourceType, SourceId)` the only way to verify the
+   chain in a SQL query was to assume the convention held and pray. ISO
+   27001 A.12.4 (logging and monitoring) wants this kind of traceability
+   to be enforced, not implied.
+2. **Product attribution was lost across renames.** When a meter was
+   renamed (`apicall_count` → `compute_units`) or a `PlanPrice` was
+   replaced by a newer version, the historical invoice lines kept their
+   stale `Description` text. There was no stable identifier on the line
+   pointing back to "the thing that was sold" — exactly the gap that
+   `Granit.Catalog.Product` was created to close (ADR-032).
+
+Phase 5 of EPIC #1155 (ORB-alignment) calls for closing both gaps in a
+single small change: a typed convention on `(SourceType, SourceId)` and a
+soft propagation of `ProductId` from the upstream entity.
+
+## Decision
+
+### 1. Typed convention on `(SourceType, SourceId)`
+
+`SourceId` is no longer free-form for the two billing source types. The
+factory `InvoiceLineItem.Create` enforces the contract at the entity
+boundary:
+
+| `SourceType` | `SourceId` contract |
+| ------------ | ------------------- |
+| `Usage` | **Required**. MUST be `MeterDefinition.Id` as a Guid string. |
+| `Subscription` | **Required**. MUST be `Subscription.Id` (or `PlanPrice.Id`) as a Guid string. |
+| `OneShot` | **Free-form**. May be a SKU, an external id, or `null`. |
+| `Credit` | **Free-form**. May be a refund reference, a credit memo number, or `null`. |
+
+Failures throw `ArgumentException` synchronously — there is no in-flight
+validation framework hop. `OneShot` and `Credit` stay free-form because
+they cover heterogeneous data sources (e-commerce SKUs, manual
+adjustments, third-party refund ids) where requiring a Guid would be
+incorrect.
+
+### 2. Optional `ProductId` on the line item
+
+`InvoiceLineItem.ProductId` (`Guid?`) is added as a **soft** reference to
+`Granit.Catalog.Product`. The same soft-reference rules from ADR-032
+apply: no SQL FK, no cross-module DbContext join, no integrity
+enforcement at the EF layer. A non-clustered index supports
+"show me all invoice lines for product X" reporting queries.
+
+The orchestrators populate the field when they have it:
+
+- `DefaultUsageInvoiceOrchestrator` reads it from the `UsageSummaryReadyEto`,
+  which the metering-side `BillingCycleUsagePublisher` populates from
+  `MeterDefinition.ProductId`.
+- `DefaultBillingCycleInvoiceOrchestrator` resolves it from the active
+  `PlanPrice` for the subscription's `(currency, interval)` slot — or
+  from the override price pinned by an active `SubscriptionPhase` when
+  one applies.
+
+When the upstream entity has no `ProductId` (no `Granit.Catalog`
+installation, or a meter / price not yet linked to a product), the field
+stays `null`. The change is fully additive.
+
+### 3. `UsageSummaryReadyEto` carries `MeterProductId`
+
+The contract change to the integration event is additive (new optional
+property, defaults to `null`). Existing publishers that don't know about
+`Granit.Catalog` continue to publish events without it; existing
+subscribers that don't read it continue to work unchanged.
+
+## Consequences
+
+### Positive
+
+- **Audit chain is enforceable in SQL.** A reviewer can write
+  `SELECT * FROM invoice_line_items WHERE source_type = 'Usage' AND source_id = '<meter_id>'`
+  and trust that every matching row genuinely came from that meter — the
+  factory rejects deviations.
+- **Stable product attribution.** Renaming a meter or replacing a plan
+  price no longer orphans historical invoice lines; the `ProductId`
+  column points to a `Granit.Catalog.Product` whose own lifecycle
+  (Draft / Published / Archived) is independent.
+- **Cross-cutting reporting.** "Revenue per product across subscriptions
+  and usage" becomes a single `GROUP BY product_id` — previously
+  impossible without joining stale name strings.
+- **Index-supported lookups.** The non-clustered index on `ProductId`
+  makes per-product invoice-line queries efficient even on multi-tenant
+  databases.
+
+### Negative
+
+- **A small breaking change at the entity boundary** for callers that
+  passed a non-Guid `SourceId` for `Usage` / `Subscription`. The
+  framework's own orchestrators always passed Guids, so this is a
+  formalization rather than a behavioral break — but downstream apps
+  with custom orchestrators that violated the convention will now fail
+  fast at construction. This is intentional: failing fast at the
+  factory is preferable to silently storing untraceable lines.
+- **The new optional field on `UsageSummaryReadyEto`** widens the public
+  contract of `Granit.Metering.Abstractions`. Wolverine's serializer
+  handles the additional nullable property transparently in both
+  directions; the change is wire-compatible with older versions of the
+  consumer / publisher.
+
+### Non-goals
+
+- **No FK enforcement on `ProductId`**. Cross-module FKs are explicitly
+  rejected by ADR-032; the catalog deletion safety check stays in the
+  application layer.
+- **No retroactive backfill**. Historical invoice lines created before
+  this change keep `ProductId = NULL`. A backfill migration is left to
+  consuming applications that want it.
+- **No tightening of `OneShot` / `Credit`**. Both stay free-form. Any
+  future tightening would belong in a separate ADR with concrete use
+  cases on the table.
+
+## References
+
+- ADR-032 — Granit.Catalog with Product as the shared billing aggregate
+- EPIC #1155 — ORB-alignment program (Phase 5)
+- ISO 27001 A.12.4 — Logging and monitoring

--- a/docs-site/src/content/docs/dotnet/saas/invoicing.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/invoicing.mdx
@@ -117,6 +117,31 @@ public enum InvoiceSourceType
 This makes Invoicing agnostic — future `Granit.Commerce` can create invoices
 with `OneShot` line items using the exact same infrastructure.
 
+### Source convention (ADR-036)
+
+`Subscription` and `Usage` lines MUST carry a Guid `SourceId` referencing the
+originating entity:
+
+| `SourceType` | `SourceId` |
+| ------------ | ---------- |
+| `Subscription` | `Subscription.Id` (or `PlanPrice.Id`) |
+| `Usage` | `MeterDefinition.Id` |
+| `OneShot` | Free-form (SKU, external id, or `null`) |
+| `Credit` | Free-form (refund reference, credit memo, or `null`) |
+
+`InvoiceLineItem.Create` rejects non-Guid `SourceId` for the two billing
+source types — the audit chain `event → metric → product → invoice line` is
+SQL-queryable by construction.
+
+### `ProductId` propagation
+
+`InvoiceLineItem.ProductId` (`Guid?`) is a soft reference to a
+`Granit.Catalog.Product`. The `Subscriptions` orchestrators populate it from
+`PlanPrice.ProductId` (Subscription line) or from `MeterDefinition.ProductId`
+forwarded via `UsageSummaryReadyEto.MeterProductId` (Usage line). The field
+survives meter / price renames and replacements, keeping invoice lines
+attributable to a stable catalog item for cross-cutting reporting.
+
 ## Provider abstractions
 
 | Interface | Purpose | Phase |

--- a/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
+++ b/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
@@ -29,10 +29,22 @@ public sealed record CreateInvoiceCommand(
 /// <param name="Quantity">Quantity.</param>
 /// <param name="UnitPrice">Price per unit.</param>
 /// <param name="SourceType">Origin (Subscription, Usage, OneShot, Credit).</param>
-/// <param name="SourceId">Optional source entity identifier.</param>
+/// <param name="SourceId">
+///   Source entity identifier. Convention (see ADR-036): when <see cref="SourceType"/> is
+///   <see cref="InvoiceSourceType.Usage"/>, this MUST be the <c>MeterDefinition.Id</c> as a Guid string;
+///   when <see cref="SourceType"/> is <see cref="InvoiceSourceType.Subscription"/>, this MUST be the
+///   <c>Subscription.Id</c> (or <c>PlanPrice.Id</c>) as a Guid string. <see cref="InvoiceSourceType.OneShot"/>
+///   and <see cref="InvoiceSourceType.Credit"/> are free-form.
+/// </param>
+/// <param name="ProductId">
+///   Optional <c>Granit.Catalog.Product</c> identifier. Should be propagated from the upstream entity's
+///   <c>ProductId</c> (e.g. <c>MeterDefinition.ProductId</c>, <c>PlanPrice.ProductId</c>) so that the
+///   invoice line carries a stable label across renames of the underlying source.
+/// </param>
 public sealed record CreateInvoiceLineItem(
     string Description,
     decimal Quantity,
     decimal UnitPrice,
     InvoiceSourceType SourceType,
-    string? SourceId = null);
+    string? SourceId = null,
+    Guid? ProductId = null);

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/InvoiceLineItemConfiguration.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/InvoiceLineItemConfiguration.cs
@@ -18,5 +18,7 @@ internal sealed class InvoiceLineItemConfiguration : IEntityTypeConfiguration<In
         builder.Property(e => e.TaxAmount).HasPrecision(18, 4).IsRequired();
         builder.Property(e => e.SourceType).IsRequired();
         builder.Property(e => e.SourceId).HasMaxLength(256);
+        builder.Property(e => e.ProductId);
+        builder.HasIndex(e => e.ProductId);
     }
 }

--- a/src/Granit.Invoicing/Domain/InvoiceLineItem.cs
+++ b/src/Granit.Invoicing/Domain/InvoiceLineItem.cs
@@ -16,16 +16,41 @@ public sealed class InvoiceLineItem : Entity
     /// <param name="source">Origin of this line item (subscription, metering, one-shot).</param>
     /// <param name="taxRate">Tax rate as a decimal fraction (e.g., 0.21 for 21%). Null if untaxed.</param>
     /// <param name="period">Billing period this line item covers.</param>
+    /// <param name="productId">Optional <c>Granit.Catalog.Product</c> identifier — stable label across renames of the underlying meter or plan price.</param>
     public static InvoiceLineItem Create(
         Guid id, string description, decimal quantity, decimal unitPrice,
         LineItemSource source,
         decimal? taxRate = null,
-        BillingPeriod? period = null)
+        BillingPeriod? period = null,
+        Guid? productId = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(description);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(quantity);
         ArgumentOutOfRangeException.ThrowIfNegative(unitPrice);
         ArgumentNullException.ThrowIfNull(source);
+
+        // ADR-036: Usage / Subscription line items MUST carry a Guid SourceId pointing to
+        // the originating MeterDefinition / Subscription (or PlanPrice) respectively.
+        // OneShot / Credit lines remain free-form (e-commerce SKUs, manual adjustments).
+        if (source.Type is InvoiceSourceType.Usage or InvoiceSourceType.Subscription)
+        {
+            if (string.IsNullOrWhiteSpace(source.Id))
+            {
+                throw new ArgumentException(
+                    $"Invoice line items with SourceType '{source.Type}' must carry a non-empty SourceId " +
+                    $"(see ADR-036).",
+                    nameof(source));
+            }
+
+            if (!Guid.TryParse(source.Id, out _))
+            {
+                throw new ArgumentException(
+                    $"Invoice line items with SourceType '{source.Type}' must carry a Guid SourceId. " +
+                    $"Got '{source.Id}' (see ADR-036).",
+                    nameof(source));
+            }
+        }
+
         decimal amount = quantity * unitPrice;
         decimal taxAmount = taxRate.HasValue ? amount * taxRate.Value : 0;
 
@@ -42,6 +67,7 @@ public sealed class InvoiceLineItem : Entity
             SourceId = source.Id,
             PeriodStart = period?.Start,
             PeriodEnd = period?.End,
+            ProductId = productId,
         };
     }
 
@@ -74,4 +100,12 @@ public sealed class InvoiceLineItem : Entity
 
     /// <summary>Billing period end covered by this line item.</summary>
     public DateTimeOffset? PeriodEnd { get; private set; }
+
+    /// <summary>
+    /// Optional <c>Granit.Catalog.Product</c> identifier propagated from
+    /// <c>MeterDefinition.ProductId</c> (Usage source) or <c>PlanPrice.ProductId</c> (Subscription source).
+    /// Provides a stable, human-friendly label that survives renames of the underlying meter or plan price
+    /// (audit-friendly). No SQL FK — cross-module reference; integrity is best-effort by convention.
+    /// </summary>
+    public Guid? ProductId { get; private set; }
 }

--- a/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
+++ b/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
@@ -36,7 +36,8 @@ internal sealed partial class DefaultInvoiceCreationService(
                 lineItem.Description,
                 lineItem.Quantity,
                 lineItem.UnitPrice,
-                new LineItemSource(lineItem.SourceType, lineItem.SourceId)));
+                new LineItemSource(lineItem.SourceType, lineItem.SourceId),
+                productId: lineItem.ProductId));
         }
 
         if (taxCalculator is not null && invoice.BillingAddress is not null)

--- a/src/Granit.Metering.Abstractions/Events/UsageSummaryReadyEto.cs
+++ b/src/Granit.Metering.Abstractions/Events/UsageSummaryReadyEto.cs
@@ -14,4 +14,5 @@ public sealed record UsageSummaryReadyEto(
     decimal AggregatedValue,
     long EventCount,
     DateTimeOffset PeriodStart,
-    DateTimeOffset PeriodEnd) : IIntegrationEvent;
+    DateTimeOffset PeriodEnd,
+    Guid? MeterProductId = null) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Handlers/BillingCycleUsagePublisher.cs
+++ b/src/Granit.Subscriptions/Handlers/BillingCycleUsagePublisher.cs
@@ -52,7 +52,8 @@ public class BillingCycleUsagePublisher
                         aggregate.AggregatedValue,
                         aggregate.EventCount,
                         eto.PeriodStart,
-                        eto.PeriodEnd),
+                        eto.PeriodEnd,
+                        MeterProductId: meter.ProductId),
                     cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Granit.Subscriptions/Handlers/UsageSummaryReadyHandler.cs
+++ b/src/Granit.Subscriptions/Handlers/UsageSummaryReadyHandler.cs
@@ -19,7 +19,8 @@ public class UsageSummaryReadyHandler
         {
             var request = new CreateUsageInvoiceRequest(
                 eto.TenantId, eto.MeterDefinitionId, eto.MeterName,
-                eto.AggregatedValue, eto.Unit, eto.PeriodStart, eto.PeriodEnd);
+                eto.AggregatedValue, eto.Unit, eto.PeriodStart, eto.PeriodEnd,
+                MeterProductId: eto.MeterProductId);
 
             await orchestrator.CreateInvoiceAsync(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs
@@ -10,7 +10,8 @@ public sealed record CreateUsageInvoiceRequest(
     decimal AggregatedValue,
     string Unit,
     DateTimeOffset PeriodStart,
-    DateTimeOffset PeriodEnd);
+    DateTimeOffset PeriodEnd,
+    Guid? MeterProductId = null);
 
 /// <summary>
 /// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -93,6 +93,16 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
 
         var lineItems = new List<CreateInvoiceLineItem>();
 
+        // ADR-036: ProductId tracks the resolved PlanPrice (current price for the
+        // (currency, interval) slot). If a SubscriptionPhase pinned an OverridePriceId
+        // pointing to a different PlanPrice, prefer that one — overrides may carry
+        // their own ProductId for a renamed/refactored catalog item.
+        Guid? subscriptionProductId =
+            (effectivePlanPriceId is { } pinnedId
+                ? plan.Prices.FirstOrDefault(p => p.Id == pinnedId)
+                : plan.GetCurrentPrice(subscription.Currency, plan.DefaultInterval))
+                ?.ProductId;
+
         if (plan.PricingModel == PricingModel.PerSeat)
         {
             int seatCount = subscription.Seats.Count;
@@ -100,7 +110,8 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
                 $"{plan.Name} — {seatCount} seat(s)",
                 seatCount, basePrice,
                 InvoiceSourceType.Subscription,
-                subscriptionId.ToString()));
+                subscriptionId.ToString(),
+                ProductId: subscriptionProductId));
         }
         else
         {
@@ -108,7 +119,8 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
                 $"{plan.Name} — {plan.DefaultInterval}",
                 1, basePrice,
                 InvoiceSourceType.Subscription,
-                subscriptionId.ToString()));
+                subscriptionId.ToString(),
+                ProductId: subscriptionProductId));
         }
 
         var command = new CreateInvoiceCommand(

--- a/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
@@ -60,13 +60,22 @@ internal sealed partial class DefaultUsageInvoiceOrchestrator(
             subscription.PlanPriceId, cancellationToken)
             .ConfigureAwait(false);
 
+        // ADR-036: ProductId on the Subscription line is taken from the resolved
+        // PlanPrice (current price for the (currency, interval) slot) — survives
+        // price versioning, since the PlanPrice carries its own ProductId across
+        // versions. PlanPriceId-pinned subscriptions resolve through the same path.
+        Guid? subscriptionProductId = plan
+            .GetCurrentPrice(subscription.Currency, plan.DefaultInterval)
+            ?.ProductId;
+
         if (basePrice > 0)
         {
             lineItems.Add(new CreateInvoiceLineItem(
                 $"{plan.Name} — {plan.DefaultInterval}",
                 1, basePrice,
                 InvoiceSourceType.Subscription,
-                subscription.Id.ToString()));
+                subscription.Id.ToString(),
+                ProductId: subscriptionProductId));
         }
 
         // Tier-aware total: when the resolved PlanPrice carries Tiers + a TieringMode,
@@ -89,7 +98,8 @@ internal sealed partial class DefaultUsageInvoiceOrchestrator(
             $"{request.MeterName}: {request.AggregatedValue} {request.Unit}",
             request.AggregatedValue, effectiveUnitPrice,
             InvoiceSourceType.Usage,
-            request.MeterDefinitionId.ToString()));
+            request.MeterDefinitionId.ToString(),
+            ProductId: request.MeterProductId));
 
         var command = new CreateInvoiceCommand(
             TenantId: request.TenantId,

--- a/tests/Granit.ArchitectureTests/InvoiceLineItemSourceConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/InvoiceLineItemSourceConventionTests.cs
@@ -1,0 +1,122 @@
+using Granit.Invoicing.Domain;
+using Granit.Invoicing.Domain.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// ADR-036 — Invoicing line item source convention.
+///
+/// <para>
+/// Lines whose <see cref="InvoiceSourceType"/> is <see cref="InvoiceSourceType.Usage"/> or
+/// <see cref="InvoiceSourceType.Subscription"/> MUST carry a Guid <c>SourceId</c>. The Guid
+/// references the originating <c>MeterDefinition.Id</c> (Usage) or
+/// <c>Subscription.Id</c> / <c>PlanPrice.Id</c> (Subscription) — making invoices traceable
+/// back to the entity that produced the charge for audit (ISO 27001 A.12.4) and reconciliation.
+/// </para>
+///
+/// <para>
+/// <see cref="InvoiceSourceType.OneShot"/> and <see cref="InvoiceSourceType.Credit"/> remain
+/// free-form: they cover e-commerce SKUs, manual adjustments, and refunds where the source
+/// identifier may be a string code rather than a Guid (or absent altogether).
+/// </para>
+///
+/// <para>
+/// The invariant is enforced at the entity boundary in <see cref="InvoiceLineItem.Create"/>;
+/// these tests document the contract and guard against accidental relaxation.
+/// </para>
+/// </summary>
+public sealed class InvoiceLineItemSourceConventionTests
+{
+    [Theory]
+    [InlineData(InvoiceSourceType.Usage)]
+    [InlineData(InvoiceSourceType.Subscription)]
+    public void Usage_and_Subscription_lines_MUST_carry_a_SourceId(InvoiceSourceType sourceType)
+    {
+        Should.Throw<ArgumentException>(() => InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(sourceType)));
+    }
+
+    [Theory]
+    [InlineData(InvoiceSourceType.Usage)]
+    [InlineData(InvoiceSourceType.Subscription)]
+    public void Usage_and_Subscription_lines_MUST_carry_a_Guid_SourceId(InvoiceSourceType sourceType)
+    {
+        Should.Throw<ArgumentException>(() => InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(sourceType, "not-a-guid")));
+    }
+
+    [Theory]
+    [InlineData(InvoiceSourceType.Usage)]
+    [InlineData(InvoiceSourceType.Subscription)]
+    public void Usage_and_Subscription_lines_accept_a_Guid_SourceId(InvoiceSourceType sourceType)
+    {
+        var sourceId = Guid.NewGuid();
+
+        var lineItem = InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(sourceType, sourceId.ToString()));
+
+        lineItem.SourceType.ShouldBe(sourceType);
+        lineItem.SourceId.ShouldBe(sourceId.ToString());
+    }
+
+    [Theory]
+    [InlineData(InvoiceSourceType.OneShot)]
+    [InlineData(InvoiceSourceType.Credit)]
+    public void OneShot_and_Credit_lines_remain_free_form(InvoiceSourceType sourceType)
+    {
+        var lineItemNullId = InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(sourceType));
+
+        var lineItemFreeForm = InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(sourceType, "SKU-123"));
+
+        lineItemNullId.SourceId.ShouldBeNull();
+        lineItemFreeForm.SourceId.ShouldBe("SKU-123");
+    }
+
+    [Fact]
+    public void ProductId_is_optional_and_propagates_when_provided()
+    {
+        var productId = Guid.NewGuid();
+
+        var withProduct = InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(InvoiceSourceType.Usage, Guid.NewGuid().ToString()),
+            productId: productId);
+
+        var withoutProduct = InvoiceLineItem.Create(
+            id: Guid.NewGuid(),
+            description: "Test",
+            quantity: 1m,
+            unitPrice: 10m,
+            source: new LineItemSource(InvoiceSourceType.OneShot, "SKU-9"));
+
+        withProduct.ProductId.ShouldBe(productId);
+        withoutProduct.ProductId.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
@@ -54,7 +54,7 @@ public sealed class DefaultOverdueInvoiceDetectionServiceTests
 
         invoice.AddLineItem(InvoiceLineItem.Create(
             Guid.NewGuid(), "Test item", 1m, 100m,
-            new Domain.ValueObjects.LineItemSource(InvoiceSourceType.Subscription, "sub_1")));
+            new Domain.ValueObjects.LineItemSource(InvoiceSourceType.Subscription, Guid.NewGuid().ToString())));
 
         invoice.Finalize("INV-001", Now.AddDays(-35), dueAt: Now.AddDays(-5));
         return invoice;

--- a/tests/Granit.Invoicing.Tests/Domain/InvoiceLineItemTests.cs
+++ b/tests/Granit.Invoicing.Tests/Domain/InvoiceLineItemTests.cs
@@ -26,7 +26,7 @@ public sealed class InvoiceLineItemTests
     {
         var lineItem = InvoiceLineItem.Create(
             Guid.NewGuid(), "Pro Plan", 1, 100.00m,
-            new LineItemSource(InvoiceSourceType.Subscription),
+            new LineItemSource(InvoiceSourceType.Subscription, Guid.NewGuid().ToString()),
             taxRate: 0.21m);
 
         lineItem.TaxRate.ShouldBe(0.21m);
@@ -53,7 +53,7 @@ public sealed class InvoiceLineItemTests
 
         var lineItem = InvoiceLineItem.Create(
             Guid.NewGuid(), "Monthly sub", 1, 29.99m,
-            new LineItemSource(InvoiceSourceType.Subscription),
+            new LineItemSource(InvoiceSourceType.Subscription, Guid.NewGuid().ToString()),
             period: new BillingPeriod(start, end));
 
         lineItem.PeriodStart.ShouldBe(start);
@@ -63,12 +63,13 @@ public sealed class InvoiceLineItemTests
     [Fact]
     public void Create_ShouldSetSourceFields()
     {
+        var meterId = Guid.NewGuid();
         var lineItem = InvoiceLineItem.Create(
             Guid.NewGuid(), "Usage charges", 150, 0.05m,
-            new LineItemSource(InvoiceSourceType.Usage, "meter_abc"));
+            new LineItemSource(InvoiceSourceType.Usage, meterId.ToString()));
 
         lineItem.SourceType.ShouldBe(InvoiceSourceType.Usage);
-        lineItem.SourceId.ShouldBe("meter_abc");
+        lineItem.SourceId.ShouldBe(meterId.ToString());
     }
 
     [Fact]
@@ -124,7 +125,7 @@ public sealed class InvoiceLineItemTests
     {
         var lineItem = InvoiceLineItem.Create(
             Guid.NewGuid(), "Free trial", 1, 0m,
-            new LineItemSource(InvoiceSourceType.Subscription));
+            new LineItemSource(InvoiceSourceType.Subscription, Guid.NewGuid().ToString()));
 
         lineItem.Amount.ShouldBe(0m);
         lineItem.UnitPrice.ShouldBe(0m);

--- a/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
+++ b/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
@@ -58,7 +58,7 @@ public sealed class DefaultInvoiceCreationServiceTests
                     Quantity: 1m,
                     UnitPrice: 50m,
                     InvoiceSourceType.Subscription,
-                    $"sub_{i}"))
+                    Guid.NewGuid().ToString()))
                 .ToList(),
             periodStart,
             periodEnd);

--- a/tests/Granit.Invoicing.Tests/InvoiceTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceTests.cs
@@ -19,7 +19,7 @@ public sealed class InvoiceTests
 
         invoice.AddLineItem(InvoiceLineItem.Create(
             Guid.NewGuid(), "Pro Plan - Monthly", 1, 29.99m,
-            new LineItemSource(InvoiceSourceType.Subscription)));
+            new LineItemSource(InvoiceSourceType.Subscription, Guid.NewGuid().ToString())));
 
         return invoice;
     }


### PR DESCRIPTION
## Summary

Phase 5 of the ORB-alignment program (EPIC #1155). Closes #1161.

Two related changes that together close the audit-chain gap left after ADR-032
(`Granit.Catalog.Product` as the shared billing aggregate):

### 1. Typed convention on `(SourceType, SourceId)`

`InvoiceLineItem.Create` now enforces:

| `SourceType` | `SourceId` contract |
| ------------ | ------------------- |
| `Usage` | **Required**, parseable Guid (= `MeterDefinition.Id`) |
| `Subscription` | **Required**, parseable Guid (= `Subscription.Id` / `PlanPrice.Id`) |
| `OneShot` | Free-form (SKU, external id, or `null`) |
| `Credit` | Free-form (refund reference, credit memo, or `null`) |

Throws `ArgumentException` synchronously when a non-Guid `SourceId` is passed
for `Usage` / `Subscription`. Failing fast at the entity boundary keeps
untraceable lines out of the ledger and makes the audit chain
`event → metric → product → invoice line` SQL-queryable.

### 2. Optional `ProductId` on `InvoiceLineItem`

Soft reference (no SQL FK, ADR-032 rule). Both orchestrators populate it:

- `DefaultUsageInvoiceOrchestrator` ← `UsageSummaryReadyEto.MeterProductId`
  (added as an optional field; `BillingCycleUsagePublisher` fills it from
  `MeterDefinition.ProductId`)
- `DefaultBillingCycleInvoiceOrchestrator` ← `PlanPrice.ProductId`, preferring
  the override price pinned by an active `SubscriptionPhase` when one applies

Survives meter/price renames and replacements. Non-clustered index on
`ProductId` supports per-product reporting queries.

### Other deliverables

- ADR-036 (`docs-site/.../architecture/adr/036-invoicing-line-source-convention.md`)
- Architecture test `InvoiceLineItemSourceConventionTests` (9 cases)
- `saas/invoicing.mdx` updated with the convention table + `ProductId` propagation flow

### Bonus

Includes a small unrelated `docs-site/astro.config.mjs` cleanup (removed a
duplicate redirect target) that was sitting in the working tree — shipped here
on user request rather than as a separate trivial PR.

## Note for reviewers

ADR-033 / ADR-034 / ADR-035 (Phase 2 metering hybrid, Phase 3 subscriptions
phases/tiered, Phase 4 customer-balance ORB mapping) were shipped in stacked
PRs and lost during squash-merge. The ADR-035 file specifically still lives on
`origin/feature/customer-balance-preexpiration-job` but is absent from
`develop`. Worth a follow-up PR to restore the three ADR files independently
of this Phase 5 work.

## Test plan

- [ ] `dotnet test tests/Granit.Invoicing.Tests` — 54 passed locally
- [ ] `dotnet test tests/Granit.Invoicing.BackgroundJobs.Tests` — 11 passed locally
- [ ] `dotnet test tests/Granit.Subscriptions.Tests` — 151 passed locally
- [ ] `dotnet test tests/Granit.ArchitectureTests` — 129 passed locally (incl. 9 new)
- [ ] `dotnet test tests/Granit.Metering.Tests` — 58 passed locally
- [ ] `dotnet format --verify-no-changes` clean on all touched files
- [ ] `npx markdownlint-cli2` clean on ADR-036
- [ ] CI green across all 6 shards