### PR TITLE
fix(metering-endpoints): replace internal nested validator with static rule helper

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40576,15 +40576,6 @@
       ]
     },
     {
-      "name": "Phases",
-      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Phases",
-      "kind": "class",
-      "project": "Granit.Subscriptions.Endpoints",
-      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
-      "line": 50,
-      "members": []
-    },
-    {
       "name": "Plans",
       "fqn": "Granit.Subscriptions.Endpoints.Permissions.Plans",
       "kind": "class",

--- a/src/Granit.Metering.Endpoints/Validators/BackfillUsageRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/BackfillUsageRequestValidator.cs
@@ -27,6 +27,6 @@ internal sealed class BackfillUsageRequestValidator : AbstractValidator<Backfill
             .WithErrorCodeAndMessage("Granit:Validation:MaxBatchSize");
 
         RuleForEach(x => x.Events)
-            .SetValidator(new MeterEventRequestValidator(clock, MaxAge));
+            .ChildRules(events => MeterEventRules.Apply(events, clock, MaxAge));
     }
 }

--- a/src/Granit.Metering.Endpoints/Validators/RecordUsageRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/RecordUsageRequestValidator.cs
@@ -20,30 +20,42 @@ internal sealed class RecordUsageRequestValidator : AbstractValidator<RecordUsag
             .WithErrorCodeAndMessage("Granit:Validation:MaxBatchSize");
 
         RuleForEach(x => x.Events)
-            .SetValidator(new MeterEventRequestValidator(clock, StandardMaxAge));
+            .ChildRules(events => MeterEventRules.Apply(events, clock, StandardMaxAge));
     }
 }
 
-internal sealed class MeterEventRequestValidator : AbstractValidator<MeterEventRequest>
+/// <summary>
+/// Per-event rule definitions shared between the standard
+/// <see cref="RecordUsageRequestValidator"/> (7-day window) and
+/// <see cref="BackfillUsageRequestValidator"/> (365-day window).
+/// </summary>
+/// <remarks>
+/// Static class — deliberately NOT an <c>AbstractValidator</c> so that
+/// FluentValidation's <c>AddValidatorsFromAssembly(includeInternalTypes: true)</c>
+/// scanner skips it (no <c>IValidator</c> implementation to discover). Exposing it
+/// as a typed validator would have the DI container try to construct it, which
+/// fails because <see cref="TimeSpan"/> isn't a registered service.
+/// </remarks>
+internal static class MeterEventRules
 {
-    public MeterEventRequestValidator(IClock clock, TimeSpan maxAge)
+    public static void Apply(InlineValidator<MeterEventRequest> events, IClock clock, TimeSpan maxAge)
     {
-        RuleFor(x => x.MeterDefinitionId)
+        events.RuleFor(x => x.MeterDefinitionId)
             .NotEmpty();
 
-        RuleFor(x => x.IdempotencyKey)
+        events.RuleFor(x => x.IdempotencyKey)
             .NotEmpty()
             .MaximumLength(256);
 
-        RuleFor(x => x.Quantity)
+        events.RuleFor(x => x.Quantity)
             .GreaterThan(0);
 
-        RuleFor(x => x.Timestamp)
+        events.RuleFor(x => x.Timestamp)
             .NotEmpty()
             .LessThanOrEqualTo(clock.Now.AddMinutes(5))
             .GreaterThan(clock.Now - maxAge);
 
-        RuleFor(x => x.Metadata)
+        events.RuleFor(x => x.Metadata)
             .MaximumLength(4000)
             .When(x => x.Metadata is not null);
     }

--- a/tests/Granit.Metering.Endpoints.Tests/Validators/MeteringEndpointsValidatorRegistrationTests.cs
+++ b/tests/Granit.Metering.Endpoints.Tests/Validators/MeteringEndpointsValidatorRegistrationTests.cs
@@ -1,0 +1,62 @@
+using FluentValidation;
+using Granit.Metering.Endpoints.Validators;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.Endpoints.Tests.Validators;
+
+/// <summary>
+/// Regression guard for the DI failure caused by an internal nested validator
+/// whose constructor took a non-injectable <see cref="TimeSpan"/> parameter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GranitValidationModule</c> calls <c>AddValidatorsFromAssembly(includeInternalTypes: true)</c>
+/// over every loaded module assembly. The previous implementation defined
+/// <c>MeterEventRequestValidator</c> as an <c>internal sealed class : AbstractValidator&lt;MeterEventRequest&gt;</c>
+/// with a <c>(IClock clock, TimeSpan maxAge)</c> constructor, used only via
+/// <c>RuleForEach(...).SetValidator(new MeterEventRequestValidator(...))</c> from inside the two
+/// top-level validators. The DI auto-discovery picked it up and tried to instantiate it through
+/// the container; building the <c>ServiceProvider</c> with <c>ValidateOnBuild</c> threw because
+/// <see cref="TimeSpan"/> isn't a registered service. <c>SIGABRT (134)</c> at host startup.
+/// </para>
+/// <para>
+/// The fix moved the per-event rules into a <c>static class MeterEventRules</c> with an
+/// <c>Apply(InlineValidator&lt;MeterEventRequest&gt;, IClock, TimeSpan)</c> method, and the two
+/// top-level validators now call <c>RuleForEach(...).ChildRules(events =&gt; MeterEventRules.Apply(events, clock, maxAge))</c>.
+/// Static classes carry no <c>IValidator</c> implementation, so the assembly scanner skips them.
+/// </para>
+/// </remarks>
+public sealed class MeteringEndpointsValidatorRegistrationTests
+{
+    [Fact]
+    public void AddValidatorsFromAssembly_WithInternalTypes_ShouldNotPickUpHelperRuleClass()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorsFromAssembly(
+            typeof(RecordUsageRequestValidator).Assembly,
+            ServiceLifetime.Scoped,
+            includeInternalTypes: true);
+
+        // Real-ish clock: validator rules call `clock.Now - maxAge` at *construction*,
+        // so a default(DateTimeOffset) stub would underflow DateTime arithmetic.
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+        services.AddSingleton(clock);
+
+        // ValidateOnBuild surfaces "no service for type 'System.TimeSpan'" if any
+        // discovered validator's ctor expects a non-DI primitive.
+        ServiceProvider provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        // Both top-level validators must still resolve normally.
+        using IServiceScope scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IValidator<Dtos.RecordUsageRequest>>()
+            .ShouldBeOfType<RecordUsageRequestValidator>();
+        scope.ServiceProvider.GetRequiredService<IValidator<Dtos.BackfillUsageRequest>>()
+            .ShouldBeOfType<BackfillUsageRequestValidator>();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a startup-time DI failure (SIGABRT 134) introduced in `Granit.Metering.Endpoints` by an internal nested validator class with a non-injectable `TimeSpan` constructor parameter.

## Root cause

`GranitValidationModule` registers validators via `AddValidatorsFromAssembly(includeInternalTypes: true)` over every loaded module assembly. The previous implementation defined:

```csharp
internal sealed class MeterEventRequestValidator : AbstractValidator<MeterEventRequest>
{
    public MeterEventRequestValidator(IClock clock, TimeSpan maxAge) { ... }
}
```

…used only via `RuleForEach(...).SetValidator(new MeterEventRequestValidator(...))` from inside `RecordUsageRequestValidator` / `BackfillUsageRequestValidator`. The DI auto-discovery picked it up regardless. Building the `ServiceProvider` with `ValidateOnBuild = true` then threw `InvalidOperationException` because `System.TimeSpan` is not a registered service.

Discovered by [@jf](https://github.com/jfmeyers) in `granit-showcase-dotnet` integration: every showcase host startup that referenced `Granit.Metering.Endpoints` 0.1.0-dev.1475 crashed with `SIGABRT (134)`.

## Fix

Move per-event rules into `internal static class MeterEventRules` with a single

```csharp
public static void Apply(InlineValidator<MeterEventRequest> events, IClock clock, TimeSpan maxAge)
```

method. The two top-level validators now use:

```csharp
RuleForEach(x => x.Events)
    .ChildRules(events => MeterEventRules.Apply(events, clock, StandardMaxAge));
```

Static classes carry no `IValidator` implementation, so FluentValidation's assembly scanner skips them — DI never tries to construct them. Behavior is identical:

- Same per-event rules (`MeterDefinitionId`, `IdempotencyKey`, `Quantity`, `Timestamp`, `Metadata`)
- 7-day window for `RecordUsageRequestValidator`, 365-day window for `BackfillUsageRequestValidator`
- Same error codes / messages

## Regression test

`MeteringEndpointsValidatorRegistrationTests.AddValidatorsFromAssembly_WithInternalTypes_ShouldNotPickUpHelperRuleClass` builds a `ServiceProvider` with `AddValidatorsFromAssembly(includeInternalTypes: true)` + `ValidateOnBuild = true` over `Granit.Metering.Endpoints` and asserts both top-level validators resolve. Guards against any future helper class accidentally implementing `IValidator<T>`.

## Verification

- ✅ `dotnet build src/Granit.Metering.Endpoints` clean
- ✅ `dotnet test tests/Granit.Metering.Endpoints.Tests` — **16/16** pass (incl. new regression test)
- ✅ `dotnet test tests/Granit.Metering.Tests + Abstractions + EntityFrameworkCore + BackgroundJobs` — **99/99** pass
- ✅ `dotnet format --verify-no-changes` clean on touched files

## Test plan

- [ ] CI green on all 6 shards
- [ ] Once a new dev build (post-1476) ships, verify a downstream `granit-showcase-dotnet` host starts without SIGABRT