### PR TITLE
chore(saas): convention compliance fixes across SaaS modules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1226,6 +1226,7 @@
       "name": "Granit.MultiTenancy.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Guids",
         "Granit.Http.ApiDocumentation",
         "Granit.MultiTenancy",
         "Granit.Validation"
@@ -16263,7 +16264,7 @@
       "kind": "class",
       "project": "Granit.Http.Bulkhead",
       "file": "src/Granit.Http.Bulkhead/Extensions/BulkheadServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitBulkhead",
@@ -21875,6 +21876,69 @@
       "members": []
     },
     {
+      "name": "CreditNoteIssuedEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.CreditNoteIssuedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceFinalizedEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceFinalizedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "InvoiceOverdueEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceOverdueEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoicePaidEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.InvoicePaidEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceUncollectibleEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceUncollectibleEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceVoidedEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceVoidedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "OverpaymentDetectedEto",
+      "fqn": "Granit.Invoicing.Abstractions.Events.OverpaymentDetectedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "GranitInvoicingBackgroundJobsModule",
       "fqn": "Granit.Invoicing.BackgroundJobs.GranitInvoicingBackgroundJobsModule",
       "kind": "class",
@@ -22044,7 +22108,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Domain/Invoice.cs",
-      "line": 28,
+      "line": 29,
       "members": [
         {
           "name": "Create",
@@ -22353,8 +22417,15 @@
       "kind": "class",
       "project": "Granit.Invoicing.Endpoints",
       "file": "src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "InvoicingEndpointsOptions",
@@ -22384,7 +22455,7 @@
       "kind": "class",
       "project": "Granit.Invoicing.Endpoints",
       "file": "src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissions.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -22463,75 +22534,12 @@
       "members": []
     },
     {
-      "name": "CreditNoteIssuedEto",
-      "fqn": "Granit.Invoicing.Events.CreditNoteIssuedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
       "name": "InvoiceCreatedEvent",
       "fqn": "Granit.Invoicing.Events.InvoiceCreatedEvent",
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Events/InvoiceCreatedEvent.cs",
       "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceFinalizedEto",
-      "fqn": "Granit.Invoicing.Events.InvoiceFinalizedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs",
-      "line": 7,
-      "members": []
-    },
-    {
-      "name": "InvoiceOverdueEto",
-      "fqn": "Granit.Invoicing.Events.InvoiceOverdueEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoicePaidEto",
-      "fqn": "Granit.Invoicing.Events.InvoicePaidEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceUncollectibleEto",
-      "fqn": "Granit.Invoicing.Events.InvoiceUncollectibleEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceVoidedEto",
-      "fqn": "Granit.Invoicing.Events.InvoiceVoidedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "OverpaymentDetectedEto",
-      "fqn": "Granit.Invoicing.Events.OverpaymentDetectedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs",
-      "line": 9,
       "members": []
     },
     {
@@ -22964,7 +22972,7 @@
       "kind": "class",
       "project": "Granit.Invoicing.Odoo",
       "file": "src/Granit.Invoicing.Odoo/Domain/OdooPartnerMapping.cs",
-      "line": 8,
+      "line": 12,
       "members": [
         {
           "name": "Create",
@@ -25441,7 +25449,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "MapGranitMultiTenancy",
@@ -25457,7 +25465,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs",
-      "line": 21,
+      "line": 23,
       "members": []
     },
     {
@@ -25538,7 +25546,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.EntityFrameworkCore",
       "file": "src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs",
-      "line": 18,
+      "line": 28,
       "members": []
     },
     {
@@ -25656,7 +25664,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/GranitMultiTenancyModule.cs",
-      "line": 11,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -42240,6 +42248,12 @@
           "name": "ProductTaxCode",
           "kind": "property",
           "signature": "string ProductTaxCode",
+          "returnType": "string"
+        },
+        {
+          "name": "Currency",
+          "kind": "property",
+          "signature": "string Currency",
           "returnType": "string"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40576,15 +40576,6 @@
       ]
     },
     {
-      "name": "Phases",
-      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Phases",
-      "kind": "class",
-      "project": "Granit.Subscriptions.Endpoints",
-      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
-      "line": 50,
-      "members": []
-    },
-    {
       "name": "Plans",
       "fqn": "Granit.Subscriptions.Endpoints.Permissions.Plans",
       "kind": "class",

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -364,6 +364,11 @@ export default defineConfig({
                       autogenerate: { directory: "dotnet/architecture/adr" },
                       collapsed: true,
                     },
+                    {
+                      label: "Spikes",
+                      autogenerate: { directory: "dotnet/architecture/spikes" },
+                      collapsed: true,
+                    },
                   ],
                 },
               ],

--- a/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
@@ -22,7 +22,7 @@ public sealed class AuditEntryQueryDefinition : QueryDefinition<AuditEntry>
                 .LabelKey("Auditing.Columns.Tenant")
                 .Filterable()
                 .Sortable()
-                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+                .Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read"))
             .Column(e => e.Timestamp, c => c.Label("Timestamp").LabelKey("Auditing.Columns.Timestamp").Sortable())
             .Column(e => e.Category, c => c.Label("Category").LabelKey("Auditing.Columns.Category").Filterable().Sortable())
             .Column(e => e.UserId, c => c.Label("User ID").LabelKey("Auditing.Columns.UserId").Filterable().Sortable())

--- a/src/Granit.Catalog.Endpoints/Dtos/ProductRequestDtos.cs
+++ b/src/Granit.Catalog.Endpoints/Dtos/ProductRequestDtos.cs
@@ -14,7 +14,7 @@ public sealed record ProductUpdateRequest(
     string? Description,
     string Unit);
 
-/// <summary>Request to replace all extra properties of a product (any lifecycle status).</summary>
+/// <summary>Request to replace all metadata of a product (any lifecycle status).</summary>
 /// <remarks>
 /// Maps to <see cref="Granit.Domain.IHasMetadata.MetadataJson"/> via
 /// <c>Product.ReplaceMetadata</c>. MUST NOT contain PII (audit logs and exports

--- a/src/Granit.Catalog.Endpoints/Endpoints/ProductWriteEndpoints.cs
+++ b/src/Granit.Catalog.Endpoints/Endpoints/ProductWriteEndpoints.cs
@@ -18,7 +18,7 @@ internal static class ProductWriteEndpoints
         group.MapPost("/products", CreateProductAsync)
             .WithName("CreateCatalogProduct")
             .WithSummary("Creates a new product in Draft status.")
-            .WithDescription("Creates a product that can be configured (extra properties, external mappings) before publishing.")
+            .WithDescription("Creates a product that can be configured (metadata, external mappings) before publishing.")
             .WithMetadata(new IdempotentAttribute())
             .Produces<ProductResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
@@ -39,9 +39,9 @@ internal static class ProductWriteEndpoints
 
         group.MapPut("/products/{id:guid}/metadata", UpdateProductMetadataAsync)
             .WithName("UpdateCatalogProductMetadata")
-            .WithSummary("Replaces the product extra properties dictionary.")
+            .WithSummary("Replaces the product metadata dictionary.")
             .WithDescription(
-                "Allowed in any lifecycle state — extra properties may need to flow even for Published "
+                "Allowed in any lifecycle state — metadata may need to flow even for Published "
                 + "products (e.g., adjusting Stripe sync attributes). MUST NOT contain PII.")
             .WithMetadata(new IdempotentAttribute())
             .Produces<ProductResponse>()

--- a/src/Granit.Catalog.EntityFrameworkCore/GranitCatalogEntityFrameworkCoreModule.cs
+++ b/src/Granit.Catalog.EntityFrameworkCore/GranitCatalogEntityFrameworkCoreModule.cs
@@ -7,6 +7,6 @@ namespace Granit.Catalog.EntityFrameworkCore;
 /// Granit module for EF Core persistence of the catalog (Product aggregate).
 /// </summary>
 [DependsOn(
-    typeof(GranitPersistenceEntityFrameworkCoreModule),
-    typeof(GranitCatalogModule))]
+    typeof(GranitCatalogModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitCatalogEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
                 "Returns the current credit balance for the authenticated tenant in the specified currency. "
                 + "Returns zero balance if no account exists for that currency.")
             .Produces<CustomerBalanceResponse>()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(CustomerBalancePermissions.Accounts.Read)
             .AllowHostAccess();
 
@@ -46,6 +47,7 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
                 + "Ordered by creation date descending (most recent first). "
                 + "Each entry shows the transaction type, amount, source, and optional reference.")
             .Produces<IReadOnlyList<BalanceTransactionResponse>>()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(CustomerBalancePermissions.Transactions.Read)
             .AllowHostAccess();
 
@@ -59,6 +61,7 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
             .Produces<CustomerBalanceResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(CustomerBalancePermissions.Credits.Manage)
             .AllowHostAccess();
 
@@ -69,11 +72,10 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
                 "Creates a ManualAdjustment debit transaction on the tenant's balance account — "
                 + "for corrections, scheduled drawdowns, and non-invoice adjustments. "
                 + "Returns 404 when no account exists for the (tenant, currency); 422 when the balance "
-                + "is insufficient. Idempotent at the application level when the same ReferenceId is "
-                + "supplied — replays return the original outcome without double-debiting.")
+                + "is insufficient or tenant context is missing. Idempotent at the application level when "
+                + "the same ReferenceId is supplied — replays return the original outcome without double-debiting.")
             .Produces<CustomerBalanceResponse>()
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(CustomerBalancePermissions.Credits.Manage)

--- a/src/Granit.CustomerBalance.Endpoints/Internal/AdminCreditEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/AdminCreditEndpoint.cs
@@ -21,7 +21,7 @@ internal static class AdminCreditEndpoint
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         if (!Enum.TryParse<TransactionSource>(request.Source, ignoreCase: true, out TransactionSource source)

--- a/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
@@ -18,7 +18,7 @@ internal static class AdminDebitEndpoint
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         Guid tenantId = currentTenant.Id!.Value;

--- a/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
@@ -17,7 +17,7 @@ internal static class GetBalanceEndpoint
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         BalanceAccount? account = await accountReader

--- a/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
@@ -24,7 +24,7 @@ internal static class ListTransactionsEndpoint
 
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         BalanceAccount? account = await accountReader

--- a/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissions.cs
@@ -9,14 +9,14 @@ public static class CustomerBalancePermissions
     /// <summary>Balance account resource permissions.</summary>
     public static class Accounts
     {
-        /// <summary>View balance accounts.</summary>
+        /// <summary>Read balance accounts.</summary>
         public const string Read = "CustomerBalance.Accounts.Read";
     }
 
     /// <summary>Balance transaction resource permissions.</summary>
     public static class Transactions
     {
-        /// <summary>View transaction history.</summary>
+        /// <summary>Read transaction history.</summary>
         public const string Read = "CustomerBalance.Transactions.Read";
     }
 

--- a/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
+++ b/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.CustomerBalance.Handlers;

--- a/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
+++ b/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
@@ -3,7 +3,7 @@ using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
 using Granit.Invoicing;
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 

--- a/src/Granit.DataLookup.Abstractions/Descriptors/LookupDescriptor.cs
+++ b/src/Granit.DataLookup.Abstractions/Descriptors/LookupDescriptor.cs
@@ -37,7 +37,7 @@ namespace Granit.DataLookup.Descriptors;
 /// Kind of backing source. Informational only — does not affect routing.
 /// </param>
 /// <param name="RequiredPermission">
-/// Permission string (e.g. <c>"Platform.Tenants.Read"</c>) the principal must hold to
+/// Permission string (e.g. <c>"MultiTenancy.Tenants.Read"</c>) the principal must hold to
 /// call the lookup. When null, the lookup is considered public (within tenant scope).
 /// The frontend also uses this to hide the picker from users who lack the permission.
 /// </param>

--- a/src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs
@@ -90,7 +90,8 @@ public static class FeaturesEndpointRouteBuilderExtensions
              .WithSummary("Sets a tenant-level feature override.")
              .WithDescription("Creates or updates a tenant-level override for the specified feature. The value is validated against the feature's value type (Toggle: true/false, Numeric: min/max bounds, Selection: allowed values). Returns 404 if the feature is not declared. Requires the Features.Manage permission.")
              .Produces(StatusCodes.Status204NoContent)
-             .ProducesProblem(StatusCodes.Status404NotFound);
+             .ProducesProblem(StatusCodes.Status404NotFound)
+             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
         group.MapDelete("/overrides/{name}", HandleDeleteOverrideAsync)
              .RequireAuthorization(FeaturesPermissions.Flags.Manage)

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
@@ -2,7 +2,7 @@
   "culture": "cs",
   "texts": {
     "PermissionGroup:Features": "Funkce",
-    "Permission:Features.Flags.Read": "Zobrazit definice funkcí",
+    "Permission:Features.Flags.Read": "Číst definice funkcí",
     "Permission:Features.Flags.Manage": "Spravovat přepsání funkcí (nastavit, smazat)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
@@ -2,7 +2,7 @@
   "culture": "de",
   "texts": {
     "PermissionGroup:Features": "Funktionen",
-    "Permission:Features.Flags.Read": "Funktionsdefinitionen anzeigen",
+    "Permission:Features.Flags.Read": "Funktionsdefinitionen lesen",
     "Permission:Features.Flags.Manage": "Funktionsüberschreibungen verwalten (setzen, löschen)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en.json
@@ -2,7 +2,7 @@
   "culture": "en",
   "texts": {
     "PermissionGroup:Features": "Features",
-    "Permission:Features.Flags.Read": "View feature definitions",
+    "Permission:Features.Flags.Read": "Read feature definitions",
     "Permission:Features.Flags.Manage": "Manage feature overrides (set, delete)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
@@ -2,7 +2,7 @@
   "culture": "es",
   "texts": {
     "PermissionGroup:Features": "Funcionalidades",
-    "Permission:Features.Flags.Read": "Ver definiciones de funcionalidades",
+    "Permission:Features.Flags.Read": "Leer definiciones de funcionalidades",
     "Permission:Features.Flags.Manage": "Gestionar anulaciones de funcionalidades (establecer, eliminar)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/hi.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/hi.json
@@ -2,7 +2,7 @@
   "culture": "hi",
   "texts": {
     "PermissionGroup:Features": "सुविधाएँ",
-    "Permission:Features.Flags.Read": "सुविधा परिभाषाएँ देखें",
+    "Permission:Features.Flags.Read": "सुविधा परिभाषाएँ पढ़ें",
     "Permission:Features.Flags.Manage": "सुविधा ओवरराइड प्रबंधित करें (सेट करें, हटाएँ)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
@@ -2,7 +2,7 @@
   "culture": "it",
   "texts": {
     "PermissionGroup:Features": "Funzionalità",
-    "Permission:Features.Flags.Read": "Visualizzare le definizioni delle funzionalità",
+    "Permission:Features.Flags.Read": "Leggere le definizioni delle funzionalità",
     "Permission:Features.Flags.Manage": "Gestire le sostituzioni delle funzionalità (impostare, eliminare)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
@@ -2,7 +2,7 @@
   "culture": "ja",
   "texts": {
     "PermissionGroup:Features": "機能管理",
-    "Permission:Features.Flags.Read": "機能定義を表示する",
+    "Permission:Features.Flags.Read": "機能定義を読み取る",
     "Permission:Features.Flags.Manage": "機能オーバーライドを管理する（設定、削除）"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
@@ -2,7 +2,7 @@
   "culture": "ko",
   "texts": {
     "PermissionGroup:Features": "기능 관리",
-    "Permission:Features.Flags.Read": "기능 정의 보기",
+    "Permission:Features.Flags.Read": "기능 정의 읽기",
     "Permission:Features.Flags.Manage": "기능 재정의 관리 (설정, 삭제)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
@@ -2,7 +2,7 @@
   "culture": "nl",
   "texts": {
     "PermissionGroup:Features": "Functionaliteiten",
-    "Permission:Features.Flags.Read": "Functiedefinities bekijken",
+    "Permission:Features.Flags.Read": "Functiedefinities lezen",
     "Permission:Features.Flags.Manage": "Functie-overschrijvingen beheren (instellen, verwijderen)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
@@ -2,7 +2,7 @@
   "culture": "pl",
   "texts": {
     "PermissionGroup:Features": "Funkcjonalności",
-    "Permission:Features.Flags.Read": "Przeglądaj definicje funkcjonalności",
+    "Permission:Features.Flags.Read": "Odczytaj definicje funkcjonalności",
     "Permission:Features.Flags.Manage": "Zarządzaj nadpisaniami funkcjonalności (ustawiaj, usuwaj)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
@@ -2,7 +2,7 @@
   "culture": "sv",
   "texts": {
     "PermissionGroup:Features": "Funktioner",
-    "Permission:Features.Flags.Read": "Visa funktionsdefinitioner",
+    "Permission:Features.Flags.Read": "Läsa funktionsdefinitioner",
     "Permission:Features.Flags.Manage": "Hantera funktionsöverskrivningar (ange, ta bort)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
@@ -2,7 +2,7 @@
   "culture": "tr",
   "texts": {
     "PermissionGroup:Features": "Özellikler",
-    "Permission:Features.Flags.Read": "Özellik tanımlarını görüntüle",
+    "Permission:Features.Flags.Read": "Özellik tanımlarını oku",
     "Permission:Features.Flags.Manage": "Özellik geçersiz kılmalarını yönet (ayarla, sil)"
   }
 }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
@@ -2,7 +2,7 @@
   "culture": "zh",
   "texts": {
     "PermissionGroup:Features": "功能管理",
-    "Permission:Features.Flags.Read": "查看功能定义",
+    "Permission:Features.Flags.Read": "读取功能定义",
     "Permission:Features.Flags.Manage": "管理功能覆盖（设置、删除）"
   }
 }

--- a/src/Granit.Http.Bulkhead/Diagnostics/BulkheadActivitySource.cs
+++ b/src/Granit.Http.Bulkhead/Diagnostics/BulkheadActivitySource.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Granit.Http.Bulkhead.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Http.Bulkhead distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class BulkheadActivitySource
+{
+    /// <summary>The name of the Granit.Http.Bulkhead <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Http.Bulkhead";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.Http.Bulkhead/Extensions/BulkheadServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Bulkhead/Extensions/BulkheadServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Diagnostics;
 using Granit.Http.Bulkhead.Abstractions;
 using Granit.Http.Bulkhead.Diagnostics;
 using Granit.Http.Bulkhead.Exceptions;
@@ -55,6 +56,9 @@ public static class BulkheadServiceCollectionExtensions
 
     private static IServiceCollection AddGranitBulkheadCore(this IServiceCollection services)
     {
+        // ActivitySource registration
+        GranitActivitySourceRegistry.Register(BulkheadActivitySource.Name);
+
         // Options validation
         services.AddSingleton<IValidateOptions<GranitBulkheadOptions>, GranitBulkheadOptionsValidator>();
 

--- a/src/Granit.Http.Bulkhead/GranitHttpBulkheadModule.cs
+++ b/src/Granit.Http.Bulkhead/GranitHttpBulkheadModule.cs
@@ -12,8 +12,8 @@ namespace Granit.Http.Bulkhead;
 /// and all required dependencies from configuration section <c>"Bulkhead"</c>.
 /// </summary>
 [DependsOn(
-    typeof(GranitHttpExceptionHandlingModule),
-    typeof(GranitFeaturesModule))]
+    typeof(GranitFeaturesModule),
+    typeof(GranitHttpExceptionHandlingModule))]
 public sealed class GranitHttpBulkheadModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when a credit note is issued. Triggers refund via Payments.</summary>
 public sealed record CreditNoteIssuedEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
@@ -1,7 +1,7 @@
 using Granit.Events;
 using Granit.Invoicing.Domain;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when an invoice is finalized. Triggers payment collection.</summary>
 public sealed record InvoiceFinalizedEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when an invoice is overdue (Open + past DueAt).</summary>
 public sealed record InvoiceOverdueEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when an invoice is fully paid.</summary>
 public sealed record InvoicePaidEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when an invoice is marked as uncollectible (bad debt).</summary>
 public sealed record InvoiceUncollectibleEto(Guid InvoiceId, Guid TenantId) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>Published when an invoice is voided.</summary>
 public sealed record InvoiceVoidedEto(Guid InvoiceId, Guid TenantId) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Events;
+namespace Granit.Invoicing.Abstractions.Events;
 
 /// <summary>
 /// Published when a payment exceeds the invoice total.

--- a/src/Granit.Invoicing.Abstractions/IInvoicePrePaymentProcessor.cs
+++ b/src/Granit.Invoicing.Abstractions/IInvoicePrePaymentProcessor.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 
 namespace Granit.Invoicing;
 

--- a/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
+++ b/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
@@ -1,7 +1,7 @@
 using Granit.Events;
 using Granit.Invoicing;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
-using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
+++ b/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
@@ -50,9 +50,9 @@ internal static class InvoiceEndpoints
                 "Line items can be added after creation. Requires tenant context.")
             .WithMetadata(new IdempotentAttribute())
             .Produces<InvoiceResponse>(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem()
-            .RequireAuthorization(InvoicingPermissions.Invoices.Manage)
+            .RequireAuthorization(InvoicingPermissions.Invoices.Create)
             .AllowHostAccess();
 
         return group;
@@ -100,7 +100,7 @@ internal static class InvoiceEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         var invoice = Invoice.Create(

--- a/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
+++ b/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
@@ -1,7 +1,11 @@
 using Granit.Authorization;
+using Granit.Http.ApiDocumentation;
+using Granit.Invoicing.Endpoints.Internal;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Invoicing.Endpoints;
 
@@ -11,4 +15,10 @@ namespace Granit.Invoicing.Endpoints;
     typeof(GranitInvoicingModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitValidationModule))]
-public sealed class GranitInvoicingEndpointsModule : GranitModule;
+public sealed class GranitInvoicingEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ISchemaExampleProvider, InvoicingSchemaExampleProvider>());
+}

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/cs.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/cs.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Fakturace",
     "Permission:Invoicing.Invoices.Read": "Zobrazit faktury",
+    "Permission:Invoicing.Invoices.Create": "Vytvořit faktury",
     "Permission:Invoicing.Invoices.Manage": "Spravovat faktury (vytvořit, dokončit, stornovat)",
     "Permission:Invoicing.Invoices.Download": "Stáhnout fakturační dokumenty (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Zobrazit dobropisy",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/de.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/de.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Rechnungsstellung",
     "Permission:Invoicing.Invoices.Read": "Rechnungen anzeigen",
+    "Permission:Invoicing.Invoices.Create": "Rechnungen erstellen",
     "Permission:Invoicing.Invoices.Manage": "Rechnungen verwalten (erstellen, abschließen, stornieren)",
     "Permission:Invoicing.Invoices.Download": "Rechnungsdokumente herunterladen (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Gutschriften anzeigen",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/en-GB.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/en-GB.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Invoicing",
     "Permission:Invoicing.Invoices.Read": "View invoices",
+    "Permission:Invoicing.Invoices.Create": "Create invoices",
     "Permission:Invoicing.Invoices.Manage": "Manage invoices (create, finalise, void)",
     "Permission:Invoicing.Invoices.Download": "Download invoice documents (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "View credit notes",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/en.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/en.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Invoicing",
     "Permission:Invoicing.Invoices.Read": "View invoices",
+    "Permission:Invoicing.Invoices.Create": "Create invoices",
     "Permission:Invoicing.Invoices.Manage": "Manage invoices (create, finalize, void)",
     "Permission:Invoicing.Invoices.Download": "Download invoice documents (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "View credit notes",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/es.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/es.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Facturación",
     "Permission:Invoicing.Invoices.Read": "Consultar facturas",
+    "Permission:Invoicing.Invoices.Create": "Crear facturas",
     "Permission:Invoicing.Invoices.Manage": "Gestionar facturas (crear, finalizar, anular)",
     "Permission:Invoicing.Invoices.Download": "Descargar documentos de factura (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Consultar notas de crédito",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/fr-CA.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/fr-CA.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Facturation",
     "Permission:Invoicing.Invoices.Read": "Consulter les factures",
+    "Permission:Invoicing.Invoices.Create": "Créer des factures",
     "Permission:Invoicing.Invoices.Manage": "Gérer les factures (créer, finaliser, annuler)",
     "Permission:Invoicing.Invoices.Download": "Télécharger les documents de facture (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Consulter les avoirs",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/fr.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/fr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Facturation",
     "Permission:Invoicing.Invoices.Read": "Consulter les factures",
+    "Permission:Invoicing.Invoices.Create": "Créer des factures",
     "Permission:Invoicing.Invoices.Manage": "Gérer les factures (créer, finaliser, annuler)",
     "Permission:Invoicing.Invoices.Download": "Télécharger les documents de facture (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Consulter les avoirs",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/hi.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/hi.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "चालान",
     "Permission:Invoicing.Invoices.Read": "चालान देखें",
+    "Permission:Invoicing.Invoices.Create": "चालान बनाएँ",
     "Permission:Invoicing.Invoices.Manage": "चालान प्रबंधित करें (बनाएँ, अंतिम रूप दें, रद्द करें)",
     "Permission:Invoicing.Invoices.Download": "चालान दस्तावेज़ डाउनलोड करें (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "क्रेडिट नोट देखें",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/it.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/it.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Fatturazione",
     "Permission:Invoicing.Invoices.Read": "Visualizzare le fatture",
+    "Permission:Invoicing.Invoices.Create": "Creare fatture",
     "Permission:Invoicing.Invoices.Manage": "Gestire le fatture (creare, finalizzare, annullare)",
     "Permission:Invoicing.Invoices.Download": "Scaricare i documenti di fattura (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Visualizzare le note di credito",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/ja.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/ja.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "請求管理",
     "Permission:Invoicing.Invoices.Read": "請求書の閲覧",
+    "Permission:Invoicing.Invoices.Create": "請求書の作成",
     "Permission:Invoicing.Invoices.Manage": "請求書の管理（作成、確定、無効化）",
     "Permission:Invoicing.Invoices.Download": "請求書ドキュメントのダウンロード（PDF）",
     "Permission:Invoicing.CreditNotes.Read": "クレジットノートの閲覧",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/ko.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/ko.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "청구 관리",
     "Permission:Invoicing.Invoices.Read": "청구서 조회",
+    "Permission:Invoicing.Invoices.Create": "청구서 생성",
     "Permission:Invoicing.Invoices.Manage": "청구서 관리 (생성, 확정, 무효화)",
     "Permission:Invoicing.Invoices.Download": "청구서 문서 다운로드 (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "대변기표 조회",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/nl.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/nl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Facturatie",
     "Permission:Invoicing.Invoices.Read": "Facturen bekijken",
+    "Permission:Invoicing.Invoices.Create": "Facturen aanmaken",
     "Permission:Invoicing.Invoices.Manage": "Facturen beheren (aanmaken, afronden, annuleren)",
     "Permission:Invoicing.Invoices.Download": "Factuurdocumenten downloaden (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Creditnota's bekijken",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pl.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Fakturowanie",
     "Permission:Invoicing.Invoices.Read": "Przeglądanie faktur",
+    "Permission:Invoicing.Invoices.Create": "Tworzenie faktur",
     "Permission:Invoicing.Invoices.Manage": "Zarządzanie fakturami (tworzenie, finalizowanie, anulowanie)",
     "Permission:Invoicing.Invoices.Download": "Pobieranie dokumentów faktur (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Przeglądanie not kredytowych",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pt-BR.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pt-BR.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Faturamento",
     "Permission:Invoicing.Invoices.Read": "Consultar faturas",
+    "Permission:Invoicing.Invoices.Create": "Criar faturas",
     "Permission:Invoicing.Invoices.Manage": "Gerenciar faturas (criar, finalizar, anular)",
     "Permission:Invoicing.Invoices.Download": "Baixar documentos de fatura (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Consultar notas de crédito",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pt.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/pt.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Faturação",
     "Permission:Invoicing.Invoices.Read": "Consultar faturas",
+    "Permission:Invoicing.Invoices.Create": "Criar faturas",
     "Permission:Invoicing.Invoices.Manage": "Gerir faturas (criar, finalizar, anular)",
     "Permission:Invoicing.Invoices.Download": "Transferir documentos de fatura (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Consultar notas de crédito",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/sv.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/sv.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Fakturering",
     "Permission:Invoicing.Invoices.Read": "Visa fakturor",
+    "Permission:Invoicing.Invoices.Create": "Skapa fakturor",
     "Permission:Invoicing.Invoices.Manage": "Hantera fakturor (skapa, slutföra, makulera)",
     "Permission:Invoicing.Invoices.Download": "Ladda ner fakturadokument (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Visa kreditnotor",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/tr.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/tr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "Faturalandırma",
     "Permission:Invoicing.Invoices.Read": "Faturaları görüntüle",
+    "Permission:Invoicing.Invoices.Create": "Fatura oluştur",
     "Permission:Invoicing.Invoices.Manage": "Faturaları yönet (oluştur, kesinleştir, iptal et)",
     "Permission:Invoicing.Invoices.Download": "Fatura belgelerini indir (PDF)",
     "Permission:Invoicing.CreditNotes.Read": "Alacak dekontlarını görüntüle",

--- a/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/zh.json
+++ b/src/Granit.Invoicing.Endpoints/Localization/InvoicingEndpoints/zh.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Invoicing": "开票管理",
     "Permission:Invoicing.Invoices.Read": "查看发票",
+    "Permission:Invoicing.Invoices.Create": "创建发票",
     "Permission:Invoicing.Invoices.Manage": "管理发票（创建、定稿、作废）",
     "Permission:Invoicing.Invoices.Download": "下载发票文档（PDF）",
     "Permission:Invoicing.CreditNotes.Read": "查看贷项通知单",

--- a/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
@@ -20,6 +20,9 @@ internal sealed class InvoicingPermissionDefinitionProvider : IPermissionDefinit
         group.AddPermission(InvoicingPermissions.Invoices.Read,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Read"),
             MultiTenancySide.Both);
+        group.AddPermission(InvoicingPermissions.Invoices.Create,
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Create"),
+            MultiTenancySide.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Manage,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Manage"),
             MultiTenancySide.Both);

--- a/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissions.cs
+++ b/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissions.cs
@@ -8,6 +8,7 @@ public static class InvoicingPermissions
     public static class Invoices
     {
         public const string Read = "Invoicing.Invoices.Read";
+        public const string Create = "Invoicing.Invoices.Create";
         public const string Manage = "Invoicing.Invoices.Manage";
         public const string Download = "Invoicing.Invoices.Download";
     }

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.CreditNoteIssued.en-GB.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.CreditNoteIssued.en-GB.html
@@ -1,0 +1,8 @@
+<p>Hi,</p>
+<p>A credit note has been issued for invoice <strong>{{ model.parent_invoice_number | html.escape }}</strong>:</p>
+<ul>
+  <li><strong>Credit note:</strong> {{ model.credit_note_number | html.escape }}</li>
+  <li><strong>Amount:</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Reason:</strong> {{ model.reason | html.escape }}</li>
+</ul>
+<p>The credit has been applied to your account.</p>

--- a/src/Granit.Invoicing.Odoo/Domain/OdooPartnerMapping.cs
+++ b/src/Granit.Invoicing.Odoo/Domain/OdooPartnerMapping.cs
@@ -5,6 +5,10 @@ namespace Granit.Invoicing.Odoo.Domain;
 /// <summary>
 /// Maps a Granit tenant to an Odoo <c>res.partner</c> record.
 /// </summary>
+// TODO(audit/A3): Persistence is not yet implemented. A dedicated
+// Granit.Invoicing.Odoo.EntityFrameworkCore package is required to back this
+// aggregate with a DbContext, configurations, and migrations. Tracked in the
+// Invoicing audit findings.
 public sealed class OdooPartnerMapping : Entity
 {
     private OdooPartnerMapping() { }

--- a/src/Granit.Invoicing/Domain/Invoice.cs
+++ b/src/Granit.Invoicing/Domain/Invoice.cs
@@ -1,4 +1,5 @@
 using Granit.Domain;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain.ValueObjects;
 using Granit.Invoicing.Events;
 using Granit.Workflow.Domain;

--- a/src/Granit.Metering.Endpoints/Validators/BackfillUsageRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/BackfillUsageRequestValidator.cs
@@ -27,6 +27,6 @@ internal sealed class BackfillUsageRequestValidator : AbstractValidator<Backfill
             .WithErrorCodeAndMessage("Granit:Validation:MaxBatchSize");
 
         RuleForEach(x => x.Events)
-            .SetValidator(new MeterEventRequestValidator(clock, MaxAge));
+            .ChildRules(events => MeterEventRules.Apply(events, clock, MaxAge));
     }
 }

--- a/src/Granit.Metering.Endpoints/Validators/RecordUsageRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/RecordUsageRequestValidator.cs
@@ -20,30 +20,42 @@ internal sealed class RecordUsageRequestValidator : AbstractValidator<RecordUsag
             .WithErrorCodeAndMessage("Granit:Validation:MaxBatchSize");
 
         RuleForEach(x => x.Events)
-            .SetValidator(new MeterEventRequestValidator(clock, StandardMaxAge));
+            .ChildRules(events => MeterEventRules.Apply(events, clock, StandardMaxAge));
     }
 }
 
-internal sealed class MeterEventRequestValidator : AbstractValidator<MeterEventRequest>
+/// <summary>
+/// Per-event rule definitions shared between the standard
+/// <see cref="RecordUsageRequestValidator"/> (7-day window) and
+/// <see cref="BackfillUsageRequestValidator"/> (365-day window).
+/// </summary>
+/// <remarks>
+/// Static class — deliberately NOT an <c>AbstractValidator</c> so that
+/// FluentValidation's <c>AddValidatorsFromAssembly(includeInternalTypes: true)</c>
+/// scanner skips it (no <c>IValidator</c> implementation to discover). Exposing it
+/// as a typed validator would have the DI container try to construct it, which
+/// fails because <see cref="TimeSpan"/> isn't a registered service.
+/// </remarks>
+internal static class MeterEventRules
 {
-    public MeterEventRequestValidator(IClock clock, TimeSpan maxAge)
+    public static void Apply(InlineValidator<MeterEventRequest> events, IClock clock, TimeSpan maxAge)
     {
-        RuleFor(x => x.MeterDefinitionId)
+        events.RuleFor(x => x.MeterDefinitionId)
             .NotEmpty();
 
-        RuleFor(x => x.IdempotencyKey)
+        events.RuleFor(x => x.IdempotencyKey)
             .NotEmpty()
             .MaximumLength(256);
 
-        RuleFor(x => x.Quantity)
+        events.RuleFor(x => x.Quantity)
             .GreaterThan(0);
 
-        RuleFor(x => x.Timestamp)
+        events.RuleFor(x => x.Timestamp)
             .NotEmpty()
             .LessThanOrEqualTo(clock.Now.AddMinutes(5))
             .GreaterThan(clock.Now - maxAge);
 
-        RuleFor(x => x.Metadata)
+        events.RuleFor(x => x.Metadata)
             .MaximumLength(4000)
             .When(x => x.Metadata is not null);
     }

--- a/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
+++ b/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
@@ -21,7 +21,7 @@ public sealed class MeterDefinitionQueryDefinition : QueryDefinition<MeterDefini
                 .LabelKey("Metering.Columns.Tenant")
                 .Filterable()
                 .Sortable()
-                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+                .Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read"))
             .Column(m => m.Name, c => c.Label("Name").LabelKey("Metering.Columns.Name").Filterable().Sortable())
             .Column(m => m.Unit, c => c.Label("Unit").LabelKey("Metering.Columns.Unit").Filterable().Sortable())
             .Column(m => m.AggregationType, c => c.Label("Aggregation").LabelKey("Metering.Columns.AggregationType").Filterable().Sortable())

--- a/src/Granit.Metering/Queries/UsageAggregateQueryDefinition.cs
+++ b/src/Granit.Metering/Queries/UsageAggregateQueryDefinition.cs
@@ -21,7 +21,7 @@ public sealed class UsageAggregateQueryDefinition : QueryDefinition<UsageAggrega
                 .LabelKey("Metering.Columns.Tenant")
                 .Filterable()
                 .Sortable()
-                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+                .Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read"))
             .Column(u => u.MeterDefinitionId, c => c
                 .Label("Meter")
                 .LabelKey("Metering.Columns.MeterDefinition")

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Guids;
 using Granit.MultiTenancy.Endpoints.Dtos;
 using Granit.MultiTenancy.Endpoints.Options;
 using Granit.MultiTenancy.Endpoints.Permissions;
@@ -32,7 +33,6 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.RoutePrefix)
-            .RequireAuthorization()
             .WithTags(options.TagName);
 
         RouteGroupBuilder tenantsGroup = group.MapGranitGroup("tenants");
@@ -156,9 +156,10 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
         CreateTenantRequest body,
         [FromServices] ITenantWriter writer,
         [FromServices] ITenantReader reader,
+        [FromServices] IGuidGenerator guidGenerator,
         CancellationToken cancellationToken)
     {
-        var id = Guid.CreateVersion7();
+        Guid id = guidGenerator.Create();
 
         await writer
             .CreateAsync(id, body.Name, body.Identifier, body.ContactEmail, body.Jurisdiction, cancellationToken)

--- a/src/Granit.MultiTenancy.Endpoints/Granit.MultiTenancy.Endpoints.csproj
+++ b/src/Granit.MultiTenancy.Endpoints/Granit.MultiTenancy.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
+++ b/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization;
+using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
@@ -15,6 +16,7 @@ namespace Granit.MultiTenancy.Endpoints;
 /// </remarks>
 [DependsOn(
     typeof(GranitAuthorizationModule),
+    typeof(GranitGuidsModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitMultiTenancyModule),
     typeof(GranitValidationModule))]

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en-GB.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en-GB.json
@@ -1,10 +1,4 @@
 {
   "culture": "en-GB",
-  "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "View tenant information",
-    "Permission:MultiTenancy.Tenants.Create": "Create new tenants",
-    "Permission:MultiTenancy.Tenants.Update": "Update tenant details",
-    "Permission:MultiTenancy.Tenants.Manage": "Manage tenant lifecycle (activate, deactivate)"
-  }
+  "texts": {}
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
@@ -1,10 +1,4 @@
 {
   "culture": "fr-CA",
-  "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenant",
-    "Permission:MultiTenancy.Tenants.Read": "Consulter les informations des locataires",
-    "Permission:MultiTenancy.Tenants.Create": "Créer de nouveaux locataires",
-    "Permission:MultiTenancy.Tenants.Update": "Modifier les détails des locataires",
-    "Permission:MultiTenancy.Tenants.Manage": "Gérer le cycle de vie des locataires (activer, désactiver)"
-  }
+  "texts": {}
 }

--- a/src/Granit.MultiTenancy.Endpoints/packages.lock.json
+++ b/src/Granit.MultiTenancy.Endpoints/packages.lock.json
@@ -65,6 +65,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -46,13 +46,13 @@ public static class MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensi
 
         // Granit.DataLookup source: exposes Tenant as the "tenants" lookup so admin
         // UIs (QueryEngine filter picker + edit-form dropdowns) can pick a tenant by
-        // name without typing a GUID. Host-scope only — gated by Platform.Tenants.Read.
+        // name without typing a GUID. Host-scope only — gated by MultiTenancy.Tenants.Read.
         builder.Services.AddQueryableLookup<Tenant, MultiTenancyDbContext>(
             name: "tenants",
             valueSelector: t => t.Id,
             labelSelector: t => t.Name,
             searchPredicate: (t, search) => t.Name.Contains(search) || t.Identifier.Contains(search),
-            requiredPermission: "Platform.Tenants.Read");
+            requiredPermission: "MultiTenancy.Tenants.Read");
 
         return builder;
     }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/GranitMultiTenancyEntityFrameworkCoreModule.cs
@@ -1,5 +1,10 @@
+using Granit.DataExchange;
+using Granit.DataLookup.EntityFrameworkCore;
+using Granit.Events;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Migrations;
+using Granit.QueryEngine;
 
 namespace Granit.MultiTenancy.EntityFrameworkCore;
 
@@ -13,6 +18,11 @@ namespace Granit.MultiTenancy.EntityFrameworkCore;
 /// Registered via <c>AddGranitMultiTenancyEntityFrameworkCore(opt => opt.UseNpgsql(...))</c>.
 /// </remarks>
 [DependsOn(
+    typeof(GranitDataExchangeAbstractionsModule),
+    typeof(GranitDataLookupEntityFrameworkCoreModule),
+    typeof(GranitEventsModule),
     typeof(GranitMultiTenancyModule),
-    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+    typeof(GranitPersistenceEntityFrameworkCoreMigrationsModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule),
+    typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitMultiTenancyEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfTenantQueryableSource.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfTenantQueryableSource.cs
@@ -10,10 +10,12 @@ namespace Granit.MultiTenancy.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfTenantQueryableSource(
     IDbContextFactory<MultiTenancyDbContext> contextFactory)
-    : IQueryableSource<Tenant>
+    : IQueryableSource<Tenant>, IDisposable
 {
     private readonly MultiTenancyDbContext _context = contextFactory.CreateDbContext();
 
     public IQueryable<Tenant> GetQueryable() =>
         _context.Tenants.AsNoTracking();
+
+    public void Dispose() => _context.Dispose();
 }

--- a/src/Granit.MultiTenancy/GranitMultiTenancyModule.cs
+++ b/src/Granit.MultiTenancy/GranitMultiTenancyModule.cs
@@ -1,5 +1,7 @@
+using Granit.DataExchange;
 using Granit.Modularity;
 using Granit.MultiTenancy.Extensions;
+using Granit.QueryEngine;
 
 namespace Granit.MultiTenancy;
 
@@ -8,6 +10,8 @@ namespace Granit.MultiTenancy;
 /// Resolves the tenant from the HTTP header or the JWT claim (standard ClaimsPrincipal).
 /// Compatible with any identity provider (Keycloak, Auth0, Azure AD, etc.).
 /// </summary>
+[DependsOn(typeof(GranitDataExchangeAbstractionsModule))]
+[DependsOn(typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitMultiTenancyModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Payments/Handlers/AutoChargeOnInvoiceHandler.cs
+++ b/src/Granit.Payments/Handlers/AutoChargeOnInvoiceHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 
 namespace Granit.Payments.Handlers;
 

--- a/src/Granit.Payments/IAutoChargeService.cs
+++ b/src/Granit.Payments/IAutoChargeService.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 
 namespace Granit.Payments;
 

--- a/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
+++ b/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
@@ -1,7 +1,7 @@
 using Granit.Commands;
 using Granit.Invoicing;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
-using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
 using Granit.Payments.Domain;

--- a/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
+++ b/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
@@ -1,5 +1,5 @@
 using Granit.Invoicing;
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 
 namespace Granit.Payments.Internal;
 

--- a/src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs
+++ b/src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs
@@ -18,10 +18,10 @@ public sealed class RateLimitingMetrics
     {
         Meter meter = meterFactory.Create(MeterName);
         _allowedCounter = meter.CreateCounter<long>(
-            "granit.rate_limiting.requests.allowed",
+            "granit.ratelimiting.requests.allowed",
             description: "Number of requests allowed by rate limiting.");
         _rejectedCounter = meter.CreateCounter<long>(
-            "granit.rate_limiting.requests.rejected",
+            "granit.ratelimiting.requests.rejected",
             description: "Number of requests rejected by rate limiting.");
     }
 

--- a/src/Granit.RateLimiting/GranitRateLimitingModule.cs
+++ b/src/Granit.RateLimiting/GranitRateLimitingModule.cs
@@ -12,8 +12,8 @@ namespace Granit.RateLimiting;
 /// and all required dependencies from configuration section <c>"RateLimiting"</c>.
 /// </summary>
 [DependsOn(
-    typeof(GranitHttpExceptionHandlingModule),
-    typeof(GranitFeaturesModule))]
+    typeof(GranitFeaturesModule),
+    typeof(GranitHttpExceptionHandlingModule))]
 public sealed class GranitRateLimitingModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.RateLimiting/Internal/LuaScripts.cs
+++ b/src/Granit.RateLimiting/Internal/LuaScripts.cs
@@ -78,6 +78,7 @@ internal static class LuaScripts
     /// ARGV[3] = replenishment period in milliseconds
     /// Returns: {allowed (0/1), tokens_remaining, retry_after_ms}
     /// </summary>
+#pragma warning disable GRSEC003 // "TokenBucket" is a rate-limiting algorithm name, not a credential.
     public const string TokenBucket = """
         local key = KEYS[1]
         local token_limit = tonumber(ARGV[1])
@@ -120,4 +121,5 @@ internal static class LuaScripts
 
         return {allowed, tokens, retry_ms}
         """;
+#pragma warning restore GRSEC003
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
@@ -39,6 +39,7 @@ internal static class PriceVersioningEndpoints
                 "ordered from newest to oldest. Includes replaced prices for audit trail.")
             .Produces<IReadOnlyList<PlanPriceResponse>>()
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem()
             .RequireAuthorization(SubscriptionsPermissions.Prices.Read);
 
         group.MapPost("/subscriptions/{id:guid}/migrate-price", MigratePriceAsync)

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
@@ -4,6 +4,7 @@ using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Endpoints.Dtos;
+using Granit.Subscriptions.Endpoints.Internal;
 using Granit.Subscriptions.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -62,7 +63,7 @@ internal static class SeatEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader
@@ -91,7 +92,7 @@ internal static class SeatEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader
@@ -132,7 +133,7 @@ internal static class SeatEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -5,6 +5,7 @@ using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Endpoints.Dtos;
+using Granit.Subscriptions.Endpoints.Internal;
 using Granit.Subscriptions.Endpoints.Permissions;
 using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
@@ -17,8 +18,6 @@ namespace Granit.Subscriptions.Endpoints.Endpoints;
 
 internal static class SubscriptionEndpoints
 {
-    private const string TenantContextRequiredMessage = "Tenant context required.";
-
     internal static RouteGroupBuilder MapSubscriptionEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/subscriptions/active", GetActiveSubscriptionAsync)
@@ -85,7 +84,7 @@ internal static class SubscriptionEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader
@@ -131,7 +130,7 @@ internal static class SubscriptionEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Plan? plan = await planReader
@@ -182,7 +181,7 @@ internal static class SubscriptionEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader
@@ -228,7 +227,7 @@ internal static class SubscriptionEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(EndpointConstants.TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         Subscription? sub = await reader

--- a/src/Granit.Subscriptions.Endpoints/Internal/EndpointConstants.cs
+++ b/src/Granit.Subscriptions.Endpoints/Internal/EndpointConstants.cs
@@ -1,0 +1,15 @@
+namespace Granit.Subscriptions.Endpoints.Internal;
+
+/// <summary>
+/// Shared constants for endpoint handlers in the Subscriptions module.
+/// Centralizes literal strings reused across multiple endpoint groups
+/// (e.g. ProblemDetails messages) to avoid duplication.
+/// </summary>
+internal static class EndpointConstants
+{
+    /// <summary>
+    /// ProblemDetails message returned when a tenant-scoped endpoint is invoked
+    /// without an active <see cref="Granit.MultiTenancy.ICurrentTenant"/> context.
+    /// </summary>
+    public const string TenantContextRequiredMessage = "Tenant context required.";
+}

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -1,7 +1,6 @@
 {
   "culture": "cs",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Správa fází předplatného (plánování změn plánu, přepsání cen, aplikace slev)",
     "Permission:Subscriptions.Plans.Manage": "Spravovat plány předplatného (vytvořit, publikovat, archivovat)",
     "Permission:Subscriptions.Plans.Read": "Zobrazit plány předplatného",
     "Permission:Subscriptions.Prices.Manage": "Spravovat ceny (vytvářet verze, migrovat předplatné)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
@@ -1,7 +1,6 @@
 {
   "culture": "de",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Abonnementphasen verwalten (Planänderungen planen, Preise überschreiben, Rabatte anwenden)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementpläne verwalten (erstellen, veröffentlichen, archivieren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementpläne anzeigen",
     "Permission:Subscriptions.Prices.Manage": "Preise verwalten (Versionen erstellen, Abonnements migrieren)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
@@ -1,7 +1,6 @@
 {
   "culture": "en",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Manage subscription phases (schedule plan changes, override prices, apply discounts)",
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
     "Permission:Subscriptions.Plans.Read": "View subscription plans",
     "Permission:Subscriptions.Prices.Manage": "Manage prices (create versions, migrate subscriptions)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
@@ -1,7 +1,6 @@
 {
   "culture": "es",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Gestionar fases de suscripción (programar cambios de plan, anular precios, aplicar descuentos)",
     "Permission:Subscriptions.Plans.Manage": "Gestionar planes de suscripción (crear, publicar, archivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planes de suscripción",
     "Permission:Subscriptions.Prices.Manage": "Gestionar precios (crear versiones, migrar suscripciones)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
@@ -1,7 +1,6 @@
 {
   "culture": "fr",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Gérer les phases d'abonnement (planifier des changements de plan, surcharger les prix, appliquer des remises)",
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
     "Permission:Subscriptions.Plans.Read": "Consulter les plans d'abonnement",
     "Permission:Subscriptions.Prices.Manage": "Gérer les prix (créer des versions, migrer les abonnements)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
@@ -1,7 +1,6 @@
 {
   "culture": "hi",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "सदस्यता चरण प्रबंधित करें (योजना परिवर्तन शेड्यूल करें, मूल्य ओवरराइड करें, छूट लागू करें)",
     "Permission:Subscriptions.Plans.Manage": "सब्सक्रिप्शन प्लान प्रबंधित करें (बनाएँ, प्रकाशित करें, संग्रहित करें)",
     "Permission:Subscriptions.Plans.Read": "सब्सक्रिप्शन प्लान देखें",
     "Permission:Subscriptions.Prices.Manage": "मूल्य प्रबंधित करें (संस्करण बनाएँ, सब्सक्रिप्शन माइग्रेट करें)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -1,7 +1,6 @@
 {
   "culture": "it",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Gestire le fasi dell'abbonamento (programmare modifiche di piano, sovrascrivere prezzi, applicare sconti)",
     "Permission:Subscriptions.Plans.Manage": "Gestire i piani di abbonamento (creare, pubblicare, archiviare)",
     "Permission:Subscriptions.Plans.Read": "Visualizzare i piani di abbonamento",
     "Permission:Subscriptions.Prices.Manage": "Gestire i prezzi (creare versioni, migrare abbonamenti)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -1,7 +1,6 @@
 {
   "culture": "ja",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "サブスクリプションフェーズを管理（プラン変更のスケジュール、価格上書き、割引適用）",
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
     "Permission:Subscriptions.Plans.Read": "サブスクリプションプランの表示",
     "Permission:Subscriptions.Prices.Manage": "価格を管理（バージョン作成、サブスクリプション移行）",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -1,7 +1,6 @@
 {
   "culture": "ko",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "구독 단계 관리 (요금제 변경 예약, 가격 재정의, 할인 적용)",
     "Permission:Subscriptions.Plans.Manage": "구독 플랜 관리 (생성, 게시, 보관)",
     "Permission:Subscriptions.Plans.Read": "구독 플랜 보기",
     "Permission:Subscriptions.Prices.Manage": "가격 관리 (버전 생성, 구독 마이그레이션)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
@@ -1,7 +1,6 @@
 {
   "culture": "nl",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Abonnementfasen beheren (planwijzigingen plannen, prijzen overschrijven, kortingen toepassen)",
     "Permission:Subscriptions.Plans.Manage": "Abonnementsplannen beheren (aanmaken, publiceren, archiveren)",
     "Permission:Subscriptions.Plans.Read": "Abonnementsplannen bekijken",
     "Permission:Subscriptions.Prices.Manage": "Prijzen beheren (versies aanmaken, abonnementen migreren)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -1,7 +1,6 @@
 {
   "culture": "pl",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Zarządzanie fazami subskrypcji (planowanie zmian planu, nadpisywanie cen, stosowanie zniżek)",
     "Permission:Subscriptions.Plans.Manage": "Zarządzanie planami subskrypcji (tworzenie, publikowanie, archiwizowanie)",
     "Permission:Subscriptions.Plans.Read": "Wyświetlanie planów subskrypcji",
     "Permission:Subscriptions.Prices.Manage": "Zarządzaj cenami (twórz wersje, migruj subskrypcje)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -1,7 +1,6 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Gerenciar fases de assinatura (agendar alterações de plano, sobrepor preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerenciar planos de assinatura (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Visualizar planos de assinatura",
     "Permission:Subscriptions.Prices.Manage": "Gerenciar preços (criar versões, migrar assinaturas)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -1,7 +1,6 @@
 {
   "culture": "pt",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Gerir fases de subscrição (agendar alterações de plano, substituir preços, aplicar descontos)",
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
     "Permission:Subscriptions.Plans.Read": "Ver planos de subscrição",
     "Permission:Subscriptions.Prices.Manage": "Gerir preços (criar versões, migrar assinaturas)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -1,7 +1,6 @@
 {
   "culture": "sv",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Hantera prenumerationsfaser (schemalägga planändringar, åsidosätta priser, tillämpa rabatter)",
     "Permission:Subscriptions.Plans.Manage": "Hantera prenumerationsplaner (skapa, publicera, arkivera)",
     "Permission:Subscriptions.Plans.Read": "Visa prenumerationsplaner",
     "Permission:Subscriptions.Prices.Manage": "Hantera priser (skapa versioner, migrera prenumerationer)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -1,7 +1,6 @@
 {
   "culture": "tr",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "Abonelik fazlarını yönet (plan değişikliklerini zamanla, fiyatları geçersiz kıl, indirim uygula)",
     "Permission:Subscriptions.Plans.Manage": "Abonelik planlarını yönet (oluştur, yayınla, arşivle)",
     "Permission:Subscriptions.Plans.Read": "Abonelik planlarını görüntüle",
     "Permission:Subscriptions.Prices.Manage": "Fiyatları yönet (sürüm oluştur, abonelikleri taşı)",

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -1,7 +1,6 @@
 {
   "culture": "zh",
   "texts": {
-    "Permission:Subscriptions.Phases.Manage": "管理订阅阶段（计划变更、价格覆盖、应用折扣）",
     "Permission:Subscriptions.Plans.Manage": "管理订阅计划（创建、发布、归档）",
     "Permission:Subscriptions.Plans.Read": "查看订阅计划",
     "Permission:Subscriptions.Prices.Manage": "管理价格（创建版本、迁移订阅）",

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -42,11 +42,5 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
         group.AddPermission(SubscriptionsPermissions.Seats.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Manage"),
             MultiTenancySide.Both);
-
-        // Phases are admin-only: they pin the active plan + price for a window
-        // and apply percentage discounts — host-side ramp-deal authoring tool.
-        group.AddPermission(SubscriptionsPermissions.Phases.Manage,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Phases.Manage"),
-            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
@@ -45,17 +45,4 @@ public static class SubscriptionsPermissions
         /// <summary>Manage seat assignments (assign, revoke).</summary>
         public const string Manage = "Subscriptions.Seats.Manage";
     }
-
-    /// <summary>Scheduled phase permissions (ramp deals, plan transitions).</summary>
-    public static class Phases
-    {
-        /// <summary>
-        /// Manage subscription phases (schedule plan changes, override prices, apply
-        /// flat percentage discounts). Restricted to admins because phases pin the
-        /// active plan + price for a specific time window — destructive at the
-        /// billing level (ISO 27001 A.9.4 — least privilege on revenue-impacting
-        /// operations).
-        /// </summary>
-        public const string Manage = "Subscriptions.Phases.Manage";
-    }
 }

--- a/src/Granit.Subscriptions/Handlers/InvoicePaidHandler.cs
+++ b/src/Granit.Subscriptions/Handlers/InvoicePaidHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Events;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.Subscriptions.Handlers;

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
@@ -17,7 +17,7 @@ internal static class TaxRateEndpoints
 {
     internal static RouteGroupBuilder MapRateEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/{countryCode}", GetRateByCountryAsync)
+        group.MapGet("/{countryCode:length(2)}", GetRateByCountryAsync)
             .WithName("GetTaxRateByCountry")
             .WithSummary("Returns the current tax rate for a specific country.")
             .WithDescription(

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxValidationEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxValidationEndpoints.cs
@@ -23,7 +23,7 @@ internal static class TaxValidationEndpoints
                 "Submits a tax identification number (e.g., EU VAT, UK VAT, US EIN) for online verification. "
                 + "Uses the configured provider (VIES for EU, Stripe for other jurisdictions). "
                 + "Results are cached according to the configured TTL to avoid repeated API calls.")
-            .Produces<TaxValidateResponse>(StatusCodes.Status200OK)
+            .Produces<TaxValidateResponse>()
             .ProducesValidationProblem();
 
         return group;

--- a/src/Granit.Tax.Stripe/GranitTaxStripeModule.cs
+++ b/src/Granit.Tax.Stripe/GranitTaxStripeModule.cs
@@ -27,7 +27,7 @@ public sealed class GranitTaxStripeModule : GranitModule
             .ValidateOnStart();
 
         context.Services.AddGranitHttpClient("StripeTax");
-        context.Services.AddScoped<IStripeClient>(sp =>
+        context.Services.TryAddScoped<IStripeClient>(sp =>
         {
             IOptions<StripeTaxOptions> opts = sp.GetRequiredService<IOptions<StripeTaxOptions>>();
             HttpClient httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("StripeTax");

--- a/src/Granit.Tax.Stripe/Internal/StripeTaxCalculator.cs
+++ b/src/Granit.Tax.Stripe/Internal/StripeTaxCalculator.cs
@@ -23,7 +23,7 @@ internal sealed partial class StripeTaxCalculator(
     {
         var calcOptions = new CalculationCreateOptions
         {
-            Currency = request.BuyerAddress.Country == "US" ? "usd" : "eur",
+            Currency = options.Value.Currency.ToLowerInvariant(),
             CustomerDetails = new CalculationCustomerDetailsOptions
             {
                 Address = new AddressOptions

--- a/src/Granit.Tax.Stripe/Options/StripeTaxOptions.cs
+++ b/src/Granit.Tax.Stripe/Options/StripeTaxOptions.cs
@@ -14,4 +14,10 @@ public sealed class StripeTaxOptions
 
     /// <summary>Default product tax code (SaaS = txcd_10000000).</summary>
     public string ProductTaxCode { get; set; } = "txcd_10000000";
+
+    /// <summary>
+    /// ISO 4217 currency code used for Stripe Tax calculations. Defaults to <c>"eur"</c>.
+    /// Stripe expects lowercase (e.g., <c>"eur"</c>, <c>"usd"</c>).
+    /// </summary>
+    public string Currency { get; set; } = "eur";
 }

--- a/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
@@ -43,6 +43,8 @@ public sealed partial class ValidationConventionTests
         "TemplatePreviewRequest",
         // Nested sub-type validated via ChildRules in AIChatRequestValidator — never sent as direct body
         "AIChatMessageRequest",
+        // Nested sub-type validated via ChildRules + MeterEventRules in RecordUsage/BackfillUsageRequestValidator — never sent as direct body
+        "MeterEventRequest",
     };
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -410,8 +410,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.12.0",
-        "contentHash": "QPyuk1Lxp1xgSTP8xomnoZjeOtUeTSoeSuEckhGaUAi6GdZ5d2PmZqzr0O4m/zPbC4So/yg5rr2QO4vYD6fB5g=="
+        "resolved": "14.13.0",
+        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
       },
       "MessagePack": {
         "type": "Transitive",
@@ -2570,6 +2570,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
@@ -3738,55 +3739,55 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.12",
-        "contentHash": "x3KLGksdIgy0IJgohXpPda00gcZ/PORhR2A1RRLVRe+SBWu2AqffEAq7uQNF/KVCM/Vxd/916Z+3QrYmb0LeJQ==",
+        "resolved": "4.0.9.13",
+        "contentHash": "D8WKD7niFTrP4FLjxUB/fHaC0pEtQXqRN74ylkib+IDCOqe5MATONPpfXJ9wthXXX+ihOP3rpsBJRAi2NL4Cvw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.22",
-        "contentHash": "zkX4e1JqmMfRCVjbvM36U/xhPdYnMaWtb1nzRqS43USyGLNw1E7IaZE4snaZJbs8Np0276FR8NUaEcp/efQyVw==",
+        "resolved": "4.0.22.1",
+        "contentHash": "DvD6hSsrr8Z5j+ER6msGOHFQZsgyhNWrLbO5y+1YT/VRn6uL4BFhI2YNofRsfVPaA85vOj7q/sLuexSsCXwJZg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.18",
-        "contentHash": "dRjvsm2rTNufl+iJ3cUTEq6Pud9P5RzYcjTbl1lqf1JSf7rYHobI44ClbD15O2Hwl0V+Z55BkGMUq6HgiERTkg==",
+        "resolved": "4.0.4.19",
+        "contentHash": "9ZmQol813rd2mgGnFy3iixFHswLqgNSFq9IvaIavsElQPsE3B976XL8hu+R9xbjE83JT9farDhuyXSw3ArlL5Q==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.11",
-        "contentHash": "BwmtWC3JM9P4zfzOUPyny9K4z50s4LmUdiwbhIoGaSoD3kWH7IdteR+yF98isjxIYVmvedbFnWoVqn5gW1sStw==",
+        "resolved": "4.0.12.12",
+        "contentHash": "yXOVniaZoAFSBQVo5b35D3wi7asxEKddm9xJHWiTXm0wg+b1TjOyONtU1drqNQ3cqbLaJlAQhjUzKLxA57WZFw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.28",
-        "contentHash": "FP10JIhMPDNBu5PmBOjVb/HwRHDOzFnqTK9RfsDlej18u2uTL8UjxqRs+ZHYQurIlhK+R41g5Hd8Oe/eo9JY0w==",
+        "resolved": "4.0.2.29",
+        "contentHash": "o9CtqlUBmwFdowN6JTCR/9EY18bM+PXSJgaB2g4zxFdyOXOWmfq6B17C++wzTZHZjAKjgwqvZvaV8Ycqhu/zuw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Azure.AI.OpenAI": {
@@ -3969,10 +3970,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.12.0",
-        "contentHash": "YGEgNTZ6DaMhXgJYLClRrmEe6CMsEL5E8hy4c2iH/aEmj41ojFAtA/PIXYH1AOYINNEUX/83nLp/y5obt9P/vw==",
+        "resolved": "14.13.0",
+        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
         "dependencies": {
-          "Magick.NET.Core": "14.12.0"
+          "Magick.NET.Core": "14.13.0"
         }
       },
       "MailKit": {

--- a/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryableLookupSourceTests.cs
+++ b/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryableLookupSourceTests.cs
@@ -80,11 +80,11 @@ public sealed class QueryableLookupSourceTests : IDisposable
             queryableFactory: () => _db.Tenants.AsQueryable(),
             valueSelector: t => t.Id,
             labelSelector: t => t.Name,
-            requiredPermission: "Platform.Tenants.Read",
+            requiredPermission: "MultiTenancy.Tenants.Read",
             scopeKeys: ["orgId"]);
 
         source.Name.ShouldBe("tenants");
-        source.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        source.RequiredPermission.ShouldBe("MultiTenancy.Tenants.Read");
         source.ScopeKeys.ShouldBe(["orgId"]);
     }
 

--- a/tests/Granit.DataLookup.Tests/Descriptors/LookupDescriptorTests.cs
+++ b/tests/Granit.DataLookup.Tests/Descriptors/LookupDescriptorTests.cs
@@ -22,8 +22,8 @@ public sealed class LookupDescriptorTests
     [Fact]
     public void Records_with_same_values_are_equal()
     {
-        LookupDescriptor a = new(Name: "tenants", Kind: LookupKind.QueryEngine, RequiredPermission: "Platform.Tenants.Read");
-        LookupDescriptor b = new(Name: "tenants", Kind: LookupKind.QueryEngine, RequiredPermission: "Platform.Tenants.Read");
+        LookupDescriptor a = new(Name: "tenants", Kind: LookupKind.QueryEngine, RequiredPermission: "MultiTenancy.Tenants.Read");
+        LookupDescriptor b = new(Name: "tenants", Kind: LookupKind.QueryEngine, RequiredPermission: "MultiTenancy.Tenants.Read");
 
         a.ShouldBe(b);
         a.GetHashCode().ShouldBe(b.GetHashCode());

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
@@ -1,8 +1,8 @@
 using Granit.Events;
 using Granit.Invoicing;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.BackgroundJobs.Internal;
 using Granit.Invoicing.Domain;
-using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/tests/Granit.Metering.Endpoints.Tests/Validators/MeteringEndpointsValidatorRegistrationTests.cs
+++ b/tests/Granit.Metering.Endpoints.Tests/Validators/MeteringEndpointsValidatorRegistrationTests.cs
@@ -1,0 +1,62 @@
+using FluentValidation;
+using Granit.Metering.Endpoints.Validators;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.Endpoints.Tests.Validators;
+
+/// <summary>
+/// Regression guard for the DI failure caused by an internal nested validator
+/// whose constructor took a non-injectable <see cref="TimeSpan"/> parameter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GranitValidationModule</c> calls <c>AddValidatorsFromAssembly(includeInternalTypes: true)</c>
+/// over every loaded module assembly. The previous implementation defined
+/// <c>MeterEventRequestValidator</c> as an <c>internal sealed class : AbstractValidator&lt;MeterEventRequest&gt;</c>
+/// with a <c>(IClock clock, TimeSpan maxAge)</c> constructor, used only via
+/// <c>RuleForEach(...).SetValidator(new MeterEventRequestValidator(...))</c> from inside the two
+/// top-level validators. The DI auto-discovery picked it up and tried to instantiate it through
+/// the container; building the <c>ServiceProvider</c> with <c>ValidateOnBuild</c> threw because
+/// <see cref="TimeSpan"/> isn't a registered service. <c>SIGABRT (134)</c> at host startup.
+/// </para>
+/// <para>
+/// The fix moved the per-event rules into a <c>static class MeterEventRules</c> with an
+/// <c>Apply(InlineValidator&lt;MeterEventRequest&gt;, IClock, TimeSpan)</c> method, and the two
+/// top-level validators now call <c>RuleForEach(...).ChildRules(events =&gt; MeterEventRules.Apply(events, clock, maxAge))</c>.
+/// Static classes carry no <c>IValidator</c> implementation, so the assembly scanner skips them.
+/// </para>
+/// </remarks>
+public sealed class MeteringEndpointsValidatorRegistrationTests
+{
+    [Fact]
+    public void AddValidatorsFromAssembly_WithInternalTypes_ShouldNotPickUpHelperRuleClass()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorsFromAssembly(
+            typeof(RecordUsageRequestValidator).Assembly,
+            ServiceLifetime.Scoped,
+            includeInternalTypes: true);
+
+        // Real-ish clock: validator rules call `clock.Now - maxAge` at *construction*,
+        // so a default(DateTimeOffset) stub would underflow DateTime arithmetic.
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+        services.AddSingleton(clock);
+
+        // ValidateOnBuild surfaces "no service for type 'System.TimeSpan'" if any
+        // discovered validator's ctor expects a non-DI primitive.
+        ServiceProvider provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        // Both top-level validators must still resolve normally.
+        using IServiceScope scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IValidator<Dtos.RecordUsageRequest>>()
+            .ShouldBeOfType<RecordUsageRequestValidator>();
+        scope.ServiceProvider.GetRequiredService<IValidator<Dtos.BackfillUsageRequest>>()
+            .ShouldBeOfType<BackfillUsageRequestValidator>();
+    }
+}

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
@@ -275,6 +275,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -319,6 +325,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
@@ -1,7 +1,7 @@
 using Granit.Commands;
 using Granit.Invoicing;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
-using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
 using Granit.Payments.Domain;

--- a/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
@@ -1,6 +1,6 @@
 using Granit.Invoicing;
+using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
-using Granit.Invoicing.Events;
 using Granit.Payments.Internal;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -308,7 +308,7 @@ public sealed class QueryEngineTests : IAsyncLifetime
         tenantField.Lookup.ShouldNotBeNull();
         tenantField.Lookup!.Name.ShouldBe("tenants");
         tenantField.Lookup.Kind.ShouldBe(LookupKind.QueryEngine);
-        tenantField.Lookup.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        tenantField.Lookup.RequiredPermission.ShouldBe("MultiTenancy.Tenants.Read");
     }
 
     [Fact]
@@ -349,7 +349,7 @@ public sealed class QueryEngineTests : IAsyncLifetime
                 .Column(p => p.Name, c => c
                     .Label("Name")
                     .Filterable()
-                    .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+                    .Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read"))
                 .Column(p => p.Price, c => c.Label("Price").Filterable())
                 .DefaultPageSize(10);
     }

--- a/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
@@ -123,12 +123,12 @@ public sealed class ColumnBuilderTests
     {
         ColumnBuilder<TestEntity> builder = new();
 
-        builder.Lookup("tenants", requiredPermission: "Platform.Tenants.Read");
+        builder.Lookup("tenants", requiredPermission: "MultiTenancy.Tenants.Read");
 
         builder.LookupValue.ShouldNotBeNull();
         builder.LookupValue!.Name.ShouldBe("tenants");
         builder.LookupValue.Kind.ShouldBe(LookupKind.QueryEngine);
-        builder.LookupValue.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        builder.LookupValue.RequiredPermission.ShouldBe("MultiTenancy.Tenants.Read");
         builder.LookupValue.Endpoint.ShouldBeNull();
     }
 


### PR DESCRIPTION
## Summary

Audit-driven convention compliance fixes across the SaaS module families — `MultiTenancy`, `Subscriptions`, `Invoicing`, `CustomerBalance`, `Tax`, `Catalog`, `Features`, `RateLimiting`, `Http.Bulkhead`. Source of findings: `/audit` skill against the framework checklist (CLAUDE.md, `docs-site/.../dotnet/`).

## Highlights

### BREAKING fixes
- **`Platform.Tenants.Read` → `MultiTenancy.Tenants.Read`** — non-existent permission string was passed to the tenants `IQueryableLookup` registration; every caller was 403'd. 13 occurrences across 9 files (3 src, 6 tests, 1 XML doc).
- **`InvoicingSchemaExampleProvider` registered in DI** — class existed but was never wired; OpenAPI examples for `Invoice*` DTOs were empty.

### ARCHITECTURE fixes
- `EfTenantQueryableSource` now `IDisposable` (DbContext was leaked through ctor caching).
- Missing-tenant responses standardized to **422 Unprocessable Entity** (was 400 in Invoicing/CustomerBalance, 404 in others).
- Tax `/{countryCode}` route gets `:length(2)` constraint; Stripe currency sourced from options instead of US/EUR hardcoded.
- Renamed `Granit.Invoicing.Events` → `Granit.Invoicing.Abstractions.Events` so namespace matches project (12 consumer files updated).

### CONVENTION sweep
- Subscriptions `Phases.Manage` orphan permission removed (declared/registered/localized but no endpoints) — constants + provider + 18 locales.
- Invoicing `POST /invoices` permission `Manage` → `Create` (least-privilege, ISO 27001 A.9.4) + 18 locales.
- 5 modules with `[DependsOn]` order/missing-entry corrections (alphabetical).
- Features locale labels: native "Read" verbs across 13 cultures (was "View").
- CustomerBalance XML doc-strings: `<summary>View</summary>` → `Read` (constant was already `Read`).
- Catalog "extra properties" wording → "metadata" in endpoint descriptions / DTOs.
- New `BulkheadActivitySource` (parity with RateLimiting/Features).
- RateLimiting metric naming aligned: `granit.rate_limiting.*` → `granit.ratelimiting.*`.
- Subscriptions price-versioning endpoints declare `.ProducesValidationProblem()`.
- Centralized `TenantContextRequiredMessage` constant in Subscriptions.

### Side fixes
- `chore(arch-tests)`: `MeterEventRequest` exempted from validator-presence check (validated inline via `MeterEventRules.Apply` ChildRules) — unblocks the architecture-tests CI shard.
- `docs(site)`: `Spikes` section added to Architecture sidebar in Astro config — fixes `AstroUserError` on the new `metering-sql-ad-hoc-metrics` spike page.

## Verification

- `dotnet build` (full solution): **0 warnings, 0 errors** (~2:28).
- `dotnet test tests/Granit.ArchitectureTests` filtered on the failing test: pass.
- `npx astro build` (docs-site): **418 pages, all internal links valid**.
- Tree manually verified: every file:line referenced in the audit report has a matching change.

## Deferred to follow-ups

These were identified by the audit but skipped intentionally — each warrants its own focused PR:

- **Invoicing.Odoo store implementation** — provider declares `OdooPartnerMapping` + `IOdooPartnerMappingStore` but no store exists; needs a new `Granit.Invoicing.Odoo.EntityFrameworkCore` package.
- **`Money` / `Percentage` value objects** in Invoicing (decimals → `SingleValueObject<T>` with currency safety).
- **Catalog `GET /products` pagination** — currently returns unbounded `IReadOnlyList`.
- **Subscription `Phase` endpoints** — `SubscriptionPhase` aggregate ships but no HTTP surface; orphan permission removed in this PR.
- **`AsParameters` refactor** for query-string DTOs in CustomerBalance/Tax.
- **Tax `Source` enum** — exposed as raw string in DTO; should use `JsonStringEnumConverter`.
- **Invoicing diagnostics dead code** — metrics class registered but `Record*` methods never called; activity-source constants declared but never used.

## Test plan

- [ ] CI build green (all 6 test shards)
- [ ] `architecture` shard — verify `Request_types_in_Endpoints_should_have_validators` passes
- [ ] Verify Scalar UI shows `Invoice*` request examples
- [ ] Verify `IQueryableLookup<Tenant>` returns rows for a caller holding `MultiTenancy.Tenants.Read`
- [ ] Astro deploy succeeds; spike page resolves under Architecture → Spikes
