### PR TITLE
docs(astro): backfill ADR-033/034/035 + align SaaS module docs with merged backend

### DIFF
--- a/docs-site/src/content/docs/blog/configureawait-false-in-library-code.md
+++ b/docs-site/src/content/docs/blog/configureawait-false-in-library-code.md
@@ -1,0 +1,205 @@
+---
+title: "ConfigureAwait(false) in Library Code — Still Relevant in .NET 10?"
+date: 2026-04-29
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - async
+  - performance
+  - code-quality
+description: "ASP.NET Core dropped the synchronization context years ago. So why do every Granit library and the .NET runtime itself still write ConfigureAwait(false) on every await? Because libraries do not get to choose their host."
+excerpt: >
+  ASP.NET Core dropped the synchronization context years ago. So why do every
+  Granit library and the .NET runtime itself still write ConfigureAwait(false)
+  on every await? Because libraries do not get to choose their host.
+---
+
+Every junior dev who reads modern ASP.NET Core code asks the same question. "If ASP.NET Core has no synchronization context, why is the codebase peppered with `.ConfigureAwait(false)`? Isn't that obsolete?" The short answer is no, but the longer answer is more interesting — and it explains why **library code** plays by different rules than **app code**, even in 2026.
+
+## What `ConfigureAwait(false)` actually does
+
+When you `await` a `Task`, the compiler captures the **current `SynchronizationContext`** (or the current `TaskScheduler` if there is none) and resumes the continuation on that context. `ConfigureAwait(false)` tells the compiler not to capture it — resume on whatever thread the awaited operation completes on, usually a thread-pool thread.
+
+```csharp title="What the compiler sees"
+// With default behavior (capture context)
+await dbContext.SaveChangesAsync();
+// Compiler: capture SyncContext, resume continuation on it
+
+// With ConfigureAwait(false)
+await dbContext.SaveChangesAsync().ConfigureAwait(false);
+// Compiler: do not capture, resume on any thread
+```
+
+That single bool determines whether your continuation runs on the UI thread, the request thread, or a thread-pool thread. In code that does not need a specific thread to run on (most of it), capturing the context is at best wasted work and at worst a deadlock generator.
+
+## Why the rule exists at all
+
+Two real failure modes drove the rule into existence:
+
+### 1. Deadlocks in apps with a captured context
+
+The classic blocking-on-async deadlock:
+
+```csharp title="DemoController.cs (WPF / WinForms / classic ASP.NET)"
+public IActionResult Index()
+{
+    // BAD: synchronously waits on async work
+    var data = _service.GetDataAsync().Result;
+    return View(data);
+}
+```
+
+```csharp title="DataService.cs"
+public async Task<Data> GetDataAsync()
+{
+    // Default: captures the calling context (UI thread / ASP.NET request thread)
+    var raw = await _http.GetStringAsync("...");
+    return Parse(raw);
+}
+```
+
+The continuation needs to resume on the captured context. The captured context is the one thread the caller has blocked by waiting on `.Result`. Deadlock. Add `ConfigureAwait(false)` inside `GetDataAsync` and the continuation runs on the thread pool, the method completes, the `.Result` returns, the world keeps turning.
+
+### 2. Performance overhead
+
+Even when there is no deadlock, capturing and posting back to the context costs. `SynchronizationContext.Post` is not free — it queues a delegate, which the context dispatcher eventually pumps. On a UI thread that is exactly what you want; on a hot async pipeline buried five layers deep in a library, you pay that cost on every await for nothing.
+
+## ASP.NET Core changed the calculus
+
+Here is what flipped the conversation in 2018: **ASP.NET Core has no `SynchronizationContext`**. None. `SynchronizationContext.Current` is `null` inside an MVC action, a Minimal API endpoint, a SignalR hub method. The runtime made a deliberate choice to ditch the request-affinity model that classic ASP.NET inherited from WebForms.
+
+Consequences:
+
+- The classic `.Result` deadlock cannot happen in ASP.NET Core. There is nothing to capture, so there is nothing to be blocked behind.
+- `ConfigureAwait(false)` is a no-op inside ASP.NET Core code. The compiler still emits the call, but the runtime has nothing to resume on either way.
+- The Microsoft team that wrote ASP.NET Core stopped using `ConfigureAwait` in their own application code.
+
+Stephen Toub's seminal "ConfigureAwait FAQ" landed the same year. The takeaway most developers remembered was *"ASP.NET Core doesn't need ConfigureAwait(false)"*, which is true. The takeaway most developers forgot was *"libraries still do"*, which is also true and matters more.
+
+## The rule that actually matters in 2026
+
+Application code and library code are not the same thing:
+
+| Code type | `ConfigureAwait(false)` rule | Reason |
+| --------- | ---------------------------- | ------ |
+| ASP.NET Core endpoint, controller, BackgroundService | Optional | No SyncContext to capture |
+| Console / worker service / CLI | Optional | No SyncContext to capture |
+| WPF / WinForms / MAUI / Blazor Server / Xamarin | **Required** to avoid UI deadlocks | These hosts install a SyncContext |
+| **Library code (NuGet packages, shared internal libs)** | **Required** | The library does not know which host it will run in |
+| xUnit `async Task` test | Optional | xUnit removed its SyncContext |
+| Roslyn analyzer / source generator | Required | Hosted by VS / Rider with rich SyncContexts |
+
+**A NuGet package never gets to choose its host.** Today it ships into an ASP.NET Core 10 service. Next quarter, the same DLL is referenced from a MAUI app, a WPF tool, a SignalR hub, a Blazor Server page, an Office add-in. If a single `await` inside that library does not call `.ConfigureAwait(false)`, the day someone uses it from a UI thread and accidentally blocks on it, they hit a deadlock — and the bug report blames your package, not their `.Result`.
+
+## The Granit answer
+
+Granit is 128 NuGet packages. Every one of them is library code by definition. The rule across the codebase is non-negotiable:
+
+> **Every `await` in `src/` calls `.ConfigureAwait(false)`. No exceptions, no analyzers turning a blind eye to a "fast path".**
+
+A `grep` across the source tree turns up over 2,700 occurrences. The convention is enforced by the .NET CA2007 analyzer in library projects and by code review on every PR. New code without it does not merge.
+
+```csharp title="EfStoreBase.cs (excerpt)"
+protected async Task<TEntity?> FindAsync(
+    Guid id, CancellationToken cancellationToken)
+{
+    return await DbContext.Set<TEntity>()
+        .AsNoTracking()
+        .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+        .ConfigureAwait(false);
+}
+```
+
+```csharp title="GranitApplication.cs (excerpt)"
+foreach (ModuleDescriptor module in modules)
+{
+    await module.Instance
+        .ConfigureServicesAsync(context)
+        .ConfigureAwait(false);
+}
+```
+
+```csharp title="FluentValidationAutoEndpointFilter.cs (excerpt)"
+ValidationResult result = await validator
+    .ValidateAsync(validationContext, context.HttpContext.RequestAborted)
+    .ConfigureAwait(false);
+```
+
+It looks repetitive because it is. That repetition is the point: a new contributor cannot accidentally introduce a host-specific assumption.
+
+## Why "but it's a no-op in ASP.NET Core" is the wrong frame
+
+The argument against the rule goes: *"99% of our users run our library on ASP.NET Core. The call is a no-op. Why pollute every line?"* Three reasons:
+
+1. **The 1% will find you.** A WPF dev tool, a MAUI sample, a Blazor Server page — sooner or later somebody hosts your code on a thread with a context. That person did not read your README and does not know your library's "ASP.NET Core only" caveat.
+2. **The convention is the enforcement mechanism.** "ConfigureAwait(false) on every await" is a one-line rule a junior dev can follow. "ConfigureAwait(false) when running outside ASP.NET Core, except in xUnit tests, except when you know the host has no context" is a rule nobody can follow consistently.
+3. **The cost is one method call.** It is JIT-elided when the compiler can prove the context is null. The "noise" argument is aesthetic, not technical.
+
+## What about `ConfigureAwait(ConfigureAwaitOptions)`?
+
+.NET 8 added a richer overload with `ConfigureAwaitOptions` flags:
+
+```csharp
+await task.ConfigureAwait(ConfigureAwaitOptions.None);
+await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+await task.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+await task.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+```
+
+This is mostly orthogonal to the original `ConfigureAwait(false)` debate. The flags exist for niche scenarios — `SuppressThrowing` lets you await a faulted task without re-throwing (handy when you only care about completion), `ForceYielding` guarantees the continuation runs asynchronously even if the task already completed.
+
+For library code, the rule stays the same: pass `ConfigureAwaitOptions.None` (the equivalent of `ConfigureAwait(false)`) when you call this overload at all. Most library code never needs the new flags and keeps the simpler `ConfigureAwait(false)` form.
+
+## What about `await using` and `await foreach`?
+
+Both have their own `ConfigureAwait` overloads. Library code should use them:
+
+```csharp title="Async disposal"
+await using var connection = new SqlConnection(connectionString)
+    .ConfigureAwait(false);
+```
+
+```csharp title="Async enumeration"
+await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+{
+    // ...
+}
+```
+
+`WithCancellation` and `ConfigureAwait` on `IAsyncEnumerable` are extension methods, so they read like normal awaits. Granit applies them everywhere — `EfStoreBase`, the export orchestrator, the SSE notification channel.
+
+## Where you can stop writing it
+
+If you are writing a top-level ASP.NET Core service that nobody else consumes — your application code, not your shared libraries — you can drop the calls. The decision should be deliberate:
+
+- The project is **never** going to be referenced as a library. (No `<PackAsNuGet>true</PackAsNuGet>`, no internal sharing.)
+- Every host that runs the code is known to have no `SynchronizationContext`. (ASP.NET Core, Worker Service, Console.)
+- You accept that any future change to the deployment model — running the same code as a library, hosting from a UI app for testing — will require auditing every await.
+
+For Granit, none of those bullets apply. Every project is potentially a library; the framework cannot know what hosts it. The rule stays.
+
+## The ten-second decision tree
+
+When reviewing a PR with a new `await`:
+
+1. Is this code inside `src/` of a NuGet-published or internally-shared library? → **`.ConfigureAwait(false)` required.**
+2. Is this code inside an ASP.NET Core endpoint, BackgroundService, or test? → Optional. Be consistent with the surrounding file.
+3. Is this code inside a WPF, MAUI, Blazor Server, or VS extension? → **`.ConfigureAwait(false)` required, unless this specific await needs to resume on the UI thread.**
+4. Are you sure? → Default to `.ConfigureAwait(false)`. The cost of getting it right is one method call. The cost of getting it wrong is a deadlock at 3 AM.
+
+## Key takeaways
+
+- **`ConfigureAwait(false)` is not obsolete.** It is a no-op in ASP.NET Core, but ASP.NET Core is not the only host your library will ever run in.
+- **Library code uses it on every `await`.** The convention is the enforcement mechanism — there is no reliable conditional rule.
+- **App code can skip it** in ASP.NET Core / Worker / Console — but only if you accept that "this stays an app forever" is a hard constraint.
+- **UI hosts (WPF, MAUI, Blazor Server, VS extensions) still install a `SynchronizationContext`.** The classic deadlock can absolutely still happen there.
+- **The new `ConfigureAwaitOptions` overload does not change the rule** — pass `None` (equivalent to `false`) in library code.
+- **If in doubt, write it.** One method call, JIT-friendly, harmless when there is no context to suppress.
+
+## Further reading
+
+- [Stephen Toub — ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/) — the canonical reference, still accurate
+- [.NET 8 ConfigureAwaitOptions reference](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.configureawaitoptions)
+- [Granit coding standards](/contributing/coding-standards/) — full async conventions
+- [Stop Using DateTime.Now](/blog/stop-using-datetime-now/) — another "the rule still applies, despite the rumor that it doesn't" best-practice

--- a/docs-site/src/content/docs/blog/hybrid-cache-redis-distributed-invalidation.mdx
+++ b/docs-site/src/content/docs/blog/hybrid-cache-redis-distributed-invalidation.mdx
@@ -1,0 +1,268 @@
+---
+title: "HybridCache + Redis: Solving Distributed Cache Invalidation"
+date: 2026-04-26
+authors:
+  - jfmeyers
+tags:
+  - caching
+  - performance
+  - architecture
+  - deep-dive
+description: "Two-tier caches are fast, but cross-pod invalidation is the part everyone gets wrong. Here is how the L1 + L2 + backplane pattern works, and how Granit wires it up."
+excerpt: >
+  Two-tier caches are fast, but cross-pod invalidation is the part everyone gets
+  wrong. Here is how the L1 + L2 + backplane pattern works, and how Granit wires
+  it up with Redis.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+You scale your API from one pod to three. Latency drops, throughput climbs, you ship a Slack message about it. Two days later support tickets land: a user updated their profile, hit refresh, and saw the *old* value. Then the new one. Then the old one again. The pattern is unmistakable: the load balancer is rotating them across three pods, each holding a stale in-process cache, each happily serving its own version of reality.
+
+The fix is not "stop caching". The fix is to **layer caches**: a fast in-process L1, a shared L2 in Redis, and a pub/sub **backplane** that tells every pod when to evict. That is what Microsoft calls `HybridCache`, what FusionCache calls hybrid caching, and what Granit ships preconfigured with sensible defaults.
+
+## Why one layer is never enough
+
+Pick any single layer and it fails on something:
+
+| Layer | Fast? | Shared? | Survives restart? | Invalidates across pods? |
+| ----- | ----- | ------- | ----------------- | ----------------------- |
+| `IMemoryCache` only | Yes (~50 ns) | No | No | No |
+| Redis only | No (~1 ms) | Yes | Yes | N/A — already shared |
+| In-memory + manual Redis sync | Yes | Yes | Partial | Only if you remember |
+
+The first row is what most teams start with and what causes the bug above. The second is fast enough for many workloads but adds 0.5–2 ms of network round-trip to every read — multiply by ten cache hits per request and your "performance optimization" became a slowdown. The third row is what most teams end up writing themselves: an `IMemoryCache` in front, a `RedisCache` behind, and a hand-rolled `Dictionary<string, DateTimeOffset>` to track invalidations. By month six it is unmaintainable.
+
+## The hybrid model
+
+A hybrid cache solves this by making the layers invisible to the caller:
+
+```mermaid
+sequenceDiagram
+    participant App as Application code
+    participant L1 as L1 (in-process)
+    participant L2 as L2 (Redis)
+    participant DB as Source of truth
+    participant BP as Backplane (Redis pub/sub)
+
+    App->>L1: Get("invoice:42")
+    alt L1 hit
+        L1-->>App: cached value (~50 ns)
+    else L1 miss, L2 hit
+        L1->>L2: Get("invoice:42")
+        L2-->>L1: cached value
+        L1-->>App: value (~1 ms)
+    else Both miss
+        L1->>DB: factory()
+        DB-->>L1: fresh value
+        L1->>L2: Set
+        L1-->>App: value
+    end
+
+    Note over App,BP: Later — write happens
+    App->>L1: Remove("invoice:42")
+    L1->>L2: Remove
+    L1->>BP: PUBLISH evict invoice:42
+    BP-->>L1: delivered to other pods
+```
+
+The caller sees a single API. The cache decides where to fetch from, where to write, and — crucially — broadcasts evictions so every other pod's L1 stays consistent.
+
+## The two implementations you will hear about
+
+The .NET ecosystem now ships **two** competing hybrid caches:
+
+- **`Microsoft.Extensions.Caching.Hybrid`** — the official one, GA in .NET 9, expanded in .NET 10. API surface is `HybridCache.GetOrCreateAsync<T>(key, factory)`. Stamping out the rough edges, but missing fail-safe (returning a stale value when the factory throws), eager refresh, and a real backplane story at the time of writing.
+- **FusionCache** — community project by Jody Donetti, around since 2021. Same hybrid model, but ships fail-safe, eager refresh, factory timeouts with background completion, OpenTelemetry, and first-class Redis backplane support. The reference implementation everybody else compares against.
+
+Granit picks **FusionCache**. The reasons are pragmatic, not ideological:
+
+1. **Fail-safe** — if the factory throws (database down, downstream API timeout), FusionCache can return the last known good value instead of a `503`. For multi-tenant SaaS where one tenant's bad data should not break another's reads, this is the difference between a Slack notification and a PagerDuty incident.
+2. **Factory timeouts** — soft and hard timeouts mean a slow database query does not pin a request thread for 30 seconds. FusionCache returns the stale value, then completes the refresh in the background.
+3. **OpenTelemetry built in** — every cache call emits `cache.hit`, `cache.miss`, `cache.factory.duration`. Drop a Grafana dashboard on top and you can see your hit rate evolve over a deployment.
+4. **Mature backplane** — `ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis` has been in production at scale for years and handles connection drops, message ordering, and self-message filtering correctly.
+
+`HybridCache` will close most of those gaps over time. Until then, FusionCache is the conservative choice — and the API is similar enough that swapping later is mostly a `using` statement.
+
+<Aside type="note">
+**Naming note.** This article uses "HybridCache" as the conceptual term for the L1 + L2 + backplane pattern. Granit's implementation is FusionCache. Microsoft's `HybridCache` follows the same model and would slot into the same architectural diagram.
+</Aside>
+
+## The setup — two NuGet packages, zero configuration code
+
+Granit ships caching as two modules:
+
+- `Granit.Caching` — registers FusionCache with an in-memory L1, fail-safe, factory timeouts, eager refresh, and tenant-aware key prefixing.
+- `Granit.Caching.StackExchangeRedis` — adds the L2 Redis cache and the Redis pub/sub backplane.
+
+Add the packages, declare the modules, and configuration takes care of the rest:
+
+```csharp title="Program.cs"
+builder.AddGranit(granit => granit
+    .AddModule<GranitCachingModule>()
+    .AddModule<GranitCachingStackExchangeRedisModule>());
+```
+
+```jsonc title="appsettings.json"
+{
+  "Cache": {
+    "KeyPrefix": "myapp",
+    "EncryptValues": true,
+    "Encryption": { "Key": "base64-key-from-vault" },
+    "Redis": {
+      "Configuration": "redis:6379",
+      "InstanceName": "myapp:"
+    }
+  }
+}
+```
+
+The Redis module declares `IsEnabled` to return `false` when no Redis configuration is present, so dev environments fall back to L1 only without any code change. CI runs against a Testcontainers Redis. Production reads the connection string from Vault via `ConnectionStringName`.
+
+## The code your services actually write
+
+```csharp title="InvoiceService.cs"
+public sealed class InvoiceService(
+    IFusionCache cache,
+    IInvoiceRepository repository)
+{
+    public Task<Invoice> GetByIdAsync(Guid invoiceId, CancellationToken ct) =>
+        cache.GetOrSetAsync(
+            $"invoice:{invoiceId}",
+            async (ctx, token) => await repository.GetAsync(invoiceId, token).ConfigureAwait(false),
+            options => options.SetDuration(TimeSpan.FromMinutes(15)),
+            token: ct);
+}
+```
+
+That is the entire pattern. `GetOrSetAsync` checks L1, then L2, then runs the factory. Every layer transition is invisible. The `SetDuration(15 minutes)` interacts with the framework defaults — fail-safe extends the entry by `FailSafeMaxDuration` if the factory ever throws, and eager refresh starts a background refresh once the entry is past its `EagerRefreshThreshold`.
+
+## The hard part: invalidation
+
+Reads are easy. The hard part is making sure all three pods drop their L1 entry the moment one of them does a write.
+
+Without a backplane:
+
+1. Pod A handles `PUT /invoices/42`, updates the database, evicts its own L1, writes the new value to L2.
+2. Pod B has `invoice:42` in L1 from a read 30 seconds ago.
+3. Next request to pod B hits L1, returns the stale value.
+4. User sees the old data for up to 15 minutes (the L1 TTL).
+
+With a Redis backplane:
+
+1. Pod A's eviction publishes a message on the Redis pub/sub channel `myapp:fusioncache:invoice:42`.
+2. Pods B and C are subscribed. They receive the message and drop the entry from their L1.
+3. Next request to any pod misses L1, hits L2 (which already has the new value), and serves it.
+
+Granit wires this up automatically. The relevant lines are six, and you do not write them:
+
+```csharp title="RedisCachingServiceCollectionExtensions.cs (excerpt)"
+services.AddFusionCache()
+    .WithRegisteredDistributedCache();           // L2 = Redis
+
+services.AddFusionCacheStackExchangeRedisBackplane(_ => { });
+services.AddOptions<RedisBackplaneOptions>()
+    .Configure<IConnectionMultiplexer>((bp, mux) =>
+        bp.ConnectionMultiplexerFactory = () => Task.FromResult(mux));
+```
+
+The backplane reuses the same `IConnectionMultiplexer` as the L2 cache, so you pay for one Redis connection, not two.
+
+## Driving invalidation from domain events
+
+Manual `cache.RemoveAsync` calls scattered across services are the second-most-common cause of stale-cache bugs after "no backplane at all". Forget one and the cache silently lies for an hour.
+
+Granit's pattern is to invalidate caches **from event handlers**, not from the write path itself. The Features module is a textbook example:
+
+```csharp title="FeatureValueChangedEvent.cs"
+public sealed record FeatureValueChangedEvent(
+    string FeatureName,
+    Guid? TenantId);
+```
+
+```csharp title="FeatureCacheInvalidationHandler.cs"
+public class FeatureCacheInvalidationHandler
+{
+    public static async Task HandleAsync(
+        FeatureValueChangedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        string key = FeatureCacheKey.Build(@event.TenantId, @event.FeatureName);
+        await cache.ExpireAsync(key, token: cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+The write path raises `FeatureValueChangedEvent`. Wolverine routes it to the handler. The handler expires the entry. Every other pod gets the backplane message and drops its copy. The write path itself never imports `IFusionCache`, never knows a cache exists, and stays focused on persisting the value.
+
+This is the pattern the framework uses everywhere caching meets writes — Permissions, Localization, Settings, Templating. Centralizing invalidation on the event makes it impossible to drift: any code path that mutates the underlying state will raise the event, and any cache layered on top will hear it.
+
+## Multi-tenancy without the footgun
+
+Granit applications are multi-tenant by default, which means key collisions across tenants are a security incident waiting to happen. The `TenantAwareFusionCache` decorator wraps the singleton `IFusionCache` and prefixes every key with `t:{tenantId}:` — transparently, by reading `ICurrentTenant` at call time:
+
+```csharp
+// Tenant A calls
+cache.GetOrSetAsync("invoice:42", ...);
+// Internally writes to: myapp:t:00000000-0000-0000-0000-...:invoice:42
+
+// Tenant B calls the same key
+cache.GetOrSetAsync("invoice:42", ...);
+// Internally writes to: myapp:t:11111111-1111-1111-1111-...:invoice:42
+```
+
+Two completely separate cache namespaces. No code change in `InvoiceService`. The decorator reads `ICurrentTenant` per call, so it stays correct even though the cache itself is a singleton — `ICurrentTenant` is backed by `AsyncLocal<T>` and reflects the current request's scope.
+
+## Encryption when L2 is shared infrastructure
+
+Redis is rarely the application's exclusive infrastructure. A shared cluster used by multiple services means cached values — invoices, user profiles, feature flags — are visible to anyone with `redis-cli` access. For workloads with personal data, this is a compliance problem (GDPR Art. 32 — protection in transit and at rest).
+
+Granit ships AES-256-GCM encryption for L2 entries:
+
+```jsonc title="appsettings.json"
+{
+  "Cache": {
+    "EncryptValues": true,
+    "Encryption": { "Key": "base64-key-from-vault" }
+  }
+}
+```
+
+Set the flag, ship the key from Vault, and `EncryptingFusionCacheSerializer` decorates the JSON serializer. L1 stays plaintext (it never leaves the process). L2 entries are ciphertext-on-the-wire and ciphertext-at-rest. The backplane pub/sub messages contain only keys, never values, so they need no encryption.
+
+If you forget to set `EncryptValues = true`, the framework logs a warning at startup. It is intentionally loud:
+
+```text
+warn: Granit.Caching.StackExchangeRedis: Redis distributed cache is active but
+      Cache:EncryptValues is disabled — cached values are stored in plaintext in
+      Redis. Set Cache:EncryptValues to true for production deployments.
+```
+
+## What to measure
+
+The two metrics that tell you a hybrid cache is working as intended:
+
+| Metric | Healthy range | Meaning |
+| ------ | ------------- | ------- |
+| `cache.hit_ratio` (L1) | > 0.85 | Most reads never leave the process |
+| `cache.factory.duration` p99 | < 100 ms | Factory itself is not the bottleneck |
+| `cache.backplane.messages_received` per pod | non-zero | Other pods are evicting; backplane is alive |
+
+A hit ratio under 0.5 usually means TTLs are too short or the eager refresh threshold is too aggressive. Zero backplane messages on a multi-pod deployment means either you have no writes (suspicious) or the backplane configuration is broken.
+
+## Key takeaways
+
+- **Single-layer caches do not survive horizontal scaling.** L1-only goes stale, L2-only loses the latency win.
+- **Hybrid caching = L1 + L2 + backplane.** All three are required. Skip the backplane and stale data is the new default.
+- **FusionCache is the mature .NET implementation today.** Microsoft's `HybridCache` follows the same model and will catch up; Granit will track it as parity lands.
+- **Invalidate from event handlers, not from write paths.** Centralizes the cache logic and makes it impossible to drift.
+- **Tenant prefixing is non-negotiable in multi-tenant apps.** The decorator does it transparently — do not roll your own.
+- **Encrypt L2 when Redis is shared infrastructure.** AES-256-GCM is one config flag and zero code change.
+
+## Further reading
+
+- [Granit.Caching module reference](/dotnet/data/caching/)
+- [FusionCache project](https://github.com/ZiggyCreatures/FusionCache)
+- [HashiCorp Vault integration](/blog/secrets-management-with-hashicorp-vault-in-dotnet-10/) — where the encryption key lives
+- [CQRS Without MediatR — How Granit Uses Wolverine](/blog/cqrs-without-mediatr-how-granit-uses-wolverine/) — the event bus that drives invalidation

--- a/docs-site/src/content/docs/blog/validation-at-the-right-layer.md
+++ b/docs-site/src/content/docs/blog/validation-at-the-right-layer.md
@@ -1,0 +1,262 @@
+---
+title: "Validation at the Right Layer: FluentValidation + Endpoint Filters"
+date: 2026-04-23
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - api
+  - architecture
+  - code-quality
+description: "Scattering validation across controllers, services, and entities produces inconsistent errors and missed cases. Pin it to the API boundary with FluentValidation and endpoint filters."
+excerpt: >
+  Scattering validation across controllers, services, and entities produces
+  inconsistent errors and missed cases. Pin it to the API boundary with
+  FluentValidation and endpoint filters — and let the platform do the rest.
+---
+
+Where should you validate input? In the controller? In the service? In the entity constructor? Most codebases answer "all three", which is how you end up with three different error formats for the same broken request, two checks that contradict each other, and a fourth code path that forgot to validate at all. The fix is mechanical: **validate exactly once, at the API boundary, and let an endpoint filter run it for you**.
+
+## The problem with ad-hoc validation
+
+Look at any mid-size .NET codebase that grew organically. You will find every variant:
+
+```csharp title="OrderEndpoints.cs — Don't do this"
+app.MapPost("/orders", async (CreateOrderRequest request, IOrderService svc) =>
+{
+    if (string.IsNullOrWhiteSpace(request.CustomerEmail))
+        return Results.BadRequest("Email required");
+    if (request.Items is null || request.Items.Count == 0)
+        return Results.BadRequest(new { error = "items.empty" });
+    if (request.Total <= 0)
+        return Results.Problem("Total must be positive", statusCode: 400);
+
+    var order = await svc.CreateAsync(request);
+    return Results.Created($"/orders/{order.Id}", order);
+});
+```
+
+Three checks, three response shapes — `string`, anonymous object, ProblemDetails. Three status codes that all happen to be `400` for completely different reasons. And the moment a second endpoint accepts a `CreateOrderRequest`, every check is duplicated or, worse, slightly different.
+
+Move the checks one layer down and the situation gets worse:
+
+```csharp title="OrderService.cs — Don't do this either"
+public async Task<Order> CreateAsync(CreateOrderRequest request)
+{
+    if (request.Items is null || request.Items.Count == 0)
+        throw new ArgumentException("items required", nameof(request));
+    // ...
+}
+```
+
+Now you have validation logic that throws an exception the controller has to catch and translate. The error format leaks even further. The endpoint and the service disagree on what "valid" means. And the analyzer that should have flagged the missing check at the endpoint never fires, because the endpoint *technically* compiles fine.
+
+## The principle: validate at the boundary
+
+Input validation is **schema enforcement**. It answers one question: *can I trust the shape of this payload enough to hand it to the domain?* That is a transport-level concern, not a domain concern. The right place to enforce it is the API boundary — the same layer that already deserializes JSON, binds form data, and resolves DI.
+
+The domain has a different job: enforce **invariants** (a `Money` cannot be negative, an `Order` cannot transition from `Cancelled` to `Shipped`). Invariants belong on aggregate roots, expressed via private setters and behavior methods. Confusing the two produces validators that re-check what the constructor already guarantees, and aggregate roots that throw `ArgumentException` to signal what should have been a `422`.
+
+Two checks, two layers, two error formats — both correct in their own scope:
+
+| Layer | Concern | Failure response |
+| ----- | ------- | ---------------- |
+| API boundary | Schema (required, length, format) | `422 Unprocessable Entity` with structured codes |
+| Domain | Invariant (state machine, business rules) | `409 Conflict` or domain exception → `400` |
+
+This article focuses on the first one — and shows how Granit makes it impossible to forget.
+
+## FluentValidation done right
+
+FluentValidation has been the de-facto .NET validator for a decade. It works by declaring rules in a class that targets a request type:
+
+```csharp title="CreateOrderRequestValidator.cs"
+public sealed class CreateOrderRequestValidator : GranitValidator<CreateOrderRequest>
+{
+    public CreateOrderRequestValidator()
+    {
+        RuleFor(x => x.CustomerEmail)
+            .NotEmpty()
+            .EmailAddress()
+            .MaximumLength(254);
+
+        RuleFor(x => x.Items)
+            .NotEmpty()
+            .Must(items => items.Count <= 100)
+            .WithErrorCodeAndMessage("Granit:Validation:TooManyItems");
+
+        RuleForEach(x => x.Items).SetValidator(new OrderItemRequestValidator());
+
+        RuleFor(x => x.Total)
+            .GreaterThan(0);
+    }
+}
+```
+
+`GranitValidator<T>` is a thin base class that emits **structured error codes** (`Granit:Validation:NotEmptyValidator`, `Granit:Validation:EmailValidator`) instead of raw English strings. The frontend resolves codes to localized messages via `GET /api/granit/localization`. No backend code change ships a French translation; no hardcoded English leaks into a German UI.
+
+For custom rules, `WithErrorCodeAndMessage("Granit:Validation:TooManyItems")` keeps the code and the message key in sync — they are the same value. Diverging the two is the single most common cause of "validation passes but UI shows nothing", and the helper makes it impossible.
+
+## Wiring it up — the wrong way
+
+The classic FluentValidation tutorial tells you to add a service registration and an explicit filter per endpoint:
+
+```csharp title="Program.cs — Don't do this in 2026"
+builder.Services.AddValidatorsFromAssemblyContaining<CreateOrderRequestValidator>();
+
+app.MapPost("/orders", async (CreateOrderRequest req, IValidator<CreateOrderRequest> v, ...) =>
+{
+    var result = await v.ValidateAsync(req);
+    if (!result.IsValid)
+        return Results.ValidationProblem(result.ToDictionary());
+    // ...
+});
+```
+
+Two problems: every endpoint has to remember to inject the validator and call it, and the moment somebody adds a new endpoint without those four lines, validation silently disappears for that route. Code review will not catch it. Tests will not catch it unless somebody writes a "did I forget to validate?" test for every endpoint, every time.
+
+## Wiring it up — the right way
+
+Granit ships an **endpoint filter** that runs validation automatically for every argument bound from the request body. You opt in once, on the route group, and every endpoint in the group is covered:
+
+```csharp title="OrderEndpoints.cs — Do this"
+public static class OrderEndpoints
+{
+    public static IEndpointRouteBuilder MapOrderEndpoints(
+        this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGranitGroup("/orders")
+            .WithTags("Orders");
+
+        group.MapPost("/", CreateAsync)
+            .WithName("CreateOrder")
+            .WithSummary("Creates a new order.")
+            .WithDescription("Validates the payload, charges the customer, and returns the created order.")
+            .Produces<OrderResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem();
+
+        return endpoints;
+    }
+
+    private static async Task<Created<OrderResponse>> CreateAsync(
+        CreateOrderRequest request,
+        IOrderService service,
+        CancellationToken cancellationToken)
+    {
+        var order = await service.CreateAsync(request, cancellationToken);
+        return TypedResults.Created($"/orders/{order.Id}", order.ToResponse());
+    }
+}
+```
+
+`MapGranitGroup("/orders")` is the only difference from a stock `MapGroup("/orders")`. Under the hood, it adds a `FluentValidationAutoEndpointFilter` that:
+
+1. Inspects every endpoint argument at request time.
+2. Skips primitives, `Guid`, `DateTime`, `IFormFile`, `HttpContext`, `ClaimsPrincipal`, and `CancellationToken` — none of those have validators.
+3. For each remaining complex argument, looks up `IValidator<T>` in the request scope.
+4. If a validator exists, runs it. If validation fails, returns `422 Unprocessable Entity` with `HttpValidationProblemDetails`.
+5. If no validator is registered, passes through silently.
+
+The handler never sees an invalid payload. There is no `if (!ModelState.IsValid)` line to forget. The endpoint signature stays focused on the happy path.
+
+## Auto-discovery: zero registration ceremony
+
+Granit's validation module auto-discovers every `IValidator<T>` from every loaded module assembly at startup:
+
+```csharp title="GranitValidationModule.cs (excerpt)"
+foreach (Assembly assembly in context.ModuleAssemblies)
+{
+    context.Services.AddValidatorsFromAssembly(
+        assembly, ServiceLifetime.Scoped, includeInternalTypes: true);
+}
+```
+
+Drop a new validator class anywhere in your module, build, and it works. No `AddValidatorsFromAssemblyContaining<>` per project. No manual registration list that drifts out of date. The same convention applies to the validators shipped with `Granit.Validation.Europe` (Belgian NISS, French RPPS), `Granit.Validation.NorthAmerica`, and `Granit.Validation.UnitedKingdom` — install the package, get the validators.
+
+## Why 422, not 400
+
+`MapGranitGroup` returns `422 Unprocessable Entity` for validation failures, not `400 Bad Request`. The distinction matters and is enforced by RFC 9110:
+
+- **`400 Bad Request`** — the server cannot parse the request at all. Malformed JSON, missing required header, invalid Content-Type. The client must fix its serializer.
+- **`422 Unprocessable Entity`** — the syntax is fine, but the values do not satisfy the API's semantic rules. The client knows how to fix it: change the data and retry.
+
+Frontend code can handle the two cases differently: a `400` is a bug, a `422` is user input the form should highlight. Conflating them forces every client to parse the body to figure out which is which. Returning `422` is one of those small details that turns "the API works" into "the API is pleasant to integrate".
+
+## Free OpenAPI enrichment
+
+Because validators are first-class .NET classes, Granit reads them at OpenAPI generation time and projects the rules into the schema:
+
+```csharp title="FluentValidationSchemaTransformer.cs (excerpt)"
+public Task TransformAsync(
+    OpenApiSchema schema,
+    OpenApiSchemaTransformerContext context,
+    CancellationToken cancellationToken)
+{
+    Type schemaType = context.JsonTypeInfo.Type;
+    if (scope.ServiceProvider.GetService(validatorType) is not IValidator validator)
+    {
+        return Task.CompletedTask;
+    }
+
+    IValidatorDescriptor descriptor = validator.CreateDescriptor();
+    // emit maxLength, minLength, pattern, minimum, maximum, required, format
+    // ...
+}
+```
+
+The result: `maxLength`, `minLength`, `pattern`, `minimum`, `maximum`, `required`, and `format` end up in the generated `openapi.json`. Frontend code generators (Kiota, NSwag, openapi-typescript) pick them up automatically. Your TypeScript types know the email field has a max length of 254. Your Zod schemas can be derived without manual reconciliation.
+
+Custom domain validators that have no standard OpenAPI equivalent — IBAN, E.164 phone, Belgian NISS — are exposed as `x-granit-validator` extensions, and a paired `WithPatternHint("Granit:Validation:Hints:Alpha2Code")` lets the frontend show a human-readable hint ("2 uppercase letters") instead of the raw regex.
+
+## Opting out — when you have to
+
+Sometimes you have an endpoint where the body cannot be validated declaratively (uploads with binary metadata, intentionally permissive admin endpoints). Add one attribute and the filter skips that route:
+
+```csharp title="DiagnosticsEndpoints.cs"
+group.MapPost("/raw-import", RawImportHandler)
+    .WithMetadata(new SkipAutoValidationAttribute());
+```
+
+Per-endpoint opt-out is intentional: it shows up in code review, it is greppable, and it does not weaken the default for every other endpoint in the group.
+
+## Architecture tests as the safety net
+
+The convention is enforced at build time by `ValidationConventionTests`, which scans the assembly and fails the build if:
+
+- A `*Request` record exists without a matching `IValidator<T>`.
+- A route group is created with stock `MapGroup` instead of `MapGranitGroup`.
+- A `WithMessage("hardcoded English string")` slips into a validator instead of `WithErrorCodeAndMessage("Granit:Validation:Code")`.
+
+These tests are not optional. They run in the same shard as every other architecture test (`tests/Granit.ArchitectureTests`) and the CI gate refuses to merge a PR that violates them. The result: a junior dev cannot accidentally bypass validation, even by copy-pasting from the wrong tutorial.
+
+## Where invariants belong
+
+Validation at the boundary stops most malformed input. It does not — and should not — try to encode every business rule. Here is the dividing line:
+
+| Concern | Where | Example |
+| ------- | ----- | ------- |
+| Required field | Validator | `RuleFor(x => x.Email).NotEmpty()` |
+| Format / length | Validator | `EmailAddress()`, `MaximumLength(254)` |
+| Cross-field consistency | Validator | `When(x => x.IsRecurring, () => RuleFor(x => x.Interval).NotNull())` |
+| Aggregate state machine | Aggregate root | `Order.Ship()` throws if `Status != Confirmed` |
+| Cross-aggregate invariant | Domain service | "User has not exceeded daily order limit" |
+| Async uniqueness check | Domain or app service | "Email is not already taken" |
+
+The async uniqueness case is the one most teams get wrong. They put it in the validator with `MustAsync`, which means the validator now needs a `DbContext` and runs an extra query on every request — including the ones that are about to fail because of trivially missing fields. Push uniqueness checks into the application service, where they share the transaction with the actual write and produce a `409 Conflict`, not a `422`.
+
+## Key takeaways
+
+- **Validate exactly once, at the API boundary.** Scattering checks across controllers, services, and entities produces drift, duplication, and silent gaps.
+- **`MapGranitGroup` runs validation automatically** for every endpoint in the group. No per-endpoint filter, no `IValidator<T>` injection, no boilerplate.
+- **Return `422 Unprocessable Entity`** for semantic validation failures, not `400 Bad Request`. The client can act on the difference.
+- **Use structured error codes** (`Granit:Validation:*`) instead of hardcoded strings. The frontend localizes them via `GET /api/granit/localization`.
+- **OpenAPI gets the rules for free** — `maxLength`, `pattern`, `required`, etc. flow into the generated schema, so frontend code generators stay accurate.
+- **Domain invariants stay on aggregate roots.** Validation is for shape; the domain owns business rules.
+
+## Further reading
+
+- [Granit.Validation module reference](/dotnet/core/validation/)
+- [RFC 7807 Problem Details — The Only Way to Return Errors](/blog/rfc-7807-problem-details-the-only-way-to-return-errors/)
+- [Never Return EF Entities](/blog/never-return-ef-entities/) — the other side of the boundary
+- [Guard Clauses Done Right](/blog/guard-clauses-done-right/) — when invariants belong in the constructor

--- a/docs-site/src/content/docs/dotnet/architecture/adr/033-metering-hybrid-lifecycle-and-recompute.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/033-metering-hybrid-lifecycle-and-recompute.md
@@ -1,0 +1,178 @@
+---
+title: "ADR-033: Metering hybrid — lifecycle, CountDistinct, recompute, backfill, deprecate"
+description: "Promote MeterDefinition to a workflow-managed lifecycle (Draft / Published / Archived), introduce CountDistinct aggregation with a typed JSON path, expose admin-side recompute / backfill / event-deprecation endpoints under a transaction-scoped advisory lock to keep aggregates consistent with concurrent ingestion."
+sidebar:
+  order: 33
+  label: "033 - Metering Hybrid"
+---
+
+> **Date:** 2026-04-25
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Metering`, `Granit.Metering.Abstractions`,
+> `Granit.Metering.Endpoints`, `Granit.Metering.EntityFrameworkCore`,
+> `Granit.Metering.BackgroundJobs`
+
+## Context
+
+`Granit.Metering` shipped as a fast-ingestion engine: events land in
+`MeterEvent`, a background job rolls them up into `UsageAggregate` rows
+keyed by `(MeterDefinitionId, Period, PeriodStart)`, and quotas /
+invoices read from those rollups. The aggregate path was deliberately
+single-direction — events flow forward, rollups flow forward, nothing
+ever reaches back into the past.
+
+Three workflows kept failing to fit that model:
+
+1. **Late-arriving authoritative data.** Customer success teams
+   occasionally need to ingest historical events (a prior month's CSV
+   handed over post-onboarding). The 7-day age cap on the standard
+   ingestion endpoint rejected these.
+2. **Bug-driven reprocessing.** When a bug in upstream emission
+   inflated a meter — say, a retry storm that double-counted API calls
+   — there was no clean way to mark the bad events as discarded and
+   rebuild the aggregate without surgically deleting rows by hand.
+3. **Distinct-count metrics.** Active-users-per-month is a textbook
+   billing metric. The aggregator only knew Sum / Count / Max / Last, so
+   downstream apps were left implementing it with raw SQL.
+
+A fourth pressure was lifecycle. `MeterDefinition.Activated` (a single
+boolean) collapsed the three states an admin actually wants — *I'm
+drafting this*, *go ahead and ingest*, *stop ingesting but keep the
+history* — into one toggle. The admin UI had no good way to author a
+meter without it immediately accepting traffic.
+
+ORB and Stripe Billing both expose lifecycle, recompute, and distinct
+aggregation as first-class operations; the cost of staying narrower was
+that every consumer rebuilt the same workarounds.
+
+## Decision
+
+### 1. Lifecycle managed by `WorkflowLifecycleStatus`
+
+`MeterDefinition` implements `IWorkflowStateful`. The lifecycle
+mirrors `Plan` (ADR-017): `Draft → Published → Archived`. Only
+`Published` meters accept ingestion; `Draft` lets admins author and
+review without polluting production aggregates; `Archived` preserves
+history and aggregates but rejects new events.
+
+The legacy `Activated` boolean is kept one release as a computed alias
+(`Activated => LifecycleStatus == Published`) and marked `[Obsolete]`.
+The deactivate endpoint stays one release as a backend alias for
+`POST …/archive`.
+
+### 2. `CountDistinct` aggregation with a typed JSON path
+
+Add `AggregationType.CountDistinct = 4` plus `MeterDefinition.DistinctProperty`
+(`string?`). The validator enforces the pairing both ways: `CountDistinct`
+requires `DistinctProperty`, every other aggregation rejects it. The
+in-memory aggregator extracts the value at the JSON path inside
+`MeterEvent.Metadata` and feeds it through a `HashSet<string>` per
+aggregate window. Events whose metadata does not contain the property
+are excluded from the count (treated as missing — never bucketed as a
+synthetic `null` value).
+
+PostgreSQL- or SQL Server-specific JSON aggregation functions were
+considered and rejected: distinct-count metrics rarely exceed a few
+thousand events per window in B2B SaaS, and the cross-DB constraint
+(ADR-024) makes provider-specific operators a maintenance burden.
+
+### 3. Admin recompute / backfill / event-deprecation
+
+Three new endpoints surface the cold-path operations:
+
+- `POST /metering/meters/{id}/recompute` — body
+  `{ from: DateTimeOffset, to: DateTimeOffset }`. Window edges snap to
+  hourly buckets server-side. The global ingestion watermark is
+  **never rewound** (rewinding would force the hot path to re-aggregate
+  events past `to` that are already covered by an existing aggregate).
+- `POST /metering/events/backfill` — accepts the same shape as the
+  standard ingestion endpoint, but the per-event age validator is
+  loosened to 365 days. Auto-triggers a recompute on every meter window
+  the backfilled events touched.
+- `POST /metering/events/{id}/deprecate` — soft-delete with audit trail
+  (`DeprecatedAt`, `DeprecationReason`). The aggregator skips deprecated
+  events; the auto-recompute on the affected hourly bucket follows.
+
+These three operations all share one critical invariant: nothing
+overlaps with concurrent ingestion or with the hourly aggregator job.
+
+### 4. Transaction-scoped advisory lock for cross-job exclusion
+
+`MeteringConcurrencyLock.AcquireAsync(db, meterId, tenantId, ct)` takes
+a per-`(meterId, tenantId)` lock that auto-releases at transaction end.
+The implementation switches on `db.Database.ProviderName`:
+
+- **PostgreSQL** — `SELECT pg_advisory_xact_lock(hashtext({0}))`
+- **SQL Server** — `EXEC sp_getapplock @LockOwner = 'Transaction', @LockTimeout = -1, ...`
+- **InMemory / unknown** — no-op (test providers + future providers
+  fall back gracefully)
+
+Both the recompute / backfill / deprecate code paths AND the hourly
+aggregation job acquire the same lock. They mutually exclude per
+`(meter, tenant)` without serializing the global metering pipeline.
+
+The lock is intentionally transaction-scoped (not session-scoped):
+crashing mid-recompute releases automatically, and there's no chance of
+leaking a held lock into the connection pool.
+
+### 5. SQL ad-hoc metric definitions — DEFER
+
+A separate spike (`docs/dotnet/architecture/spikes/metering-sql-ad-hoc-metrics`)
+explored letting admins define ad-hoc metrics as SQL queries against
+`MeterEvent`. **Decision: defer** until there are at least three
+independent users with a concrete need that the five built-in
+aggregations cannot serve. Re-evaluation criterion is documented in the
+spike.
+
+## Consequences
+
+### Positive
+
+- **Authorable meters.** Admins can build, review, and validate a meter
+  in `Draft` without it consuming production events.
+- **Reversible billing data.** Bug-driven over-counts are correctable
+  in minutes (deprecate the offending events, run a recompute on the
+  affected window) instead of an emergency SQL surgery.
+- **First-class active-users.** `CountDistinct` covers the dominant
+  per-tenant active-user metric without consumers writing SQL.
+- **Cross-DB safety.** The advisory lock pattern works on PostgreSQL
+  AND SQL Server with the same call site; tests run against InMemory
+  with the no-op fallback.
+
+### Negative
+
+- **One-release deprecation tail.** `Activated` and the deactivate
+  endpoint stay one release for backward compatibility — downstream
+  apps must migrate during that window.
+- **Recompute cost is unbounded.** A 12-month recompute on a busy
+  meter scans 12 months of events. The advisory lock holds for the
+  duration. Mitigation: window edges snap to hourly buckets, the lock
+  is per-`(meter, tenant)` so other tenants are unaffected, and the
+  endpoint is gated by `Metering.Meters.Manage` (admin-only).
+- **Wider permission surface.** Two new permissions
+  (`Metering.Events.Manage`, `Metering.Events.Backfill`) — separated
+  from `Metering.Usage.Record` because they're destructive at the
+  billing-data level (ISO 27001 A.9.4 — least privilege).
+
+### Non-goals
+
+- **No retroactive lifecycle migration.** Existing `Activated = true`
+  meters are mapped to `Published`, `Activated = false` to `Archived`.
+  No `PendingReview` state; the workflow stays Draft / Published /
+  Archived for parity with `Plan`.
+- **No bulk-deprecate UX.** Per-event deprecation is the single tool;
+  bulk operations (`deprecate all events for meter X between A and B`)
+  belong to a future admin tool.
+- **No two-phase commit.** The recompute and backfill operations are
+  idempotent within their advisory-lock window; the lock + idempotent
+  rebuild eliminates the need for a saga.
+
+## References
+
+- ADR-017 — DDD Aggregate Root vs Entity (lifecycle pattern shared with `Plan`)
+- ADR-024 — Cross-database SQL provider strategy
+- ADR-032 — `Granit.Catalog.Product` as the shared billing aggregate
+  (`MeterDefinition.ProductId` soft reference)
+- ADR-036 — Invoicing line item source + product convention
+- Spike: `dotnet/architecture/spikes/metering-sql-ad-hoc-metrics` — SQL ad-hoc metric definitions (DEFER)
+- ISO 27001 A.9.4 — Least privilege on destructive operations

--- a/docs-site/src/content/docs/dotnet/architecture/adr/034-subscriptions-phases-and-tiered-pricing.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/034-subscriptions-phases-and-tiered-pricing.md
@@ -1,0 +1,224 @@
+---
+title: "ADR-034: Subscriptions — pricing tiers, phases, discounts, price overrides"
+description: "Add four child entities to Subscription/PlanPrice — PricingTier (volume / graduated brackets), SubscriptionPhase (scheduled plan changes with optional override price + discount), SubscriptionDiscount (cumulative reductions), SubscriptionPriceOverride (per-customer negotiated amounts) — to support usage-based billing patterns without exposing them as HTTP endpoints in the MVP."
+sidebar:
+  order: 34
+  label: "034 - Subscriptions Phases & Tiered"
+---
+
+> **Date:** 2026-04-25
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Subscriptions`, `Granit.Subscriptions.EntityFrameworkCore`,
+> `Granit.Subscriptions.Endpoints` (orchestrators only — no new HTTP surface yet)
+
+## Context
+
+Pre-ADR, `Granit.Subscriptions` modeled a flat `(Plan, PlanPrice,
+Subscription)` triple: one subscription points at one plan with one
+active price, and the billing-cycle orchestrator multiplies quantity by
+unit price. That's enough for vanilla SaaS (Stripe Billing — Subscription
+plus Standard pricing), but four real workflows kept slipping through:
+
+1. **Tiered pricing.** Once a plan crosses "$0.10 per call up to 10K,
+   then $0.05 above 10K", the orchestrator can't compute the invoice
+   from a single unit price. Both the Volume model (every unit at the
+   bracket's rate) and the Graduated model (each bracket charged at its
+   own rate) are common; ORB exposes them as first-class.
+2. **Scheduled plan changes.** Customer Success negotiates a
+   downgrade-at-renewal or a 90-day promotional plan. The orchestrator
+   needs to know "which plan is active *for this billing cycle*" and
+   apply the right one — but the existing model only carried the
+   subscription's current plan id.
+3. **Negotiated discounts.** Sales gives a key account 20% off for
+   12 months. Today this requires duplicating the plan price or
+   surgically editing the invoice — neither is auditable.
+4. **Per-customer price overrides.** Distinct from a discount: the
+   subscription points at a specific `PlanPriceOverride` row that
+   replaces the catalog price for this one customer. Used for
+   grandfathered enterprise terms.
+
+Three of these four (tiers, phases, discounts) are billing-engine
+primitives — they live in the domain regardless of whether admins ever
+edit them through HTTP. The fourth (price override) is admin-driven and
+needs an endpoint eventually, but not in this iteration.
+
+## Decision
+
+### 1. Four new child entities (Entity, no `AggregateRoot`)
+
+| Entity | Parent | Cardinality |
+| ------ | ------ | ----------- |
+| `PricingTier` | `PlanPrice` | 1..n (zero = flat pricing) |
+| `SubscriptionPhase` | `Subscription` | 0..n (zero = single-phase, current model) |
+| `SubscriptionDiscount` | `Subscription` | 0..n (cumulative) |
+| `SubscriptionPriceOverride` | `Subscription` | 0..1 (per active phase) |
+
+All four are domain entities, mutable through behavior methods on the
+parent aggregate, never instantiated from outside. They don't carry their
+own state machine (`SubscriptionPhase` doesn't have `Draft → Active →
+Expired`; activeness is computed from `(StartDate, EndDate)` against
+`clock.Now`).
+
+### 2. `PricingTier` — Volume vs Graduated
+
+```csharp
+public sealed class PricingTier : Entity
+{
+    public decimal? UpToQuantity { get; }  // null = open-ended (last tier)
+    public decimal UnitAmount { get; }
+    public decimal? FlatAmount { get; }    // optional package fee on top of UnitAmount * Qty
+    public int SortOrder { get; }
+}
+
+public enum TieringMode { Volume, Graduated }
+```
+
+`PlanPrice.Tiers` (read-only collection) + `PlanPrice.TieringMode`
+(`TieringMode?`). The mode is null when the price is flat
+(`Tiers.Count == 0`); the validator on the create endpoint enforces the
+pairing. The bracket sequence is validated at insertion: ascending
+`UpToQuantity`, exactly one open-ended tier (`UpToQuantity = null`)
+which must be the last.
+
+`TieredPricingCalculator.Compute(quantity, mode, tiers)` is the single
+math entry point — both `DefaultUsageInvoiceOrchestrator` and any
+future ad-hoc preview UI go through it. Volume math walks the brackets
+to find the one containing `quantity` and applies its rate to the full
+quantity; Graduated walks every bracket and sums the partial usages.
+
+### 3. `SubscriptionPhase` — half-open intervals + active resolution
+
+```csharp
+public sealed class SubscriptionPhase : Entity
+{
+    public DateTimeOffset StartDate { get; }
+    public DateTimeOffset? EndDate { get; }   // null = open-ended
+    public PlanId PlanId { get; }
+    public Guid? OverridePriceId { get; }     // pin a specific PlanPrice
+    public decimal? DiscountPercent { get; }  // 0–100; phase-flat discount
+    public bool Covers(DateTimeOffset instant);
+}
+```
+
+Subscriptions resolve the active phase via
+`subscription.GetActivePhase(clock.Now)`. Half-open semantics: `[Start, End)`
+— end-exclusive so back-to-back phases don't double-count an instant.
+When no phase covers `now`, the orchestrator falls back to
+`subscription.PlanId` / `PlanPriceId` (single-phase = backward
+compatible with pre-Phase-3 behavior).
+
+The phase's optional `OverridePriceId` lets sales pin a grandfathered
+price for a phase without touching the global plan price catalog. The
+optional `DiscountPercent` is a phase-flat reduction applied
+multiplicatively to the resolved base price.
+
+### 4. `SubscriptionDiscount` — cumulative stacking
+
+```csharp
+public sealed class SubscriptionDiscount : Entity
+{
+    public DiscountType Type { get; }   // Percentage | FixedAmount | Trial
+    public decimal Value { get; }
+    public DateTimeOffset? StartsAt { get; }
+    public DateTimeOffset? ExpiresAt { get; }
+}
+```
+
+Multiple active discounts cumulate via
+`SubscriptionDiscountCalculator.Apply(basePrice, discounts, clock)`.
+Cumulation order: Trial first (zeroes the bill), then Percentage
+discounts (combined multiplicatively to avoid the order-dependence of
+sequential subtraction), then FixedAmount discounts. Banker's rounding
+to four decimals after each step. Negative result is clamped to zero —
+discounts can't generate a refund.
+
+### 5. `SubscriptionPriceOverride` — per-customer negotiated amount
+
+```csharp
+public sealed class SubscriptionPriceOverride : Entity
+{
+    public Guid PlanPriceId { get; }   // the plan price being overridden
+    public decimal Amount { get; }     // negotiated amount in PlanPrice.Currency
+}
+```
+
+When an active phase pins an `OverridePriceId` AND the subscription has
+a matching override, the orchestrator uses the override's `Amount`
+instead of the plan price's catalog amount. The override is
+single-currency by construction (matches the plan price's currency);
+multi-currency negotiations require a separate override per currency.
+
+### 6. NO HTTP endpoints in this iteration — orchestrator-only
+
+All four entities are populated by the orchestrator at billing time
+from existing data; none of them have admin-side `POST` endpoints in
+this PR. Rationale:
+
+- Tiers and phases are typically authored by configuration tooling
+  (Stripe sync, internal admin scripts), not click-by-click in a UI.
+- Discounts and overrides need a richer authoring UX (customer search,
+  approval workflow, audit trail) than this PR is scoped for.
+- Shipping the domain primitives without HTTP keeps the MVP small and
+  lets the orchestrator behavior stabilize in production before the
+  endpoint surface is locked.
+
+A follow-up ADR will spec the HTTP surface.
+
+## Consequences
+
+### Positive
+
+- **Tiered pricing works end-to-end.** A plan with `PricingModel.Tiered`
+  combined with a populated `Tiers` collection produces correct invoices
+  in both Volume and Graduated modes — closes a recurring user request.
+- **Scheduled plan changes are first-class.** Phase resolution lives
+  in the domain, not the orchestrator's caller — every billing-cycle
+  computation goes through the same path.
+- **Discount stacking is deterministic.** The cumulation order is fixed
+  (Trial → Percentage cumulated multiplicatively → FixedAmount), so
+  the same set of active discounts always produces the same final
+  amount regardless of insertion order.
+- **No HTTP yet means no API breaking change.** Apps that don't use
+  these primitives are unaffected; apps that want them populate the
+  child collections through their own data path.
+
+### Negative
+
+- **Orchestrator complexity grew.** `DefaultBillingCycleInvoiceOrchestrator`
+  now does phase resolution + price override + discount stacking +
+  optional tier math. Compensated by extracting
+  `TieredPricingCalculator` and `SubscriptionDiscountCalculator` as
+  pure functions with their own test suites.
+- **Domain entities without endpoints surprise some readers.**
+  Documented in `saas/subscriptions.mdx` that the entities are
+  populated through configuration tooling for now.
+- **The `Tiered` enum in `PricingModel` only matters when `Tiers`
+  is non-empty.** Plans with `PricingModel.Tiered` and no tiers fall
+  back to per-unit pricing. This is intentional (avoids an invariant
+  during plan creation) but documented.
+
+### Non-goals
+
+- **No usage-based discount stacking.** Discounts apply to base price
+  per phase, not per usage line. Mixing the two opens credit-stacking
+  fraud surfaces; revisit when there's a concrete use case.
+- **No multi-currency overrides.** A `SubscriptionPriceOverride` is
+  scoped to one `PlanPriceId` (one currency). Multi-currency
+  negotiations require multiple overrides.
+- **No retroactive phase activation.** Phases are forward-looking;
+  past billing cycles aren't re-billed if a phase is added with a
+  past `StartDate`.
+- **No discount on top of tiered usage.** When a discount is active
+  on a tiered plan, the discount applies to the base subscription
+  charge only — usage lines stay at their bracketed rate.
+
+## References
+
+- ADR-017 — DDD Aggregate Root vs Entity (PricingTier, SubscriptionPhase,
+  SubscriptionDiscount, SubscriptionPriceOverride are entities)
+- ADR-032 — `Granit.Catalog.Product` (PlanPrice.ProductId reference)
+- ADR-036 — Invoicing line item source + product convention
+  (orchestrator populates `productId` on line items from the resolved
+  PlanPrice)
+- Stripe Billing — pricing tiers documentation (Volume vs Graduated)
+- ORB — schedule + price override semantics (alignment target)

--- a/docs-site/src/content/docs/dotnet/architecture/adr/035-customer-balance-orb-credits-mapping.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/035-customer-balance-orb-credits-mapping.md
@@ -1,0 +1,154 @@
+---
+title: "ADR-035: Granit.CustomerBalance ↔ ORB Credits term-by-term mapping"
+description: "Document the conceptual mapping between the existing Granit.CustomerBalance module and ORB's Credits feature, formalize the additions made to close the residual gap (admin debit endpoint, pre-expiration notification job), and call out the deliberate non-goals (drawdown ordering, period quotas, distributed sagas)."
+sidebar:
+  order: 35
+  label: "035 - CustomerBalance ↔ ORB Credits"
+---
+
+> **Date:** 2026-04-25
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.CustomerBalance`, `Granit.CustomerBalance.Endpoints`,
+> `Granit.CustomerBalance.BackgroundJobs`,
+> `Granit.CustomerBalance.EntityFrameworkCore`
+
+## Context
+
+`Granit.CustomerBalance` shipped before the ORB-alignment audit
+(EPIC #1155). When the audit surveyed each SaaS module against ORB feature
+parity, CustomerBalance came back at **85–90% coverage** of ORB's
+Credits feature — close enough that recreating the module from scratch
+would be wasteful, but with three concrete gaps that would force every
+adopter to rebuild the same workarounds:
+
+1. **No admin debit endpoint.** Debits happened only through the
+   pre-payment processor (invoice deduction). Manual corrections,
+   scheduled drawdowns, and non-invoice adjustments required a SQL
+   surgery.
+2. **No pre-expiration warning.** Promotional credits expired silently
+   on the configured date. ORB notifies the tenant N days before
+   expiration so they can use the credit or contact support; without
+   this, expiring credits surprise everyone.
+3. **No documented mapping.** Adopters integrating with ORB-style
+   billing flows had no reference for "what's the Granit name for an
+   ORB Drawdown?" — every team rederived it.
+
+The decision: **extend in place**, not rewrite. Document the mapping,
+ship the two missing operations, and explicitly enumerate the
+non-goals so future contributors don't re-relitigate them.
+
+## Decision
+
+### 1. Term-by-term mapping (the existing 85% surface)
+
+| ORB concept | Granit concept | Notes |
+| ----------- | -------------- | ----- |
+| Customer | `BalanceAccount` | Per-tenant aggregate root, keyed by `(TenantId, Currency)` (composite business key, unique index) |
+| Currency-scoped balance | `BalanceAccount.Balance` | Cached running total; protected by `IConcurrencyAware` (optimistic concurrency token) |
+| Credit grant | `BalanceTransaction { Type = Credit }` | Append-only entry; never updated or deleted |
+| Drawdown / consumption | `BalanceTransaction { Type = Debit }` | Append-only entry; idempotent via `(ReferenceId, Source)` lookup |
+| Credit source — Promotional | `TransactionSource.Promotional` | |
+| Credit source — Customer overpayment | `TransactionSource.Overpayment` | Auto-credited by `OverpaymentCreditHandler` consuming `OverpaymentDetectedEto` |
+| Credit source — Manual adjustment | `TransactionSource.ManualAdjustment` | Admin-driven |
+| Credit source — Refund | `TransactionSource.RefundCredit` | |
+| Drawdown — Invoice deduction | `TransactionSource.InvoiceDeduction` | Auto-applied by `CustomerBalancePrePaymentProcessor` (`IInvoicePrePaymentProcessor` implementation) |
+| Drawdown — Expiration | `TransactionSource.Expiration` | Auto-applied by `CreditExpirationScanJob` (`0 */6 * * *` cron) |
+| Credit expiration policy | `BalanceTransaction.ExpiresAt` | Per-credit (`null` for non-expiring) |
+| Credit creation event | `BalanceCreditedEto` | Wolverine integration event |
+| Credit consumption event | `BalanceDebitedEto` | Wolverine integration event |
+| Credit expiration event | `CreditExpiredEto` | Wolverine integration event, raised by the expiration job |
+| Strategy injection — billing flow | `IInvoicePrePaymentProcessor` | Without CustomerBalance: `PassThroughPrePaymentProcessor` (full amount). With CustomerBalance: `CustomerBalancePrePaymentProcessor` (deducts credit first). Wired via `services.Replace(...)` |
+
+The mapping is term-by-term, not behavior-by-behavior — naming choices
+were made for Granit's broader vocabulary (`BalanceAccount` instead of
+`Customer` because Granit already has a `Customer` aggregate in
+upstream tenant-management), but the operations are 1:1.
+
+### 2. Additions to close the residual gap
+
+**`POST /api/granit/customer-balance/balance/debit`** (admin debit) —
+allows manual drawdown for corrections, scheduled debits, and non-invoice
+adjustments. Idempotent via `(ReferenceId, Source = ManualAdjustment)`
+lookup: a previous debit with the same `ReferenceId` short-circuits the
+call. Permission: `CustomerBalance.Credits.Manage` (the existing one;
+no new permission needed because debit is the inverse of credit and
+both are `Manage`-level destructive operations).
+
+**`CreditPreExpirationScanJob`** (`0 9 * * *` daily) — scans for credits
+expiring within `CustomerBalanceOptions.PreExpirationWarningDays`
+(default 7) and publishes `CreditNearExpirationEto` per (tenant, credit)
+pair. Idempotent via `BalanceTransaction.LastPreExpirationNoticedAt`:
+a credit already noticed on the current calendar day won't generate a
+duplicate event. Notification routing (email / in-app / Slack) lives in
+the consuming app, not in Granit.
+
+### 3. Idempotency strategy: lookup-then-act, not saga
+
+The transactional risk surfaced during the audit — *what if the wallet
+debit succeeds but the invoice credit-applier fails?* — is closed by:
+
+1. **Lookup before debit.** `(ReferenceId, Source = InvoiceDeduction)`
+   uniquely identifies a debit-for-an-invoice. If the lookup finds an
+   existing row, the processor skips the debit and proceeds to the
+   credit-application step. Wolverine's at-least-once retry replays
+   the whole flow safely.
+2. **Same UoW for debit + credit-applier.** The
+   `CustomerBalancePrePaymentProcessor` and the `IInvoiceCreditApplier`
+   share the same EF Core `DbContext` and commit together. A partial
+   failure is impossible under the standard transaction guarantees.
+
+A distributed saga (compensating debit on credit-application failure)
+was considered and rejected: the lookup + same-UoW pattern eliminates
+the failure mode that a saga would compensate for, and adds zero
+Wolverine surface.
+
+## Consequences
+
+### Positive
+
+- **Same module, broader surface.** Adopters integrating against ORB
+  semantics can now use `Granit.CustomerBalance` without writing any
+  custom code for admin drawdown or pre-expiration warnings.
+- **Documented vocabulary.** The mapping table is the authoritative
+  reference for "where does X from ORB live in Granit?" — eliminates
+  per-team rediscovery.
+- **No new permissions.** `Credits.Manage` covers both directions;
+  smaller permission surface is easier to grant correctly.
+
+### Negative
+
+- **Naming asymmetry.** ORB calls them "credits"; Granit's resource
+  permissions still say `Credits.Manage` even though the new endpoint
+  is a debit. Kept this way deliberately — it's the customer-balance
+  manage permission, the verb is implementation detail.
+- **Notification routing left to the app.** The pre-expiration job
+  publishes the event but doesn't send the email itself. Consequence:
+  app authors must wire `CreditNearExpirationEto` to a notification
+  channel; documented in `saas/customer-balance.mdx`.
+
+### Non-goals (explicitly out of scope)
+
+- **No drawdown ordering / FIFO / expiry-first policies.** ORB lets
+  admins configure which credit gets consumed first. Granit deducts
+  from the running total and selects which credit "expired" through
+  the order of `BalanceTransaction.ExpiresAt`. The drawdown-ordering
+  feature would require a per-credit balance ledger; revisit if the
+  use case appears.
+- **No period-bound quotas.** ORB caps "$X per month from this credit
+  source"; Granit treats credits as a single bucket. The same effect is
+  achievable by issuing N monthly credits.
+- **No distributed saga.** See §3 above — the lookup + same-UoW
+  pattern eliminates the failure mode.
+- **No three-way reconciliation with the PSP.** Granit doesn't sync
+  `BalanceAccount` state into Stripe Customer Balance. Adopters who
+  need cross-system reconciliation can subscribe to the events and
+  push to the PSP themselves.
+
+## References
+
+- ADR-017 — DDD Aggregate Root vs Entity (`BalanceAccount` is an
+  AuditedAggregateRoot, `BalanceTransaction` is an Entity)
+- ADR-032 — `Granit.Catalog.Product` (related: cross-module soft
+  references, `IInvoicePrePaymentProcessor` strategy pattern)
+- ORB Credits documentation (alignment target)
+- Stripe Customer Balance (related but not synced — see Non-goals)

--- a/docs-site/src/content/docs/dotnet/saas/customer-balance.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/customer-balance.mdx
@@ -142,3 +142,9 @@ builder.AddModule<GranitCustomerBalanceWolverineModule>();
 // Credit expiration (optional)
 builder.AddModule<GranitCustomerBalanceBackgroundJobsModule>();
 ```
+
+## See also
+
+- [SaaS Overview](/dotnet/saas/) — ecosystem architecture and choreography
+- [Invoicing](/dotnet/saas/invoicing/) — pre-payment processor that consumes the balance
+- [ADR-035 — Granit.CustomerBalance ↔ ORB Credits mapping](/dotnet/architecture/adr/035-customer-balance-orb-credits-mapping/) — term-by-term mapping, admin debit, pre-expiration warning, non-goals

--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -27,15 +27,18 @@ API call metering, IoT telemetry, storage tracking, or any usage-based scenario.
 
 ### MeterDefinition (AggregateRoot)
 
-Defines what to measure and how to aggregate:
+Defines what to measure and how to aggregate. Implements `IWorkflowStateful`
+with the `Draft → Published → Archived` lifecycle (ADR-033) — only `Published`
+meters accept ingestion.
 
 ```csharp
 var meter = MeterDefinition.Create(
     Guid.NewGuid(), "API Calls", "requests",
-    AggregationType.Sum, "HTTP API request counter");
+    AggregationType.Sum, "HTTP API request counter",
+    productId: catalogProductId);          // optional Granit.Catalog.Product reference
 
-meter.Deactivate();  // Stops accepting new events
-meter.Activate();    // Re-enables event recording
+meter.Publish();   // Draft → Published; ingestion accepted
+meter.Archive();   // Published → Archived; aggregates remain readable, ingestion rejected
 ```
 
 | Aggregation type | Description |
@@ -44,6 +47,20 @@ meter.Activate();    // Re-enables event recording
 | `Max` | Maximum event quantity in the period |
 | `Count` | Count of events (ignores quantity) |
 | `Last` | Last recorded value (gauge-style) |
+| `CountDistinct` | Count of distinct values at `MeterDefinition.DistinctProperty` (a JSON path inside `MeterEvent.Metadata`). Events whose metadata does not contain the property are excluded from the count. |
+
+For `CountDistinct`, `DistinctProperty` is **required** at meter creation and
+**must be `null`** for every other aggregation type — the validator enforces both
+directions.
+
+`MeterDefinition.ProductId` (`Guid?`) is an optional soft reference to a
+`Granit.Catalog.Product` (no SQL FK across modules). When set, downstream invoice
+lines surface the product id automatically (see ADR-036).
+
+The legacy `Activated` boolean is retained one release as a computed alias
+(`Activated => LifecycleStatus == Published`) and marked `[Obsolete]`. The
+`POST /meters/{id}/deactivate` endpoint stays one release as an alias for
+`POST /meters/{id}/archive`.
 
 ### MeterEvent (Entity — append-only)
 
@@ -173,6 +190,66 @@ The threshold percentage is configurable via `GranitMeteringOptions`:
 }
 ```
 
+## Admin reprocessing — recompute, backfill, deprecate (ADR-033)
+
+Three cold-path operations for fixing billing data. All three acquire a
+**transaction-scoped advisory lock** per `(meter, tenant)` so they mutually
+exclude with the hourly aggregator job and with each other (PostgreSQL
+`pg_advisory_xact_lock(hashtext(...))`, SQL Server `sp_getapplock @LockOwner='Transaction'`).
+
+### Recompute on-demand
+
+Rebuilds `UsageAggregate` rows for an arbitrary window. Window edges snap to
+hourly buckets server-side. The global ingestion watermark is **never rewound** —
+events past `to` keep flowing through the hot path.
+
+```http
+POST /api/granit/metering/meters/{id}/recompute
+{
+  "from": "2026-04-01T00:00:00Z",
+  "to":   "2026-04-15T00:00:00Z"
+}
+
+→ 200 RecomputeUsageResponse {
+    meterDefinitionId, windowStart, windowEnd,
+    eventsScanned, aggregatesRebuilt, durationMilliseconds
+  }
+```
+
+Permission: `Metering.Meters.Manage`.
+
+### Backfill historical events
+
+Same shape as `POST /events`, but the per-event age validator allows up to
+**365 days** instead of the standard 7-day window. Auto-triggers a recompute
+on every meter window the backfilled events touched.
+
+```http
+POST /api/granit/metering/events/backfill
+{ "events": [ { meterDefinitionId, idempotencyKey, quantity, timestamp, metadata }, ... ] }
+
+→ 200 BackfillUsageResponse { eventsAccepted, metersAffected, aggregatesRebuilt }
+```
+
+Permission: `Metering.Events.Backfill` (deliberately separated from
+`Metering.Usage.Record` because backfill is destructive at the billing-data
+level — ISO 27001 A.9.4 — least privilege).
+
+### Soft-deprecate an event
+
+Marks an individual event as discarded for billing purposes. The event row is
+preserved (audit trail, `DeprecatedAt` + `DeprecationReason` columns); the
+auto-recompute on the affected hourly bucket follows.
+
+```http
+POST /api/granit/metering/events/{id}/deprecate
+{ "reason": "duplicate from retried client" }
+
+→ 200 DeprecateEventResponse { eventId, meterDefinitionId, deprecatedAt, aggregatesRebuilt }
+```
+
+Permission: `Metering.Events.Manage`.
+
 ## Integration with Subscriptions
 
 When a billing-period aggregation completes, `UsageSummaryReadyEto` is published.
@@ -224,9 +301,15 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | `Id` | GUID | Primary key |
 | `Name` | varchar(200) | Meter display name |
 | `Unit` | varchar(50) | Unit of measure |
-| `AggregationType` | int | Sum/Max/Count/Last |
-| `Activated` | bool | Accepts new events |
+| `AggregationType` | int | Sum / Max / Count / Last / CountDistinct |
+| `LifecycleStatus` | int | Draft / Published / Archived (ADR-033) |
+| `DistinctProperty` | varchar(256)? | JSON path inside `MeterEvent.Metadata` (`CountDistinct` only) |
+| `ProductId` | GUID? | Soft reference to `Granit.Catalog.Product` (no FK) |
 | `TenantId` | GUID? | Multi-tenant isolation |
+
+The legacy `Activated` column is dropped by the
+`MeterDefinition_StatusFromActivated` migration (`Activated => true` ⇒
+`LifecycleStatus = Published`, `Activated => false` ⇒ `Archived`).
 
 ### metering_meter_events
 
@@ -238,6 +321,8 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | `Quantity` | decimal(18,6) | Measured quantity |
 | `Timestamp` | datetimeoffset | When usage occurred |
 | `Metadata` | varchar(4000) | Optional JSON context |
+| `DeprecatedAt` | datetimeoffset? | Set when the event is soft-deprecated; aggregator skips it |
+| `DeprecationReason` | varchar(500)? | Audit trail for the deprecation |
 | `TenantId` | GUID? | Multi-tenant isolation |
 
 **Indexes:**
@@ -262,9 +347,14 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | GET | `/api/granit/metering/meters` | `Metering.Meters.Read` |
 | POST | `/api/granit/metering/meters` | `Metering.Meters.Manage` |
 | PUT | `/api/granit/metering/meters/{id}` | `Metering.Meters.Manage` |
+| POST | `/api/granit/metering/meters/{id}/publish` | `Metering.Meters.Manage` |
+| POST | `/api/granit/metering/meters/{id}/archive` | `Metering.Meters.Manage` |
+| POST | `/api/granit/metering/meters/{id}/recompute` | `Metering.Meters.Manage` |
 | GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
 | GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
 | POST | `/api/granit/metering/events` | `Metering.Usage.Record` |
+| POST | `/api/granit/metering/events/backfill` | `Metering.Events.Backfill` |
+| POST | `/api/granit/metering/events/{id}/deprecate` | `Metering.Events.Manage` |
 | GET | `/api/granit/metering/meter-definitions` | `Metering.Meters.Read` |
 | GET | `/api/granit/metering/usage-aggregates` | `Metering.Usage.Read` |
 
@@ -320,3 +410,6 @@ layers** — neither replaces the other.
 - [SaaS Overview](/dotnet/saas/) — ecosystem architecture and choreography
 - [Subscriptions](/dotnet/saas/subscriptions/) — billing cycle orchestration
 - [Invoicing](/dotnet/saas/invoicing/) — invoice creation from usage data
+- [ADR-033 — Metering hybrid](/dotnet/architecture/adr/033-metering-hybrid-lifecycle-and-recompute/) — lifecycle, CountDistinct, recompute, backfill, deprecate
+- [ADR-036 — Invoicing line item source convention](/dotnet/architecture/adr/036-invoicing-line-source-convention/) — `MeterDefinition.ProductId` propagation
+- [Spike — SQL ad-hoc metric definitions (DEFER)](/dotnet/architecture/spikes/metering-sql-ad-hoc-metrics/)

--- a/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
@@ -58,7 +58,77 @@ plan.AddPrice(PlanPrice.Create(Guid.NewGuid(), 299.99m, "EUR", BillingInterval.Y
 | `Flat` | Fixed price per interval |
 | `PerSeat` | Price multiplied by seat count |
 | `PerUnit` | Price per unit of consumption |
-| `Tiered` | Volume-based pricing tiers |
+| `Tiered` | Bracketed pricing — see [Tiered pricing](#tiered-pricing--pricingtier-adr-034) |
+
+`PlanPrice.ProductId` (`Guid?`) is an optional soft reference to a
+`Granit.Catalog.Product`, preserved across price versions. The orchestrator
+propagates it onto invoice lines (see ADR-036).
+
+## Tiered pricing — `PricingTier` (ADR-034)
+
+When a `PlanPrice` carries a non-empty `Tiers` collection and a `TieringMode`,
+the usage orchestrator computes the invoice amount via
+`TieredPricingCalculator.Compute(quantity, mode, tiers)`:
+
+```csharp
+var price = PlanPrice.Create(
+    Guid.NewGuid(), amount: 0m, "EUR", BillingInterval.Monthly,
+    effectiveFrom: clock.Now, productId: apiProduct.Id,
+    tieringMode: TieringMode.Graduated);
+
+price.SetTiers(TieringMode.Graduated, [
+    PricingTier.Create(upToQuantity: 10_000m, unitAmount: 0.10m, sortOrder: 0),
+    PricingTier.Create(upToQuantity: 100_000m, unitAmount: 0.05m, sortOrder: 1),
+    PricingTier.Create(upToQuantity: null,    unitAmount: 0.02m, sortOrder: 2), // open-ended last tier
+]);
+```
+
+| `TieringMode` | Math |
+| ------------- | ---- |
+| `Volume` | The bracket containing `quantity` is selected; its `UnitAmount` applies to the **full quantity** |
+| `Graduated` | Each bracket charged at its own `UnitAmount`; results summed (`PricingTier.FlatAmount` is added on top per bracket if set) |
+
+Validator invariants (enforced at the create endpoint):
+
+- Ascending `UpToQuantity`
+- Exactly one open-ended tier (`UpToQuantity = null`), which must be last
+- `TieringMode` is required when `Tiers.Count > 0`, must be `null` otherwise
+
+## Scheduled plan changes — `SubscriptionPhase` (ADR-034)
+
+A subscription can carry zero or more `SubscriptionPhase` entries. Each phase
+covers a half-open `[StartDate, EndDate)` window and pins:
+
+- a `PlanId` (the plan active during that window)
+- an optional `OverridePriceId` (a specific `PlanPrice` row, used for grandfathered enterprise terms)
+- an optional `DiscountPercent` (0–100, applied to the resolved base price)
+
+```csharp
+subscription.SchedulePhase(SubscriptionPhase.Create(
+    startDate: clock.Now.AddMonths(3),
+    endDate:   clock.Now.AddMonths(6),
+    planId:    promotionalPlanId,
+    overridePriceId: null,
+    discountPercent: 20m));   // 20% off for 3 months starting 3 months from now
+```
+
+At billing time, `subscription.GetActivePhase(clock.Now)` resolves the phase
+covering "now". When no phase covers the instant, the orchestrator falls back
+to `subscription.PlanId` / `PlanPriceId` (single-phase = backward compatible
+with pre-Phase-3 behavior).
+
+The orchestrator combines all four ingredients in one pass: phase-resolved
+plan → phase-pinned override price (if any) → phase-flat discount → cumulative
+`SubscriptionDiscount` stack. Implementation lives in
+`DefaultBillingCycleInvoiceOrchestrator`; the math is covered in detail in
+[ADR-034](/dotnet/architecture/adr/034-subscriptions-phases-and-tiered-pricing/).
+
+:::note[No HTTP surface yet]
+`PricingTier`, `SubscriptionPhase`, `SubscriptionDiscount`, and
+`SubscriptionPriceOverride` are domain entities populated through configuration
+tooling (Stripe sync, internal admin scripts, EF Core migrations). Admin
+endpoints will land in a follow-up — see [ADR-034 §6](/dotnet/architecture/adr/034-subscriptions-phases-and-tiered-pricing/#6-no-http-endpoints-in-this-iteration--orchestrator-only).
+:::
 
 ## Subscription FSM
 
@@ -166,18 +236,37 @@ var subscription = Subscription.Create(
 
 ## Pricing resolution
 
-`IPricingResolver` resolves prices from the plan's `PlanPrice` entries:
+`IPricingResolver` resolves prices from the plan's `PlanPrice` entries.
+`planPriceId` (optional) lets the caller pin a specific price version (used
+for grandfathered subscriptions and `SubscriptionPhase.OverridePriceId`):
 
 ```csharp
 public interface IPricingResolver
 {
     Task<decimal> ResolveBasePriceAsync(
-        PlanId planId, string currency, BillingInterval interval, CancellationToken ct);
+        PlanId planId, string currency, BillingInterval interval,
+        Guid? planPriceId = null, CancellationToken ct = default);
+
     Task<decimal> ResolveUsageUnitPriceAsync(
         PlanId planId, string currency, BillingInterval interval,
-        string meterId, CancellationToken ct);
+        string meterId, Guid? planPriceId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the total amount owed for the given quantity, applying tiered
+    /// pricing (Volume / Graduated) when the resolved PlanPrice carries a
+    /// non-empty Tiers collection. Falls back to quantity × unit-price for
+    /// flat per-unit pricing.
+    /// </summary>
+    Task<decimal> ResolveUsageAmountAsync(
+        PlanId planId, string currency, BillingInterval interval,
+        string meterId, decimal quantity, Guid? planPriceId = null,
+        CancellationToken ct = default);
 }
 ```
+
+`ResolveUsageAmountAsync` is the canonical entry point for usage billing —
+it dispatches to `TieredPricingCalculator` when tiers are present and
+falls back to `quantity × unit price` otherwise.
 
 ## Billing cycle orchestration
 
@@ -325,3 +414,5 @@ Default channels: Email + InApp. Email templates are Phase 2 (requires `Granit.T
 - [Metering](/dotnet/saas/metering/) — usage-based metering
 - [Scheduling](/dotnet/infrastructure/scheduling/) — scheduled plan changes
 - [Feature Flags](/dotnet/infrastructure/feature-flags/) — plan-driven cascade
+- [ADR-034 — Subscriptions phases & tiered pricing](/dotnet/architecture/adr/034-subscriptions-phases-and-tiered-pricing/)
+- [ADR-036 — Invoicing line item source convention](/dotnet/architecture/adr/036-invoicing-line-source-convention/) — `PlanPrice.ProductId` propagation

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 58;
-export const ADR_COUNT = 31;
+export const ADR_COUNT = 36;


### PR DESCRIPTION
## Summary

The Astro docs site lagged behind the ORB-alignment program (EPIC #1155). Three ADRs that should have shipped with their respective code PRs were either lost in stacked-PR squash merges (ADR-035 was on a stacked branch that never landed in develop) or never written; the SaaS module docs (`metering.mdx`, `subscriptions.mdx`, `customer-balance.mdx`) didn't mention any of the new operations, types, or columns.

This PR closes that gap retroactively — **pure documentation, no code**.

## New ADRs

| ADR | Topic | Backend PRs documented |
| --- | ----- | ---------------------- |
| **ADR-033** | Metering hybrid (lifecycle, CountDistinct, recompute, backfill, deprecate, cross-DB advisory lock) | #1187 → #1196 |
| **ADR-034** | Subscriptions phases & tiered pricing (PricingTier, SubscriptionPhase, SubscriptionDiscount, SubscriptionPriceOverride) | #1200, #1202 |
| **ADR-035** | Granit.CustomerBalance ↔ ORB Credits term-by-term mapping + admin debit + pre-expiration scan | #1205, #1206 |

Each ADR includes the standard sections: Context, Decision, Consequences (Positive / Negative / Non-goals), References. Non-goals are deliberately enumerated to prevent re-litigation (e.g. ADR-035's "no drawdown ordering / no period quotas / no distributed saga / no PSP reconciliation").

## SaaS module docs updated

- **`saas/metering.mdx`** — `MeterDefinition` lifecycle, `CountDistinct` row, `ProductId` soft reference, new "Admin reprocessing" section (recompute / backfill / deprecate with HTTP shapes + permissions), updated database schema (`LifecycleStatus`, `DistinctProperty`, `ProductId`, `DeprecatedAt`, `DeprecationReason`), updated Admin API table.
- **`saas/subscriptions.mdx`** — `PlanPrice.ProductId`, new "Tiered pricing" section (Volume vs Graduated math + validator invariants), new "Scheduled plan changes" section (SubscriptionPhase, half-open `[Start, End)` semantics), `IPricingResolver` signature updated (added `planPriceId` param + `ResolveUsageAmountAsync`).
- **`saas/customer-balance.mdx`** — added `## See also` cross-link to ADR-035.

## Counter

\`ADR_COUNT = 31\` → \`36\` (matches the actual `*.md` file count: 032 + 033 + 034 + 035 + 036 = +5 over the stale 31).

## Verification

- ✅ `npx markdownlint-cli2` clean on the three new ADRs and `customer-balance.mdx`. Two pre-existing table-style warnings on `metering.mdx` / `subscriptions.mdx` are not introduced here.
- ✅ `npx astro build` — **426 pages built** (was 418 before this PR; +3 ADRs + meta). Internal anchor + cross-link validation passes.

## Test plan

- [ ] Reviewer skims ADR-033/034/035 for fidelity to the actual code that shipped
- [ ] CI green