### PR TITLE
chore: recover docs-branch WIP + partial SonarQube cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,37 @@ jobs:
           exit-code: 1
           format: table
 
+  # NuGet audit feed: complements Trivy (different CVE source, also catches
+  # transitive dependencies disclosed AFTER lockfile generation).
+  dotnet-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: NuGet cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore (locked mode)
+        run: dotnet restore --locked-mode
+
+      - name: List vulnerable packages (transitive)
+        run: |
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee vuln.txt
+          if grep -E "^\s*>\s.*(High|Critical)" vuln.txt; then
+            echo "::error::High or Critical vulnerable NuGet packages detected."
+            exit 1
+          fi
+
   codeql:
     runs-on: ubuntu-latest
     permissions:

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7793,7 +7793,7 @@
       "kind": "record",
       "project": "Granit.Bff",
       "file": "src/Granit.Bff/BffTokenSet.cs",
-      "line": 8,
+      "line": 19,
       "members": []
     },
     {
@@ -11915,7 +11915,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Handlers/ExecuteExportCommandHandler.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "HandleAsync",
@@ -11931,7 +11931,7 @@
       "kind": "class",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Handlers/ExecuteImportCommandHandler.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "HandleAsync",
@@ -14623,7 +14623,7 @@
       "kind": "class",
       "project": "Granit.Encryption",
       "file": "src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "ProviderName",
@@ -17682,6 +17682,12 @@
           "returnType": "string?"
         },
         {
+          "name": "EnableHsts",
+          "kind": "property",
+          "signature": "bool EnableHsts",
+          "returnType": "bool"
+        },
+        {
           "name": "HstsMaxAgeSeconds",
           "kind": "property",
           "signature": "int HstsMaxAgeSeconds",
@@ -18174,7 +18180,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.Cognito.BackgroundJobs/Jobs/CognitoClientRoleSyncHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -18421,7 +18427,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.EntraId.BackgroundJobs/Jobs/EntraIdClientRoleSyncHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -18438,6 +18444,15 @@
       "project": "Granit.Identity.Federated.EntraId.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.EntraId.BackgroundJobs/Jobs/EntraIdClientRoleSyncJob.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntraIdClientNotFoundException",
+      "fqn": "Granit.Identity.Federated.EntraId.Exceptions.EntraIdClientNotFoundException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.EntraId",
+      "file": "src/Granit.Identity.Federated.EntraId/Exceptions/EntraIdClientNotFoundException.cs",
+      "line": 12,
       "members": []
     },
     {
@@ -18761,7 +18776,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.Keycloak.BackgroundJobs/Jobs/KeycloakClientRoleSyncHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -18778,6 +18793,24 @@
       "project": "Granit.Identity.Federated.Keycloak.BackgroundJobs",
       "file": "src/Granit.Identity.Federated.Keycloak.BackgroundJobs/Jobs/KeycloakClientRoleSyncJob.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "KeycloakClientNotFoundException",
+      "fqn": "Granit.Identity.Federated.Keycloak.Exceptions.KeycloakClientNotFoundException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.Keycloak",
+      "file": "src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakClientNotFoundException.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "KeycloakTokenExchangeRateLimitedException",
+      "fqn": "Granit.Identity.Federated.Keycloak.Exceptions.KeycloakTokenExchangeRateLimitedException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.Keycloak",
+      "file": "src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakTokenExchangeRateLimitedException.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -18952,7 +18985,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Privacy",
       "file": "src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPersonalDataExportHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -20867,7 +20900,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Privacy",
       "file": "src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPersonalDataExportHandler.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "HandleAsync",
@@ -21876,69 +21909,6 @@
       "members": []
     },
     {
-      "name": "CreditNoteIssuedEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.CreditNoteIssuedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceFinalizedEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceFinalizedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs",
-      "line": 7,
-      "members": []
-    },
-    {
-      "name": "InvoiceOverdueEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceOverdueEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoicePaidEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.InvoicePaidEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceUncollectibleEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceUncollectibleEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "InvoiceVoidedEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.InvoiceVoidedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs",
-      "line": 6,
-      "members": []
-    },
-    {
-      "name": "OverpaymentDetectedEto",
-      "fqn": "Granit.Invoicing.Abstractions.Events.OverpaymentDetectedEto",
-      "kind": "record",
-      "project": "Granit.Invoicing.Abstractions",
-      "file": "src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs",
-      "line": 9,
-      "members": []
-    },
-    {
       "name": "GranitInvoicingBackgroundJobsModule",
       "fqn": "Granit.Invoicing.BackgroundJobs.GranitInvoicingBackgroundJobsModule",
       "kind": "class",
@@ -22108,7 +22078,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Domain/Invoice.cs",
-      "line": 29,
+      "line": 28,
       "members": [
         {
           "name": "Create",
@@ -22534,12 +22504,75 @@
       "members": []
     },
     {
+      "name": "CreditNoteIssuedEto",
+      "fqn": "Granit.Invoicing.Events.CreditNoteIssuedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "InvoiceCreatedEvent",
       "fqn": "Granit.Invoicing.Events.InvoiceCreatedEvent",
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Events/InvoiceCreatedEvent.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceFinalizedEto",
+      "fqn": "Granit.Invoicing.Events.InvoiceFinalizedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "InvoiceOverdueEto",
+      "fqn": "Granit.Invoicing.Events.InvoiceOverdueEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoicePaidEto",
+      "fqn": "Granit.Invoicing.Events.InvoicePaidEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceUncollectibleEto",
+      "fqn": "Granit.Invoicing.Events.InvoiceUncollectibleEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "InvoiceVoidedEto",
+      "fqn": "Granit.Invoicing.Events.InvoiceVoidedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "OverpaymentDetectedEto",
+      "fqn": "Granit.Invoicing.Events.OverpaymentDetectedEto",
+      "kind": "record",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs",
+      "line": 9,
       "members": []
     },
     {
@@ -25648,7 +25681,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitMultiTenancy",
@@ -25746,7 +25779,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs",
-      "line": 25,
+      "line": 27,
       "members": [
         {
           "name": "IsEnabled",
@@ -25848,7 +25881,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Provisioning",
       "file": "src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs",
-      "line": 26,
+      "line": 28,
       "members": [
         {
           "name": "HandleAsync",
@@ -27976,7 +28009,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Privacy",
       "file": "src/Granit.Notifications.Privacy/DataExport/NotificationsPersonalDataExportHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -30383,7 +30416,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs",
-      "line": 109,
+      "line": 127,
       "members": [
         {
           "name": "WithFapi2Profile",
@@ -31792,7 +31825,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Handlers/InitiatePaymentCommandHandler.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "HandleAsync",
@@ -31824,7 +31857,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Handlers/RequestRefundCommandHandler.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "HandleAsync",
@@ -33860,7 +33893,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/Handlers/RunMigrationBatchHandler.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "HandleAsync",
@@ -34682,6 +34715,15 @@
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/ExportManifest.cs",
       "line": 34,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportSizeLimitExceededException",
+      "fqn": "Granit.Privacy.BlobStorage.DataExport.Internal.PrivacyExportSizeLimitExceededException",
+      "kind": "class",
+      "project": "Granit.Privacy.BlobStorage",
+      "file": "src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs",
+      "line": 100,
       "members": []
     },
     {
@@ -40879,7 +40921,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Features",
       "file": "src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "HandleAsync",
@@ -40971,7 +41013,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Handlers/PaymentFailedHandler.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "HandleAsync",
@@ -40987,7 +41029,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Handlers/RetryPaymentHandler.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "HandleAsync",
@@ -45957,7 +45999,7 @@
       "kind": "record",
       "project": "Granit.Vault",
       "file": "src/Granit.Vault/SecretDescriptor.cs",
-      "line": 22,
+      "line": 32,
       "members": [
         {
           "name": "Name",

--- a/src/Granit.Auditing.ConfigurationChanges/Internal/SensitiveValueMasker.cs
+++ b/src/Granit.Auditing.ConfigurationChanges/Internal/SensitiveValueMasker.cs
@@ -40,8 +40,13 @@ internal static partial class SensitiveValueMasker
         return value;
     }
 
+    // Negative lookahead `(?![a-z])` prevents over-masking on words that
+    // happen to start with a sensitive token (e.g. "KeyboardLayout" — `Key`
+    // followed by `b` rejects the match). PascalCase suffixes such as
+    // "ClientSecret" or "ApiKey" still match because the trailing lookahead
+    // is satisfied by end-of-string or by the next non-lowercase character.
     [GeneratedRegex(
-        @"(Password|Secret|Key|Token|Credential|ConnectionString|ApiKey|PrivateKey|SigningKey|HmacKey|EncryptionKey)",
+        @"(Password|Pwd|Secret|Token|Credential|ConnectionString|ConnString|ApiKey|PrivateKey|PublicKey|SigningKey|HmacKey|EncryptionKey|Bearer|Authorization|AccessKey|SharedAccessKey|SasToken|Key)(?![a-z])",
         RegexOptions.IgnoreCase,
         matchTimeoutMilliseconds: 100)]
     private static partial Regex SensitiveNamePattern();

--- a/src/Granit.Auditing.ConfigurationChanges/packages.lock.json
+++ b/src/Granit.Auditing.ConfigurationChanges/packages.lock.json
@@ -25,6 +25,23 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -84,6 +101,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -185,6 +203,19 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
@@ -134,15 +134,15 @@ internal sealed partial class ApiKeyAuthenticationHandler(
 
     private static ClaimsPrincipal BuildClaimsPrincipal(ApiKeyEntry apiKey)
     {
-        var claims = new List<Claim>
-        {
+        List<Claim> claims =
+        [
             new(ClaimTypes.NameIdentifier, apiKey.Id.ToString()),
             new(ClaimTypes.Name, apiKey.Name),
             new(ApiKeyClaimTypes.ActorKind, nameof(Users.ActorKind.ExternalSystem)),
             new(ApiKeyClaimTypes.ApiKeyId, apiKey.Id.ToString()),
             new(ApiKeyClaimTypes.ApiKeyType, apiKey.Type.ToString()),
             new(ApiKeyClaimTypes.Environment, apiKey.Environment),
-        };
+        ];
 
         foreach (string permission in apiKey.Permissions)
         {

--- a/src/Granit.Authentication.DPoP/Validation/Internal/DPoPProofValidator.cs
+++ b/src/Granit.Authentication.DPoP/Validation/Internal/DPoPProofValidator.cs
@@ -66,16 +66,21 @@ internal sealed class DPoPProofValidator(
             return nonceResult;
         }
 
-        DPoPValidationResult? replayResult = await ValidateReplayProtectionAsync(payload, opts, cancellationToken).ConfigureAwait(false);
-        if (replayResult is not null)
-        {
-            return replayResult with { ServerNonce = serverNonce };
-        }
-
+        // SECURITY: signature MUST be verified before any side effect on cache state.
+        // If we recorded the jti before signature verification, an unauthenticated
+        // attacker could pollute the replay cache with attacker-chosen jti values
+        // (forged proofs are cheap to generate), denying legitimate clients whose
+        // proofs use the same jti.
         DPoPValidationResult? signatureResult = ValidateSignature(parts, jwk, algorithm, opts);
         if (signatureResult is not null)
         {
             return signatureResult with { ServerNonce = serverNonce };
+        }
+
+        DPoPValidationResult? replayResult = await ValidateReplayProtectionAsync(payload, opts, cancellationToken).ConfigureAwait(false);
+        if (replayResult is not null)
+        {
+            return replayResult with { ServerNonce = serverNonce };
         }
 
         string thumbprint = JwkThumbprintCalculator.ComputeThumbprint(jwk);
@@ -237,7 +242,7 @@ internal sealed class DPoPProofValidator(
         bool signatureValid = kty switch
         {
             "EC" => VerifyEcSignature(jwk, signingInput, signature, algorithm),
-            "RSA" => VerifyRsaSignature(jwk, signingInput, signature, opts.MinimumRsaKeySize),
+            "RSA" => VerifyRsaSignature(jwk, signingInput, signature, algorithm, opts.MinimumRsaKeySize),
             _ => false,
         };
 
@@ -288,7 +293,7 @@ internal sealed class DPoPProofValidator(
         }
     }
 
-    private static bool VerifyRsaSignature(JsonElement jwk, byte[] data, byte[] signature, int minimumKeySizeBits)
+    private static bool VerifyRsaSignature(JsonElement jwk, byte[] data, byte[] signature, string algorithm, int minimumKeySizeBits)
     {
         try
         {
@@ -302,8 +307,24 @@ internal sealed class DPoPProofValidator(
                 return false;
             }
 
+            (HashAlgorithmName hashAlg, RSASignaturePadding padding) = algorithm switch
+            {
+                "PS256" => (HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
+                "PS384" => (HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
+                "PS512" => (HashAlgorithmName.SHA512, RSASignaturePadding.Pss),
+                "RS256" => (HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+                "RS384" => (HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+                "RS512" => (HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+                _ => (default, null!),
+            };
+
+            if (padding is null)
+            {
+                return false;
+            }
+
             using var rsa = RSA.Create(new RSAParameters { Modulus = n, Exponent = e });
-            return rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+            return rsa.VerifyData(data, signature, hashAlg, padding);
         }
         catch
         {

--- a/src/Granit.Bff.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Bff.BackgroundJobs/packages.lock.json
@@ -291,6 +291,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Bff.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Bff.EntityFrameworkCore/packages.lock.json
@@ -285,6 +285,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Bff/BffTokenSet.cs
+++ b/src/Granit.Bff/BffTokenSet.cs
@@ -1,9 +1,20 @@
+using Granit.Caching;
+
 namespace Granit.Bff;
 
 /// <summary>
 /// Represents a set of OIDC tokens stored server-side for a BFF session.
 /// Tokens never leave the server — the browser only holds a session cookie.
 /// </summary>
+/// <remarks>
+/// SECURITY: <see cref="CacheEncryptedAttribute"/> forces AES-256-GCM encryption
+/// of the cached payload regardless of the global
+/// <see cref="Granit.Caching.Options.CachingOptions.EncryptValues"/> setting.
+/// This protects access tokens, refresh tokens, ID tokens, and the DPoP
+/// private key from any read-side breach of the L2 cache (Redis snapshot,
+/// AOF leak, ACL bypass).
+/// </remarks>
+[CacheEncrypted]
 #pragma warning disable GRSEC003 // Record contains token properties — stored server-side only
 public sealed record BffTokenSet(
     string AccessToken,

--- a/src/Granit.Bff/Internal/HmacBffCsrfTokenGenerator.cs
+++ b/src/Granit.Bff/Internal/HmacBffCsrfTokenGenerator.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Granit.Bff.Options;
 using Granit.Timing;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -21,10 +22,15 @@ namespace Granit.Bff.Internal;
 internal sealed partial class HmacBffCsrfTokenGenerator(
     IClock clock,
     IOptions<GranitBffOptions> options,
+    IHostEnvironment environment,
     ILogger<HmacBffCsrfTokenGenerator> logger) : IBffCsrfTokenGenerator
 {
-    private static readonly TimeSpan ValidationWindow = TimeSpan.FromHours(24);
-    private readonly byte[] _key = ResolveKey(options.Value, logger);
+    // Validation window kept short (1h) to limit replay surface from leaked tokens
+    // (referer headers, browser caches, dev tools). Future timestamps are rejected
+    // outright with a small clock-skew tolerance.
+    private static readonly TimeSpan ValidationWindow = TimeSpan.FromHours(1);
+    private static readonly TimeSpan ClockSkew = TimeSpan.FromSeconds(60);
+    private readonly byte[] _key = ResolveKey(options.Value, environment, logger);
 
     public string Generate(string sessionId)
     {
@@ -56,9 +62,11 @@ internal sealed partial class HmacBffCsrfTokenGenerator(
             return false;
         }
 
-        // Check timestamp is within the validation window
+        // Reject expired tokens (older than ValidationWindow) and future-dated tokens
+        // beyond clock-skew tolerance — both indicate forgery or significant drift.
         long nowSeconds = clock.Now.ToUnixTimeSeconds();
-        if (Math.Abs(nowSeconds - timestamp) > (long)ValidationWindow.TotalSeconds)
+        long age = nowSeconds - timestamp;
+        if (age > (long)ValidationWindow.TotalSeconds || age < -(long)ClockSkew.TotalSeconds)
         {
             return false;
         }
@@ -78,11 +86,23 @@ internal sealed partial class HmacBffCsrfTokenGenerator(
         return Convert.ToHexStringLower(hash);
     }
 
-    private static byte[] ResolveKey(GranitBffOptions bffOptions, ILogger logger)
+    private static byte[] ResolveKey(GranitBffOptions bffOptions, IHostEnvironment environment, ILogger logger)
     {
         if (!string.IsNullOrEmpty(bffOptions.CsrfHmacKey))
         {
             return Convert.FromBase64String(bffOptions.CsrfHmacKey);
+        }
+
+        // Auto-generated keys are per-instance: tokens minted on instance A are
+        // rejected by instance B, breaking sessions silently in any multi-replica
+        // deployment. Refuse outside Development.
+        if (!environment.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                "Bff:CsrfHmacKey is required outside the Development environment "
+                + $"(current: '{environment.EnvironmentName}'). Without a shared key, multi-instance "
+                + "deployments cannot validate each other's CSRF tokens. Generate one with "
+                + "Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)) and store it in Vault.");
         }
 
         LogCsrfKeyGenerated(logger);

--- a/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
+++ b/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.CustomerBalance.Handlers;

--- a/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
+++ b/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
@@ -3,7 +3,7 @@ using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 

--- a/src/Granit.DataExchange/Handlers/ExecuteExportCommandHandler.cs
+++ b/src/Granit.DataExchange/Handlers/ExecuteExportCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Messages;
 
@@ -10,6 +11,7 @@ namespace Granit.DataExchange.Handlers;
 /// <remarks>
 /// Export jobs do not cascade — each command is a self-contained unit of work.
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed class ExecuteExportCommandHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.DataExchange/Handlers/ExecuteImportCommandHandler.cs
+++ b/src/Granit.DataExchange/Handlers/ExecuteImportCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.DataExchange.Import.Messages;
 using Granit.DataExchange.Import.Pipeline;
 
@@ -10,6 +11,7 @@ namespace Granit.DataExchange.Handlers;
 /// <remarks>
 /// Import jobs do not cascade — each command is a self-contained unit of work.
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed class ExecuteImportCommandHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.DataLookup/Registry/LookupRegistry.cs
+++ b/src/Granit.DataLookup/Registry/LookupRegistry.cs
@@ -38,21 +38,14 @@ internal sealed class LookupRegistry : ILookupRegistry
         return _sources.TryGetValue(name, out ILookupSource? source) ? source : null;
     }
 
-    public IReadOnlyList<LookupManifestEntry> GetManifest()
-    {
-        List<LookupManifestEntry> entries = new(_sources.Count);
-        foreach (ILookupSource source in _sources.Values)
-        {
-            entries.Add(new LookupManifestEntry(
+    public IReadOnlyList<LookupManifestEntry> GetManifest() =>
+        [.. _sources.Values
+            .Select(source => new LookupManifestEntry(
                 source.Name,
                 InferKind(source),
                 source.RequiredPermission,
-                source.ScopeKeys));
-        }
-
-        entries.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
-        return entries;
-    }
+                source.ScopeKeys))
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)];
 
     private static LookupKind InferKind(ILookupSource source) =>
         source is IKindProviderLookupSource provider ? provider.Kind : LookupKind.Simple;

--- a/src/Granit.Encryption.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Encryption.BackgroundJobs/packages.lock.json
@@ -122,6 +122,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Encryption.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Encryption.EntityFrameworkCore/packages.lock.json
@@ -106,6 +106,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Encryption/Granit.Encryption.csproj
+++ b/src/Granit.Encryption/Granit.Encryption.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>

--- a/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
+++ b/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Granit.Encryption;
 using Granit.Encryption.Options;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -49,6 +50,7 @@ public sealed partial class AesStringEncryptionProvider : IStringEncryptionProvi
 
     public AesStringEncryptionProvider(
         IOptions<StringEncryptionOptions> options,
+        IHostEnvironment environment,
         ILogger<AesStringEncryptionProvider> logger)
     {
         StringEncryptionOptions opts = options.Value;
@@ -62,6 +64,16 @@ public sealed partial class AesStringEncryptionProvider : IStringEncryptionProvi
                     "Encryption:PassPhrase is required. " +
                     "Configure a stable passphrase via Vault for production use, " +
                     "or set Encryption:AllowEphemeralPassPhrase to true for development.");
+            }
+
+            // Ephemeral passphrases cause permanent data loss on restart — refuse outside Development.
+            if (!environment.IsDevelopment())
+            {
+                throw new InvalidOperationException(
+                    "Encryption:AllowEphemeralPassPhrase is forbidden outside the Development environment " +
+                    $"(current: '{environment.EnvironmentName}'). " +
+                    "An ephemeral passphrase is regenerated at every process start, which would render all " +
+                    "previously encrypted data unrecoverable. Configure Encryption:PassPhrase via Vault.");
             }
 
             passPhrase = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));

--- a/src/Granit.Encryption/packages.lock.json
+++ b/src/Granit.Encryption/packages.lock.json
@@ -14,6 +14,19 @@
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -54,6 +67,23 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -70,6 +100,15 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "10.0.7",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       }
     }

--- a/src/Granit.Http.ApiDocumentation/Transformers/SortedTagsDocumentTransformer.cs
+++ b/src/Granit.Http.ApiDocumentation/Transformers/SortedTagsDocumentTransformer.cs
@@ -21,30 +21,15 @@ internal sealed class SortedTagsDocumentTransformer : IOpenApiDocumentTransforme
             return Task.CompletedTask;
         }
 
-        HashSet<string> names = [];
-        foreach (OpenApiPathItem path in document.Paths.Values)
-        {
-            if (path.Operations is null)
-            {
-                continue;
-            }
-
-            foreach (OpenApiOperation operation in path.Operations.Values)
-            {
-                if (operation.Tags is null)
-                {
-                    continue;
-                }
-
-                foreach (OpenApiTagReference reference in operation.Tags)
-                {
-                    if (!string.IsNullOrEmpty(reference.Name))
-                    {
-                        names.Add(reference.Name);
-                    }
-                }
-            }
-        }
+        HashSet<string> names = new(
+            document.Paths.Values
+                .Where(path => path.Operations is not null)
+                .SelectMany(path => path.Operations!.Values)
+                .Where(operation => operation.Tags is not null)
+                .SelectMany(operation => operation.Tags!)
+                .Select(reference => reference.Name)
+                .Where(name => !string.IsNullOrEmpty(name))!,
+            StringComparer.Ordinal);
 
         if (names.Count == 0)
         {

--- a/src/Granit.Http.ExceptionHandling/Internal/ValidationErrorsSanitizer.cs
+++ b/src/Granit.Http.ExceptionHandling/Internal/ValidationErrorsSanitizer.cs
@@ -44,17 +44,7 @@ internal sealed class ValidationErrorsSanitizer(SensitivePropertyRegistry? regis
         // (common case for non-PII endpoints), and avoids the ordering bug
         // where a sensitive key found after non-sensitive keys would leave the
         // earlier ones out of the rebuilt dictionary.
-        bool hasSensitive = false;
-        foreach (string key in errors.Keys)
-        {
-            if (IsPathSensitive(key))
-            {
-                hasSensitive = true;
-                break;
-            }
-        }
-
-        if (!hasSensitive)
+        if (!errors.Keys.Any(IsPathSensitive))
         {
             return errors;
         }
@@ -89,21 +79,6 @@ internal sealed class ValidationErrorsSanitizer(SensitivePropertyRegistry? regis
         return false;
     }
 
-    private static bool IsPurelyNumeric(string segment)
-    {
-        if (segment.Length == 0)
-        {
-            return false;
-        }
-
-        foreach (char c in segment)
-        {
-            if (c is < '0' or > '9')
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    private static bool IsPurelyNumeric(string segment) =>
+        segment.Length > 0 && segment.All(c => c is >= '0' and <= '9');
 }

--- a/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptions.cs
+++ b/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptions.cs
@@ -63,13 +63,20 @@ public sealed class GranitSecurityHeadersOptions
 
     /// <summary>
     /// Sets <c>Content-Security-Policy</c> header.
-    /// Default: <c>null</c> (not set — CSP is highly application-specific).
+    /// Default: API-grade strict CSP suitable for any JSON-only endpoint.
     /// </summary>
     /// <remarks>
-    /// CSP should be configured per application. The BFF module sets
-    /// <c>frame-ancestors 'none'</c> on login/callback routes independently.
+    /// <para>
+    /// <c>default-src 'none'; frame-ancestors 'none'; base-uri 'none'</c> is safe
+    /// for <c>application/json</c> responses: no scripts, no embeddable content,
+    /// no relative URL hijacking. BFF / SPA hosts that serve HTML must override
+    /// with a stricter CSP that includes <c>script-src</c> rules and a nonce
+    /// injection middleware.
+    /// </para>
+    /// <para>Set to <c>null</c> to omit the header entirely (not recommended).</para>
     /// </remarks>
-    public string? ContentSecurityPolicy { get; set; }
+    public string? ContentSecurityPolicy { get; set; } =
+        "default-src 'none'; frame-ancestors 'none'; base-uri 'none'";
 
     // -------------------------------------------------------------------------
     // HSTS (HTTP Strict Transport Security)

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/Jobs/CognitoClientRoleSyncHandler.cs
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/Jobs/CognitoClientRoleSyncHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Identity.Federated.Cognito.Sync;
 
 namespace Granit.Identity.Federated.Cognito.BackgroundJobs.Jobs;
@@ -7,6 +8,7 @@ namespace Granit.Identity.Federated.Cognito.BackgroundJobs.Jobs;
 /// <c>CognitoClientRoleSyncService.SyncAsync</c> — the same code path invoked at
 /// host boot by <c>CognitoClientRoleSyncContributor</c>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class CognitoClientRoleSyncHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -10,8 +10,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -144,6 +144,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -237,10 +238,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Cronos": {

--- a/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
+++ b/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Federated.Cognito.Diagnostics;
 internal static class IdentityCognitoActivitySource
 {
     /// <summary>Activity source name.</summary>
-    public const string Name = "Granit.Identity.Cognito";
+    public const string Name = "Granit.Identity.Federated.Cognito";
 
     /// <summary>Shared activity source instance.</summary>
     internal static readonly ActivitySource Source = new(Name);

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -152,6 +152,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/Jobs/EntraIdClientRoleSyncHandler.cs
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/Jobs/EntraIdClientRoleSyncHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Identity.Federated.EntraId.Sync;
 
 namespace Granit.Identity.Federated.EntraId.BackgroundJobs.Jobs;
@@ -7,6 +8,7 @@ namespace Granit.Identity.Federated.EntraId.BackgroundJobs.Jobs;
 /// <c>EntraIdClientRoleSyncService.SyncAsync</c> — the same code path invoked at
 /// host boot by <c>EntraIdClientRoleSyncContributor</c>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class EntraIdClientRoleSyncHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
@@ -284,6 +284,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
+++ b/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Granit.Identity.Federated.EntraId.Diagnostics;
 
 /// <summary>
-/// Central <see cref="ActivitySource"/> for Granit.Identity.EntraId distributed tracing.
+/// Central <see cref="ActivitySource"/> for Granit.Identity.Federated.EntraId distributed tracing.
 /// </summary>
 /// <remarks>
 /// Register this source in the OpenTelemetry tracer provider (via
@@ -15,8 +15,8 @@ namespace Granit.Identity.Federated.EntraId.Diagnostics;
 /// </remarks>
 internal static class IdentityEntraIdActivitySource
 {
-    /// <summary>The name of the Granit.Identity.EntraId <see cref="ActivitySource"/>.</summary>
-    internal const string Name = "Granit.Identity.EntraId";
+    /// <summary>The name of the Granit.Identity.Federated.EntraId <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Identity.Federated.EntraId";
 
     /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
     internal static readonly ActivitySource Source = new(Name);

--- a/src/Granit.Identity.Federated.EntraId/Exceptions/EntraIdClientNotFoundException.cs
+++ b/src/Granit.Identity.Federated.EntraId/Exceptions/EntraIdClientNotFoundException.cs
@@ -9,7 +9,7 @@ namespace Granit.Identity.Federated.EntraId.Exceptions;
 /// Sibling of <c>KeycloakClientNotFoundException</c> in the Keycloak provider — the sync
 /// pipeline catches it and logs a Warning before skipping the client.
 /// </remarks>
-internal sealed class EntraIdClientNotFoundException : Exception
+public sealed class EntraIdClientNotFoundException : Exception
 {
     public EntraIdClientNotFoundException(string appId)
         : base($"No Service Principal found with appId '{appId}' in the configured Entra tenant.")

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -309,6 +309,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.GoogleCloud/Diagnostics/IdentityGoogleCloudActivitySource.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Diagnostics/IdentityGoogleCloudActivitySource.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Federated.GoogleCloud.Diagnostics;
 internal static class IdentityGoogleCloudActivitySource
 {
     /// <summary>Activity source name.</summary>
-    public const string Name = "Granit.Identity.GoogleCloud";
+    public const string Name = "Granit.Identity.Federated.GoogleCloud";
 
     /// <summary>Shared activity source instance.</summary>
     internal static readonly ActivitySource Source = new(Name);

--- a/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
@@ -191,6 +191,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/Jobs/KeycloakClientRoleSyncHandler.cs
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/Jobs/KeycloakClientRoleSyncHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Identity.Federated.Keycloak.Sync;
 
 namespace Granit.Identity.Federated.Keycloak.BackgroundJobs.Jobs;
@@ -7,6 +8,7 @@ namespace Granit.Identity.Federated.Keycloak.BackgroundJobs.Jobs;
 /// to <c>KeycloakClientRoleSyncService.SyncAsync</c> — the same code path invoked at
 /// host boot by <c>KeycloakClientRoleSyncContributor</c>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class KeycloakClientRoleSyncHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
@@ -284,6 +284,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Granit.Identity.Federated.Keycloak.Diagnostics;
 
 /// <summary>
-/// Central <see cref="ActivitySource"/> for Granit.Identity.Keycloak distributed tracing.
+/// Central <see cref="ActivitySource"/> for Granit.Identity.Federated.Keycloak distributed tracing.
 /// </summary>
 /// <remarks>
 /// Register this source in the OpenTelemetry tracer provider (via
@@ -15,8 +15,8 @@ namespace Granit.Identity.Federated.Keycloak.Diagnostics;
 /// </remarks>
 internal static class IdentityKeycloakActivitySource
 {
-    /// <summary>The name of the Granit.Identity.Keycloak <see cref="ActivitySource"/>.</summary>
-    internal const string Name = "Granit.Identity.Keycloak";
+    /// <summary>The name of the Granit.Identity.Federated.Keycloak <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Identity.Federated.Keycloak";
 
     /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
     internal static readonly ActivitySource Source = new(Name);

--- a/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakClientNotFoundException.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakClientNotFoundException.cs
@@ -9,7 +9,7 @@ namespace Granit.Identity.Federated.Keycloak.Exceptions;
 /// Warning before skipping the client — a missing tracked client is not fatal (realm
 /// configuration drift, typo in <c>TrackedClientIds</c>).
 /// </remarks>
-internal sealed class KeycloakClientNotFoundException : Exception
+public sealed class KeycloakClientNotFoundException : Exception
 {
     public KeycloakClientNotFoundException(string clientId)
         : base($"Keycloak client '{clientId}' not found in the configured realm.")

--- a/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakTokenExchangeRateLimitedException.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakTokenExchangeRateLimitedException.cs
@@ -5,7 +5,7 @@ namespace Granit.Identity.Federated.Keycloak.Exceptions;
 /// is denied by the configured <c>ITokenExchangeRateLimiter</c>. Maps cleanly to a
 /// 429 Too Many Requests at the HTTP boundary.
 /// </summary>
-internal sealed class KeycloakTokenExchangeRateLimitedException : Exception
+public sealed class KeycloakTokenExchangeRateLimitedException : Exception
 {
     public KeycloakTokenExchangeRateLimitedException(string targetUserId, TimeSpan retryAfter)
         : base($"Keycloak token exchange for user '{targetUserId}' is rate-limited. Retry after {retryAfter.TotalSeconds:F0}s.")

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -40,6 +40,7 @@ internal sealed partial class KeycloakIdentityProvider(
     ILogger<KeycloakIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
     private const string ProviderName = "keycloak";
+    private const string GetUserOperation = "get_user";
 
     /// <summary>
     /// Detects authorisation failures wrapped in <see cref="HttpRequestException"/>.
@@ -106,21 +107,21 @@ internal sealed partial class KeycloakIdentityProvider(
                 .GetFromJsonAsync<KeycloakUserRepresentation>(endpoint, cancellationToken)
                 .ConfigureAwait(false);
 
-            metrics.RecordOperationCompleted(null, "get_user", ProviderName, user is not null ? "found" : "not_found");
-            metrics.RecordOperationDuration(null, "get_user", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
+            metrics.RecordOperationCompleted(null, GetUserOperation, ProviderName, user is not null ? "found" : "not_found");
+            metrics.RecordOperationDuration(null, GetUserOperation, ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
 
             return user is not null ? ToIdentityUser(user) : null;
         }
         catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            metrics.RecordOperationError(null, "get_user", ProviderName);
-            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
+            metrics.RecordOperationError(null, GetUserOperation, ProviderName);
+            throw new IdentityProviderUnauthorizedException(ProviderName, GetUserOperation, ex);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            metrics.RecordOperationError(null, "get_user", ProviderName);
+            metrics.RecordOperationError(null, GetUserOperation, ProviderName);
             LogKeycloakGetUserFailed(ex, userId);
             return null;
         }

--- a/src/Granit.Identity.Federated.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak/packages.lock.json
@@ -309,6 +309,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPersonalDataExportHandler.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPersonalDataExportHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport.Events;
 
@@ -7,6 +8,7 @@ namespace Granit.Identity.Federated.Privacy.DataExport;
 /// Wolverine handler that bridges <see cref="PersonalDataRequestedEto"/> to the
 /// <see cref="IdentityFederatedPrivacyDataProvider"/> via <see cref="PrivacyFragmentUploader"/>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class IdentityFederatedPersonalDataExportHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -509,6 +509,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -58,7 +58,6 @@ internal static class GranitRoleEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .RequireAuthorization(IdentityLocalPermissions.Roles.Manage);
 
         group.MapPut("/{id:guid}", RenameAsync)
@@ -69,7 +68,6 @@ internal static class GranitRoleEndpoints
             .Produces<RoleResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .RequireAuthorization(IdentityLocalPermissions.Roles.Manage);
 
         group.MapDelete("/{id:guid}", DeleteAsync)
@@ -79,7 +77,6 @@ internal static class GranitRoleEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .RequireAuthorization(IdentityLocalPermissions.Roles.Delete);
 
         return group;

--- a/src/Granit.Identity.Local.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Local.Notifications/packages.lock.json
@@ -25,6 +25,23 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -75,6 +92,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -201,6 +219,19 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPersonalDataExportHandler.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPersonalDataExportHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport.Events;
 
@@ -12,6 +13,7 @@ namespace Granit.Identity.Local.Privacy.DataExport;
 /// needed. Must be a <c>public class</c> (non-static) with a <c>public static Handle*</c>
 /// method so Wolverine picks it up without a <c>[WolverineHandler]</c> attribute dependency.
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class IdentityLocalPersonalDataExportHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Identity.Local.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Local.Privacy/packages.lock.json
@@ -524,6 +524,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when a credit note is issued. Triggers refund via Payments.</summary>
 public sealed record CreditNoteIssuedEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
@@ -1,7 +1,7 @@
 using Granit.Events;
 using Granit.Invoicing.Domain;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is finalized. Triggers payment collection.</summary>
 public sealed record InvoiceFinalizedEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is overdue (Open + past DueAt).</summary>
 public sealed record InvoiceOverdueEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is fully paid.</summary>
 public sealed record InvoicePaidEto(

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceUncollectibleEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is marked as uncollectible (bad debt).</summary>
 public sealed record InvoiceUncollectibleEto(Guid InvoiceId, Guid TenantId) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceVoidedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is voided.</summary>
 public sealed record InvoiceVoidedEto(Guid InvoiceId, Guid TenantId) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
@@ -1,6 +1,6 @@
 using Granit.Events;
 
-namespace Granit.Invoicing.Abstractions.Events;
+namespace Granit.Invoicing.Events;
 
 /// <summary>
 /// Published when a payment exceeds the invoice total.

--- a/src/Granit.Invoicing.Abstractions/IInvoicePrePaymentProcessor.cs
+++ b/src/Granit.Invoicing.Abstractions/IInvoicePrePaymentProcessor.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 
 namespace Granit.Invoicing;
 

--- a/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
+++ b/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
@@ -1,7 +1,7 @@
 using Granit.Events;
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Invoicing/Domain/Invoice.cs
+++ b/src/Granit.Invoicing/Domain/Invoice.cs
@@ -1,5 +1,4 @@
 using Granit.Domain;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain.ValueObjects;
 using Granit.Invoicing.Events;
 using Granit.Workflow.Domain;

--- a/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
+++ b/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
@@ -206,13 +206,16 @@ internal sealed class PropertyRedactionSanitizer(SensitivePropertyRegistry regis
         return $"sha256:{Convert.ToHexStringLower(hash)[..16]}";
     }
 
-    internal static string MaskValue(string value)
-    {
-        if (value.Length <= 4)
-        {
-            return "****";
-        }
-
-        return $"{value[..2]}{"".PadRight(value.Length - 4, '*')}{value[^2..]}";
-    }
+    /// <summary>
+    /// Returns an opaque, length-only marker for masked values.
+    /// </summary>
+    /// <remarks>
+    /// SECURITY: never echo any plaintext characters from a redacted secret. The
+    /// previous Stripe-style "first two + last two" mask leaked enough structure
+    /// to identify Granit key prefixes (gk_pr…), bearer-token kinds (ey…), AWS
+    /// access keys (AKIA…), and to materially shrink the brute-force search space
+    /// when correlated with leaked digests from other breaches.
+    /// </remarks>
+    internal static string MaskValue(string value) =>
+        value.Length == 0 ? "***" : $"***[{value.Length}]";
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -19,6 +19,8 @@ namespace Granit.Metering.Endpoints.Endpoints;
 
 internal static class UsageEndpoints
 {
+    private const string TenantContextRequiredMessage = "Tenant context required.";
+
     internal static RouteGroupBuilder MapUsageEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/usage", GetUsageForPeriodAsync)
@@ -112,7 +114,7 @@ internal static class UsageEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         UsageAggregate? aggregate = await usageReader
@@ -137,7 +139,7 @@ internal static class UsageEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         QuotaStatus status = await quotaChecker
@@ -157,7 +159,7 @@ internal static class UsageEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         var meterIds = request.Events.Select(e => e.MeterDefinitionId).Distinct().ToList();
@@ -208,7 +210,7 @@ internal static class UsageEndpoints
     {
         if (!currentTenant.IsAvailable)
         {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(TenantContextRequiredMessage, statusCode: StatusCodes.Status400BadRequest);
         }
 
         // Reject upfront if any referenced meter is missing or not Published. The

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -174,14 +174,12 @@ internal sealed partial class EfAggregationRunner(
 
         HashSet<string> distinct = new(StringComparer.Ordinal);
 
-        foreach (MeterEvent ev in events)
+        IEnumerable<string?> values = events
+            .Select(ev => ev.Metadata)
+            .Where(metadata => !string.IsNullOrWhiteSpace(metadata))
+            .Select(metadata => TryExtractStringValue(metadata!, property));
+        foreach (string? value in values)
         {
-            if (string.IsNullOrWhiteSpace(ev.Metadata))
-            {
-                continue;
-            }
-
-            string? value = TryExtractStringValue(ev.Metadata, property);
             if (value is not null)
             {
                 distinct.Add(value);

--- a/src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs
+++ b/src/Granit.MultiTenancy.Provisioning/Handlers/TenantProvisioningHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.MultiTenancy.Events;
 using Granit.Persistence.EntityFrameworkCore.Hosting;
 
@@ -23,6 +24,7 @@ namespace Granit.MultiTenancy.Provisioning.Handlers;
 /// this message without side effects.
 /// </para>
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class TenantProvisioningHandler
 {
     /// <summary>

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Granit.MultiTenancy.Url;
 using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.MultiTenancy.Extensions;
 
@@ -31,6 +32,8 @@ public static class MultiTenancyServiceCollectionExtensions
             .BindConfiguration(MultiTenancyOptions.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        services.TryAddSingleton<IValidateOptions<MultiTenancyOptions>, MultiTenancyOptionsValidator>();
 
         // Replace the NullTenantContext registered by AddGranit<T>() with the real implementation.
         services.Replace(ServiceDescriptor.Singleton<ICurrentTenant, CurrentTenant>());

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
@@ -6,17 +6,19 @@ namespace Granit.MultiTenancy.Options;
 public enum TenantHeaderTrustMode
 {
     /// <summary>
-    /// Header is accepted without cross-validation (default, backward-compatible).
-    /// Use behind a BFF or reverse proxy that sets the header from authenticated context.
-    /// </summary>
-    Unrestricted,
-
-    /// <summary>
     /// When the user is authenticated and has a <c>tenant_id</c> JWT claim,
     /// the resolved tenant must match the claim. Mismatches return 403 Forbidden.
-    /// Prevents spoofing via <c>X-Tenant-Id</c> header tampering.
+    /// Prevents spoofing via <c>X-Tenant-Id</c> header tampering. Default since
+    /// the framework's secure-by-default tenant-isolation hardening.
     /// </summary>
     CrossValidate,
+
+    /// <summary>
+    /// Header is accepted without cross-validation. Only safe behind a fully
+    /// trusted reverse proxy (BFF) that scrubs the header from external traffic
+    /// and re-emits it from the authenticated session.
+    /// </summary>
+    Unrestricted,
 }
 
 /// <summary>
@@ -47,11 +49,12 @@ public sealed class MultiTenancyOptions
 
     /// <summary>
     /// Controls how the tenant header is validated against JWT claims.
-    /// Default: <see cref="TenantHeaderTrustMode.Unrestricted"/> (backward-compatible).
-    /// Set to <see cref="TenantHeaderTrustMode.CrossValidate"/> for environments where
-    /// the header may be attacker-controlled (no trusted reverse proxy).
+    /// Default: <see cref="TenantHeaderTrustMode.CrossValidate"/> — secure-by-default.
+    /// Authenticated callers cannot pivot tenants via the <c>X-Tenant-Id</c> header.
+    /// Set to <see cref="TenantHeaderTrustMode.Unrestricted"/> only for deployments
+    /// that fully trust their reverse proxy to scrub and re-emit the header.
     /// </summary>
-    public TenantHeaderTrustMode HeaderTrustMode { get; set; } = TenantHeaderTrustMode.Unrestricted;
+    public TenantHeaderTrustMode HeaderTrustMode { get; set; } = TenantHeaderTrustMode.CrossValidate;
 
     /// <summary>
     /// Domain template for subdomain-based tenant resolution.

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptionsValidator.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptionsValidator.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Granit.MultiTenancy.Options;
+
+/// <summary>
+/// Production-time validator for <see cref="MultiTenancyOptions"/>.
+/// Refuses to start when development-only resolvers are enabled outside Development.
+/// </summary>
+internal sealed class MultiTenancyOptionsValidator(IHostEnvironment environment)
+    : IValidateOptions<MultiTenancyOptions>
+{
+    public ValidateOptionsResult Validate(string? name, MultiTenancyOptions options)
+    {
+        if (!environment.IsDevelopment()
+            && !string.IsNullOrEmpty(options.QueryStringParamName))
+        {
+            return ValidateOptionsResult.Fail(
+                $"MultiTenancy:QueryStringParamName must be empty outside the Development "
+                + $"environment (current: '{environment.EnvironmentName}'). The query-string "
+                + "tenant resolver allows any caller to select an arbitrary tenant context "
+                + "and is forbidden in production.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Notifications.EntityFrameworkCore/packages.lock.json
@@ -112,6 +112,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Notifications.Privacy/DataExport/NotificationsPersonalDataExportHandler.cs
+++ b/src/Granit.Notifications.Privacy/DataExport/NotificationsPersonalDataExportHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Privacy.BlobStorage;
 using Granit.Privacy.DataExport.Events;
 
@@ -7,6 +8,7 @@ namespace Granit.Notifications.Privacy.DataExport;
 /// Wolverine handler that bridges <see cref="PersonalDataRequestedEto"/> to the
 /// <see cref="NotificationsPrivacyDataProvider"/> via <see cref="PrivacyFragmentUploader"/>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class NotificationsPersonalDataExportHandler
 {
     public static Task HandleAsync(

--- a/src/Granit.Notifications.Privacy/packages.lock.json
+++ b/src/Granit.Notifications.Privacy/packages.lock.json
@@ -499,6 +499,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -547,6 +547,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Notifications/packages.lock.json
+++ b/src/Granit.Notifications/packages.lock.json
@@ -113,6 +113,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -456,6 +456,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -102,8 +102,20 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
             }
 
             // ──── Signing & encryption ────
-            // Development keys — host application MUST replace with production keys
-            // via options.AddSigningCertificate() / options.AddEncryptionCertificate()
+            // Ephemeral keys: regenerated at every process start. Only allowed in
+            // Development OR when explicitly opted in via AllowEphemeralKeys = true
+            // (typically for unit tests). Production deployments MUST replace with
+            // options.AddSigningCertificate() / options.AddEncryptionCertificate()
+            // or load keys from Vault via Granit.Vault.HashiCorp.
+            bool ephemeralAllowed = builder.Environment.IsDevelopment()
+                || granitOptions.AllowEphemeralKeys;
+            if (!ephemeralAllowed)
+            {
+                throw new InvalidOperationException(
+                    "OpenIddict ephemeral signing/encryption keys are forbidden outside Development. " +
+                    "Configure persistent keys (AddSigningCertificate / AddEncryptionCertificate) " +
+                    "or set GranitOpenIddictOptions.AllowEphemeralKeys = true at your own risk.");
+            }
             options
                 .AddEphemeralEncryptionKey()
                 .AddEphemeralSigningKey();

--- a/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
+++ b/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
@@ -12,12 +12,10 @@ namespace Granit.OpenIddict.Server;
 [DependsOn(typeof(GranitOpenIddictModule))]
 public sealed class GranitOpenIddictServerModule : GranitModule
 {
+    // Scoped handlers must be registered in DI for OpenIddict to resolve them
+    // via UseScopedHandler<T>(). The descriptor itself is attached to the
+    // OpenIddict server options in AddGranitOpenIddictServer().
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
-        // Scoped handlers must be registered in DI for OpenIddict to resolve them
-        // via UseScopedHandler<T>(). The descriptor itself is attached to the
-        // OpenIddict server options in AddGranitOpenIddictServer().
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.TryAddScoped<ClientSideAuthorizationHandler>();
-    }
 }

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
@@ -101,6 +101,24 @@ public sealed class GranitOpenIddictOptions
     /// <para>Default: <see langword="false"/>.</para>
     /// </remarks>
     public bool EnableFapi2Profile { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the OpenIddict server is allowed to start with
+    /// ephemeral signing and encryption keys (regenerated at every process start).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ephemeral keys invalidate every issued token on restart and produce inconsistent
+    /// signing material across instances of a multi-replica deployment — symptoms range
+    /// from mass session loss to intermittent token validation failures.
+    /// </para>
+    /// <para>
+    /// Default: <see langword="false"/>. The framework refuses to start in non-Development
+    /// environments unless persistent signing/encryption material is configured.
+    /// Set to <see langword="true"/> only for tests or single-instance dev loops.
+    /// </para>
+    /// </remarks>
+    public bool AllowEphemeralKeys { get; set; }
 }
 
 /// <summary>

--- a/src/Granit.Payments/Handlers/AutoChargeOnInvoiceHandler.cs
+++ b/src/Granit.Payments/Handlers/AutoChargeOnInvoiceHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 
 namespace Granit.Payments.Handlers;
 

--- a/src/Granit.Payments/Handlers/InitiatePaymentCommandHandler.cs
+++ b/src/Granit.Payments/Handlers/InitiatePaymentCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
@@ -14,8 +15,10 @@ namespace Granit.Payments.Handlers;
 /// creates a <see cref="PaymentTransaction"/> aggregate, charges via the provider,
 /// and applies the resulting FSM transition.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed partial class InitiatePaymentCommandHandler
 {
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Wolverine handler injects DI services per-message; no natural domain wrapper for these orthogonal collaborators (resolver, providers, writer, guid, clock, metrics, tenant, logger).")]
     public static async Task HandleAsync(
         InitiatePaymentCommand command,
         IPaymentProviderResolver providerResolver,

--- a/src/Granit.Payments/Handlers/RequestRefundCommandHandler.cs
+++ b/src/Granit.Payments/Handlers/RequestRefundCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
@@ -15,8 +16,10 @@ namespace Granit.Payments.Handlers;
 /// calls the domain's <see cref="PaymentTransaction.RequestRefund"/> method,
 /// executes the refund via the payment provider, and persists the result.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed partial class RequestRefundCommandHandler
 {
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Wolverine handler injects DI services per-message; no natural domain wrapper for these orthogonal collaborators (reader, writer, providers, guid, clock, metrics, tenant, logger).")]
     public static async Task HandleAsync(
         RequestRefundCommand command,
         IPaymentTransactionReader transactionReader,

--- a/src/Granit.Payments/IAutoChargeService.cs
+++ b/src/Granit.Payments/IAutoChargeService.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 
 namespace Granit.Payments;
 

--- a/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
+++ b/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
@@ -1,7 +1,7 @@
 using Granit.Commands;
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
 using Granit.Payments.Domain;

--- a/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
+++ b/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
@@ -1,5 +1,5 @@
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 
 namespace Granit.Payments.Internal;
 

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Handlers/RunMigrationBatchHandler.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Handlers/RunMigrationBatchHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Commands;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Messages;
 
@@ -11,6 +12,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Handlers;
 /// The follow-up command is dispatched via <see cref="ICommandSender"/> (provider-agnostic).
 /// The cascade stops when the executor returns <c>null</c> (no more rows).
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed class RunMigrationBatchHandler
 {
     public static async Task HandleAsync(

--- a/src/Granit.Persistence.EntityFrameworkCore/SchemaEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/SchemaEnsurer.cs
@@ -49,9 +49,11 @@ public static partial class SchemaEnsurer
             }
 
             await using DbCommand cmd = connection.CreateCommand();
-            // Schema names cannot be parameterized in SQL; input is validated
+            // Schema names cannot be parameterized in SQL DDL; input is validated
             // above against a strict allowlist to prevent injection.
+#pragma warning disable S2077 // Formatting SQL queries: validated against SafeSchemaNameRegex allowlist above
             cmd.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{schema}\"";
+#pragma warning restore S2077
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }
@@ -109,7 +111,11 @@ public static partial class SchemaEnsurer
             }
 
             await using DbCommand cmd = connection.CreateCommand();
+            // Schema names cannot be parameterized in SQL DDL; input is validated
+            // above against a strict allowlist to prevent injection.
+#pragma warning disable S2077 // Formatting SQL queries: validated against SafeSchemaNameRegex allowlist above
             cmd.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{schema}\"";
+#pragma warning restore S2077
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
@@ -97,7 +97,7 @@ internal sealed class CountingStream(Stream inner, long maxBytes) : Stream
 /// Caught by the archive assembler to transition the request to
 /// <see cref="Granit.Privacy.DataExport.ExportRequestState.SizeLimitExceeded"/>.
 /// </summary>
-internal sealed class PrivacyExportSizeLimitExceededException(long maxBytes, long observedBytes)
+public sealed class PrivacyExportSizeLimitExceededException(long maxBytes, long observedBytes)
     : Exception($"Export archive exceeded the configured size limit of {maxBytes} bytes (observed {observedBytes}).")
 {
     public long MaxBytes { get; } = maxBytes;

--- a/src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs
+++ b/src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs
@@ -16,12 +16,14 @@ public sealed class RateLimitingMetrics
 
     public RateLimitingMetrics(IMeterFactory meterFactory)
     {
+        // Metric names follow the framework convention: granit.{module_snake_case}.{entity}.{action}
+        // RateLimiting → rate_limiting (multi-word modules use snake_case in the metric name space).
         Meter meter = meterFactory.Create(MeterName);
         _allowedCounter = meter.CreateCounter<long>(
-            "granit.ratelimiting.requests.allowed",
+            "granit.rate_limiting.requests.allowed",
             description: "Number of requests allowed by rate limiting.");
         _rejectedCounter = meter.CreateCounter<long>(
-            "granit.ratelimiting.requests.rejected",
+            "granit.rate_limiting.requests.rejected",
             description: "Number of requests rejected by rate limiting.");
     }
 

--- a/src/Granit.Settings.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Settings.EntityFrameworkCore/packages.lock.json
@@ -129,6 +129,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Settings/Definitions/SettingDefinition.cs
+++ b/src/Granit.Settings/Definitions/SettingDefinition.cs
@@ -88,13 +88,11 @@ public sealed class SettingDefinition
 
         if (AllowedValues is { Count: > 0 })
         {
-            foreach (string allowed in AllowedValues)
+            string? unparseable = AllowedValues.FirstOrDefault(v => !TryParseAs(v, ValueKind));
+            if (unparseable is not null)
             {
-                if (!TryParseAs(allowed, ValueKind))
-                {
-                    throw new InvalidOperationException(
-                        $"Setting '{Name}': AllowedValues entry '{allowed}' is not parseable as {ValueKind}.");
-                }
+                throw new InvalidOperationException(
+                    $"Setting '{Name}': AllowedValues entry '{unparseable}' is not parseable as {ValueKind}.");
             }
         }
     }

--- a/src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs
+++ b/src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Features.Cache;
 using Granit.Features.Definitions;
 using Granit.Subscriptions.Events;
@@ -15,6 +16,7 @@ namespace Granit.Subscriptions.Features.Handlers;
 /// stale entries must be evicted immediately. Discovered by Wolverine's handler
 /// scanning convention: non-static public class with public static HandleAsync methods.
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public class SubscriptionLifecycleCacheInvalidationHandler
 {
     /// <summary>Invalidates the feature cache when a subscription is suspended.</summary>

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -377,13 +377,11 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
                 $"Phase '{phase.Id}' belongs to subscription '{phase.SubscriptionId}', not '{Id}'.");
         }
 
-        foreach (SubscriptionPhase existing in _phases)
+        SubscriptionPhase? overlapping = _phases.FirstOrDefault(existing => Overlaps(existing, phase));
+        if (overlapping is not null)
         {
-            if (Overlaps(existing, phase))
-            {
-                throw new InvalidOperationException(
-                    $"Phase [{phase.StartDate:O}, {phase.EndDate?.ToString("O") ?? "∞"}) overlaps existing phase '{existing.Id}'.");
-            }
+            throw new InvalidOperationException(
+                $"Phase [{phase.StartDate:O}, {phase.EndDate?.ToString("O") ?? "∞"}) overlaps existing phase '{overlapping.Id}'.");
         }
 
         _phases.Add(phase);

--- a/src/Granit.Subscriptions/Handlers/InvoicePaidHandler.cs
+++ b/src/Granit.Subscriptions/Handlers/InvoicePaidHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Invoicing.Abstractions.Events;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.Subscriptions.Handlers;

--- a/src/Granit.Subscriptions/Handlers/PaymentFailedHandler.cs
+++ b/src/Granit.Subscriptions/Handlers/PaymentFailedHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.MultiTenancy;
 using Granit.Payments.Events;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ namespace Granit.Subscriptions.Handlers;
 /// <summary>
 /// Dunning entry point. Delegates to <see cref="IDunningService"/> for payment failure processing.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public partial class PaymentFailedHandler
 {
     public static async Task HandleAsync(

--- a/src/Granit.Subscriptions/Handlers/RetryPaymentHandler.cs
+++ b/src/Granit.Subscriptions/Handlers/RetryPaymentHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Commands;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
@@ -11,6 +12,7 @@ namespace Granit.Subscriptions.Handlers;
 /// <see cref="InitiatePaymentCommand"/> from the retry payload and sends it via
 /// <see cref="ICommandSender"/>.
 /// </summary>
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "Wolverine message handler — public class with public static Handle method is required for discovery (CLAUDE.md).")]
 public sealed partial class RetryPaymentHandler
 {
     public static async Task HandleAsync(

--- a/src/Granit.Tax/Exports/TaxRateEntryExportDefinition.cs
+++ b/src/Granit.Tax/Exports/TaxRateEntryExportDefinition.cs
@@ -8,6 +8,8 @@ namespace Granit.Tax.Exports;
 /// </summary>
 public sealed class TaxRateEntryExportDefinition : ExportDefinition<TaxRateEntry>
 {
+    private const string DecimalFormat = "#,##0.00";
+
     /// <inheritdoc/>
     public override string Name => "Granit.Tax.TaxRateEntryExport";
 
@@ -16,10 +18,10 @@ public sealed class TaxRateEntryExportDefinition : ExportDefinition<TaxRateEntry
     {
         builder
             .Field(r => r.CountryCode)
-            .Field(r => r.StandardRate, f => f.Format("#,##0.00"))
-            .Field(r => r.ReducedRate, f => f.Format("#,##0.00"))
-            .Field(r => r.SuperReducedRate, f => f.Format("#,##0.00"))
-            .Field(r => r.ParkingRate, f => f.Format("#,##0.00"))
+            .Field(r => r.StandardRate, f => f.Format(DecimalFormat))
+            .Field(r => r.ReducedRate, f => f.Format(DecimalFormat))
+            .Field(r => r.SuperReducedRate, f => f.Format(DecimalFormat))
+            .Field(r => r.ParkingRate, f => f.Format(DecimalFormat))
             .Field(r => r.EffectiveFrom, f => f.Format("O"))
             .Field(r => r.EffectiveTo, f => f.Format("O"));
     }

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.12",
-        "contentHash": "x3KLGksdIgy0IJgohXpPda00gcZ/PORhR2A1RRLVRe+SBWu2AqffEAq7uQNF/KVCM/Vxd/916Z+3QrYmb0LeJQ==",
+        "resolved": "4.0.9.13",
+        "contentHash": "D8WKD7niFTrP4FLjxUB/fHaC0pEtQXqRN74ylkib+IDCOqe5MATONPpfXJ9wthXXX+ihOP3rpsBJRAi2NL4Cvw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.18",
-        "contentHash": "dRjvsm2rTNufl+iJ3cUTEq6Pud9P5RzYcjTbl1lqf1JSf7rYHobI44ClbD15O2Hwl0V+Z55BkGMUq6HgiERTkg==",
+        "resolved": "4.0.4.19",
+        "contentHash": "9ZmQol813rd2mgGnFy3iixFHswLqgNSFq9IvaIavsElQPsE3B976XL8hu+R9xbjE83JT9farDhuyXSw3ArlL5Q==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -163,6 +163,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Vault.Azure/packages.lock.json
+++ b/src/Granit.Vault.Azure/packages.lock.json
@@ -229,6 +229,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Vault.GoogleCloud/packages.lock.json
+++ b/src/Granit.Vault.GoogleCloud/packages.lock.json
@@ -303,6 +303,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Vault.HashiCorp/packages.lock.json
+++ b/src/Granit.Vault.HashiCorp/packages.lock.json
@@ -146,6 +146,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Vault/SecretDescriptor.cs
+++ b/src/Granit.Vault/SecretDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Granit.Caching;
 using Granit.DataProtection;
 
 namespace Granit.Vault;
@@ -18,7 +19,16 @@ namespace Granit.Vault;
 /// <see cref="ToString"/> override additionally redacts the payload for any serializer
 /// that bypasses the attribute.
 /// </para>
+/// <para>
+/// <b>Cache encryption:</b> <see cref="CacheEncryptedAttribute"/> forces AES-256-GCM
+/// encryption when this type is stored in <c>IFusionCache</c> via
+/// <see cref="Internal.CachedSecretStore"/>, regardless of the global
+/// <see cref="Granit.Caching.Options.CachingOptions.EncryptValues"/> flag. Without
+/// it, secrets cached in Redis would sit in plaintext if an operator forgets to
+/// set <c>EncryptValues=true</c>.
+/// </para>
 /// </remarks>
+[CacheEncrypted]
 public sealed record SecretDescriptor
 {
     /// <summary>Provider-addressable secret name (as requested).</summary>

--- a/src/Granit.Vault/packages.lock.json
+++ b/src/Granit.Vault/packages.lock.json
@@ -95,6 +95,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Webhooks.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Webhooks.EntityFrameworkCore/packages.lock.json
@@ -286,6 +286,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -296,11 +296,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -318,10 +318,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
@@ -641,6 +641,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -821,14 +822,14 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/src/bundles/Granit.Bundle.Notifications/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Notifications/packages.lock.json
@@ -185,6 +185,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -554,6 +554,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.ArchitectureTests/CacheEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/CacheEncryptionConventionTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using Granit.Caching;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces that types known to flow through the L2 cache (Redis via
+/// <c>IFusionCache</c>) and that carry secrets / PII are annotated with
+/// <see cref="CacheEncryptedAttribute"/>, so the cached payload is
+/// AES-256-GCM encrypted regardless of the global
+/// <c>CachingOptions.EncryptValues</c> flag.
+/// </summary>
+/// <remarks>
+/// SECURITY: <see cref="CacheEncryptedAttribute"/> historically existed but
+/// was never applied to any framework type. A Redis breach would expose BFF
+/// OAuth tokens, DPoP private keys, and cached Vault secrets in plaintext.
+/// This test is a positive allowlist: every cached "carries-secrets" type
+/// MUST be enumerated AND must declare the attribute. Adding a new cached
+/// type without listing it here passes the test only by accident — adding
+/// it without the attribute fails immediately.
+/// </remarks>
+public sealed class CacheEncryptionConventionTests
+{
+    /// <summary>
+    /// Types that the framework is known to store in <c>IFusionCache</c> and
+    /// that carry secrets, OAuth tokens, or PII. Each entry must be annotated
+    /// with <see cref="CacheEncryptedAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// When you add a new type to <c>IFusionCache.SetAsync&lt;T&gt;</c> that
+    /// holds tokens, credentials, signing keys, or PII, append it here AND
+    /// decorate the type with <c>[CacheEncrypted]</c>. The test fails on
+    /// either omission.
+    /// </remarks>
+    private static readonly string[] CachedTypesCarryingSecrets =
+    [
+        "Granit.Bff.BffTokenSet",          // OAuth tokens + DPoP private key
+        "Granit.Vault.SecretDescriptor",   // Vault-cached secret payload
+    ];
+
+    [Fact]
+    public void All_known_cached_secret_types_are_annotated_with_CacheEncrypted()
+    {
+        // Load assemblies from the test output directory so types from packages
+        // we don't directly reference (e.g. via using directives) are still
+        // discoverable. AppDomain.CurrentDomain.GetAssemblies() only contains
+        // assemblies the runtime has already chosen to load.
+        string outputDir = Path.GetDirectoryName(typeof(CacheEncryptionConventionTests).Assembly.Location)!;
+
+        IEnumerable<Assembly> assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)!
+            .Cast<Assembly>();
+
+        var typeIndex = assemblies
+            .SelectMany(a =>
+            {
+                try { return a.GetTypes().AsEnumerable(); }
+                catch (ReflectionTypeLoadException ex) { return ex.Types.OfType<Type>(); }
+                catch { return []; }
+            })
+            .Where(t => t.FullName is not null)
+            .GroupBy(t => t.FullName!)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        List<string> violations = [];
+
+        foreach (string fullName in CachedTypesCarryingSecrets)
+        {
+            if (!typeIndex.TryGetValue(fullName, out Type? type))
+            {
+                violations.Add($"{fullName} (type not found — was it renamed or deleted?)");
+                continue;
+            }
+
+            if (!type.IsDefined(typeof(CacheEncryptedAttribute), inherit: false))
+            {
+                violations.Add($"{fullName} (missing [CacheEncrypted])");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Types listed in CacheEncryptionConventionTests.CachedTypesCarryingSecrets "
+            + "MUST be annotated with [CacheEncrypted] from Granit.Caching. Without the "
+            + "attribute, a Redis snapshot/AOF/replica leak yields plaintext OAuth tokens, "
+            + "DPoP private keys, and Vault secrets. Violators: "
+            + string.Join(", ", violations));
+    }
+}

--- a/tests/Granit.Auditing.ConfigurationChanges.Tests/Internal/SensitiveValueMaskerTests.cs
+++ b/tests/Granit.Auditing.ConfigurationChanges.Tests/Internal/SensitiveValueMaskerTests.cs
@@ -29,6 +29,11 @@ public sealed class SensitiveValueMaskerTests
     [InlineData("UI:PageSize")]
     [InlineData("Feature:DarkMode")]
     [InlineData("Logging:Level")]
+    // Word-boundary anchors prevent benign names that contain a sensitive
+    // substring from being over-masked (audit trail loses signal otherwise).
+    [InlineData("UI:KeyboardLayout")]
+    [InlineData("Feature:TokenColor")]
+    [InlineData("Limits:KeyCount")]
     public void MaskIfSensitive_WithNonSensitiveSettingName_ReturnsOriginalValue(string settingName)
     {
         string? result = SensitiveValueMasker.MaskIfSensitive(settingName, "light");

--- a/tests/Granit.Authorization.Tests/PermissionCheckerCacheTagTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerCacheTagTests.cs
@@ -41,8 +41,5 @@ public sealed class PermissionCheckerCacheTagTests
     }
 
     [Fact]
-    public void RoleTag_FormatStable()
-    {
-        PermissionChecker.RoleTag("X").ShouldBe("role:X");
-    }
+    public void RoleTag_FormatStable() => PermissionChecker.RoleTag("X").ShouldBe("role:X");
 }

--- a/tests/Granit.Bff.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Bff.BackgroundJobs.Tests/packages.lock.json
@@ -541,6 +541,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
@@ -62,7 +62,7 @@ public sealed class BffTokenInjectionMiddlewareTests
             Frontends = [Frontend("host", "http://localhost:5173")],
         };
 
-        HttpContext context = CreateContext(new Dictionary<string, string>());
+        HttpContext context = CreateContext([]);
 
         (BffFrontendOptions? frontend, string? sessionId) =
             BffTokenInjectionMiddleware.ResolveFrontendFromCookies(context, options);
@@ -352,7 +352,7 @@ public sealed class BffTokenInjectionMiddlewareTests
     // HMAC secret (observed as the "403 on /account/login" symptom when logging
     // in on the second frontend after logging in on the first).
 
-    public static IEnumerable<object?[]> MatrixCases()
+    public static TheoryData<string, string, string?, string?> MatrixCases()
     {
         const string HostUrl = "http://localhost:5173";
         const string AppUrl = "http://localhost:5174";
@@ -361,20 +361,23 @@ public sealed class BffTokenInjectionMiddlewareTests
         const string AppSession = "session-app-bbb";
 
         // Setup, origin, expectedFrontendName (null = must reject), expectedSession
-        // HOST-ONLY cookie
-        yield return ["host-only", HostUrl, "host", HostSession];
-        yield return ["host-only", AppUrl, null, null];         // cross-side → drop
-        yield return ["host-only", UnknownUrl, null, null];     // stranger origin → drop
+        return new TheoryData<string, string, string?, string?>
+        {
+            // HOST-ONLY cookie
+            { "host-only", HostUrl, "host", HostSession },
+            { "host-only", AppUrl, null, null },        // cross-side → drop
+            { "host-only", UnknownUrl, null, null },    // stranger origin → drop
 
-        // APP-ONLY cookie
-        yield return ["app-only", HostUrl, null, null];         // cross-side → drop
-        yield return ["app-only", AppUrl, "app", AppSession];
-        yield return ["app-only", UnknownUrl, null, null];      // stranger origin → drop
+            // APP-ONLY cookie
+            { "app-only", HostUrl, null, null },        // cross-side → drop
+            { "app-only", AppUrl, "app", AppSession },
+            { "app-only", UnknownUrl, null, null },     // stranger origin → drop
 
-        // BOTH cookies (the bug scenario after user logs in on both sides)
-        yield return ["both", HostUrl, "host", HostSession];
-        yield return ["both", AppUrl, "app", AppSession];
-        yield return ["both", UnknownUrl, null, null];          // stranger origin → drop
+            // BOTH cookies (the bug scenario after user logs in on both sides)
+            { "both", HostUrl, "host", HostSession },
+            { "both", AppUrl, "app", AppSession },
+            { "both", UnknownUrl, null, null },         // stranger origin → drop
+        };
     }
 
     [Theory]

--- a/tests/Granit.Bff.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Bff.EntityFrameworkCore.Tests/packages.lock.json
@@ -514,6 +514,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Bff.Tests/Internal/HmacBffCsrfTokenGeneratorTests.cs
+++ b/tests/Granit.Bff.Tests/Internal/HmacBffCsrfTokenGeneratorTests.cs
@@ -1,6 +1,7 @@
 using Granit.Bff.Internal;
 using Granit.Bff.Options;
 using Granit.Timing;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -17,9 +18,12 @@ public sealed class HmacBffCsrfTokenGeneratorTests
     public HmacBffCsrfTokenGeneratorTests()
     {
         _clock.Now.Returns(DateTimeOffset.UtcNow);
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns("Development");
         _generator = new HmacBffCsrfTokenGenerator(
             _clock,
             Microsoft.Extensions.Options.Options.Create(new GranitBffOptions()),
+            environment,
             NullLogger<HmacBffCsrfTokenGenerator>.Instance);
     }
 
@@ -77,11 +81,13 @@ public sealed class HmacBffCsrfTokenGeneratorTests
     [Fact]
     public void Validate_ReturnsFalse_ForExpiredToken()
     {
-        DateTimeOffset pastTime = DateTimeOffset.UtcNow.AddHours(-25);
-        _clock.Now.Returns(pastTime);
+        // Validation window is 1 hour. Generate the token 90 minutes in the past
+        // and re-validate "now" — must be rejected as expired.
+        var now = new DateTimeOffset(2026, 3, 22, 12, 0, 0, TimeSpan.Zero);
+        _clock.Now.Returns(now.AddMinutes(-90));
         string token = _generator.Generate("session-123");
 
-        _clock.Now.Returns(DateTimeOffset.UtcNow);
+        _clock.Now.Returns(now);
         bool result = _generator.Validate("session-123", token);
 
         result.ShouldBeFalse();
@@ -94,11 +100,26 @@ public sealed class HmacBffCsrfTokenGeneratorTests
         _clock.Now.Returns(now);
         string token = _generator.Generate("session-123");
 
-        // Move clock forward 23 hours (still within 24h window)
-        _clock.Now.Returns(now.AddHours(23));
+        // Move clock forward 50 minutes (still within the 1-hour window)
+        _clock.Now.Returns(now.AddMinutes(50));
         bool result = _generator.Validate("session-123", token);
 
         result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ReturnsFalse_ForFutureTokenBeyondClockSkew()
+    {
+        // Future-dated tokens beyond the 60s clock-skew tolerance must be rejected
+        // outright — significant skew is more likely forgery than time drift.
+        var now = new DateTimeOffset(2026, 3, 22, 12, 0, 0, TimeSpan.Zero);
+        _clock.Now.Returns(now.AddMinutes(5));
+        string token = _generator.Generate("session-123");
+
+        _clock.Now.Returns(now);
+        bool result = _generator.Validate("session-123", token);
+
+        result.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/Granit.DataLookup.Abstractions.Tests/GranitDataLookupAbstractionsModuleTests.cs
+++ b/tests/Granit.DataLookup.Abstractions.Tests/GranitDataLookupAbstractionsModuleTests.cs
@@ -7,20 +7,14 @@ namespace Granit.DataLookup.Abstractions.Tests;
 public sealed class GranitDataLookupAbstractionsModuleTests
 {
     [Fact]
-    public void Module_is_a_GranitModule()
-    {
+    public void Module_is_a_GranitModule() =>
         typeof(GranitModule).IsAssignableFrom(typeof(GranitDataLookupAbstractionsModule)).ShouldBeTrue();
-    }
 
     [Fact]
-    public void Module_is_publicly_visible()
-    {
+    public void Module_is_publicly_visible() =>
         typeof(GranitDataLookupAbstractionsModule).IsPublic.ShouldBeTrue();
-    }
 
     [Fact]
-    public void Module_is_sealed()
-    {
+    public void Module_is_sealed() =>
         typeof(GranitDataLookupAbstractionsModule).IsSealed.ShouldBeTrue();
-    }
 }

--- a/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryableLookupSourceTests.cs
+++ b/tests/Granit.DataLookup.EntityFrameworkCore.Tests/QueryableLookupSourceTests.cs
@@ -102,9 +102,7 @@ public sealed class QueryableLookupSourceTests : IDisposable
     {
         public DbSet<Tenant> Tenants => Set<Tenant>();
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
             modelBuilder.Entity<Tenant>().HasKey(t => t.Id);
-        }
     }
 }

--- a/tests/Granit.Encryption.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Encryption.BackgroundJobs.Tests/packages.lock.json
@@ -406,6 +406,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/packages.lock.json
@@ -406,6 +406,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
+++ b/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
@@ -5,8 +5,10 @@
 using Granit.Encryption;
 using Granit.Encryption.Options;
 using Granit.Encryption.Providers;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -14,7 +16,16 @@ namespace Granit.Encryption.Tests;
 
 public sealed class AesStringEncryptionProviderTests
 {
-    private static AesStringEncryptionProvider CreateProvider(string passPhrase = "P@ssw0rdVaultSecret!ISO270012026")
+    private static IHostEnvironment DevEnvironment()
+    {
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns("Development");
+        return env;
+    }
+
+    private static AesStringEncryptionProvider CreateProvider(
+        string passPhrase = "P@ssw0rdVaultSecret!ISO270012026",
+        IHostEnvironment? environment = null)
     {
         IOptions<StringEncryptionOptions> options = Microsoft.Extensions.Options.Options.Create(new StringEncryptionOptions
         {
@@ -23,7 +34,10 @@ public sealed class AesStringEncryptionProviderTests
             ProviderName = StringEncryptionOptions.AesProviderName
         });
 
-        return new AesStringEncryptionProvider(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        return new AesStringEncryptionProvider(
+            options,
+            environment ?? DevEnvironment(),
+            NullLogger<AesStringEncryptionProvider>.Instance);
     }
 
     [Fact]
@@ -141,7 +155,7 @@ public sealed class AesStringEncryptionProviderTests
             AllowEphemeralPassPhrase = true
         });
 
-        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider = new(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("ephemeral empty test");
         provider.Decrypt(cipherText).ShouldBe("ephemeral empty test");
@@ -168,7 +182,7 @@ public sealed class AesStringEncryptionProviderTests
             AllowEphemeralPassPhrase = true
         });
 
-        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider = new(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("ephemeral test");
         provider.Decrypt(cipherText).ShouldBe("ephemeral test");
@@ -240,7 +254,7 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 128,
             ProviderName = StringEncryptionOptions.AesProviderName
         });
-        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider = new(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("hello 128-bit");
         string? decrypted = provider.Decrypt(cipherText);
@@ -257,7 +271,7 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 192,
             ProviderName = StringEncryptionOptions.AesProviderName
         });
-        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider = new(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("hello 192-bit");
         string? decrypted = provider.Decrypt(cipherText);
@@ -279,8 +293,8 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 128
         });
 
-        AesStringEncryptionProvider provider256 = new(options256, NullLogger<AesStringEncryptionProvider>.Instance);
-        AesStringEncryptionProvider provider128 = new(options128, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider256 = new(options256, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider128 = new(options128, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider256.Encrypt("cross-key test");
         string? result = provider128.Decrypt(cipherText);
@@ -299,9 +313,25 @@ public sealed class AesStringEncryptionProviderTests
             AllowEphemeralPassPhrase = false
         });
 
-        Action act = () => _ = new AesStringEncryptionProvider(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        Action act = () => _ = new AesStringEncryptionProvider(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         Should.Throw<InvalidOperationException>(act).Message.ShouldContain("PassPhrase");
+    }
+
+    [Fact]
+    public void Constructor_EphemeralPassPhrase_OutsideDevelopment_Throws_InvalidOperationException()
+    {
+        IOptions<StringEncryptionOptions> options = Microsoft.Extensions.Options.Options.Create(new StringEncryptionOptions
+        {
+            PassPhrase = string.Empty,
+            AllowEphemeralPassPhrase = true,
+        });
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns("Production");
+
+        Action act = () => _ = new AesStringEncryptionProvider(options, env, NullLogger<AesStringEncryptionProvider>.Instance);
+
+        Should.Throw<InvalidOperationException>(act).Message.ShouldContain("Development");
     }
 
     [Theory]
@@ -317,7 +347,7 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = keySize
         });
 
-        Action act = () => _ = new AesStringEncryptionProvider(options, NullLogger<AesStringEncryptionProvider>.Instance);
+        Action act = () => _ = new AesStringEncryptionProvider(options, DevEnvironment(), NullLogger<AesStringEncryptionProvider>.Instance);
 
         Should.Throw<ArgumentException>(act).Message.ShouldContain(keySize.ToString());
     }

--- a/tests/Granit.Encryption.Tests/GranitEncryptionModuleTests.cs
+++ b/tests/Granit.Encryption.Tests/GranitEncryptionModuleTests.cs
@@ -24,12 +24,15 @@ public sealed class GranitEncryptionModuleTests : IDisposable
 
     public GranitEncryptionModuleTests()
     {
-        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(
+            new HostApplicationBuilderSettings { EnvironmentName = Environments.Development });
         builder.Services.AddMetrics();
         builder.Services.AddLogging();
         builder.Services.AddSingleton(TimeProvider.System);
 
-        // Allow ephemeral passphrase so AES provider works without Vault
+        // Allow ephemeral passphrase so AES provider works without Vault.
+        // Combined with the Development environment above, this passes the
+        // production guard introduced in AesStringEncryptionProvider.
         builder.Services.Configure<StringEncryptionOptions>(opts =>
             opts.AllowEphemeralPassPhrase = true);
 

--- a/tests/Granit.Encryption.Tests/packages.lock.json
+++ b/tests/Granit.Encryption.Tests/packages.lock.json
@@ -146,6 +146,23 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.6",
@@ -324,6 +341,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -344,13 +362,26 @@
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {

--- a/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsTests.cs
@@ -38,8 +38,9 @@ public sealed class GranitSecurityHeadersOptionsTests
                        "accelerometer=(), gyroscope=(), magnetometer=(), usb=()");
 
     [Fact]
-    public void ContentSecurityPolicy_DefaultsToNull() =>
-        new GranitSecurityHeadersOptions().ContentSecurityPolicy.ShouldBeNull();
+    public void ContentSecurityPolicy_DefaultsToApiGradeStrictPolicy() =>
+        new GranitSecurityHeadersOptions().ContentSecurityPolicy
+            .ShouldBe("default-src 'none'; frame-ancestors 'none'; base-uri 'none'");
 
     [Fact]
     public void EnableHsts_DefaultsToTrue() =>

--- a/tests/Granit.Http.SecurityHeaders.Tests/SecurityHeadersMiddlewareTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/SecurityHeadersMiddlewareTests.cs
@@ -33,14 +33,27 @@ public sealed class SecurityHeadersMiddlewareTests
     }
 
     [Fact]
-    public async Task Middleware_OmitsContentSecurityPolicy_WhenNull()
+    public async Task Middleware_OmitsContentSecurityPolicy_WhenExplicitlyNull()
+    {
+        DefaultHttpContext context = new();
+        SecurityHeadersMiddleware middleware = CreateMiddleware(opts =>
+            opts.ContentSecurityPolicy = null);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Headers.ContainsKey("Content-Security-Policy").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Middleware_AddsApiGradeContentSecurityPolicy_ByDefault()
     {
         DefaultHttpContext context = new();
         SecurityHeadersMiddleware middleware = CreateMiddleware();
 
         await middleware.InvokeAsync(context);
 
-        context.Response.Headers.ContainsKey("Content-Security-Policy").ShouldBeFalse();
+        context.Response.Headers.ContentSecurityPolicy.ToString()
+            .ShouldBe("default-src 'none'; frame-ancestors 'none'; base-uri 'none'");
     }
 
     [Fact]

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/Jobs/CognitoClientRoleSyncJobTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/Jobs/CognitoClientRoleSyncJobTests.cs
@@ -34,8 +34,6 @@ public sealed class CognitoClientRoleSyncJobTests
     }
 
     [Fact]
-    public void Job_implements_IBackgroundJob()
-    {
+    public void Job_implements_IBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(CognitoClientRoleSyncJob)).ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -376,6 +376,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -476,10 +477,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Cronos": {

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "coverlet.collector": {
@@ -102,8 +102,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -1339,6 +1339,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -362,6 +362,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -455,10 +456,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.8.1",
-        "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
+        "resolved": "4.0.8.2",
+        "contentHash": "yMtPsLO/6+NzvnpztmUFXnLvNzo9GmeoTzQGGro8SUoAVqorFi5Hjo88b/e+Fr3BdRmxcLOhf52cpudVCSeuOg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -349,6 +349,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/Jobs/EntraIdClientRoleSyncJobTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/Jobs/EntraIdClientRoleSyncJobTests.cs
@@ -34,8 +34,6 @@ public sealed class EntraIdClientRoleSyncJobTests
     }
 
     [Fact]
-    public void Job_implements_IBackgroundJob()
-    {
+    public void Job_implements_IBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(EntraIdClientRoleSyncJob)).ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
@@ -516,6 +516,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -1455,6 +1455,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -502,6 +502,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
@@ -377,6 +377,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/Jobs/KeycloakClientRoleSyncJobTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/Jobs/KeycloakClientRoleSyncJobTests.cs
@@ -35,8 +35,6 @@ public sealed class KeycloakClientRoleSyncJobTests
     }
 
     [Fact]
-    public void Job_implements_IBackgroundJob()
-    {
+    public void Job_implements_IBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(KeycloakClientRoleSyncJob)).ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
@@ -516,6 +516,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/InMemoryRoleMetadataStore.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/InMemoryRoleMetadataStore.cs
@@ -40,12 +40,10 @@ internal sealed class InMemoryRoleMetadataStore : IRoleMetadataStore
         return Task.CompletedTask;
     }
 
-    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default)
-    {
-        // The role is already tracked by reference — the sync calls Rename() on the
-        // existing instance before UpdateAsync(). Nothing else to do in the in-memory store.
-        return Task.CompletedTask;
-    }
+    // The role is already tracked by reference — the sync calls Rename() on the
+    // existing instance before UpdateAsync(). Nothing else to do in the in-memory store.
+    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
 
     public Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)
     {

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
@@ -729,6 +729,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
@@ -513,6 +513,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
@@ -726,6 +726,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -556,6 +556,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
@@ -118,6 +118,23 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -307,6 +324,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -441,6 +459,19 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
@@ -741,6 +741,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
@@ -1,8 +1,8 @@
 using Granit.Events;
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.BackgroundJobs.Internal;
 using Granit.Invoicing.Domain;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
+++ b/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
@@ -143,19 +143,33 @@ public sealed class PropertyRedactionSanitizerTests
     }
 
     [Fact]
-    public void MaskValue_ShortValue_ReturnsFourStars()
+    public void MaskValue_EmptyValue_ReturnsOpaqueMarker()
     {
-        PropertyRedactionSanitizer.MaskValue("ab").ShouldBe("****");
-        PropertyRedactionSanitizer.MaskValue("abcd").ShouldBe("****");
+        PropertyRedactionSanitizer.MaskValue(string.Empty).ShouldBe("***");
     }
 
     [Fact]
-    public void MaskValue_LongerValue_KeepsFirstAndLastTwoChars()
+    public void MaskValue_NeverDisclosesPlaintextCharacters()
     {
-        string masked = PropertyRedactionSanitizer.MaskValue("abcdef");
+        // SECURITY: redacted values must never echo any plaintext characters,
+        // since prefixes/suffixes alone identify secret types (Bearer ey…, gk_…,
+        // AKIA…) and shrink brute-force search space.
+        const string secret = "gk_live_sk_abcdefghijABCDEF";
+        string masked = PropertyRedactionSanitizer.MaskValue(secret);
 
-        masked.ShouldStartWith("ab");
-        masked.ShouldEndWith("ef");
-        masked.ShouldContain("**");
+        foreach (char c in secret.Distinct())
+        {
+            if (c is not '*' and not '[' and not ']' and not (>= '0' and <= '9'))
+            {
+                masked.ShouldNotContain(c.ToString());
+            }
+        }
+    }
+
+    [Fact]
+    public void MaskValue_PreservesLengthInformationOnly()
+    {
+        PropertyRedactionSanitizer.MaskValue("abcdef").ShouldBe("***[6]");
+        PropertyRedactionSanitizer.MaskValue("abcd").ShouldBe("***[4]");
     }
 }

--- a/tests/Granit.Notifications.Email.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Tests/packages.lock.json
@@ -299,6 +299,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Endpoints.Tests/packages.lock.json
@@ -556,6 +556,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/packages.lock.json
@@ -401,6 +401,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.GoogleFcm.Tests/packages.lock.json
@@ -456,6 +456,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.MobilePush.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.Tests/packages.lock.json
@@ -299,6 +299,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Privacy.Tests/packages.lock.json
@@ -716,6 +716,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.SignalR.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.SignalR.Tests/packages.lock.json
@@ -323,6 +323,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Sms.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.Tests/packages.lock.json
@@ -299,6 +299,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Sse.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sse.Tests/packages.lock.json
@@ -326,6 +326,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Tests/packages.lock.json
@@ -353,6 +353,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.WebPush.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.WebPush.Tests/packages.lock.json
@@ -304,6 +304,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.WhatsApp.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.WhatsApp.Tests/packages.lock.json
@@ -299,6 +299,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -731,6 +731,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Notifications.Zulip.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Zulip.Tests/packages.lock.json
@@ -467,6 +467,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -670,6 +670,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
@@ -1,7 +1,7 @@
 using Granit.Commands;
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
+using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
 using Granit.Payments.Domain;

--- a/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
@@ -1,6 +1,6 @@
 using Granit.Invoicing;
-using Granit.Invoicing.Abstractions.Events;
 using Granit.Invoicing.Domain;
+using Granit.Invoicing.Events;
 using Granit.Payments.Internal;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.ReferenceData.Tests/Lookups/ReferenceDataLookupNamingTests.cs
+++ b/tests/Granit.ReferenceData.Tests/Lookups/ReferenceDataLookupNamingTests.cs
@@ -10,32 +10,24 @@ public sealed class ReferenceDataLookupNamingTests
     [InlineData(typeof(SingleWordEntity), "ref-single-word-entity")]
     [InlineData(typeof(Country), "ref-country")]
     [InlineData(typeof(ProductCategoryXml), "ref-product-category-xml")]
-    public void ForEntity_produces_kebab_case_with_ref_prefix(Type type, string expected)
-    {
+    public void ForEntity_produces_kebab_case_with_ref_prefix(Type type, string expected) =>
         ReferenceDataLookupNaming.ForEntity(type).ShouldBe(expected);
-    }
 
     [Theory]
     [InlineData("Countries", "ref-countries")]
     [InlineData("DocumentTypes", "ref-document-types")]
     [InlineData("IBAN", "ref-iban")]          // all-caps acronym stays glued
     [InlineData("HTTPClient", "ref-http-client")] // acronym followed by Pascal-cased word
-    public void ForTypeName_produces_kebab_case(string typeName, string expected)
-    {
+    public void ForTypeName_produces_kebab_case(string typeName, string expected) =>
         ReferenceDataLookupNaming.ForTypeName(typeName).ShouldBe(expected);
-    }
 
     [Fact]
-    public void ForEntity_throws_on_null()
-    {
+    public void ForEntity_throws_on_null() =>
         Should.Throw<ArgumentNullException>(() => ReferenceDataLookupNaming.ForEntity(null!));
-    }
 
     [Fact]
-    public void ForTypeName_throws_on_blank()
-    {
+    public void ForTypeName_throws_on_blank() =>
         Should.Throw<ArgumentException>(() => ReferenceDataLookupNaming.ForTypeName(""));
-    }
 
     private sealed class SingleWordEntity;
     private sealed class Country;

--- a/tests/Granit.Settings.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Settings.Endpoints.Tests/packages.lock.json
@@ -556,6 +556,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Settings.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Settings.EntityFrameworkCore.Tests/packages.lock.json
@@ -338,6 +338,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -368,6 +368,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -406,19 +407,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.12",
-        "contentHash": "x3KLGksdIgy0IJgohXpPda00gcZ/PORhR2A1RRLVRe+SBWu2AqffEAq7uQNF/KVCM/Vxd/916Z+3QrYmb0LeJQ==",
+        "resolved": "4.0.9.13",
+        "contentHash": "D8WKD7niFTrP4FLjxUB/fHaC0pEtQXqRN74ylkib+IDCOqe5MATONPpfXJ9wthXXX+ihOP3rpsBJRAi2NL4Cvw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.18",
-        "contentHash": "dRjvsm2rTNufl+iJ3cUTEq6Pud9P5RzYcjTbl1lqf1JSf7rYHobI44ClbD15O2Hwl0V+Z55BkGMUq6HgiERTkg==",
+        "resolved": "4.0.4.19",
+        "contentHash": "9ZmQol813rd2mgGnFy3iixFHswLqgNSFq9IvaIavsElQPsE3B976XL8hu+R9xbjE83JT9farDhuyXSw3ArlL5Q==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Vault.Azure.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Azure.Tests/packages.lock.json
@@ -366,6 +366,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
@@ -480,6 +480,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Vault.HashiCorp.Tests/packages.lock.json
+++ b/tests/Granit.Vault.HashiCorp.Tests/packages.lock.json
@@ -315,6 +315,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Vault.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Tests/packages.lock.json
@@ -369,6 +369,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
@@ -181,11 +181,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -198,10 +198,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -507,6 +507,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -714,14 +715,14 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
@@ -573,6 +573,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Tests/packages.lock.json
@@ -176,11 +176,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -193,10 +193,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -489,6 +489,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -589,14 +590,14 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -361,11 +361,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -383,10 +383,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
@@ -835,6 +835,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -1023,14 +1024,14 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {


### PR DESCRIPTION
## Summary

Recovers work that was auto-stashed when `docs/astro-align-phase-2-4-backend` was merged into `develop` (PR #1212), and lands a partial pass on the open SonarQube backlog.

### SonarQube cleanup applied

- **Test methods → expression body** (Roslyn IDE0022, 8 files)
- **Constants for repeated literals**: `UsageEndpoints`, `TaxRateEntryExportDefinition`, `KeycloakIdentityProvider` (`get_user`)
- **LINQ Where/Select simplifications**: `LookupRegistry`, `ValidationErrorsSanitizer`, `SortedTagsDocumentTransformer`, `SettingDefinition`, `Subscription`, `EfAggregationRunner`
- **Exceptions made public**: `EntraIdClientNotFoundException`, `KeycloakClientNotFoundException`, `KeycloakTokenExchangeRateLimitedException`, `PrivacyExportSizeLimitExceededException`
- **`[SuppressMessage]` S1118** on 15 Wolverine handlers per CLAUDE.md (handlers must be `public class` with `public static Handle` for discovery — false positive)
- **`[SuppressMessage]` S107** on `InitiatePaymentCommandHandler` and `RequestRefundCommandHandler` (no natural domain wrapper for orthogonal DI collaborators)
- **S2077 hotspot** in `SchemaEnsurer` suppressed inline with regex-allowlist justification (DDL is not parameterizable)
- **BFF tests**: `MatrixCases` migrated to `TheoryData<>`; empty dictionary init simplified to `[]`

### Recovered WIP

Pre-existing in-flight work that was on the docs branch when it merged: Invoicing/Payments/Subscriptions/Bff/Auth adjustments, lockfile regeneration across the Notifications/Vault/Webhooks/Identity/Bff trees, plus 2 new files (`MultiTenancyOptionsValidator`, `CacheEncryptionConventionTests`).

### Deferred

The remaining SonarQube items (S107 on services and minimal-API endpoints, cognitive complexity in `TokenRequestEncoder`, enum naming on `PaymentMethodSequenceType` / `MultiTenancySide`, misc null-check / cast / deprecated / commented-code) are **not** in this PR — they will land in follow-ups.

## Test plan

- [ ] CI green on all shards
- [ ] `dotnet build` clean (verified locally — 0 warning / 0 error after revert of `IdentityLocalSchemaExampleProvider` constants that tripped GRSEC003)
- [ ] `dotnet format --verify-no-changes` clean (verified locally)
- [ ] Architecture tests pass