### PR TITLE
chore(sonar): batches 6-9 — S107 + cognitive complexity + enum naming + misc

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -34684,12 +34684,21 @@
       ]
     },
     {
+      "name": "PrivacyExportSizeLimitExceededException",
+      "fqn": "Granit.Privacy.BlobStorage.DataExport.Exceptions.PrivacyExportSizeLimitExceededException",
+      "kind": "class",
+      "project": "Granit.Privacy.BlobStorage",
+      "file": "src/Granit.Privacy.BlobStorage/DataExport/Exceptions/PrivacyExportSizeLimitExceededException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "ExportArchiveAssemblyHandler",
       "fqn": "Granit.Privacy.BlobStorage.DataExport.ExportArchiveAssemblyHandler",
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs",
-      "line": 44,
+      "line": 45,
       "members": [
         {
           "name": "HandleAsync",
@@ -34715,15 +34724,6 @@
       "project": "Granit.Privacy.BlobStorage",
       "file": "src/Granit.Privacy.BlobStorage/DataExport/ExportManifest.cs",
       "line": 34,
-      "members": []
-    },
-    {
-      "name": "PrivacyExportSizeLimitExceededException",
-      "fqn": "Granit.Privacy.BlobStorage.DataExport.PrivacyExportSizeLimitExceededException",
-      "kind": "class",
-      "project": "Granit.Privacy.BlobStorage",
-      "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportSizeLimitExceededException.cs",
-      "line": 8,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7093,7 +7093,7 @@
         {
           "name": "AddPermission",
           "kind": "method",
-          "signature": "AddPermission(string name, LocalizableString? displayName = null, MultiTenancySide multiTenancySide = MultiTenancySide.Both)",
+          "signature": "AddPermission(string name, LocalizableString? displayName = null, MultiTenancySides multiTenancySide = MultiTenancySides.Both)",
           "returnType": "PermissionDefinition"
         }
       ]
@@ -8133,8 +8133,8 @@
         {
           "name": "ClientSide",
           "kind": "property",
-          "signature": "MultiTenancySide? ClientSide",
-          "returnType": "MultiTenancySide?"
+          "signature": "MultiTenancySides? ClientSide",
+          "returnType": "MultiTenancySides?"
         },
         {
           "name": "StaticFilesPath",
@@ -12945,7 +12945,7 @@
       "kind": "class",
       "project": "Granit.DataLookup.Endpoints",
       "file": "src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {
@@ -15120,7 +15120,7 @@
       "kind": "class",
       "project": "Granit",
       "file": "src/Granit/Extensions/GranitHostBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranit",
@@ -18299,7 +18299,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito",
       "file": "src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs",
-      "line": 44,
+      "line": 45,
       "members": [
         {
           "name": "SyncAsync",
@@ -18589,7 +18589,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId",
       "file": "src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "SyncAsync",
@@ -18925,7 +18925,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak",
       "file": "src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "SyncAsync",
@@ -22207,7 +22207,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Domain/InvoiceLineItem.cs",
-      "line": 7,
+      "line": 8,
       "members": [
         {
           "name": "Create",
@@ -25765,11 +25765,11 @@
       ]
     },
     {
-      "name": "MultiTenancySide",
-      "fqn": "Granit.MultiTenancy.MultiTenancySide",
+      "name": "MultiTenancySides",
+      "fqn": "Granit.MultiTenancy.MultiTenancySides",
       "kind": "enum",
       "project": "Granit",
-      "file": "src/Granit/MultiTenancy/MultiTenancySide.cs",
+      "file": "src/Granit/MultiTenancy/MultiTenancySides.cs",
       "line": 24,
       "members": []
     },
@@ -30266,7 +30266,7 @@
         {
           "name": "SetClientSide",
           "kind": "method",
-          "signature": "SetClientSide(this OpenIddictApplicationDescriptor descriptor, MultiTenancySide? clientSide)",
+          "signature": "SetClientSide(this OpenIddictApplicationDescriptor descriptor, MultiTenancySides? clientSide)",
           "returnType": "void"
         }
       ]
@@ -30817,7 +30817,7 @@
         {
           "name": "new",
           "kind": "method",
-          "signature": "new(SupportedCountries: ImmutableHashSet<string>.Empty, SupportedCurrencies: ImmutableHashSet<string>.Empty, SupportedSequenceTypes: PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)",
+          "signature": "new(SupportedCountries: ImmutableHashSet<string>.Empty, SupportedCurrencies: ImmutableHashSet<string>.Empty, SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring, AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)",
           "returnType": "PaymentMethodCapability Wildcard { get; } ="
         }
       ]
@@ -31053,7 +31053,7 @@
           "name": "Activate",
           "kind": "method",
           "signature": "Activate()",
-          "returnType": "bool Activated { get; private set; } public ImmutableHashSet<string>? SupportedCountries { get; private set; } public ImmutableHashSet<string>? SupportedCurrencies { get; private set; } public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; } public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; } public void"
+          "returnType": "bool Activated { get; private set; } public ImmutableHashSet<string>? SupportedCountries { get; private set; } public ImmutableHashSet<string>? SupportedCurrencies { get; private set; } public PaymentMethodSequenceTypes? SupportedSequenceTypes { get; private set; } public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; } public void"
         },
         {
           "name": "Deactivate",
@@ -31102,11 +31102,11 @@
       ]
     },
     {
-      "name": "PaymentMethodSequenceType",
-      "fqn": "Granit.Payments.Domain.PaymentMethodSequenceType",
+      "name": "PaymentMethodSequenceTypes",
+      "fqn": "Granit.Payments.Domain.PaymentMethodSequenceTypes",
       "kind": "enum",
       "project": "Granit.Payments",
-      "file": "src/Granit.Payments/Domain/PaymentMethodSequenceType.cs",
+      "file": "src/Granit.Payments/Domain/PaymentMethodSequenceTypes.cs",
       "line": 14,
       "members": []
     },
@@ -34719,11 +34719,11 @@
     },
     {
       "name": "PrivacyExportSizeLimitExceededException",
-      "fqn": "Granit.Privacy.BlobStorage.DataExport.Internal.PrivacyExportSizeLimitExceededException",
+      "fqn": "Granit.Privacy.BlobStorage.DataExport.PrivacyExportSizeLimitExceededException",
       "kind": "class",
       "project": "Granit.Privacy.BlobStorage",
-      "file": "src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs",
-      "line": 100,
+      "file": "src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportSizeLimitExceededException.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -36848,7 +36848,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.AI.Endpoints/Permissions/AIPermissionDefinitionProvider.cs
+++ b/src/Granit.AI.Endpoints/Permissions/AIPermissionDefinitionProvider.cs
@@ -41,30 +41,30 @@ internal sealed class AIPermissionDefinitionProvider : IPermissionDefinitionProv
             AIPermissions.Workspaces.Read,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
                 "Permission:AI.Workspaces.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             AIPermissions.Workspaces.Manage,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
                 "Permission:AI.Workspaces.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             AIPermissions.Usage.Read,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
                 "Permission:AI.Usage.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             AIPermissions.Chat.Execute,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
                 "Permission:AI.Chat.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             AIPermissions.Embeddings.Execute,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
                 "Permission:AI.Embeddings.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Auditing.Endpoints/Permissions/AuditingPermissionDefinitionProvider.cs
+++ b/src/Granit.Auditing.Endpoints/Permissions/AuditingPermissionDefinitionProvider.cs
@@ -25,7 +25,7 @@ internal sealed class AuditingPermissionDefinitionProvider : IPermissionDefiniti
             AuditingPermissions.AuditEntries.Read,
             LocalizableString.Create<AuditingEndpointsLocalizationResource>(
                 "Permission:Auditing.AuditEntries.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Managing (pruning, redacting) audit entries is an infrastructure concern and
         // should not be delegated to tenant admins — mis-use could break compliance trails.
@@ -33,6 +33,6 @@ internal sealed class AuditingPermissionDefinitionProvider : IPermissionDefiniti
             AuditingPermissions.AuditEntries.Manage,
             LocalizableString.Create<AuditingEndpointsLocalizationResource>(
                 "Permission:Auditing.AuditEntries.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissionDefinitionProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissionDefinitionProvider.cs
@@ -22,30 +22,30 @@ internal sealed class ApiKeyPermissionDefinitionProvider : IPermissionDefinition
             ApiKeyPermissions.Keys.Read,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
                 "Permission:AuthenticationApiKeys.Keys.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Create,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
                 "Permission:AuthenticationApiKeys.Keys.Create"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Revoke,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
                 "Permission:AuthenticationApiKeys.Keys.Revoke"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Rotate,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
                 "Permission:AuthenticationApiKeys.Keys.Rotate"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.UpdateScopes,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
                 "Permission:AuthenticationApiKeys.Keys.UpdateScopes"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs
+++ b/src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs
@@ -8,7 +8,7 @@ namespace Granit.Authorization.Endpoints.Dtos;
 /// </summary>
 /// <param name="Name">Stable permission identifier (e.g. <c>"Invoices.Invoices.Read"</c>).</param>
 /// <param name="DisplayName">Localized display name for admin UIs, or <see langword="null"/> if not set.</param>
-/// <param name="MultiTenancySide">
+/// <param name="MultiTenancySides">
 /// Declared scope of the permission: <c>"Host"</c>, <c>"Tenant"</c>, or <c>"Both"</c>.
 /// Consumed by admin UIs to filter grantable permissions by the current scope and to render
 /// a side badge next to each permission. Serialized as the enum name.
@@ -16,4 +16,4 @@ namespace Granit.Authorization.Endpoints.Dtos;
 public sealed record PermissionDefinitionResponse(
     string Name,
     string? DisplayName,
-    MultiTenancySide MultiTenancySide);
+    MultiTenancySides MultiTenancySides);

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionDefinitionsEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionDefinitionsEndpoints.cs
@@ -51,7 +51,7 @@ internal static class PermissionDefinitionsEndpoints
                     .Select(p => new PermissionDefinitionResponse(
                         p.Name,
                         p.DisplayName?.Localize(localizerFactory),
-                        p.MultiTenancySide))
+                        p.MultiTenancySides))
                     .ToList()))
             .ToList();
 

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -217,7 +217,7 @@ internal static partial class PermissionGrantEndpoints
     private static partial Regex ValidNameRegex();
 
     /// <summary>
-    /// Applies the <see cref="MultiTenancySide"/> visibility matrix to a role name.
+    /// Applies the <see cref="MultiTenancySides"/> visibility matrix to a role name.
     /// Returns <see langword="true"/> when the role either has no <see cref="RoleMetadata"/>
     /// row (legacy / externally-managed role, not under Granit's visibility regime) or
     /// its row is visible in the caller's context.
@@ -259,11 +259,11 @@ internal static partial class PermissionGrantEndpoints
             return true;
         }
 
-        return role.MultiTenancySide switch
+        return role.MultiTenancySides switch
         {
-            MultiTenancySide.Host => false,
-            MultiTenancySide.Both => true,
-            MultiTenancySide.Tenant => role.TenantId == currentTenant.Id,
+            MultiTenancySides.Host => false,
+            MultiTenancySides.Both => true,
+            MultiTenancySides.Tenant => role.TenantId == currentTenant.Id,
             _ => false,
         };
     }

--- a/src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissionDefinitionProvider.cs
+++ b/src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissionDefinitionProvider.cs
@@ -22,12 +22,12 @@ internal sealed class AuthorizationEndpointsPermissionDefinitionProvider : IPerm
             AuthorizationEndpointsPermissions.Definitions.Read,
             LocalizableString.Create<AuthorizationEndpointsLocalizationResource>(
                 "Permission:Authorization.Definitions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             AuthorizationEndpointsPermissions.Grants.Manage,
             LocalizableString.Create<AuthorizationEndpointsLocalizationResource>(
                 "Permission:Authorization.Grants.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
@@ -14,7 +14,7 @@ public interface IPermissionGrantDbContext
     DbSet<PermissionGrant> PermissionGrants { get; }
 
     /// <summary>
-    /// Role metadata table — declarative scope (<see cref="Granit.MultiTenancy.MultiTenancySide"/>,
+    /// Role metadata table — declarative scope (<see cref="Granit.MultiTenancy.MultiTenancySides"/>,
     /// optional tenant / OIDC client) for roles managed via <see cref="IRoleMetadataStore"/>.
     /// </summary>
     /// <remarks>

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
@@ -11,7 +11,7 @@ public static class RoleMetadataModelBuilderExtensions
     /// Applies the entity configuration for <see cref="RoleMetadata"/>: host-level table
     /// name, column constraints, unique composite index on <c>(Name, TenantId, ClientId)</c>
     /// with PostgreSQL <c>NULLS NOT DISTINCT</c> semantics, and a CHECK constraint enforcing
-    /// the <c>MultiTenancySide</c> ↔ <c>TenantId</c> invariant at the database level.
+    /// the <c>MultiTenancySides</c> ↔ <c>TenantId</c> invariant at the database level.
     /// </summary>
     /// <remarks>
     /// Call from <c>OnModelCreating</c> in the host application's DbContext alongside
@@ -27,15 +27,15 @@ public static class RoleMetadataModelBuilderExtensions
                 table => table.HasCheckConstraint(
                     $"ck_{GranitAuthorizationDbProperties.DbTablePrefix}role_metadata_side_tenant_consistency",
                     // Side values: Host = 1, Tenant = 2, Both = 3 (Host | Tenant)
-                    $"(\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Host} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
-                    $" OR (\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Both} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
-                    $" OR (\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Tenant} AND \"{nameof(RoleMetadata.TenantId)}\" IS NOT NULL)"));
+                    $"(\"{nameof(RoleMetadata.MultiTenancySides)}\" = {(int)MultiTenancySides.Host} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
+                    $" OR (\"{nameof(RoleMetadata.MultiTenancySides)}\" = {(int)MultiTenancySides.Both} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
+                    $" OR (\"{nameof(RoleMetadata.MultiTenancySides)}\" = {(int)MultiTenancySides.Tenant} AND \"{nameof(RoleMetadata.TenantId)}\" IS NOT NULL)"));
 
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Name).HasMaxLength(256).IsRequired();
             entity.Property(e => e.ClientId).HasMaxLength(256);
             entity.Property(e => e.Description).HasMaxLength(2048);
-            entity.Property(e => e.MultiTenancySide).IsRequired();
+            entity.Property(e => e.MultiTenancySides).IsRequired();
             entity.Property(e => e.IsSystem).IsRequired();
             entity.Property(e => e.IsOrphaned).IsRequired().HasDefaultValue(false);
             entity.Property(e => e.OrphanedAt);

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -6,7 +6,7 @@ namespace Granit.Authorization.Domain;
 
 /// <summary>
 /// Declarative metadata for a role: its name, tenant scope, owning OIDC client (if any),
-/// and <see cref="Granit.MultiTenancy.MultiTenancySide"/>.
+/// and <see cref="Granit.MultiTenancy.MultiTenancySides"/>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,9 +22,9 @@ namespace Granit.Authorization.Domain;
 /// <c>CHECK</c> constraint:
 /// </para>
 /// <list type="bullet">
-///   <item><see cref="MultiTenancySide.Host"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/>.</item>
-///   <item><see cref="MultiTenancySide.Both"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/> (role is defined globally but assignable in any tenant context).</item>
-///   <item><see cref="MultiTenancySide.Tenant"/> ⇒ <see cref="TenantId"/> must be non-null.</item>
+///   <item><see cref="MultiTenancySides.Host"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/>.</item>
+///   <item><see cref="MultiTenancySides.Both"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/> (role is defined globally but assignable in any tenant context).</item>
+///   <item><see cref="MultiTenancySides.Tenant"/> ⇒ <see cref="TenantId"/> must be non-null.</item>
 /// </list>
 /// <para>
 /// Uniqueness is enforced on the composite <c>(Name, TenantId, ClientId)</c> with
@@ -37,7 +37,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
     /// <summary>Human-readable role name, e.g. <c>"TenantAdministrator"</c>. Max 256 characters.</summary>
     public string Name { get; private set; } = string.Empty;
 
-    /// <summary>Tenant scope. Non-null only when <see cref="MultiTenancySide"/> is <see cref="MultiTenancySide.Tenant"/>.</summary>
+    /// <summary>Tenant scope. Non-null only when <see cref="MultiTenancySides"/> is <see cref="MultiTenancySides.Tenant"/>.</summary>
     public Guid? TenantId { get; private set; }
 
     /// <summary>
@@ -51,8 +51,8 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
     /// </remarks>
     public string? ClientId { get; private set; }
 
-    /// <summary>Host / tenant applicability side. Default on new declarations is <see cref="MultiTenancySide.Both"/>.</summary>
-    public MultiTenancySide MultiTenancySide { get; private set; } = MultiTenancySide.Both;
+    /// <summary>Host / tenant applicability side. Default on new declarations is <see cref="MultiTenancySides.Both"/>.</summary>
+    public MultiTenancySides MultiTenancySides { get; private set; } = MultiTenancySides.Both;
 
     /// <summary>Optional description displayed in admin UIs. Max 2048 characters.</summary>
     public string? Description { get; private set; }
@@ -100,14 +100,14 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
     /// <param name="id">Aggregate identifier (typically supplied by <c>IGuidGenerator</c>).</param>
     /// <param name="name">Role name. Max 256 chars, non-empty.</param>
     /// <param name="multiTenancySide">Side applicability.</param>
-    /// <param name="tenantId">Tenant scope. Must be non-null iff side is <see cref="MultiTenancySide.Tenant"/>.</param>
+    /// <param name="tenantId">Tenant scope. Must be non-null iff side is <see cref="MultiTenancySides.Tenant"/>.</param>
     /// <param name="clientId">Optional OIDC client scope. Max 256 chars.</param>
     /// <param name="description">Optional description. Max 2048 chars.</param>
     /// <param name="isSystem">Mark as seeded by the platform.</param>
     public static RoleMetadata Create(
         Guid id,
         string name,
-        MultiTenancySide multiTenancySide,
+        MultiTenancySides multiTenancySide,
         Guid? tenantId,
         string? clientId = null,
         string? description = null,
@@ -121,7 +121,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         {
             Id = id,
             Name = name,
-            MultiTenancySide = multiTenancySide,
+            MultiTenancySides = multiTenancySide,
             TenantId = tenantId,
             ClientId = clientId,
             Description = description,
@@ -161,7 +161,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         Description = newDescription;
 
         AddDomainEvent(new RoleUpdatedEvent(
-            Id, Name, previousName, MultiTenancySide, TenantId, ClientId));
+            Id, Name, previousName, MultiTenancySides, TenantId, ClientId));
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
     /// the still-tracked <c>Deleted</c> entry.
     /// </summary>
     public void MarkAsDeleted() =>
-        AddDomainEvent(new RoleDeletedEvent(Id, Name, MultiTenancySide, TenantId, ClientId));
+        AddDomainEvent(new RoleDeletedEvent(Id, Name, MultiTenancySides, TenantId, ClientId));
 
     /// <summary>
     /// Flips <see cref="IsOrphaned"/> to <see langword="true"/>, stamps <see cref="OrphanedAt"/>,
@@ -190,7 +190,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         OrphanedAt = now;
 
         AddDomainEvent(new RoleOrphanedEvent(
-            Id, Name, MultiTenancySide, TenantId, ClientId, now));
+            Id, Name, MultiTenancySides, TenantId, ClientId, now));
     }
 
     /// <summary>
@@ -210,7 +210,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         OrphanedAt = null;
 
         AddDomainEvent(new RoleRestoredEvent(
-            Id, Name, MultiTenancySide, TenantId, ClientId));
+            Id, Name, MultiTenancySides, TenantId, ClientId));
     }
 
     private static void ValidateLengths(string name, string? clientId, string? description)
@@ -231,20 +231,20 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
         }
     }
 
-    private static void ValidateSideTenantConsistency(MultiTenancySide side, Guid? tenantId)
+    private static void ValidateSideTenantConsistency(MultiTenancySides side, Guid? tenantId)
     {
         switch (side)
         {
-            case MultiTenancySide.Host:
-            case MultiTenancySide.Both:
+            case MultiTenancySides.Host:
+            case MultiTenancySides.Both:
                 if (tenantId is not null)
                 {
                     throw new ArgumentException(
-                        $"Role with MultiTenancySide '{side}' must have a null TenantId.",
+                        $"Role with MultiTenancySides '{side}' must have a null TenantId.",
                         nameof(tenantId));
                 }
                 break;
-            case MultiTenancySide.Tenant:
+            case MultiTenancySides.Tenant:
                 if (tenantId is null)
                 {
                     throw new ArgumentException(
@@ -254,7 +254,7 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
                 break;
             default:
                 throw new ArgumentOutOfRangeException(
-                    nameof(side), side, "Unknown MultiTenancySide value.");
+                    nameof(side), side, "Unknown MultiTenancySides value.");
         }
     }
 }

--- a/src/Granit.Authorization/Events/RoleCreatedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleCreatedEvent.cs
@@ -12,12 +12,12 @@ namespace Granit.Authorization.Events;
 /// </remarks>
 /// <param name="RoleId">Aggregate identifier.</param>
 /// <param name="Name">Role name.</param>
-/// <param name="MultiTenancySide">Side applicability declared at creation.</param>
-/// <param name="TenantId">Tenant scope (<see langword="null"/> for <see cref="MultiTenancySide.Host"/> / <see cref="MultiTenancySide.Both"/>).</param>
+/// <param name="MultiTenancySides">Side applicability declared at creation.</param>
+/// <param name="TenantId">Tenant scope (<see langword="null"/> for <see cref="MultiTenancySides.Host"/> / <see cref="MultiTenancySides.Both"/>).</param>
 /// <param name="ClientId">OIDC client scope (<see langword="null"/> for realm / global roles).</param>
 public sealed record RoleCreatedEvent(
     Guid RoleId,
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleDeletedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleDeletedEvent.cs
@@ -12,12 +12,12 @@ namespace Granit.Authorization.Events;
 /// </remarks>
 /// <param name="RoleId">Aggregate identifier.</param>
 /// <param name="Name">Name at deletion time.</param>
-/// <param name="MultiTenancySide">Side applicability.</param>
+/// <param name="MultiTenancySides">Side applicability.</param>
 /// <param name="TenantId">Tenant scope.</param>
 /// <param name="ClientId">OIDC client scope.</param>
 public sealed record RoleDeletedEvent(
     Guid RoleId,
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleOrphanedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleOrphanedEvent.cs
@@ -16,14 +16,14 @@ namespace Granit.Authorization.Events;
 /// </remarks>
 /// <param name="RoleId">Aggregate identifier.</param>
 /// <param name="Name">Role name at the moment of orphaning.</param>
-/// <param name="MultiTenancySide">Side applicability (unchanged).</param>
+/// <param name="MultiTenancySides">Side applicability (unchanged).</param>
 /// <param name="TenantId">Tenant scope (unchanged).</param>
 /// <param name="ClientId">OIDC client scope (unchanged) — the sync's <c>TrackedClientId</c> key.</param>
 /// <param name="OrphanedAt">Timestamp captured by the sync when the flag was flipped.</param>
 public sealed record RoleOrphanedEvent(
     Guid RoleId,
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId,
     DateTimeOffset OrphanedAt) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleRestoredEvent.cs
+++ b/src/Granit.Authorization/Events/RoleRestoredEvent.cs
@@ -11,12 +11,12 @@ namespace Granit.Authorization.Events;
 /// </summary>
 /// <param name="RoleId">Aggregate identifier.</param>
 /// <param name="Name">Role name at the moment of restoration.</param>
-/// <param name="MultiTenancySide">Side applicability (unchanged).</param>
+/// <param name="MultiTenancySides">Side applicability (unchanged).</param>
 /// <param name="TenantId">Tenant scope (unchanged).</param>
 /// <param name="ClientId">OIDC client scope (unchanged).</param>
 public sealed record RoleRestoredEvent(
     Guid RoleId,
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
@@ -14,13 +14,13 @@ namespace Granit.Authorization.Events;
 /// when only the description changed (name was not renamed). Cache invalidation
 /// handlers use this to flush entries keyed on the stale name.
 /// </param>
-/// <param name="MultiTenancySide">Side applicability (unchanged since creation).</param>
+/// <param name="MultiTenancySides">Side applicability (unchanged since creation).</param>
 /// <param name="TenantId">Tenant scope (unchanged since creation).</param>
 /// <param name="ClientId">OIDC client scope (unchanged since creation).</param>
 public sealed record RoleUpdatedEvent(
     Guid RoleId,
     string Name,
     string? PreviousName,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
+++ b/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
@@ -12,7 +12,7 @@ public sealed class RoleMetadataExportDefinition : ExportDefinition<RoleMetadata
         builder
             .IncludeId()
             .Field(r => r.Name)
-            .Field(r => r.MultiTenancySide)
+            .Field(r => r.MultiTenancySides)
             .Field(r => r.TenantId)
             .Field(r => r.ClientId)
             .Field(r => r.Description)

--- a/src/Granit.Authorization/PermissionDefinition.cs
+++ b/src/Granit.Authorization/PermissionDefinition.cs
@@ -7,12 +7,12 @@ namespace Granit.Authorization;
 /// <param name="Name">Unique permission name, e.g. <c>"Invoices.Delete"</c>.</param>
 /// <param name="DisplayName">Optional localizable label for admin UIs.</param>
 /// <param name="GroupName">Name of the group this permission belongs to.</param>
-/// <param name="MultiTenancySide">
-/// Tenant/host scope of the permission. Defaults to <see cref="MultiTenancySide.Both"/> for
+/// <param name="MultiTenancySides">
+/// Tenant/host scope of the permission. Defaults to <see cref="MultiTenancySides.Both"/> for
 /// backwards compatibility with existing permission declarations.
 /// </param>
 public sealed record PermissionDefinition(
     string Name,
     LocalizableString? DisplayName,
     string GroupName,
-    MultiTenancySide MultiTenancySide = MultiTenancySide.Both);
+    MultiTenancySides MultiTenancySides = MultiTenancySides.Both);

--- a/src/Granit.Authorization/PermissionGrantValidationContext.cs
+++ b/src/Granit.Authorization/PermissionGrantValidationContext.cs
@@ -11,7 +11,7 @@ namespace Granit.Authorization;
 /// Target tenant scope. <see langword="null"/> means the grant is host-level (cross-tenant
 /// or infrastructure-level).
 /// </param>
-/// <param name="Definition">The resolved permission definition (includes <see cref="MultiTenancySide"/>).</param>
+/// <param name="Definition">The resolved permission definition (includes <see cref="MultiTenancySides"/>).</param>
 public sealed record PermissionGrantValidationContext(
     string PermissionName,
     string ProviderName,

--- a/src/Granit.Authorization/PermissionGroup.cs
+++ b/src/Granit.Authorization/PermissionGroup.cs
@@ -21,7 +21,7 @@ public sealed class PermissionGroup(string name, LocalizableString? displayName 
     public PermissionDefinition AddPermission(
         string name,
         LocalizableString? displayName = null,
-        MultiTenancySide multiTenancySide = MultiTenancySide.Both)
+        MultiTenancySides multiTenancySide = MultiTenancySides.Both)
     {
         PermissionDefinition definition = new(name, displayName, Name, multiTenancySide);
         _permissions.Add(definition);

--- a/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
+++ b/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
@@ -19,7 +19,7 @@ public sealed class RoleMetadataQueryDefinition : QueryDefinition<RoleMetadata>
             .Column(r => r.Name, c => c.Label("Name").LabelKey("Authorization.Columns.RoleName").Filterable().Sortable())
             .Column(r => r.TenantId, c => c.Label("Tenant").LabelKey("Authorization.Columns.Tenant").Filterable().Sortable())
             .Column(r => r.ClientId, c => c.Label("Client").LabelKey("Authorization.Columns.ClientId").Filterable().Sortable())
-            .Column(r => r.MultiTenancySide, c => c.Label("Side").LabelKey("Authorization.Columns.MultiTenancySide").Filterable().Sortable())
+            .Column(r => r.MultiTenancySides, c => c.Label("Side").LabelKey("Authorization.Columns.MultiTenancySides").Filterable().Sortable())
             .Column(r => r.Description, c => c.Label("Description").LabelKey("Authorization.Columns.Description").Filterable())
             .Column(r => r.IsSystem, c => c.Label("System").LabelKey("Authorization.Columns.IsSystem").Filterable().Sortable())
             .Column(r => r.CreatedAt, c => c.Label("Created At").LabelKey("Authorization.Columns.CreatedAt").Sortable())

--- a/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
+++ b/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
@@ -5,25 +5,25 @@ namespace Granit.Authorization.Services;
 
 /// <summary>
 /// Rejects permission grants whose target scope contradicts either the permission's
-/// declared <see cref="MultiTenancySide"/> or — for role grants — the role's declared
-/// scope (<see cref="RoleMetadata.MultiTenancySide"/> / <see cref="RoleMetadata.TenantId"/>).
+/// declared <see cref="MultiTenancySides"/> or — for role grants — the role's declared
+/// scope (<see cref="RoleMetadata.MultiTenancySides"/> / <see cref="RoleMetadata.TenantId"/>).
 /// </summary>
 /// <remarks>
 /// <para>
 /// Permission checks (always applied):
 /// <list type="bullet">
-///   <item><see cref="MultiTenancySide.Host"/> permissions must be granted with <c>TenantId == null</c>.</item>
-///   <item><see cref="MultiTenancySide.Tenant"/> permissions must be granted with a non-null <c>TenantId</c>.</item>
-///   <item><see cref="MultiTenancySide.Both"/> permissions are accepted regardless.</item>
+///   <item><see cref="MultiTenancySides.Host"/> permissions must be granted with <c>TenantId == null</c>.</item>
+///   <item><see cref="MultiTenancySides.Tenant"/> permissions must be granted with a non-null <c>TenantId</c>.</item>
+///   <item><see cref="MultiTenancySides.Both"/> permissions are accepted regardless.</item>
 /// </list>
 /// </para>
 /// <para>
 /// Role-side checks (only when <see cref="PermissionGrantValidationContext.ProviderName"/>
 /// is <see cref="PermissionGrantProviderNames.Role"/>):
 /// <list type="bullet">
-///   <item>A <see cref="MultiTenancySide.Host"/> role cannot receive tenant-scoped grants.</item>
-///   <item>A <see cref="MultiTenancySide.Tenant"/> role cannot receive host-level grants, and its <see cref="RoleMetadata.TenantId"/> must match the grant's tenant scope.</item>
-///   <item>A <see cref="MultiTenancySide.Both"/> role is accepted in either context.</item>
+///   <item>A <see cref="MultiTenancySides.Host"/> role cannot receive tenant-scoped grants.</item>
+///   <item>A <see cref="MultiTenancySides.Tenant"/> role cannot receive host-level grants, and its <see cref="RoleMetadata.TenantId"/> must match the grant's tenant scope.</item>
+///   <item>A <see cref="MultiTenancySides.Both"/> role is accepted in either context.</item>
 /// </list>
 /// The role is located via <see cref="IRoleMetadataStore"/>, trying the grant's tenant
 /// scope first and falling back to the global namespace. When no matching role metadata
@@ -41,16 +41,16 @@ internal sealed class MultiTenancySidePermissionGrantValidator(
         PermissionGrantValidationContext context,
         CancellationToken cancellationToken = default)
     {
-        MultiTenancySide permissionSide = context.Definition.MultiTenancySide;
+        MultiTenancySides permissionSide = context.Definition.MultiTenancySides;
 
-        if (!permissionSide.HasFlag(MultiTenancySide.Host) && context.TenantId is null)
+        if (!permissionSide.HasFlag(MultiTenancySides.Host) && context.TenantId is null)
         {
             return PermissionGrantValidationResult.Reject(
                 "side_host_forbidden",
                 $"Permission '{context.PermissionName}' is Tenant-only; host-level grant (TenantId == null) refused.");
         }
 
-        if (!permissionSide.HasFlag(MultiTenancySide.Tenant) && context.TenantId is not null)
+        if (!permissionSide.HasFlag(MultiTenancySides.Tenant) && context.TenantId is not null)
         {
             return PermissionGrantValidationResult.Reject(
                 "side_tenant_forbidden",
@@ -82,14 +82,14 @@ internal sealed class MultiTenancySidePermissionGrantValidator(
             return PermissionGrantValidationResult.Success;
         }
 
-        if (role.MultiTenancySide == MultiTenancySide.Host && context.TenantId is not null)
+        if (role.MultiTenancySides == MultiTenancySides.Host && context.TenantId is not null)
         {
             return PermissionGrantValidationResult.Reject(
                 "role_side_forbidden",
                 $"Role '{context.ProviderKey}' is Host-only; tenant-scoped grant refused.");
         }
 
-        if (role.MultiTenancySide == MultiTenancySide.Tenant)
+        if (role.MultiTenancySides == MultiTenancySides.Tenant)
         {
             if (context.TenantId is null)
             {

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -15,7 +15,7 @@ namespace Granit.Authorization.Services;
 /// <item>AlwaysAllow (dev/test, authenticated users only) → granted</item>
 /// <item>AdminRole bypass (root of trust, case-insensitive) → granted without DB</item>
 /// <item>Permission undefined → <see cref="InvalidOperationException"/></item>
-/// <item>Permission's <see cref="MultiTenancySide"/> incompatible with current tenant context → denied</item>
+/// <item>Permission's <see cref="MultiTenancySides"/> incompatible with current tenant context → denied</item>
 /// <item>For each registered <see cref="IPermissionGrantProvider"/> (default order: User, Role, Client),
 ///   query each of the provider's keys through cache / store. First positive match wins (fail-fast).</item>
 /// </list>
@@ -285,8 +285,8 @@ internal sealed class PermissionChecker(
     // multi-tenancy should not declare Tenant-sided permissions in the first place.
     internal static bool IsCompatibleWithCurrentSide(PermissionDefinition definition, ICurrentTenant currentTenant) =>
         currentTenant.IsAvailable
-            ? definition.MultiTenancySide.HasFlag(MultiTenancySide.Tenant)
-            : definition.MultiTenancySide.HasFlag(MultiTenancySide.Host);
+            ? definition.MultiTenancySides.HasFlag(MultiTenancySides.Tenant)
+            : definition.MultiTenancySides.HasFlag(MultiTenancySides.Host);
 
     private static PermissionGrantLookupContext BuildLookupContext(
         ICurrentUserService currentUserService,

--- a/src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissionDefinitionProvider.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissionDefinitionProvider.cs
@@ -47,12 +47,12 @@ internal sealed class BackgroundJobsPermissionDefinitionProvider : IPermissionDe
             BackgroundJobsPermissions.Jobs.Read,
             LocalizableString.Create<BackgroundJobsEndpointsLocalizationResource>(
                 "Permission:BackgroundJobs.Jobs.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         group.AddPermission(
             BackgroundJobsPermissions.Jobs.Manage,
             LocalizableString.Create<BackgroundJobsEndpointsLocalizationResource>(
                 "Permission:BackgroundJobs.Jobs.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -132,7 +132,7 @@ public sealed class BffFrontendOptions
     /// <c>OpenIddictApplicationDescriptor.SetClientSide(...)</c>).
     /// </para>
     /// </remarks>
-    public MultiTenancySide? ClientSide { get; set; }
+    public MultiTenancySides? ClientSide { get; set; }
 
     /// <summary>
     /// URL path prefix for this frontend (e.g., <c>"/admin"</c>, <c>"/patient"</c>).

--- a/src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissionDefinitionProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissionDefinitionProvider.cs
@@ -22,12 +22,12 @@ internal sealed class BlobStoragePermissionDefinitionProvider : IPermissionDefin
             BlobStoragePermissions.Administration.Read,
             LocalizableString.Create<BlobStorageEndpointsLocalizationResource>(
                 "Permission:BlobStorage.Administration.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             BlobStoragePermissions.Administration.Manage,
             LocalizableString.Create<BlobStorageEndpointsLocalizationResource>(
                 "Permission:BlobStorage.Administration.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Catalog.Endpoints/Permissions/CatalogPermissionDefinitionProvider.cs
+++ b/src/Granit.Catalog.Endpoints/Permissions/CatalogPermissionDefinitionProvider.cs
@@ -19,9 +19,9 @@ internal sealed class CatalogPermissionDefinitionProvider : IPermissionDefinitio
         // a Both-sided variant or a separate Tenant.* permission set will be added.
         group.AddPermission(CatalogPermissions.Products.Read,
             LocalizableString.Create<CatalogEndpointsLocalizationResource>("Permission:Catalog.Products.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
         group.AddPermission(CatalogPermissions.Products.Manage,
             LocalizableString.Create<CatalogEndpointsLocalizationResource>("Permission:Catalog.Products.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissionDefinitionProvider.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissionDefinitionProvider.cs
@@ -20,14 +20,14 @@ internal sealed class CustomerBalancePermissionDefinitionProvider : IPermissionD
         group.AddPermission(CustomerBalancePermissions.Accounts.Read,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
                 "Permission:CustomerBalance.Accounts.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(CustomerBalancePermissions.Transactions.Read,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
                 "Permission:CustomerBalance.Transactions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(CustomerBalancePermissions.Credits.Manage,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
                 "Permission:CustomerBalance.Credits.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissionDefinitionProvider.cs
+++ b/src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissionDefinitionProvider.cs
@@ -41,24 +41,24 @@ internal sealed class DataExchangePermissionDefinitionProvider : IPermissionDefi
             DataExchangePermissions.Imports.Read,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
                 "Permission:DataExchange.Imports.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             DataExchangePermissions.Imports.Execute,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
                 "Permission:DataExchange.Imports.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             DataExchangePermissions.Exports.Read,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
                 "Permission:DataExchange.Exports.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             DataExchangePermissions.Exports.Execute,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
                 "Permission:DataExchange.Exports.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
+++ b/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization;
 using Granit.DataLookup.Descriptors;
 using Granit.DataLookup.Diagnostics;
@@ -36,6 +37,7 @@ public static class LookupEndpointHandlers
     }
 
     /// <summary>GET /api/granit/lookups/{name} — paginated search.</summary>
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/[FromQuery] parameters explicitly; no natural domain wrapper for orthogonal request inputs and DI collaborators.")]
     public static async Task<Results<Ok<LookupResultResponse>, NotFound, ForbidHttpResult, ProblemHttpResult>> SearchAsync(
         string name,
         [FromServices] ILookupRegistry registry,

--- a/src/Granit.DataLookup.Endpoints/Permissions/DataLookupPermissionDefinitionProvider.cs
+++ b/src/Granit.DataLookup.Endpoints/Permissions/DataLookupPermissionDefinitionProvider.cs
@@ -28,6 +28,6 @@ internal sealed class DataLookupPermissionDefinitionProvider : IPermissionDefini
             DataLookupPermissions.Lookups.Read,
             LocalizableString.Create<DataLookupEndpointsLocalizationResource>(
                 "Permission:DataLookup.Lookups.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissionDefinitionProvider.cs
+++ b/src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissionDefinitionProvider.cs
@@ -24,6 +24,6 @@ internal sealed class DiagnosticsPermissionDefinitionProvider : IPermissionDefin
             DiagnosticsPermissions.Monitoring.Read,
             LocalizableString.Create<DiagnosticsEndpointsLocalizationResource>(
                 "Permission:Diagnostics.Monitoring.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Features.Endpoints/Permissions/FeaturesPermissionDefinitionProvider.cs
+++ b/src/Granit.Features.Endpoints/Permissions/FeaturesPermissionDefinitionProvider.cs
@@ -24,7 +24,7 @@ internal sealed class FeaturesPermissionDefinitionProvider : IPermissionDefiniti
             FeaturesPermissions.Flags.Read,
             LocalizableString.Create<FeaturesEndpointsLocalizationResource>(
                 "Permission:Features.Flags.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Defining/toggling feature flags is a platform concern — tenant-level overrides,
         // if needed, warrant a dedicated permission rather than reusing this one.
@@ -32,6 +32,6 @@ internal sealed class FeaturesPermissionDefinitionProvider : IPermissionDefiniti
             FeaturesPermissions.Flags.Manage,
             LocalizableString.Create<FeaturesEndpointsLocalizationResource>(
                 "Permission:Features.Flags.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Http.Cookies/Options/GranitCookiesOptionsValidator.cs
+++ b/src/Granit.Http.Cookies/Options/GranitCookiesOptionsValidator.cs
@@ -11,17 +11,17 @@ internal sealed class GranitCookiesOptionsValidator : IValidateOptions<GranitCoo
 {
     public ValidateOptionsResult Validate(string? name, GranitCookiesOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
 
         if (options.DefaultRetentionDays <= 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{nameof(GranitCookiesOptions.DefaultRetentionDays)} must be > 0. " +
                 $"Got {options.DefaultRetentionDays}.");
         }
         else if (options.DefaultRetentionDays > GranitCookiesOptions.MaxRetentionDays)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{nameof(GranitCookiesOptions.DefaultRetentionDays)} must be <= " +
                 $"{GranitCookiesOptions.MaxRetentionDays} (CNIL 13-month hard cap — RGPD Art. 5(1)(e) " +
                 $"storage limitation). Got {options.DefaultRetentionDays}. For cookies that need a " +
@@ -29,7 +29,7 @@ internal sealed class GranitCookiesOptionsValidator : IValidateOptions<GranitCoo
                 "legal basis documented in your data-protection impact assessment.");
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.Identity.Endpoints/Permissions/IdentityPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Endpoints/Permissions/IdentityPermissionDefinitionProvider.cs
@@ -23,70 +23,70 @@ internal sealed class IdentityPermissionDefinitionProvider : IPermissionDefiniti
             IdentityPermissions.Users.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Users.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Users.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Sync,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Users.Sync"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Delete,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Users.Delete"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Roles
         group.AddPermission(
             IdentityPermissions.Roles.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Roles.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Roles.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Roles.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Groups
         group.AddPermission(
             IdentityPermissions.Groups.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Groups.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Groups.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Groups.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Sessions
         group.AddPermission(
             IdentityPermissions.Sessions.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Sessions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityPermissions.Sessions.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Sessions.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // Passwords
         group.AddPermission(
             IdentityPermissions.Passwords.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
                 "Permission:Identity.Passwords.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Cognito/Sync/CognitoClientRoleSyncService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Granit.Authorization;
@@ -111,7 +112,7 @@ public sealed partial class CognitoClientRoleSyncService(
                 var metadata = RoleMetadata.Create(
                     id: guidGenerator.Create(),
                     name: role.Name,
-                    multiTenancySide: MultiTenancySide.Host,
+                    multiTenancySide: MultiTenancySides.Host,
                     tenantId: null,
                     clientId: clientId,
                     description: role.Description,
@@ -221,6 +222,7 @@ public sealed partial class CognitoClientRoleSyncService(
         Message = "Cognito client-role sync for '{ClientId}' completed: " +
                   "{Added} added, {Updated} updated, {Unchanged} unchanged, {Restored} restored, " +
                   "{OrphanedKept} kept-orphaned, {OrphanedSoftDeleted} soft-deleted, {OrphanedHardDeleted} hard-deleted.")]
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Source-generated [LoggerMessage] partial — one parameter per template placeholder; collapsing into a wrapper would defeat structured logging.")]
     private static partial void LogClientSynced(
         ILogger logger, string clientId,
         int added, int updated, int unchanged, int restored,

--- a/src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.EntraId/Sync/EntraIdClientRoleSyncService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Guids;
@@ -93,7 +94,7 @@ public sealed partial class EntraIdClientRoleSyncService(
                 var metadata = RoleMetadata.Create(
                     id: guidGenerator.Create(),
                     name: role.Name,
-                    multiTenancySide: MultiTenancySide.Host,
+                    multiTenancySide: MultiTenancySides.Host,
                     tenantId: null,
                     clientId: appId,
                     description: role.Description,
@@ -207,6 +208,7 @@ public sealed partial class EntraIdClientRoleSyncService(
         Message = "Entra ID client-role sync for '{AppId}' completed: " +
                   "{Added} added, {Updated} updated, {Unchanged} unchanged, {Restored} restored, " +
                   "{OrphanedKept} kept-orphaned, {OrphanedSoftDeleted} soft-deleted, {OrphanedHardDeleted} hard-deleted.")]
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Source-generated [LoggerMessage] partial — one parameter per template placeholder; collapsing into a wrapper would defeat structured logging.")]
     private static partial void LogAppSynced(
         ILogger logger, string appId,
         int added, int updated, int unchanged, int restored,

--- a/src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Sync/KeycloakClientRoleSyncService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Guids;
@@ -107,7 +108,7 @@ public sealed partial class KeycloakClientRoleSyncService(
                 var metadata = RoleMetadata.Create(
                     id: guidGenerator.Create(),
                     name: role.Name,
-                    multiTenancySide: MultiTenancySide.Host,
+                    multiTenancySide: MultiTenancySides.Host,
                     tenantId: null,
                     clientId: clientId,
                     description: role.Description,
@@ -223,6 +224,7 @@ public sealed partial class KeycloakClientRoleSyncService(
         Message = "Keycloak client-role sync for '{ClientId}' completed: " +
                   "{Added} added, {Updated} updated, {Unchanged} unchanged, {Restored} restored, " +
                   "{OrphanedKept} kept-orphaned, {OrphanedSoftDeleted} soft-deleted, {OrphanedHardDeleted} hard-deleted.")]
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Source-generated [LoggerMessage] partial — one parameter per template placeholder; collapsing into a wrapper would defeat structured logging.")]
     private static partial void LogClientSynced(
         ILogger logger, string clientId,
         int added, int updated, int unchanged, int restored,

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
@@ -264,7 +264,7 @@ internal sealed partial class AspNetPasskeyService(
                     AssertionResponse = assertionResponse,
                     OriginalOptions = originalOptions,
                     StoredPublicKey = storedPasskey.PublicKey,
-                    StoredSignatureCounter = (uint)storedPasskey.SignCount,
+                    StoredSignatureCounter = storedPasskey.SignCount,
                     IsUserHandleOwnerOfCredentialIdCallback =
                         static (_, _) => Task.FromResult(true),
                 },

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -232,7 +232,7 @@ internal sealed partial class GranitRoleOrchestrator(
                     var metadata = RoleMetadata.Create(
                         roleId,
                         command.Name,
-                        command.MultiTenancySide,
+                        command.MultiTenancySides,
                         command.TenantId,
                         command.ClientId,
                         command.Description,
@@ -432,7 +432,7 @@ internal sealed partial class GranitRoleOrchestrator(
             var metadata = RoleMetadata.Create(
                 roleId,
                 command.Name,
-                command.MultiTenancySide,
+                command.MultiTenancySides,
                 command.TenantId,
                 command.ClientId,
                 command.Description,

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/IdentityLocalRoleSeedContributor.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/IdentityLocalRoleSeedContributor.cs
@@ -12,9 +12,9 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <summary>
 /// Seeds the three platform-provided system roles and their <see cref="RoleMetadata"/> rows:
 /// <list type="bullet">
-///   <item><c>SuperAdmin</c> — <see cref="MultiTenancySide.Host"/>, platform administrator.</item>
-///   <item><c>TenantAdministrator</c> — <see cref="MultiTenancySide.Both"/>, defined globally, assignable per tenant.</item>
-///   <item><c>User</c> — <see cref="MultiTenancySide.Both"/>, default role for new users.</item>
+///   <item><c>SuperAdmin</c> — <see cref="MultiTenancySides.Host"/>, platform administrator.</item>
+///   <item><c>TenantAdministrator</c> — <see cref="MultiTenancySides.Both"/>, defined globally, assignable per tenant.</item>
+///   <item><c>User</c> — <see cref="MultiTenancySides.Both"/>, default role for new users.</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -30,9 +30,9 @@ internal sealed partial class IdentityLocalRoleSeedContributor(
 {
     private static readonly SystemRoleDescriptor[] SystemRoles =
     [
-        new("SuperAdmin", MultiTenancySide.Host, "Platform administrator with cross-tenant access."),
-        new("TenantAdministrator", MultiTenancySide.Both, "Administrator within a tenant — can manage tenant users, roles, and settings."),
-        new("User", MultiTenancySide.Both, "Default role assigned to every authenticated user."),
+        new("SuperAdmin", MultiTenancySides.Host, "Platform administrator with cross-tenant access."),
+        new("TenantAdministrator", MultiTenancySides.Both, "Administrator within a tenant — can manage tenant users, roles, and settings."),
+        new("User", MultiTenancySides.Both, "Default role assigned to every authenticated user."),
     ];
 
     /// <inheritdoc />
@@ -70,7 +70,7 @@ internal sealed partial class IdentityLocalRoleSeedContributor(
         await orchestrator.CreateAsync(
             new CreateRoleCommand(
                 Name: descriptor.Name,
-                MultiTenancySide: descriptor.Side,
+                MultiTenancySides: descriptor.Side,
                 TenantId: null,
                 ClientId: null,
                 Description: descriptor.Description,
@@ -80,7 +80,7 @@ internal sealed partial class IdentityLocalRoleSeedContributor(
         LogRoleCreated(logger, descriptor.Name, descriptor.Side);
     }
 
-    private sealed record SystemRoleDescriptor(string Name, MultiTenancySide Side, string Description);
+    private sealed record SystemRoleDescriptor(string Name, MultiTenancySides Side, string Description);
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Identity.Local system role seeding completed — {RoleCount} role(s) verified.")]
@@ -92,7 +92,7 @@ internal sealed partial class IdentityLocalRoleSeedContributor(
 
     [LoggerMessage(Level = LogLevel.Debug,
         Message = "Created system role '{RoleName}' with side {Side}.")]
-    private static partial void LogRoleCreated(ILogger logger, string roleName, MultiTenancySide side);
+    private static partial void LogRoleCreated(ILogger logger, string roleName, MultiTenancySides side);
 
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "Orphan GranitRole '{RoleName}' without RoleMetadata removed before re-seed.")]

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -19,7 +19,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// </para>
 /// <para>
 /// Host-scope roles (<see cref="Granit.Authorization.Domain.RoleMetadata"/> with
-/// <see cref="MultiTenancySide.Host"/> or <see cref="MultiTenancySide.Both"/>) are seeded and
+/// <see cref="MultiTenancySides.Host"/> or <see cref="MultiTenancySides.Both"/>) are seeded and
 /// resolved outside a tenant context, so their normalized names stay un-prefixed.
 /// </para>
 /// <para>

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -4,19 +4,19 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 
 /// <summary>Request to create a new local role.</summary>
 /// <param name="Name">Display name of the role (max 256 chars).</param>
-/// <param name="MultiTenancySide">
-/// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused
+/// <param name="MultiTenancySides">
+/// Host / Tenant / Both applicability. <see cref="MultiTenancySides.Tenant"/> is refused
 /// when <c>RoleEndpointsOptions.AllowTenantRoles</c> is explicitly disabled (enabled by
 /// default).
 /// </param>
 /// <param name="TenantId">
-/// Tenant identifier — required iff <paramref name="MultiTenancySide"/> is
-/// <see cref="MultiTenancySide.Tenant"/>. Must match the caller's tenant context when
+/// Tenant identifier — required iff <paramref name="MultiTenancySides"/> is
+/// <see cref="MultiTenancySides.Tenant"/>. Must match the caller's tenant context when
 /// invoked from a tenant admin.
 /// </param>
 /// <param name="Description">Optional description (max 2048 chars).</param>
 public sealed record RoleCreateRequest(
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? Description);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
@@ -5,7 +5,7 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>Role detail payload returned by the CRUD endpoints.</summary>
 /// <param name="Id">Aggregate identifier.</param>
 /// <param name="Name">Role display name.</param>
-/// <param name="MultiTenancySide">Host / Tenant / Both applicability.</param>
+/// <param name="MultiTenancySides">Host / Tenant / Both applicability.</param>
 /// <param name="TenantId">Tenant scope (null for Host / Both).</param>
 /// <param name="ClientId">OIDC client scope — reserved for future realm / client role distinction; currently always null.</param>
 /// <param name="Description">Optional description.</param>
@@ -15,7 +15,7 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 public sealed record RoleResponse(
     Guid Id,
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId,
     string? Description,

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -117,7 +117,7 @@ internal static class GranitRoleEndpoints
     {
         RoleEndpointsOptions opts = options.Value;
 
-        if (request.MultiTenancySide == MultiTenancySide.Tenant && !opts.AllowTenantRoles)
+        if (request.MultiTenancySides == MultiTenancySides.Tenant && !opts.AllowTenantRoles)
         {
             return TypedResults.Problem(
                 statusCode: StatusCodes.Status403Forbidden,
@@ -126,7 +126,7 @@ internal static class GranitRoleEndpoints
         }
 
         // Tenant admins may only create roles in their own tenant.
-        if (currentTenant.IsAvailable && request.MultiTenancySide == MultiTenancySide.Tenant
+        if (currentTenant.IsAvailable && request.MultiTenancySides == MultiTenancySides.Tenant
             && request.TenantId != currentTenant.Id)
         {
             return TypedResults.Problem(
@@ -135,7 +135,7 @@ internal static class GranitRoleEndpoints
         }
 
         // Tenant admins cannot create Host or Both roles (platform-level scope).
-        if (currentTenant.IsAvailable && request.MultiTenancySide != MultiTenancySide.Tenant)
+        if (currentTenant.IsAvailable && request.MultiTenancySides != MultiTenancySides.Tenant)
         {
             return TypedResults.Problem(
                 statusCode: StatusCodes.Status403Forbidden,
@@ -148,7 +148,7 @@ internal static class GranitRoleEndpoints
             created = await orchestrator.CreateAsync(
                 new CreateRoleCommand(
                     Name: request.Name,
-                    MultiTenancySide: request.MultiTenancySide,
+                    MultiTenancySides: request.MultiTenancySides,
                     TenantId: request.TenantId,
                     ClientId: null,
                     Description: request.Description,
@@ -251,11 +251,11 @@ internal static class GranitRoleEndpoints
         }
 
         // Tenant admin context.
-        return role.MultiTenancySide switch
+        return role.MultiTenancySides switch
         {
-            MultiTenancySide.Host => false,
-            MultiTenancySide.Both => true,
-            MultiTenancySide.Tenant => role.TenantId == currentTenant.Id,
+            MultiTenancySides.Host => false,
+            MultiTenancySides.Both => true,
+            MultiTenancySides.Tenant => role.TenantId == currentTenant.Id,
             _ => false,
         };
     }
@@ -271,14 +271,14 @@ internal static class GranitRoleEndpoints
             return true;
         }
 
-        return role.MultiTenancySide == MultiTenancySide.Tenant
+        return role.MultiTenancySides == MultiTenancySides.Tenant
             && role.TenantId == currentTenant.Id;
     }
 
     private static RoleResponse Map(RoleMetadata role) =>
         new(role.Id,
             role.Name,
-            role.MultiTenancySide,
+            role.MultiTenancySides,
             role.TenantId,
             role.ClientId,
             role.Description,

--- a/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
@@ -13,7 +13,7 @@ public sealed class RoleEndpointsOptions
 
     /// <summary>
     /// When <see langword="true"/> (default), tenant admins can create / rename / delete
-    /// <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/>-scoped roles in their
+    /// <see cref="Granit.MultiTenancy.MultiTenancySides.Tenant"/>-scoped roles in their
     /// own tenant. Host and Both roles remain host-admin only regardless of this flag.
     /// </summary>
     /// <remarks>

--- a/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
@@ -25,7 +25,7 @@ internal sealed class IdentityLocalPermissionDefinitionProvider : IPermissionDef
             IdentityLocalPermissions.Users.Impersonate,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "Permission:IdentityLocal.Users.Impersonate"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         // Role CRUD — assignable in both host and tenant admin contexts. Visibility matrix
         // + the AllowTenantRoles feature flag on endpoint options gate who can create
@@ -35,18 +35,18 @@ internal sealed class IdentityLocalPermissionDefinitionProvider : IPermissionDef
             IdentityLocalPermissions.Roles.Read,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "Permission:IdentityLocal.Roles.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityLocalPermissions.Roles.Manage,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "Permission:IdentityLocal.Roles.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             IdentityLocalPermissions.Roles.Delete,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "Permission:IdentityLocal.Roles.Delete"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Identity.Local.Endpoints/Validators/RoleCreateRequestValidator.cs
+++ b/src/Granit.Identity.Local.Endpoints/Validators/RoleCreateRequestValidator.cs
@@ -18,16 +18,16 @@ internal sealed class RoleCreateRequestValidator : GranitValidator<RoleCreateReq
         RuleFor(x => x.Description)
             .MaximumLength(2048);
 
-        RuleFor(x => x.MultiTenancySide)
+        RuleFor(x => x.MultiTenancySides)
             .IsInEnum();
 
         // Side ↔ TenantId consistency (mirrors RoleMetadata.Create domain invariant).
         RuleFor(x => x)
-            .Must(x => x.MultiTenancySide != MultiTenancySide.Tenant || x.TenantId is not null)
+            .Must(x => x.MultiTenancySides != MultiTenancySides.Tenant || x.TenantId is not null)
             .WithErrorCodeAndMessage("Granit:Identity:Role:TenantIdRequired");
 
         RuleFor(x => x)
-            .Must(x => x.MultiTenancySide == MultiTenancySide.Tenant || x.TenantId is null)
+            .Must(x => x.MultiTenancySides == MultiTenancySides.Tenant || x.TenantId is null)
             .WithErrorCodeAndMessage("Granit:Identity:Role:TenantIdForbidden");
     }
 }

--- a/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
@@ -52,14 +52,14 @@ public interface IGranitRoleOrchestrator
 
 /// <summary>Input for <see cref="IGranitRoleOrchestrator.CreateAsync"/>.</summary>
 /// <param name="Name">Role display name, e.g. <c>"Manager"</c>.</param>
-/// <param name="MultiTenancySide">Declarative scope of the role.</param>
-/// <param name="TenantId">Tenant identifier — must be set iff <paramref name="MultiTenancySide"/> is <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/>.</param>
+/// <param name="MultiTenancySides">Declarative scope of the role.</param>
+/// <param name="TenantId">Tenant identifier — must be set iff <paramref name="MultiTenancySides"/> is <see cref="Granit.MultiTenancy.MultiTenancySides.Tenant"/>.</param>
 /// <param name="ClientId">Optional OIDC client scope — reserved for future realm / client role distinction.</param>
 /// <param name="Description">Optional description.</param>
 /// <param name="IsSystem">Mark the role as platform-provisioned (prevents CRUD via endpoints).</param>
 public sealed record CreateRoleCommand(
     string Name,
-    MultiTenancySide MultiTenancySide,
+    MultiTenancySides MultiTenancySides,
     Guid? TenantId,
     string? ClientId = null,
     string? Description = null,

--- a/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
@@ -19,21 +19,21 @@ internal sealed class InvoicingPermissionDefinitionProvider : IPermissionDefinit
         // can tighten these to Tenant-only in their own permission provider.
         group.AddPermission(InvoicingPermissions.Invoices.Read,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Create,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Create"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Manage,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Download,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Download"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(InvoicingPermissions.CreditNotes.Read,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(InvoicingPermissions.CreditNotes.Manage,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Invoicing/Domain/InvoiceLineItem.cs
+++ b/src/Granit.Invoicing/Domain/InvoiceLineItem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
 
@@ -17,6 +18,7 @@ public sealed class InvoiceLineItem : Entity
     /// <param name="taxRate">Tax rate as a decimal fraction (e.g., 0.21 for 21%). Null if untaxed.</param>
     /// <param name="period">Billing period this line item covers.</param>
     /// <param name="productId">Optional <c>Granit.Catalog.Product</c> identifier — stable label across renames of the underlying meter or plan price.</param>
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Each parameter is a distinct domain concept (id, description, quantity, unit price, source, tax, period, product); a wrapper type would not represent any real aggregate.")]
     public static InvoiceLineItem Create(
         Guid id, string description, decimal quantity, decimal unitPrice,
         LineItemSource source,

--- a/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
+++ b/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
@@ -41,12 +41,12 @@ internal sealed class LocalizationOverridesPermissionDefinitionProvider : IPermi
             LocalizationOverridesPermissions.Overrides.Read,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
                 "Permission:Localization.Overrides.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             LocalizationOverridesPermissions.Overrides.Manage,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
                 "Permission:Localization.Overrides.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Mcp.Server/Permissions/McpPermissionDefinitionProvider.cs
+++ b/src/Granit.Mcp.Server/Permissions/McpPermissionDefinitionProvider.cs
@@ -19,26 +19,26 @@ internal sealed class McpPermissionDefinitionProvider : IPermissionDefinitionPro
         group.AddPermission(
             McpPermissions.Server.Access,
             LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Server.Access"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             McpPermissions.Tools.Read,
             LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             McpPermissions.Tools.Execute,
             LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             McpPermissions.Resources.Read,
             LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Resources.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             McpPermissions.Prompts.Read,
             LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Prompts.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -243,7 +243,7 @@ internal static class MeterDefinitionEndpoints
         // RFC 8594 deprecation signal — kept for one release as alias for /archive.
         httpContext.Response.Headers["Deprecation"] = "true";
         httpContext.Response.Headers["Sunset"] = "Wed, 31 Dec 2026 23:59:59 GMT";
-        httpContext.Response.Headers["Link"] = "</metering/meters/{id}/archive>; rel=\"successor-version\"";
+        httpContext.Response.Headers.Link = "</metering/meters/{id}/archive>; rel=\"successor-version\"";
 
         return await ArchiveMeterAsync(id, reader, writer, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
+++ b/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
@@ -16,21 +16,21 @@ internal sealed class MeteringPermissionDefinitionProvider : IPermissionDefiniti
 
         group.AddPermission(MeteringPermissions.Meters.Read,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(MeteringPermissions.Meters.Manage,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(MeteringPermissions.Usage.Read,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(MeteringPermissions.Usage.Record,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Record"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(MeteringPermissions.Events.Manage,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Events.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(MeteringPermissions.Events.Backfill,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Events.Backfill"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -37,15 +37,9 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
 
         RouteGroupBuilder tenantsGroup = group.MapGranitGroup("tenants");
 
-        // Note: Tenant listing is handled by Granit.QueryEngine. Consumers should register
-        // a query endpoint at the same prefix as the CRUD endpoints above, e.g.:
-        //   api.MapGranitQuery<Tenant>(
-        //       sp => sp.GetRequiredService<IQueryableSource<Tenant>>().GetQueryable(),
-        //       "multi-tenancy/tenants",
-        //       opts => opts.AuthorizationPolicy = MultiTenancyPermissions.Tenants.Read);
-        //
-        // This keeps Granit.MultiTenancy.Endpoints decoupled from EF Core and the query engine,
-        // while letting consumers customize the queryable source, projections, and authorization.
+        // Tenant listing is intentionally not mapped here — consumers register a Granit.QueryEngine
+        // endpoint at the same prefix to keep Granit.MultiTenancy.Endpoints decoupled from EF Core
+        // and the query engine. See the multi-tenancy module reference docs for the recipe.
         MapGetByIdEndpoint(tenantsGroup);
         MapCreateEndpoint(tenantsGroup);
         MapUpdateEndpoint(tenantsGroup);

--- a/src/Granit.MultiTenancy.Endpoints/Permissions/MultiTenancyPermissionDefinitionProvider.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Permissions/MultiTenancyPermissionDefinitionProvider.cs
@@ -23,24 +23,24 @@ internal sealed class MultiTenancyPermissionDefinitionProvider : IPermissionDefi
             MultiTenancyPermissions.Tenants.Read,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
                 "Permission:MultiTenancy.Tenants.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Create,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
                 "Permission:MultiTenancy.Tenants.Create"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Update,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
                 "Permission:MultiTenancy.Tenants.Update"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Manage,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
                 "Permission:MultiTenancy.Tenants.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
     }
 }

--- a/src/Granit.Notifications.Endpoints/Permissions/NotificationPermissionDefinitionProvider.cs
+++ b/src/Granit.Notifications.Endpoints/Permissions/NotificationPermissionDefinitionProvider.cs
@@ -41,12 +41,12 @@ internal sealed class NotificationPermissionDefinitionProvider : IPermissionDefi
             NotificationPermissions.UserNotifications.Read,
             LocalizableString.Create<NotificationsEndpointsLocalizationResource>(
                 "Permission:Notifications.UserNotifications.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             NotificationPermissions.UserNotifications.Manage,
             LocalizableString.Create<NotificationsEndpointsLocalizationResource>(
                 "Permission:Notifications.UserNotifications.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
+++ b/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
@@ -48,6 +48,7 @@ namespace Granit.Oidc.TokenManagement.Handlers;
 ///   <item>Binds tokens to a per-process DPoP key by default.</item>
 /// </list>
 /// </remarks>
+[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "DelegatingHandler injects orthogonal collaborators (token endpoint, cache, DPoP, http context, tenant, user, options, clock, metrics, logger); no natural domain wrapper.")]
 internal sealed partial class OnBehalfOfTokenHandler(
     ITokenEndpointService tokenEndpointService,
     IConditionalCache tokenCache,

--- a/src/Granit.Oidc.TokenManagement/Options/OnBehalfOfOptionsValidator.cs
+++ b/src/Granit.Oidc.TokenManagement/Options/OnBehalfOfOptionsValidator.cs
@@ -14,29 +14,29 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
 {
     public ValidateOptionsResult Validate(string? name, OnBehalfOfOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
         string prefix = string.IsNullOrEmpty(name) ? "OnBehalfOfOptions" : $"OnBehalfOfOptions[{name}]";
 
         if (string.IsNullOrWhiteSpace(options.Authority))
         {
-            (failures ??= []).Add($"{prefix}.{nameof(options.Authority)} is required.");
+            failures.Add($"{prefix}.{nameof(options.Authority)} is required.");
         }
         else if (!environment.IsDevelopment()
                  && !options.Authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{prefix}.{nameof(options.Authority)} must be https in non-Development environments. " +
                 $"Got '{options.Authority}'.");
         }
 
         if (string.IsNullOrWhiteSpace(options.ClientId))
         {
-            (failures ??= []).Add($"{prefix}.{nameof(options.ClientId)} is required.");
+            failures.Add($"{prefix}.{nameof(options.ClientId)} is required.");
         }
 
         if (string.IsNullOrWhiteSpace(options.Audience))
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{prefix}.{nameof(options.Audience)} is required. Without an audience the " +
                 "exchanged token is not narrowed to the downstream API, defeating the purpose " +
                 "of token exchange (RFC 8693).");
@@ -44,7 +44,7 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
 
         if (options.AllowedHosts is null || options.AllowedHosts.Length == 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{prefix}.{nameof(options.AllowedHosts)} must contain at least one host. " +
                 "Without it the handler has no way to detect attacker-influenced target URLs.");
         }
@@ -56,13 +56,13 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
         switch (options.ClientAuthenticationMethod)
         {
             case ClientAuthenticationMethod.ClientSecretPost when !hasClientSecret:
-                (failures ??= []).Add(
+                failures.Add(
                     $"{prefix}.{nameof(options.ClientSecret)} is required when " +
                     $"{nameof(options.ClientAuthenticationMethod)} = ClientSecretPost.");
                 break;
 
             case ClientAuthenticationMethod.PrivateKeyJwt when !hasSigningKey:
-                (failures ??= []).Add(
+                failures.Add(
                     $"{prefix}.{nameof(options.ClientSigningKeyJwk)} is required when " +
                     $"{nameof(options.ClientAuthenticationMethod)} = PrivateKeyJwt.");
                 break;
@@ -70,11 +70,11 @@ internal sealed class OnBehalfOfOptionsValidator(IHostEnvironment environment)
 
         if (options.TokenLifetimeSafetyMargin < TimeSpan.Zero)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"{prefix}.{nameof(options.TokenLifetimeSafetyMargin)} must be non-negative.");
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.Oidc/Internal/TokenRequestEncoder.cs
+++ b/src/Granit.Oidc/Internal/TokenRequestEncoder.cs
@@ -47,66 +47,7 @@ internal static class TokenRequestEncoder
             [OidcConstants.Parameters.ClientId] = request.ClientId,
         };
 
-        switch (request)
-        {
-            case AuthorizationCodeTokenRequest authCode:
-                parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.AuthorizationCode;
-                parameters[OidcConstants.Parameters.Code] = authCode.Code;
-                parameters[OidcConstants.Parameters.RedirectUri] = authCode.RedirectUri;
-                parameters[OidcConstants.Parameters.CodeVerifier] = authCode.CodeVerifier;
-                break;
-
-            case RefreshTokenRequest refresh:
-                parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.RefreshToken;
-                parameters[OidcConstants.Parameters.RefreshToken] = refresh.RefreshToken;
-                if (refresh.Scope is not null)
-                {
-                    parameters[OidcConstants.Parameters.Scope] = refresh.Scope;
-                }
-
-                break;
-
-            case ClientCredentialsTokenRequest clientCreds:
-                parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.ClientCredentials;
-                if (clientCreds.Scope is not null)
-                {
-                    parameters[OidcConstants.Parameters.Scope] = clientCreds.Scope;
-                }
-
-                break;
-
-            case TokenExchangeTokenRequest exchange:
-                parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.TokenExchange;
-                parameters[OidcConstants.Parameters.SubjectToken] = exchange.SubjectToken;
-                parameters[OidcConstants.Parameters.SubjectTokenType] = exchange.SubjectTokenType;
-                parameters[OidcConstants.Parameters.Audience] = exchange.Audience;
-                if (exchange.Scope is not null)
-                {
-                    parameters[OidcConstants.Parameters.Scope] = exchange.Scope;
-                }
-
-                if (exchange.Resource is not null)
-                {
-                    parameters[OidcConstants.Parameters.Resource] = exchange.Resource;
-                }
-
-                if (exchange.RequestedTokenType is not null)
-                {
-                    parameters[OidcConstants.Parameters.RequestedTokenType] = exchange.RequestedTokenType;
-                }
-
-                if (exchange.ActorToken is not null)
-                {
-                    parameters[OidcConstants.Parameters.ActorToken] = exchange.ActorToken;
-                }
-
-                if (exchange.ActorTokenType is not null)
-                {
-                    parameters[OidcConstants.Parameters.ActorTokenType] = exchange.ActorTokenType;
-                }
-
-                break;
-        }
+        AppendGrantParameters(parameters, request);
 
         foreach (KeyValuePair<string, string> kvp in request.AdditionalParameters)
         {
@@ -114,6 +55,88 @@ internal static class TokenRequestEncoder
         }
 
         return parameters;
+    }
+
+    private static void AppendGrantParameters(Dictionary<string, string> parameters, TokenRequest request)
+    {
+        switch (request)
+        {
+            case AuthorizationCodeTokenRequest authCode:
+                AppendAuthorizationCode(parameters, authCode);
+                break;
+
+            case RefreshTokenRequest refresh:
+                AppendRefreshToken(parameters, refresh);
+                break;
+
+            case ClientCredentialsTokenRequest clientCreds:
+                AppendClientCredentials(parameters, clientCreds);
+                break;
+
+            case TokenExchangeTokenRequest exchange:
+                AppendTokenExchange(parameters, exchange);
+                break;
+        }
+    }
+
+    private static void AppendAuthorizationCode(Dictionary<string, string> parameters, AuthorizationCodeTokenRequest authCode)
+    {
+        parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.AuthorizationCode;
+        parameters[OidcConstants.Parameters.Code] = authCode.Code;
+        parameters[OidcConstants.Parameters.RedirectUri] = authCode.RedirectUri;
+        parameters[OidcConstants.Parameters.CodeVerifier] = authCode.CodeVerifier;
+    }
+
+    private static void AppendRefreshToken(Dictionary<string, string> parameters, RefreshTokenRequest refresh)
+    {
+        parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.RefreshToken;
+        parameters[OidcConstants.Parameters.RefreshToken] = refresh.RefreshToken;
+        if (refresh.Scope is not null)
+        {
+            parameters[OidcConstants.Parameters.Scope] = refresh.Scope;
+        }
+    }
+
+    private static void AppendClientCredentials(Dictionary<string, string> parameters, ClientCredentialsTokenRequest clientCreds)
+    {
+        parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.ClientCredentials;
+        if (clientCreds.Scope is not null)
+        {
+            parameters[OidcConstants.Parameters.Scope] = clientCreds.Scope;
+        }
+    }
+
+    private static void AppendTokenExchange(Dictionary<string, string> parameters, TokenExchangeTokenRequest exchange)
+    {
+        parameters[OidcConstants.Parameters.GrantType] = OidcConstants.GrantTypes.TokenExchange;
+        parameters[OidcConstants.Parameters.SubjectToken] = exchange.SubjectToken;
+        parameters[OidcConstants.Parameters.SubjectTokenType] = exchange.SubjectTokenType;
+        parameters[OidcConstants.Parameters.Audience] = exchange.Audience;
+
+        if (exchange.Scope is not null)
+        {
+            parameters[OidcConstants.Parameters.Scope] = exchange.Scope;
+        }
+
+        if (exchange.Resource is not null)
+        {
+            parameters[OidcConstants.Parameters.Resource] = exchange.Resource;
+        }
+
+        if (exchange.RequestedTokenType is not null)
+        {
+            parameters[OidcConstants.Parameters.RequestedTokenType] = exchange.RequestedTokenType;
+        }
+
+        if (exchange.ActorToken is not null)
+        {
+            parameters[OidcConstants.Parameters.ActorToken] = exchange.ActorToken;
+        }
+
+        if (exchange.ActorTokenType is not null)
+        {
+            parameters[OidcConstants.Parameters.ActorTokenType] = exchange.ActorTokenType;
+        }
     }
 
     /// <summary>

--- a/src/Granit.OpenIddict.Endpoints/Permissions/OpenIddictPermissionDefinitionProvider.cs
+++ b/src/Granit.OpenIddict.Endpoints/Permissions/OpenIddictPermissionDefinitionProvider.cs
@@ -26,17 +26,17 @@ internal sealed class OpenIddictPermissionDefinitionProvider : IPermissionDefini
             OpenIddictPermissions.Applications.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Applications.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(
             OpenIddictPermissions.Applications.Manage,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Applications.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(
             OpenIddictPermissions.Applications.Rotate,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Applications.Rotate"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         // OIDC Scopes — scopes are a global OAuth primitive by spec (RFC 6749 §3.3):
         // they identify capabilities, not resource ownership. Managing them is host-level.
@@ -44,12 +44,12 @@ internal sealed class OpenIddictPermissionDefinitionProvider : IPermissionDefini
             OpenIddictPermissions.Scopes.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Scopes.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
         group.AddPermission(
             OpenIddictPermissions.Scopes.Manage,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Scopes.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         // OIDC Authorizations — live authorizations can belong to a tenant user or a host
         // admin; the permission must be usable in both contexts.
@@ -57,11 +57,11 @@ internal sealed class OpenIddictPermissionDefinitionProvider : IPermissionDefini
             OpenIddictPermissions.Authorizations.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Authorizations.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(
             OpenIddictPermissions.Authorizations.Revoke,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "Permission:OpenIddict.Authorizations.Revoke"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -164,7 +164,7 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                 "offline_access");
 
             // ──── Custom event handlers ────
-            // Enforces the MultiTenancySide policy declared on each OIDC application
+            // Enforces the MultiTenancySides policy declared on each OIDC application
             // at sign-in: host-only clients reject tenant users, tenant-only clients
             // reject host users. See ClientSideAuthorizationHandler for semantics.
             options.AddEventHandler(ClientSideAuthorizationHandler.Descriptor);

--- a/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
@@ -8,7 +8,7 @@ using static OpenIddict.Server.OpenIddictServerEvents;
 namespace Granit.OpenIddict.Server.Handlers;
 
 /// <summary>
-/// OpenIddict server handler that enforces the <see cref="MultiTenancySide"/> policy
+/// OpenIddict server handler that enforces the <see cref="MultiTenancySides"/> policy
 /// declared on an OIDC application. Rejects sign-in when the authenticated user's
 /// tenancy (host or tenant, as carried by the <c>tenant_id</c> claim) does not
 /// match the application's declared side.
@@ -23,11 +23,11 @@ namespace Granit.OpenIddict.Server.Handlers;
 /// Policy semantics:
 /// </para>
 /// <list type="bullet">
-/// <item><description><see cref="MultiTenancySide.Host"/> — only users with
+/// <item><description><see cref="MultiTenancySides.Host"/> — only users with
 /// <c>TenantId = null</c> (no <c>tenant_id</c> claim) may obtain tokens.</description></item>
-/// <item><description><see cref="MultiTenancySide.Tenant"/> — only users with a
+/// <item><description><see cref="MultiTenancySides.Tenant"/> — only users with a
 /// non-empty <c>tenant_id</c> claim may obtain tokens.</description></item>
-/// <item><description><see cref="MultiTenancySide.Both"/> or <see langword="null"/> —
+/// <item><description><see cref="MultiTenancySides.Both"/> or <see langword="null"/> —
 /// no restriction (backward-compatible default).</description></item>
 /// </list>
 /// <para>
@@ -86,18 +86,18 @@ public sealed partial class ClientSideAuthorizationHandler(
             return;
         }
 
-        MultiTenancySide? clientSide = await applicationManager
+        MultiTenancySides? clientSide = await applicationManager
             .GetClientSideAsync(application, context.CancellationToken)
             .ConfigureAwait(false);
 
-        if (clientSide is null || clientSide == MultiTenancySide.Both)
+        if (clientSide is null || clientSide == MultiTenancySides.Both)
         {
             return;
         }
 
         bool userIsTenant = HasTenantIdClaim(context);
 
-        bool policyViolated = clientSide == MultiTenancySide.Host
+        bool policyViolated = clientSide == MultiTenancySides.Host
             ? userIsTenant
             : !userIsTenant;
 

--- a/src/Granit.OpenIddict/Extensions/OpenIddictApplicationClientSideExtensions.cs
+++ b/src/Granit.OpenIddict/Extensions/OpenIddictApplicationClientSideExtensions.cs
@@ -5,7 +5,7 @@ using OpenIddict.Abstractions;
 namespace Granit.OpenIddict.Extensions;
 
 /// <summary>
-/// Read/write helpers for the <see cref="MultiTenancySide"/> policy persisted on an
+/// Read/write helpers for the <see cref="MultiTenancySides"/> policy persisted on an
 /// OpenIddict application via its <c>Properties</c> dictionary. Used by seeding and
 /// by the OIDC server pipeline to enforce host/tenant isolation at sign-in.
 /// </summary>
@@ -43,7 +43,7 @@ public static class OpenIddictApplicationClientSideExtensions
     /// </summary>
     public static void SetClientSide(
         this OpenIddictApplicationDescriptor descriptor,
-        MultiTenancySide? clientSide)
+        MultiTenancySides? clientSide)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
 
@@ -61,9 +61,9 @@ public static class OpenIddictApplicationClientSideExtensions
     /// Reads the client-side policy from the descriptor's
     /// <see cref="OpenIddictApplicationDescriptor.Properties"/>, or
     /// <see langword="null"/> when the key is absent or its value is not a recognised
-    /// <see cref="MultiTenancySide"/> member.
+    /// <see cref="MultiTenancySides"/> member.
     /// </summary>
-    public static MultiTenancySide? GetClientSide(this OpenIddictApplicationDescriptor descriptor)
+    public static MultiTenancySides? GetClientSide(this OpenIddictApplicationDescriptor descriptor)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
 
@@ -78,9 +78,9 @@ public static class OpenIddictApplicationClientSideExtensions
     /// <summary>
     /// Reads the client-side policy from an application record via the OpenIddict
     /// application manager. Returns <see langword="null"/> when the key is absent
-    /// or its value is not a recognised <see cref="MultiTenancySide"/> member.
+    /// or its value is not a recognised <see cref="MultiTenancySides"/> member.
     /// </summary>
-    public static async ValueTask<MultiTenancySide?> GetClientSideAsync(
+    public static async ValueTask<MultiTenancySides?> GetClientSideAsync(
         this IOpenIddictApplicationManager applicationManager,
         object application,
         CancellationToken cancellationToken = default)
@@ -97,7 +97,7 @@ public static class OpenIddictApplicationClientSideExtensions
             : null;
     }
 
-    private static MultiTenancySide? ParseClientSide(JsonElement element)
+    private static MultiTenancySides? ParseClientSide(JsonElement element)
     {
         if (element.ValueKind != JsonValueKind.String)
         {
@@ -105,7 +105,7 @@ public static class OpenIddictApplicationClientSideExtensions
         }
 
         string? raw = element.GetString();
-        return Enum.TryParse(raw, ignoreCase: false, out MultiTenancySide value)
+        return Enum.TryParse(raw, ignoreCase: false, out MultiTenancySides value)
             && Enum.IsDefined(value)
             ? value
             : null;

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -32,7 +32,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="PostLogoutRedirectUris">Allowed post-logout redirect URIs.</param>
 /// <param name="SigningKeyJwk">Optional public signing key as JWK JSON for <c>private_key_jwt</c> client authentication (RFC 7523). When set, the client authenticates with a signed JWT assertion instead of a shared secret.</param>
 /// <param name="ConsentType">The consent type for the application (<c>"implicit"</c>, <c>"explicit"</c>, or <c>"systematic"</c>). Default: <c>"implicit"</c> (auto-grant for first-party apps).</param>
-/// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySide.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySide.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySide.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
+/// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySides.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySides.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySides.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
     string? ClientSecret,
@@ -42,7 +42,7 @@ public sealed record OidcApplicationSeedDescriptor(
     string[] PostLogoutRedirectUris,
     string? SigningKeyJwk = null,
     string? ConsentType = null,
-    MultiTenancySide? ClientSide = null);
+    MultiTenancySides? ClientSide = null);
 
 /// <summary>
 /// Describes an OIDC scope to seed.

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
@@ -186,6 +187,7 @@ internal static class PaymentMethodConfigurationEndpoints
     // POST /{provider}/{method}/activate
     // -------------------------------------------------------------------------
 
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/route parameters explicitly; collaborators are orthogonal.")]
     private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ActivateAsync(
         string providerName,
         string methodType,
@@ -240,6 +242,7 @@ internal static class PaymentMethodConfigurationEndpoints
     // POST /{provider}/{method}/deactivate
     // -------------------------------------------------------------------------
 
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/route parameters explicitly; collaborators are orthogonal.")]
     private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> DeactivateAsync(
         string providerName,
         string methodType,
@@ -295,6 +298,7 @@ internal static class PaymentMethodConfigurationEndpoints
     // POST /{provider}/{method}/resync
     // -------------------------------------------------------------------------
 
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/route parameters explicitly; collaborators are orthogonal.")]
     private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ResyncAsync(
         string providerName,
         string methodType,

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
@@ -95,6 +96,7 @@ internal static class PaymentMethodEndpoints
         return TypedResults.Ok(response);
     }
 
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/[FromQuery] parameters explicitly.")]
     private static async Task<Results<Ok<IReadOnlyList<PaymentAvailableMethodResponse>>, ProblemHttpResult>> GetAvailableAsync(
         [FromServices] IPaymentProviderResolver resolver,
         [FromServices] ICurrentTenant currentTenant,

--- a/src/Granit.Payments.Endpoints/Internal/PaymentAvailabilityContextParser.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentAvailabilityContextParser.cs
@@ -59,18 +59,18 @@ internal static partial class PaymentAvailabilityContextParser
             return null;
         }
 
-        PaymentMethodSequenceType sequence = PaymentMethodSequenceType.OneOff;
+        PaymentMethodSequenceTypes sequence = PaymentMethodSequenceTypes.OneOff;
         if (!string.IsNullOrWhiteSpace(sequenceType))
         {
             sequence = sequenceType.Trim().ToLowerInvariant() switch
             {
-                "oneoff" => PaymentMethodSequenceType.OneOff,
-                "first" => PaymentMethodSequenceType.First,
-                "recurring" => PaymentMethodSequenceType.Recurring,
-                _ => PaymentMethodSequenceType.None,
+                "oneoff" => PaymentMethodSequenceTypes.OneOff,
+                "first" => PaymentMethodSequenceTypes.First,
+                "recurring" => PaymentMethodSequenceTypes.Recurring,
+                _ => PaymentMethodSequenceTypes.None,
             };
 
-            if (sequence == PaymentMethodSequenceType.None)
+            if (sequence == PaymentMethodSequenceTypes.None)
             {
                 error = $"'{sequenceType}' is not a valid sequence type (expected: oneoff, first, recurring).";
                 return null;

--- a/src/Granit.Payments.Endpoints/Internal/PaymentMethodCapabilityMapper.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentMethodCapabilityMapper.cs
@@ -30,21 +30,21 @@ internal static class PaymentMethodCapabilityMapper
     public static PaymentMethodCapabilityResponse? ToResponseOrNull(PaymentMethodCapability? capability) =>
         capability is null ? null : ToResponse(capability);
 
-    private static List<string> FlagsToNames(PaymentMethodSequenceType flags)
+    private static List<string> FlagsToNames(PaymentMethodSequenceTypes flags)
     {
         List<string> names = new(3);
 
-        if (flags.HasFlag(PaymentMethodSequenceType.OneOff))
+        if (flags.HasFlag(PaymentMethodSequenceTypes.OneOff))
         {
             names.Add("oneoff");
         }
 
-        if (flags.HasFlag(PaymentMethodSequenceType.First))
+        if (flags.HasFlag(PaymentMethodSequenceTypes.First))
         {
             names.Add("first");
         }
 
-        if (flags.HasFlag(PaymentMethodSequenceType.Recurring))
+        if (flags.HasFlag(PaymentMethodSequenceTypes.Recurring))
         {
             names.Add("recurring");
         }

--- a/src/Granit.Payments.Endpoints/Internal/PaymentMethodLabelResolver.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentMethodLabelResolver.cs
@@ -26,7 +26,7 @@ internal static class PaymentMethodLabelResolver
     /// <example><c>sepa_debit</c> → <c>Sepa Debit</c>; <c>klarna_pay_later</c> → <c>Klarna Pay Later</c>.</example>
     private static string ToTitleCase(string snakeOrKebab) =>
         string.Join(' ', snakeOrKebab
-            .Split(['_', '-'])
+            .Split('_', '-')
             .Select(word => word.Length == 0
                 ? word
                 : char.ToUpperInvariant(word[0]) + word[1..]));

--- a/src/Granit.Payments.Endpoints/Permissions/PaymentsPermissionDefinitionProvider.cs
+++ b/src/Granit.Payments.Endpoints/Permissions/PaymentsPermissionDefinitionProvider.cs
@@ -19,21 +19,21 @@ internal sealed class PaymentsPermissionDefinitionProvider : IPermissionDefiniti
         // merchant flow can tighten these to Tenant in their own provider.
         group.AddPermission(PaymentsPermissions.Transactions.Read,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Transactions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(PaymentsPermissions.Charges.Execute,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Charges.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(PaymentsPermissions.Refunds.Execute,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Refunds.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(PaymentsPermissions.Methods.Read,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(PaymentsPermissions.Methods.Manage,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(PaymentsPermissions.Configuration.Manage,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Configuration.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Payments.Mollie/Internal/MollieCatalog.cs
+++ b/src/Granit.Payments.Mollie/Internal/MollieCatalog.cs
@@ -31,8 +31,8 @@ internal static class MollieCatalog
     private static readonly ImmutableHashSet<string> Global =
         ImmutableHashSet<string>.Empty;
 
-    private const PaymentMethodSequenceType AllSequences =
-        PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring;
+    private const PaymentMethodSequenceTypes AllSequences =
+        PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring;
 
     /// <summary>Ordered catalog entries covering Mollie's European surface.</summary>
     public static IReadOnlyList<PaymentMethodCatalogEntry> Entries { get; } =
@@ -43,46 +43,46 @@ internal static class MollieCatalog
         // Bank redirects — typically OneOff | First (mandate setup possible), per-country
         new(PaymentMethods.Bancontact, PaymentMethodCategory.BankRedirect, "Bancontact",
             new(Set("BE"), PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First, NoBounds)),
 
         new(PaymentMethods.Ideal, PaymentMethodCategory.BankRedirect, "iDEAL",
             new(Set("NL"), PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First, NoBounds)),
 
         new(PaymentMethods.Eps, PaymentMethodCategory.BankRedirect, "EPS",
-            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Giropay, PaymentMethodCategory.BankRedirect, "Giropay",
-            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Przelewy24, PaymentMethodCategory.BankRedirect, "Przelewy24",
-            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Twint, PaymentMethodCategory.BankRedirect, "TWINT",
-            new(Set("CH"), Set("CHF"), PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("CH"), Set("CHF"), PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Trustly, PaymentMethodCategory.BankRedirect, "Trustly",
             new(Set("SE", "FI", "EE", "LV", "LT", "DK", "NO", "GB"), GlobalCurrencies,
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.MyBank, PaymentMethodCategory.BankRedirect, "MyBank",
-            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Belfius, PaymentMethodCategory.BankRedirect, "Belfius Pay Button",
-            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Kbc, PaymentMethodCategory.BankRedirect, "KBC/CBC Payment Button",
-            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         // Bank transfer — SEPA zone, EUR, OneOff
         new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "Bank transfer",
             new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         // SEPA Direct Debit — mandate-based, First | Recurring
         new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit",
             new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, NoBounds)),
+                PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring, NoBounds)),
 
         // Wallets — global
         new(PaymentMethods.ApplePay, PaymentMethodCategory.Wallet, "Apple Pay",
@@ -96,7 +96,7 @@ internal static class MollieCatalog
             new(
                 Set("AT", "BE", "CH", "CZ", "DE", "DK", "ES", "FI", "FR", "GB", "IE", "IT", "NL", "NO", "PL", "PT", "SE", "US"),
                 Set("EUR", "GBP", "SEK", "DKK", "NOK", "CHF", "USD"),
-                PaymentMethodSequenceType.OneOff,
+                PaymentMethodSequenceTypes.OneOff,
                 Bounds(
                     ("EUR", 1m, 10_000m),
                     ("GBP", 1m, 10_000m),
@@ -110,14 +110,14 @@ internal static class MollieCatalog
             new(
                 Set("AT", "CH", "DE", "NL"),
                 Set("EUR", "CHF"),
-                PaymentMethodSequenceType.OneOff,
+                PaymentMethodSequenceTypes.OneOff,
                 Bounds(
                     ("EUR", 5m, 1_500m),
                     ("CHF", 5m, 1_500m)))),
 
         // Vouchers — country-specific
         new(PaymentMethods.Paysafecard, PaymentMethodCategory.Voucher, "Paysafecard",
-            new(Global, Set("EUR", "USD"), PaymentMethodSequenceType.OneOff,
+            new(Global, Set("EUR", "USD"), PaymentMethodSequenceTypes.OneOff,
                 Bounds(("EUR", 1m, 1_000m), ("USD", 1m, 1_000m)))),
     ];
 

--- a/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
@@ -35,7 +35,7 @@ internal sealed partial class SepaDirectDebitPaymentProvider(
                 Capability: new PaymentMethodCapability(
                     SupportedCountries: PaymentMethodCountries.SepaZone,
                     SupportedCurrencies: PaymentMethodCurrencies.EurOnly,
-                    SupportedSequenceTypes: PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+                    SupportedSequenceTypes: PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring,
                     AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)),
         ];
         return Task.FromResult(catalog);

--- a/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
+++ b/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
@@ -40,7 +40,7 @@ internal sealed partial class SepaTransferPaymentProvider(
                 Capability: new PaymentMethodCapability(
                     SupportedCountries: PaymentMethodCountries.SepaZone,
                     SupportedCurrencies: PaymentMethodCurrencies.EurOnly,
-                    SupportedSequenceTypes: PaymentMethodSequenceType.OneOff,
+                    SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff,
                     AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)),
         ];
         return Task.FromResult(catalog);

--- a/src/Granit.Payments.Stripe/Internal/StripeCatalog.cs
+++ b/src/Granit.Payments.Stripe/Internal/StripeCatalog.cs
@@ -28,8 +28,8 @@ internal static class StripeCatalog
     private static readonly ImmutableHashSet<string> GlobalCurrencies = ImmutableHashSet<string>.Empty;
     private static readonly ImmutableHashSet<string> Global = ImmutableHashSet<string>.Empty;
 
-    private const PaymentMethodSequenceType AllSequences =
-        PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring;
+    private const PaymentMethodSequenceTypes AllSequences =
+        PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring;
 
     /// <summary>Ordered catalog covering Stripe's European surface.</summary>
     public static IReadOnlyList<PaymentMethodCatalogEntry> Entries { get; } =
@@ -39,41 +39,41 @@ internal static class StripeCatalog
 
         new(PaymentMethods.Bancontact, PaymentMethodCategory.BankRedirect, "Bancontact",
             new(Set("BE"), PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First, NoBounds)),
 
         new(PaymentMethods.Ideal, PaymentMethodCategory.BankRedirect, "iDEAL",
             new(Set("NL"), PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First, NoBounds)),
 
         new(PaymentMethods.Eps, PaymentMethodCategory.BankRedirect, "EPS",
-            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Giropay, PaymentMethodCategory.BankRedirect, "Giropay",
-            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Przelewy24, PaymentMethodCategory.BankRedirect, "Przelewy24",
-            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Blik, PaymentMethodCategory.BankRedirect, "BLIK",
-            new(Set("PL"), Set("PLN"), PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("PL"), Set("PLN"), PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Twint, PaymentMethodCategory.BankRedirect, "TWINT",
-            new(Set("CH"), Set("CHF"), PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("CH"), Set("CHF"), PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Trustly, PaymentMethodCategory.BankRedirect, "Trustly",
             new(Set("SE", "FI", "EE", "LV", "LT", "DK", "NO", "GB"), GlobalCurrencies,
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.MyBank, PaymentMethodCategory.BankRedirect, "MyBank",
-            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "Bank transfer",
             new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit",
             new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
-                PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, NoBounds)),
+                PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring, NoBounds)),
 
         new(PaymentMethods.ApplePay, PaymentMethodCategory.Wallet, "Apple Pay",
             new(Global, GlobalCurrencies, AllSequences, NoBounds)),
@@ -86,17 +86,17 @@ internal static class StripeCatalog
 
         new(PaymentMethods.Alipay, PaymentMethodCategory.Wallet, "Alipay",
             new(Set("CN", "HK", "SG"), Set("CNY", "USD", "EUR", "GBP", "HKD", "SGD"),
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.WechatPay, PaymentMethodCategory.Wallet, "WeChat Pay",
             new(Set("CN", "HK"), Set("CNY", "USD", "EUR", "GBP", "HKD"),
-                PaymentMethodSequenceType.OneOff, NoBounds)),
+                PaymentMethodSequenceTypes.OneOff, NoBounds)),
 
         new(PaymentMethods.Klarna, PaymentMethodCategory.BuyNowPayLater, "Klarna",
             new(
                 Set("AT", "BE", "CH", "CZ", "DE", "DK", "ES", "FI", "FR", "GB", "IE", "IT", "NL", "NO", "PL", "PT", "SE", "US"),
                 Set("EUR", "GBP", "SEK", "DKK", "NOK", "CHF", "USD"),
-                PaymentMethodSequenceType.OneOff,
+                PaymentMethodSequenceTypes.OneOff,
                 Bounds(
                     ("EUR", 1m, 10_000m),
                     ("GBP", 1m, 10_000m),
@@ -110,7 +110,7 @@ internal static class StripeCatalog
             new(
                 Set("AT", "CH", "DE", "NL"),
                 Set("EUR", "CHF"),
-                PaymentMethodSequenceType.OneOff,
+                PaymentMethodSequenceTypes.OneOff,
                 Bounds(
                     ("EUR", 5m, 1_500m),
                     ("CHF", 5m, 1_500m)))),

--- a/src/Granit.Payments/Contracts/PaymentAvailabilityContext.cs
+++ b/src/Granit.Payments/Contracts/PaymentAvailabilityContext.cs
@@ -16,4 +16,4 @@ public sealed record PaymentAvailabilityContext(
     string? CountryCode,
     string? CurrencyCode,
     decimal? Amount,
-    PaymentMethodSequenceType SequenceType = PaymentMethodSequenceType.OneOff);
+    PaymentMethodSequenceTypes SequenceType = PaymentMethodSequenceTypes.OneOff);

--- a/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
+++ b/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
@@ -18,7 +18,7 @@ namespace Granit.Payments.Contracts;
 public sealed record PaymentMethodCapability(
     IReadOnlySet<string> SupportedCountries,
     IReadOnlySet<string> SupportedCurrencies,
-    PaymentMethodSequenceType SupportedSequenceTypes,
+    PaymentMethodSequenceTypes SupportedSequenceTypes,
     IReadOnlyDictionary<string, PaymentMethodAmountBound> AmountBounds)
 {
     /// <summary>
@@ -28,8 +28,8 @@ public sealed record PaymentMethodCapability(
     public static PaymentMethodCapability Wildcard { get; } = new(
         SupportedCountries: ImmutableHashSet<string>.Empty,
         SupportedCurrencies: ImmutableHashSet<string>.Empty,
-        SupportedSequenceTypes: PaymentMethodSequenceType.OneOff
-            | PaymentMethodSequenceType.First
-            | PaymentMethodSequenceType.Recurring,
+        SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff
+            | PaymentMethodSequenceTypes.First
+            | PaymentMethodSequenceTypes.Recurring,
         AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
 }

--- a/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
@@ -67,7 +67,7 @@ public sealed class PaymentMethodConfiguration : AuditedEntity, IActive
     /// Snapshot of the sequence modes supported by the provider for this method.
     /// <see langword="null"/> when no snapshot has been captured yet.
     /// </summary>
-    public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; }
+    public PaymentMethodSequenceTypes? SupportedSequenceTypes { get; private set; }
 
     /// <summary>
     /// Snapshot of the per-currency amount bounds declared by the provider for this method.

--- a/src/Granit.Payments/Domain/PaymentMethodSequenceTypes.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodSequenceTypes.cs
@@ -11,7 +11,7 @@ namespace Granit.Payments.Domain;
 /// subsequent charges) — the filter does not infer this sequencing.
 /// </remarks>
 [Flags]
-public enum PaymentMethodSequenceType
+public enum PaymentMethodSequenceTypes
 {
     /// <summary>No sequence declared. Invalid on a capability; used only as a sentinel.</summary>
     None = 0,

--- a/src/Granit.Payments/Internal/DefaultPaymentMethodAvailabilityFilter.cs
+++ b/src/Granit.Payments/Internal/DefaultPaymentMethodAvailabilityFilter.cs
@@ -14,8 +14,8 @@ namespace Granit.Payments.Internal;
 /// <para>
 /// Sequence type matching uses a bitwise containment test:
 /// <c>(capability.SupportedSequenceTypes &amp; context.SequenceType) == context.SequenceType</c>.
-/// A caller requesting <see cref="PaymentMethodSequenceType.Recurring"/> against a method
-/// that supports only <see cref="PaymentMethodSequenceType.OneOff"/> is rejected; the filter
+/// A caller requesting <see cref="PaymentMethodSequenceTypes.Recurring"/> against a method
+/// that supports only <see cref="PaymentMethodSequenceTypes.OneOff"/> is rejected; the filter
 /// does not infer mandate-setup chains.
 /// </para>
 /// </remarks>
@@ -40,7 +40,7 @@ internal sealed class DefaultPaymentMethodAvailabilityFilter : IPaymentMethodAva
             return false;
         }
 
-        if (context.SequenceType != PaymentMethodSequenceType.None
+        if (context.SequenceType != PaymentMethodSequenceTypes.None
             && (capability.SupportedSequenceTypes & context.SequenceType) != context.SequenceType)
         {
             return false;

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationBatchExecutor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationBatchExecutor.cs
@@ -24,7 +24,7 @@ internal sealed partial class MigrationBatchExecutor(
     /// </summary>
     public async Task<RunMigrationBatchCommand?> ExecuteBatchAsync(
         RunMigrationBatchCommand command,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         MigrationCycleRegistration? registration = registry.Find(command.CycleId);
         if (registration is null)

--- a/src/Granit.Privacy.BlobStorage/DataExport/Exceptions/PrivacyExportSizeLimitExceededException.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Exceptions/PrivacyExportSizeLimitExceededException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Privacy.BlobStorage.DataExport;
+namespace Granit.Privacy.BlobStorage.DataExport.Exceptions;
 
 /// <summary>
 /// Raised by the streaming archive assembler when a privacy export write exceeds the

--- a/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Granit.BlobStorage;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Options;
+using Granit.Privacy.BlobStorage.DataExport.Exceptions;
 using Granit.Privacy.BlobStorage.DataExport.Internal;
 using Granit.Privacy.DataExport;
 using Granit.Privacy.DataExport.Events;

--- a/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
@@ -1,3 +1,5 @@
+using Granit.Privacy.BlobStorage.DataExport.Exceptions;
+
 namespace Granit.Privacy.BlobStorage.DataExport.Internal;
 
 /// <summary>

--- a/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/Internal/CountingStream.cs
@@ -92,15 +92,3 @@ internal sealed class CountingStream(Stream inner, long maxBytes) : Stream
     }
 }
 
-/// <summary>
-/// Raised by <see cref="CountingStream"/> when the archive write exceeds the configured cap.
-/// Caught by the archive assembler to transition the request to
-/// <see cref="Granit.Privacy.DataExport.ExportRequestState.SizeLimitExceeded"/>.
-/// </summary>
-public sealed class PrivacyExportSizeLimitExceededException(long maxBytes, long observedBytes)
-    : Exception($"Export archive exceeded the configured size limit of {maxBytes} bytes (observed {observedBytes}).")
-{
-    public long MaxBytes { get; } = maxBytes;
-
-    public long ObservedBytes { get; } = observedBytes;
-}

--- a/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportSizeLimitExceededException.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/PrivacyExportSizeLimitExceededException.cs
@@ -1,0 +1,14 @@
+namespace Granit.Privacy.BlobStorage.DataExport;
+
+/// <summary>
+/// Raised by the streaming archive assembler when a privacy export write exceeds the
+/// configured cap (<c>GranitPrivacyOptions.ExportMaxSizeMb</c>). Caught by the assembler
+/// to transition the request to <c>ExportRequestState.SizeLimitExceeded</c>.
+/// </summary>
+public sealed class PrivacyExportSizeLimitExceededException(long maxBytes, long observedBytes)
+    : Exception($"Export archive exceeded the configured size limit of {maxBytes} bytes (observed {observedBytes}).")
+{
+    public long MaxBytes { get; } = maxBytes;
+
+    public long ObservedBytes { get; } = observedBytes;
+}

--- a/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
@@ -23,30 +23,30 @@ internal sealed class PrivacyPermissionDefinitionProvider : IPermissionDefinitio
             PrivacyPermissions.Export.Execute,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
                 "Permission:Privacy.Export.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             PrivacyPermissions.Deletion.Execute,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
                 "Permission:Privacy.Deletion.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             PrivacyPermissions.Purposes.Read,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
                 "Permission:Privacy.Purposes.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             PrivacyPermissions.Agreements.Read,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
                 "Permission:Privacy.Agreements.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             PrivacyPermissions.Agreements.Create,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
                 "Permission:Privacy.Agreements.Create"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Granit.QueryEngine.AspNetCore.Dtos;
@@ -67,6 +68,7 @@ public static class QueryEndpointRouteBuilderExtensions
     ///   <item><c>POST /saved-views/{id}/set-default</c> — set default saved view</item>
     /// </list>
     /// </remarks>
+    [SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields", Justification = "Setup-time reflection over an internal helper to dispatch to a generic projection-typed overload; private accessor used precisely so consumers cannot bypass the public API.")]
     public static RouteGroupBuilder MapGranitQuery<TEntity>(
         this IEndpointRouteBuilder endpoints,
         Func<IServiceProvider, IQueryable<TEntity>> sourceProvider,

--- a/src/Granit.ReferenceData.Endpoints/Permissions/ReferenceDataPermissionDefinitionProvider.cs
+++ b/src/Granit.ReferenceData.Endpoints/Permissions/ReferenceDataPermissionDefinitionProvider.cs
@@ -27,12 +27,12 @@ internal sealed class ReferenceDataPermissionDefinitionProvider : IPermissionDef
             ReferenceDataPermissions.Entries.Read,
             LocalizableString.Create<ReferenceDataEndpointsLocalizationResource>(
                 "Permission:ReferenceData.Entries.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             ReferenceDataPermissions.Entries.Manage,
             LocalizableString.Create<ReferenceDataEndpointsLocalizationResource>(
                 "Permission:ReferenceData.Entries.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Scheduling.Endpoints/Permissions/SchedulingPermissionDefinitionProvider.cs
+++ b/src/Granit.Scheduling.Endpoints/Permissions/SchedulingPermissionDefinitionProvider.cs
@@ -23,12 +23,12 @@ internal sealed class SchedulingPermissionDefinitionProvider : IPermissionDefini
             SchedulingPermissions.Actions.Read,
             LocalizableString.Create<SchedulingEndpointsLocalizationResource>(
                 "Permission:Scheduling.Actions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             SchedulingPermissions.Actions.Manage,
             LocalizableString.Create<SchedulingEndpointsLocalizationResource>(
                 "Permission:Scheduling.Actions.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
+++ b/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
@@ -24,25 +24,25 @@ internal sealed class SettingsPermissionDefinitionProvider : IPermissionDefiniti
             SettingsPermissions.Global.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Global.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         group.AddPermission(
             SettingsPermissions.Global.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Global.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         // Tenant settings are only meaningful inside a tenant context.
         group.AddPermission(
             SettingsPermissions.Tenant.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Tenant.Read"),
-            MultiTenancySide.Tenant);
+            MultiTenancySides.Tenant);
 
         group.AddPermission(
             SettingsPermissions.Tenant.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Tenant.Manage"),
-            MultiTenancySide.Tenant);
+            MultiTenancySides.Tenant);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -17,30 +17,30 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
         // Plans and Prices are the SaaS catalog: they are authored at the host level only.
         group.AddPermission(SubscriptionsPermissions.Plans.Read,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
         group.AddPermission(SubscriptionsPermissions.Plans.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
         group.AddPermission(SubscriptionsPermissions.Prices.Read,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Read"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
         group.AddPermission(SubscriptionsPermissions.Prices.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Manage"),
-            MultiTenancySide.Host);
+            MultiTenancySides.Host);
 
         // Subscriptions and Seats: the host provisions and adjusts tenant subscriptions,
         // and each tenant also needs to see/manage its own plan and seats. Both-sided.
         group.AddPermission(SubscriptionsPermissions.Subscriptions.Read,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(SubscriptionsPermissions.Subscriptions.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(SubscriptionsPermissions.Seats.Read,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(SubscriptionsPermissions.Seats.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Tax.Endpoints/Permissions/TaxPermissionDefinitionProvider.cs
+++ b/src/Granit.Tax.Endpoints/Permissions/TaxPermissionDefinitionProvider.cs
@@ -17,15 +17,15 @@ internal sealed class TaxPermissionDefinitionProvider : IPermissionDefinitionPro
         // tenant's own billing flow (tenant). Validations run from either context.
         group.AddPermission(TaxPermissions.Rates.Read,
             LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(TaxPermissions.Rates.Manage,
             LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(TaxPermissions.Validations.Read,
             LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
         group.AddPermission(TaxPermissions.Validations.Execute,
             LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Templating.Endpoints/Permissions/TemplatingPermissionDefinitionProvider.cs
+++ b/src/Granit.Templating.Endpoints/Permissions/TemplatingPermissionDefinitionProvider.cs
@@ -25,24 +25,24 @@ internal sealed class TemplatingPermissionDefinitionProvider : IPermissionDefini
             TemplatingPermissions.Templates.Read,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
                 "Permission:Templating.Templates.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TemplatingPermissions.Templates.Manage,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
                 "Permission:Templating.Templates.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TemplatingPermissions.Categories.Read,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
                 "Permission:Templating.Categories.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TemplatingPermissions.Categories.Manage,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
                 "Permission:Templating.Categories.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
+++ b/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
@@ -22,30 +22,30 @@ internal sealed class TimelinePermissionDefinitionProvider : IPermissionDefiniti
             TimelinePermissions.Entries.Read,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.Entries.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TimelinePermissions.Entries.Create,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.Entries.Create"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TimelinePermissions.Entries.Manage,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.Entries.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TimelinePermissions.InternalNotes.Read,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.InternalNotes.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             TimelinePermissions.Followers.Manage,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.Followers.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissionDefinitionProvider.cs
+++ b/src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissionDefinitionProvider.cs
@@ -41,12 +41,12 @@ internal sealed class WebhooksPermissionDefinitionProvider : IPermissionDefiniti
             WebhooksPermissions.Subscriptions.Read,
             LocalizableString.Create<WebhooksEndpointsLocalizationResource>(
                 "Permission:Webhooks.Subscriptions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             WebhooksPermissions.Subscriptions.Manage,
             LocalizableString.Create<WebhooksEndpointsLocalizationResource>(
                 "Permission:Webhooks.Subscriptions.Manage"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissionDefinitionProvider.cs
+++ b/src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissionDefinitionProvider.cs
@@ -27,18 +27,18 @@ internal sealed class WorkflowPermissionDefinitionProvider : IPermissionDefiniti
             WorkflowPermissions.History.Read,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
                 "Permission:Workflow.History.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             WorkflowPermissions.Transitions.Read,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
                 "Permission:Workflow.Transitions.Read"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
 
         group.AddPermission(
             WorkflowPermissions.Transitions.Execute,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
                 "Permission:Workflow.Transitions.Execute"),
-            MultiTenancySide.Both);
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit/Extensions/GranitHostBuilderExtensions.cs
+++ b/src/Granit/Extensions/GranitHostBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using Granit.Json;
@@ -159,8 +160,10 @@ public static class GranitHostBuilderExtensions
     }
 
     /// <summary>
-    /// Marker type to prevent duplicate JSON converter registration.
+    /// Marker type to prevent duplicate JSON converter registration. Intentionally empty —
+    /// presence in DI signals that <c>AddGranit</c> already configured JSON defaults.
     /// </summary>
+    [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Marker type — used as a DI registration sentinel to detect duplicate AddGranit calls; an interface would expose a useless contract.")]
     private sealed record GranitJsonDefaultsMarker;
 
     private static IReadOnlyList<Assembly> GetDistinctModuleAssemblies(

--- a/src/Granit/MultiTenancy/MultiTenancySides.cs
+++ b/src/Granit/MultiTenancy/MultiTenancySides.cs
@@ -21,7 +21,7 @@ namespace Granit.MultiTenancy;
 /// </para>
 /// </remarks>
 [Flags]
-public enum MultiTenancySide
+public enum MultiTenancySides
 {
     /// <summary>Applicable only when no tenant context is active (host-level admin, cross-tenant operations).</summary>
     Host = 1 << 0,

--- a/tests/Granit.Authorization.Endpoints.Tests/DtoTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/DtoTests.cs
@@ -33,20 +33,20 @@ public sealed class DtoTests
     [Fact]
     public void PermissionDefinitionResponse_SetsAllProperties()
     {
-        PermissionDefinitionResponse response = new("Invoices.Read", "Read invoices", MultiTenancySide.Tenant);
+        PermissionDefinitionResponse response = new("Invoices.Read", "Read invoices", MultiTenancySides.Tenant);
 
         response.Name.ShouldBe("Invoices.Read");
         response.DisplayName.ShouldBe("Read invoices");
-        response.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        response.MultiTenancySides.ShouldBe(MultiTenancySides.Tenant);
     }
 
     [Fact]
     public void PermissionDefinitionResponse_NullDisplayName_IsValid()
     {
-        PermissionDefinitionResponse response = new("Invoices.Read", null, MultiTenancySide.Both);
+        PermissionDefinitionResponse response = new("Invoices.Read", null, MultiTenancySides.Both);
 
         response.DisplayName.ShouldBeNull();
-        response.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        response.MultiTenancySides.ShouldBe(MultiTenancySides.Both);
     }
 
     // ── PermissionGroupResponse ────────────────────────────────────────────
@@ -56,8 +56,8 @@ public sealed class DtoTests
     {
         List<PermissionDefinitionResponse> permissions =
         [
-            new("Invoices.Read", "Read invoices", MultiTenancySide.Tenant),
-            new("Invoices.Create", "Create invoices", MultiTenancySide.Tenant)
+            new("Invoices.Read", "Read invoices", MultiTenancySides.Tenant),
+            new("Invoices.Create", "Create invoices", MultiTenancySides.Tenant)
         ];
 
         PermissionGroupResponse response = new("Invoices", "Invoice Management", permissions);

--- a/tests/Granit.Authorization.Endpoints.Tests/PermissionGrantEndpointsVisibilityTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/PermissionGrantEndpointsVisibilityTests.cs
@@ -57,14 +57,14 @@ public sealed class PermissionGrantEndpointsVisibilityTests
     // ─────────────────────────────────────────────────────────────────────
 
     [Theory]
-    [InlineData(MultiTenancySide.Host)]
-    [InlineData(MultiTenancySide.Both)]
-    [InlineData(MultiTenancySide.Tenant)]
-    public async Task HostContext_AnyRoleSide_ReturnsTrue(MultiTenancySide side)
+    [InlineData(MultiTenancySides.Host)]
+    [InlineData(MultiTenancySides.Both)]
+    [InlineData(MultiTenancySides.Tenant)]
+    public async Task HostContext_AnyRoleSide_ReturnsTrue(MultiTenancySides side)
     {
         _currentTenant.IsAvailable.Returns(false);
 
-        Guid? tenantIdForTenantSide = side == MultiTenancySide.Tenant ? Guid.NewGuid() : null;
+        Guid? tenantIdForTenantSide = side == MultiTenancySides.Tenant ? Guid.NewGuid() : null;
         var role = RoleMetadata.Create(
             Guid.NewGuid(), "X", side, tenantIdForTenantSide);
         _store.FindByNameAsync("X", (Guid?)null, null, Arg.Any<CancellationToken>())
@@ -87,7 +87,7 @@ public sealed class PermissionGrantEndpointsVisibilityTests
         _currentTenant.Id.Returns(Guid.NewGuid());
 
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySides.Host, tenantId: null);
         // Tenant-scope lookup returns null (no tenant row), host-scope returns the host role.
         _store.FindByNameAsync("SuperAdmin", _currentTenant.Id, null, Arg.Any<CancellationToken>())
             .Returns((RoleMetadata?)null);
@@ -107,7 +107,7 @@ public sealed class PermissionGrantEndpointsVisibilityTests
         _currentTenant.Id.Returns(Guid.NewGuid());
 
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "User", MultiTenancySides.Both, tenantId: null);
         _store.FindByNameAsync("User", _currentTenant.Id, null, Arg.Any<CancellationToken>())
             .Returns((RoleMetadata?)null);
         _store.FindByNameAsync("User", (Guid?)null, null, Arg.Any<CancellationToken>())
@@ -127,7 +127,7 @@ public sealed class PermissionGrantEndpointsVisibilityTests
         _currentTenant.Id.Returns(tenantA);
 
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId: tenantA);
+            Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantId: tenantA);
         _store.FindByNameAsync("Manager", tenantA, null, Arg.Any<CancellationToken>())
             .Returns(role);
 
@@ -158,7 +158,7 @@ public sealed class PermissionGrantEndpointsVisibilityTests
         _store.FindByNameAsync("TenantBRole", (Guid?)null, null, Arg.Any<CancellationToken>())
             .Returns((RoleMetadata?)null);
         // Only tenantB has the row.
-        _ = RoleMetadata.Create(Guid.NewGuid(), "TenantBRole", MultiTenancySide.Tenant, tenantId: tenantB);
+        _ = RoleMetadata.Create(Guid.NewGuid(), "TenantBRole", MultiTenancySides.Tenant, tenantId: tenantB);
 
         bool visible = await PermissionGrantEndpoints.IsRoleVisibleAsync(
             "TenantBRole", _store, _currentTenant, TestContext.Current.CancellationToken);
@@ -180,7 +180,7 @@ public sealed class PermissionGrantEndpointsVisibilityTests
         // practice because we query with tenantA, but the helper must still refuse
         // to leak the row.
         var row = RoleMetadata.Create(
-            Guid.NewGuid(), "X", MultiTenancySide.Tenant, tenantId: tenantB);
+            Guid.NewGuid(), "X", MultiTenancySides.Tenant, tenantId: tenantB);
         _store.FindByNameAsync("X", tenantA, null, Arg.Any<CancellationToken>())
             .Returns(row);
 

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/RoleMetadataPostgresTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/RoleMetadataPostgresTests.cs
@@ -60,12 +60,12 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     public async Task HostRole_DuplicateName_RejectedByUniqueIndex()
     {
         var first = RoleMetadata.Create(
-            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySides.Host, tenantId: null);
         _context.Set<RoleMetadata>().Add(first);
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var duplicate = RoleMetadata.Create(
-            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySides.Host, tenantId: null);
         _context.Set<RoleMetadata>().Add(duplicate);
 
         DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
@@ -80,12 +80,12 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     {
         // Both rows have (Name, TenantId, ClientId) = (X, null, null) — must collide under NULLS NOT DISTINCT.
         var first = RoleMetadata.Create(
-            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "User", MultiTenancySides.Both, tenantId: null);
         _context.Set<RoleMetadata>().Add(first);
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var duplicate = RoleMetadata.Create(
-            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "User", MultiTenancySides.Both, tenantId: null);
         _context.Set<RoleMetadata>().Add(duplicate);
 
         DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
@@ -102,9 +102,9 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
         var tenantB = Guid.NewGuid();
 
         _context.Set<RoleMetadata>().Add(
-            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantA));
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantA));
         _context.Set<RoleMetadata>().Add(
-            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantB));
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantB));
 
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -121,7 +121,7 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     public async Task CheckConstraint_RejectsHostRoleWithNonNullTenantId()
     {
         RoleMetadata invalid = BuildInvalidRoleMetadata(
-            name: "GhostHost", side: MultiTenancySide.Host, tenantId: Guid.NewGuid());
+            name: "GhostHost", side: MultiTenancySides.Host, tenantId: Guid.NewGuid());
         _context.Set<RoleMetadata>().Add(invalid);
 
         DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
@@ -136,7 +136,7 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     public async Task CheckConstraint_RejectsTenantRoleWithNullTenantId()
     {
         RoleMetadata invalid = BuildInvalidRoleMetadata(
-            name: "GhostTenant", side: MultiTenancySide.Tenant, tenantId: null);
+            name: "GhostTenant", side: MultiTenancySides.Tenant, tenantId: null);
         _context.Set<RoleMetadata>().Add(invalid);
 
         DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
@@ -154,13 +154,13 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     /// invariant, not to exercise the factory itself.
     /// </summary>
     private static RoleMetadata BuildInvalidRoleMetadata(
-        string name, MultiTenancySide side, Guid? tenantId)
+        string name, MultiTenancySides side, Guid? tenantId)
     {
         var instance = (RoleMetadata)Activator.CreateInstance(
             typeof(RoleMetadata), nonPublic: true)!;
         SetProperty(instance, nameof(RoleMetadata.Id), Guid.NewGuid());
         SetProperty(instance, nameof(RoleMetadata.Name), name);
-        SetProperty(instance, nameof(RoleMetadata.MultiTenancySide), side);
+        SetProperty(instance, nameof(RoleMetadata.MultiTenancySides), side);
         SetProperty(instance, nameof(RoleMetadata.TenantId), tenantId);
         SetProperty(instance, nameof(RoleMetadata.IsSystem), false);
         return instance;
@@ -183,7 +183,7 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     {
         EfCoreRoleMetadataStore<TestAuthorizationDbContext> store = new(_context);
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "TenantAdministrator", MultiTenancySide.Both, tenantId: null,
+            Guid.NewGuid(), "TenantAdministrator", MultiTenancySides.Both, tenantId: null,
             description: "Administrator within a tenant.");
 
         await store.AddAsync(role, TestContext.Current.CancellationToken);
@@ -194,7 +194,7 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
 
         found.ShouldNotBeNull();
         found.Id.ShouldBe(role.Id);
-        found.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        found.MultiTenancySides.ShouldBe(MultiTenancySides.Both);
         found.Description.ShouldBe("Administrator within a tenant.");
     }
 
@@ -203,7 +203,7 @@ public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, 
     {
         EfCoreRoleMetadataStore<TestAuthorizationDbContext> store = new(_context);
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "DisposableRole", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "DisposableRole", MultiTenancySides.Both, tenantId: null);
         await store.AddAsync(role, TestContext.Current.CancellationToken);
 
         RoleMetadata? tracked = await _context.Set<RoleMetadata>()

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
@@ -31,12 +31,12 @@ public sealed class RoleMetadataEntityTests
         var id = Guid.NewGuid();
 
         var role = RoleMetadata.Create(
-            id, "SuperAdmin", MultiTenancySide.Host, tenantId: null,
+            id, "SuperAdmin", MultiTenancySides.Host, tenantId: null,
             clientId: null, description: "Platform administrator", isSystem: true);
 
         role.Id.ShouldBe(id);
         role.Name.ShouldBe("SuperAdmin");
-        role.MultiTenancySide.ShouldBe(MultiTenancySide.Host);
+        role.MultiTenancySides.ShouldBe(MultiTenancySides.Host);
         role.TenantId.ShouldBeNull();
         role.ClientId.ShouldBeNull();
         role.Description.ShouldBe("Platform administrator");
@@ -49,20 +49,20 @@ public sealed class RoleMetadataEntityTests
         var tenantId = Guid.NewGuid();
 
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId);
+            Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantId);
 
         role.TenantId.ShouldBe(tenantId);
-        role.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        role.MultiTenancySides.ShouldBe(MultiTenancySides.Tenant);
     }
 
     [Fact]
     public void Create_Both_LeavesTenantIdNull()
     {
         var role = RoleMetadata.Create(
-            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "User", MultiTenancySides.Both, tenantId: null);
 
         role.TenantId.ShouldBeNull();
-        role.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        role.MultiTenancySides.ShouldBe(MultiTenancySides.Both);
     }
 
     [Fact]
@@ -72,13 +72,13 @@ public sealed class RoleMetadataEntityTests
         var tenantId = Guid.NewGuid();
 
         var role = RoleMetadata.Create(
-            id, "Manager", MultiTenancySide.Tenant, tenantId, clientId: "client-a");
+            id, "Manager", MultiTenancySides.Tenant, tenantId, clientId: "client-a");
 
         role.DomainEvents.Count.ShouldBe(1);
         RoleCreatedEvent evt = role.DomainEvents.Single().ShouldBeOfType<RoleCreatedEvent>();
         evt.RoleId.ShouldBe(id);
         evt.Name.ShouldBe("Manager");
-        evt.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        evt.MultiTenancySides.ShouldBe(MultiTenancySides.Tenant);
         evt.TenantId.ShouldBe(tenantId);
         evt.ClientId.ShouldBe("client-a");
     }
@@ -90,7 +90,7 @@ public sealed class RoleMetadataEntityTests
     public void Create_RejectsNullOrWhitespaceName(string? name)
     {
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), name!, MultiTenancySide.Host, null));
+            RoleMetadata.Create(Guid.NewGuid(), name!, MultiTenancySides.Host, null));
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed class RoleMetadataEntityTests
         string longName = new('x', 257);
 
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), longName, MultiTenancySide.Host, null));
+            RoleMetadata.Create(Guid.NewGuid(), longName, MultiTenancySides.Host, null));
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public sealed class RoleMetadataEntityTests
         string longClient = new('c', 257);
 
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Host, null, clientId: longClient));
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySides.Host, null, clientId: longClient));
     }
 
     [Fact]
@@ -117,28 +117,28 @@ public sealed class RoleMetadataEntityTests
         string longDesc = new('d', 2049);
 
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Host, null, description: longDesc));
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySides.Host, null, description: longDesc));
     }
 
     [Fact]
     public void Create_Host_WithTenantId_Throws()
     {
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, Guid.NewGuid()));
+            RoleMetadata.Create(Guid.NewGuid(), "SuperAdmin", MultiTenancySides.Host, Guid.NewGuid()));
     }
 
     [Fact]
     public void Create_Both_WithTenantId_Throws()
     {
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), "User", MultiTenancySide.Both, Guid.NewGuid()));
+            RoleMetadata.Create(Guid.NewGuid(), "User", MultiTenancySides.Both, Guid.NewGuid()));
     }
 
     [Fact]
     public void Create_Tenant_WithoutTenantId_Throws()
     {
         Should.Throw<ArgumentException>(() =>
-            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId: null));
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantId: null));
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public sealed class RoleMetadataEntityTests
         RoleMetadata.Create(
             Guid.NewGuid(),
             "SuperAdmin",
-            MultiTenancySide.Host,
+            MultiTenancySides.Host,
             tenantId: null,
             description: "Initial description");
 }

--- a/tests/Granit.Authorization.Tests/Domain/RoleMetadataOrphanTests.cs
+++ b/tests/Granit.Authorization.Tests/Domain/RoleMetadataOrphanTests.cs
@@ -14,7 +14,7 @@ namespace Granit.Authorization.Tests.Domain;
 public sealed class RoleMetadataOrphanTests
 {
     private static RoleMetadata CreateSut() => RoleMetadata.Create(
-        Guid.NewGuid(), "tester", MultiTenancySide.Host,
+        Guid.NewGuid(), "tester", MultiTenancySides.Host,
         tenantId: null, clientId: "client-a");
 
     [Fact]

--- a/tests/Granit.Authorization.Tests/MultiTenancySidePermissionGrantValidatorTests.cs
+++ b/tests/Granit.Authorization.Tests/MultiTenancySidePermissionGrantValidatorTests.cs
@@ -21,7 +21,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task TenantOnlyPermission_HostLevelGrant_Rejected()
     {
         PermissionGrantValidationResult result = await Validate(
-            permissionSide: MultiTenancySide.Tenant,
+            permissionSide: MultiTenancySides.Tenant,
             providerName: R,
             providerKey: "accountant",
             grantTenantId: null);
@@ -34,7 +34,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task HostOnlyPermission_TenantGrant_Rejected()
     {
         PermissionGrantValidationResult result = await Validate(
-            permissionSide: MultiTenancySide.Host,
+            permissionSide: MultiTenancySides.Host,
             providerName: R,
             providerKey: "accountant",
             grantTenantId: TenantA);
@@ -46,8 +46,8 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     [Fact]
     public async Task BothPermission_AnyScope_Accepted_WhenNoRoleMetadata()
     {
-        (await Validate(MultiTenancySide.Both, R, "accountant", null)).IsValid.ShouldBeTrue();
-        (await Validate(MultiTenancySide.Both, R, "accountant", TenantA)).IsValid.ShouldBeTrue();
+        (await Validate(MultiTenancySides.Both, R, "accountant", null)).IsValid.ShouldBeTrue();
+        (await Validate(MultiTenancySides.Both, R, "accountant", TenantA)).IsValid.ShouldBeTrue();
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
         IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
 
         PermissionGrantValidationResult result = await Validate(
-            permissionSide: MultiTenancySide.Both,
+            permissionSide: MultiTenancySides.Both,
             providerName: PermissionGrantProviderNames.User,
             providerKey: Guid.NewGuid().ToString(),
             grantTenantId: TenantA,
@@ -77,7 +77,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
         IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
 
         PermissionGrantValidationResult result = await Validate(
-            permissionSide: MultiTenancySide.Both,
+            permissionSide: MultiTenancySides.Both,
             providerName: PermissionGrantProviderNames.Client,
             providerKey: "client-a",
             grantTenantId: null,
@@ -96,7 +96,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task HostRole_HostGrant_Accepted()
     {
         IRoleMetadataStore store = StoreWithRole(HostRole("SuperAdmin"));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Host, R, "SuperAdmin", null, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Host, R, "SuperAdmin", null, store);
         result.IsValid.ShouldBeTrue();
     }
 
@@ -104,7 +104,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task HostRole_TenantGrant_Rejected()
     {
         IRoleMetadataStore store = StoreWithRole(HostRole("SuperAdmin"));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "SuperAdmin", TenantA, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Both, R, "SuperAdmin", TenantA, store);
         result.IsValid.ShouldBeFalse();
         result.ReasonCode.ShouldBe("role_side_forbidden");
     }
@@ -113,7 +113,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task TenantRole_HostGrant_Rejected()
     {
         IRoleMetadataStore store = StoreWithRole(TenantRole("Manager", TenantA));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "Manager", null, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Both, R, "Manager", null, store);
         result.IsValid.ShouldBeFalse();
         result.ReasonCode.ShouldBe("role_side_forbidden");
     }
@@ -122,7 +122,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task TenantRole_MatchingTenantGrant_Accepted()
     {
         IRoleMetadataStore store = StoreWithRole(TenantRole("Manager", TenantA));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantA, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Tenant, R, "Manager", TenantA, store);
         result.IsValid.ShouldBeTrue();
     }
 
@@ -136,7 +136,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
         store.FindByNameAsync("Manager", null, null, Arg.Any<CancellationToken>())
              .Returns(TenantRole("Manager", TenantA));
 
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantB, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Tenant, R, "Manager", TenantB, store);
         result.IsValid.ShouldBeFalse();
         result.ReasonCode.ShouldBe("role_tenant_mismatch");
     }
@@ -145,7 +145,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task BothRole_HostGrant_Accepted()
     {
         IRoleMetadataStore store = StoreWithRole(BothRole("User"));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "User", null, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Both, R, "User", null, store);
         result.IsValid.ShouldBeTrue();
     }
 
@@ -153,7 +153,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     public async Task BothRole_TenantGrant_Accepted()
     {
         IRoleMetadataStore store = StoreWithRole(BothRole("User"));
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "User", TenantA, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Both, R, "User", TenantA, store);
         result.IsValid.ShouldBeTrue();
     }
 
@@ -164,7 +164,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
         store.FindByNameAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
              .Returns((RoleMetadata?)null);
 
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "legacy-role", TenantA, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Both, R, "legacy-role", TenantA, store);
 
         result.IsValid.ShouldBeTrue();
     }
@@ -183,7 +183,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
         store.FindByNameAsync("Manager", null, null, Arg.Any<CancellationToken>())
              .Returns(globalRole);
 
-        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantA, store);
+        PermissionGrantValidationResult result = await Validate(MultiTenancySides.Tenant, R, "Manager", TenantA, store);
 
         result.IsValid.ShouldBeTrue();
         // Assert: only the tenant-scoped lookup was needed (global fallback not called).
@@ -196,7 +196,7 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     // ─────────────────────────────────────────────────────────────────────
 
     private static async Task<PermissionGrantValidationResult> Validate(
-        MultiTenancySide permissionSide,
+        MultiTenancySides permissionSide,
         string providerName,
         string providerKey,
         Guid? grantTenantId,
@@ -225,11 +225,11 @@ public sealed class MultiTenancySidePermissionGrantValidatorTests
     }
 
     private static RoleMetadata HostRole(string name) =>
-        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Host, tenantId: null);
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySides.Host, tenantId: null);
 
     private static RoleMetadata BothRole(string name) =>
-        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Both, tenantId: null);
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySides.Both, tenantId: null);
 
     private static RoleMetadata TenantRole(string name, Guid tenantId) =>
-        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Tenant, tenantId);
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySides.Tenant, tenantId);
 }

--- a/tests/Granit.Authorization.Tests/PermissionCheckerProviderOrchestrationTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerProviderOrchestrationTests.cs
@@ -117,7 +117,7 @@ public sealed class PermissionCheckerProviderOrchestrationTests
     {
         // Host-only permission checked under an active tenant: should deny without hitting the store.
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        PermissionDefinition definition = new(Permission, null, "TestGroup", MultiTenancySide.Host);
+        PermissionDefinition definition = new(Permission, null, "TestGroup", MultiTenancySides.Host);
 
         PermissionChecker checker = BuildChecker(
             userId: "alice", roles: ["editor"], clientId: "spa",
@@ -155,7 +155,7 @@ public sealed class PermissionCheckerProviderOrchestrationTests
         IPermissionDefinitionManager manager = Substitute.For<IPermissionDefinitionManager>();
         manager.Exists(Permission).Returns(true);
         manager.Find(Permission).Returns(definition
-            ?? new PermissionDefinition(Permission, null, "TestGroup", MultiTenancySide.Both));
+            ?? new PermissionDefinition(Permission, null, "TestGroup", MultiTenancySides.Both));
 
         IFusionCache cache = new FusionCache(new FusionCacheOptions());
 

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -341,7 +341,7 @@ public sealed class PermissionCheckerTests
         IPermissionDefinitionManager manager = Substitute.For<IPermissionDefinitionManager>();
         manager.Exists(DefinedPermission).Returns(true);
         manager.Find(DefinedPermission)
-            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySides.Both));
 
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
         IFusionCache cache = Substitute.For<IFusionCache>();
@@ -433,7 +433,7 @@ public sealed class PermissionCheckerTests
         manager.Exists(DefinedPermission).Returns(true);
         manager.Exists(UndefinedPermission).Returns(false);
         manager.Find(DefinedPermission)
-            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySides.Both));
         manager.Find(UndefinedPermission).Returns((PermissionDefinition?)null);
 
         IPermissionGrantStore grantStore = store ?? Substitute.For<IPermissionGrantStore>();

--- a/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
@@ -204,7 +204,7 @@ public sealed class PermissionManagerTests
         definitionManager.Exists(DefinedPermission).Returns(true);
         definitionManager.Exists(UndefinedPermission).Returns(false);
         definitionManager.Find(DefinedPermission)
-            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySides.Both));
         definitionManager.Find(UndefinedPermission).Returns((PermissionDefinition?)null);
 
         ILogger<PermissionManager> logger = Substitute.For<ILogger<PermissionManager>>();

--- a/tests/Granit.Authorization.Tests/RoleCacheInvalidationHandlerTests.cs
+++ b/tests/Granit.Authorization.Tests/RoleCacheInvalidationHandlerTests.cs
@@ -25,7 +25,7 @@ public sealed class RoleCacheInvalidationHandlerTests
             RoleId: Guid.NewGuid(),
             Name: "TeamLead",
             PreviousName: "Manager",
-            MultiTenancySide: MultiTenancySide.Tenant,
+            MultiTenancySides: MultiTenancySides.Tenant,
             TenantId: Guid.NewGuid(),
             ClientId: null);
 
@@ -46,7 +46,7 @@ public sealed class RoleCacheInvalidationHandlerTests
             RoleId: Guid.NewGuid(),
             Name: "Manager",
             PreviousName: null,
-            MultiTenancySide: MultiTenancySide.Tenant,
+            MultiTenancySides: MultiTenancySides.Tenant,
             TenantId: Guid.NewGuid(),
             ClientId: null);
 
@@ -66,7 +66,7 @@ public sealed class RoleCacheInvalidationHandlerTests
         var @event = new RoleDeletedEvent(
             RoleId: Guid.NewGuid(),
             Name: "Disposable",
-            MultiTenancySide: MultiTenancySide.Both,
+            MultiTenancySides: MultiTenancySides.Both,
             TenantId: null,
             ClientId: null);
 

--- a/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class CognitoClientRoleSyncServiceTests
 
         await _store.Received(2).AddAsync(
             Arg.Is<RoleMetadata>(r => r.ClientId == "client-a"
-                && r.MultiTenancySide == MultiTenancySide.Host
+                && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
         await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
@@ -90,7 +90,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut("client-a");
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a", description: "Edit docs");
         _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("client-a:editor", "editor", "Edit docs") { ClientId = "client-a" }]);
@@ -108,7 +108,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut("client-a");
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a", description: "OLD description");
         _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("client-a:editor", "editor", "NEW description") { ClientId = "client-a" }]);
@@ -145,7 +145,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.KeepAndLog, "client-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a");
 
         _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>()).Returns([]);
@@ -163,7 +163,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "client-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a");
 
         _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>()).Returns([]);
@@ -182,7 +182,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "client-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a");
         orphan.MarkAsOrphaned(DateTimeOffset.UtcNow.AddDays(-3));
 
@@ -199,7 +199,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.HardDelete, "client-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a");
 
         _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>()).Returns([]);
@@ -215,7 +215,7 @@ public sealed class CognitoClientRoleSyncServiceTests
     {
         CognitoClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "client-a");
         var previouslyOrphaned = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "client-a", description: "Edit docs");
         previouslyOrphaned.MarkAsOrphaned(DateTimeOffset.UtcNow.AddHours(-1));
 

--- a/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
@@ -80,7 +80,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         await _store.Received(2).AddAsync(
-            Arg.Is<RoleMetadata>(r => r.ClientId == appId && r.MultiTenancySide == MultiTenancySide.Host
+            Arg.Is<RoleMetadata>(r => r.ClientId == appId && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
         await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
@@ -92,7 +92,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "22222222-2222-2222-2222-222222222222";
         EntraIdClientRoleSyncService sut = BuildSut(appId);
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "Editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "Editor", MultiTenancySides.Host,
             tenantId: null, clientId: appId, description: "Edit docs");
         _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("r1", "Editor", "Edit docs") { ClientId = appId }]);
@@ -111,7 +111,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "33333333-3333-3333-3333-333333333333";
         EntraIdClientRoleSyncService sut = BuildSut(appId);
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "Editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "Editor", MultiTenancySides.Host,
             tenantId: null, clientId: appId, description: "OLD description");
         _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("r1", "Editor", "NEW description") { ClientId = appId }]);
@@ -151,7 +151,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "55555555-5555-5555-5555-555555555555";
         EntraIdClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.KeepAndLog, appId);
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "Gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "Gone", MultiTenancySides.Host,
             tenantId: null, clientId: appId);
 
         _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>()).Returns([]);
@@ -170,7 +170,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "66666666-6666-6666-6666-666666666666";
         EntraIdClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, appId);
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "Gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "Gone", MultiTenancySides.Host,
             tenantId: null, clientId: appId);
 
         _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>()).Returns([]);
@@ -190,7 +190,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "77777777-7777-7777-7777-777777777777";
         EntraIdClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, appId);
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "Gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "Gone", MultiTenancySides.Host,
             tenantId: null, clientId: appId);
         orphan.MarkAsOrphaned(DateTimeOffset.UtcNow.AddDays(-3));
 
@@ -208,7 +208,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "88888888-8888-8888-8888-888888888888";
         EntraIdClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.HardDelete, appId);
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "Gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "Gone", MultiTenancySides.Host,
             tenantId: null, clientId: appId);
 
         _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>()).Returns([]);
@@ -225,7 +225,7 @@ public sealed class EntraIdClientRoleSyncServiceTests
         const string appId = "99999999-9999-9999-9999-999999999999";
         EntraIdClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, appId);
         var previouslyOrphaned = RoleMetadata.Create(
-            Guid.NewGuid(), "Editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "Editor", MultiTenancySides.Host,
             tenantId: null, clientId: appId, description: "Edit docs");
         previouslyOrphaned.MarkAsOrphaned(DateTimeOffset.UtcNow.AddHours(-1));
 

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
         await sut.SyncAsync(TestContext.Current.CancellationToken);
 
         await _store.Received(2).AddAsync(
-            Arg.Is<RoleMetadata>(r => r.ClientId == "app-a" && r.MultiTenancySide == MultiTenancySide.Host
+            Arg.Is<RoleMetadata>(r => r.ClientId == "app-a" && r.MultiTenancySides == MultiTenancySides.Host
                 && !r.IsSystem && r.TenantId == null),
             Arg.Any<CancellationToken>());
         await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
@@ -90,7 +90,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut("app-a");
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a", description: "Edit docs");
         _clientRoleManager.GetClientRolesAsync("app-a", Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("r1", "editor", "Edit docs") { ClientId = "app-a" }]);
@@ -108,7 +108,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut("app-a");
         var existing = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a", description: "OLD description");
         _clientRoleManager.GetClientRolesAsync("app-a", Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("r1", "editor", "NEW description") { ClientId = "app-a" }]);
@@ -145,7 +145,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.KeepAndLog, "app-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a");
 
         _clientRoleManager.GetClientRolesAsync("app-a", Arg.Any<CancellationToken>())
@@ -166,7 +166,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "app-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a");
 
         _clientRoleManager.GetClientRolesAsync("app-a", Arg.Any<CancellationToken>())
@@ -188,7 +188,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "app-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a");
         orphan.MarkAsOrphaned(DateTimeOffset.UtcNow.AddDays(-3));
 
@@ -207,7 +207,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.HardDelete, "app-a");
         var orphan = RoleMetadata.Create(
-            Guid.NewGuid(), "gone", MultiTenancySide.Host,
+            Guid.NewGuid(), "gone", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a");
 
         _clientRoleManager.GetClientRolesAsync("app-a", Arg.Any<CancellationToken>())
@@ -225,7 +225,7 @@ public sealed class KeycloakClientRoleSyncServiceTests
     {
         KeycloakClientRoleSyncService sut = BuildSut(OrphanedRolePolicy.SoftDelete, "app-a");
         var previouslyOrphaned = RoleMetadata.Create(
-            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            Guid.NewGuid(), "editor", MultiTenancySides.Host,
             tenantId: null, clientId: "app-a", description: "Edit docs");
         previouslyOrphaned.MarkAsOrphaned(DateTimeOffset.UtcNow.AddHours(-1));
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
@@ -57,7 +57,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage response = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -85,7 +85,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage response = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
@@ -107,7 +107,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage post = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
         post.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
     }
@@ -124,7 +124,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage post = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
         post.StatusCode.ShouldBe(HttpStatusCode.Created);
 
@@ -145,7 +145,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage post = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
         post.StatusCode.ShouldBe(HttpStatusCode.Created);
         RoleResponseLite? created = await post.Content
@@ -172,7 +172,7 @@ public sealed class GranitRoleEndpointsPermissionTests
 
         HttpResponseMessage post = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
         RoleResponseLite? created = await post.Content
             .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
@@ -191,7 +191,7 @@ public sealed class GranitRoleEndpointsPermissionTests
         // POST is refused with the Delete-only grant.
         HttpResponseMessage post = await client.PostAsJsonAsync(
             "/admin/roles",
-            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySides.Host },
             TestContext.Current.CancellationToken);
         post.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
 
@@ -265,7 +265,7 @@ public sealed class GranitRoleEndpointsPermissionTests
         var metadata = RoleMetadata.Create(
             id: Guid.NewGuid(),
             name: name,
-            multiTenancySide: MultiTenancySide.Host,
+            multiTenancySide: MultiTenancySides.Host,
             tenantId: null,
             clientId: null,
             description: null,
@@ -278,7 +278,7 @@ public sealed class GranitRoleEndpointsPermissionTests
     private sealed record RoleResponseLite(
         Guid Id,
         string Name,
-        MultiTenancySide MultiTenancySide,
+        MultiTenancySides MultiTenancySides,
         Guid? TenantId,
         string? ClientId,
         string? Description,

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
@@ -36,10 +36,10 @@ public sealed class GranitRoleEndpointsTests
     [Fact]
     public async Task List_AsHostAdmin_SeesAllRoles()
     {
-        await SeedMetadataAsync("SuperAdmin", MultiTenancySide.Host, tenantId: null);
-        await SeedMetadataAsync("User", MultiTenancySide.Both, tenantId: null);
-        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
-        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+        await SeedMetadataAsync("SuperAdmin", MultiTenancySides.Host, tenantId: null);
+        await SeedMetadataAsync("User", MultiTenancySides.Both, tenantId: null);
+        await SeedMetadataAsync("Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
+        await SeedMetadataAsync("Manager", MultiTenancySides.Tenant, tenantId: _tenantB);
 
         HttpResponseMessage response = await _app.HttpClient
             .GetAsync("/admin/roles", TestContext.Current.CancellationToken);
@@ -56,10 +56,10 @@ public sealed class GranitRoleEndpointsTests
     [Fact]
     public async Task List_AsTenantAdmin_SeesBothAndOwnTenantOnly()
     {
-        await SeedMetadataAsync("SuperAdmin", MultiTenancySide.Host, tenantId: null);
-        await SeedMetadataAsync("User", MultiTenancySide.Both, tenantId: null);
-        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
-        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+        await SeedMetadataAsync("SuperAdmin", MultiTenancySides.Host, tenantId: null);
+        await SeedMetadataAsync("User", MultiTenancySides.Both, tenantId: null);
+        await SeedMetadataAsync("Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
+        await SeedMetadataAsync("Manager", MultiTenancySides.Tenant, tenantId: _tenantB);
 
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -74,7 +74,7 @@ public sealed class GranitRoleEndpointsTests
         roles.ShouldNotBeNull();
         roles.Select(r => r.Name).OrderBy(n => n, StringComparer.Ordinal)
             .ShouldBe(["Manager", "User"]);
-        roles.ShouldNotContain(r => r.MultiTenancySide == MultiTenancySide.Host);
+        roles.ShouldNotContain(r => r.MultiTenancySides == MultiTenancySides.Host);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -85,7 +85,7 @@ public sealed class GranitRoleEndpointsTests
     public async Task GetById_AsTenantAdmin_HostRole_Returns404()
     {
         RoleMetadata hostRole = await SeedMetadataAsync(
-            "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+            "SuperAdmin", MultiTenancySides.Host, tenantId: null);
 
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -99,7 +99,7 @@ public sealed class GranitRoleEndpointsTests
     public async Task GetById_AsTenantAdmin_OtherTenantRole_Returns404()
     {
         RoleMetadata otherTenantRole = await SeedMetadataAsync(
-            "Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+            "Manager", MultiTenancySides.Tenant, tenantId: _tenantB);
 
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -123,7 +123,7 @@ public sealed class GranitRoleEndpointsTests
             new
             {
                 name = "Manager",
-                multiTenancySide = (int)MultiTenancySide.Tenant,
+                multiTenancySide = (int)MultiTenancySides.Tenant,
                 tenantId = _tenantA,
                 description = "Tenant-A managers.",
             },
@@ -136,7 +136,7 @@ public sealed class GranitRoleEndpointsTests
 
         created.ShouldNotBeNull();
         created.Name.ShouldBe("Manager");
-        created.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        created.MultiTenancySides.ShouldBe(MultiTenancySides.Tenant);
         created.TenantId.ShouldBe(_tenantA);
     }
 
@@ -150,7 +150,7 @@ public sealed class GranitRoleEndpointsTests
             new
             {
                 name = "Manager",
-                multiTenancySide = (int)MultiTenancySide.Tenant,
+                multiTenancySide = (int)MultiTenancySides.Tenant,
                 tenantId = _tenantB,
             },
             TestContext.Current.CancellationToken);
@@ -169,7 +169,7 @@ public sealed class GranitRoleEndpointsTests
                 new
                 {
                     name = "Manager",
-                    multiTenancySide = (int)MultiTenancySide.Tenant,
+                    multiTenancySide = (int)MultiTenancySides.Tenant,
                     tenantId = _tenantA,
                 },
                 TestContext.Current.CancellationToken);
@@ -201,7 +201,7 @@ public sealed class GranitRoleEndpointsTests
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
         Guid roleId = await CreateViaEndpointAsync(
-            "Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+            "Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
 
         HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
             $"/admin/roles/{roleId:D}",
@@ -222,7 +222,7 @@ public sealed class GranitRoleEndpointsTests
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
         Guid roleId = await CreateViaEndpointAsync(
-            "Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+            "Manager", MultiTenancySides.Tenant, tenantId: _tenantA);
 
         HttpResponseMessage response = await _app.HttpClient.DeleteAsync(
             $"/admin/roles/{roleId:D}", TestContext.Current.CancellationToken);
@@ -242,7 +242,7 @@ public sealed class GranitRoleEndpointsTests
     public async Task Delete_SystemRole_Returns403()
     {
         RoleMetadata system = await SeedMetadataAsync(
-            "SuperAdmin", MultiTenancySide.Host, tenantId: null, isSystem: true);
+            "SuperAdmin", MultiTenancySides.Host, tenantId: null, isSystem: true);
 
         HttpResponseMessage response = await _app.HttpClient.DeleteAsync(
             $"/admin/roles/{system.Id:D}", TestContext.Current.CancellationToken);
@@ -254,7 +254,7 @@ public sealed class GranitRoleEndpointsTests
     public async Task Rename_SystemRole_Returns403()
     {
         RoleMetadata system = await SeedMetadataAsync(
-            "User", MultiTenancySide.Both, tenantId: null, isSystem: true);
+            "User", MultiTenancySides.Both, tenantId: null, isSystem: true);
 
         HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
             $"/admin/roles/{system.Id:D}",
@@ -272,7 +272,7 @@ public sealed class GranitRoleEndpointsTests
     public async Task Rename_AsTenantAdmin_OtherTenantRole_Returns404()
     {
         RoleMetadata otherTenantRole = await SeedMetadataAsync(
-            "Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+            "Manager", MultiTenancySides.Tenant, tenantId: _tenantB);
 
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -296,7 +296,7 @@ public sealed class GranitRoleEndpointsTests
             new
             {
                 name = "Auditor",
-                multiTenancySide = (int)MultiTenancySide.Host,
+                multiTenancySide = (int)MultiTenancySides.Host,
                 tenantId = (Guid?)null,
                 description = "Read-only platform auditor.",
             },
@@ -309,7 +309,7 @@ public sealed class GranitRoleEndpointsTests
 
         created.ShouldNotBeNull();
         created.Name.ShouldBe("Auditor");
-        created.MultiTenancySide.ShouldBe(MultiTenancySide.Host);
+        created.MultiTenancySides.ShouldBe(MultiTenancySides.Host);
         created.IsSystem.ShouldBeFalse();
     }
 
@@ -318,7 +318,7 @@ public sealed class GranitRoleEndpointsTests
     // ─────────────────────────────────────────────────────────────────────
 
     private async Task<Guid> CreateViaEndpointAsync(
-        string name, MultiTenancySide side, Guid? tenantId)
+        string name, MultiTenancySides side, Guid? tenantId)
     {
         HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
             "/admin/roles",
@@ -337,7 +337,7 @@ public sealed class GranitRoleEndpointsTests
     }
 
     private async Task<RoleMetadata> SeedMetadataAsync(
-        string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false)
+        string name, MultiTenancySides side, Guid? tenantId, bool isSystem = false)
     {
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
@@ -358,7 +358,7 @@ public sealed class GranitRoleEndpointsTests
     private sealed record RoleResponseLite(
         Guid Id,
         string Name,
-        MultiTenancySide MultiTenancySide,
+        MultiTenancySides MultiTenancySides,
         Guid? TenantId,
         string? ClientId,
         string? Description,

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
@@ -41,7 +41,7 @@ public sealed class RoleOrchestratorAtomicTests
         RoleMetadata created = await orchestrator.CreateAsync(
             new CreateRoleCommand(
                 Name: "AtomicManager",
-                MultiTenancySide: MultiTenancySide.Both,
+                MultiTenancySides: MultiTenancySides.Both,
                 TenantId: null,
                 Description: "Verifies atomic commit."),
             TestContext.Current.CancellationToken);
@@ -69,7 +69,7 @@ public sealed class RoleOrchestratorAtomicTests
         await using (TestHostDbContext hostCtx = await hostFactory.CreateDbContextAsync(TestContext.Current.CancellationToken))
         {
             hostCtx.Set<RoleMetadata>().Add(RoleMetadata.Create(
-                Guid.NewGuid(), "Collide", MultiTenancySide.Both, tenantId: null));
+                Guid.NewGuid(), "Collide", MultiTenancySides.Both, tenantId: null));
             await hostCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
@@ -80,7 +80,7 @@ public sealed class RoleOrchestratorAtomicTests
 
         await Should.ThrowAsync<DbUpdateException>(async () =>
             await orchestrator.CreateAsync(
-                new CreateRoleCommand("Collide", MultiTenancySide.Both, TenantId: null),
+                new CreateRoleCommand("Collide", MultiTenancySides.Both, TenantId: null),
                 TestContext.Current.CancellationToken));
 
         // Atomic invariant: the Identity INSERT rolled back with the transaction.
@@ -98,7 +98,7 @@ public sealed class RoleOrchestratorAtomicTests
         IGranitRoleOrchestrator createOrchestrator = createScope.ServiceProvider
             .GetRequiredService<IGranitRoleOrchestrator>();
         RoleMetadata created = await createOrchestrator.CreateAsync(
-            new CreateRoleCommand("Alpha", MultiTenancySide.Both, TenantId: null),
+            new CreateRoleCommand("Alpha", MultiTenancySides.Both, TenantId: null),
             TestContext.Current.CancellationToken);
 
         // Rename in a fresh scope (mirrors production request-per-scope semantics).

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
@@ -44,7 +44,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
         RoleMetadata created = await orchestrator.CreateAsync(
             new CreateRoleCommand(
                 Name: "Manager",
-                MultiTenancySide: MultiTenancySide.Both,
+                MultiTenancySides: MultiTenancySides.Both,
                 TenantId: null,
                 Description: "Business manager."),
             TestContext.Current.CancellationToken);
@@ -58,7 +58,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
 
         RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
         metadata.ShouldNotBeNull();
-        metadata.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        metadata.MultiTenancySides.ShouldBe(MultiTenancySides.Both);
         metadata.TenantId.ShouldBeNull();
         metadata.IsSystem.ShouldBeFalse();
     }
@@ -70,7 +70,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
         // No matching GranitRole exists, so the Identity CreateAsync step succeeds;
         // the metadata AddAsync then violates the (Name, TenantId, ClientId) unique
         // index and must trigger the compensating delete.
-        await SeedMetadataOnlyAsync("Manager", MultiTenancySide.Both, tenantId: null);
+        await SeedMetadataOnlyAsync("Manager", MultiTenancySides.Both, tenantId: null);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -80,7 +80,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
 
         await Should.ThrowAsync<DbUpdateException>(async () =>
             await orchestrator.CreateAsync(
-                new CreateRoleCommand("Manager", MultiTenancySide.Both, TenantId: null),
+                new CreateRoleCommand("Manager", MultiTenancySides.Both, TenantId: null),
                 TestContext.Current.CancellationToken));
 
         // Invariant: no orphan GranitRole remains with display name "Manager".
@@ -96,7 +96,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     public async Task RenameAsync_HappyPath_UpdatesBothRoleAndMetadata()
     {
         RoleMetadata created = await CreateRoleViaOrchestratorAsync(
-            "Alpha", MultiTenancySide.Both, tenantId: null);
+            "Alpha", MultiTenancySides.Both, tenantId: null);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -127,12 +127,12 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     {
         // Alpha has a matched GranitRole + RoleMetadata (via orchestrator).
         RoleMetadata alpha = await CreateRoleViaOrchestratorAsync(
-            "Alpha", MultiTenancySide.Both, tenantId: null);
+            "Alpha", MultiTenancySides.Both, tenantId: null);
 
         // Beta exists only in RoleMetadata. When we rename Alpha → "Beta", the
         // Identity update on Alpha succeeds (no "Beta" GranitRole yet) but the
         // metadata update hits the unique index → orchestrator compensates.
-        await SeedMetadataOnlyAsync("Beta", MultiTenancySide.Both, tenantId: null);
+        await SeedMetadataOnlyAsync("Beta", MultiTenancySides.Both, tenantId: null);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -159,7 +159,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
         // IsSystem=true is only settable via the factory — use the store directly so
         // we don't need an orchestrator code path for seeding system roles.
         RoleMetadata system = await SeedMetadataOnlyAsync(
-            "SuperAdmin", MultiTenancySide.Host, tenantId: null, isSystem: true);
+            "SuperAdmin", MultiTenancySides.Host, tenantId: null, isSystem: true);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -181,7 +181,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     public async Task DeleteAsync_HappyPath_RemovesBothRoleAndMetadata()
     {
         RoleMetadata created = await CreateRoleViaOrchestratorAsync(
-            "Disposable", MultiTenancySide.Both, tenantId: null);
+            "Disposable", MultiTenancySides.Both, tenantId: null);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -203,7 +203,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     public async Task DeleteAsync_SystemRole_Refused()
     {
         RoleMetadata system = await SeedMetadataOnlyAsync(
-            "TenantAdministrator", MultiTenancySide.Both, tenantId: null, isSystem: true);
+            "TenantAdministrator", MultiTenancySides.Both, tenantId: null, isSystem: true);
 
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -220,7 +220,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     // ─────────────────────────────────────────────────────────────────────
 
     private async Task<RoleMetadata> CreateRoleViaOrchestratorAsync(
-        string name, MultiTenancySide side, Guid? tenantId)
+        string name, MultiTenancySides side, Guid? tenantId)
     {
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
@@ -231,7 +231,7 @@ public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestAp
     }
 
     private async Task<RoleMetadata> SeedMetadataOnlyAsync(
-        string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false)
+        string name, MultiTenancySides side, Guid? tenantId, bool isSystem = false)
     {
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
         TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/GranitRoleLookupTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/GranitRoleLookupTests.cs
@@ -22,7 +22,7 @@ public sealed class GranitRoleLookupTests
     {
         _currentTenant.IsAvailable.Returns(false);
         var hostRole = RoleMetadata.Create(
-            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySides.Host, tenantId: null);
         _store.FindByNameAsync("SuperAdmin", null, null, Arg.Any<CancellationToken>())
             .Returns(hostRole);
 
@@ -51,7 +51,7 @@ public sealed class GranitRoleLookupTests
         _currentTenant.Id.Returns(tenantId);
 
         var tenantRole = RoleMetadata.Create(
-            Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId);
+            Guid.NewGuid(), "Manager", MultiTenancySides.Tenant, tenantId);
         _store.FindByNameAsync("Manager", tenantId, null, Arg.Any<CancellationToken>())
             .Returns(tenantRole);
 
@@ -75,7 +75,7 @@ public sealed class GranitRoleLookupTests
         _currentTenant.Id.Returns(tenantId);
 
         var bothRole = RoleMetadata.Create(
-            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+            Guid.NewGuid(), "User", MultiTenancySides.Both, tenantId: null);
         _store.FindByNameAsync("User", tenantId, null, Arg.Any<CancellationToken>())
             .Returns((RoleMetadata?)null);
         _store.FindByNameAsync("User", (Guid?)null, null, Arg.Any<CancellationToken>())

--- a/tests/Granit.OpenIddict.Server.Tests/Handlers/ClientSideAuthorizationHandlerTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Handlers/ClientSideAuthorizationHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Granit.OpenIddict.Server.Tests.Handlers;
 
 /// <summary>
 /// Unit tests for <see cref="ClientSideAuthorizationHandler"/> — the OIDC server
-/// handler that enforces the <see cref="MultiTenancySide"/> policy declared on
+/// handler that enforces the <see cref="MultiTenancySides"/> policy declared on
 /// each application. Verifies the full policy matrix (Host/Tenant/Both/null ×
 /// host-user/tenant-user) and the carve-outs for service-to-service flows.
 /// </summary>
@@ -29,7 +29,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     public async Task HostOnly_HostUser_Allowed()
     {
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Host,
+            clientSide: MultiTenancySides.Host,
             userTenantId: null);
 
         context.IsRejected.ShouldBeFalse();
@@ -39,7 +39,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     public async Task HostOnly_TenantUser_Rejected()
     {
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Host,
+            clientSide: MultiTenancySides.Host,
             userTenantId: TenantId);
 
         context.IsRejected.ShouldBeTrue();
@@ -50,7 +50,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     public async Task TenantOnly_HostUser_Rejected()
     {
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Tenant,
+            clientSide: MultiTenancySides.Tenant,
             userTenantId: null);
 
         context.IsRejected.ShouldBeTrue();
@@ -61,7 +61,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     public async Task TenantOnly_TenantUser_Allowed()
     {
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Tenant,
+            clientSide: MultiTenancySides.Tenant,
             userTenantId: TenantId);
 
         context.IsRejected.ShouldBeFalse();
@@ -73,7 +73,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     public async Task Both_AnyUser_Allowed(string? userTenantId)
     {
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Both,
+            clientSide: MultiTenancySides.Both,
             userTenantId: userTenantId);
 
         context.IsRejected.ShouldBeFalse();
@@ -98,7 +98,7 @@ public sealed class ClientSideAuthorizationHandlerTests
         // policy would lock out any host-only API client that uses client_credentials —
         // the policy is about USERS, not clients.
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Host,
+            clientSide: MultiTenancySides.Host,
             userTenantId: TenantId,
             grantType: OpenIddictConstants.GrantTypes.ClientCredentials);
 
@@ -111,7 +111,7 @@ public sealed class ClientSideAuthorizationHandlerTests
         // Defensive: the built-in OpenIddict validation handlers reject missing
         // client_id long before we run, but we must never throw if we see a null.
         ProcessSignInContext context = await RunAsync(
-            clientSide: MultiTenancySide.Host,
+            clientSide: MultiTenancySides.Host,
             userTenantId: TenantId,
             clientId: null);
 
@@ -134,7 +134,7 @@ public sealed class ClientSideAuthorizationHandlerTests
     }
 
     private static async Task<ProcessSignInContext> RunAsync(
-        MultiTenancySide? clientSide,
+        MultiTenancySides? clientSide,
         string? userTenantId,
         string? grantType = null,
         string? clientId = ClientId)

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -69,6 +69,10 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
 
         // Explicit issuer — TestServer has no real URL for OpenIddict to auto-detect
         builder.Configuration["OpenIddict:Issuer"] = TestIssuer;
+        // TestServer runs as Production by default; ephemeral signing/encryption keys
+        // are forbidden there unless explicitly opted in. Persistent keys are not
+        // worth provisioning for an in-memory integration suite.
+        builder.Configuration["OpenIddict:AllowEphemeralKeys"] = "true";
 
         // 1. Register OpenIddict EF Core + Server + Identity
         builder.AddGranitOpenIddict(

--- a/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationClientSideExtensionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationClientSideExtensionsTests.cs
@@ -11,16 +11,16 @@ namespace Granit.OpenIddict.Tests.Extensions;
 
 /// <summary>
 /// Tests for <see cref="OpenIddictApplicationClientSideExtensions"/> — the read/write
-/// helpers that persist a <see cref="MultiTenancySide"/> policy on an OIDC
+/// helpers that persist a <see cref="MultiTenancySides"/> policy on an OIDC
 /// application's <see cref="OpenIddictApplicationDescriptor.Properties"/> bag.
 /// </summary>
 public sealed class OpenIddictApplicationClientSideExtensionsTests
 {
     [Theory]
-    [InlineData(MultiTenancySide.Host)]
-    [InlineData(MultiTenancySide.Tenant)]
-    [InlineData(MultiTenancySide.Both)]
-    public void SetClientSide_Then_GetClientSide_Roundtrip(MultiTenancySide side)
+    [InlineData(MultiTenancySides.Host)]
+    [InlineData(MultiTenancySides.Tenant)]
+    [InlineData(MultiTenancySides.Both)]
+    public void SetClientSide_Then_GetClientSide_Roundtrip(MultiTenancySides side)
     {
         OpenIddictApplicationDescriptor descriptor = new();
 
@@ -34,7 +34,7 @@ public sealed class OpenIddictApplicationClientSideExtensionsTests
     {
         OpenIddictApplicationDescriptor descriptor = new();
 
-        descriptor.SetClientSide(MultiTenancySide.Tenant);
+        descriptor.SetClientSide(MultiTenancySides.Tenant);
 
         descriptor.Properties.ShouldContainKey(
             OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey);
@@ -48,7 +48,7 @@ public sealed class OpenIddictApplicationClientSideExtensionsTests
     public void SetClientSide_Null_Removes_Property()
     {
         OpenIddictApplicationDescriptor descriptor = new();
-        descriptor.SetClientSide(MultiTenancySide.Host);
+        descriptor.SetClientSide(MultiTenancySides.Host);
 
         descriptor.SetClientSide(null);
 
@@ -104,10 +104,10 @@ public sealed class OpenIddictApplicationClientSideExtensionsTests
     }
 
     [Theory]
-    [InlineData(MultiTenancySide.Host)]
-    [InlineData(MultiTenancySide.Tenant)]
-    [InlineData(MultiTenancySide.Both)]
-    public async Task GetClientSideAsync_Reads_FromApplicationManager(MultiTenancySide side)
+    [InlineData(MultiTenancySides.Host)]
+    [InlineData(MultiTenancySides.Tenant)]
+    [InlineData(MultiTenancySides.Both)]
+    public async Task GetClientSideAsync_Reads_FromApplicationManager(MultiTenancySides side)
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
@@ -121,7 +121,7 @@ public sealed class OpenIddictApplicationClientSideExtensionsTests
         manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
             .Returns(properties);
 
-        MultiTenancySide? resolved = await manager.GetClientSideAsync(application, cancellationToken);
+        MultiTenancySides? resolved = await manager.GetClientSideAsync(application, cancellationToken);
 
         resolved.ShouldBe(side);
     }
@@ -136,7 +136,7 @@ public sealed class OpenIddictApplicationClientSideExtensionsTests
         manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
             .Returns(ImmutableDictionary<string, JsonElement>.Empty);
 
-        MultiTenancySide? resolved = await manager.GetClientSideAsync(application, cancellationToken);
+        MultiTenancySides? resolved = await manager.GetClientSideAsync(application, cancellationToken);
 
         resolved.ShouldBeNull();
     }

--- a/tests/Granit.Payments.Endpoints.Tests/Internal/PaymentAvailabilityContextParserTests.cs
+++ b/tests/Granit.Payments.Endpoints.Tests/Internal/PaymentAvailabilityContextParserTests.cs
@@ -62,10 +62,10 @@ public sealed class PaymentAvailabilityContextParserTests
     }
 
     [Theory]
-    [InlineData("oneoff", PaymentMethodSequenceType.OneOff)]
-    [InlineData("First", PaymentMethodSequenceType.First)]
-    [InlineData("RECURRING", PaymentMethodSequenceType.Recurring)]
-    public void SequenceType_CaseInsensitive(string input, PaymentMethodSequenceType expected)
+    [InlineData("oneoff", PaymentMethodSequenceTypes.OneOff)]
+    [InlineData("First", PaymentMethodSequenceTypes.First)]
+    [InlineData("RECURRING", PaymentMethodSequenceTypes.Recurring)]
+    public void SequenceType_CaseInsensitive(string input, PaymentMethodSequenceTypes expected)
     {
         PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
             .TryParse(country: null, currency: null, amount: null, sequenceType: input, out string? error);
@@ -96,7 +96,7 @@ public sealed class PaymentAvailabilityContextParserTests
         context!.CountryCode.ShouldBe("BE");
         context.CurrencyCode.ShouldBe("EUR");
         context.Amount.ShouldBe(25m);
-        context.SequenceType.ShouldBe(PaymentMethodSequenceType.OneOff);
+        context.SequenceType.ShouldBe(PaymentMethodSequenceTypes.OneOff);
     }
 
     [Fact]
@@ -106,6 +106,6 @@ public sealed class PaymentAvailabilityContextParserTests
             .TryParse(country: "BE", currency: null, amount: null, sequenceType: null, out string? error);
 
         error.ShouldBeNull();
-        context!.SequenceType.ShouldBe(PaymentMethodSequenceType.OneOff);
+        context!.SequenceType.ShouldBe(PaymentMethodSequenceTypes.OneOff);
     }
 }

--- a/tests/Granit.Payments.Tests/Domain/PaymentMethodConfigurationSnapshotTests.cs
+++ b/tests/Granit.Payments.Tests/Domain/PaymentMethodConfigurationSnapshotTests.cs
@@ -32,7 +32,7 @@ public sealed class PaymentMethodConfigurationSnapshotTests
         PaymentMethodCapability capability = new(
             SupportedCountries: ImmutableHashSet.Create("BE", "NL"),
             SupportedCurrencies: ImmutableHashSet.Create("EUR"),
-            SupportedSequenceTypes: PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First,
+            SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First,
             AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
             {
                 ["EUR"] = new("EUR", 1m, 10_000m),
@@ -78,7 +78,7 @@ public sealed class PaymentMethodConfigurationSnapshotTests
         PaymentMethodCapability original = new(
             SupportedCountries: ImmutableHashSet.Create("BE", "NL", "FR"),
             SupportedCurrencies: ImmutableHashSet.Create("EUR", "GBP"),
-            SupportedSequenceTypes: PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+            SupportedSequenceTypes: PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring,
             AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
             {
                 ["EUR"] = new("EUR", 10m, 10_000m),

--- a/tests/Granit.Payments.Tests/Internal/DefaultPaymentMethodAvailabilityFilterTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/DefaultPaymentMethodAvailabilityFilterTests.cs
@@ -12,9 +12,9 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     private static readonly PaymentMethodCapability Wildcard = new(
         SupportedCountries: ImmutableHashSet<string>.Empty,
         SupportedCurrencies: ImmutableHashSet<string>.Empty,
-        SupportedSequenceTypes: PaymentMethodSequenceType.OneOff
-            | PaymentMethodSequenceType.First
-            | PaymentMethodSequenceType.Recurring,
+        SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff
+            | PaymentMethodSequenceTypes.First
+            | PaymentMethodSequenceTypes.Recurring,
         AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
 
     private readonly DefaultPaymentMethodAvailabilityFilter _filter = new();
@@ -27,7 +27,7 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     public void EmptyContext_IgnoresAllAxes() =>
         _filter.IsAvailable(
                 Wildcard,
-                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.None))
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceTypes.None))
             .ShouldBeTrue();
 
     [Fact]
@@ -65,11 +65,11 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     [Fact]
     public void SequenceType_RequestedRecurring_AgainstOneOffOnly_Rejected()
     {
-        PaymentMethodCapability oneOffOnly = Wildcard with { SupportedSequenceTypes = PaymentMethodSequenceType.OneOff };
+        PaymentMethodCapability oneOffOnly = Wildcard with { SupportedSequenceTypes = PaymentMethodSequenceTypes.OneOff };
 
         _filter.IsAvailable(
                 oneOffOnly,
-                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.Recurring))
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceTypes.Recurring))
             .ShouldBeFalse();
     }
 
@@ -78,12 +78,12 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     {
         PaymentMethodCapability sepa = Wildcard with
         {
-            SupportedSequenceTypes = PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+            SupportedSequenceTypes = PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring,
         };
 
         _filter.IsAvailable(
                 sepa,
-                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.Recurring))
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceTypes.Recurring))
             .ShouldBeTrue();
     }
 
@@ -92,12 +92,12 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     {
         PaymentMethodCapability bancontact = Wildcard with
         {
-            SupportedSequenceTypes = PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First,
+            SupportedSequenceTypes = PaymentMethodSequenceTypes.OneOff | PaymentMethodSequenceTypes.First,
         };
 
         _filter.IsAvailable(
                 bancontact,
-                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.First))
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceTypes.First))
             .ShouldBeTrue();
     }
 
@@ -106,12 +106,12 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
     {
         PaymentMethodCapability sepa = Wildcard with
         {
-            SupportedSequenceTypes = PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+            SupportedSequenceTypes = PaymentMethodSequenceTypes.First | PaymentMethodSequenceTypes.Recurring,
         };
 
         _filter.IsAvailable(
                 sepa,
-                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.None))
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceTypes.None))
             .ShouldBeTrue();
     }
 
@@ -193,7 +193,7 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
         PaymentMethodCapability method = new(
             SupportedCountries: ImmutableHashSet.Create("BE", "NL"),
             SupportedCurrencies: ImmutableHashSet.Create("EUR"),
-            SupportedSequenceTypes: PaymentMethodSequenceType.OneOff,
+            SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff,
             AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
             {
                 ["EUR"] = new("EUR", 1m, 500m),
@@ -214,7 +214,7 @@ public sealed class DefaultPaymentMethodAvailabilityFilterTests
         // Sequence fails
         _filter.IsAvailable(
                 method,
-                new PaymentAvailabilityContext("BE", "EUR", 50m, PaymentMethodSequenceType.Recurring))
+                new PaymentAvailabilityContext("BE", "EUR", 50m, PaymentMethodSequenceTypes.Recurring))
             .ShouldBeFalse();
     }
 }

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
@@ -1,4 +1,4 @@
-using Granit.Privacy.BlobStorage.DataExport;
+using Granit.Privacy.BlobStorage.DataExport.Exceptions;
 using Granit.Privacy.BlobStorage.DataExport.Internal;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
+++ b/tests/Granit.Privacy.BlobStorage.Tests/DataExport/Internal/CountingStreamTests.cs
@@ -1,3 +1,4 @@
+using Granit.Privacy.BlobStorage.DataExport;
 using Granit.Privacy.BlobStorage.DataExport.Internal;
 using Shouldly;
 using Xunit;


### PR DESCRIPTION
## Summary

Continues the SonarQube cleanup started in #1213. Stacks on top of the now-merged `develop`.

### S107 — too many parameters (`[SuppressMessage]` with justification)

Per CLAUDE.md, suppressed where there is no natural domain wrapper:

- `LogClientSynced` / `LogAppSynced` source-generated `[LoggerMessage]` partials in the Cognito / EntraId / Keycloak client-role sync services (one parameter per template placeholder)
- `LookupEndpointHandlers.SearchAsync` — minimal-API binding
- `InvoiceLineItem.Create` — eight distinct domain concepts (id, description, quantity, unit price, source, tax, period, product)
- `PaymentMethodConfigurationEndpoints` (`Activate` / `Deactivate` / `Resync`)
- `PaymentMethodEndpoints.GetAvailableAsync`
- `OnBehalfOfTokenHandler` primary constructor

### Cognitive complexity

- `TokenRequestEncoder.ToParameters(TokenRequest)` split into per-grant-type helpers (`AppendAuthorizationCode`, `AppendRefreshToken`, `AppendClientCredentials`, `AppendTokenExchange`). Drops main method's complexity from 16 to well below the 15 threshold; tokens-exchange still has its share but isolated from the dispatcher.

### Enum naming (Flags-enum plural per Microsoft Framework Design Guidelines)

- `PaymentMethodSequenceType` → `PaymentMethodSequenceTypes` (14 references updated)
- `MultiTenancySide` → `MultiTenancySides` (89 references updated)

### Misc fixes

- `MultiTenancyEndpointRouteBuilderExtensions`: collapsed the inline commented-out example into a one-line note pointing at the docs (S125 — commented-out code)
- `PaymentMethodLabelResolver`: drop redundant array creation in `Split(['_', '-'])` → `Split('_', '-')`
- `MigrationBatchExecutor.ExecuteBatchAsync`: restored the default parameter value matching the interface (S1006)
- `QueryEndpointRouteBuilderExtensions.MapGranitQuery`: `[SuppressMessage]` S3011 with justification — setup-time reflection used precisely so consumers cannot bypass the public API
- `GranitJsonDefaultsMarker`: `[SuppressMessage]` S2094 with justification — DI registration sentinel; an interface would expose a useless contract
- `MeterDefinitionEndpoints`: use strongly-typed `Headers.Link` property instead of dictionary access
- `AspNetPasskeyService`: drop redundant `(uint)` cast on `SignCount`
- `GranitCookiesOptionsValidator` + `OnBehalfOfOptionsValidator`: replaced the `List<string>? failures = null` + `(failures ??= []).Add(...)` + `failures is null ? Success : Fail(failures)` pattern with the simpler `List<string> failures = []` + `failures.Count == 0` form. One alloc per validation pass (negligible at startup); silences S2589.

### Architecture-rule fix

- `PrivacyExportSizeLimitExceededException` extracted from `CountingStream.cs` into its own file under `DataExport/` (out of `Internal/`). It was made public in #1213 to satisfy S3871, but `Public_types_should_not_reside_in_Internal_namespaces` (architecture suite) then flagged it. New location aligns with both rules.

### Test fixture fix

- `OpenIddictTestApplication` now sets `OpenIddict:AllowEphemeralKeys = "true"` in test configuration. The fixture runs as `Production` (default for `WebApplication.CreateBuilder`), and `AddGranitOpenIddictServer` rejects ephemeral signing/encryption keys outside Development. Persistent keys are not worth provisioning for an in-memory integration suite. Unblocks the OpenIddict integration test collection.

## Test plan

- [ ] CI green on all shards
- [ ] Architecture tests pass (verified locally — `Public_types_should_not_reside_in_Internal_namespaces` now passes)
- [ ] OpenIddict integration tests pass (fix targeted at the fixture-init failure observed in CI)
- [ ] Format clean (verified locally)