### PR TITLE
fix(tests): align federated provider ActivitySource name assertions

### DIFF
--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoActivitySourceTests.cs
@@ -8,7 +8,7 @@ public sealed class IdentityCognitoActivitySourceTests
 {
     [Fact]
     public void Source_HasCorrectName() =>
-        IdentityCognitoActivitySource.Source.Name.ShouldBe("Granit.Identity.Cognito");
+        IdentityCognitoActivitySource.Source.Name.ShouldBe("Granit.Identity.Federated.Cognito");
 
     [Fact]
     public void Operations_ListUsers_HasCorrectValue() =>

--- a/tests/Granit.Identity.Federated.EntraId.Tests/Diagnostics/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/Diagnostics/IdentityEntraIdActivitySourceTests.cs
@@ -24,8 +24,8 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
     public void Dispose() => _listener.Dispose();
 
     [Fact]
-    public void Name_is_Granit_Identity_EntraId() =>
-        IdentityEntraIdActivitySource.Name.ShouldBe("Granit.Identity.EntraId");
+    public void Name_is_Granit_Identity_Federated_EntraId() =>
+        IdentityEntraIdActivitySource.Name.ShouldBe("Granit.Identity.Federated.EntraId");
 
     [Fact]
     public void StartActivity_returns_activity_when_listener_attached()

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -224,7 +224,7 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
     [Fact]
     public void ActivitySource_HasCorrectName() =>
-        IdentityEntraIdActivitySource.Name.ShouldBe("Granit.Identity.EntraId");
+        IdentityEntraIdActivitySource.Name.ShouldBe("Granit.Identity.Federated.EntraId");
 
     [Fact]
     public async Task SpansDoNotContainPii()

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/IdentityGoogleCloudActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/IdentityGoogleCloudActivitySourceTests.cs
@@ -8,11 +8,11 @@ public sealed class IdentityGoogleCloudActivitySourceTests
 {
     [Fact]
     public void Name_IsCorrect() =>
-        IdentityGoogleCloudActivitySource.Name.ShouldBe("Granit.Identity.GoogleCloud");
+        IdentityGoogleCloudActivitySource.Name.ShouldBe("Granit.Identity.Federated.GoogleCloud");
 
     [Fact]
     public void Source_HasCorrectName() =>
-        IdentityGoogleCloudActivitySource.Source.Name.ShouldBe("Granit.Identity.GoogleCloud");
+        IdentityGoogleCloudActivitySource.Source.Name.ShouldBe("Granit.Identity.Federated.GoogleCloud");
 
     [Fact]
     public void Operations_ListUsers_IsCorrect() =>

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/Diagnostics/IdentityKeycloakActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/Diagnostics/IdentityKeycloakActivitySourceTests.cs
@@ -23,8 +23,8 @@ public sealed class IdentityKeycloakActivitySourceTests : IDisposable
     public void Dispose() => _listener.Dispose();
 
     [Fact]
-    public void Name_is_Granit_Identity_Keycloak() =>
-        IdentityKeycloakActivitySource.Name.ShouldBe("Granit.Identity.Keycloak");
+    public void Name_is_Granit_Identity_Federated_Keycloak() =>
+        IdentityKeycloakActivitySource.Name.ShouldBe("Granit.Identity.Federated.Keycloak");
 
     [Fact]
     public void StartActivity_returns_activity_when_listener_attached()


### PR DESCRIPTION
## Summary

- 4 federated identity provider test projects (Cognito, EntraId, GoogleCloud, Keycloak) asserted the **pre-rename** short ActivitySource name (`"Granit.Identity.{Provider}"`) while the source code emits the namespaced form (`"Granit.Identity.Federated.{Provider}"`) — these tests have been failing in CI.
- Source code is correct: it matches the assembly name and the `"Granit.{Module}"` diagnostics convention from `CLAUDE.md`. Downstream consumers (`OpenTelemetry.AddSource`, `GranitActivitySourceRegistry.Register`) already use the constant — no production impact.
- Fix updates 5 stale assertions across 5 files and renames two test methods so the method name documents the asserted value (`Name_is_Granit_Identity_{EntraId,Keycloak}` → `Name_is_Granit_Identity_Federated_{EntraId,Keycloak}`).

| Module | Assertion before | Assertion after |
|---|---|---|
| Cognito | `Granit.Identity.Cognito` | `Granit.Identity.Federated.Cognito` |
| EntraId (×2 files) | `Granit.Identity.EntraId` | `Granit.Identity.Federated.EntraId` |
| GoogleCloud (×2 sites) | `Granit.Identity.GoogleCloud` | `Granit.Identity.Federated.GoogleCloud` |
| Keycloak | `Granit.Identity.Keycloak` | `Granit.Identity.Federated.Keycloak` |

## Test plan

- [x] `dotnet test` on `Granit.Identity.Federated.Cognito.Tests` — 69/69 ✅
- [x] `dotnet test` on `Granit.Identity.Federated.EntraId.Tests` — 134/134 ✅
- [x] `dotnet test` on `Granit.Identity.Federated.GoogleCloud.Tests` — 58/58 ✅
- [x] `dotnet test` on `Granit.Identity.Federated.Keycloak.Tests` — 177/177 ✅
- [ ] CI green
