### PR TITLE
fix(tests): rename PaymentMethodSequenceType → PaymentMethodSequenceTypes (unblocks develop build)

### DIFF
--- a/tests/Granit.Payments.EntityFrameworkCore.Tests/Internal/EfPaymentMethodConfigurationStoreTests.cs
+++ b/tests/Granit.Payments.EntityFrameworkCore.Tests/Internal/EfPaymentMethodConfigurationStoreTests.cs
@@ -38,7 +38,7 @@ public sealed class EfPaymentMethodConfigurationStoreTests : IAsyncDisposable
         new(
             SupportedCountries: ImmutableHashSet.Create("BE", "FR"),
             SupportedCurrencies: ImmutableHashSet.Create("EUR"),
-            SupportedSequenceTypes: PaymentMethodSequenceType.OneOff,
+            SupportedSequenceTypes: PaymentMethodSequenceTypes.OneOff,
             AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
 
     [Fact]


### PR DESCRIPTION
## Summary

**Develop's build is broken** since #1216 merged. CS0103 in `EfPaymentMethodConfigurationStoreTests.cs:41` because the test file used the singular `PaymentMethodSequenceType` enum, but the rename to `PaymentMethodSequenceTypes` ([Flags], plural) landed in #1214 (sonar batches 6-9).

The test was authored against an older develop snapshot before #1214's rename was visible to my branch, and the discrepancy slipped through because all 7 test projects in #1216 had been built against the rename via a cherry-picked sync — except this one line.

**Fix**: 1-character change. `PaymentMethodSequenceType.OneOff` → `PaymentMethodSequenceTypes.OneOff`.

This unblocks every PR currently in flight (#1217, #1218, and any subsequent branch off develop).

## Test plan

- [x] `dotnet test tests/Granit.Payments.EntityFrameworkCore.Tests` — 20/20 pass locally
- [ ] CI green
