### PR TITLE
test(contacts): dual-use scope semantics — host vs tenant (US #1230)

### DIFF
--- a/src/Granit.Contacts.EntityFrameworkCore/Internal/EfContactStore.cs
+++ b/src/Granit.Contacts.EntityFrameworkCore/Internal/EfContactStore.cs
@@ -1,7 +1,6 @@
 using Granit.Contacts.Domain;
 using Granit.Contacts.Domain.ValueObjects;
 using Granit.MultiTenancy;
-using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -21,9 +20,19 @@ internal sealed class EfContactStore(
     : EfStoreBase<Contact, ContactsDbContext>(contextFactory, currentTenant),
       IContactReader, IContactWriter
 {
+    /// <summary>
+    /// Overrides <see cref="EfStoreBase{TEntity,TContext}.Query(TContext)"/> to keep the
+    /// multi-tenant query filter active in <i>both</i> tenant and host scope. The dual-use
+    /// design treats <c>TenantId == null</c> as the host's own scope (its tenants-as-customers,
+    /// vendors, internal staff) — leaking other tenants' contacts into a host browser would be
+    /// a privacy regression. The standard host-mode bypass remains available explicitly via
+    /// <c>IDataFilter.Disable&lt;IMultiTenant&gt;()</c>.
+    /// </summary>
+    private static DbSet<Contact> ContactQuery(ContactsDbContext db) => db.Contacts;
+
     public Task<Contact?> GetByIdAsync(ContactId id, CancellationToken cancellationToken = default) =>
         ReadAsync(
-            db => Query(db)
+            db => ContactQuery(db)
                 .Include(c => c.Addresses)
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
@@ -38,7 +47,7 @@ internal sealed class EfContactStore(
         ArgumentException.ThrowIfNullOrWhiteSpace(externalId);
 
         return ReadAsync(
-            db => Query(db)
+            db => ContactQuery(db)
                 .Include(c => c.Addresses)
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
@@ -58,7 +67,7 @@ internal sealed class EfContactStore(
         }
 
         return ReadAsync(
-            db => Query(db)
+            db => ContactQuery(db)
                 .Include(c => c.Addresses)
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
@@ -68,12 +77,16 @@ internal sealed class EfContactStore(
     }
 
     public Task<IReadOnlyList<Contact>> ListAsync(CancellationToken cancellationToken = default) =>
-        ListAsync(Spec.For<Contact>(), cancellationToken);
+        ReadAsync<IReadOnlyList<Contact>>(
+            async db => await ContactQuery(db).ToListAsync(cancellationToken).ConfigureAwait(false),
+            cancellationToken);
 
     public Task<IReadOnlyList<Contact>> ListByRoleAsync(
         ContactRoles role, CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<Contact>().Where(c => (c.Roles & role) == role),
+        ReadAsync<IReadOnlyList<Contact>>(
+            async db => await ContactQuery(db)
+                .Where(c => (c.Roles & role) == role)
+                .ToListAsync(cancellationToken).ConfigureAwait(false),
             cancellationToken);
 
     Task IContactWriter.AddAsync(Contact contact, CancellationToken cancellationToken) =>

--- a/src/Granit.Contacts/README.md
+++ b/src/Granit.Contacts/README.md
@@ -15,6 +15,35 @@ by provider name (one mapping per provider).
 
 Part of the [granit](https://granit-fx.dev) framework.
 
+## Two usage modes
+
+The aggregate is `IMultiTenant`, but unlike most Granit modules it intentionally treats
+`TenantId == null` as a **first-class scope** — the SaaS host's own contacts — rather
+than as "missing data". The store's read path enforces the corresponding visibility
+rules without consumer code branches:
+
+| Active context | What the store returns |
+| -------------- | ---------------------- |
+| `ICurrentTenant.IsAvailable == true` (tenant `T`) | Only contacts where `TenantId == T` |
+| `ICurrentTenant.IsAvailable == false` (host) | Only contacts where `TenantId == null` |
+| Any context, after `IDataFilter.Disable<IMultiTenant>()` | All contacts cross-scope |
+
+Two example call sites:
+
+```csharp
+// Host SaaS — billing relationships with the platform's own tenants-as-customers.
+Contact platformCustomer = Contact.Create(
+    Guid.NewGuid(), tenantId: null, ContactKind.Company, "ACME Inc.", "EUR");
+
+// Tenant e-commerce app — that tenant's own end-customer base.
+Contact endCustomer = Contact.Create(
+    Guid.NewGuid(), tenantId: currentTenant.Id, ContactKind.Individual, "Jean Dupont", "EUR");
+```
+
+Cross-scope reads (e.g., a host admin browsing a tenant's contacts during a support
+incident) require an explicit `using IDataFilter.Disable<IMultiTenant>()` scope and
+should be reviewed for privacy implications.
+
 ## Installation
 
 ```bash

--- a/tests/Granit.Contacts.EntityFrameworkCore.Tests/Internal/EfContactStoreScopeTests.cs
+++ b/tests/Granit.Contacts.EntityFrameworkCore.Tests/Internal/EfContactStoreScopeTests.cs
@@ -1,0 +1,260 @@
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.Contacts.EntityFrameworkCore.Internal;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Contacts.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Integration tests covering the dual-use design (US #1230): the same <see cref="Contact"/>
+/// aggregate must back both host-scoped (<c>TenantId == null</c>) and tenant-scoped
+/// (<c>TenantId == &lt;tenant&gt;</c>) usage without consumer code branches.
+///
+/// Three contacts are seeded with the multi-tenant filter <i>disabled</i> so each row lands
+/// at its intended scope. Subsequent reads exercise the filter under each context (tenant A,
+/// tenant B, host, no-filter) and assert that <see cref="EfContactStore"/> honours the
+/// active scope on every query path — including <c>GetByIdAsync</c>.
+/// </summary>
+[Collection(ContactsDbSerialGroup.Name)]
+public sealed class EfContactStoreScopeTests : IAsyncDisposable
+{
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly Guid _tenantB = Guid.NewGuid();
+    private readonly DataFilter _filter = new();
+    private readonly string _databaseName = $"contacts-scope-{Guid.NewGuid()}";
+    // Shared in-memory root so the per-scope service providers (each with its own
+    // IModelSource and model cache) all read/write the same underlying store.
+    private readonly InMemoryDatabaseRoot _dbRoot = new();
+
+    private Contact _hostContact = null!;
+    private Contact _tenantAContact = null!;
+    private Contact _tenantBContact = null!;
+
+    public async ValueTask DisposeAsync()
+    {
+        // Each test scope creates its own context; cleanup is per-test via the unique DB name.
+        StubCurrentTenant t = new();
+        DbContextOptions<ContactsDbContext> opts = BuildOptions();
+        await using ContactsDbContext db = new(opts, t, _filter);
+        await db.Database.EnsureDeletedAsync();
+    }
+
+    private DbContextOptions<ContactsDbContext> BuildOptions() =>
+        new DbContextOptionsBuilder<ContactsDbContext>()
+            // Share the in-memory store across scopes (different service providers) so a
+            // tenant-scoped query reads rows persisted by the host-scoped seeder.
+            .UseInMemoryDatabase(_databaseName, _dbRoot)
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            // Force a fresh EF service provider per scope so OnModelCreating runs again,
+            // re-capturing the current ICurrentTenant in the multi-tenant query-filter
+            // expression. Without this, all scopes within a fixture would share a model
+            // built with whichever ICurrentTenant happened to be active first.
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    /// <summary>
+    /// Builds a fresh DbContext + EfContactStore pair pinned to the given tenant. EF Core
+    /// captures the <see cref="ICurrentTenant"/> instance into the query-filter expression
+    /// at model-build time. To exercise different scopes we therefore build a NEW model
+    /// (via a fresh <see cref="UniqueModelCacheKeyFactory"/>) each time, with the tenant
+    /// already in the desired state.
+    /// </summary>
+    private (EfContactStore Store, ScopedFactory Factory) ScopedStore(Guid? tenantId)
+    {
+        StubCurrentTenant tenant = new();
+        if (tenantId is { } id) { tenant.Set(id); }
+        ScopedFactory factory = new(BuildOptions(), tenant, _filter);
+        return (new EfContactStore(factory, tenant), factory);
+    }
+
+    private async Task SeedAsync()
+    {
+        // Seed via a host-scoped store with the multi-tenant filter disabled so rows land
+        // at their intended scope regardless of the active context.
+        _hostContact = Contact.Create(Guid.NewGuid(), null, ContactKind.Company, "Host", "EUR");
+        _tenantAContact = Contact.Create(Guid.NewGuid(), _tenantA, ContactKind.Company, "TenantA", "EUR");
+        _tenantBContact = Contact.Create(Guid.NewGuid(), _tenantB, ContactKind.Company, "TenantB", "EUR");
+
+        (_, ScopedFactory factory) = ScopedStore(tenantId: null);
+        using IDisposable bypass = _filter.Disable<IMultiTenant>();
+        await using ContactsDbContext db = await factory.CreateDbContextAsync();
+        db.Contacts.AddRange(_hostContact, _tenantAContact, _tenantBContact);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── ListAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_InTenantContext_ReturnsOnlyThatTenantsContacts()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        IReadOnlyList<Contact> result = await store.ListAsync(TestContext.Current.CancellationToken);
+
+        result.Select(c => c.Name).ShouldBe(["TenantA"]);
+    }
+
+    [Fact]
+    public async Task ListAsync_InHostContext_ReturnsOnlyHostScopedContacts()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(tenantId: null);
+
+        IReadOnlyList<Contact> result = await store.ListAsync(TestContext.Current.CancellationToken);
+
+        result.Select(c => c.Name).ShouldBe(["Host"]);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithFilterDisabled_ReturnsAllScopes()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        using IDisposable bypass = _filter.Disable<IMultiTenant>();
+        IReadOnlyList<Contact> result = await store.ListAsync(TestContext.Current.CancellationToken);
+
+        result.Select(c => c.Name).ShouldBe(["Host", "TenantA", "TenantB"], ignoreOrder: true);
+    }
+
+    // ── GetByIdAsync — must honour the active scope ──────────────────
+
+    [Fact]
+    public async Task GetByIdAsync_TenantContext_ReturnsOwnContact()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        Contact? hit = await store.GetByIdAsync(
+            ContactId.Create(_tenantAContact.Id), TestContext.Current.CancellationToken);
+
+        hit.ShouldNotBeNull();
+        hit.Id.ShouldBe(_tenantAContact.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_TenantContext_HostContact_ReturnsNull()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        Contact? hit = await store.GetByIdAsync(
+            ContactId.Create(_hostContact.Id), TestContext.Current.CancellationToken);
+
+        hit.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_TenantContext_OtherTenantContact_ReturnsNull()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        Contact? hit = await store.GetByIdAsync(
+            ContactId.Create(_tenantBContact.Id), TestContext.Current.CancellationToken);
+
+        hit.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HostContext_HostContact_Returns()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(tenantId: null);
+
+        Contact? hit = await store.GetByIdAsync(
+            ContactId.Create(_hostContact.Id), TestContext.Current.CancellationToken);
+
+        hit.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_HostContext_TenantContact_ReturnsNull()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(tenantId: null);
+
+        Contact? hit = await store.GetByIdAsync(
+            ContactId.Create(_tenantAContact.Id), TestContext.Current.CancellationToken);
+
+        hit.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithFilterDisabled_FindsAcrossScopes()
+    {
+        await SeedAsync();
+        (EfContactStore store, _) = ScopedStore(_tenantA);
+
+        using IDisposable bypass = _filter.Disable<IMultiTenant>();
+        Contact? host = await store.GetByIdAsync(
+            ContactId.Create(_hostContact.Id), TestContext.Current.CancellationToken);
+        Contact? other = await store.GetByIdAsync(
+            ContactId.Create(_tenantBContact.Id), TestContext.Current.CancellationToken);
+
+        host.ShouldNotBeNull();
+        other.ShouldNotBeNull();
+    }
+
+    /// <summary>Mutable <see cref="ICurrentTenant"/> stub for scoped reads inside one fixture.</summary>
+    private sealed class StubCurrentTenant : ICurrentTenant
+    {
+        public bool IsAvailable => Id is not null;
+        public Guid? Id { get; private set; }
+        public string? Name { get; private set; }
+
+        public void Set(Guid tenantId, string? name = null)
+        {
+            Id = tenantId;
+            Name = name;
+        }
+
+        public void Clear()
+        {
+            Id = null;
+            Name = null;
+        }
+
+        public IDisposable Change(Guid? id, string? name = null)
+        {
+            Guid? previousId = Id;
+            string? previousName = Name;
+            Id = id;
+            Name = name;
+            return new RestoreScope(() =>
+            {
+                Id = previousId;
+                Name = previousName;
+            });
+        }
+
+        private sealed class RestoreScope(Action onDispose) : IDisposable
+        {
+            public void Dispose() => onDispose();
+        }
+    }
+
+    /// <summary>
+    /// Per-fixture <see cref="IDbContextFactory{TContext}"/> that injects a real
+    /// <see cref="ICurrentTenant"/> + <see cref="IDataFilter"/> into every <see cref="ContactsDbContext"/>
+    /// so the multi-tenant query filter is wired and active.
+    /// </summary>
+    private sealed class ScopedFactory(
+        DbContextOptions<ContactsDbContext> options,
+        ICurrentTenant tenant,
+        IDataFilter filter) : IDbContextFactory<ContactsDbContext>
+    {
+        public ContactsDbContext CreateDbContext() => new(options, tenant, filter);
+
+        public Task<ContactsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ContactsDbContext(options, tenant, filter));
+    }
+
+}

--- a/tests/Granit.Contacts.Tests/Architecture/ContactConventionTests.cs
+++ b/tests/Granit.Contacts.Tests/Architecture/ContactConventionTests.cs
@@ -1,0 +1,25 @@
+using Granit.Contacts.Domain;
+using Granit.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Contacts.Tests.Architecture;
+
+/// <summary>
+/// Convention tests for the <see cref="Contact"/> aggregate. Pinned because the dual-use
+/// design (host scope + tenant scope, both backed by the same row) hinges on the
+/// <see cref="IMultiTenant"/> contract — losing it would silently break the multi-tenant
+/// query filter.
+/// </summary>
+public sealed class ContactConventionTests
+{
+    [Fact]
+    public void Contact_ImplementsIMultiTenant() =>
+        typeof(IMultiTenant).IsAssignableFrom(typeof(Contact))
+            .ShouldBeTrue("Contact must remain IMultiTenant for the dual-use scope filter");
+
+    [Fact]
+    public void Contact_TenantIdIsNullable() =>
+        typeof(Contact).GetProperty(nameof(IMultiTenant.TenantId))!.PropertyType
+            .ShouldBe(typeof(Guid?), "host-scoped contacts require TenantId = null");
+}


### PR DESCRIPTION
## Summary

Pins the dual-use design of the `Contact` aggregate (host scope `TenantId == null` + tenant scope `TenantId == <T>`) with both convention assertions and end-to-end integration tests, and aligns `EfContactStore` with the AC's privacy-first defaults.

- **Convention tests** ([ContactConventionTests.cs](tests/Granit.Contacts.Tests/Architecture/ContactConventionTests.cs)): `Contact` implements `IMultiTenant` and exposes a nullable `TenantId`
- **Integration tests** ([EfContactStoreScopeTests.cs](tests/Granit.Contacts.EntityFrameworkCore.Tests/Internal/EfContactStoreScopeTests.cs), 9 cases): `ListAsync` and `GetByIdAsync` against three seeded contacts (host, tenant A, tenant B) under each scope:
  - Tenant context → only that tenant's contacts
  - Host context (`IsAvailable == false`) → only host-scoped contacts (`TenantId == null`)
  - `IDataFilter.Disable<IMultiTenant>()` → all contacts cross-scope
  - `GetByIdAsync` returns `null` on a cross-scope id
- **Behaviour change in `EfContactStore`** ([EfContactStore.cs](src/Granit.Contacts.EntityFrameworkCore/Internal/EfContactStore.cs)): override the standard host-mode bypass from `EfStoreBase.Query` so the multi-tenant filter stays active even when no tenant is current. The framework default ("host admin sees everything cross-tenant") is wrong for this aggregate — leaking other tenants' contacts into a host browser would be a privacy regression. Explicit `Disable<IMultiTenant>()` remains the documented escape hatch
- **README** ([README.md](src/Granit.Contacts/README.md)): new "Two usage modes" section with a visibility matrix and a call-site example for both host and tenant

Test infrastructure note: shares an `InMemoryDatabaseRoot` across per-scope service providers so tenant-scoped reads see rows persisted by the host-scoped seeder, while `EnableServiceProviderCaching(false)` forces a fresh `OnModelCreating` per scope so the multi-tenant filter expression captures the right `ICurrentTenant` instance.

Closes [#1230](https://github.com/granit-fx/granit-dotnet/issues/1230).

## Test plan

- [x] 101 / 101 domain tests
- [x] 26 / 26 EFCore tests (including 9 new dual-use scope tests)
- [x] 29 / 29 endpoints tests
- [x] 8 / 8 privacy tests
- [x] 130 / 130 architecture tests
- [x] markdownlint clean on README
- [ ] CI green