### PR TITLE
docs(contacts): standard role-handler pattern + dependency-direction guard (US #1248)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -161,6 +161,7 @@ export default defineConfig({
                         { label: "Add Background Jobs", link: "/dotnet/guides/add-background-jobs/" },
                         { label: "Configure Blob Storage", link: "/dotnet/guides/configure-blob-storage/" },
                         { label: "Implement Webhooks", link: "/dotnet/guides/implement-webhooks/" },
+                        { label: "Auto-maintain Contact Roles", link: "/dotnet/guides/contacts-role-handler/" },
                       ],
                     },
                     {

--- a/docs-site/src/content/docs/dotnet/guides/contacts-role-handler.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/contacts-role-handler.mdx
@@ -1,0 +1,103 @@
+---
+title: "Auto-maintain Contact.Roles via integration events"
+description: Standard handler pattern for downstream modules (Invoicing, Procurement, CRM, HR…) that toggle ContactRoles flags without inverting the dependency direction.
+sidebar:
+  order: 30
+  label: Contact roles handler
+---
+
+`Contact.Roles` is a cheap `[Flags] int` column that reflects the actual activity of
+a contact across the platform — `Customer` if they have invoices, `Supplier` if a
+purchase order has been issued to them, `Employee` if HR has onboarded them, etc.
+
+Granit deliberately does NOT compute these flags via cross-module joins (Odoo tried
+that in v8/v9 and rolled back to counter columns for the same reasons it would hurt
+us): query cost, broken module isolation, reversed dependency direction. Instead,
+each downstream module pushes role flags into the central `Contact` aggregate via
+its own integration-event handlers.
+
+## When to add a handler
+
+Add one when your module emits an event that proves a contact is acting in a given
+role. The handler converts that "first time we observed activity" signal into an
+idempotent `Contact.AddRole(role)` call.
+
+| Source event (your module) | Role to add | Why |
+| --------------------------- | ----------- | --- |
+| `InvoiceCreatedEto` / `InvoiceFinalizedEto` | `ContactRoles.Customer` | Contact has an invoice → they are a customer. |
+| `SubscriptionCreatedEto` | `ContactRoles.Customer` | Recurring billing relationship. |
+| `PurchaseOrderCreatedEto` | `ContactRoles.Supplier` | We bought from this contact. |
+| `LeadCreatedEto` | `ContactRoles.Lead` | CRM has registered a sales lead. |
+| `EmployeeOnboardedEto` | `ContactRoles.Employee` | HR onboarded this contact as staff. |
+
+## Handler pattern
+
+The handler is a Wolverine-discovered `public class` in your module's `.Wolverine`
+package (or wherever your other event handlers live), with a `public static
+HandleAsync` method matching the [Granit handler discovery rules](../infrastructure/wolverine-messaging.md).
+
+```csharp
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Invoicing.Events;
+
+namespace Granit.Invoicing.Wolverine;
+
+public class InvoiceCustomerRoleHandler
+{
+    public static async Task HandleAsync(
+        InvoiceCreatedEto @event,
+        IContactReader contacts,
+        IContactWriter writer,
+        IDataFilter dataFilter,
+        CancellationToken cancellationToken)
+    {
+        // Lookup with the multi-tenant filter disabled — this handler runs in a
+        // background context where the active scope may not match the contact's.
+        Contact? contact;
+        using (dataFilter.Disable<IMultiTenant>())
+        {
+            contact = await contacts
+                .GetByIdAsync(ContactId.Create(@event.ContactId), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (contact is null) { return; }
+
+        // AddRole is idempotent: calling it on every event is safe.
+        if (contact.AddRole(ContactRoles.Customer))
+        {
+            await writer.UpdateAsync(contact, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+```
+
+The handler MUST:
+
+- Be `public class` (non-static) with a `public static HandleAsync` method — required
+  for Wolverine handler discovery without taking a dependency on `WolverineFx` itself.
+- Use `IDataFilter.Disable<IMultiTenant>()` around the lookup so the contact resolves
+  regardless of the integration-event's active scope.
+- Treat `AddRole` as idempotent. Persist only when the call returns `true` so the
+  outbox does not accumulate no-op rows.
+- Live in a downstream module that depends on `Granit.Contacts` — never the reverse.
+  An [architecture test](https://github.com/granit-fx/granit-dotnet/blob/develop/tests/Granit.ArchitectureTests/ContactsDependencyDirectionTests.cs)
+  enforces this dependency direction.
+
+## Manual admin overrides
+
+The auto-maintenance handler does not preclude manual admin curation. The endpoint
+exposed by `Granit.Contacts.Endpoints` (`POST /contacts/{id}/roles`) lets a host
+operator assign or revoke roles directly — typically for legacy data backfills or
+GDPR-driven contact closures.
+
+## Future extension
+
+A `RoleAddedAt` / `LastObservedAt` timestamp per role is intentionally NOT part of
+the current contract. Add it (and a corresponding event) only if a retention or
+decay rule lands on the roadmap; until then, the simpler `[Flags] int` keeps reads
+to a single index lookup.

--- a/tests/Granit.ArchitectureTests/ContactsDependencyDirectionTests.cs
+++ b/tests/Granit.ArchitectureTests/ContactsDependencyDirectionTests.cs
@@ -1,0 +1,57 @@
+using ArchUnitNET.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Pins the dependency direction around the central <c>Granit.Contacts</c> aggregate
+/// (US #1248): downstream modules (Invoicing, Subscriptions, Payments, Tax,
+/// CustomerBalance, Procurement, Crm, Hr) consume <c>Contact</c> and push role flags
+/// via integration events, but the Contacts module must never depend on any of them.
+/// Reversing this would re-introduce the cross-module-join anti-pattern that the hybrid
+/// flag design exists to avoid.
+/// </summary>
+public sealed class ContactsDependencyDirectionTests
+{
+    private static readonly ArchUnitNET.Domain.Architecture Architecture = GranitArchitecture.Instance;
+
+    /// <summary>
+    /// Namespaces of consumer modules that <c>Granit.Contacts</c> must NOT depend on.
+    /// Adding a new role-emitting module? Wire its handler in the consumer module, not
+    /// in Contacts — and add the namespace to this list.
+    /// </summary>
+    private static readonly string[] DownstreamConsumerNamespaces =
+    [
+        "Granit.Invoicing",
+        "Granit.Subscriptions",
+        "Granit.Payments",
+        "Granit.Tax",
+        "Granit.CustomerBalance",
+        "Granit.Procurement",
+        "Granit.Crm",
+        "Granit.Hr",
+    ];
+
+    [Fact]
+    public void Contacts_module_must_not_depend_on_downstream_consumers()
+    {
+        IEnumerable<IType> contactsTypes = Architecture.Types.Where(t =>
+            t.FullName.StartsWith("Granit.Contacts.", StringComparison.Ordinal)
+            || string.Equals(t.Namespace.FullName, "Granit.Contacts", StringComparison.Ordinal)
+            || t.Namespace.FullName.StartsWith("Granit.Contacts.", StringComparison.Ordinal));
+
+        var violations = contactsTypes
+            .SelectMany(t => t.Dependencies.Select(d => (Source: t, TargetFullName: d.Target.FullName)))
+            .Where(pair => DownstreamConsumerNamespaces.Any(ns =>
+                pair.TargetFullName.StartsWith(ns + ".", StringComparison.Ordinal)
+                || string.Equals(pair.TargetFullName, ns, StringComparison.Ordinal)))
+            .Select(pair => $"{pair.Source.FullName} -> {pair.TargetFullName}")
+            .Distinct()
+            .ToList();
+
+        violations.ShouldBeEmpty(
+            "Granit.Contacts must remain consumer-direction-only — downstream modules push role flags " +
+            "via integration events, never the reverse. See docs/guide/contacts/role-handler-pattern.md.");
+    }
+}


### PR DESCRIPTION
## Summary

Locks down the hybrid model for `Contact.Roles` auto-maintenance: downstream modules push role flags via Wolverine integration-event handlers, `Granit.Contacts` never reaches back. The cross-module-join anti-pattern that the `[Flags] int` design exists to avoid (Odoo v8/v9 lesson) stays permanently off the table.

- **Architecture test** ([ContactsDependencyDirectionTests.cs](tests/Granit.ArchitectureTests/ContactsDependencyDirectionTests.cs)): `Granit.Contacts` and its sub-packages (`*.Endpoints`, `*.EntityFrameworkCore`, `*.Privacy`) must not depend on any consumer module — Invoicing, Subscriptions, Payments, Tax, CustomerBalance, Procurement, Crm, Hr. Adding a new role-emitting consumer? Add it to the guard list, not as a Contacts dependency
- **Contributor guide** ([contacts-role-handler.mdx](docs-site/src/content/docs/dotnet/guides/contacts-role-handler.mdx)): documents the standard handler shape — `public class` with a `public static HandleAsync` for Wolverine discovery, `IDataFilter.Disable<IMultiTenant>()` around the lookup, `AddRole`-then-persist for idempotency, and the table mapping each source event to its target role. Sidebar entry added under "Messaging & Events"

## Out of scope

- The actual `Granit.Invoicing` handler ships with **Feature 2** (Invoicing migration to `ContactId`) — `Granit.Invoicing` does not yet reference `Granit.Contacts`. The pattern is documented and the dependency direction is now enforced so the migration follows it
- `RoleAddedAt` / `LastObservedAt` timestamps stay out unless validated separately (per the issue)

Stacked on [#1255](https://github.com/granit-fx/granit-dotnet/pull/1255). Will be retargeted to `develop` once #1254 + #1255 merge.

Closes [#1248](https://github.com/granit-fx/granit-dotnet/issues/1248).

## Test plan

- [x] 131 / 131 architecture tests (1 new)
- [x] `npx astro build` — 427 pages, no errors
- [x] `npx markdownlint-cli2` clean on the new guide
- [ ] CI green