### PR TITLE
feat(invoicing): add Invoice.ContactId — billing identity FK to Contact (US #1232)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -57,6 +57,7 @@
       "src/Granit.Catalog.Endpoints/Granit.Catalog.Endpoints.csproj",
       "src/Granit.Catalog.EntityFrameworkCore/Granit.Catalog.EntityFrameworkCore.csproj",
       "src/Granit.Catalog/Granit.Catalog.csproj",
+      "src/Granit.Contacts/Granit.Contacts.csproj",
       "src/Granit.CustomerBalance.BackgroundJobs/Granit.CustomerBalance.BackgroundJobs.csproj",
       "src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj",
       "src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj",

--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -10,6 +10,7 @@
       "src/Granit.Catalog.Endpoints/Granit.Catalog.Endpoints.csproj",
       "src/Granit.Catalog.EntityFrameworkCore/Granit.Catalog.EntityFrameworkCore.csproj",
       "src/Granit.Catalog/Granit.Catalog.csproj",
+      "src/Granit.Contacts/Granit.Contacts.csproj",
       "src/Granit.CustomerBalance.BackgroundJobs/Granit.CustomerBalance.BackgroundJobs.csproj",
       "src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj",
       "src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1076,6 +1076,7 @@
       "name": "Granit.Invoicing",
       "deps": [
         "Granit",
+        "Granit.Contacts",
         "Granit.DataExchange.Abstractions",
         "Granit.Invoicing.Abstractions",
         "Granit.Guids",
@@ -22957,7 +22958,7 @@
       "kind": "record",
       "project": "Granit.Invoicing.Abstractions",
       "file": "src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs",
-      "line": 17,
+      "line": 23,
       "members": []
     },
     {
@@ -22966,7 +22967,7 @@
       "kind": "record",
       "project": "Granit.Invoicing.Abstractions",
       "file": "src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs",
-      "line": 44,
+      "line": 51,
       "members": []
     },
     {
@@ -23064,13 +23065,19 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Domain/Invoice.cs",
-      "line": 28,
+      "line": 29,
       "members": [
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, Guid tenantId, InvoiceDocumentType documentType, string currency, CollectionMethod collectionMethod, BillingReason billingReason, BillingAddress? billingAddress = null, CreditNoteInfo? creditNoteInfo = null, BillingPeriod? period = null)",
+          "signature": "Create(Guid id, Guid tenantId, ContactId contactId, InvoiceDocumentType documentType, string currency, CollectionMethod collectionMethod, BillingReason billingReason, BillingAddress? billingAddress = null, CreditNoteInfo? creditNoteInfo = null, BillingPeriod? period = null)",
           "returnType": "Invoice"
+        },
+        {
+          "name": "ContactId",
+          "kind": "property",
+          "signature": "ContactId ContactId",
+          "returnType": "ContactId"
         },
         {
           "name": "DocumentType",
@@ -23599,7 +23606,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/GranitInvoicingModule.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -23711,7 +23718,7 @@
       "kind": "interface",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/IInvoiceReader.cs",
-      "line": 7,
+      "line": 8,
       "members": [
         {
           "name": "GetByIdAsync",
@@ -23735,6 +23742,12 @@
           "name": "GetOverdueAsync",
           "kind": "method",
           "signature": "GetOverdueAsync(DateTimeOffset now, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Invoice>>"
+        },
+        {
+          "name": "GetByContactAsync",
+          "kind": "method",
+          "signature": "GetByContactAsync(ContactId contactId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Invoice>>"
         },
         {

--- a/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
+++ b/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
@@ -6,11 +6,17 @@ namespace Granit.Invoicing.Commands;
 /// Command to create an invoice. Can be published by any module
 /// (Subscriptions, Commerce, admin) without creating a dependency on Invoicing.
 /// </summary>
-/// <param name="TenantId">The tenant for which to create the invoice.</param>
+/// <param name="TenantId">The tenant for which to create the invoice (multi-tenant isolation).</param>
 /// <param name="Currency">ISO 4217 currency code (e.g., "EUR").</param>
 /// <param name="CollectionMethod">How payment should be collected.</param>
 /// <param name="BillingReason">Why the invoice is being created.</param>
 /// <param name="LineItems">Line items to add to the invoice.</param>
+/// <param name="ContactId">
+///   Optional identifier of the <c>Granit.Contacts.Contact</c> that holds the billing identity for this invoice.
+///   When <c>null</c>, the invoicing service resolves the tenant's default host-scoped contact via
+///   <c>IDefaultContactResolver.GetDefaultForTenantAsync</c>. Pass an explicit value when the caller already
+///   knows the contact (admin endpoints, manually issued invoices, multi-contact tenants).
+/// </param>
 /// <param name="PeriodStart">Optional billing period start.</param>
 /// <param name="PeriodEnd">Optional billing period end.</param>
 /// <param name="IdempotencyKey">Optional key to prevent duplicate invoice creation.</param>
@@ -20,6 +26,7 @@ public sealed record CreateInvoiceCommand(
     CollectionMethod CollectionMethod,
     BillingReason BillingReason,
     IReadOnlyList<CreateInvoiceLineItem> LineItems,
+    Guid? ContactId = null,
     DateTimeOffset? PeriodStart = null,
     DateTimeOffset? PeriodEnd = null,
     string? IdempotencyKey = null);

--- a/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/CreditNoteIssuedEto.cs
@@ -4,4 +4,4 @@ namespace Granit.Invoicing.Events;
 
 /// <summary>Published when a credit note is issued. Triggers refund via Payments.</summary>
 public sealed record CreditNoteIssuedEto(
-    Guid CreditNoteId, Guid InvoiceId, Guid TenantId, decimal Total) : IIntegrationEvent;
+    Guid CreditNoteId, Guid InvoiceId, Guid TenantId, Guid ContactId, decimal Total) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceFinalizedEto.cs
@@ -5,5 +5,5 @@ namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is finalized. Triggers payment collection.</summary>
 public sealed record InvoiceFinalizedEto(
-    Guid InvoiceId, Guid TenantId, decimal Total,
+    Guid InvoiceId, Guid TenantId, Guid ContactId, decimal Total,
     string Currency, CollectionMethod CollectionMethod) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoiceOverdueEto.cs
@@ -4,4 +4,4 @@ namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is overdue (Open + past DueAt).</summary>
 public sealed record InvoiceOverdueEto(
-    Guid InvoiceId, Guid TenantId, DateTimeOffset DueAt) : IIntegrationEvent;
+    Guid InvoiceId, Guid TenantId, Guid ContactId, DateTimeOffset DueAt) : IIntegrationEvent;

--- a/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/InvoicePaidEto.cs
@@ -4,4 +4,4 @@ namespace Granit.Invoicing.Events;
 
 /// <summary>Published when an invoice is fully paid.</summary>
 public sealed record InvoicePaidEto(
-    Guid InvoiceId, Guid TenantId, DateTimeOffset PaidAt) : IIntegrationEvent;
+    Guid InvoiceId, Guid TenantId, Guid ContactId, DateTimeOffset PaidAt) : IIntegrationEvent;

--- a/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
+++ b/src/Granit.Invoicing.BackgroundJobs/Internal/DefaultOverdueInvoiceDetectionService.cs
@@ -26,7 +26,7 @@ internal sealed partial class DefaultOverdueInvoiceDetectionService(
             using (currentTenant.Change(invoice.TenantId))
             {
                 await distributedEventBus.PublishAsync(
-                    new InvoiceOverdueEto(invoice.Id, invoice.TenantId!.Value, invoice.DueAt!.Value),
+                    new InvoiceOverdueEto(invoice.Id, invoice.TenantId!.Value, invoice.ContactId.Value, invoice.DueAt!.Value),
                     cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
@@ -86,6 +86,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -110,6 +120,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing.Builtin/packages.lock.json
+++ b/src/Granit.Invoicing.Builtin/packages.lock.json
@@ -72,6 +72,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -102,6 +112,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing.Endpoints/Dtos/InvoiceCreateRequest.cs
+++ b/src/Granit.Invoicing.Endpoints/Dtos/InvoiceCreateRequest.cs
@@ -4,6 +4,7 @@ namespace Granit.Invoicing.Endpoints.Dtos;
 
 /// <summary>Request to create a new invoice or credit note.</summary>
 public sealed record InvoiceCreateRequest(
+    Guid ContactId,
     InvoiceDocumentType DocumentType,
     string Currency,
     CollectionMethod CollectionMethod,

--- a/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
+++ b/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization.Extensions;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Invoicing.Domain;
@@ -106,6 +107,7 @@ internal static class InvoiceEndpoints
         var invoice = Invoice.Create(
             guidGenerator.Create(),
             currentTenant.Id!.Value,
+            ContactId.Create(request.ContactId),
             request.DocumentType,
             request.Currency,
             request.CollectionMethod,

--- a/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
@@ -15,6 +15,7 @@ internal sealed class InvoicingSchemaExampleProvider : ISchemaExampleProvider
         {
             [typeof(InvoiceCreateRequest)] = new JsonObject
             {
+                ["contactId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
                 ["documentType"] = "Invoice",
                 ["currency"] = "EUR",
                 ["collectionMethod"] = "ChargeAutomatically",

--- a/src/Granit.Invoicing.Endpoints/packages.lock.json
+++ b/src/Granit.Invoicing.Endpoints/packages.lock.json
@@ -53,6 +53,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -100,6 +110,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
 using Granit.MultiTenancy;
@@ -21,6 +22,12 @@ internal sealed class EfInvoiceStore(
 
     public Task<IReadOnlyList<Invoice>> GetForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default) =>
         ListAsync(Spec.For<Invoice>().Where(i => i.TenantId == tenantId), cancellationToken);
+
+    public Task<IReadOnlyList<Invoice>> GetByContactAsync(
+        ContactId contactId, CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<Invoice>().Where(i => i.ContactId.Value == contactId.Value),
+            cancellationToken);
 
     public Task<IReadOnlyList<Invoice>> GetOverdueAsync(DateTimeOffset now, CancellationToken cancellationToken = default) =>
         ListAsync(

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/InvoiceConfiguration.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/InvoiceConfiguration.cs
@@ -26,10 +26,11 @@ internal sealed class InvoiceConfiguration : IEntityTypeConfiguration<Invoice>
         builder.Property(e => e.AmountRemaining).HasPrecision(18, 4).IsRequired();
         builder.Property(e => e.Overpayment).HasPrecision(18, 4).IsRequired();
 
-        // ParentInvoiceId is a SingleValueObject<Guid> — must be declared as a scalar property
-        // to prevent EF Core from discovering it as a navigation/entity type.
-        // The value converter is applied automatically by ApplyGranitConventions.
+        // ParentInvoiceId and ContactId are SingleValueObject<Guid> — declared as scalar
+        // properties to prevent EF Core from discovering them as navigations. The value
+        // converter is applied automatically by ApplyGranitConventions.
         builder.Property(e => e.ParentInvoiceId);
+        builder.Property(e => e.ContactId).IsRequired();
 
         builder.OwnsOne(e => e.BillingAddress, ba =>
         {
@@ -53,6 +54,9 @@ internal sealed class InvoiceConfiguration : IEntityTypeConfiguration<Invoice>
 
         builder.HasIndex(e => new { e.TenantId, e.Status })
             .HasDatabaseName($"ix_{GranitInvoicingDbProperties.DbTablePrefix}invoices_tenant_status");
+
+        builder.HasIndex(e => e.ContactId)
+            .HasDatabaseName($"ix_{GranitInvoicingDbProperties.DbTablePrefix}invoices_contact");
 
         builder.HasIndex(e => e.DueAt)
             .HasFilter("\"Status\" = 1")

--- a/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
@@ -130,6 +130,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -160,6 +170,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing.Notifications/packages.lock.json
+++ b/src/Granit.Invoicing.Notifications/packages.lock.json
@@ -72,6 +72,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -96,6 +106,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing.Odoo/packages.lock.json
+++ b/src/Granit.Invoicing.Odoo/packages.lock.json
@@ -243,6 +243,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -274,6 +284,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing/Domain/Invoice.cs
+++ b/src/Granit.Invoicing/Domain/Invoice.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
 using Granit.Invoicing.Events;
@@ -35,7 +36,8 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
 
     /// <summary>Creates a new invoice in Draft status.</summary>
     /// <param name="id">Unique invoice identifier.</param>
-    /// <param name="tenantId">Owning tenant identifier.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="contactId"/>).</param>
+    /// <param name="contactId">Identifier of the <c>Granit.Contacts.Contact</c> that holds the billing identity for this invoice. Required.</param>
     /// <param name="documentType">Whether this is an invoice or a credit note.</param>
     /// <param name="currency">ISO 4217 currency code.</param>
     /// <param name="collectionMethod">How payment is collected (auto-charge or manual).</param>
@@ -46,6 +48,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     public static Invoice Create(
         Guid id,
         Guid tenantId,
+        ContactId contactId,
         InvoiceDocumentType documentType,
         string currency,
         CollectionMethod collectionMethod,
@@ -54,6 +57,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         CreditNoteInfo? creditNoteInfo = null,
         BillingPeriod? period = null)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
 
         if (documentType == InvoiceDocumentType.CreditNote && creditNoteInfo is null)
@@ -66,6 +70,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         {
             Id = id,
             TenantId = tenantId,
+            ContactId = contactId,
             DocumentType = documentType,
             Currency = currency,
             CollectionMethod = collectionMethod,
@@ -78,7 +83,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
             PeriodEnd = period?.End,
         };
 
-        invoice.AddDomainEvent(new InvoiceCreatedEvent(id, tenantId));
+        invoice.AddDomainEvent(new InvoiceCreatedEvent(id, tenantId, contactId.Value));
         return invoice;
     }
 
@@ -86,15 +91,25 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     public static Invoice CreateCreditNote(
         Guid id,
         Guid tenantId,
+        ContactId contactId,
         InvoiceId parentInvoiceId,
         string currency,
         string reason) =>
         Create(
-            id, tenantId, InvoiceDocumentType.CreditNote, currency,
+            id, tenantId, contactId, InvoiceDocumentType.CreditNote, currency,
             CollectionMethod.Auto, BillingReason.Manual,
             creditNoteInfo: new CreditNoteInfo(parentInvoiceId, reason));
 
     // ── Properties ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Identifier of the <c>Granit.Contacts.Contact</c> aggregate that holds the billing
+    /// identity (legal name, addresses, external mappings) for this invoice. Required —
+    /// the invoice is meaningless without a billing party. Use
+    /// <c>IDefaultContactResolver.GetDefaultForTenantAsync</c> to obtain the host-scoped
+    /// contact representing a tenant when migrating from tenant-keyed billing.
+    /// </summary>
+    public ContactId ContactId { get; private set; } = null!;
 
     /// <summary>Whether this is an invoice or a credit note.</summary>
     public InvoiceDocumentType DocumentType { get; private set; }
@@ -243,12 +258,12 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         if (IsCreditNote)
         {
             AddDistributedEvent(new CreditNoteIssuedEto(
-                Id, ParentInvoiceId!, TenantId!.Value, Total));
+                Id, ParentInvoiceId!, TenantId!.Value, ContactId.Value, Total));
         }
         else
         {
             AddDistributedEvent(new InvoiceFinalizedEto(
-                Id, TenantId!.Value, Total, Currency, CollectionMethod));
+                Id, TenantId!.Value, ContactId.Value, Total, Currency, CollectionMethod));
         }
 
         return true;
@@ -294,7 +309,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         {
             PaidAt = paidAt;
             Status = InvoiceStatus.Paid;
-            AddDistributedEvent(new InvoicePaidEto(Id, TenantId!.Value, paidAt));
+            AddDistributedEvent(new InvoicePaidEto(Id, TenantId!.Value, ContactId.Value, paidAt));
 
             if (Overpayment > 0)
             {
@@ -335,7 +350,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         {
             PaidAt = creditNoteIssuedAt;
             Status = InvoiceStatus.Paid;
-            AddDistributedEvent(new InvoicePaidEto(Id, TenantId!.Value, creditNoteIssuedAt));
+            AddDistributedEvent(new InvoicePaidEto(Id, TenantId!.Value, ContactId.Value, creditNoteIssuedAt));
             return true;
         }
 

--- a/src/Granit.Invoicing/Events/InvoiceCreatedEvent.cs
+++ b/src/Granit.Invoicing/Events/InvoiceCreatedEvent.cs
@@ -3,4 +3,4 @@ using Granit.Events;
 namespace Granit.Invoicing.Events;
 
 /// <summary>Raised when a draft invoice is created.</summary>
-public sealed record InvoiceCreatedEvent(Guid InvoiceId, Guid TenantId) : IDomainEvent;
+public sealed record InvoiceCreatedEvent(Guid InvoiceId, Guid TenantId, Guid ContactId) : IDomainEvent;

--- a/src/Granit.Invoicing/Granit.Invoicing.csproj
+++ b/src/Granit.Invoicing/Granit.Invoicing.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Contacts\Granit.Contacts.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />

--- a/src/Granit.Invoicing/GranitInvoicingModule.cs
+++ b/src/Granit.Invoicing/GranitInvoicingModule.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts;
 using Granit.Guids;
 using Granit.Invoicing.Extensions;
 using Granit.Modularity;
@@ -10,6 +11,7 @@ namespace Granit.Invoicing;
 /// Granit module for agnostic invoicing (invoices, credit notes, tax, sync, PDF).
 /// </summary>
 [DependsOn(
+    typeof(GranitContactsModule),
     typeof(GranitGuidsModule),
     typeof(GranitTimingModule),
     typeof(GranitWorkflowModule))]

--- a/src/Granit.Invoicing/IInvoiceReader.cs
+++ b/src/Granit.Invoicing/IInvoiceReader.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
 
@@ -10,6 +11,9 @@ public interface IInvoiceReader
     Task<Invoice?> GetByNumberAsync(string invoiceNumber, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Invoice>> GetForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Invoice>> GetOverdueAsync(DateTimeOffset now, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all invoices billed to the given contact, regardless of tenant scope.</summary>
+    Task<IReadOnlyList<Invoice>> GetByContactAsync(ContactId contactId, CancellationToken cancellationToken = default);
 
     /// <summary>Returns all credit notes linked to a parent invoice.</summary>
     Task<IReadOnlyList<Invoice>> GetCreditNotesForInvoiceAsync(InvoiceId parentInvoiceId, CancellationToken cancellationToken = default);

--- a/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
+++ b/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
@@ -1,3 +1,6 @@
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Guids;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
@@ -12,15 +15,19 @@ internal sealed partial class DefaultInvoiceCreationService(
     IInvoiceWriter invoiceWriter,
     IGuidGenerator guidGenerator,
     IClock clock,
+    IDefaultContactResolver defaultContactResolver,
     ILogger<DefaultInvoiceCreationService> logger,
     ITaxCalculator? taxCalculator = null,
     IInvoiceNumberGenerator? numberGenerator = null) : IInvoiceCreationService
 {
     public async Task CreateAsync(CreateInvoiceCommand command, CancellationToken cancellationToken = default)
     {
+        ContactId contactId = await ResolveContactIdAsync(command, cancellationToken).ConfigureAwait(false);
+
         var invoice = Invoice.Create(
             guidGenerator.Create(),
             command.TenantId,
+            contactId,
             InvoiceDocumentType.Invoice,
             command.Currency,
             command.CollectionMethod,
@@ -71,6 +78,26 @@ internal sealed partial class DefaultInvoiceCreationService(
 
         await invoiceWriter.AddAsync(invoice, cancellationToken).ConfigureAwait(false);
         Log.InvoiceCreated(logger, invoice.Id, command.TenantId);
+    }
+
+    private async Task<ContactId> ResolveContactIdAsync(CreateInvoiceCommand command, CancellationToken cancellationToken)
+    {
+        if (command.ContactId is { } explicitId)
+        {
+            return ContactId.Create(explicitId);
+        }
+
+        Contact? defaultContact = await defaultContactResolver
+            .GetDefaultForTenantAsync(command.TenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return defaultContact is not null
+            ? ContactId.Create(defaultContact.Id)
+            : throw new InvalidOperationException(
+                $"No default Contact resolved for tenant '{command.TenantId}'. Either pass " +
+                $"{nameof(CreateInvoiceCommand)}.{nameof(CreateInvoiceCommand.ContactId)} explicitly or " +
+                $"seed a host-scoped Contact with provider '{ContactExternalProviderNames.Tenant}' = " +
+                $"'{command.TenantId}' (typically done at tenant-provisioning time).");
     }
 
     private static partial class Log

--- a/src/Granit.Invoicing/packages.lock.json
+++ b/src/Granit.Invoicing/packages.lock.json
@@ -85,6 +85,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Tax.Builtin/packages.lock.json
+++ b/src/Granit.Tax.Builtin/packages.lock.json
@@ -248,6 +248,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -285,6 +295,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Tax.Stripe/packages.lock.json
+++ b/src/Granit.Tax.Stripe/packages.lock.json
@@ -277,6 +277,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +318,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.ArchitectureTests/InvoiceContactIdConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/InvoiceContactIdConventionTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.Invoicing.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Pins the contract from US #1232: <c>Invoice.ContactId</c> is the typed
+/// <see cref="ContactId"/> value object — never a bare <see cref="Guid"/>. Reverting it
+/// would lose compile-time safety and let downstream callers pass arbitrary Guids that
+/// happen to be the wrong identifier (TenantId, UserId…).
+/// </summary>
+public sealed class InvoiceContactIdConventionTests
+{
+    [Fact]
+    public void Invoice_ContactId_IsTypedContactIdValueObject()
+    {
+        PropertyInfo? prop = typeof(Invoice).GetProperty(nameof(Invoice.ContactId));
+
+        prop.ShouldNotBeNull();
+        prop.PropertyType.ShouldBe(typeof(ContactId),
+            "Invoice.ContactId must remain the typed ContactId value object — using a bare Guid " +
+            "would let callers pass any unrelated identifier (TenantId, UserId, etc.) without " +
+            "compile-time checks.");
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1875,6 +1875,16 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
@@ -2392,6 +2402,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/Internal/DefaultOverdueInvoiceDetectionServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Events;
 using Granit.Invoicing;
 using Granit.Invoicing.BackgroundJobs.Internal;
@@ -47,6 +48,7 @@ public sealed class DefaultOverdueInvoiceDetectionServiceTests
         var invoice = Invoice.Create(
             Guid.NewGuid(),
             tid,
+            ContactId.Create(Guid.NewGuid()),
             InvoiceDocumentType.Invoice,
             "EUR",
             CollectionMethod.Auto,

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
@@ -318,6 +318,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -342,6 +352,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -539,6 +539,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -588,6 +598,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/EfInvoiceStoreTests.cs
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/EfInvoiceStoreTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Invoicing.Domain;
@@ -35,9 +36,10 @@ public sealed class EfInvoiceStoreTests : IAsyncDisposable
         await db.Database.EnsureDeletedAsync();
     }
 
-    private static Invoice NewDraftInvoice(Guid? tenantId = null) =>
+    private static Invoice NewDraftInvoice(Guid? tenantId = null, Guid? contactId = null) =>
         Invoice.Create(
             Guid.NewGuid(), tenantId ?? Guid.NewGuid(),
+            ContactId.Create(contactId ?? Guid.NewGuid()),
             InvoiceDocumentType.Invoice, "EUR",
             CollectionMethod.Auto, BillingReason.SubscriptionCycle);
 
@@ -121,6 +123,7 @@ public sealed class EfInvoiceStoreTests : IAsyncDisposable
 
         var creditNote = Invoice.Create(
             Guid.NewGuid(), parent.TenantId!.Value,
+            parent.ContactId,
             InvoiceDocumentType.CreditNote, "EUR",
             CollectionMethod.Auto, BillingReason.Manual,
             creditNoteInfo: new CreditNoteInfo(InvoiceId.Create(parent.Id), "test refund"));

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
@@ -348,6 +348,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -378,6 +388,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
+++ b/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts;
 using Granit.Guids;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
@@ -20,12 +21,14 @@ public sealed class DefaultInvoiceCreationServiceTests
     private readonly IInvoiceWriter _invoiceWriter = Substitute.For<IInvoiceWriter>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
     private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IDefaultContactResolver _defaultContactResolver = Substitute.For<IDefaultContactResolver>();
     private readonly ILogger<DefaultInvoiceCreationService> _logger = NullLoggerFactory.Instance.CreateLogger<DefaultInvoiceCreationService>();
     private readonly ITaxCalculator _taxCalculator = Substitute.For<ITaxCalculator>();
     private readonly IInvoiceNumberGenerator _numberGenerator = Substitute.For<IInvoiceNumberGenerator>();
 
     private static readonly DateTimeOffset Now = new(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
     private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid ContactId = Guid.NewGuid();
 
     public DefaultInvoiceCreationServiceTests()
     {
@@ -39,6 +42,7 @@ public sealed class DefaultInvoiceCreationServiceTests
             _invoiceWriter,
             _guidGenerator,
             _clock,
+            _defaultContactResolver,
             _logger,
             taxCalculator,
             numberGenerator);
@@ -60,8 +64,9 @@ public sealed class DefaultInvoiceCreationServiceTests
                     InvoiceSourceType.Subscription,
                     Guid.NewGuid().ToString()))
                 .ToList(),
-            periodStart,
-            periodEnd);
+            ContactId: ContactId,
+            PeriodStart: periodStart,
+            PeriodEnd: periodEnd);
 
     // ======== Happy Path: Basic Creation ========
 

--- a/tests/Granit.Invoicing.Tests/InvoiceTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
 using Shouldly;
@@ -12,6 +13,7 @@ public sealed class InvoiceTests
         var invoice = Invoice.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             InvoiceDocumentType.Invoice,
             "EUR",
             CollectionMethod.Auto,
@@ -154,6 +156,7 @@ public sealed class InvoiceTests
         var creditNote = Invoice.CreateCreditNote(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             InvoiceId.Create(Guid.NewGuid()),
             "EUR",
             "Refund for defective service");

--- a/tests/Granit.Invoicing.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Tests/packages.lock.json
@@ -304,6 +304,16 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -328,6 +338,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/DefaultAutoChargeServiceTests.cs
@@ -28,6 +28,7 @@ public sealed class DefaultAutoChargeServiceTests
 
     private static readonly Guid TenantId = Guid.NewGuid();
     private static readonly Guid InvoiceId = Guid.NewGuid();
+    private static readonly Guid ContactId = Guid.NewGuid();
 
     public DefaultAutoChargeServiceTests()
     {
@@ -45,7 +46,7 @@ public sealed class DefaultAutoChargeServiceTests
     private static InvoiceFinalizedEto CreateEto(
         CollectionMethod collectionMethod = CollectionMethod.Auto,
         decimal total = 100m) =>
-        new(InvoiceId, TenantId, total, "EUR", collectionMethod);
+        new(InvoiceId, TenantId, ContactId, total, "EUR", collectionMethod);
 
     private static PaymentMethod CreateDefaultPaymentMethod() =>
         PaymentMethod.Create(Guid.NewGuid(), TenantId, "card", "stripe", "pm_123", "Visa **** 4242");

--- a/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/PassThroughPrePaymentProcessorTests.cs
@@ -17,7 +17,7 @@ public sealed class PassThroughPrePaymentProcessorTests
     public async Task ProcessAsync_ShouldReturnFullInvoiceTotal()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        var eto = new InvoiceFinalizedEto(Guid.NewGuid(), Guid.NewGuid(), 250.75m, "EUR", CollectionMethod.Auto);
+        var eto = new InvoiceFinalizedEto(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 250.75m, "EUR", CollectionMethod.Auto);
 
         PrePaymentResult result = await _sut.ProcessAsync(eto, ct);
 
@@ -28,7 +28,7 @@ public sealed class PassThroughPrePaymentProcessorTests
     public async Task ProcessAsync_ZeroTotal_ShouldReturnZero()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        var eto = new InvoiceFinalizedEto(Guid.NewGuid(), Guid.NewGuid(), 0m, "USD", CollectionMethod.Auto);
+        var eto = new InvoiceFinalizedEto(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 0m, "USD", CollectionMethod.Auto);
 
         PrePaymentResult result = await _sut.ProcessAsync(eto, ct);
 


### PR DESCRIPTION
## Summary

First step of Feature 2 ([#1222](https://github.com/granit-fx/granit-dotnet/issues/1222)). Replaces direct tenant-keyed billing on `Granit.Invoicing` with a typed `Contact` reference, so invoices carry a stable billing identity (legal name, addresses, polyglot external mappings) that survives across the upcoming Subscriptions / Payments / Tax / CustomerBalance migrations. `TenantId` remains for multi-tenant isolation — orthogonal to `ContactId`.

- `Granit.Invoicing` now `[DependsOn]` `Granit.Contacts`. `Invoice.ContactId` is the typed `ContactId` value object — a new architecture test pins this (a bare `Guid` would let callers pass any unrelated identifier without compile-time checks)
- `Invoice.Create` + `Invoice.CreateCreditNote` now require `ContactId`
- New `IInvoiceReader.GetByContactAsync` for cross-tenant reverse lookup
- `ContactId` added to all integration events emitted by the `Invoice` aggregate (`InvoiceCreatedEvent`, `InvoiceFinalizedEto`, `InvoicePaidEto`, `InvoiceOverdueEto`, `CreditNoteIssuedEto`) — additive change; downstream consumers (Payments tests) updated to pass through
- EF: `Property` + index on `ContactId`; auto-converted by `ApplyGranitConventions`
- `CreateInvoiceCommand.ContactId` stays **optional** with a transparent fallback in `DefaultInvoiceCreationService` that resolves the tenant's default host-scoped contact via `IDefaultContactResolver`. This unblocks Invoicing without forcing the Subscriptions / commerce-side migrations to land first
- `InvoiceCreateRequest.ContactId` required for the admin endpoint (Scalar example updated)

## Out of scope

- `BillingAddress` move from `Invoice` to `Contact` — [US #1233](https://github.com/granit-fx/granit-dotnet/issues/1233)
- EF migration script + tenant backfill — [US #1234](https://github.com/granit-fx/granit-dotnet/issues/1234)
- Endpoint / DTO surface (validators, OpenAPI) — [US #1235](https://github.com/granit-fx/granit-dotnet/issues/1235)
- Subscriptions handler that auto-marks Customer role on first invoice — Feature 3

Closes [#1232](https://github.com/granit-fx/granit-dotnet/issues/1232).

## Test plan

- [x] 54 / 54 Invoicing domain tests
- [x] 11 / 11 Invoicing EFCore tests
- [x] 7 / 7 Invoicing endpoints tests
- [x] 11 / 11 Invoicing background-jobs tests
- [x] 100 / 100 Payments tests (downstream Eto consumers)
- [x] 132 / 132 architecture tests (1 new: `InvoiceContactIdConventionTests`)
- [ ] CI green