### PR TITLE
feat(subscriptions): migrate to ContactId — Feature 3 (US #1236 + #1238)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2029,6 +2029,7 @@
       "name": "Granit.Subscriptions",
       "deps": [
         "Granit",
+        "Granit.Contacts.Abstractions",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
         "Granit.Invoicing.Abstractions",
@@ -41277,12 +41278,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/Subscription.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(SubscriptionId id, Guid tenantId, PlanId planId, string currency, SubscriptionPeriod period, DateTimeOffset? trialEndsAt = null, Guid? planPriceId = null)",
+          "signature": "Create(SubscriptionId id, Guid tenantId, ContactId contactId, PlanId planId, string currency, SubscriptionPeriod period, DateTimeOffset? trialEndsAt = null, Guid? planPriceId = null)",
           "returnType": "Subscription"
         },
         {
@@ -41310,10 +41311,10 @@
           "returnType": "IReadOnlyList<SubscriptionPhase>"
         },
         {
-          "name": "nameof",
-          "kind": "method",
-          "signature": "nameof(Status)",
-          "returnType": "Guid? TenantId { get; private set; } Guid? IMultiTenant.TenantId { get; set; } string IWorkflowStateful.StatusPropertyName =>"
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
         },
         {
           "name": "GetWorkflowEntityId",
@@ -41580,7 +41581,7 @@
       "kind": "record",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {
@@ -41589,7 +41590,7 @@
       "kind": "record",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
@@ -114,6 +114,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -199,6 +205,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Builtin/packages.lock.json
+++ b/src/Granit.Subscriptions.Builtin/packages.lock.json
@@ -100,6 +100,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -185,6 +191,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs
@@ -2,6 +2,7 @@ namespace Granit.Subscriptions.Endpoints.Dtos;
 
 /// <summary>Request to create a new subscription.</summary>
 public sealed record SubscriptionCreateRequest(
+    Guid ContactId,
     Guid PlanId,
     string Currency,
     DateTimeOffset? TrialEndsAt = null);

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
@@ -5,6 +5,7 @@ namespace Granit.Subscriptions.Endpoints.Dtos;
 /// <summary>Subscription details.</summary>
 public sealed record SubscriptionResponse(
     Guid Id,
+    Guid ContactId,
     Guid PlanId,
     string Status,
     string Currency,
@@ -19,6 +20,7 @@ public sealed record SubscriptionResponse(
 {
     internal static SubscriptionResponse FromEntity(Subscription sub) => new(
         sub.Id,
+        sub.ContactId.Value,
         sub.PlanId,
         sub.Status.ToString(),
         sub.Currency,

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization.Extensions;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
@@ -158,6 +159,7 @@ internal static class SubscriptionEndpoints
         var sub = Subscription.Create(
             guidGenerator.Create(),
             currentTenant.Id!.Value,
+            ContactId.Create(request.ContactId),
             PlanId.Create(request.PlanId),
             request.Currency,
             new SubscriptionPeriod(now, periodEnd, BillingCycleAnchor: now),

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -63,6 +63,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -186,6 +192,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
@@ -14,10 +14,11 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
 
         builder.HasKey(e => e.Id);
 
-        // PlanId is a SingleValueObject<Guid> — must be declared as a scalar property
-        // to prevent EF Core from discovering it as a navigation/entity type.
-        // The value converter is applied automatically by ApplyGranitConventions.
+        // PlanId and ContactId are SingleValueObject<Guid> — declared as scalar properties
+        // so EF Core does not discover them as navigations. The value converter is applied
+        // automatically by ApplyGranitConventions.
         builder.Property(e => e.PlanId).IsRequired();
+        builder.Property(e => e.ContactId).IsRequired();
 
         builder.Property(e => e.Status).IsRequired();
         builder.Property(e => e.CurrentPeriodStart).IsRequired();
@@ -44,6 +45,9 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
 
         builder.HasIndex(e => new { e.TenantId, e.Status })
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscriptions_tenant_status");
+
+        builder.HasIndex(e => e.ContactId)
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}subscriptions_contact");
 
         builder.HasIndex(e => e.TrialEndsAt)
             .HasFilter($"\"Status\" = {(int)SubscriptionStatus.Trial}")

--- a/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
@@ -130,6 +130,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -242,6 +248,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Features/packages.lock.json
+++ b/src/Granit.Subscriptions.Features/packages.lock.json
@@ -100,6 +100,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -192,6 +198,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Notifications/packages.lock.json
+++ b/src/Granit.Subscriptions.Notifications/packages.lock.json
@@ -100,6 +100,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -192,6 +198,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Events;
@@ -30,7 +31,8 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
     /// <summary>Creates a new subscription in Trial or Active status.</summary>
     /// <param name="id">Unique subscription identifier.</param>
-    /// <param name="tenantId">Owning tenant identifier.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="contactId"/>).</param>
+    /// <param name="contactId">Identifier of the <c>Granit.Contacts.Contact</c> that holds the billing identity for this subscription. Required.</param>
     /// <param name="planId">Plan the subscription is for.</param>
     /// <param name="currency">ISO 4217 currency code (e.g., "EUR").</param>
     /// <param name="period">Initial billing period boundaries.</param>
@@ -39,12 +41,14 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     public static Subscription Create(
         SubscriptionId id,
         Guid tenantId,
+        ContactId contactId,
         PlanId planId,
         string currency,
         SubscriptionPeriod period,
         DateTimeOffset? trialEndsAt = null,
         Guid? planPriceId = null)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
         ArgumentNullException.ThrowIfNull(period);
 
@@ -56,6 +60,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         {
             Id = id,
             TenantId = tenantId,
+            ContactId = contactId,
             PlanId = planId,
             Currency = currency.ToUpperInvariant(),
             Status = initialStatus,
@@ -67,9 +72,9 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
             PlanPriceId = planPriceId,
         };
 
-        subscription.AddDomainEvent(new SubscriptionCreatedEvent(id, planId, tenantId));
+        subscription.AddDomainEvent(new SubscriptionCreatedEvent(id, planId, tenantId, contactId.Value));
         subscription.AddDistributedEvent(new SubscriptionCreatedEto(
-            id, planId, tenantId, trialEndsAt.HasValue));
+            id, planId, tenantId, contactId.Value, trialEndsAt.HasValue));
 
         return subscription;
     }
@@ -135,6 +140,14 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     /// <inheritdoc />
     Guid? IMultiTenant.TenantId { get; set; }
 
+    /// <summary>
+    /// Identifier of the <c>Granit.Contacts.Contact</c> that holds the billing identity
+    /// (legal name, addresses, payment methods) for this subscription. Required — pinned
+    /// at creation. Switching contact mid-life-cycle is not supported (would invalidate
+    /// the running invoice cycle); cancel + re-create instead.
+    /// </summary>
+    public ContactId ContactId { get; private set; } = null!;
+
     // ── IWorkflowStateful ──────────────────────────────────────────────
 
     static string IWorkflowStateful.StatusPropertyName => nameof(Status);
@@ -156,7 +169,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
         EnsureTransitionAllowed(SubscriptionStatus.Active);
         Status = SubscriptionStatus.Active;
-        AddDistributedEvent(new SubscriptionActivatedEto(Id, PlanId, TenantId!.Value));
+        AddDistributedEvent(new SubscriptionActivatedEto(Id, PlanId, TenantId!.Value, ContactId.Value));
         return true;
     }
 
@@ -183,7 +196,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
         EnsureTransitionAllowed(SubscriptionStatus.Suspended);
         Status = SubscriptionStatus.Suspended;
-        AddDistributedEvent(new SubscriptionSuspendedEto(Id, PlanId, TenantId!.Value));
+        AddDistributedEvent(new SubscriptionSuspendedEto(Id, PlanId, TenantId!.Value, ContactId.Value));
         return true;
     }
 
@@ -205,7 +218,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         CancelledAt = cancelledAt;
         CancellationReason = reason;
         CancelAtPeriodEnd = false;
-        AddDistributedEvent(new SubscriptionCancelledEto(Id, PlanId, TenantId!.Value, reason));
+        AddDistributedEvent(new SubscriptionCancelledEto(Id, PlanId, TenantId!.Value, ContactId.Value, reason));
         return true;
     }
 
@@ -219,7 +232,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
         EnsureTransitionAllowed(SubscriptionStatus.Expired);
         Status = SubscriptionStatus.Expired;
-        AddDistributedEvent(new SubscriptionExpiredEto(Id, PlanId, TenantId!.Value));
+        AddDistributedEvent(new SubscriptionExpiredEto(Id, PlanId, TenantId!.Value, ContactId.Value));
         return true;
     }
 
@@ -258,7 +271,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
         PlanId oldPlanId = PlanId;
         PlanId = newPlanId;
-        AddDistributedEvent(new SubscriptionPlanChangedEto(Id, oldPlanId, newPlanId, TenantId!.Value));
+        AddDistributedEvent(new SubscriptionPlanChangedEto(Id, oldPlanId, newPlanId, TenantId!.Value, ContactId.Value));
     }
 
     /// <summary>Advances to the next billing period.</summary>

--- a/src/Granit.Subscriptions/Events/SubscriptionActivatedEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionActivatedEto.cs
@@ -6,4 +6,5 @@ namespace Granit.Subscriptions.Events;
 public sealed record SubscriptionActivatedEto(
     Guid SubscriptionId,
     Guid PlanId,
-    Guid TenantId) : IIntegrationEvent;
+    Guid TenantId,
+    Guid ContactId) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionCancelledEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionCancelledEto.cs
@@ -7,4 +7,5 @@ public sealed record SubscriptionCancelledEto(
     Guid SubscriptionId,
     Guid PlanId,
     Guid TenantId,
+    Guid ContactId,
     string? Reason) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionCreatedEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionCreatedEto.cs
@@ -7,4 +7,5 @@ public sealed record SubscriptionCreatedEto(
     Guid SubscriptionId,
     Guid PlanId,
     Guid TenantId,
+    Guid ContactId,
     bool HasTrial) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionCreatedEvent.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionCreatedEvent.cs
@@ -7,4 +7,5 @@ namespace Granit.Subscriptions.Events;
 public sealed record SubscriptionCreatedEvent(
     Guid SubscriptionId,
     PlanId PlanId,
-    Guid TenantId) : IDomainEvent;
+    Guid TenantId,
+    Guid ContactId) : IDomainEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionExpiredEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionExpiredEto.cs
@@ -6,4 +6,5 @@ namespace Granit.Subscriptions.Events;
 public sealed record SubscriptionExpiredEto(
     Guid SubscriptionId,
     Guid PlanId,
-    Guid TenantId) : IIntegrationEvent;
+    Guid TenantId,
+    Guid ContactId) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionPlanChangedEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionPlanChangedEto.cs
@@ -7,4 +7,5 @@ public sealed record SubscriptionPlanChangedEto(
     Guid SubscriptionId,
     Guid OldPlanId,
     Guid NewPlanId,
-    Guid TenantId) : IIntegrationEvent;
+    Guid TenantId,
+    Guid ContactId) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionSuspendedEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionSuspendedEto.cs
@@ -6,4 +6,5 @@ namespace Granit.Subscriptions.Events;
 public sealed record SubscriptionSuspendedEto(
     Guid SubscriptionId,
     Guid PlanId,
-    Guid TenantId) : IIntegrationEvent;
+    Guid TenantId,
+    Guid ContactId) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Granit.Subscriptions.csproj
+++ b/src/Granit.Subscriptions/Granit.Subscriptions.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Contacts.Abstractions\Granit.Contacts.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -129,6 +129,7 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
             CollectionMethod: CollectionMethod.Auto,
             BillingReason: BillingReason.SubscriptionCycle,
             LineItems: lineItems,
+            ContactId: subscription.ContactId.Value,
             PeriodStart: periodStart,
             PeriodEnd: periodEnd);
 

--- a/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
@@ -107,6 +107,7 @@ internal sealed partial class DefaultUsageInvoiceOrchestrator(
             CollectionMethod: CollectionMethod.Auto,
             BillingReason: BillingReason.SubscriptionCycle,
             LineItems: lineItems,
+            ContactId: subscription.ContactId.Value,
             PeriodStart: request.PeriodStart,
             PeriodEnd: request.PeriodEnd);
 

--- a/src/Granit.Subscriptions/packages.lock.json
+++ b/src/Granit.Subscriptions/packages.lock.json
@@ -125,6 +125,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/SubscriptionContactIdConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SubscriptionContactIdConventionTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.Subscriptions.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Pins the contract from US #1236: <c>Subscription.ContactId</c> is the typed
+/// <see cref="ContactId"/> value object — never a bare <see cref="Guid"/>. Mirrors
+/// <c>InvoiceContactIdConventionTests</c> for the Subscription aggregate so the
+/// next module migrations stay consistent.
+/// </summary>
+public sealed class SubscriptionContactIdConventionTests
+{
+    [Fact]
+    public void Subscription_ContactId_IsTypedContactIdValueObject()
+    {
+        PropertyInfo? prop = typeof(Subscription).GetProperty(nameof(Subscription.ContactId));
+
+        prop.ShouldNotBeNull();
+        prop.PropertyType.ShouldBe(typeof(ContactId),
+            "Subscription.ContactId must remain the typed ContactId value object — using a bare Guid " +
+            "would let callers pass any unrelated identifier (TenantId, UserId, etc.) without compile-time checks.");
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3305,6 +3305,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -346,6 +346,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -431,6 +437,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
@@ -332,6 +332,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -417,6 +423,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -549,6 +549,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -678,6 +684,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Internal/EfSubscriptionQueryableSourceTests.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Internal/EfSubscriptionQueryableSourceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.MultiTenancy;
@@ -37,6 +38,7 @@ public sealed class EfSubscriptionQueryableSourceTests : IDisposable
         var period = new SubscriptionPeriod(Now.AddMonths(-1), Now.AddMonths(1), BillingCycleAnchor: Now.AddMonths(-1));
         return Subscription.Create(
             Guid.NewGuid(), tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()), "EUR", period);
     }
 

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Internal/EfSubscriptionStoreTests.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Internal/EfSubscriptionStoreTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
@@ -54,6 +55,7 @@ public sealed class EfSubscriptionStoreTests : IAsyncDisposable
         var sub = Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(planId ?? Guid.NewGuid()),
             "EUR",
             period,

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -348,6 +348,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -460,6 +466,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -332,6 +332,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -424,6 +430,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -332,6 +332,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -424,6 +430,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhasesIntegrationTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Domain/SubscriptionPhasesIntegrationTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Shouldly;
@@ -18,6 +19,7 @@ public sealed class SubscriptionPhasesIntegrationTests
     private static Subscription NewSubscription() => Subscription.Create(
         SubscriptionId.Create(Guid.NewGuid()),
         Guid.NewGuid(),
+        ContactId.Create(Guid.NewGuid()),
         PlanId.Create(Guid.NewGuid()),
         currency: "EUR",
         period: new SubscriptionPeriod(T0, T0.AddMonths(12), BillingCycleAnchor: T0));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultBillingCycleInvoiceOrchestratorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultBillingCycleInvoiceOrchestratorTests.cs
@@ -1,4 +1,5 @@
 using Granit.Commands;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
@@ -39,6 +40,7 @@ public sealed class DefaultBillingCycleInvoiceOrchestratorTests
         return Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             planId,
             currency: "EUR",
             new SubscriptionPeriod(PeriodStart, PeriodEnd, BillingCycleAnchor: PeriodStart),

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultCancelAtPeriodEndServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultCancelAtPeriodEndServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.MultiTenancy;
@@ -39,6 +40,7 @@ public sealed class DefaultCancelAtPeriodEndServiceTests
         var sub = Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now.AddMonths(-1), now, BillingCycleAnchor: now.AddMonths(-1)));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultDunningServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultDunningServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Scheduling;
 using Granit.Scheduling.Domain.ValueObjects;
 using Granit.Subscriptions.Domain;
@@ -40,6 +41,7 @@ public sealed class DefaultDunningServiceTests
         return Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultPeriodAdvancementServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultPeriodAdvancementServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.MultiTenancy;
@@ -42,6 +43,7 @@ public sealed class DefaultPeriodAdvancementServiceTests
         return Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             planId,
             currency: "EUR",
             new SubscriptionPeriod(periodStart, periodEnd, BillingCycleAnchor: periodStart));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionProviderSyncServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionProviderSyncServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Internal;
@@ -29,6 +30,7 @@ public sealed class DefaultSubscriptionProviderSyncServiceTests
         return Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             planId,
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionReactivationServiceTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultSubscriptionReactivationServiceTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Internal;
@@ -28,6 +29,7 @@ public sealed class DefaultSubscriptionReactivationServiceTests
         var sub = Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));
@@ -59,6 +61,7 @@ public sealed class DefaultSubscriptionReactivationServiceTests
         var sub = Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));

--- a/tests/Granit.Subscriptions.Tests/Internal/DefaultUsageInvoiceOrchestratorTests.cs
+++ b/tests/Granit.Subscriptions.Tests/Internal/DefaultUsageInvoiceOrchestratorTests.cs
@@ -1,4 +1,5 @@
 using Granit.Commands;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
@@ -36,6 +37,7 @@ public sealed class DefaultUsageInvoiceOrchestratorTests
         return Subscription.Create(
             Guid.NewGuid(),
             tenantId,
+            ContactId.Create(Guid.NewGuid()),
             planId,
             currency: "EUR",
             new SubscriptionPeriod(PeriodStart, PeriodEnd, BillingCycleAnchor: PeriodStart),

--- a/tests/Granit.Subscriptions.Tests/SubscriptionTests.cs
+++ b/tests/Granit.Subscriptions.Tests/SubscriptionTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Shouldly;
@@ -13,6 +14,7 @@ public sealed class SubscriptionTests
         return Subscription.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now),
@@ -25,6 +27,7 @@ public sealed class SubscriptionTests
         return Subscription.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));
@@ -188,6 +191,7 @@ public sealed class SubscriptionTests
         var sub = Subscription.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now),
@@ -225,6 +229,7 @@ public sealed class SubscriptionTests
         var sub = Subscription.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
+            ContactId.Create(Guid.NewGuid()),
             PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now),

--- a/tests/Granit.Subscriptions.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Tests/packages.lock.json
@@ -332,6 +332,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -417,6 +423,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Replaces direct tenant addressing on `Granit.Subscriptions` with a typed `Contact` reference. Subscriptions now carry a `ContactId` pinned at creation, mirror the Invoice migration pattern from [#1232](https://github.com/granit-fx/granit-dotnet/pull/1257), and reference `Granit.Contacts.Abstractions` only — they don't need the full aggregate or the EF stack.

Folds **US #1236** (domain + services) and **US #1238** (endpoints + DTOs) into a single PR — they share most of the affected files and the AC for #1238 reduces to "expose the new field" once #1236 is in. **US #1237** (EF migration / backfill) reframes to a no-op for the same reason as the Invoicing flavour: no production data, runtime seeding already shipped via [#1260](https://github.com/granit-fx/granit-dotnet/pull/1260) — Wolverine creates the host-scoped contact on `TenantCreatedEvent`, downstream Subscription writes already carry `ContactId` via `IDefaultContactResolver` if a caller doesn't pass one explicitly.

## US #1236 — domain + services

- `Granit.Subscriptions` now references `Granit.Contacts.Abstractions`
- `Subscription.ContactId : ContactId` (required) added to the aggregate
- `Subscription.Create` accepts `ContactId`; pinned at creation, switching mid-life-cycle is not supported (would invalidate the running invoice cycle — cancel + re-create instead)
- `SubscriptionExternalMapping` is preserved — subscription-level external IDs remain distinct from customer-level external IDs (Stripe distinguishes customer ID and subscription ID; both must be storable)
- Domain + integration events carry `ContactId`: `SubscriptionCreatedEvent`, `SubscriptionCreatedEto`, `SubscriptionActivatedEto`, `SubscriptionSuspendedEto`, `SubscriptionCancelledEto`, `SubscriptionExpiredEto`, `SubscriptionPlanChangedEto`
- `DefaultUsageInvoiceOrchestrator` + `DefaultBillingCycleInvoiceOrchestrator` now thread `subscription.ContactId.Value` into `CreateInvoiceCommand` instead of relying on the tenant-fallback resolver — **explicit beats implicit** at the orchestrator boundary
- EF config: `Property` + index on `ContactId`, value converter applied automatically by `ApplyGranitConventions`
- Architecture test pins the typed value-object contract (mirrors `InvoiceContactIdConventionTests`)

## US #1238 — endpoints / DTOs

- `SubscriptionCreateRequest.ContactId` required (positional, first)
- `SubscriptionResponse.ContactId` surfaced as additive output
- The optional `?expand=customer` `ContactSummary` expansion is intentionally **deferred** — keeping this PR scoped to the core flip; a follow-up can add the projection without churning the aggregate

## Mass-update via script

22 test call sites of `Subscription.Create(...)` were updated through a one-shot Python regex script (the new positional `ContactId` slot lands between `tenantId` and `planId`); each affected file got `using Granit.Contacts.Domain.ValueObjects;` added. One false-positive in `Granit.Webhooks.EntityFrameworkCore.Tests` (matched `WebhookSubscription.Create`) was reverted manually.

Closes [#1236](https://github.com/granit-fx/granit-dotnet/issues/1236), [#1238](https://github.com/granit-fx/granit-dotnet/issues/1238). Will close [#1237](https://github.com/granit-fx/granit-dotnet/issues/1237) with a comment explaining the reframing (runtime seeding already in develop).

## Test plan

- [x] 151 / 151 Subscriptions domain
- [x] 41 / 41 Subscriptions EFCore
- [x] 8 / 8 Subscriptions Endpoints
- [x] 12 / 12 Subscriptions BackgroundJobs
- [x] 7 / 7 Subscriptions Builtin
- [x] 8 / 8 Subscriptions Features
- [x] 20 / 20 Subscriptions Notifications
- [x] 133 / 133 architecture (1 new fact)
- [ ] CI green