### PR TITLE
feat(customer-balance,invoicing): keyed by ContactId + cross-module typing guard (US #1243 + #1245)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -540,6 +540,7 @@
       "name": "Granit.CustomerBalance",
       "deps": [
         "Granit",
+        "Granit.Contacts.Abstractions",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
         "Granit.Invoicing.Abstractions",
@@ -560,6 +561,7 @@
       "name": "Granit.CustomerBalance.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Contacts",
         "Granit.CustomerBalance",
         "Granit.QueryEngine.AspNetCore",
         "Granit.Validation"
@@ -11468,12 +11470,12 @@
       "kind": "class",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Domain/BalanceAccount.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, Guid tenantId, string currency)",
+          "signature": "Create(Guid id, Guid tenantId, ContactId contactId, string currency)",
           "returnType": "BalanceAccount"
         },
         {
@@ -11487,6 +11489,12 @@
           "kind": "property",
           "signature": "Guid? TenantId",
           "returnType": "Guid?"
+        },
+        {
+          "name": "ContactId",
+          "kind": "property",
+          "signature": "ContactId ContactId",
+          "returnType": "ContactId"
         },
         {
           "name": "ConcurrencyStamp",
@@ -11588,7 +11596,7 @@
       "kind": "record",
       "project": "Granit.CustomerBalance.Endpoints",
       "file": "src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs",
-      "line": 16,
+      "line": 17,
       "members": []
     },
     {
@@ -11855,7 +11863,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "HandleAsync",
@@ -11871,12 +11879,12 @@
       "kind": "interface",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/IAdminCreditService.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "ApplyAsync",
           "kind": "method",
-          "signature": "ApplyAsync(Guid tenantId, decimal amount, string currency, TransactionSource source, string reason, DateTimeOffset? expiresAt, CancellationToken cancellationToken = default)",
+          "signature": "ApplyAsync(Guid tenantId, ContactId contactId, decimal amount, string currency, TransactionSource source, string reason, DateTimeOffset? expiresAt, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount>"
         }
       ]
@@ -11887,12 +11895,12 @@
       "kind": "interface",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/IAdminDebitService.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "DebitAsync",
           "kind": "method",
-          "signature": "DebitAsync(Guid tenantId, decimal amount, string currency, string reason, Guid? referenceId = null, string? referenceType = null, CancellationToken cancellationToken = default)",
+          "signature": "DebitAsync(Guid tenantId, ContactId contactId, decimal amount, string currency, string reason, Guid? referenceId = null, string? referenceType = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount>"
         }
       ]
@@ -11903,7 +11911,7 @@
       "kind": "interface",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/IBalanceAccountReader.cs",
-      "line": 7,
+      "line": 8,
       "members": [
         {
           "name": "GetByIdAsync",
@@ -11912,9 +11920,9 @@
           "returnType": "Task<BalanceAccount?>"
         },
         {
-          "name": "GetByTenantAndCurrencyAsync",
+          "name": "GetByContactAndCurrencyAsync",
           "kind": "method",
-          "signature": "GetByTenantAndCurrencyAsync(Guid tenantId, string currency, CancellationToken cancellationToken = default)",
+          "signature": "GetByContactAndCurrencyAsync(ContactId contactId, string currency, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount?>"
         },
         {
@@ -11991,12 +11999,12 @@
       "kind": "interface",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/IOverpaymentCreditService.cs",
-      "line": 7,
+      "line": 9,
       "members": [
         {
           "name": "CreditOverpaymentAsync",
           "kind": "method",
-          "signature": "CreditOverpaymentAsync(Guid tenantId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
+          "signature": "CreditOverpaymentAsync(Guid tenantId, ContactId contactId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]

--- a/src/Granit.CustomerBalance.BackgroundJobs/packages.lock.json
+++ b/src/Granit.CustomerBalance.BackgroundJobs/packages.lock.json
@@ -64,10 +64,17 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.CustomerBalance.Endpoints/Dtos/AdminCreditRequest.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Dtos/AdminCreditRequest.cs
@@ -1,7 +1,8 @@
 namespace Granit.CustomerBalance.Endpoints.Dtos;
 
-/// <summary>Request to add a manual credit to a tenant's balance.</summary>
+/// <summary>Request to add a manual credit to a contact's balance.</summary>
 public sealed record AdminCreditRequest(
+    Guid ContactId,
     decimal Amount,
     string Currency,
     string Source,

--- a/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
@@ -1,9 +1,10 @@
 namespace Granit.CustomerBalance.Endpoints.Dtos;
 
 /// <summary>
-/// Request to debit a tenant's <c>BalanceAccount</c> manually — admin tooling
+/// Request to debit a contact's <c>BalanceAccount</c> manually — admin tooling
 /// for corrections, scheduled drawdowns, and non-invoice adjustments.
 /// </summary>
+/// <param name="ContactId">Contact whose balance account is debited.</param>
 /// <param name="Amount">Amount to debit (must be > 0).</param>
 /// <param name="Currency">ISO 4217 currency code identifying the target balance account.</param>
 /// <param name="Reason">Free-text justification (audit trail; ≤ 500 chars; no PII per GDPR).</param>
@@ -14,6 +15,7 @@ namespace Granit.CustomerBalance.Endpoints.Dtos;
 /// </param>
 /// <param name="ReferenceType">Type of the referenced document (e.g. <c>"AdminAdjustment"</c>).</param>
 public sealed record AdminDebitRequest(
+    Guid ContactId,
     decimal Amount,
     string Currency,
     string Reason,

--- a/src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj
+++ b/src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Contacts\Granit.Contacts.csproj" />
     <ProjectReference Include="..\Granit.CustomerBalance\Granit.CustomerBalance.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.CustomerBalance.Endpoints/Internal/AdminCreditEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/AdminCreditEndpoint.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.MultiTenancy;
@@ -37,6 +38,7 @@ internal static class AdminCreditEndpoint
 
         BalanceAccount account = await creditService.ApplyAsync(
             tenantId,
+            ContactId.Create(request.ContactId),
             request.Amount,
             currency,
             source,

--- a/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/AdminDebitEndpoint.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.CustomerBalance.Exceptions;
@@ -29,6 +30,7 @@ internal static class AdminDebitEndpoint
             BalanceAccount account = await debitService
                 .DebitAsync(
                     tenantId,
+                    ContactId.Create(request.ContactId),
                     request.Amount,
                     currency,
                     request.Reason,

--- a/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
@@ -1,3 +1,6 @@
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.MultiTenancy;
@@ -12,6 +15,7 @@ internal static class GetBalanceEndpoint
     internal static async Task<Results<Ok<CustomerBalanceResponse>, ProblemHttpResult>> HandleAsync(
         string currency,
         [FromServices] IBalanceAccountReader accountReader,
+        [FromServices] IDefaultContactResolver contactResolver,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -20,8 +24,18 @@ internal static class GetBalanceEndpoint
             return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
+        Contact? contact = await contactResolver
+            .GetDefaultForTenantAsync(currentTenant.Id!.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (contact is null)
+        {
+            return TypedResults.Ok(new CustomerBalanceResponse(
+                Guid.Empty, currency.ToUpperInvariant(), 0m, null));
+        }
+
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(currentTenant.Id!.Value, currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(ContactId.Create(contact.Id), currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)

--- a/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
@@ -1,5 +1,7 @@
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
-using Granit.CustomerBalance.Domain.ValueObjects;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Http;
@@ -16,6 +18,7 @@ internal static class ListTransactionsEndpoint
         int pageSize,
         [FromServices] IBalanceAccountReader accountReader,
         [FromServices] IBalanceTransactionReader transactionReader,
+        [FromServices] IDefaultContactResolver contactResolver,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -27,8 +30,17 @@ internal static class ListTransactionsEndpoint
             return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
+        Contact? contact = await contactResolver
+            .GetDefaultForTenantAsync(currentTenant.Id!.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (contact is null)
+        {
+            return TypedResults.Ok<IReadOnlyList<BalanceTransactionResponse>>([]);
+        }
+
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(currentTenant.Id!.Value, currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(ContactId.Create(contact.Id), currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)

--- a/src/Granit.CustomerBalance.Endpoints/packages.lock.json
+++ b/src/Granit.CustomerBalance.Endpoints/packages.lock.json
@@ -53,10 +53,28 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountConfiguration.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountConfiguration.cs
@@ -14,13 +14,22 @@ internal sealed class BalanceAccountConfiguration : IEntityTypeConfiguration<Bal
         builder.Property(e => e.Currency).HasMaxLength(3).IsRequired();
         builder.Property(e => e.Balance).HasPrecision(18, 4).IsRequired();
 
+        // ContactId is a SingleValueObject<Guid> — declared as a scalar property so EF Core
+        // does not discover it as a navigation. Value converter applied by ApplyGranitConventions.
+        builder.Property(e => e.ContactId).IsRequired();
+
         builder.HasMany(e => e.Transactions)
             .WithOne()
             .HasForeignKey(t => t.BalanceAccountId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        builder.HasIndex(e => new { e.TenantId, e.Currency })
+        // Uniqueness is now per-(contact, currency) — a tenant can hold many balances,
+        // one per (contact, currency) pair, matching real e-commerce / multi-buyer flows.
+        builder.HasIndex(e => new { e.ContactId, e.Currency })
             .IsUnique()
-            .HasDatabaseName($"uq_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_tenant_currency");
+            .HasDatabaseName($"uq_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_contact_currency");
+
+        builder.HasIndex(e => e.TenantId)
+            .HasDatabaseName($"ix_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_tenant");
     }
 }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Domain.ValueObjects;
 using Granit.MultiTenancy;
@@ -18,8 +19,8 @@ internal sealed class EfBalanceAccountStore(
     public Task<BalanceAccount?> GetByIdAsync(BalanceAccountId id, CancellationToken cancellationToken = default) =>
         FindByIdAsync(id.Value, cancellationToken);
 
-    public async Task<BalanceAccount?> GetByTenantAndCurrencyAsync(
-        Guid tenantId, string currency, CancellationToken cancellationToken = default)
+    public async Task<BalanceAccount?> GetByContactAndCurrencyAsync(
+        ContactId contactId, string currency, CancellationToken cancellationToken = default)
     {
         string normalizedCurrency = currency.ToUpperInvariant();
         await using CustomerBalanceDbContext context = await _contextFactory
@@ -27,7 +28,7 @@ internal sealed class EfBalanceAccountStore(
         return await context.Accounts
             .Include(a => a.Transactions)
             .FirstOrDefaultAsync(
-                a => a.TenantId == tenantId && a.Currency == normalizedCurrency,
+                a => a.ContactId.Value == contactId.Value && a.Currency == normalizedCurrency,
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
@@ -99,10 +99,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
+++ b/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Events;
 using Granit.CustomerBalance.Exceptions;
 using Granit.Domain;
@@ -25,15 +26,21 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
 
     private BalanceAccount() { }
 
-    /// <summary>Creates a new balance account for the specified tenant and currency.</summary>
-    public static BalanceAccount Create(Guid id, Guid tenantId, string currency)
+    /// <summary>Creates a new balance account for the given contact, tenant and currency.</summary>
+    /// <param name="id">Unique account identifier.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
+    /// <param name="contactId">Identifier of the <c>Granit.Contacts.Contact</c> that owns this balance — required.</param>
+    /// <param name="currency">ISO 4217 currency code (e.g., "EUR").</param>
+    public static BalanceAccount Create(Guid id, Guid tenantId, ContactId contactId, string currency)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
 
         return new BalanceAccount
         {
             Id = id,
             TenantId = tenantId,
+            ContactId = contactId,
             Currency = currency.ToUpperInvariant(),
             Balance = 0m,
             ConcurrencyStamp = string.Empty,
@@ -54,6 +61,13 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
 
     /// <summary>Explicit interface for interceptor injection.</summary>
     Guid? IMultiTenant.TenantId { get => TenantId; set => TenantId = value; }
+
+    /// <summary>
+    /// Identifier of the <c>Granit.Contacts.Contact</c> that owns this balance. The
+    /// module's name finally matches its domain — a tenant can hold many balance accounts,
+    /// one per (contact, currency) tuple, so e-commerce tenants run per-buyer balances.
+    /// </summary>
+    public ContactId ContactId { get; private set; } = null!;
 
     /// <inheritdoc/>
     public string ConcurrencyStamp { get; set; } = string.Empty;
@@ -95,7 +109,7 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
         Balance += amount;
 
         AddDistributedEvent(new BalanceCreditedEto(
-            Id, TenantId!.Value, amount, Currency, source));
+            Id, TenantId!.Value, ContactId.Value, amount, Currency, source));
     }
 
     /// <summary>
@@ -138,6 +152,6 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
         Balance -= amount;
 
         AddDistributedEvent(new BalanceDebitedEto(
-            Id, TenantId!.Value, amount, Currency, referenceId, referenceType));
+            Id, TenantId!.Value, ContactId.Value, amount, Currency, referenceId, referenceType));
     }
 }

--- a/src/Granit.CustomerBalance/Events/BalanceCreditedEto.cs
+++ b/src/Granit.CustomerBalance/Events/BalanceCreditedEto.cs
@@ -7,6 +7,7 @@ namespace Granit.CustomerBalance.Events;
 public sealed record BalanceCreditedEto(
     Guid BalanceAccountId,
     Guid TenantId,
+    Guid ContactId,
     decimal Amount,
     string Currency,
     TransactionSource Source) : IIntegrationEvent;

--- a/src/Granit.CustomerBalance/Events/BalanceDebitedEto.cs
+++ b/src/Granit.CustomerBalance/Events/BalanceDebitedEto.cs
@@ -6,6 +6,7 @@ namespace Granit.CustomerBalance.Events;
 public sealed record BalanceDebitedEto(
     Guid BalanceAccountId,
     Guid TenantId,
+    Guid ContactId,
     decimal Amount,
     string Currency,
     Guid? ReferenceId,

--- a/src/Granit.CustomerBalance/Granit.CustomerBalance.csproj
+++ b/src/Granit.CustomerBalance/Granit.CustomerBalance.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Contacts.Abstractions\Granit.Contacts.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />

--- a/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
+++ b/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
@@ -1,11 +1,13 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Invoicing.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.CustomerBalance.Handlers;
 
 /// <summary>
-/// Credits overpayment surplus to the tenant's balance account.
-/// Delegates to <see cref="IOverpaymentCreditService"/>.
+/// Credits overpayment surplus to the contact's balance account.
+/// Delegates to <see cref="IOverpaymentCreditService"/>. Idempotent — Wolverine's
+/// at-least-once delivery is therefore safe.
 /// </summary>
 public class OverpaymentCreditHandler
 {
@@ -19,6 +21,7 @@ public class OverpaymentCreditHandler
         {
             await overpaymentCreditService.CreditOverpaymentAsync(
                 eto.TenantId,
+                ContactId.Create(eto.ContactId),
                 eto.Currency,
                 eto.OverpaymentAmount,
                 eto.InvoiceId,

--- a/src/Granit.CustomerBalance/IAdminCreditService.cs
+++ b/src/Granit.CustomerBalance/IAdminCreditService.cs
@@ -1,17 +1,19 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 
 namespace Granit.CustomerBalance;
 
 /// <summary>
-/// Applies admin credits (promotional, manual adjustment) to a tenant's balance account.
-/// Creates the account if it does not exist for the (TenantId, Currency) pair.
+/// Applies admin credits (promotional, manual adjustment) to a contact's balance account.
+/// Creates the account if it does not exist for the <c>(ContactId, Currency)</c> pair.
 /// </summary>
 public interface IAdminCreditService
 {
     /// <summary>
-    /// Credits the specified amount to the tenant's balance account for the given currency.
+    /// Credits the specified amount to the contact's balance account for the given currency.
     /// </summary>
-    /// <param name="tenantId">Tenant whose balance account receives the credit.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
+    /// <param name="contactId">Contact whose balance account receives the credit.</param>
     /// <param name="amount">Amount to credit.</param>
     /// <param name="currency">ISO 4217 currency code for the balance account.</param>
     /// <param name="source">Origin of the credit (e.g., Promotional, ManualAdjustment).</param>
@@ -20,6 +22,7 @@ public interface IAdminCreditService
     /// <param name="cancellationToken"></param>
     Task<BalanceAccount> ApplyAsync(
         Guid tenantId,
+        ContactId contactId,
         decimal amount,
         string currency,
         TransactionSource source,

--- a/src/Granit.CustomerBalance/IAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/IAdminDebitService.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 
 namespace Granit.CustomerBalance;
@@ -21,7 +22,8 @@ public interface IAdminDebitService
     /// Debits the supplied amount from the tenant's <see cref="BalanceAccount"/>
     /// for the given currency.
     /// </summary>
-    /// <param name="tenantId">Tenant whose balance account is debited.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
+    /// <param name="contactId">Contact whose balance account is debited.</param>
     /// <param name="amount">Amount to debit (must be positive).</param>
     /// <param name="currency">ISO 4217 currency code.</param>
     /// <param name="reason">Human-readable description (audit trail).</param>
@@ -29,10 +31,11 @@ public interface IAdminDebitService
     /// <param name="referenceType">Type of the referenced document (e.g. <c>"AdminAdjustment"</c>).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The updated <see cref="BalanceAccount"/>.</returns>
-    /// <exception cref="System.InvalidOperationException">Thrown when no account exists for the tenant/currency.</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when no account exists for the contact/currency.</exception>
     /// <exception cref="Exceptions.InsufficientBalanceException">Thrown when the balance is insufficient.</exception>
     Task<BalanceAccount> DebitAsync(
         Guid tenantId,
+        ContactId contactId,
         decimal amount,
         string currency,
         string reason,

--- a/src/Granit.CustomerBalance/IBalanceAccountReader.cs
+++ b/src/Granit.CustomerBalance/IBalanceAccountReader.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Domain.ValueObjects;
 
@@ -9,9 +10,9 @@ public interface IBalanceAccountReader
     /// <summary>Returns a balance account by ID, including transactions.</summary>
     Task<BalanceAccount?> GetByIdAsync(BalanceAccountId id, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns the balance account for a tenant and currency.</summary>
-    Task<BalanceAccount?> GetByTenantAndCurrencyAsync(Guid tenantId, string currency, CancellationToken cancellationToken = default);
+    /// <summary>Returns the balance account for a contact and currency.</summary>
+    Task<BalanceAccount?> GetByContactAndCurrencyAsync(ContactId contactId, string currency, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all balance accounts for a tenant.</summary>
+    /// <summary>Returns all balance accounts for a tenant (ledger management view).</summary>
     Task<IReadOnlyList<BalanceAccount>> GetByTenantAsync(Guid tenantId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.CustomerBalance/IOverpaymentCreditService.cs
+++ b/src/Granit.CustomerBalance/IOverpaymentCreditService.cs
@@ -1,21 +1,25 @@
+using Granit.Contacts.Domain.ValueObjects;
+
 namespace Granit.CustomerBalance;
 
 /// <summary>
-/// Credits overpayment surplus to a tenant's balance account.
-/// Creates the account if it does not exist for the (TenantId, Currency) pair.
+/// Credits overpayment surplus to a contact's balance account.
+/// Creates the account if it does not exist for the <c>(ContactId, Currency)</c> pair.
 /// </summary>
 public interface IOverpaymentCreditService
 {
     /// <summary>
-    /// Credits overpayment amount to the tenant's balance account for the given currency.
+    /// Credits the overpayment amount to the contact's balance account for the given currency.
     /// </summary>
-    /// <param name="tenantId">Tenant whose balance account receives the credit.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
+    /// <param name="contactId">Contact whose balance account receives the credit.</param>
     /// <param name="currency">ISO 4217 currency code for the balance account.</param>
     /// <param name="amount">Overpayment amount to credit.</param>
     /// <param name="invoiceId">Source invoice that generated the overpayment.</param>
     /// <param name="cancellationToken"></param>
     Task CreditOverpaymentAsync(
         Guid tenantId,
+        ContactId contactId,
         string currency,
         decimal amount,
         Guid invoiceId,

--- a/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
+++ b/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
@@ -30,7 +31,7 @@ internal sealed partial class CustomerBalancePrePaymentProcessor(
             .StartActivity(CustomerBalanceActivitySource.DebitBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(eto.TenantId, eto.Currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(ContactId.Create(eto.ContactId), eto.Currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null || account.Balance <= 0)

--- a/src/Granit.CustomerBalance/Internal/DefaultAdminCreditService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultAdminCreditService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
@@ -22,6 +23,7 @@ internal sealed partial class DefaultAdminCreditService(
 {
     public async Task<BalanceAccount> ApplyAsync(
         Guid tenantId,
+        ContactId contactId,
         decimal amount,
         string currency,
         TransactionSource source,
@@ -29,22 +31,24 @@ internal sealed partial class DefaultAdminCreditService(
         DateTimeOffset? expiresAt,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
+
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.CreditBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)
         {
-            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, currency);
+            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, contactId, currency);
             await accountWriter.AddAsync(account, cancellationToken).ConfigureAwait(false);
-            Log.AccountCreated(logger, tenantId, currency);
+            Log.AccountCreated(logger, contactId.Value, currency);
 
             // Reload to get tracked entity with transactions collection.
             account = (await accountReader
-                .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+                .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
                 .ConfigureAwait(false))!;
         }
 
@@ -68,7 +72,7 @@ internal sealed partial class DefaultAdminCreditService(
         [LoggerMessage(Level = LogLevel.Information, Message = "Admin credit ({Source}) of {Amount} applied, new balance: {NewBalance}")]
         public static partial void AdminCredited(ILogger logger, TransactionSource source, decimal amount, decimal newBalance);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for tenant {TenantId} ({Currency})")]
-        public static partial void AccountCreated(ILogger logger, Guid tenantId, string currency);
+        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for contact {ContactId} ({Currency})")]
+        public static partial void AccountCreated(ILogger logger, Guid contactId, string currency);
     }
 }

--- a/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
@@ -18,6 +19,7 @@ internal sealed partial class DefaultAdminDebitService(
 {
     public async Task<BalanceAccount> DebitAsync(
         Guid tenantId,
+        ContactId contactId,
         decimal amount,
         string currency,
         string reason,
@@ -25,14 +27,16 @@ internal sealed partial class DefaultAdminDebitService(
         string? referenceType = null,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
+
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.DebitBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new InvalidOperationException(
-                $"No balance account exists for tenant '{tenantId}' in currency '{currency}'.");
+                $"No balance account exists for contact '{contactId.Value}' in currency '{currency}'.");
 
         // Idempotency: if a previous ManualAdjustment debit with the same
         // referenceId already landed, return the account unchanged. Mirrors the
@@ -63,7 +67,7 @@ internal sealed partial class DefaultAdminDebitService(
             referenceType: referenceType);
 
         await accountWriter.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
-        metrics.RecordDebited(tenantId.ToString(), currency, TransactionSource.ManualAdjustment.ToString());
+        metrics.RecordDebited(contactId.Value.ToString(), currency, TransactionSource.ManualAdjustment.ToString());
         Log.AdminDebited(logger, amount, account.Balance);
 
         return account;

--- a/src/Granit.CustomerBalance/Internal/DefaultOverpaymentCreditService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultOverpaymentCreditService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.Guids;
@@ -22,27 +23,30 @@ internal sealed partial class DefaultOverpaymentCreditService(
 {
     public async Task CreditOverpaymentAsync(
         Guid tenantId,
+        ContactId contactId,
         string currency,
         decimal amount,
         Guid invoiceId,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(contactId);
+
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.CreditBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)
         {
-            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, currency);
+            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, contactId, currency);
             await accountWriter.AddAsync(account, cancellationToken).ConfigureAwait(false);
-            Log.AccountCreated(logger, tenantId, currency);
+            Log.AccountCreated(logger, contactId.Value, currency);
 
             // Reload to get tracked entity with transactions collection.
             account = await accountReader
-                .GetByTenantAndCurrencyAsync(tenantId, currency, cancellationToken)
+                .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -65,7 +69,7 @@ internal sealed partial class DefaultOverpaymentCreditService(
         [LoggerMessage(Level = LogLevel.Information, Message = "Overpayment of {Amount} credited for invoice {InvoiceId}, new balance: {NewBalance}")]
         public static partial void OverpaymentCredited(ILogger logger, Guid invoiceId, decimal amount, decimal newBalance);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for tenant {TenantId} ({Currency})")]
-        public static partial void AccountCreated(ILogger logger, Guid tenantId, string currency);
+        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for contact {ContactId} ({Currency})")]
+        public static partial void AccountCreated(ILogger logger, Guid contactId, string currency);
     }
 }

--- a/src/Granit.CustomerBalance/packages.lock.json
+++ b/src/Granit.CustomerBalance/packages.lock.json
@@ -54,6 +54,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
+++ b/src/Granit.Invoicing.Abstractions/Events/OverpaymentDetectedEto.cs
@@ -7,5 +7,5 @@ namespace Granit.Invoicing.Events;
 /// The Platform Operator should issue a refund or credit to the next invoice.
 /// </summary>
 public sealed record OverpaymentDetectedEto(
-    Guid InvoiceId, Guid TenantId,
+    Guid InvoiceId, Guid TenantId, Guid ContactId,
     decimal OverpaymentAmount, string Currency) : IIntegrationEvent;

--- a/src/Granit.Invoicing/Domain/Invoice.cs
+++ b/src/Granit.Invoicing/Domain/Invoice.cs
@@ -329,7 +329,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
             if (Overpayment > 0)
             {
                 AddDistributedEvent(new OverpaymentDetectedEto(
-                    Id, TenantId!.Value, Overpayment, Currency));
+                    Id, TenantId!.Value, ContactId.Value, Overpayment, Currency));
             }
 
             return true;

--- a/tests/Granit.ArchitectureTests/CrossModuleContactIdTypingTests.cs
+++ b/tests/Granit.ArchitectureTests/CrossModuleContactIdTypingTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.CustomerBalance.Domain;
+using Granit.Invoicing.Domain;
+using Granit.Subscriptions.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// US #1245 — pin cross-module consistency: every aggregate that exposes a contact
+/// reference uses the typed <see cref="ContactId"/> value object, not a bare
+/// <see cref="Guid"/> named "contactId" / "customerId". Reverting any of these to a
+/// raw <c>Guid</c> would let downstream callers pass an unrelated identifier
+/// (TenantId, UserId, …) without compile-time checks.
+/// </summary>
+public sealed class CrossModuleContactIdTypingTests
+{
+    private static readonly Type[] AggregatesCarryingContactId =
+    [
+        typeof(Invoice),
+        typeof(Subscription),
+        typeof(BalanceAccount),
+    ];
+
+    [Theory]
+    [InlineData(typeof(Invoice))]
+    [InlineData(typeof(Subscription))]
+    [InlineData(typeof(BalanceAccount))]
+    public void Aggregate_ContactId_IsTypedValueObject(Type aggregateType)
+    {
+        PropertyInfo? prop = aggregateType.GetProperty("ContactId");
+
+        prop.ShouldNotBeNull(
+            $"{aggregateType.Name} must expose a ContactId property after the Contacts migration.");
+        prop.PropertyType.ShouldBe(typeof(ContactId),
+            $"{aggregateType.Name}.ContactId must remain the typed ContactId value object — using a bare Guid " +
+            "would let callers pass any unrelated identifier (TenantId, UserId, etc.) without compile-time checks.");
+    }
+
+    [Fact]
+    public void All_5_migrated_aggregates_carry_a_typed_ContactId()
+    {
+        IEnumerable<string> missing = AggregatesCarryingContactId
+            .Where(t => t.GetProperty("ContactId")?.PropertyType != typeof(ContactId))
+            .Select(t => t.Name);
+
+        missing.ShouldBeEmpty(
+            "Every aggregate listed in CrossModuleContactIdTypingTests must expose a typed ContactId property. " +
+            "Add the missing ContactId or remove the type from the registry if the aggregate genuinely does not " +
+            "need a billing identity.");
+    }
+
+    /// <summary>
+    /// US #1245 AC: every Eto event raised by a contact-aware aggregate carries a Guid ContactId.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(Granit.Invoicing.Events.InvoiceFinalizedEto))]
+    [InlineData(typeof(Granit.Invoicing.Events.InvoicePaidEto))]
+    [InlineData(typeof(Granit.Invoicing.Events.InvoiceOverdueEto))]
+    [InlineData(typeof(Granit.Invoicing.Events.CreditNoteIssuedEto))]
+    [InlineData(typeof(Granit.Invoicing.Events.OverpaymentDetectedEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionCreatedEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionActivatedEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionSuspendedEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionCancelledEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionExpiredEto))]
+    [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionPlanChangedEto))]
+    [InlineData(typeof(Granit.CustomerBalance.Events.BalanceCreditedEto))]
+    [InlineData(typeof(Granit.CustomerBalance.Events.BalanceDebitedEto))]
+    public void Eto_CarriesGuidContactId(Type etoType)
+    {
+        PropertyInfo? prop = etoType.GetProperty("ContactId");
+
+        prop.ShouldNotBeNull($"{etoType.Name} must carry a ContactId.");
+        prop.PropertyType.ShouldBe(typeof(Guid),
+            $"{etoType.Name}.ContactId must be a Guid (Etos serialise across process boundaries — typed VOs " +
+            "do not survive JSON deserialisation by every consumer). The aggregate-side property uses the " +
+            "typed ContactId value object; the wire-side Eto carries its raw Guid value.");
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1896,6 +1896,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
@@ -1914,6 +1915,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.CustomerBalance": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.CustomerBalance.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.BackgroundJobs.Tests/packages.lock.json
@@ -296,10 +296,17 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.CustomerBalance.Endpoints.Tests/AdminCreditRequestValidatorTests.cs
+++ b/tests/Granit.CustomerBalance.Endpoints.Tests/AdminCreditRequestValidatorTests.cs
@@ -12,7 +12,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Valid_Request_ShouldPass()
     {
-        var request = new AdminCreditRequest(100m, "EUR", "Promotional", "Welcome credit", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 100m, "EUR", "Promotional", "Welcome credit", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -22,7 +22,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Amount_Zero_ShouldFail()
     {
-        var request = new AdminCreditRequest(0m, "EUR", "Promotional", "Test", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 0m, "EUR", "Promotional", "Test", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -32,7 +32,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Amount_Negative_ShouldFail()
     {
-        var request = new AdminCreditRequest(-10m, "EUR", "Promotional", "Test", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), -10m, "EUR", "Promotional", "Test", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -42,7 +42,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Currency_Empty_ShouldFail()
     {
-        var request = new AdminCreditRequest(10m, "", "Promotional", "Test", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 10m, "", "Promotional", "Test", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -52,7 +52,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Currency_TooLong_ShouldFail()
     {
-        var request = new AdminCreditRequest(10m, "EURO", "Promotional", "Test", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 10m, "EURO", "Promotional", "Test", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -62,7 +62,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Source_Empty_ShouldFail()
     {
-        var request = new AdminCreditRequest(10m, "EUR", "", "Test", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 10m, "EUR", "", "Test", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 
@@ -72,7 +72,7 @@ public sealed class AdminCreditRequestValidatorTests
     [Fact]
     public void Reason_Empty_ShouldFail()
     {
-        var request = new AdminCreditRequest(10m, "EUR", "Promotional", "", null);
+        var request = new AdminCreditRequest(Guid.NewGuid(), 10m, "EUR", "Promotional", "", null);
 
         TestValidationResult<AdminCreditRequest> result = _validator.TestValidate(request);
 

--- a/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
@@ -343,10 +343,28 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
@@ -359,6 +377,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.CustomerBalance": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/packages.lock.json
@@ -306,10 +306,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Events;
 using Granit.CustomerBalance.Exceptions;
@@ -24,7 +25,7 @@ public sealed class BalanceAccountTests
     [Fact]
     public void Create_ShouldNormalizeCurrencyToUpperCase()
     {
-        var account = BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), "eur");
+        var account = BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), ContactId.Create(Guid.NewGuid()), "eur");
 
         account.Currency.ShouldBe("EUR");
     }
@@ -33,7 +34,7 @@ public sealed class BalanceAccountTests
     public void Create_WithEmptyCurrency_ShouldThrow()
     {
         Should.Throw<ArgumentException>(() =>
-            BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), ""));
+            BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), ContactId.Create(Guid.NewGuid()), ""));
     }
 
     [Fact]
@@ -182,7 +183,7 @@ public sealed class BalanceAccountTests
     }
 
     private static BalanceAccount CreateAccount() =>
-        BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), "EUR");
+        BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), ContactId.Create(Guid.NewGuid()), "EUR");
 
     private static BalanceAccount CreateAccountWithBalance(decimal balance)
     {

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminCreditServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminCreditServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Internal;
@@ -50,13 +51,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, 100m, "EUR", TransactionSource.ManualAdjustment, "Test credit", null, ct);
+            tenantId, contactId, 100m, "EUR", TransactionSource.ManualAdjustment, "Test credit", null, ct);
 
         result.ShouldBe(account);
         result.Balance.ShouldBe(100m);
@@ -75,12 +77,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
 
-        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        var contactId = ContactId.Create(Guid.NewGuid());
+
+        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(null as BalanceAccount, newAccount);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, 50m, "EUR", TransactionSource.Promotional, "Welcome bonus", null, ct);
+            tenantId, contactId, 50m, "EUR", TransactionSource.Promotional, "Welcome bonus", null, ct);
 
         await _accountWriter.Received(1).AddAsync(Arg.Any<BalanceAccount>(), Arg.Any<CancellationToken>());
         await _accountWriter.Received(1).UpdateAsync(newAccount, Arg.Any<CancellationToken>());
@@ -94,13 +98,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "USD");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "USD");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "USD", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "USD", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, 200m, "USD", TransactionSource.Promotional, "Promo credit", null, ct);
+            tenantId, contactId, 200m, "USD", TransactionSource.Promotional, "Promo credit", null, ct);
 
         account.Transactions[0].Source.ShouldBe(TransactionSource.Promotional);
     }
@@ -112,14 +117,15 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
         DateTimeOffset expiresAt = Now.AddDays(30);
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, 75m, "EUR", TransactionSource.Promotional, "Limited promo", expiresAt, ct);
+            tenantId, contactId, 75m, "EUR", TransactionSource.Promotional, "Limited promo", expiresAt, ct);
 
         account.Transactions[0].ExpiresAt.ShouldBe(expiresAt);
     }
@@ -131,13 +137,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, 50m, "EUR", TransactionSource.ManualAdjustment, "Permanent credit", null, ct);
+            tenantId, contactId, 50m, "EUR", TransactionSource.ManualAdjustment, "Permanent credit", null, ct);
 
         account.Transactions[0].ExpiresAt.ShouldBeNull();
     }
@@ -149,15 +156,16 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, 100m, "EUR", TransactionSource.ManualAdjustment, "First", null, ct);
+            tenantId, contactId, 100m, "EUR", TransactionSource.ManualAdjustment, "First", null, ct);
         await _sut.ApplyAsync(
-            tenantId, 50m, "EUR", TransactionSource.Promotional, "Second", null, ct);
+            tenantId, contactId, 50m, "EUR", TransactionSource.Promotional, "Second", null, ct);
 
         account.Balance.ShouldBe(150m);
         account.Transactions.Count.ShouldBe(2);
@@ -170,13 +178,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, 42.50m, "EUR", TransactionSource.RefundCredit, "Refund", null, ct);
+            tenantId, contactId, 42.50m, "EUR", TransactionSource.RefundCredit, "Refund", null, ct);
 
         result.Balance.ShouldBe(42.50m);
         result.Currency.ShouldBe("EUR");
@@ -189,13 +198,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, 10m, "EUR", TransactionSource.ManualAdjustment, "Custom reason text", null, ct);
+            tenantId, contactId, 10m, "EUR", TransactionSource.ManualAdjustment, "Custom reason text", null, ct);
 
         account.Transactions[0].Reason.ShouldBe("Custom reason text");
     }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Exceptions;
@@ -44,9 +45,9 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
 
     public void Dispose() => _meter.Dispose();
 
-    private BalanceAccount AccountWithBalance(Guid tenantId, string currency, decimal balance)
+    private BalanceAccount AccountWithBalance(Guid tenantId, ContactId contactId, string currency, decimal balance)
     {
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, currency);
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, currency);
         if (balance > 0m)
         {
             account.Credit(
@@ -54,7 +55,7 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
                 Now.AddDays(-1), Guid.NewGuid());
         }
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, currency, Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, currency, Arg.Any<CancellationToken>())
             .Returns(account);
         return account;
     }
@@ -64,10 +65,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+        var contactId = ContactId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
 
         BalanceAccount result = await _sut.DebitAsync(
-            tenantId, 30m, "EUR", "Manual correction", referenceId: null, referenceType: null, ct);
+            tenantId, contactId, 30m, "EUR", "Manual correction", referenceId: null, referenceType: null, ct);
 
         result.Balance.ShouldBe(70m);
         result.Transactions.Count.ShouldBe(2);   // seed credit + this debit
@@ -82,11 +84,12 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        var contactId = ContactId.Create(Guid.NewGuid());
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns((BalanceAccount?)null);
 
         await Should.ThrowAsync<InvalidOperationException>(() =>
-            _sut.DebitAsync(tenantId, 10m, "EUR", "x", null, null, ct));
+            _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "x", null, null, ct));
 
         await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
     }
@@ -96,10 +99,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        AccountWithBalance(tenantId, "EUR", balance: 20m);
+        var contactId = ContactId.Create(Guid.NewGuid());
+        AccountWithBalance(tenantId, contactId, "EUR", balance: 20m);
 
         await Should.ThrowAsync<InsufficientBalanceException>(() =>
-            _sut.DebitAsync(tenantId, 50m, "EUR", "x", null, null, ct));
+            _sut.DebitAsync(tenantId, contactId, 50m, "EUR", "x", null, null, ct));
 
         await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
     }
@@ -109,16 +113,17 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
+        var contactId = ContactId.Create(Guid.NewGuid());
         var refId = Guid.NewGuid();
-        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
 
         // First call: real debit
-        await _sut.DebitAsync(tenantId, 30m, "EUR", "first", referenceId: refId, "AdminAdjustment", ct);
+        await _sut.DebitAsync(tenantId, contactId, 30m, "EUR", "first", referenceId: refId, "AdminAdjustment", ct);
         account.Balance.ShouldBe(70m);
 
         // Second call with the same refId: short-circuited, no second debit
         BalanceAccount second = await _sut.DebitAsync(
-            tenantId, 30m, "EUR", "retry", referenceId: refId, "AdminAdjustment", ct);
+            tenantId, contactId, 30m, "EUR", "retry", referenceId: refId, "AdminAdjustment", ct);
 
         second.Balance.ShouldBe(70m);                          // unchanged
         account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(1);
@@ -130,10 +135,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+        var contactId = ContactId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
 
-        await _sut.DebitAsync(tenantId, 20m, "EUR", "a", referenceId: Guid.NewGuid(), "x", ct);
-        await _sut.DebitAsync(tenantId, 30m, "EUR", "b", referenceId: Guid.NewGuid(), "x", ct);
+        await _sut.DebitAsync(tenantId, contactId, 20m, "EUR", "a", referenceId: Guid.NewGuid(), "x", ct);
+        await _sut.DebitAsync(tenantId, contactId, 30m, "EUR", "b", referenceId: Guid.NewGuid(), "x", ct);
 
         account.Balance.ShouldBe(50m);
         account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(2);
@@ -144,11 +150,12 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        BalanceAccount account = AccountWithBalance(tenantId, "EUR", balance: 100m);
+        var contactId = ContactId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
 
         // No idempotency without referenceId — both debits land.
-        await _sut.DebitAsync(tenantId, 10m, "EUR", "first", null, null, ct);
-        await _sut.DebitAsync(tenantId, 10m, "EUR", "second", null, null, ct);
+        await _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "first", null, null, ct);
+        await _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "second", null, null, ct);
 
         account.Balance.ShouldBe(80m);
     }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpirationServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpirationServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Events;
@@ -90,7 +91,7 @@ public sealed class DefaultCreditExpirationServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         BalanceTransaction credit = CreateExpiredCredit();
-        var account = BalanceAccount.Create(credit.BalanceAccountId, Guid.NewGuid(), "EUR");
+        var account = BalanceAccount.Create(credit.BalanceAccountId, Guid.NewGuid(), ContactId.Create(Guid.NewGuid()), "EUR");
 
         _transactionReader.GetExpiredCreditsAsync(Now, Arg.Any<CancellationToken>())
             .Returns([credit]);
@@ -186,7 +187,7 @@ public sealed class DefaultCreditExpirationServiceTests : IDisposable
 
     private static BalanceAccount CreateAccountWithBalance(Guid accountId, Guid tenantId, decimal balance)
     {
-        var account = BalanceAccount.Create(accountId, tenantId, "EUR");
+        var account = BalanceAccount.Create(accountId, tenantId, ContactId.Create(Guid.NewGuid()), "EUR");
         account.Credit(balance, TransactionSource.Promotional, "Setup", Now.AddDays(-15), Guid.NewGuid());
         account.ClearIntegrationEvents();
         return account;

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultOverpaymentCreditServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultOverpaymentCreditServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Internal;
@@ -50,13 +51,15 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
+        var contactId = ContactId.Create(Guid.NewGuid());
         var invoiceId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
-        await _sut.CreditOverpaymentAsync(tenantId, "EUR", 42.50m, invoiceId, ct);
+        await _sut.CreditOverpaymentAsync(
+            tenantId, contactId, "EUR", 42.50m, invoiceId, ct);
 
         account.Balance.ShouldBe(42.50m);
         account.Transactions.Count.ShouldBe(1);
@@ -74,14 +77,16 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
+        var contactId = ContactId.Create(Guid.NewGuid());
         var invoiceId = Guid.NewGuid();
 
         // First call returns null (account does not exist), second call returns the newly created account.
-        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(null as BalanceAccount, newAccount);
 
-        await _sut.CreditOverpaymentAsync(tenantId, "EUR", 75m, invoiceId, ct);
+        await _sut.CreditOverpaymentAsync(
+            tenantId, contactId, "EUR", 75m, invoiceId, ct);
 
         await _accountWriter.Received(1).AddAsync(Arg.Any<BalanceAccount>(), Arg.Any<CancellationToken>());
         await _accountWriter.Received(1).UpdateAsync(newAccount, Arg.Any<CancellationToken>());
@@ -95,12 +100,14 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "USD");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "USD");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "USD", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "USD", Arg.Any<CancellationToken>())
             .Returns(account);
 
-        await _sut.CreditOverpaymentAsync(tenantId, "USD", 123.45m, Guid.NewGuid(), ct);
+        await _sut.CreditOverpaymentAsync(
+            tenantId, contactId, "USD", 123.45m, Guid.NewGuid(), ct);
 
         account.Balance.ShouldBe(123.45m);
         account.Transactions[0].Reason.ShouldBe("Overpayment on invoice");
@@ -113,13 +120,16 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, "EUR");
+        var contactId = ContactId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
 
-        _accountReader.GetByTenantAndCurrencyAsync(tenantId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
-        await _sut.CreditOverpaymentAsync(tenantId, "EUR", 10m, Guid.NewGuid(), ct);
-        await _sut.CreditOverpaymentAsync(tenantId, "EUR", 25m, Guid.NewGuid(), ct);
+        await _sut.CreditOverpaymentAsync(
+            tenantId, contactId, "EUR", 10m, Guid.NewGuid(), ct);
+        await _sut.CreditOverpaymentAsync(
+            tenantId, contactId, "EUR", 25m, Guid.NewGuid(), ct);
 
         account.Balance.ShouldBe(35m);
         account.Transactions.Count.ShouldBe(2);

--- a/tests/Granit.CustomerBalance.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.Tests/packages.lock.json
@@ -273,10 +273,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Closes **US #1243** (CustomerBalance keyed by ContactId) and **US #1245** (cross-module ContactId typing consistency). Defers **US #1244** (Tax customer-specific status) to a follow-up PR — the new `TaxStatus` value object on `Contact` + tax-rate-provider override is sizeable enough to deserve its own review surface.

## US #1243 — CustomerBalance migration

- `Granit.CustomerBalance` now references `Granit.Contacts.Abstractions`
- `BalanceAccount.ContactId : ContactId` required at construction. The module's name finally matches its domain — a tenant can hold many balance accounts, one per `(contact, currency)` tuple, so e-commerce tenants run per-buyer balances natively
- `BalanceCreditedEto` + `BalanceDebitedEto` carry `ContactId` (additive `Guid`)
- `IBalanceAccountReader.GetByTenantAndCurrencyAsync` renamed to `GetByContactAndCurrencyAsync` — the writer-side identity is the contact, not the tenant. `GetByTenantAsync` stays for ledger-management views
- `IOverpaymentCreditService`, `IAdminCreditService`, `IAdminDebitService`, and `CustomerBalancePrePaymentProcessor` all thread the contact identity
- EF: `ContactId` `Property` + unique index on `(ContactId, Currency)`; standalone index on `TenantId` for tenant-scoped views
- Endpoints (admin credit/debit, get balance, list transactions) accept or resolve `ContactId` — admin endpoints take it explicitly, user endpoints resolve via `IDefaultContactResolver` from the active tenant
- DTOs: `AdminCreditRequest` + `AdminDebitRequest` carry `ContactId`

## US #1245 — cross-module typing guard

New `CrossModuleContactIdTypingTests` architecture test pins **two invariants** in one place:

1. The typed `ContactId` value object on every aggregate (`Invoice`, `Subscription`, `BalanceAccount`)
2. The raw `Guid ContactId` on every Eto event raised by a contact-aware aggregate — 13 Etos across the 3 modules (Invoicing, Subscriptions, CustomerBalance)

The test enforces the rationale: aggregates use the typed VO for compile-time safety; Etos use raw `Guid` for wire-format portability across consumers (typed VOs do not survive JSON deserialisation by every consumer).

## Side-effect

`Granit.Invoicing.OverpaymentDetectedEto` now carries `ContactId` (was missing from the Feature 2 batch); `Invoice.RecordPayment` threads `ContactId.Value` through. Eto-only change — `CustomerBalance.OverpaymentCreditHandler` consumes it directly.

Closes [#1243](https://github.com/granit-fx/customer-balance), [#1245](https://github.com/granit-fx/cross-module-consistency). [#1244](https://github.com/granit-fx/customer-tax-status) deferred — separate follow-up.

## Test plan

- [x] 51 / 51 CustomerBalance domain
- [x] 41 / 41 CustomerBalance EFCore (transitive — no behaviour change)
- [x] 15 / 15 CustomerBalance Endpoints (DTO ctor updates)
- [x] 57 / 57 Invoicing domain (`Invoice.RecordPayment` update for `OverpaymentDetectedEto`)
- [x] 100 / 100 Payments (transitive)
- [x] 150 / 150 architecture (17 new facts: 3 aggregate properties + 13 Eto properties + 1 registry summary)
- [ ] CI green