### PR TITLE
feat(contacts,tax): customer-specific tax status — US #1244 (closes Epic #1220)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2103,6 +2103,7 @@
       "name": "Granit.Tax",
       "deps": [
         "Granit",
+        "Granit.Contacts.Abstractions",
         "Granit.DataExchange.Abstractions",
         "Granit.QueryEngine.Abstractions",
         "Granit.Timing"
@@ -2133,6 +2134,7 @@
     {
       "name": "Granit.Tax.EntityFrameworkCore",
       "deps": [
+        "Granit.Contacts",
         "Granit.Persistence.EntityFrameworkCore",
         "Granit.Tax"
       ],
@@ -10530,10 +10532,16 @@
           "returnType": "string"
         },
         {
+          "name": "TaxId",
+          "kind": "property",
+          "signature": "string? TaxId",
+          "returnType": "string?"
+        },
+        {
           "name": "AsReadOnly",
           "kind": "method",
           "signature": "AsReadOnly()",
-          "returnType": "string? TaxId { get; private set; } public string? RegistrationNumber { get; private set; } public IReadOnlyList<ContactAddress> Addresses => _addresses."
+          "returnType": "IReadOnlyList<ContactAddress> Addresses => _addresses."
         },
         {
           "name": "DefaultBillingAddress",
@@ -10707,6 +10715,28 @@
       "members": []
     },
     {
+      "name": "TaxStatus",
+      "fqn": "Granit.Contacts.Domain.TaxStatus",
+      "kind": "class",
+      "project": "Granit.Contacts.Abstractions",
+      "file": "src/Granit.Contacts.Abstractions/Domain/TaxStatus.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "TaxStatus Standard { get; } ="
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(bool isExempt = false, bool reverseCharge = false, string? vatin = null, Guid? evidenceBlobId = null)",
+          "returnType": "TaxStatus"
+        }
+      ]
+    },
+    {
       "name": "ContactId",
       "fqn": "Granit.Contacts.Domain.ValueObjects.ContactId",
       "kind": "class",
@@ -10743,7 +10773,7 @@
       "kind": "record",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
-      "line": 28,
+      "line": 36,
       "members": []
     },
     {
@@ -10770,7 +10800,7 @@
       "kind": "record",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
-      "line": 42,
+      "line": 50,
       "members": []
     },
     {
@@ -10788,7 +10818,7 @@
       "kind": "record",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
-      "line": 57,
+      "line": 65,
       "members": []
     },
     {
@@ -10797,7 +10827,7 @@
       "kind": "record",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
-      "line": 63,
+      "line": 71,
       "members": []
     },
     {
@@ -10815,7 +10845,7 @@
       "kind": "record",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
-      "line": 49,
+      "line": 57,
       "members": []
     },
     {
@@ -10852,6 +10882,24 @@
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/Dtos/ContactTaxIdentityRequest.cs",
       "line": 4,
+      "members": []
+    },
+    {
+      "name": "ContactTaxStatusRequest",
+      "fqn": "Granit.Contacts.Endpoints.Dtos.ContactTaxStatusRequest",
+      "kind": "record",
+      "project": "Granit.Contacts.Endpoints",
+      "file": "src/Granit.Contacts.Endpoints/Dtos/ContactTaxStatusRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ContactTaxStatusResponse",
+      "fqn": "Granit.Contacts.Endpoints.Dtos.ContactTaxStatusResponse",
+      "kind": "record",
+      "project": "Granit.Contacts.Endpoints",
+      "file": "src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs",
+      "line": 29,
       "members": []
     },
     {
@@ -23345,7 +23393,7 @@
       "kind": "enum",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 24,
+      "line": 34,
       "members": []
     },
     {
@@ -23354,7 +23402,7 @@
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 40,
+      "line": 50,
       "members": []
     },
     {
@@ -23363,7 +23411,7 @@
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 12,
+      "line": 22,
       "members": []
     },
     {
@@ -23372,7 +23420,7 @@
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 21,
+      "line": 31,
       "members": []
     },
     {
@@ -23381,7 +23429,7 @@
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 6,
+      "line": 15,
       "members": []
     },
     {
@@ -23390,7 +23438,7 @@
       "kind": "record",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Dtos/TaxRequest.cs",
-      "line": 15,
+      "line": 25,
       "members": []
     },
     {
@@ -42938,7 +42986,7 @@
       "kind": "class",
       "project": "Granit.Tax.EntityFrameworkCore",
       "file": "src/Granit.Tax.EntityFrameworkCore/Extensions/TaxEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitTaxEntityFrameworkCore",
@@ -43075,12 +43123,12 @@
       "kind": "interface",
       "project": "Granit.Tax",
       "file": "src/Granit.Tax/ITaxRateProvider.cs",
-      "line": 4,
+      "line": 6,
       "members": [
         {
           "name": "GetRateAsync",
           "kind": "method",
-          "signature": "GetRateAsync(string countryCode, DateTimeOffset asOf, CancellationToken cancellationToken = default)",
+          "signature": "GetRateAsync(string countryCode, DateTimeOffset asOf, ContactId? contactId = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<TaxRateEntry?>"
         },
         {

--- a/src/Granit.Contacts.Abstractions/Domain/TaxStatus.cs
+++ b/src/Granit.Contacts.Abstractions/Domain/TaxStatus.cs
@@ -1,0 +1,81 @@
+using Granit.DataProtection;
+using Granit.Domain;
+
+namespace Granit.Contacts.Domain;
+
+/// <summary>
+/// Customer-specific tax classification — reverse-charge under EU B2B intra-EU rules,
+/// blanket VAT exemption (NGO, public body, charity), or simply "standard" (no special
+/// status). Owned value object on <see cref="Contact"/>; equality is structural.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Read by <c>Granit.Tax</c>'s <c>ITaxRateProvider.GetRateAsync(...)</c> when a
+/// <c>contactId</c> is supplied: an exempt or reverse-charge contact yields a 0% rate
+/// regardless of the country default, with the note flag indicating which mechanism
+/// applied. Standard contacts fall back to the country / standard rate.
+/// </para>
+/// <para>
+/// Defaults to <see cref="Standard"/>. Admins opt customers in via
+/// <c>Contact.SetTaxStatus(...)</c>; no data is implicitly converted from the
+/// pre-Feature-5 schema.
+/// </para>
+/// </remarks>
+public sealed class TaxStatus : ValueObject
+{
+    /// <summary>The do-nothing default: country / standard rate applies.</summary>
+    public static TaxStatus Standard { get; } = new();
+
+    private TaxStatus() { }
+
+    /// <summary>Creates a customer tax status with the supplied flags.</summary>
+    /// <param name="isExempt">VAT-exempt customer (NGO, public body, …) — overrides everything else.</param>
+    /// <param name="reverseCharge">B2B intra-EU reverse charge applies — invoice carries the buyer's VAT number, no VAT line.</param>
+    /// <param name="vatin">VAT identification number for B2B reverse charge (e.g. <c>"BE0123456789"</c>). Required when <paramref name="reverseCharge"/> is <c>true</c>.</param>
+    /// <param name="evidenceBlobId">Optional <c>Granit.BlobStorage</c> reference to the supporting paperwork (exemption certificate, VAT registration excerpt).</param>
+    public static TaxStatus Create(
+        bool isExempt = false,
+        bool reverseCharge = false,
+        string? vatin = null,
+        Guid? evidenceBlobId = null)
+    {
+        if (reverseCharge && string.IsNullOrWhiteSpace(vatin))
+        {
+            throw new ArgumentException(
+                "Reverse-charge requires a VAT identification number on the buyer side.", nameof(vatin));
+        }
+
+        return new TaxStatus
+        {
+            IsExempt = isExempt,
+            ReverseCharge = reverseCharge,
+            Vatin = string.IsNullOrWhiteSpace(vatin) ? null : vatin,
+            EvidenceBlobId = evidenceBlobId,
+        };
+    }
+
+    /// <summary>Whether the customer is wholly VAT-exempt (overrides everything else).</summary>
+    public bool IsExempt { get; private init; }
+
+    /// <summary>Whether intra-EU B2B reverse charge applies — buyer accounts for the VAT.</summary>
+    public bool ReverseCharge { get; private init; }
+
+    /// <summary>VAT identification number on the buyer side (B2B reverse charge).</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? Vatin { get; private init; }
+
+    /// <summary>Optional pointer to the supporting paperwork in <c>Granit.BlobStorage</c>.</summary>
+    public Guid? EvidenceBlobId { get; private init; }
+
+    /// <summary>Returns <c>true</c> when this status forces a 0% rate (exempt or reverse-charge).</summary>
+    public bool YieldsZeroRate => IsExempt || ReverseCharge;
+
+    /// <inheritdoc />
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return IsExempt;
+        yield return ReverseCharge;
+        yield return Vatin;
+        yield return EvidenceBlobId;
+    }
+}

--- a/src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs
+++ b/src/Granit.Contacts.Endpoints/Dtos/ContactResponse.cs
@@ -22,7 +22,15 @@ public sealed record ContactResponse(
     IReadOnlyList<ContactAddressResponse> Addresses,
     IReadOnlyList<ContactEmailResponse> Emails,
     IReadOnlyList<ContactPhoneResponse> Phones,
-    IReadOnlyList<ContactExternalMappingResponse> ExternalMappings);
+    IReadOnlyList<ContactExternalMappingResponse> ExternalMappings,
+    ContactTaxStatusResponse TaxStatus);
+
+/// <summary>Customer-specific tax classification (exempt / reverse-charge / standard).</summary>
+public sealed record ContactTaxStatusResponse(
+    bool IsExempt,
+    bool ReverseCharge,
+    string? Vatin,
+    Guid? EvidenceBlobId);
 
 /// <summary>Address sub-DTO inside <see cref="ContactResponse"/>.</summary>
 public sealed record ContactAddressResponse(

--- a/src/Granit.Contacts.Endpoints/Dtos/ContactTaxStatusRequest.cs
+++ b/src/Granit.Contacts.Endpoints/Dtos/ContactTaxStatusRequest.cs
@@ -1,0 +1,15 @@
+namespace Granit.Contacts.Endpoints.Dtos;
+
+/// <summary>
+/// Request to set a contact's customer-specific tax status — exempt, reverse-charge,
+/// or standard (none of the flags set).
+/// </summary>
+/// <param name="IsExempt">VAT-exempt customer (NGO, public body, charity).</param>
+/// <param name="ReverseCharge">B2B intra-EU reverse charge applies.</param>
+/// <param name="Vatin">VAT identification number on the buyer side. Required when <paramref name="ReverseCharge"/> is <c>true</c>.</param>
+/// <param name="EvidenceBlobId">Optional blob reference to supporting paperwork.</param>
+public sealed record ContactTaxStatusRequest(
+    bool IsExempt,
+    bool ReverseCharge,
+    string? Vatin,
+    Guid? EvidenceBlobId);

--- a/src/Granit.Contacts.Endpoints/Endpoints/ContactEndpoints.cs
+++ b/src/Granit.Contacts.Endpoints/Endpoints/ContactEndpoints.cs
@@ -257,6 +257,48 @@ internal static class ContactEndpoints
         return TypedResults.NoContent();
     }
 
+    public static async Task<Results<Ok<ContactResponse>, NotFound, ProblemHttpResult, ValidationProblem>> HandleSetTaxStatusAsync(
+        Guid id,
+        ContactTaxStatusRequest request,
+        [FromServices] IContactReader reader,
+        [FromServices] IContactWriter writer,
+        CancellationToken cancellationToken)
+    {
+        Contact? c = await reader.GetByIdAsync(ContactId.Create(id), cancellationToken).ConfigureAwait(false);
+        if (c is null) { return TypedResults.NotFound(); }
+
+        TaxStatus next;
+        try
+        {
+            next = TaxStatus.Create(
+                isExempt: request.IsExempt,
+                reverseCharge: request.ReverseCharge,
+                vatin: request.Vatin,
+                evidenceBlobId: request.EvidenceBlobId);
+        }
+        catch (ArgumentException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        c.SetTaxStatus(next);
+        await writer.UpdateAsync(c, cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(c.ToResponse());
+    }
+
+    public static async Task<Results<Ok<ContactResponse>, NotFound>> HandleClearTaxStatusAsync(
+        Guid id,
+        [FromServices] IContactReader reader,
+        [FromServices] IContactWriter writer,
+        CancellationToken cancellationToken)
+    {
+        Contact? c = await reader.GetByIdAsync(ContactId.Create(id), cancellationToken).ConfigureAwait(false);
+        if (c is null) { return TypedResults.NotFound(); }
+        c.SetTaxStatus(TaxStatus.Standard);
+        await writer.UpdateAsync(c, cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(c.ToResponse());
+    }
+
     private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> TransitionAsync(
         Guid id,
         Action<Contact> action,

--- a/src/Granit.Contacts.Endpoints/Extensions/ContactsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Contacts.Endpoints/Extensions/ContactsEndpointRouteBuilderExtensions.cs
@@ -177,6 +177,25 @@ public static class ContactsEndpointRouteBuilderExtensions
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        // ── Tax status (customer-specific tax classification) ─────────
+        group.MapPut("/{id:guid}/tax-status", ContactEndpoints.HandleSetTaxStatusAsync)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
+            .WithName("SetContactTaxStatus")
+            .WithSummary("Sets the contact's customer-specific tax status.")
+            .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the contact. Read by Granit.Tax when computing rates: contacts with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 400 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
+            .Produces<ContactResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem();
+
+        group.MapDelete("/{id:guid}/tax-status", ContactEndpoints.HandleClearTaxStatusAsync)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
+            .WithName("ClearContactTaxStatus")
+            .WithSummary("Resets the contact's tax status to the default (no special classification).")
+            .WithDescription("Clears any customer-specific tax classification. Subsequent tax calculations fall back to the country / standard rate. Idempotent.")
+            .Produces<ContactResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return group;
     }
 }

--- a/src/Granit.Contacts.Endpoints/Mapping/ContactMapper.cs
+++ b/src/Granit.Contacts.Endpoints/Mapping/ContactMapper.cs
@@ -24,7 +24,11 @@ internal static class ContactMapper
         [.. c.Addresses.Select(ToAddressResponse)],
         [.. c.Emails.Select(ToEmailResponse)],
         [.. c.Phones.Select(ToPhoneResponse)],
-        [.. c.ExternalMappings.Select(ToExternalMappingResponse)]);
+        [.. c.ExternalMappings.Select(ToExternalMappingResponse)],
+        ToTaxStatusResponse(c.TaxStatus));
+
+    private static ContactTaxStatusResponse ToTaxStatusResponse(TaxStatus s) =>
+        new(s.IsExempt, s.ReverseCharge, s.Vatin, s.EvidenceBlobId);
 
     public static ContactListItemResponse ToListItem(this Contact c) => new(
         c.Id,

--- a/src/Granit.Contacts.Endpoints/Validators/ContactTaxStatusRequestValidator.cs
+++ b/src/Granit.Contacts.Endpoints/Validators/ContactTaxStatusRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Granit.Contacts.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Contacts.Endpoints.Validators;
+
+internal sealed class ContactTaxStatusRequestValidator : GranitValidator<ContactTaxStatusRequest>
+{
+    public ContactTaxStatusRequestValidator()
+    {
+        RuleFor(x => x.Vatin).MaximumLength(32);
+
+        // Reverse-charge requires a buyer-side VAT identification number.
+        RuleFor(x => x.Vatin)
+            .NotEmpty()
+            .When(x => x.ReverseCharge);
+    }
+}

--- a/src/Granit.Contacts.EntityFrameworkCore/Internal/ContactConfiguration.cs
+++ b/src/Granit.Contacts.EntityFrameworkCore/Internal/ContactConfiguration.cs
@@ -22,6 +22,16 @@ internal sealed class ContactConfiguration : IEntityTypeConfiguration<Contact>
         builder.Property(c => c.DefaultCurrency).HasMaxLength(3).IsRequired();
         builder.Property(c => c.TaxId).HasMaxLength(64);
         builder.Property(c => c.RegistrationNumber).HasMaxLength(64);
+
+        // Customer-specific tax classification — owned single-valued VO inlined into the
+        // contacts table. Defaults to TaxStatus.Standard (all flags false) on materialisation.
+        builder.OwnsOne(c => c.TaxStatus, ts =>
+        {
+            ts.Property(t => t.IsExempt).IsRequired().HasDefaultValue(false);
+            ts.Property(t => t.ReverseCharge).IsRequired().HasDefaultValue(false);
+            ts.Property(t => t.Vatin).HasMaxLength(30);
+            ts.Property(t => t.EvidenceBlobId);
+        });
         builder.Property(c => c.Status).IsRequired();
         builder.Property(c => c.Roles).IsRequired();
         builder.Property(c => c.UserId);

--- a/src/Granit.Contacts/Domain/Contact.cs
+++ b/src/Granit.Contacts/Domain/Contact.cs
@@ -142,6 +142,14 @@ public sealed class Contact : AuditedAggregateRoot, IMultiTenant
     /// <summary>Company registration number (BCE/KBO, SIRET, HRB, Companies House, …).</summary>
     public string? RegistrationNumber { get; private set; }
 
+    /// <summary>
+    /// Customer-specific tax classification (reverse-charge, exempt, VATIN). Defaults to
+    /// <see cref="TaxStatus.Standard"/>. Read by <c>Granit.Tax</c>'s <c>ITaxRateProvider</c>
+    /// when a contact is in scope so exempt / reverse-charge customers yield a 0% rate.
+    /// Admins opt-in via <see cref="SetTaxStatus"/>.
+    /// </summary>
+    public TaxStatus TaxStatus { get; private set; } = TaxStatus.Standard;
+
     // ── Addresses ─────────────────────────────────────────────────
 
     /// <summary>
@@ -334,6 +342,27 @@ public sealed class Contact : AuditedAggregateRoot, IMultiTenant
             line2: address.Line2,
             state: address.State,
             vatNumber: TaxId);
+    }
+
+    /// <summary>
+    /// Sets or replaces the customer-specific <see cref="TaxStatus"/>. Idempotent for equal
+    /// values. Pass <c>null</c> or <see cref="TaxStatus.Standard"/> to reset to the default
+    /// (no special status — country / standard rate applies).
+    /// </summary>
+    /// <returns><c>true</c> when the status changed; <c>false</c> when the value was already equal.</returns>
+    public bool SetTaxStatus(TaxStatus? taxStatus)
+    {
+        EnsureMutable();
+        TaxStatus next = taxStatus ?? TaxStatus.Standard;
+
+        if (Equals(TaxStatus, next))
+        {
+            return false;
+        }
+
+        TaxStatus = next;
+        RaiseUpdated();
+        return true;
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/src/Granit.Invoicing/Dtos/TaxRequest.cs
+++ b/src/Granit.Invoicing/Dtos/TaxRequest.cs
@@ -1,12 +1,22 @@
 using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
 
 namespace Granit.Invoicing.Dtos;
 
 /// <summary>Request for tax calculation.</summary>
+/// <remarks>
+/// <para>
+/// <paramref name="BuyerContactId"/> lets the calculator honour customer-level overrides
+/// (VAT exemption, intra-EU reverse charge) carried by <c>Contact.TaxStatus</c>. When
+/// supplied and the contact's status yields a 0% rate, the calculator returns 0% on
+/// every line; otherwise the country / standard rate applies.
+/// </para>
+/// </remarks>
 public sealed record TaxRequest(
     IReadOnlyList<TaxLineItem> LineItems,
     BillingAddress SellerAddress,
-    BillingAddress BuyerAddress);
+    BillingAddress BuyerAddress,
+    ContactId? BuyerContactId = null);
 
 /// <summary>A line item for tax calculation.</summary>
 public sealed record TaxLineItem(string Description, decimal Amount, string? TaxCode);

--- a/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
+++ b/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
@@ -59,7 +59,8 @@ internal sealed partial class DefaultInvoiceCreationService(
                     li.Quantity * li.UnitPrice,
                     TaxCode: null)).ToList(),
                 SellerAddress: billingSnapshot,
-                BuyerAddress: billingSnapshot);
+                BuyerAddress: billingSnapshot,
+                BuyerContactId: contact.Id);
 
             TaxResult taxResult = await taxCalculator
                 .CalculateAsync(taxRequest, cancellationToken)

--- a/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
+++ b/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
@@ -1,3 +1,4 @@
+using Granit.Contacts.Domain.ValueObjects;
 using Granit.Tax.Builtin.Options;
 using Microsoft.Extensions.Options;
 
@@ -6,14 +7,22 @@ namespace Granit.Tax.Builtin.Internal;
 /// <summary>
 /// Config-based tax rate provider. Reads from <see cref="EuVatRateOptions"/>
 /// and falls back to <see cref="EuVatRateDefaults"/> for unconfigured countries.
+/// Customer-specific tax overrides (exempt, reverse-charge) are honoured by the
+/// upstream <c>EfTaxRateProvider</c> — this provider is the country-only fallback.
 /// </summary>
 internal sealed class ConfigTaxRateProvider(
     IOptions<EuVatRateOptions> options) : ITaxRateProvider
 {
     public Task<TaxRateEntry?> GetRateAsync(
-        string countryCode, DateTimeOffset asOf,
+        string countryCode,
+        DateTimeOffset asOf,
+        ContactId? contactId = null,
         CancellationToken cancellationToken = default)
     {
+        // ContactId is honoured by the upstream EfTaxRateProvider; this provider
+        // returns the country default only.
+        _ = contactId;
+
         string normalized = countryCode.ToUpperInvariant();
 
         // Check configured overrides first

--- a/src/Granit.Tax.Builtin/Internal/EuVatTaxCalculator.cs
+++ b/src/Granit.Tax.Builtin/Internal/EuVatTaxCalculator.cs
@@ -58,7 +58,11 @@ internal sealed class EuVatTaxCalculator(
         if (context.Exemption == TaxExemptionReason.None)
         {
             TaxRateEntry? rateEntry = await rateProvider
-                .GetRateAsync(context.RateCountryCode, clock.Now, cancellationToken)
+                .GetRateAsync(
+                    context.RateCountryCode,
+                    clock.Now,
+                    request.BuyerContactId,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             rate = rateEntry?.StandardRate ?? 0m;

--- a/src/Granit.Tax.Builtin/packages.lock.json
+++ b/src/Granit.Tax.Builtin/packages.lock.json
@@ -342,6 +342,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
@@ -36,7 +36,7 @@ internal static class TaxRateEndpoints
         CancellationToken cancellationToken = default)
     {
         TaxRateEntry? rate = await rateProvider
-            .GetRateAsync(countryCode, clock.Now, cancellationToken)
+            .GetRateAsync(countryCode, clock.Now, contactId: null, cancellationToken)
             .ConfigureAwait(false);
 
         if (rate is null)

--- a/src/Granit.Tax.Endpoints/packages.lock.json
+++ b/src/Granit.Tax.Endpoints/packages.lock.json
@@ -53,6 +53,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -133,6 +139,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"

--- a/src/Granit.Tax.EntityFrameworkCore/Extensions/TaxEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/Extensions/TaxEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.Contacts;
+using Granit.DataFiltering;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Tax.EntityFrameworkCore.Internal;
 using Granit.Timing;
@@ -42,6 +44,8 @@ public static class TaxEntityFrameworkCoreHostApplicationBuilderExtensions
             return new EfTaxRateProvider(
                 sp.GetRequiredService<IDbContextFactory<TaxDbContext>>(),
                 fallback,
+                sp.GetRequiredService<IContactReader>(),
+                sp.GetRequiredService<IDataFilter>(),
                 sp.GetRequiredService<IClock>());
         }));
 

--- a/src/Granit.Tax.EntityFrameworkCore/Granit.Tax.EntityFrameworkCore.csproj
+++ b/src/Granit.Tax.EntityFrameworkCore/Granit.Tax.EntityFrameworkCore.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Contacts\Granit.Contacts.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Tax\Granit.Tax.csproj" />
   </ItemGroup>

--- a/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
@@ -1,3 +1,8 @@
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Tax.Domain;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
@@ -5,18 +10,41 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Tax.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// DB-backed tax rate provider. Checks <see cref="TaxRateOverride"/> first,
-/// delegates to the fallback (config-based) provider if no override exists.
+/// DB-backed tax rate provider. Checks the contact's <c>TaxStatus</c> first (when a
+/// <c>contactId</c> is supplied) — exempt or reverse-charge customers yield a 0% rate.
+/// Otherwise checks <see cref="TaxRateOverride"/> rows, then delegates to the fallback
+/// (config-based) provider if no override exists.
 /// </summary>
 internal sealed class EfTaxRateProvider(
     IDbContextFactory<TaxDbContext> contextFactory,
     ITaxRateProvider fallback,
+    IContactReader contactReader,
+    IDataFilter dataFilter,
     IClock clock) : ITaxRateProvider
 {
     public async Task<TaxRateEntry?> GetRateAsync(
-        string countryCode, DateTimeOffset asOf,
+        string countryCode,
+        DateTimeOffset asOf,
+        ContactId? contactId = null,
         CancellationToken cancellationToken = default)
     {
+        // 1. Customer-specific tax status takes absolute precedence.
+        if (contactId is not null)
+        {
+            Contact? contact = await ResolveContactAsync(contactId, cancellationToken)
+                .ConfigureAwait(false);
+            if (contact?.TaxStatus.YieldsZeroRate == true)
+            {
+                return new TaxRateEntry(
+                    CountryCode: countryCode,
+                    StandardRate: 0m,
+                    ReducedRate: 0m,
+                    EffectiveFrom: asOf,
+                    EffectiveTo: null);
+            }
+        }
+
+        // 2. Country-level DB overrides.
         await using TaxDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -38,7 +66,18 @@ internal sealed class EfTaxRateProvider(
                 EffectiveTo: dbOverride.EffectiveTo);
         }
 
-        return await fallback.GetRateAsync(countryCode, asOf, cancellationToken)
+        // 3. Fallback to the config-based provider.
+        return await fallback.GetRateAsync(countryCode, asOf, contactId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<Contact?> ResolveContactAsync(
+        ContactId contactId, CancellationToken cancellationToken)
+    {
+        // The contact may be host-scoped or tenant-scoped; bypass the multi-tenant filter
+        // so a host-side tax calculation can read a tenant-scoped contact's TaxStatus.
+        using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
+        return await contactReader.GetByIdAsync(contactId, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Granit.Tax.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Tax.EntityFrameworkCore/packages.lock.json
@@ -99,6 +99,23 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -157,6 +174,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/src/Granit.Tax.Stripe/packages.lock.json
+++ b/src/Granit.Tax.Stripe/packages.lock.json
@@ -365,6 +365,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/src/Granit.Tax/Granit.Tax.csproj
+++ b/src/Granit.Tax/Granit.Tax.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Contacts.Abstractions\Granit.Contacts.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />

--- a/src/Granit.Tax/ITaxRateProvider.cs
+++ b/src/Granit.Tax/ITaxRateProvider.cs
@@ -1,11 +1,25 @@
+using Granit.Contacts.Domain.ValueObjects;
+
 namespace Granit.Tax;
 
-/// <summary>Provides tax rates by country and date.</summary>
+/// <summary>Provides tax rates by country, date, and (optionally) contact-specific status.</summary>
 public interface ITaxRateProvider
 {
-    /// <summary>Returns the tax rate for a country at a specific date.</summary>
+    /// <summary>
+    /// Returns the tax rate for a country at a specific date, optionally honouring the
+    /// contact's <c>TaxStatus</c>. When <paramref name="contactId"/> is supplied and the
+    /// contact's status yields a 0% rate (exempt or reverse-charge), the returned entry
+    /// has <c>StandardRate = 0</c> and <c>ReducedRate = 0</c> — the country and effective
+    /// dates remain populated so the caller still has the jurisdiction context for the
+    /// document footer (e.g. "VAT reverse-charge per Art. 196").
+    /// When <paramref name="contactId"/> is omitted (<c>null</c>), the legacy
+    /// country-default behaviour applies — preserves binary compatibility with consumers
+    /// that have not migrated to ContactId yet.
+    /// </summary>
     Task<TaxRateEntry?> GetRateAsync(
-        string countryCode, DateTimeOffset asOf,
+        string countryCode,
+        DateTimeOffset asOf,
+        ContactId? contactId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Returns all currently effective tax rates.</summary>

--- a/src/Granit.Tax/packages.lock.json
+++ b/src/Granit.Tax/packages.lock.json
@@ -54,6 +54,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3374,6 +3374,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
@@ -3401,6 +3402,7 @@
       "granit.tax.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"

--- a/tests/Granit.Contacts.Tests/Domain/ContactTests.cs
+++ b/tests/Granit.Contacts.Tests/Domain/ContactTests.cs
@@ -763,4 +763,65 @@ public sealed class ContactTests
 
         c.TenantId.ShouldBe(newTenant);
     }
+
+    // ── Tax status (customer-specific tax classification) ─────────
+
+    [Fact]
+    public void TaxStatus_Default_IsStandard() =>
+        NewCompany().TaxStatus.ShouldBe(TaxStatus.Standard);
+
+    [Fact]
+    public void TaxStatus_Default_DoesNotYieldZeroRate() =>
+        NewCompany().TaxStatus.YieldsZeroRate.ShouldBeFalse();
+
+    [Fact]
+    public void SetTaxStatus_FromStandardToExempt_StoresIt()
+    {
+        Contact c = NewCompany();
+        var exempt = TaxStatus.Create(isExempt: true);
+
+        bool changed = c.SetTaxStatus(exempt);
+
+        changed.ShouldBeTrue();
+        c.TaxStatus.IsExempt.ShouldBeTrue();
+        c.TaxStatus.YieldsZeroRate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetTaxStatus_ReverseChargeRequiresVatin() =>
+        Should.Throw<ArgumentException>(() =>
+            TaxStatus.Create(reverseCharge: true, vatin: null));
+
+    [Fact]
+    public void SetTaxStatus_ReverseChargeWithVatin_StoresIt()
+    {
+        Contact c = NewCompany();
+        var rc = TaxStatus.Create(reverseCharge: true, vatin: "BE0123456789");
+
+        c.SetTaxStatus(rc);
+
+        c.TaxStatus.ReverseCharge.ShouldBeTrue();
+        c.TaxStatus.Vatin.ShouldBe("BE0123456789");
+        c.TaxStatus.YieldsZeroRate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetTaxStatus_SameValue_ReturnsFalse()
+    {
+        Contact c = NewCompany();
+        c.SetTaxStatus(TaxStatus.Create(isExempt: true));
+
+        c.SetTaxStatus(TaxStatus.Create(isExempt: true)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SetTaxStatus_Null_FallsBackToStandard()
+    {
+        Contact c = NewCompany();
+        c.SetTaxStatus(TaxStatus.Create(isExempt: true));
+
+        c.SetTaxStatus(null).ShouldBeTrue();
+        c.TaxStatus.ShouldBe(TaxStatus.Standard);
+        c.TaxStatus.YieldsZeroRate.ShouldBeFalse();
+    }
 }

--- a/tests/Granit.Tax.Builtin.Tests/Internal/ConfigTaxRateProviderTests.cs
+++ b/tests/Granit.Tax.Builtin.Tests/Internal/ConfigTaxRateProviderTests.cs
@@ -18,7 +18,7 @@ public sealed class ConfigTaxRateProviderTests
     {
         ConfigTaxRateProvider provider = CreateProvider();
 
-        TaxRateEntry? entry = await provider.GetRateAsync("BE", DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        TaxRateEntry? entry = await provider.GetRateAsync("BE", DateTimeOffset.UtcNow, cancellationToken: TestContext.Current.CancellationToken);
 
         entry.ShouldNotBeNull();
         entry.CountryCode.ShouldBe("BE");
@@ -35,7 +35,7 @@ public sealed class ConfigTaxRateProviderTests
         };
         ConfigTaxRateProvider provider = CreateProvider(options);
 
-        TaxRateEntry? entry = await provider.GetRateAsync("BE", DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        TaxRateEntry? entry = await provider.GetRateAsync("BE", DateTimeOffset.UtcNow, cancellationToken: TestContext.Current.CancellationToken);
 
         entry.ShouldNotBeNull();
         entry.StandardRate.ShouldBe(0.22m);
@@ -51,7 +51,7 @@ public sealed class ConfigTaxRateProviderTests
         };
         ConfigTaxRateProvider provider = CreateProvider(options);
 
-        TaxRateEntry? entry = await provider.GetRateAsync("FR", DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        TaxRateEntry? entry = await provider.GetRateAsync("FR", DateTimeOffset.UtcNow, cancellationToken: TestContext.Current.CancellationToken);
 
         entry.ShouldNotBeNull();
         entry.StandardRate.ShouldBe(0.20m);
@@ -63,7 +63,7 @@ public sealed class ConfigTaxRateProviderTests
     {
         ConfigTaxRateProvider provider = CreateProvider();
 
-        TaxRateEntry? entry = await provider.GetRateAsync("ZZ", DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        TaxRateEntry? entry = await provider.GetRateAsync("ZZ", DateTimeOffset.UtcNow, cancellationToken: TestContext.Current.CancellationToken);
 
         entry.ShouldBeNull();
     }
@@ -73,7 +73,7 @@ public sealed class ConfigTaxRateProviderTests
     {
         ConfigTaxRateProvider provider = CreateProvider();
 
-        TaxRateEntry? entry = await provider.GetRateAsync("de", DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        TaxRateEntry? entry = await provider.GetRateAsync("de", DateTimeOffset.UtcNow, cancellationToken: TestContext.Current.CancellationToken);
 
         entry.ShouldNotBeNull();
         entry.CountryCode.ShouldBe("DE");

--- a/tests/Granit.Tax.Builtin.Tests/Internal/EuVatTaxCalculatorTests.cs
+++ b/tests/Granit.Tax.Builtin.Tests/Internal/EuVatTaxCalculatorTests.cs
@@ -60,7 +60,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_DomesticSale_ShouldApplyStandardRate()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(CreateAddress("BE"), 100m);
@@ -118,7 +118,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
         _taxOptions.OssEnabled = true;
         _taxOptions.OssRegisteredCountries = ["DE", "FR"];
 
-        _rateProvider.GetRateAsync("DE", FixedNow, ct)
+        _rateProvider.GetRateAsync("DE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("DE", 0.19m));
 
         TaxRequest request = CreateRequest(CreateAddress("DE"), 100m);
@@ -136,7 +136,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_IntraEuB2CWithoutOss_ShouldApplySellerCountryRate()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(CreateAddress("FR"), 100m);
@@ -154,7 +154,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_MultipleLineItems_ShouldTaxEachIndependently()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(CreateAddress("BE"), 100m, 50m, 25m);
@@ -182,7 +182,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
                 RequestIdentifier: null, ValidatedAt: FixedNow,
                 Source: TaxIdValidationSource.Vies));
 
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(buyer, 100m);
@@ -204,7 +204,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
         CancellationToken ct = TestContext.Current.CancellationToken;
         BillingAddress buyer = CreateAddress("DE", vatNumber);
 
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(buyer, 100m);
@@ -222,7 +222,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_ShouldRoundHalfAwayFromZero()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         // 33.33 * 0.21 = 6.9993 -> rounds to 7.00
@@ -239,7 +239,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_RateNotFoundForCountry_ShouldApplyZeroRate()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns((TaxRateEntry?)null);
 
         TaxRequest request = CreateRequest(CreateAddress("BE"), 100m);
@@ -262,7 +262,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_ShouldRecordMetricsWithoutThrowing()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(CreateAddress("BE"), 100m);
@@ -296,7 +296,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_MidpointRoundingEdge_ShouldRoundUp()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         // 1.005 * 0.21 = 0.21105 -> rounds to 0.21 (not a midpoint case)
@@ -317,7 +317,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
         _taxOptions.OssEnabled = true;
         _taxOptions.OssRegisteredCountries = ["FR", "IT"];
 
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         TaxRequest request = CreateRequest(CreateAddress("DE"), 100m);
@@ -334,7 +334,7 @@ public sealed class EuVatTaxCalculatorTests : IDisposable
     public async Task CalculateAsync_WithTenantId_ShouldRecordMetricsWithTenant()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
-        _rateProvider.GetRateAsync("BE", FixedNow, ct)
+        _rateProvider.GetRateAsync("BE", FixedNow, cancellationToken: ct)
             .Returns(new TaxRateEntry("BE", 0.21m));
 
         var tenantId = Guid.NewGuid();

--- a/tests/Granit.Tax.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Builtin.Tests/packages.lock.json
@@ -560,6 +560,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
@@ -333,6 +333,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -417,6 +423,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/Granit.Tax.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/Granit.Tax.EntityFrameworkCore.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Tax.EntityFrameworkCore\Granit.Tax.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Contacts\Granit.Contacts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
@@ -1,3 +1,7 @@
+using Granit.Contacts;
+using Granit.Contacts.Domain;
+using Granit.Contacts.Domain.ValueObjects;
+using Granit.DataFiltering;
 using Granit.Tax;
 using Granit.Tax.Domain;
 using Granit.Tax.EntityFrameworkCore.Internal;
@@ -16,6 +20,8 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
 
     private readonly TestFactory _factory;
     private readonly ITaxRateProvider _fallback = Substitute.For<ITaxRateProvider>();
+    private readonly IContactReader _contactReader = Substitute.For<IContactReader>();
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly EfTaxRateProvider _sut;
 
@@ -27,7 +33,13 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
             .Options;
         _factory = new TestFactory(options);
         _clock.Now.Returns(Now);
-        _sut = new EfTaxRateProvider(_factory, _fallback, _clock);
+        _dataFilter.Disable<Granit.Domain.IMultiTenant>().Returns(new NullDisposable());
+        _sut = new EfTaxRateProvider(_factory, _fallback, _contactReader, _dataFilter, _clock);
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public void Dispose() { }
     }
 
     public async ValueTask DisposeAsync()
@@ -54,26 +66,23 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     {
         await SeedOverrideAsync("BE", 0.21m, reduced: 0.06m);
 
-        TaxRateEntry? result = await _sut.GetRateAsync(
-            "BE", Now, TestContext.Current.CancellationToken);
+        TaxRateEntry? result = await _sut.GetRateAsync("BE", Now, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.CountryCode.ShouldBe("BE");
         result.StandardRate.ShouldBe(0.21m);
         result.ReducedRate.ShouldBe(0.06m);
-        await _fallback.DidNotReceive().GetRateAsync(
-            Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await _fallback.DidNotReceive().GetRateAsync(Arg.Any<string>(), Arg.Any<DateTimeOffset>(), cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetRateAsync_NoOverride_DelegatesToFallback()
     {
         TaxRateEntry fallbackEntry = new("FR", 0.20m, ReducedRate: 0.055m, EffectiveFrom: Now.AddYears(-1));
-        _fallback.GetRateAsync("FR", Now, Arg.Any<CancellationToken>())
+        _fallback.GetRateAsync("FR", Now, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(fallbackEntry);
 
-        TaxRateEntry? result = await _sut.GetRateAsync(
-            "FR", Now, TestContext.Current.CancellationToken);
+        TaxRateEntry? result = await _sut.GetRateAsync("FR", Now, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldBe(fallbackEntry);
     }
@@ -85,11 +94,10 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
             from: Now.AddDays(-365),
             to: Now.AddDays(-7)); // expired
 
-        _fallback.GetRateAsync("BE", Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+        _fallback.GetRateAsync("BE", Arg.Any<DateTimeOffset>(), cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new TaxRateEntry("BE", 0.21m, EffectiveFrom: Now.AddYears(-2)));
 
-        TaxRateEntry? result = await _sut.GetRateAsync(
-            "BE", Now, TestContext.Current.CancellationToken);
+        TaxRateEntry? result = await _sut.GetRateAsync("BE", Now, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.StandardRate.ShouldBe(0.21m); // fallback
@@ -101,8 +109,7 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
         await SeedOverrideAsync("BE", 0.20m, from: Now.AddDays(-90));
         await SeedOverrideAsync("BE", 0.21m, from: Now.AddDays(-30));
 
-        TaxRateEntry? result = await _sut.GetRateAsync(
-            "BE", Now, TestContext.Current.CancellationToken);
+        TaxRateEntry? result = await _sut.GetRateAsync("BE", Now, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.StandardRate.ShouldBe(0.21m);
@@ -145,6 +152,85 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
 
         result.Count.ShouldBe(1);
         result[0].StandardRate.ShouldBe(0.99m);
+    }
+
+    // ── Customer-specific tax status (US #1244) ────────────────────────
+
+    [Fact]
+    public async Task GetRateAsync_ContactExempt_ReturnsZeroRate_BypassingDbAndFallback()
+    {
+        await SeedOverrideAsync("BE", 0.21m); // would normally apply
+        var contactId = ContactId.Create(Guid.NewGuid());
+        Contact contact = NewContactWithStatus(TaxStatus.Create(isExempt: true));
+        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
+            .Returns(contact);
+
+        TaxRateEntry? result = await _sut.GetRateAsync(
+            "BE", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.StandardRate.ShouldBe(0m);
+        result.ReducedRate.ShouldBe(0m);
+        await _fallback.DidNotReceive().GetRateAsync(
+            Arg.Any<string>(), Arg.Any<DateTimeOffset>(),
+            Arg.Any<ContactId?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetRateAsync_ContactReverseCharge_ReturnsZeroRate()
+    {
+        var contactId = ContactId.Create(Guid.NewGuid());
+        Contact contact = NewContactWithStatus(TaxStatus.Create(reverseCharge: true, vatin: "BE0123456789"));
+        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
+            .Returns(contact);
+
+        TaxRateEntry? result = await _sut.GetRateAsync(
+            "FR", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.StandardRate.ShouldBe(0m);
+        result.ReducedRate.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task GetRateAsync_ContactStandard_DelegatesToFallback()
+    {
+        var contactId = ContactId.Create(Guid.NewGuid());
+        Contact contact = NewContactWithStatus(TaxStatus.Standard);
+        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
+            .Returns(contact);
+
+        TaxRateEntry fallbackEntry = new("FR", 0.20m, EffectiveFrom: Now.AddYears(-1));
+        _fallback.GetRateAsync(
+                "FR", Now, contactId, Arg.Any<CancellationToken>())
+            .Returns(fallbackEntry);
+
+        TaxRateEntry? result = await _sut.GetRateAsync(
+            "FR", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBe(fallbackEntry);
+    }
+
+    [Fact]
+    public async Task GetRateAsync_ContactNotFound_FallsThroughToCountryRate()
+    {
+        var contactId = ContactId.Create(Guid.NewGuid());
+        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
+            .Returns((Contact?)null);
+        await SeedOverrideAsync("BE", 0.21m);
+
+        TaxRateEntry? result = await _sut.GetRateAsync(
+            "BE", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.StandardRate.ShouldBe(0.21m);
+    }
+
+    private static Contact NewContactWithStatus(TaxStatus status)
+    {
+        var c = Contact.Create(Guid.NewGuid(), tenantId: null, ContactKind.Company, "Test", "EUR");
+        c.SetTaxStatus(status);
+        return c;
     }
 
     private sealed class TestFactory(DbContextOptions<TaxDbContext> options)

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/packages.lock.json
@@ -317,6 +317,23 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -375,6 +392,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -384,6 +402,7 @@
       "granit.tax.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Contacts": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",

--- a/tests/Granit.Tax.Stripe.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Stripe.Tests/packages.lock.json
@@ -563,6 +563,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Tax.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Tests/packages.lock.json
@@ -273,6 +273,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.contacts.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -296,6 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Contacts.Abstractions": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Last user story of Epic #1220. Adds **customer-specific tax classification**
to the Contact aggregate so admins can flag a customer as VAT-exempt or
B2B intra-EU reverse-charge. `Granit.Tax` honours the status when computing
rates: exempt or reverse-charge contacts yield 0% on every line, standard
contacts fall back to the country / standard rate.

Closes US #1244 → closes Epic #1220.

### Domain

- `TaxStatus` value object in `Granit.Contacts.Abstractions`
  (`IsExempt` / `ReverseCharge` / `Vatin` / `EvidenceBlobId`, structural equality).
- `Contact.TaxStatus` (default `Standard`) + `Contact.SetTaxStatus(...)`
  with idempotent change detection.
- Reverse-charge requires a buyer-side VAT identification number —
  enforced at the value object boundary.
- EF mapping: `OwnsOne(c.TaxStatus, ...)` on `ContactConfiguration`.

### Tax provider

- `ITaxRateProvider.GetRateAsync` now accepts an optional `ContactId`.
- `TaxRequest` carries `BuyerContactId`; `EuVatTaxCalculator` threads it
  through to the rate provider.
- `EfTaxRateProvider` checks `Contact.TaxStatus.YieldsZeroRate` first
  (bypassing the `IMultiTenant` filter so a host-side calculation can
  read a tenant-scoped contact's status), then falls through to country-level
  DB overrides and finally the config-based fallback.

### Admin endpoints

| Method | Route | Permission | Description |
|--------|-------|-----------|-------------|
| `PUT` | `/contacts/{id}/tax-status` | `Contacts.Contacts.Manage` | Set exempt / reverse-charge / vatin / evidence blob |
| `DELETE` | `/contacts/{id}/tax-status` | `Contacts.Contacts.Manage` | Reset to `Standard` (idempotent) |

`ContactResponse` exposes a new `TaxStatus` sub-DTO.

### Out of scope

- `StripeTaxCalculator` continues to delegate to Stripe Tax API and does
  **not** short-circuit on `Contact.TaxStatus`. Stripe has its own
  `customer.tax_exempt` mechanism — alignment can be done in a follow-up
  if/when we keep both calculators side by side.

## Test plan

- [x] `dotnet build` — solution clean (0 errors, 0 warnings).
- [x] `dotnet format Granit.slnx --verify-no-changes` — clean.
- [x] `Granit.Contacts.Tests` — 112 passed (7 new tax-status tests).
- [x] `Granit.Tax.EntityFrameworkCore.Tests` — 11 passed (4 new tests:
      exempt → 0%, reverse-charge → 0%, standard → fallback, missing
      contact → falls through).
- [x] `Granit.Tax.Builtin.Tests` — 64 passed.
- [x] `Granit.Invoicing.Tests` — 57 passed.
- [x] `Granit.ArchitectureTests` — 150 passed.
