### PR TITLE
chore(contacts): align module with Granit framework conventions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10878,15 +10878,6 @@
       "members": []
     },
     {
-      "name": "ContactTaxIdentityRequest",
-      "fqn": "Granit.Contacts.Endpoints.Dtos.ContactTaxIdentityRequest",
-      "kind": "record",
-      "project": "Granit.Contacts.Endpoints",
-      "file": "src/Granit.Contacts.Endpoints/Dtos/ContactTaxIdentityRequest.cs",
-      "line": 4,
-      "members": []
-    },
-    {
       "name": "ContactTaxStatusRequest",
       "fqn": "Granit.Contacts.Endpoints.Dtos.ContactTaxStatusRequest",
       "kind": "record",
@@ -10935,7 +10926,7 @@
       "kind": "class",
       "project": "Granit.Contacts.Endpoints",
       "file": "src/Granit.Contacts.Endpoints/GranitContactsEndpointsModule.cs",
-      "line": 13,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/business/contacts.mdx
+++ b/docs-site/src/content/docs/dotnet/business/contacts.mdx
@@ -1,0 +1,222 @@
+---
+title: "Contacts — Central Party-Management Aggregate"
+description: Odoo res.partner-style aggregate for any party the platform interacts with — customers, suppliers, employees, leads — with multi-role flags, parent-child hierarchy, polyglot external mappings, and customer-specific tax classification.
+sidebar:
+  label: Contacts
+  order: 20
+---
+
+import { Tabs, TabItem, FileTree } from "@astrojs/starlight/components";
+
+`Granit.Contacts` is the central party-management aggregate for the framework,
+modelled after Odoo's `res.partner`. A **Contact** represents any natural person,
+legal entity, or organisational unit the platform interacts with — customers,
+suppliers, employees, leads — and can carry several roles simultaneously via the
+`[Flags]` `ContactRoles` enum. It powers Invoicing, Subscriptions, Payments, Tax,
+and CustomerBalance today, and is designed to absorb future Procurement / HR /
+CRM modules without schema churn.
+
+## Why this module exists
+
+Before `Granit.Contacts`, billing identity was duplicated across Invoicing,
+Subscriptions, Payments, and CustomerBalance. Each module carried its own subset
+of name / address / VAT number / external-provider identifiers, and downstream
+consumers had to reconcile them. `Granit.Contacts` consolidates the party
+abstraction in one aggregate so:
+
+- Tax / billing / payment data is captured once, referenced everywhere by `ContactId`.
+- External provider identifiers (Stripe, Mollie, Odoo, Sage, NetSuite) live on the
+  contact rather than scattered across module-specific mapping tables.
+- A single GDPR Article 17 erasure pseudonymises the contact and lets
+  downstream modules retain the row for accounting integrity.
+
+## Package structure
+
+<FileTree>
+- Granit.Contacts.Abstractions/ Value objects, enums, integration events (lightweight)
+- Granit.Contacts/ Aggregate root, domain events, query / export definitions
+  - Granit.Contacts.EntityFrameworkCore EF Core persistence — ContactsDbContext, EfContactStore
+  - Granit.Contacts.Endpoints Admin REST API — CRUD, lifecycle, addresses / emails / phones, tax status
+  - Granit.Contacts.MultiTenancy Wolverine handler that seeds a host-scoped Contact per tenant
+  - Granit.Contacts.Privacy GDPR Article 15/17 export + erasure (pseudonymisation)
+</FileTree>
+
+| Package | Role | Depends on |
+|---------|------|------------|
+| `Granit.Contacts.Abstractions` | `ContactId`, `Address`, `BillingAddress`, enums, ETOs | `Granit` |
+| `Granit.Contacts` | `Contact` aggregate, `IContactReader`/`IContactWriter`, query + export definitions | `Granit.Contacts.Abstractions`, `Granit.QueryEngine.Abstractions`, `Granit.DataExchange.Abstractions` |
+| `Granit.Contacts.EntityFrameworkCore` | Isolated DbContext + child-graph reconciliation writer | `Granit.Contacts`, `Granit.Persistence.EntityFrameworkCore` |
+| `Granit.Contacts.Endpoints` | Admin API (host + tenant scope) | `Granit.Contacts`, `Granit.Authorization`, `Granit.Validation` |
+| `Granit.Contacts.MultiTenancy` | Tenant-creation seeder (creates host-scoped Contact per tenant) | `Granit.Contacts`, `Granit.MultiTenancy` |
+| `Granit.Contacts.Privacy` | Privacy export provider + Article 17 pseudonymisation handler | `Granit.Contacts`, `Granit.Privacy.BlobStorage` |
+
+## Dependency graph
+
+```mermaid
+graph TD
+    CA[Granit.Contacts.Abstractions] --> G[Granit]
+    C[Granit.Contacts] --> CA
+    CEF[Granit.Contacts.EntityFrameworkCore] --> C
+    CEF --> P[Granit.Persistence.EntityFrameworkCore]
+    CE[Granit.Contacts.Endpoints] --> C
+    CE --> AUTH[Granit.Authorization]
+    CE --> V[Granit.Validation]
+    CMT[Granit.Contacts.MultiTenancy] --> C
+    CMT --> MT[Granit.MultiTenancy]
+    CP[Granit.Contacts.Privacy] --> C
+    CP --> PV[Granit.Privacy.BlobStorage]
+```
+
+---
+
+## Core concepts
+
+### Dual-use scope
+
+`Contact` is `IMultiTenant`. The multi-tenant filter is **always** active, even in
+host scope:
+
+- `TenantId == null` → **host-scoped** contacts (the SaaS host's tenants-as-customers, vendors, internal staff).
+- `TenantId == <tenant>` → **tenant-scoped** (a tenant's e-commerce / CRM / procurement contacts).
+
+Cross-scope reads must explicitly bypass the filter via
+`IDataFilter.Disable<IMultiTenant>()` — leaking a tenant's contacts into a host
+admin browser would be a privacy regression.
+
+### Multi-role flags
+
+A single contact may simultaneously hold any combination of `ContactRoles`:
+
+```csharp
+[Flags]
+public enum ContactRoles
+{
+    None     = 0,
+    Customer = 1 << 0,  // Invoicing, Subscriptions, Payments, Tax, CustomerBalance
+    Supplier = 1 << 1,  // future Granit.Procurement
+    Employee = 1 << 2,  // future Granit.Hr
+    Lead     = 1 << 3,  // future Granit.Crm
+}
+```
+
+Roles are added/removed individually via `Contact.AddRole(...)` /
+`Contact.RemoveRole(...)`. Downstream modules typically push role flags via event
+handlers (e.g., Invoicing adds `Customer` on first invoice).
+
+### External mappings
+
+Polyglot identity — at most one mapping per provider, enforced by a unique
+`(ContactId, ProviderName)` index and defensively at the aggregate:
+
+```csharp
+contact.AddExternalMapping(id, ContactExternalProviderNames.Stripe, "cus_NffrFeUfNV2Hib");
+contact.AddExternalMapping(id, ContactExternalProviderNames.Odoo,   "12345");
+
+string? stripeId = contact.FindExternalId(ContactExternalProviderNames.Stripe);
+```
+
+The reserved `"tenant"` provider name is used by `Granit.Contacts.MultiTenancy` to
+link a host-scoped contact back to its tenant.
+
+### Lifecycle
+
+`Active` ⇄ `Suspended`; either may transition to terminal `Archived`. Archived
+contacts are immutable. Pseudonymisation (GDPR Article 17) bypasses the
+mutability guard so erasure succeeds even on archived rows.
+
+### Customer-specific tax classification
+
+`TaxStatus` is an owned value object capturing whether the customer is VAT-exempt
+(NGO, public body), under B2B intra-EU reverse charge, or standard. Read by
+`Granit.Tax.ITaxRateProvider` when a `contactId` is supplied — exempt /
+reverse-charge customers yield a 0% rate regardless of country defaults.
+
+---
+
+## Setup
+
+<Tabs>
+<TabItem label="Tenant-aware app">
+
+```csharp
+[DependsOn(
+    typeof(GranitContactsModule),
+    typeof(GranitContactsEndpointsModule),
+    typeof(GranitContactsMultiTenancyModule))]
+public class AppModule : GranitModule { }
+```
+
+```csharp
+builder.AddGranitContactsEntityFrameworkCore(o =>
+    o.UseNpgsql(builder.Configuration.GetConnectionString("Default")));
+```
+
+```csharp
+app.MapGranitContacts();
+```
+
+</TabItem>
+<TabItem label="With privacy stack">
+
+```csharp
+[DependsOn(
+    typeof(GranitContactsModule),
+    typeof(GranitContactsEndpointsModule),
+    typeof(GranitContactsPrivacyModule))]
+public class AppModule : GranitModule { }
+```
+
+```csharp
+builder.Services.AddGranitPrivacy(p => p.AddGranitContactsPrivacyProvider());
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+## API surface
+
+`MapGranitContacts()` exposes 19 endpoints under `/contacts` (configurable via
+`Contacts:Endpoints:RoutePrefix`). All endpoints require either
+`Contacts.Contacts.Read` or `Contacts.Contacts.Manage`.
+
+| Method | Path | Permission |
+|--------|------|-----------|
+| `GET` | `/contacts` | `Read` |
+| `GET` | `/contacts/{id}` | `Read` |
+| `POST` | `/contacts` | `Manage` |
+| `PATCH` | `/contacts/{id}` | `Manage` |
+| `POST` | `/contacts/{id}/{suspend\|activate\|archive}` | `Manage` |
+| `POST` / `DELETE` | `/contacts/{id}/addresses[/{addressId}]` | `Manage` |
+| `POST` / `DELETE` | `/contacts/{id}/emails[/{emailId}]` | `Manage` |
+| `POST` / `DELETE` | `/contacts/{id}/phones[/{phoneId}]` | `Manage` |
+| `POST` / `DELETE` | `/contacts/{id}/external-mappings[/{provider}]` | `Manage` |
+| `POST` / `DELETE` | `/contacts/{id}/roles[/{role}]` | `Manage` |
+| `PUT` / `DELETE` | `/contacts/{id}/tax-status` | `Manage` |
+
+---
+
+## Integration events
+
+Published via the Wolverine outbox to `Granit.Contacts.Abstractions`:
+
+| Event | When |
+|-------|------|
+| `ContactCreatedEto` | Contact aggregate created |
+| `ContactUpdatedEto` | Identity / address / contact-info changed |
+| `ContactSuspendedEto` | Lifecycle → Suspended |
+| `ContactActivatedEto` | Lifecycle → Active |
+| `ContactArchivedEto` | Lifecycle → Archived (terminal) |
+| `ContactExternalMappingAddedEto` | External provider id registered |
+| `ContactPersonalDataPseudonymizedEto` | GDPR Article 17 erasure ran |
+
+---
+
+## See also
+
+- [Contacts — external mappings guide](/dotnet/guides/contacts-external-mappings/)
+- [Contacts — tenant seeding guide](/dotnet/guides/contacts-tenant-seeding/)
+- [Contacts — role handler guide](/dotnet/guides/contacts-role-handler/)
+- [Privacy — data export and erasure](/dotnet/compliance/privacy/)
+- [Multi-tenancy](/dotnet/concepts/multi-tenancy/)

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 275;
+export const PACKAGE_COUNT = 281;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;

--- a/src/Granit.AI.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Endpoints/packages.lock.json
@@ -212,8 +212,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Auditing.Endpoints/packages.lock.json
+++ b/src/Granit.Auditing.Endpoints/packages.lock.json
@@ -206,8 +206,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Authentication.ApiKeys.Endpoints/packages.lock.json
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/packages.lock.json
@@ -198,8 +198,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Authorization.Endpoints/packages.lock.json
+++ b/src/Granit.Authorization.Endpoints/packages.lock.json
@@ -171,8 +171,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Bff.Endpoints/packages.lock.json
+++ b/src/Granit.Bff.Endpoints/packages.lock.json
@@ -282,8 +282,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.BlobStorage.Endpoints/packages.lock.json
+++ b/src/Granit.BlobStorage.Endpoints/packages.lock.json
@@ -234,8 +234,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.22",
-        "contentHash": "zkX4e1JqmMfRCVjbvM36U/xhPdYnMaWtb1nzRqS43USyGLNw1E7IaZE4snaZJbs8Np0276FR8NUaEcp/efQyVw==",
+        "resolved": "4.0.22.1",
+        "contentHash": "DvD6hSsrr8Z5j+ER6msGOHFQZsgyhNWrLbO5y+1YT/VRn6uL4BFhI2YNofRsfVPaA85vOj7q/sLuexSsCXwJZg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -67,8 +67,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Catalog.Endpoints/packages.lock.json
+++ b/src/Granit.Catalog.Endpoints/packages.lock.json
@@ -218,8 +218,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Contacts.Endpoints/Dtos/ContactTaxIdentityRequest.cs
+++ b/src/Granit.Contacts.Endpoints/Dtos/ContactTaxIdentityRequest.cs
@@ -1,4 +1,0 @@
-namespace Granit.Contacts.Endpoints.Dtos;
-
-/// <summary>Request to update a contact's tax / legal identity.</summary>
-public sealed record ContactTaxIdentityRequest(string? TaxId, string? RegistrationNumber);

--- a/src/Granit.Contacts.Endpoints/Endpoints/ContactEndpoints.cs
+++ b/src/Granit.Contacts.Endpoints/Endpoints/ContactEndpoints.cs
@@ -278,7 +278,7 @@ internal static class ContactEndpoints
         }
         catch (ArgumentException ex)
         {
-            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status400BadRequest);
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
         c.SetTaxStatus(next);

--- a/src/Granit.Contacts.Endpoints/Extensions/ContactsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Contacts.Endpoints/Extensions/ContactsEndpointRouteBuilderExtensions.cs
@@ -27,174 +27,173 @@ public static class ContactsEndpointRouteBuilderExtensions
 
         // ── List & detail ─────────────────────────────────────────────
         group.MapGet("", ContactEndpoints.HandleListAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Read)
             .WithName("ListContacts")
             .WithSummary("Lists contacts in the active scope, optionally filtered by role.")
             .WithDescription("Returns all contacts visible in the active scope (host or tenant). When the optional 'role' query parameter is set, only contacts whose Roles flags include the requested role are returned. Requires Contacts.Contacts.Read.")
-            .Produces<IReadOnlyList<ContactListItemResponse>>();
+            .Produces<IReadOnlyList<ContactListItemResponse>>()
+            .RequireAuthorization(ContactsPermissions.Contacts.Read);
 
         group.MapGet("/{id:guid}", ContactEndpoints.HandleGetByIdAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Read)
             .WithName("GetContactById")
             .WithSummary("Returns a single contact by id.")
             .WithDescription("Returns the contact aggregate including all its addresses, emails, phones, and external mappings. Returns 404 if no contact with that id exists in the active scope.")
             .Produces<ContactResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Read);
 
         // ── Create / update ───────────────────────────────────────────
         group.MapPost("", ContactEndpoints.HandleCreateAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("CreateContact")
             .WithSummary("Creates a new contact in the active scope.")
             .WithDescription("Creates an Active contact in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation.")
             .Produces<ContactResponse>(StatusCodes.Status201Created)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapPatch("/{id:guid}", ContactEndpoints.HandleUpdateAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("UpdateContact")
             .WithSummary("Updates the contact's identity (name, website, locale, timezone).")
             .WithDescription("Updates the contact's display fields. Emails / phones / addresses live in their own child collections — see the dedicated /emails, /phones, /addresses endpoints. Currency is intentionally not editable here. Returns 404 if the contact does not exist; 400 on validation failure.")
             .Produces<ContactResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Lifecycle ─────────────────────────────────────────────────
         group.MapPost("/{id:guid}/suspend", ContactEndpoints.HandleSuspendAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("SuspendContact")
             .WithSummary("Suspends a contact (idempotent; throws on Archived).")
             .WithDescription("Sets the contact's status to Suspended. The aggregate is idempotent: re-suspending an already-suspended contact is a no-op. Suspending an Archived contact returns 409 Conflict.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status409Conflict);
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapPost("/{id:guid}/activate", ContactEndpoints.HandleActivateAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("ActivateContact")
             .WithSummary("Reactivates a suspended contact (idempotent; throws on Archived).")
             .WithDescription("Sets the contact's status back to Active. No-op if already active. Returns 409 Conflict on Archived contacts.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status409Conflict);
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapPost("/{id:guid}/archive", ContactEndpoints.HandleArchiveAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("ArchiveContact")
             .WithSummary("Archives a contact (terminal state).")
             .WithDescription("Sets the contact's status to Archived. Archived contacts are immutable and can no longer be edited. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Addresses (multi-typed: Billing / Shipping / Other) ───────
         group.MapPost("/{id:guid}/addresses", ContactEndpoints.HandleAddAddressAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("AddContactAddress")
             .WithSummary("Adds a typed address to a contact.")
             .WithDescription("Adds a typed address. The first address of a kind is auto-promoted to default. Pass IsDefault=true to demote any existing default of the same kind.")
             .Produces<ContactResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/addresses/{addressId:guid}", ContactEndpoints.HandleRemoveAddressAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("RemoveContactAddress")
             .WithSummary("Removes an address from a contact.")
             .WithDescription("Removes an address by id. If the removed address was the default for its kind, another address of the same kind (if any) is promoted to default. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Emails ────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/emails", ContactEndpoints.HandleAddEmailAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("AddContactEmail")
             .WithSummary("Adds an email to a contact.")
             .WithDescription("Adds an email. The first email is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary email.")
             .Produces<ContactResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/emails/{emailId:guid}", ContactEndpoints.HandleRemoveEmailAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("RemoveContactEmail")
             .WithSummary("Removes an email from a contact.")
             .WithDescription("Removes an email by id. If the removed email was primary, another email (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Phones (typed: Mobile / Office / Home / Other) ────────────
         group.MapPost("/{id:guid}/phones", ContactEndpoints.HandleAddPhoneAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("AddContactPhone")
             .WithSummary("Adds a phone number to a contact.")
             .WithDescription("Adds a typed phone (Mobile / Office / Home / Other). The first phone is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary phone.")
             .Produces<ContactResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/phones/{phoneId:guid}", ContactEndpoints.HandleRemovePhoneAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("RemoveContactPhone")
             .WithSummary("Removes a phone number from a contact.")
             .WithDescription("Removes a phone by id. If the removed phone was primary, another phone (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── External mappings (one per provider) ──────────────────────
         group.MapPost("/{id:guid}/external-mappings", ContactEndpoints.HandleAddExternalMappingAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("AddContactExternalMapping")
             .WithSummary("Registers an external provider identifier (Stripe / Mollie / Odoo / …).")
             .WithDescription("Registers a polyglot external mapping. Returns 409 Conflict if a mapping for the same provider already exists — remove the existing one first.")
             .Produces<ContactResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/external-mappings/{providerName}", ContactEndpoints.HandleRemoveExternalMappingAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("RemoveContactExternalMapping")
             .WithSummary("Removes an external mapping.")
             .WithDescription("Removes the contact's external mapping for the given provider. Idempotent — returns 204 even if no mapping existed.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Roles ─────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/roles", ContactEndpoints.HandleAddRoleAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("AddContactRole")
             .WithSummary("Adds a role flag to a contact.")
             .WithDescription("Adds the requested role flag(s) to the contact's Roles set. Idempotent. The standard pattern is for downstream modules to push role flags via event handlers (e.g., Invoicing adds Customer on first invoice) — this endpoint covers manual administrative overrides.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/roles/{role}", ContactEndpoints.HandleRemoveRoleAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("RemoveContactRole")
             .WithSummary("Removes a role flag from a contact.")
             .WithDescription("Removes the requested role flag from the contact's Roles set. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         // ── Tax status (customer-specific tax classification) ─────────
         group.MapPut("/{id:guid}/tax-status", ContactEndpoints.HandleSetTaxStatusAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("SetContactTaxStatus")
             .WithSummary("Sets the contact's customer-specific tax status.")
-            .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the contact. Read by Granit.Tax when computing rates: contacts with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 400 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
+            .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the contact. Read by Granit.Tax when computing rates: contacts with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 422 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
             .Produces<ContactResponse>()
-            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         group.MapDelete("/{id:guid}/tax-status", ContactEndpoints.HandleClearTaxStatusAsync)
-            .RequireAuthorization(ContactsPermissions.Contacts.Manage)
             .WithName("ClearContactTaxStatus")
             .WithSummary("Resets the contact's tax status to the default (no special classification).")
             .WithDescription("Clears any customer-specific tax classification. Subsequent tax calculations fall back to the country / standard rate. Idempotent.")
             .Produces<ContactResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(ContactsPermissions.Contacts.Manage);
 
         return group;
     }

--- a/src/Granit.Contacts.Endpoints/GranitContactsEndpointsModule.cs
+++ b/src/Granit.Contacts.Endpoints/GranitContactsEndpointsModule.cs
@@ -1,15 +1,20 @@
+using Granit.Authorization;
 using Granit.Contacts.Endpoints.Options;
 using Granit.Contacts.Exports;
 using Granit.Contacts.Queries;
 using Granit.DataExchange.Extensions;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
+using Granit.Validation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Contacts.Endpoints;
 
 /// <summary>Admin REST API for the Granit.Contacts module.</summary>
-[DependsOn(typeof(GranitContactsModule))]
+[DependsOn(
+    typeof(GranitAuthorizationModule),
+    typeof(GranitContactsModule),
+    typeof(GranitValidationModule))]
 public sealed class GranitContactsEndpointsModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Contacts.Endpoints/Validators/ContactRoleRequestValidator.cs
+++ b/src/Granit.Contacts.Endpoints/Validators/ContactRoleRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Granit.Contacts.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Contacts.Endpoints.Validators;
+
+internal sealed class ContactRoleRequestValidator : GranitValidator<ContactRoleRequest>
+{
+    public ContactRoleRequestValidator()
+    {
+        RuleFor(x => x.Role).IsInEnum();
+    }
+}

--- a/src/Granit.Contacts.Endpoints/Validators/ContactSuspendRequestValidator.cs
+++ b/src/Granit.Contacts.Endpoints/Validators/ContactSuspendRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Granit.Contacts.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Contacts.Endpoints.Validators;
+
+internal sealed class ContactSuspendRequestValidator : GranitValidator<ContactSuspendRequest>
+{
+    public ContactSuspendRequestValidator()
+    {
+        RuleFor(x => x.Reason).MaximumLength(512);
+    }
+}

--- a/src/Granit.Contacts.Endpoints/packages.lock.json
+++ b/src/Granit.Contacts.Endpoints/packages.lock.json
@@ -197,8 +197,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.CustomerBalance.Endpoints/packages.lock.json
+++ b/src/Granit.CustomerBalance.Endpoints/packages.lock.json
@@ -231,8 +231,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.DataExchange.Endpoints/packages.lock.json
+++ b/src/Granit.DataExchange.Endpoints/packages.lock.json
@@ -202,8 +202,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Diagnostics.Endpoints/packages.lock.json
+++ b/src/Granit.Diagnostics.Endpoints/packages.lock.json
@@ -177,8 +177,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Features.Endpoints/packages.lock.json
+++ b/src/Granit.Features.Endpoints/packages.lock.json
@@ -178,8 +178,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Http.ApiDocumentation/packages.lock.json
+++ b/src/Granit.Http.ApiDocumentation/packages.lock.json
@@ -20,8 +20,8 @@
       "Scalar.AspNetCore": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Http.Cookies.Endpoints/packages.lock.json
+++ b/src/Granit.Http.Cookies.Endpoints/packages.lock.json
@@ -81,8 +81,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       }
     }
   }

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -203,8 +203,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -229,8 +229,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Imaging.MagickNet/packages.lock.json
+++ b/src/Granit.Imaging.MagickNet/packages.lock.json
@@ -5,10 +5,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
         "requested": "[14.*, )",
-        "resolved": "14.12.0",
-        "contentHash": "YGEgNTZ6DaMhXgJYLClRrmEe6CMsEL5E8hy4c2iH/aEmj41ojFAtA/PIXYH1AOYINNEUX/83nLp/y5obt9P/vw==",
+        "resolved": "14.13.0",
+        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
         "dependencies": {
-          "Magick.NET.Core": "14.12.0"
+          "Magick.NET.Core": "14.13.0"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.12.0",
-        "contentHash": "QPyuk1Lxp1xgSTP8xomnoZjeOtUeTSoeSuEckhGaUAi6GdZ5d2PmZqzr0O4m/zPbC4So/yg5rr2QO4vYD6fB5g=="
+        "resolved": "14.13.0",
+        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
       },
       "granit": {
         "type": "Project"

--- a/src/Granit.Invoicing.Endpoints/packages.lock.json
+++ b/src/Granit.Invoicing.Endpoints/packages.lock.json
@@ -244,8 +244,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Localization.Endpoints/packages.lock.json
+++ b/src/Granit.Localization.Endpoints/packages.lock.json
@@ -171,8 +171,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Metering.Endpoints/packages.lock.json
+++ b/src/Granit.Metering.Endpoints/packages.lock.json
@@ -224,8 +224,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.MultiTenancy.Endpoints/packages.lock.json
+++ b/src/Granit.MultiTenancy.Endpoints/packages.lock.json
@@ -185,8 +185,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.11",
-        "contentHash": "BwmtWC3JM9P4zfzOUPyny9K4z50s4LmUdiwbhIoGaSoD3kWH7IdteR+yF98isjxIYVmvedbFnWoVqn5gW1sStw==",
+        "resolved": "4.0.12.12",
+        "contentHash": "yXOVniaZoAFSBQVo5b35D3wi7asxEKddm9xJHWiTXm0wg+b1TjOyONtU1drqNQ3cqbLaJlAQhjUzKLxA57WZFw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Endpoints/packages.lock.json
+++ b/src/Granit.Notifications.Endpoints/packages.lock.json
@@ -207,8 +207,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.28",
-        "contentHash": "FP10JIhMPDNBu5PmBOjVb/HwRHDOzFnqTK9RfsDlej18u2uTL8UjxqRs+ZHYQurIlhK+R41g5Hd8Oe/eo9JY0w==",
+        "resolved": "4.0.2.29",
+        "contentHash": "o9CtqlUBmwFdowN6JTCR/9EY18bM+PXSJgaB2g4zxFdyOXOWmfq6B17C++wzTZHZjAKjgwqvZvaV8Ycqhu/zuw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.28",
-        "contentHash": "FP10JIhMPDNBu5PmBOjVb/HwRHDOzFnqTK9RfsDlej18u2uTL8UjxqRs+ZHYQurIlhK+R41g5Hd8Oe/eo9JY0w==",
+        "resolved": "4.0.2.29",
+        "contentHash": "o9CtqlUBmwFdowN6JTCR/9EY18bM+PXSJgaB2g4zxFdyOXOWmfq6B17C++wzTZHZjAKjgwqvZvaV8Ycqhu/zuw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -570,8 +570,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.Endpoints/packages.lock.json
+++ b/src/Granit.Payments.Endpoints/packages.lock.json
@@ -248,8 +248,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.QueryEngine.AspNetCore/packages.lock.json
+++ b/src/Granit.QueryEngine.AspNetCore/packages.lock.json
@@ -185,8 +185,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.ReferenceData.Endpoints/packages.lock.json
+++ b/src/Granit.ReferenceData.Endpoints/packages.lock.json
@@ -213,8 +213,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Scheduling.Endpoints/packages.lock.json
+++ b/src/Granit.Scheduling.Endpoints/packages.lock.json
@@ -207,8 +207,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Settings.Endpoints/packages.lock.json
+++ b/src/Granit.Settings.Endpoints/packages.lock.json
@@ -193,8 +193,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -291,8 +291,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Tax.Endpoints/packages.lock.json
+++ b/src/Granit.Tax.Endpoints/packages.lock.json
@@ -212,8 +212,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Templating.Endpoints/packages.lock.json
+++ b/src/Granit.Templating.Endpoints/packages.lock.json
@@ -186,8 +186,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Timeline.Endpoints/packages.lock.json
+++ b/src/Granit.Timeline.Endpoints/packages.lock.json
@@ -187,8 +187,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Validation.Endpoints/packages.lock.json
+++ b/src/Granit.Validation.Endpoints/packages.lock.json
@@ -163,8 +163,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Webhooks.Endpoints/packages.lock.json
+++ b/src/Granit.Webhooks.Endpoints/packages.lock.json
@@ -313,8 +313,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Workflow.Endpoints/packages.lock.json
+++ b/src/Granit.Workflow.Endpoints/packages.lock.json
@@ -179,8 +179,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.Api/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Api/packages.lock.json
@@ -724,8 +724,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "Serilog.AspNetCore": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.Notifications/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Notifications/packages.lock.json
@@ -613,8 +613,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -1101,8 +1101,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Endpoints.Tests/packages.lock.json
@@ -612,8 +612,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3134,7 +3134,8 @@
         "type": "Project",
         "dependencies": {
           "Granit.Notifications.Abstractions": "[0.1.0-dev, )",
-          "Granit.Privacy": "[0.1.0-dev, )"
+          "Granit.Privacy": "[0.1.0-dev, )",
+          "Granit.Templating": "[0.1.0-dev, )"
         }
       },
       "granit.privacy.regulations": {

--- a/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
@@ -426,8 +426,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/packages.lock.json
@@ -454,8 +454,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Authorization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Authorization.Endpoints.Tests/packages.lock.json
@@ -771,8 +771,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
@@ -552,8 +552,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
@@ -636,8 +636,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -72,8 +72,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -359,10 +359,10 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.22",
-        "contentHash": "zkX4e1JqmMfRCVjbvM36U/xhPdYnMaWtb1nzRqS43USyGLNw1E7IaZE4snaZJbs8Np0276FR8NUaEcp/efQyVw==",
+        "resolved": "4.0.22.1",
+        "contentHash": "DvD6hSsrr8Z5j+ER6msGOHFQZsgyhNWrLbO5y+1YT/VRn6uL4BFhI2YNofRsfVPaA85vOj7q/sLuexSsCXwJZg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Bundle.Tests/packages.lock.json
+++ b/tests/Granit.Bundle.Tests/packages.lock.json
@@ -1074,8 +1074,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "Scriban": {
         "type": "CentralTransitive",

--- a/tests/Granit.Catalog.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Catalog.Endpoints.Tests/packages.lock.json
@@ -824,8 +824,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Contacts.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Contacts.Endpoints.Tests/packages.lock.json
@@ -568,8 +568,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
@@ -630,8 +630,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.DataExchange.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Endpoints.Tests/packages.lock.json
@@ -808,8 +808,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
@@ -778,8 +778,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Features.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Features.Endpoints.Tests/packages.lock.json
@@ -779,8 +779,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
+++ b/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
@@ -616,8 +616,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       }
     }
   }

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
@@ -630,8 +630,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       }
     }
   }

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -814,8 +814,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -723,8 +723,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -852,8 +852,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
+++ b/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.12.0",
-        "contentHash": "QPyuk1Lxp1xgSTP8xomnoZjeOtUeTSoeSuEckhGaUAi6GdZ5d2PmZqzr0O4m/zPbC4So/yg5rr2QO4vYD6fB5g=="
+        "resolved": "14.13.0",
+        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -265,10 +265,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.12.0",
-        "contentHash": "YGEgNTZ6DaMhXgJYLClRrmEe6CMsEL5E8hy4c2iH/aEmj41ojFAtA/PIXYH1AOYINNEUX/83nLp/y5obt9P/vw==",
+        "resolved": "14.13.0",
+        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
         "dependencies": {
-          "Magick.NET.Core": "14.12.0"
+          "Magick.NET.Core": "14.13.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -850,8 +850,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Localization.Endpoints.Tests/packages.lock.json
@@ -781,8 +781,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
@@ -844,8 +844,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
@@ -405,8 +405,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -374,10 +374,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.11",
-        "contentHash": "BwmtWC3JM9P4zfzOUPyny9K4z50s4LmUdiwbhIoGaSoD3kWH7IdteR+yF98isjxIYVmvedbFnWoVqn5gW1sStw==",
+        "resolved": "4.0.12.12",
+        "contentHash": "yXOVniaZoAFSBQVo5b35D3wi7asxEKddm9xJHWiTXm0wg+b1TjOyONtU1drqNQ3cqbLaJlAQhjUzKLxA57WZFw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Endpoints.Tests/packages.lock.json
@@ -824,8 +824,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -310,10 +310,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.28",
-        "contentHash": "FP10JIhMPDNBu5PmBOjVb/HwRHDOzFnqTK9RfsDlej18u2uTL8UjxqRs+ZHYQurIlhK+R41g5Hd8Oe/eo9JY0w==",
+        "resolved": "4.0.2.29",
+        "contentHash": "o9CtqlUBmwFdowN6JTCR/9EY18bM+PXSJgaB2g4zxFdyOXOWmfq6B17C++wzTZHZjAKjgwqvZvaV8Ycqhu/zuw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.32",
-        "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
+        "resolved": "4.0.4",
+        "contentHash": "RjBk1WDrOCpsSRGn6j2lYhgiyYnXEhMctwJevNnIPIIGpgj49ifbU6FmG1Dk+1M/VSuqeTQ1WVsssziTty7b2w=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -309,10 +309,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.28",
-        "contentHash": "FP10JIhMPDNBu5PmBOjVb/HwRHDOzFnqTK9RfsDlej18u2uTL8UjxqRs+ZHYQurIlhK+R41g5Hd8Oe/eo9JY0w==",
+        "resolved": "4.0.2.29",
+        "contentHash": "o9CtqlUBmwFdowN6JTCR/9EY18bM+PXSJgaB2g4zxFdyOXOWmfq6B17C++wzTZHZjAKjgwqvZvaV8Ycqhu/zuw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+          "AWSSDK.Core": "[4.0.4, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -887,8 +887,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -1030,8 +1030,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
@@ -856,8 +856,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/packages.lock.json
@@ -790,8 +790,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
@@ -790,8 +790,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.ReferenceData.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/packages.lock.json
@@ -820,8 +820,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
@@ -665,8 +665,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Settings.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Settings.Endpoints.Tests/packages.lock.json
@@ -801,8 +801,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -901,8 +901,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
@@ -610,8 +610,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
@@ -788,8 +788,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Timeline.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Timeline.Endpoints.Tests/packages.lock.json
@@ -791,8 +791,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Validation.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Validation.Endpoints.Tests/packages.lock.json
@@ -394,8 +394,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
@@ -809,8 +809,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Workflow.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Endpoints.Tests/packages.lock.json
@@ -781,8 +781,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.4",
-        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
+        "resolved": "2.14.5",
+        "contentHash": "+wDlTk8GDZMosJ9wHIYHJI6yVvufkm6p2ky1hSjsNaUwnliTOEj6D5zqEUYG9VwAwjbF9yPpbc9zdvtZeW7WiQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Framework-audit findings for the new `Granit.Contacts.*` module family — applied
in one bundled PR. Output of `/audit Contacts --fix corrige tout`.

### Findings fixed (severity)

| # | Severity | What |
|---|----------|------|
| A1 | ARCHITECTURE | `[DependsOn]` on `GranitContactsEndpointsModule` was missing `GranitAuthorizationModule` and `GranitValidationModule` — added (alphabetical, matches the Invoicing / Subscriptions / BlobStorage pattern). |
| C1 | CONVENTION | `PUT /contacts/{id}/tax-status` returned **400** when `TaxStatus.Create` rejected reverse-charge without a VAT number. Switched to **422 Unprocessable Entity** per the HTTP conventions (RFC 7807). |
| C2 | CONVENTION | Missing FluentValidation validators (would fail `ValidationConventionTests`): added `ContactSuspendRequestValidator` and `ContactRoleRequestValidator`. |
| C3 | CONVENTION | Deleted unused DTO `ContactTaxIdentityRequest` (no endpoint binds it; `Contact.UpdateTaxIdentity` is reachable via `PATCH /contacts`). |
| C4 | CONVENTION | Added `docs-site/src/content/docs/dotnet/business/contacts.mdx` reference page; bumped `PACKAGE_COUNT` to 281. |
| C6 | CONVENTION | Reordered OpenAPI metadata chain across all 19 endpoints to put `.RequireAuthorization(...)` last (canonical order: `WithName / WithSummary / WithDescription / Produces* / RequireAuthorization`). |

### Findings deferred (intentional)

- **C5 (false positive)** — flagged in the initial audit as "no `MapGranitQueryEndpoint<Contact>` wired", but no such helper exists in the framework today. The `ContactQueryDefinition` is correctly registered for export + admin-grid metadata; nothing to fix.
- **CL1, CL2, I1** — non-blocking improvements (DependsOn for Guids/Timing, writer indirection in the seeder, `ContactsMetrics` / `ContactsActivitySource`). Tracked separately if needed.

### Lockfiles

`packages.lock.json` regenerated solution-wide via `dotnet restore --force-evaluate Granit.slnx`. The bulk of the diff is a transitive `Scalar.AspNetCore` patch bump (2.14.4 → 2.14.5) propagating through all `*.Endpoints` modules, plus the new direct dependencies on `Granit.Authorization` / `Granit.Validation` from the `[DependsOn]` fix.

## Test plan

- [x] `dotnet build src/Granit.Contacts.Endpoints` — 0 warnings, 0 errors
- [x] `Granit.Contacts.Tests` — 112/112 passed
- [x] `Granit.Contacts.Endpoints.Tests` — 29/29 passed
- [x] `Granit.Contacts.EntityFrameworkCore.Tests` — 38/38 passed
- [x] `Granit.Contacts.MultiTenancy.Tests` — 1/1 passed
- [x] `Granit.Contacts.Privacy.Tests` — 8/8 passed
- [x] `Granit.Contacts.Abstractions.Tests` — 7/7 passed
- [x] `Granit.ArchitectureTests` — 150/150 passed
- [x] `dotnet format --verify-no-changes` — clean

## Manual verification

- Hit `PUT /contacts/{id}/tax-status` with `{ "ReverseCharge": true, "Vatin": null }` and confirm the response is `422 Unprocessable Entity` with a problem+json payload.
- Confirm OpenAPI document under Scalar shows the `Contacts` tag, all 19 operation IDs unique, and no spurious 400/401/403/500 declarations on individual operations (auto-injected by the framework transformer).