### PR TITLE
feat(persistence): IHasMergeTombstone EF convention (#1283)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14107,6 +14107,15 @@
       ]
     },
     {
+      "name": "IHasMergeTombstone",
+      "fqn": "Granit.Domain.IHasMergeTombstone",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/Domain/IHasMergeTombstone.cs",
+      "line": 23,
+      "members": []
+    },
+    {
       "name": "IHasMetadata",
       "fqn": "Granit.Domain.IHasMetadata",
       "kind": "interface",
@@ -24216,21 +24225,12 @@
       "members": []
     },
     {
-      "name": "IHasMergeTombstone",
-      "fqn": "Granit.Mergeable.Domain.IHasMergeTombstone",
-      "kind": "interface",
-      "project": "Granit.Mergeable",
-      "file": "src/Granit.Mergeable/Domain/IHasMergeTombstone.cs",
-      "line": 22,
-      "members": []
-    },
-    {
       "name": "IMergeable",
       "fqn": "Granit.Mergeable.Domain.IMergeable",
       "kind": "interface",
       "project": "Granit.Mergeable",
       "file": "src/Granit.Mergeable/Domain/IMergeable.cs",
-      "line": 25,
+      "line": 29,
       "members": [
         {
           "name": "GetConflicts",
@@ -24245,6 +24245,15 @@
           "returnType": "void"
         }
       ]
+    },
+    {
+      "name": "MergeException",
+      "fqn": "Granit.Mergeable.Exceptions.MergeException",
+      "kind": "class",
+      "project": "Granit.Mergeable",
+      "file": "src/Granit.Mergeable/Exceptions/MergeException.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "MergeableServiceCollectionExtensions",
@@ -24316,15 +24325,6 @@
           "returnType": "Task<int>"
         }
       ]
-    },
-    {
-      "name": "MergeException",
-      "fqn": "Granit.Mergeable.MergeException",
-      "kind": "class",
-      "project": "Granit.Mergeable",
-      "file": "src/Granit.Mergeable/MergeException.cs",
-      "line": 8,
-      "members": []
     },
     {
       "name": "MergeFieldChoices",

--- a/src/Granit.Mergeable/Domain/IMergeable.cs
+++ b/src/Granit.Mergeable/Domain/IMergeable.cs
@@ -2,6 +2,10 @@ using Granit.Domain;
 
 namespace Granit.Mergeable.Domain;
 
+// IHasMergeTombstone lives in Granit.Domain (next to ISoftDeletable, IMultiTenant, etc.) so
+// Granit.Persistence.EntityFrameworkCore can auto-apply the EF column + index + query filter
+// without taking a dependency on Granit.Mergeable.
+
 /// <summary>
 /// Aggregate marker: this aggregate root knows how to absorb a <em>loser</em> instance into
 /// the current <em>survivor</em>, applying per-field admin choices to resolve scalar conflicts.

--- a/src/Granit.Mergeable/Exceptions/MergeException.cs
+++ b/src/Granit.Mergeable/Exceptions/MergeException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Mergeable;
+namespace Granit.Mergeable.Exceptions;
 
 /// <summary>
 /// Thrown when a merge violates a hard invariant — tenant mismatch, kind mismatch, currency

--- a/src/Granit.Mergeable/README.md
+++ b/src/Granit.Mergeable/README.md
@@ -1,0 +1,109 @@
+# Granit.Mergeable
+
+Generic merge primitive for Granit aggregates. Lets a domain aggregate absorb a duplicate
+(the **loser**) into the surviving instance, with per-field admin override at merge time
+and pluggable cross-module reference rewriting.
+
+## Why
+
+Multi-channel data entry (CRM imports, ERP sync, signup forms) inevitably generates
+duplicates. Without a merge tool, downstream aggregates corrupt: invoices issued against
+the wrong party, ledger balances fragmented, provider mappings in conflict. This package
+ships the framework-level primitive; first consumer is `Granit.Parties` (party
+deduplication, [Epic granit-fx/granit-dotnet#1278](https://github.com/granit-fx/granit-dotnet/issues/1278)),
+but the contract is aggregate-agnostic and reusable for catalog products, future
+leads/opportunities, etc.
+
+## Public surface
+
+| Type | Role |
+|---|---|
+| `IHasMergeTombstone` (in `Granit`) | State-only contract: `MergedIntoId` + `MergedAt`. Decoupled from the merge behaviour so EF query filters, admin listings, and audit views can target it without depending on this package. |
+| `IMergeable<TSelf>` | Aggregate marker carrying `GetConflicts(loser)` + `MergeFrom(loser, choices)`. |
+| `IReferenceRewriter<TAggregate>` | Plug-in registry: each module that owns a foreign key to `TAggregate` registers one rewriter (`RewriteAsync` for live UPDATE, `CountAsync` for dry-run preview). |
+| `IMergeService<TAggregate>` | Orchestrator contract — concrete EF impl ships in `Granit.Mergeable.EntityFrameworkCore`. |
+| `MergeRequest` / `MergeResult<T>` / `FieldConflict` | API records. Idempotency-key support baked in. |
+| `MergeFieldChoices` (+ `MergeFieldChoicesBuilder`, `WinnerSide`) | Per-field admin override for conflict resolution at merge time (Salesforce/Dynamics-style preview). |
+| `MergeException` | Translates to HTTP 422 at the endpoint boundary. |
+| `AddReferenceRewriter<TAggregate, TRewriter>()` | DI helper for module authors to plug their rewriter in at startup. |
+| `GranitMergeableModule` | Module marker (no service registration here — consumer modules wire their own rewriters). |
+
+## Usage
+
+### Aggregate side
+
+```csharp
+public sealed class Party : AuditedAggregateRoot, IMergeable<Party>
+{
+    public Guid? MergedIntoId { get; private set; }
+    public DateTimeOffset? MergedAt { get; private set; }
+    public string Name { get; private set; }
+    // ...
+
+    public IReadOnlyList<FieldConflict> GetConflicts(Party loser) =>
+        // Compare scalar fields; return non-empty diffs with default winner.
+        ...
+
+    public void MergeFrom(Party loser, MergeFieldChoices choices)
+    {
+        // Apply per-field choices; fall back to defaults via choices.ResolveOrDefault(...)
+        // NEVER touch child collections (Addresses, Emails, ...) — they are rewritten by
+        // a registered IReferenceRewriter via SQL bulk-update on the shadow FK.
+    }
+}
+```
+
+### Module side (rewriter)
+
+```csharp
+internal sealed class InvoicePartyReferenceRewriter(IDbContextFactory<InvoicingDbContext> f)
+    : IReferenceRewriter<Party>
+{
+    public string Description => "Invoice.PartyId";
+
+    public Task<int> RewriteAsync(Guid survivor, Guid loser, CancellationToken ct) =>
+        f.CreateDbContext().Invoices
+            .Where(i => i.PartyId == loser)
+            .ExecuteUpdateAsync(s => s.SetProperty(i => i.PartyId, survivor), ct);
+
+    public Task<int> CountAsync(Guid survivor, Guid loser, CancellationToken ct) =>
+        f.CreateDbContext().Invoices.CountAsync(i => i.PartyId == loser, ct);
+}
+```
+
+### Wiring
+
+```csharp
+services.AddReferenceRewriter<Party, InvoicePartyReferenceRewriter>();
+```
+
+## Persistence convention
+
+When the aggregate implements `IHasMergeTombstone`, `ApplyGranitConventions` (in
+`Granit.Persistence.EntityFrameworkCore`) auto-applies:
+
+- `MergedIntoId` (Guid?) + `MergedAt` (DateTimeOffset?) columns
+- Index on `MergedIntoId`
+- Named query filter `GranitFilterNames.MergeTombstone` excluding tombstoned rows
+  (bypass via `IDataFilter.Disable<IHasMergeTombstone>()` for admin views)
+
+No per-module mapping required.
+
+## Critical design decisions
+
+- **Scalar vs collection split** — `MergeFrom` only handles scalar fields. Child collections
+  (HasMany shadow-FK) MUST be rewritten by a dedicated `IReferenceRewriter` via SQL bulk-update;
+  in-memory `Collection.AddRange` would conflict with EF PK tracking.
+- **Single-Postgres assumption** — the orchestrator wraps cross-module rewriters in a
+  `TransactionScope` with `IsolationLevel.Serializable`. Single physical Postgres expected
+  (no DTC).
+- **Tombstone chain collapse** — when A→B is followed by B→C, the orchestrator updates
+  `A.MergedIntoId` from B to C in the same transaction. A single hop always resolves a stale
+  id to the current survivor.
+- **Idempotency multi-layer** — Stripe-style `IdempotencyKey` on `MergeRequest`; replay-safe
+  via DB UNIQUE constraint on `(survivorId, loserId, requestHash)` plus the HTTP middleware
+  layer.
+
+## License
+
+Apache 2.0 — same as the rest of the Granit framework.

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -22,6 +22,10 @@ public static class ModelBuilderExtensions
         typeof(ModelBuilderExtensions)
             .GetMethod(nameof(ConfigureConcurrencyStamp), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
 
+    private static readonly MethodInfo ConfigureMergeTombstoneMethod =
+        typeof(ModelBuilderExtensions)
+            .GetMethod(nameof(ConfigureMergeTombstone), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
+
     /// <summary>
     /// Applies Granit conventions to all entity types in the model:
     /// <list type="bullet">
@@ -30,9 +34,14 @@ public static class ModelBuilderExtensions
     ///     <see cref="IActive"/> (<see cref="GranitFilterNames.Active"/>),
     ///     <see cref="IProcessingRestrictable"/> (<see cref="GranitFilterNames.ProcessingRestrictable"/>),
     ///     <see cref="IMultiTenant"/> (<see cref="GranitFilterNames.MultiTenant"/>),
-    ///     <see cref="IPublishable"/> (<see cref="GranitFilterNames.Publishable"/>).
+    ///     <see cref="IPublishable"/> (<see cref="GranitFilterNames.Publishable"/>),
+    ///     <see cref="IHasMergeTombstone"/> (<see cref="GranitFilterNames.MergeTombstone"/>).
     ///     Each interface registers its own independent named filter — bypass one without affecting others:
     ///     <c>query.IgnoreQueryFilters([GranitFilterNames.SoftDelete])</c>.
+    ///   </item>
+    ///   <item><b>Merge tombstone column convention</b>:
+    ///     Implementors of <see cref="IHasMergeTombstone"/> get the <c>MergedIntoId</c> +
+    ///     <c>MergedAt</c> columns and an index on <c>MergedIntoId</c> auto-applied.
     ///   </item>
     ///   <item><b>Translation conventions</b>:
     ///     <see cref="ITranslation{TParent}"/> → FK, cascade delete, unique index (ParentId, Culture).
@@ -71,8 +80,9 @@ public static class ModelBuilderExtensions
             bool hasMultiTenant = typeof(IMultiTenant).IsAssignableFrom(clrType)
                 && currentTenant is not null;
             bool hasPublishable = typeof(IPublishable).IsAssignableFrom(clrType);
+            bool hasMergeTombstone = typeof(IHasMergeTombstone).IsAssignableFrom(clrType);
 
-            if (!hasSoftDelete && !hasActive && !hasProcessingRestriction && !hasMultiTenant && !hasPublishable)
+            if (!hasSoftDelete && !hasActive && !hasProcessingRestriction && !hasMultiTenant && !hasPublishable && !hasMergeTombstone)
             {
                 continue;
             }
@@ -91,6 +101,21 @@ public static class ModelBuilderExtensions
             .Where(clrType => typeof(IConcurrencyAware).IsAssignableFrom(clrType)))
         {
             ConfigureConcurrencyStampMethod // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
+                .MakeGenericMethod(clrType)
+                .Invoke(null, [modelBuilder]);
+        }
+
+        // --- Merge tombstone column conventions ---
+        // Detects IHasMergeTombstone implementors and adds:
+        //   - MergedIntoId column (Guid?) + index (lookup "who merged into X" + tombstone listing)
+        //   - MergedAt column (DateTimeOffset?)
+        // The matching query filter (excludes tombstoned rows from standard queries) is
+        // registered earlier alongside SoftDelete / IMultiTenant / etc.
+        foreach (Type clrType in modelBuilder.Model.GetEntityTypes()
+            .Select(entityType => entityType.ClrType)
+            .Where(clrType => typeof(IHasMergeTombstone).IsAssignableFrom(clrType)))
+        {
+            ConfigureMergeTombstoneMethod // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
                 .MakeGenericMethod(clrType)
                 .Invoke(null, [modelBuilder]);
         }
@@ -282,6 +307,21 @@ public static class ModelBuilderExtensions
             builder.HasQueryFilter(GranitFilterNames.Publishable,
                 Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, isPublished), param));
         }
+
+        if (typeof(IHasMergeTombstone).IsAssignableFrom(typeof(TEntity)))
+        {
+            // Standard listings exclude tombstoned aggregates (those that have been merged
+            // into another instance). Bypass via IDataFilter.Disable<IHasMergeTombstone>()
+            // to surface tombstones in admin / audit views, or per-query via
+            // IgnoreQueryFilters([GranitFilterNames.MergeTombstone]).
+            Expression bypass = Expression.Not(
+                Expression.Property(Expression.Constant(proxy), nameof(FilterProxy.MergeTombstoneEnabled)));
+            Expression notTombstoned = Expression.Equal(
+                Expression.Property(param, nameof(IHasMergeTombstone.MergedIntoId)),
+                Expression.Constant(null, typeof(Guid?)));
+            builder.HasQueryFilter(GranitFilterNames.MergeTombstone,
+                Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, notTombstoned), param));
+        }
     }
 
     // Configures the ConcurrencyStamp property as a concurrency token with VARCHAR(36).
@@ -292,6 +332,23 @@ public static class ModelBuilderExtensions
             .Property(e => e.ConcurrencyStamp)
             .HasMaxLength(36)
             .IsConcurrencyToken();
+    }
+
+    // Configures the MergedIntoId / MergedAt columns + index for IHasMergeTombstone implementors.
+    // The properties are declared as get-only on the interface; the implementing aggregate must
+    // expose them as { get; private set; } (or private setter via reflection) for EF to populate.
+    private static void ConfigureMergeTombstone<TEntity>(ModelBuilder modelBuilder)
+        where TEntity : class, IHasMergeTombstone
+    {
+        Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<TEntity> builder =
+            modelBuilder.Entity<TEntity>();
+
+        builder.Property(e => e.MergedIntoId);
+        builder.Property(e => e.MergedAt);
+
+        // Index on MergedIntoId : (1) speeds up "who merged into X" lookups during chain-collapse
+        // at merge time, (2) supports admin tombstone listings.
+        builder.HasIndex(e => e.MergedIntoId);
     }
 
     // Internal wrapper: EF Core evaluates simple property access on a ConstantExpression
@@ -307,5 +364,6 @@ public static class ModelBuilderExtensions
         public bool ProcessingRestrictableEnabled => _dataFilter?.IsEnabled<IProcessingRestrictable>() ?? true;
         public bool MultiTenantEnabled => _dataFilter?.IsEnabled<IMultiTenant>() ?? true;
         public bool PublishableEnabled => _dataFilter?.IsEnabled<IPublishable>() ?? true;
+        public bool MergeTombstoneEnabled => _dataFilter?.IsEnabled<IHasMergeTombstone>() ?? true;
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitFilterNames.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitFilterNames.cs
@@ -26,4 +26,7 @@ public static class GranitFilterNames
 
     /// <summary>Filter key for <see cref="Core.Domain.IPublishable"/> — excludes unpublished entities.</summary>
     public const string Publishable = "Publishable";
+
+    /// <summary>Filter key for <see cref="Core.Domain.IHasMergeTombstone"/> — excludes aggregates merged out into another instance.</summary>
+    public const string MergeTombstone = "MergeTombstone";
 }

--- a/src/Granit/Domain/IHasMergeTombstone.cs
+++ b/src/Granit/Domain/IHasMergeTombstone.cs
@@ -1,10 +1,11 @@
-namespace Granit.Mergeable.Domain;
+namespace Granit.Domain;
 
 /// <summary>
 /// Tombstone state for an aggregate that has been absorbed into another instance via a merge.
-/// Independent of the merge behaviour (<see cref="IMergeable{TSelf}"/>) so EF query filters,
-/// admin listings, audit views, and a future un-merge endpoint can target this contract
-/// without knowing the merge orchestrator.
+/// Independent of the merge behaviour (the merge orchestrator and per-aggregate <c>MergeFrom</c>
+/// methods live in <c>Granit.Mergeable</c>) so EF query filters, admin listings, audit views,
+/// and a future un-merge endpoint can target this contract without taking a dependency on
+/// the merge module.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -581,6 +581,95 @@ public sealed class ModelBuilderExtensionsTests
     }
 
     // -------------------------------------------------------------------------
+    // IHasMergeTombstone — auto-column + index + named query filter
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ApplyGranitConventions_Mergeable_AddsMergedIntoIdProperty()
+    {
+        using TestDbContextWithMergeable context = CreateMergeableContext();
+
+        IEntityType? entityType = context.Model.FindEntityType(typeof(TestMergeableEntity));
+        entityType.ShouldNotBeNull();
+
+        Microsoft.EntityFrameworkCore.Metadata.IProperty? mergedIntoId =
+            entityType!.FindProperty(nameof(IHasMergeTombstone.MergedIntoId));
+        mergedIntoId.ShouldNotBeNull("MergedIntoId must be auto-mapped on IHasMergeTombstone implementors");
+        mergedIntoId!.ClrType.ShouldBe(typeof(Guid?));
+        mergedIntoId.IsNullable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_Mergeable_AddsMergedAtProperty()
+    {
+        using TestDbContextWithMergeable context = CreateMergeableContext();
+
+        IEntityType? entityType = context.Model.FindEntityType(typeof(TestMergeableEntity));
+        Microsoft.EntityFrameworkCore.Metadata.IProperty? mergedAt =
+            entityType!.FindProperty(nameof(IHasMergeTombstone.MergedAt));
+        mergedAt.ShouldNotBeNull();
+        mergedAt!.ClrType.ShouldBe(typeof(DateTimeOffset?));
+        mergedAt.IsNullable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_Mergeable_AddsIndexOnMergedIntoId()
+    {
+        using TestDbContextWithMergeable context = CreateMergeableContext();
+
+        IEntityType entityType = context.Model.FindEntityType(typeof(TestMergeableEntity))!;
+        bool hasIndex = entityType.GetIndexes()
+            .Any(idx => idx.Properties.Count == 1
+                        && idx.Properties[0].Name == nameof(IHasMergeTombstone.MergedIntoId));
+        hasIndex.ShouldBeTrue("an index on MergedIntoId is required for tombstone lookups");
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_Mergeable_RegistersNamedQueryFilter()
+    {
+        using TestDbContextWithMergeable context = CreateMergeableContext();
+
+        IEntityType entityType = context.Model.FindEntityType(typeof(TestMergeableEntity))!;
+        bool hasFilter = entityType.GetDeclaredQueryFilters()
+            .Any(f => f.Key == GranitFilterNames.MergeTombstone);
+        hasFilter.ShouldBeTrue("a named MergeTombstone filter must be registered");
+    }
+
+    [Fact]
+    public async Task ApplyGranitConventions_Mergeable_FiltersTombstonedEntities()
+    {
+        using TestDbContextWithMergeable context = CreateMergeableContext();
+
+        var alive = new TestMergeableEntity { Name = "alive" };
+        var tombstoned = new TestMergeableEntity
+        {
+            Name = "tombstoned",
+            MergedIntoId = alive.Id,
+            MergedAt = DateTimeOffset.UtcNow,
+        };
+        context.Mergeables.AddRange(alive, tombstoned);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        List<TestMergeableEntity> visible = await context.Mergeables
+            .ToListAsync(TestContext.Current.CancellationToken);
+        visible.ShouldHaveSingleItem().Name.ShouldBe("alive");
+
+        List<TestMergeableEntity> all = await context.Mergeables
+            .IgnoreQueryFilters([GranitFilterNames.MergeTombstone])
+            .ToListAsync(TestContext.Current.CancellationToken);
+        all.Count.ShouldBe(2);
+    }
+
+    private static TestDbContextWithMergeable CreateMergeableContext()
+    {
+        DbContextOptions<TestDbContextWithMergeable> options =
+            new DbContextOptionsBuilder<TestDbContextWithMergeable>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+        return new TestDbContextWithMergeable(options);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -912,6 +1001,22 @@ internal sealed class TestConcurrencyAwareEntity : IConcurrencyAware
 internal sealed class TestDbContextWithConcurrencyAware(DbContextOptions<TestDbContextWithConcurrencyAware> options) : DbContext(options)
 {
     public DbSet<TestConcurrencyAwareEntity> ConcurrencyAwareEntities => Set<TestConcurrencyAwareEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions();
+}
+
+internal sealed class TestMergeableEntity : IHasMergeTombstone
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = string.Empty;
+    public Guid? MergedIntoId { get; set; }
+    public DateTimeOffset? MergedAt { get; set; }
+}
+
+internal sealed class TestDbContextWithMergeable(DbContextOptions<TestDbContextWithMergeable> options) : DbContext(options)
+{
+    public DbSet<TestMergeableEntity> Mergeables => Set<TestMergeableEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
         modelBuilder.ApplyGranitConventions();


### PR DESCRIPTION
## Summary

Auto-applies merge-tombstone EF mapping (column + index + named query filter) to any entity
implementing `IHasMergeTombstone`. Mirrors the existing convention for `ISoftDeletable` /
`IMultiTenant` / `IActive` / `IConcurrencyAware`.

Story [#1283](https://github.com/granit-fx/granit-dotnet/issues/1283) of the Party-merge
feature ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) / [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).
Builds on [#1305](https://github.com/granit-fx/granit-dotnet/pull/1305) (Granit.Mergeable framework scaffold).

## Reorganisation

`IHasMergeTombstone` moves from `Granit.Mergeable.Domain` to `Granit.Domain` (next to
`ISoftDeletable` et al.) so `Granit.Persistence.EntityFrameworkCore` can auto-detect it
without depending on `Granit.Mergeable`. The `IMergeable<T>` behaviour interface in
`Granit.Mergeable` still derives from it transparently.

## ApplyGranitConventions extension

| Aspect | Behaviour |
|---|---|
| **Column auto-mapping** | `MergedIntoId` (Guid?) + `MergedAt` (DateTimeOffset?) added to any entity implementing `IHasMergeTombstone`. |
| **Index** | `MergedIntoId` indexed (chain-collapse lookups + tombstone listings). |
| **Named query filter** | `GranitFilterNames.MergeTombstone` excludes tombstoned rows by default. |
| **Bypass** | `IDataFilter.Disable<IHasMergeTombstone>()` (service-level) or `IgnoreQueryFilters([GranitFilterNames.MergeTombstone])` (per query). |

## Drive-by fixes

Leftovers from #1305 surfaced by `Granit.ArchitectureTests`:
- `src/Granit.Mergeable/README.md` created (every src package must have one).
- `MergeException` moved to `src/Granit.Mergeable/Exceptions/` with the namespace updated
  to `Granit.Mergeable.Exceptions` (every exception class must reside in `Exceptions/`).

## Test plan

- [x] `dotnet build` solution-wide — clean.
- [x] `dotnet format Granit.slnx --verify-no-changes` — clean.
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` — 312/312 passing (5 new tombstone tests:
      property mapping ×2, index, named filter registration, live filter behaviour with
      `IgnoreQueryFilters` bypass).
- [x] `Granit.Mergeable.Tests` — 9/9 passing.
- [x] `Granit.ArchitectureTests` — 150/150 passing (was 148/150 with leftover violations,
      now green after drive-by fixes).

Closes [#1283](https://github.com/granit-fx/granit-dotnet/issues/1283).
