### PR TITLE
feat(parties): PartyId tombstone follow-through (#1282)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2275,7 +2275,8 @@
       "name": "Granit.Timeline.Notifications",
       "deps": [
         "Granit.Timeline",
-        "Granit.Notifications.Abstractions"
+        "Granit.Notifications.Abstractions",
+        "Granit.Templating"
       ],
       "framework": "net10.0"
     },
@@ -2480,7 +2481,8 @@
         "Granit.Authorization",
         "Granit.Identity",
         "Granit.Workflow",
-        "Granit.Notifications.Abstractions"
+        "Granit.Notifications.Abstractions",
+        "Granit.Templating"
       ],
       "framework": "net10.0"
     }
@@ -31074,7 +31076,7 @@
           "name": "SetInternalNotes",
           "kind": "method",
           "signature": "SetInternalNotes(string? notes)",
-          "returnType": "string? InternalNotes { get; private set; } public void"
+          "returnType": "string? InternalNotes { get; private set; } public Guid? MergedIntoId { get; private set; } public DateTimeOffset? MergedAt { get; private set; } public void"
         },
         {
           "name": "DefaultBillingAddress",
@@ -31193,6 +31195,22 @@
           "kind": "method",
           "signature": "IsReserved(string? providerName)",
           "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PartyIdTombstoneExtensions",
+      "fqn": "Granit.Parties.Domain.PartyIdTombstoneExtensions",
+      "kind": "class",
+      "project": "Granit.Parties",
+      "file": "src/Granit.Parties/Domain/PartyIdTombstoneExtensions.cs",
+      "line": 44,
+      "members": [
+        {
+          "name": "ResolveCurrentAsync",
+          "kind": "method",
+          "signature": "ResolveCurrentAsync(this PartyId partyId, IPartyReader reader, IDataFilter dataFilter, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<PartyId>"
         }
       ]
     },
@@ -45731,7 +45749,7 @@
       "kind": "class",
       "project": "Granit.Timeline.Notifications",
       "file": "src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs",
-      "line": 15,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -49621,7 +49639,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Notifications",
       "file": "src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs",
-      "line": 31,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Parties/Domain/Party.cs
+++ b/src/Granit.Parties/Domain/Party.cs
@@ -34,7 +34,7 @@ namespace Granit.Parties.Domain;
 /// <para><b>External mappings.</b> Polyglot — at most one mapping per provider, enforced
 /// defensively at the aggregate and by a unique index in the EF configuration.</para>
 /// </remarks>
-public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata
+public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IHasMergeTombstone
 {
     /// <summary>Per-aggregate cap on emails. Bounds reconciliation cost in <c>EfPartyStore.UpdateAsync</c>
     /// and prevents an authenticated <c>Parties.Manage</c> holder from exhausting storage / write throughput
@@ -221,6 +221,21 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata
     /// </remarks>
     [SensitiveData(Level = Sensitivity.Internal)]
     public string? InternalNotes { get; private set; }
+
+    /// <summary>
+    /// Tombstone — survivor id when this party has been merged out, <c>null</c> when alive.
+    /// Set by the merge orchestrator (<c>EfMergeService&lt;Party&gt;</c>) inside the merge
+    /// transaction; never mutated by the aggregate's own domain methods.
+    /// </summary>
+    /// <remarks>
+    /// EF column + index + standard query filter are auto-applied by
+    /// <c>ApplyGranitConventions</c> via the <see cref="IHasMergeTombstone"/> contract —
+    /// no per-aggregate mapping required.
+    /// </remarks>
+    public Guid? MergedIntoId { get; private set; }
+
+    /// <summary>Merge timestamp — companion to <see cref="MergedIntoId"/>.</summary>
+    public DateTimeOffset? MergedAt { get; private set; }
 
     /// <summary>Sets or clears the internal-notes free-form text. Pass <c>null</c> or empty to clear.</summary>
     public void SetInternalNotes(string? notes)

--- a/src/Granit.Parties/Domain/PartyIdTombstoneExtensions.cs
+++ b/src/Granit.Parties/Domain/PartyIdTombstoneExtensions.cs
@@ -1,0 +1,76 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Parties.Domain.ValueObjects;
+
+namespace Granit.Parties.Domain;
+
+/// <summary>
+/// Tombstone follow-through for <see cref="PartyId"/> — resolves a (possibly stale) id to its
+/// current survivor by reading the <see cref="IHasMergeTombstone.MergedIntoId"/> column on the
+/// underlying <see cref="Party"/>. Used in the frontline of Wolverine handlers, scheduled
+/// background jobs, webhook senders, and notification dispatchers — anywhere a
+/// <see cref="PartyId"/> can survive a merge in a serialised payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> Bulk-UPDATE rewriters (registered via
+/// <c>IReferenceRewriter&lt;Party&gt;</c>) cover persisted columns like
+/// <c>Invoice.PartyId</c>, <c>Subscription.PartyId</c>, etc. They do <em>not</em> cover
+/// <see cref="PartyId"/> values living inside JSON payloads of in-flight Wolverine messages,
+/// scheduled jobs, queued webhooks, or pending notifications. The follow-through lets every
+/// such consumer transparently route to the survivor without any out-of-band reconciliation.
+/// </para>
+/// <para>
+/// <b>Single-hop guarantee.</b> The merge orchestrator collapses chain merges
+/// (<c>A → B → C</c>) at merge time by running
+/// <c>UPDATE parties SET MergedIntoId = newSurvivor WHERE MergedIntoId = oldSurvivor</c>
+/// in the same transaction as the new merge. Therefore one hop is always enough — this
+/// extension never needs to recurse.
+/// </para>
+/// <para>
+/// <b>Filter bypass.</b> The standard <see cref="IHasMergeTombstone"/> query filter hides
+/// tombstoned rows. <see cref="ResolveCurrentAsync"/> disables the filter for the duration
+/// of the lookup so the loser row remains readable. The disable is async-flow-scoped via
+/// <see cref="IDataFilter"/>, restored on dispose.
+/// </para>
+/// <para>
+/// <b>Frontline call sites.</b> Every Wolverine handler / background job that takes a
+/// <see cref="PartyId"/> in its payload should call
+/// <see cref="ResolveCurrentAsync(PartyId, IPartyReader, IDataFilter, CancellationToken)"/>
+/// in its first statement. Endpoints accepting a <c>partyId</c> route param can either
+/// resolve transparently or return <c>308 Permanent Redirect</c> to the survivor URL.
+/// </para>
+/// </remarks>
+public static class PartyIdTombstoneExtensions
+{
+    /// <summary>
+    /// Resolves <paramref name="partyId"/> to its current survivor via the tombstone, or
+    /// returns the original id when the party is alive (no tombstone) or no longer exists.
+    /// </summary>
+    /// <param name="partyId">The (possibly stale) party id carried in a serialised payload.</param>
+    /// <param name="reader">Party reader used to look the row up.</param>
+    /// <param name="dataFilter">Data filter — required so the lookup can transparently
+    /// bypass the <see cref="IHasMergeTombstone"/> query filter and observe the tombstone.</param>
+    /// <param name="cancellationToken">Cooperative cancellation.</param>
+    /// <returns>The survivor id when the party has been merged out, otherwise <paramref name="partyId"/>.</returns>
+    public static async ValueTask<PartyId> ResolveCurrentAsync(
+        this PartyId partyId,
+        IPartyReader reader,
+        IDataFilter dataFilter,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(partyId);
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(dataFilter);
+
+        // Disable the IHasMergeTombstone query filter so the lookup observes tombstoned rows.
+        // Restored on dispose; async-flow-scoped via IDataFilter, no other queries on this
+        // flow are affected outside the using block.
+        using IDisposable bypass = dataFilter.Disable<IHasMergeTombstone>();
+
+        Party? party = await reader.GetByIdAsync(partyId, cancellationToken).ConfigureAwait(false);
+        return party?.MergedIntoId is { } survivor
+            ? PartyId.Create(survivor)
+            : partyId;
+    }
+}

--- a/tests/Granit.Parties.Tests/Domain/PartyIdTombstoneExtensionsTests.cs
+++ b/tests/Granit.Parties.Tests/Domain/PartyIdTombstoneExtensionsTests.cs
@@ -1,0 +1,103 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Tests.Domain;
+
+public sealed class PartyIdTombstoneExtensionsTests
+{
+    private readonly IPartyReader _reader = Substitute.For<IPartyReader>();
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
+
+    public PartyIdTombstoneExtensionsTests()
+    {
+        _dataFilter.Disable<IHasMergeTombstone>().Returns(Substitute.For<IDisposable>());
+    }
+
+    [Fact]
+    public async Task ResolveCurrentAsync_AliveParty_ReturnsSameId()
+    {
+        Party alive = NewParty();
+        var id = PartyId.Create(alive.Id);
+        _reader.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(alive);
+
+        PartyId resolved = await id.ResolveCurrentAsync(_reader, _dataFilter, TestContext.Current.CancellationToken);
+
+        resolved.Value.ShouldBe(alive.Id);
+    }
+
+    [Fact]
+    public async Task ResolveCurrentAsync_TombstonedParty_ReturnsSurvivorId()
+    {
+        Party tombstoned = NewParty();
+        var survivorId = Guid.NewGuid();
+        SetTombstone(tombstoned, survivorId);
+
+        var id = PartyId.Create(tombstoned.Id);
+        _reader.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(tombstoned);
+
+        PartyId resolved = await id.ResolveCurrentAsync(_reader, _dataFilter, TestContext.Current.CancellationToken);
+
+        resolved.Value.ShouldBe(survivorId);
+    }
+
+    [Fact]
+    public async Task ResolveCurrentAsync_PartyNotFound_ReturnsSameId()
+    {
+        var id = PartyId.Create(Guid.NewGuid());
+        _reader.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((Party?)null);
+
+        PartyId resolved = await id.ResolveCurrentAsync(_reader, _dataFilter, TestContext.Current.CancellationToken);
+
+        resolved.Value.ShouldBe(id.Value);
+    }
+
+    [Fact]
+    public async Task ResolveCurrentAsync_DisablesAndRestoresTombstoneFilter()
+    {
+        Party alive = NewParty();
+        var id = PartyId.Create(alive.Id);
+        _reader.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(alive);
+
+        IDisposable disposable = Substitute.For<IDisposable>();
+        _dataFilter.Disable<IHasMergeTombstone>().Returns(disposable);
+
+        await id.ResolveCurrentAsync(_reader, _dataFilter, TestContext.Current.CancellationToken);
+
+        _dataFilter.Received(1).Disable<IHasMergeTombstone>();
+        disposable.Received(1).Dispose();
+    }
+
+    [Fact]
+    public async Task ResolveCurrentAsync_RejectsNullPartyId() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            ((PartyId)null!).ResolveCurrentAsync(_reader, _dataFilter, default).AsTask());
+
+    [Fact]
+    public async Task ResolveCurrentAsync_RejectsNullReader() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            PartyId.Create(Guid.NewGuid()).ResolveCurrentAsync(null!, _dataFilter, default).AsTask());
+
+    [Fact]
+    public async Task ResolveCurrentAsync_RejectsNullDataFilter() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            PartyId.Create(Guid.NewGuid()).ResolveCurrentAsync(_reader, null!, default).AsTask());
+
+    private static Party NewParty() =>
+        Party.Create(Guid.NewGuid(), tenantId: null, PartyKind.Company, "Acme Corp", "EUR");
+
+    // Reflection helper — MergedIntoId / MergedAt have private setters; the merge
+    // orchestrator (#1284) sets them inside the merge transaction. For tests we mutate
+    // them directly to construct a tombstoned aggregate.
+    private static void SetTombstone(Party party, Guid survivorId)
+    {
+        typeof(Party).GetProperty(nameof(Party.MergedIntoId))!
+            .SetValue(party, (Guid?)survivorId);
+        typeof(Party).GetProperty(nameof(Party.MergedAt))!
+            .SetValue(party, (DateTimeOffset?)DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
## Summary

Lets stale `PartyId` values that survive a merge in serialised payloads (Wolverine
messages, scheduled background jobs, queued webhooks, pending notifications) resolve
transparently to the current survivor — closing the last gap in the merge consistency
model.

Story [#1282](https://github.com/granit-fx/granit-dotnet/issues/1282) of the Party-merge
feature ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) / [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).
Builds on [#1305](https://github.com/granit-fx/granit-dotnet/pull/1305) (framework scaffold)
and [#1314](https://github.com/granit-fx/granit-dotnet/pull/1314) (EF tombstone convention).

## Why

Bulk-UPDATE rewriters (registered via `IReferenceRewriter<Party>`) handle **persisted columns**
like `Invoice.PartyId`, `Subscription.PartyId`, etc. They do NOT cover `PartyId` values
living inside **JSON payloads of in-flight messages**. Without follow-through, those messages
would dispatch to a tombstoned party and either fail or — worse — create dangling state.

## Public surface

```csharp
public static class PartyIdTombstoneExtensions
{
    public static ValueTask<PartyId> ResolveCurrentAsync(
        this PartyId partyId,
        IPartyReader reader,
        IDataFilter dataFilter,
        CancellationToken cancellationToken = default);
}
```

Every Wolverine handler / scheduled job taking a `PartyId` in its payload should call
`ResolveCurrentAsync` as its first statement. Endpoints accepting `partyId` route params
can either resolve transparently or return `308 Permanent Redirect`.

## Single-hop guarantee

The merge orchestrator (#1284) collapses chain merges (A → B → C) at merge time by running
`UPDATE parties SET MergedIntoId = newSurvivor WHERE MergedIntoId = oldSurvivor` in the same
transaction as the new merge. One hop is therefore always enough — this extension never
recurses.

## Filter bypass

Disables the `IHasMergeTombstone` query filter (introduced in #1314) for the duration of the
lookup so the loser row remains readable. Disable is async-flow-scoped via `IDataFilter` and
restored on dispose; no other queries on the flow are affected.

## Drive-by structural prep for #1285

Adds `Party : IHasMergeTombstone` + the `MergedIntoId` / `MergedAt` properties with private
setters. Without these the extension method would not compile. The actual `MergeFrom` /
`IMergeable<Party>` contract + conflict rules remain in [#1285](https://github.com/granit-fx/granit-dotnet/issues/1285)
as planned. EF column + index + named query filter come for free via the convention shipped
in #1314 — no `PartyConfiguration` change required.

## Test plan

- [x] `dotnet build` — clean.
- [x] `dotnet format Granit.slnx --verify-no-changes` — clean.
- [x] `Granit.Parties.Tests` — 131/131 (7 new: alive returns same id, tombstoned returns
      survivor, missing party falls back to original id, filter disable+restore, null-arg
      validation × 3).
- [x] `Granit.ArchitectureTests` — 150/150 (no regression).

The "every handler calls ResolveCurrentAsync" arch test from the story's acceptance criteria
is deferred — there are no Wolverine handlers consuming a `PartyId` in the codebase yet.
Will land when the first such handler ships so the test has real targets to guard against.

Closes [#1282](https://github.com/granit-fx/granit-dotnet/issues/1282).
