### PR TITLE
test(architecture): NotificationType with Email channel must ship neutral template (US #1329)

### DIFF
--- a/tests/Granit.ArchitectureTests/NotificationTemplateCoverageTests.cs
+++ b/tests/Granit.ArchitectureTests/NotificationTemplateCoverageTests.cs
@@ -1,0 +1,280 @@
+using System.Reflection;
+using Granit.Notifications;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Validates that every concrete <see cref="NotificationType{TData}"/> whose
+/// <c>DefaultChannels</c> include a text-rendered channel (currently <see cref="NotificationChannels.Email"/>)
+/// ships an embedded <c>Templates/{Name}.html</c> resource in the same assembly.
+/// <para>
+/// The check validates the deliverable directly (HTML present in the DLL) rather than
+/// a proxy such as the existence of a per-package <c>EmbeddedTemplatesTests</c> class.
+/// NetArchTest does not reliably see test assemblies, and forcing a per-package test
+/// class is fragile — scanning every <c>Granit.*.Notifications</c> runtime assembly
+/// catches a missing template the moment the build artefact is produced.
+/// </para>
+/// </summary>
+public sealed class NotificationTemplateCoverageTests
+{
+    /// <summary>
+    /// Channels rendered by the templating pipeline (`Granit.Notifications.Email` &amp; co).
+    /// In-app / SignalR / SSE channels are NOT in this set — they don't render HTML.
+    /// </summary>
+    private static readonly HashSet<string> TextRenderedChannels =
+        new(StringComparer.Ordinal)
+        {
+            NotificationChannels.Email,
+        };
+
+    /// <summary>
+    /// Discovers, across every loaded <c>Granit.*.Notifications</c> assembly, the
+    /// concrete <see cref="NotificationType{TData}"/> subclasses whose
+    /// <c>DefaultChannels</c> contain at least one text-rendered channel and emits one
+    /// row per (assembly, notification name, expected resource name).
+    /// </summary>
+    public static TheoryData<string, string, string> NotificationsRequiringTemplate()
+    {
+        var data = new TheoryData<string, string, string>();
+
+        foreach (Assembly assembly in EnumerateNotificationAssemblies())
+        {
+            string assemblyName = assembly.GetName().Name!;
+
+            foreach (Type type in SafeGetTypes(assembly))
+            {
+                if (!IsConcreteNotificationType(type))
+                {
+                    continue;
+                }
+
+                NotificationTypeProbe? probe = TryReadNotificationType(type);
+                if (probe is null)
+                {
+                    continue;
+                }
+
+                if (!probe.DefaultChannels.Any(TextRenderedChannels.Contains))
+                {
+                    continue;
+                }
+
+                string expectedResource = $"{assemblyName}.Templates.{probe.Name}.html";
+                data.Add(assemblyName, probe.Name, expectedResource);
+            }
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// For each in-scope <see cref="NotificationType{TData}"/>, asserts that the neutral
+    /// (English) HTML template is embedded in the same assembly. The test fails if the
+    /// template is missing, renamed, or excluded by an incorrect <c>EmbeddedResource</c>
+    /// glob in the <c>.csproj</c>.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NotificationsRequiringTemplate))]
+    public void Notification_with_text_rendered_channel_must_ship_neutral_template(
+        string assemblyName,
+        string notificationName,
+        string expectedResource)
+    {
+        var assembly = Assembly.Load(new AssemblyName(assemblyName));
+
+        string[] resources = assembly.GetManifestResourceNames();
+
+        resources.ShouldContain(
+            expectedResource,
+            customMessage:
+                $"NotificationType '{notificationName}' in {assemblyName} declares a text-rendered "
+                + $"channel (e.g. Email) but no '{expectedResource}' is embedded in the assembly. "
+                + "Add 'Templates/{Name}.html' to the package, ensure the .csproj has "
+                + "<EmbeddedResource Include=\"Templates\\**\\*.html\" WithCulture=\"false\" />, "
+                + "or remove the text-rendered channel from DefaultChannels.");
+    }
+
+    /// <summary>
+    /// Guard rail: at least one notification type must surface in the theory data so a
+    /// silent reflection regression (e.g. base type renamed) is detected. We assert a
+    /// realistic floor, not the exact count, so adding a new notification type doesn't
+    /// require touching this test.
+    /// </summary>
+    [Fact]
+    public void Theory_data_should_discover_at_least_one_notification_type()
+    {
+        TheoryData<string, string, string> data = NotificationsRequiringTemplate();
+        data.Count.ShouldBeGreaterThan(
+            0,
+            "Reflection failed to discover any NotificationType<> subclass with a text-rendered "
+            + "channel. Either no Granit.*.Notifications assembly was loaded, or NotificationType<> "
+            + "was renamed.");
+    }
+
+    /// <summary>
+    /// Enumerates every <c>Granit.*.Notifications</c> assembly available next to the test
+    /// project's output. We scan <see cref="Assembly.Location"/>'s directory rather than
+    /// <c>GetReferencedAssemblies()</c> because the C# compiler strips
+    /// <c>ProjectReference</c>s that aren't used in code — every <c>*.Notifications</c>
+    /// package would be invisible otherwise. The <c>.csproj</c> declares a
+    /// <c>ProjectReference</c> to every framework package (one of the responsibilities of
+    /// <c>Granit.ArchitectureTests</c>), so the compiled DLLs are guaranteed to land here.
+    /// </summary>
+    private static IEnumerable<Assembly> EnumerateNotificationAssemblies()
+    {
+        string? directory = Path.GetDirectoryName(
+            typeof(NotificationTemplateCoverageTests).Assembly.Location);
+        if (string.IsNullOrEmpty(directory))
+        {
+            yield break;
+        }
+
+        foreach (string dllPath in Directory.EnumerateFiles(
+                     directory,
+                     "Granit.*.Notifications.dll",
+                     SearchOption.TopDirectoryOnly))
+        {
+            string simpleName = Path.GetFileNameWithoutExtension(dllPath);
+
+            // Skip the umbrella `Granit.Notifications` package — it doesn't ship
+            // notification types, only the dispatch infrastructure. (Filename glob
+            // already excludes it, but be explicit for sub-packages like
+            // `Granit.Notifications.Email` that aren't notification catalogues.)
+            if (simpleName == "Granit.Notifications"
+                || !simpleName.EndsWith(".Notifications", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Assembly? loaded = TryLoad(simpleName);
+            if (loaded is not null)
+            {
+                yield return loaded;
+            }
+        }
+    }
+
+    private static Assembly? TryLoad(string simpleName)
+    {
+        try
+        {
+            return Assembly.Load(new AssemblyName(simpleName));
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(static t => t is not null)!;
+        }
+    }
+
+    private static bool IsConcreteNotificationType(Type type)
+    {
+        if (type is null || type.IsAbstract || type.IsGenericTypeDefinition || type.IsInterface)
+        {
+            return false;
+        }
+
+        Type? current = type.BaseType;
+        while (current is not null && current != typeof(object))
+        {
+            if (current.IsGenericType
+                && current.GetGenericTypeDefinition() == typeof(NotificationType<>))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads <c>Name</c> and <c>DefaultChannels</c> from a notification type. Prefers the
+    /// conventional <c>public static readonly Instance</c> singleton; falls back to
+    /// <see cref="Activator.CreateInstance(Type)"/> when the type exposes a public
+    /// parameterless constructor (also conventional). Returns <c>null</c> when neither
+    /// approach succeeds — those edge cases are exempted, not a hard failure.
+    /// </summary>
+    private static NotificationTypeProbe? TryReadNotificationType(Type type)
+    {
+        object? instance = ReadSingletonInstance(type) ?? ActivateDefault(type);
+        if (instance is null)
+        {
+            return null;
+        }
+
+        string? name = type.GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(instance) as string;
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        if (type.GetProperty("DefaultChannels", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(instance) is not IEnumerable<string> channels)
+        {
+            return null;
+        }
+
+        return new NotificationTypeProbe(name, [.. channels]);
+    }
+
+    private static object? ReadSingletonInstance(Type type)
+    {
+        FieldInfo? field = type.GetField(
+            "Instance",
+            BindingFlags.Public | BindingFlags.Static);
+        if (field is not null && type.IsAssignableFrom(field.FieldType))
+        {
+            return field.GetValue(null);
+        }
+
+        PropertyInfo? property = type.GetProperty(
+            "Instance",
+            BindingFlags.Public | BindingFlags.Static);
+        if (property is not null && type.IsAssignableFrom(property.PropertyType))
+        {
+            return property.GetValue(null);
+        }
+
+        return null;
+    }
+
+    private static object? ActivateDefault(Type type)
+    {
+        try
+        {
+            return type.GetConstructor(Type.EmptyTypes) is null
+                ? null
+                : Activator.CreateInstance(type);
+        }
+        catch (TargetInvocationException)
+        {
+            return null;
+        }
+        catch (MemberAccessException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record NotificationTypeProbe(string Name, IReadOnlyList<string> DefaultChannels);
+}


### PR DESCRIPTION
## Summary

- Adds `NotificationTemplateCoverageTests` to `tests/Granit.ArchitectureTests/`. For every `Granit.*.Notifications` assembly shipped by the framework, it enumerates concrete `NotificationType<>` subclasses, reads the singleton `Instance` (or activates a default), and — when `DefaultChannels` contains a text-rendered channel (currently `NotificationChannels.Email`) — asserts that an embedded `{assembly}.Templates.{Name}.html` resource exists in the same assembly.
- Discovery scans the test project's output directory (`Granit.*.Notifications.dll`) rather than `GetReferencedAssemblies()`, because the C# compiler strips unused project references — every `*.Notifications` package would be invisible otherwise.
- Adds a guard-rail `[Fact]` that fails if reflection discovers zero in-scope notification types, so a silent regression (e.g. `NotificationType<>` renamed) never goes unnoticed.
- Validates the **deliverable** (HTML in the DLL) rather than a proxy such as a per-package `EmbeddedTemplatesTests` class — per Gemini review of the plan: NetArchTest does not reliably see test assemblies, and forcing per-package tests is fragile.

Closes #1329 (Epic #1306, Feature D1).

## Stacked PR — based on `feature/timeline-workflow-email-templates`

This PR is **stacked on PR #1334**. Reason: the architecture test is strict by design and would fail on `develop` for `timeline.user_mentioned` and `workflow.approval_requested` (those packages don't ship a `Templates/` folder until #1334 lands). Branching off the parent ensures the new test passes immediately and demonstrates that #1334 is a complete fix.

**When #1334 merges**, retarget this PR to `develop` (per `feedback_stacked_pr_retarget.md` — child commits get orphaned otherwise).

## Test count

| Before | After | Delta |
| ------ | ----- | ----- |
| 150    | 185   | +35 (34 theory rows, one per Email-channel `NotificationType`, + 1 guard-rail `[Fact]`) |

Discovered notification types (sample of 34): Privacy (8), Identity.Local (9), Subscriptions (6), Payments (5), Invoicing (4), Timeline (1), Workflow (1). All currently pass.

## Negative-case validation

Reproduced locally by temporarily moving `src/Granit.Workflow.Notifications/Templates/workflow.approval_requested.html` aside and re-running the suite:

```text
[FAIL] Granit.ArchitectureTests.NotificationTemplateCoverageTests.Notification_with_text_rendered_channel_must_ship_neutral_template(assemblyName: "Granit.Workflow.Notifications", notificationName: "workflow.approval_requested", expectedResource: "Granit.Workflow.Notifications.Templates.workflow.a"...)

Shouldly.ShouldAssertException : resources
  should contain
"Granit.Workflow.Notifications.Templates.workflow.approval_requested.html"
  but was actually
["Granit.Workflow.Notifications.Templates.workflow.approval_requested.fr.html"]

Additional Info:
  NotificationType 'workflow.approval_requested' in Granit.Workflow.Notifications declares a text-rendered
  channel (e.g. Email) but no 'Granit.Workflow.Notifications.Templates.workflow.approval_requested.html'
  is embedded in the assembly. Add 'Templates/{Name}.html' to the package, ensure the .csproj has
  <EmbeddedResource Include="Templates\**\*.html" WithCulture="false" />, or remove the text-rendered
  channel from DefaultChannels.

Failed!  - Failed: 1, Passed: 34, Skipped: 0, Total: 35
```

Template restored after the screenshot was captured — diff is empty.

## Test plan

- [x] `dotnet build tests/Granit.ArchitectureTests` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.ArchitectureTests` — 185/185 pass (was 150)
- [x] `dotnet format tests/Granit.ArchitectureTests --verify-no-changes` — clean
- [x] Negative-case demo (template removed → precise diagnostic, template restored)
- [ ] Retarget to `develop` once #1334 merges
- [ ] CI green on the `architecture` shard
