### PR TITLE
feat(payments-notifications): fill accidental regional template gaps

### DIFF
--- a/src/Granit.Payments.Notifications/Templates/Payments.DisputeOpened.en-GB.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.DisputeOpened.en-GB.html
@@ -1,0 +1,9 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Hi,</p>
+<p>A payment dispute (chargeback) has been opened on your account:</p>
+<ul>
+  <li><strong>Amount:</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Reason:</strong> {{ model.reason | html.escape }}</li>
+</ul>
+<p>Our team has been notified and will review the dispute. You may be contacted for further information.</p>
+<p>If you believe this dispute is valid, no action is required on your part.</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.DisputeOpened.fr-CA.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.DisputeOpened.fr-CA.html
@@ -1,0 +1,9 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Bonjour,</p>
+<p>Une contestation de paiement (rétrofacturation) a été ouverte sur votre compte :</p>
+<ul>
+  <li><strong>Montant :</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Motif :</strong> {{ model.reason | html.escape }}</li>
+</ul>
+<p>Notre équipe a été avisée et examinera la contestation. Nous pourrions communiquer avec vous pour obtenir des renseignements supplémentaires.</p>
+<p>Si vous estimez que cette contestation est valide, aucune action n'est requise de votre part.</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.en-GB.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.en-GB.html
@@ -1,0 +1,14 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Hi,</p>
+<p>We were unable to process your payment:</p>
+<ul>
+  <li><strong>Amount:</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Provider:</strong> {{ model.provider_name | html.escape }}</li>
+  {{- if model.failure_code }}
+  <li><strong>Reason:</strong> {{ model.failure_code | html.escape }}</li>
+  {{- end }}
+</ul>
+<p>Please update your payment method to avoid any interruption to your service. We will automatically retry the payment.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Update payment method</a>
+</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.fr-CA.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.fr-CA.html
@@ -1,0 +1,14 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Bonjour,</p>
+<p>Nous n'avons pas pu traiter votre paiement :</p>
+<ul>
+  <li><strong>Montant :</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Fournisseur :</strong> {{ model.provider_name | html.escape }}</li>
+  {{- if model.failure_code }}
+  <li><strong>Motif :</strong> {{ model.failure_code | html.escape }}</li>
+  {{- end }}
+</ul>
+<p>Veuillez mettre à jour votre mode de paiement afin d'éviter toute interruption de service. Nous tenterons automatiquement le paiement à nouveau.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mettre à jour le mode de paiement</a>
+</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.en-GB.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.en-GB.html
@@ -1,0 +1,7 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Hi,</p>
+<p>Your payment method <strong>{{ model.display_label | html.escape }}</strong> will expire in <strong>{{ model.days_remaining }} day(s)</strong>, on {{ model.expires_at | to_user_time | date.to_string "%B %Y" }}.</p>
+<p>Please update your payment method to ensure uninterrupted service.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Update payment method</a>
+</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.fr-CA.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.fr-CA.html
@@ -1,0 +1,7 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Bonjour,</p>
+<p>Votre mode de paiement <strong>{{ model.display_label | html.escape }}</strong> expirera dans <strong>{{ model.days_remaining }} jour(s)</strong>, le {{ model.expires_at | to_user_time | date.to_string "%B %Y" }}.</p>
+<p>Veuillez mettre à jour votre mode de paiement afin d'assurer un service ininterrompu.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mettre à jour le mode de paiement</a>
+</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentSucceeded.en-GB.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentSucceeded.en-GB.html
@@ -1,0 +1,9 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Hi,</p>
+<p>Your payment has been processed successfully:</p>
+<ul>
+  <li><strong>Amount:</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Provider:</strong> {{ model.provider_name | html.escape }}</li>
+  <li><strong>Date:</strong> {{ model.succeeded_at | to_user_time | date.to_string "%d %B %Y at %H:%M" }}</li>
+</ul>
+<p>A receipt will be available in your account shortly.</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentSucceeded.fr-CA.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentSucceeded.fr-CA.html
@@ -1,0 +1,9 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Bonjour,</p>
+<p>Votre paiement a été traité avec succès :</p>
+<ul>
+  <li><strong>Montant :</strong> {{ model.amount }} {{ model.currency }}</li>
+  <li><strong>Fournisseur :</strong> {{ model.provider_name | html.escape }}</li>
+  <li><strong>Date :</strong> {{ model.succeeded_at | to_user_time | date.to_string "%Y-%m-%d à %H:%M" }}</li>
+</ul>
+<p>Un reçu sera disponible dans votre compte sous peu.</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.RefundProcessed.en-GB.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.RefundProcessed.en-GB.html
@@ -1,0 +1,10 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Hi,</p>
+<p>A refund has been processed for your account:</p>
+<ul>
+  <li><strong>Amount:</strong> {{ model.amount }} {{ model.currency }}</li>
+  {{- if model.reason }}
+  <li><strong>Reason:</strong> {{ model.reason | html.escape }}</li>
+  {{- end }}
+</ul>
+<p>The refund should appear in your account within 5–10 working days, depending on your payment provider.</p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.RefundProcessed.fr-CA.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.RefundProcessed.fr-CA.html
@@ -1,0 +1,10 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<p>Bonjour,</p>
+<p>Un remboursement a été traité pour votre compte :</p>
+<ul>
+  <li><strong>Montant :</strong> {{ model.amount }} {{ model.currency }}</li>
+  {{- if model.reason }}
+  <li><strong>Motif :</strong> {{ model.reason | html.escape }}</li>
+  {{- end }}
+</ul>
+<p>Le remboursement devrait apparaître dans votre compte dans un délai de 5 à 10 jours ouvrables, selon votre fournisseur de paiement.</p>

--- a/tests/Granit.Payments.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
+++ b/tests/Granit.Payments.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Payments.Notifications.Tests.Templates;
+
+/// <summary>
+/// Pin the set of embedded templates shipped by the package. A renamed file or a missing
+/// `.csproj` glob would break notification rendering at runtime — better to fail here.
+/// </summary>
+public sealed class EmbeddedTemplatesTests
+{
+    public static TheoryData<string> ExpectedTemplates() =>
+    [
+        // Neutral (= EN) variant, one per notification type.
+        "Templates.Payments.DisputeOpened.html",
+        "Templates.Payments.PaymentFailed.html",
+        "Templates.Payments.PaymentMethodExpiring.html",
+        "Templates.Payments.PaymentSucceeded.html",
+        "Templates.Payments.RefundProcessed.html",
+        // Czech (cs) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.cs.html",
+        "Templates.Payments.PaymentFailed.cs.html",
+        "Templates.Payments.PaymentMethodExpiring.cs.html",
+        "Templates.Payments.PaymentSucceeded.cs.html",
+        "Templates.Payments.RefundProcessed.cs.html",
+        // German (de) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.de.html",
+        "Templates.Payments.PaymentFailed.de.html",
+        "Templates.Payments.PaymentMethodExpiring.de.html",
+        "Templates.Payments.PaymentSucceeded.de.html",
+        "Templates.Payments.RefundProcessed.de.html",
+        // English (en-GB) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.en-GB.html",
+        "Templates.Payments.PaymentFailed.en-GB.html",
+        "Templates.Payments.PaymentMethodExpiring.en-GB.html",
+        "Templates.Payments.PaymentSucceeded.en-GB.html",
+        "Templates.Payments.RefundProcessed.en-GB.html",
+        // Spanish (es) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.es.html",
+        "Templates.Payments.PaymentFailed.es.html",
+        "Templates.Payments.PaymentMethodExpiring.es.html",
+        "Templates.Payments.PaymentSucceeded.es.html",
+        "Templates.Payments.RefundProcessed.es.html",
+        // French (fr) — second baseline culture shipped out of the box.
+        "Templates.Payments.DisputeOpened.fr.html",
+        "Templates.Payments.PaymentFailed.fr.html",
+        "Templates.Payments.PaymentMethodExpiring.fr.html",
+        "Templates.Payments.PaymentSucceeded.fr.html",
+        "Templates.Payments.RefundProcessed.fr.html",
+        // French Canadian (fr-CA) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.fr-CA.html",
+        "Templates.Payments.PaymentFailed.fr-CA.html",
+        "Templates.Payments.PaymentMethodExpiring.fr-CA.html",
+        "Templates.Payments.PaymentSucceeded.fr-CA.html",
+        "Templates.Payments.RefundProcessed.fr-CA.html",
+        // Hindi (hi) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.hi.html",
+        "Templates.Payments.PaymentFailed.hi.html",
+        "Templates.Payments.PaymentMethodExpiring.hi.html",
+        "Templates.Payments.PaymentSucceeded.hi.html",
+        "Templates.Payments.RefundProcessed.hi.html",
+        // Italian (it) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.it.html",
+        "Templates.Payments.PaymentFailed.it.html",
+        "Templates.Payments.PaymentMethodExpiring.it.html",
+        "Templates.Payments.PaymentSucceeded.it.html",
+        "Templates.Payments.RefundProcessed.it.html",
+        // Japanese (ja) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.ja.html",
+        "Templates.Payments.PaymentFailed.ja.html",
+        "Templates.Payments.PaymentMethodExpiring.ja.html",
+        "Templates.Payments.PaymentSucceeded.ja.html",
+        "Templates.Payments.RefundProcessed.ja.html",
+        // Korean (ko) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.ko.html",
+        "Templates.Payments.PaymentFailed.ko.html",
+        "Templates.Payments.PaymentMethodExpiring.ko.html",
+        "Templates.Payments.PaymentSucceeded.ko.html",
+        "Templates.Payments.RefundProcessed.ko.html",
+        // Dutch (nl) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.nl.html",
+        "Templates.Payments.PaymentFailed.nl.html",
+        "Templates.Payments.PaymentMethodExpiring.nl.html",
+        "Templates.Payments.PaymentSucceeded.nl.html",
+        "Templates.Payments.RefundProcessed.nl.html",
+        // Polish (pl) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.pl.html",
+        "Templates.Payments.PaymentFailed.pl.html",
+        "Templates.Payments.PaymentMethodExpiring.pl.html",
+        "Templates.Payments.PaymentSucceeded.pl.html",
+        "Templates.Payments.RefundProcessed.pl.html",
+        // Portuguese (pt) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.pt.html",
+        "Templates.Payments.PaymentFailed.pt.html",
+        "Templates.Payments.PaymentMethodExpiring.pt.html",
+        "Templates.Payments.PaymentSucceeded.pt.html",
+        "Templates.Payments.RefundProcessed.pt.html",
+        // Portuguese Brazilian (pt-BR) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.pt-BR.html",
+        "Templates.Payments.PaymentFailed.pt-BR.html",
+        "Templates.Payments.PaymentMethodExpiring.pt-BR.html",
+        "Templates.Payments.PaymentSucceeded.pt-BR.html",
+        "Templates.Payments.RefundProcessed.pt-BR.html",
+        // Swedish (sv) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.sv.html",
+        "Templates.Payments.PaymentFailed.sv.html",
+        "Templates.Payments.PaymentMethodExpiring.sv.html",
+        "Templates.Payments.PaymentSucceeded.sv.html",
+        "Templates.Payments.RefundProcessed.sv.html",
+        // Turkish (tr) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.tr.html",
+        "Templates.Payments.PaymentFailed.tr.html",
+        "Templates.Payments.PaymentMethodExpiring.tr.html",
+        "Templates.Payments.PaymentSucceeded.tr.html",
+        "Templates.Payments.RefundProcessed.tr.html",
+        // Chinese Simplified (zh) — auto-translated, review before production.
+        "Templates.Payments.DisputeOpened.zh.html",
+        "Templates.Payments.PaymentFailed.zh.html",
+        "Templates.Payments.PaymentMethodExpiring.zh.html",
+        "Templates.Payments.PaymentSucceeded.zh.html",
+        "Templates.Payments.RefundProcessed.zh.html",
+    ];
+
+    [Theory]
+    [MemberData(nameof(ExpectedTemplates))]
+    public void EachExpectedTemplate_IsEmbeddedInTheAssembly(string suffix)
+    {
+        Assembly assembly = typeof(GranitPaymentsNotificationsModule).Assembly;
+        string assemblyName = assembly.GetName().Name!;
+        string fullResourceName = $"{assemblyName}.{suffix}";
+
+        string[] resources = assembly.GetManifestResourceNames();
+
+        resources.ShouldContain(
+            fullResourceName,
+            customMessage: $"Embedded resource '{fullResourceName}' is missing. Check the <EmbeddedResource> glob in the .csproj and the file presence under Templates/.");
+    }
+
+    [Theory]
+    [MemberData(nameof(ExpectedTemplates))]
+    public void EachExpectedTemplate_IsNotEmpty(string suffix)
+    {
+        Assembly assembly = typeof(GranitPaymentsNotificationsModule).Assembly;
+        string fullResourceName = $"{assembly.GetName().Name}.{suffix}";
+
+        using Stream? stream = assembly.GetManifestResourceStream(fullResourceName);
+        stream.ShouldNotBeNull($"Resource '{fullResourceName}' should be loadable.");
+        stream.Length.ShouldBeGreaterThan(0, $"Resource '{fullResourceName}' should not be empty.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1317 (US A5 of Epic #1306).

Audited the `Granit.Payments.Notifications` template manifest and filled 10
accidental regional gaps (fr-CA + en-GB across 5 notification types). Adds an
`EmbeddedTemplatesTests` manifest-pinning theory test so the next regression
fails at build time.

## Audit (per missing pair)

5 notification types × 2 missing regional cultures = 10 missing files.
Conservative classification — payment / PCI emails diverge across regions
(currency conventions, polite forms, date formats), so all 10 treated as
**accidental** gaps.

| Notification type | fr-CA | en-GB | Classification |
| ----------------- | ----- | ----- | -------------- |
| DisputeOpened | missing | missing | Accidental — filled |
| PaymentFailed | missing | missing | Accidental — filled |
| PaymentMethodExpiring | missing | missing | Accidental — filled |
| PaymentSucceeded | missing | missing | Accidental — filled |
| RefundProcessed | missing | missing | Accidental — filled |

**Intentional: 0  |  Accidental: 10**

## Files added (count by culture)

| Culture | Files added |
| ------- | ----------- |
| `en-GB` | 5 |
| `fr-CA` | 5 |
| **Total** | **10** |

Each carries the `<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->`
marker on line 1.

## Validation

| Check | Result |
| ----- | ------ |
| `{{` count source vs output (per file) | identical (4/7/3/4/5 — matched) |
| `}}` count source vs output (per file) | identical (matched) |
| HTML tag counts (`<p>`, `<li>`, `<a>`) | identical (matched) |
| Random `{{ identifier }}` block sampling | verbatim — no placeholder mutation |
| Format check (`dotnet format --verify-no-changes`) | clean (src + tests) |

## Self-assessment of weakest translations

- **fr-CA `DisputeOpened`** — translated "chargeback" as "rétrofacturation". This is
  the technically correct Quebec banking term but in practice fr-CA banking
  communications often retain "chargeback" as an English loan word. **Review
  recommended** with a Quebec finance speaker.
- **fr-CA `PaymentFailed`** — used "Fournisseur" for provider; fr-FR uses
  "Prestataire". This matches Quebec usage (fournisseur de services de paiement)
  but creates intra-locale divergence. Acceptable.
- **fr-CA date format** — used `%Y-%m-%d à %H:%M` (ISO-style) per Quebec/CSA T1.301
  recommendation; differs from fr-FR `%d/%m/%Y à %H:%M`. **Verify with product**:
  if mixed European/Quebec audience expects fr-FR formatting, override at runtime.
- **en-GB** — light surface changes only (date format `%d %B %Y`, "working days"
  vs "business days", "any interruption" vs "service interruption", "further"
  vs "additional"). Low risk.

## Tests

| Metric | Before | After |
| ------ | ------ | ----- |
| `Granit.Payments.Notifications.Tests` | 18 | 198 |
| Architecture tests | 150 | 150 |

`EmbeddedTemplatesTests` ships 90 expected template entries × 2 theory tests
(`IsEmbeddedInTheAssembly` + `IsNotEmpty`) = 180 new tests.

## Test plan

- [ ] Native fr-CA reviewer to validate Quebec banking register (esp. "rétrofacturation")
- [ ] Confirm date format expectations with product (fr-CA ISO vs fr-FR slash)
- [ ] CI green on all 6 shards (esp. `infrastructure` and `architecture`)
- [ ] No regression in `Granit.Payments.*` integration tests
