### PR TITLE
feat(parties): bulk SQL rewriters for parent + child collections (#1287)

### DIFF
--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -88,6 +88,7 @@
       "tests/Granit.Parties.Abstractions.Tests/Granit.Parties.Abstractions.Tests.csproj",
       "tests/Granit.Parties.Endpoints.Tests/Granit.Parties.Endpoints.Tests.csproj",
       "tests/Granit.Parties.EntityFrameworkCore.Tests/Granit.Parties.EntityFrameworkCore.Tests.csproj",
+      "tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj",
       "tests/Granit.Parties.Mergeable.Tests/Granit.Parties.Mergeable.Tests.csproj",
       "tests/Granit.Parties.MultiTenancy.Tests/Granit.Parties.MultiTenancy.Tests.csproj",
       "tests/Granit.Parties.Privacy.Tests/Granit.Parties.Privacy.Tests.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -57,6 +57,7 @@
         "tests/Granit.Parties.Endpoints.Tests",
         "tests/Granit.Parties.EntityFrameworkCore.Tests",
         "tests/Granit.Parties.Mergeable.Tests",
+        "tests/Granit.Parties.Mergeable.Tests.Integration",
         "tests/Granit.Parties.MultiTenancy.Tests",
         "tests/Granit.Parties.Privacy.Tests",
         "tests/Granit.Parties.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32813,7 +32813,7 @@
       "kind": "class",
       "project": "Granit.Parties.Mergeable",
       "file": "src/Granit.Parties.Mergeable/Extensions/PartiesMergeableHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitPartiesMergeable",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -301,6 +301,7 @@
       "tests/Granit.Parties.Abstractions.Tests/Granit.Parties.Abstractions.Tests.csproj",
       "tests/Granit.Parties.Endpoints.Tests/Granit.Parties.Endpoints.Tests.csproj",
       "tests/Granit.Parties.EntityFrameworkCore.Tests/Granit.Parties.EntityFrameworkCore.Tests.csproj",
+      "tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj",
       "tests/Granit.Parties.Mergeable.Tests/Granit.Parties.Mergeable.Tests.csproj",
       "tests/Granit.Parties.MultiTenancy.Tests/Granit.Parties.MultiTenancy.Tests.csproj",
       "tests/Granit.Parties.Privacy.Tests/Granit.Parties.Privacy.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -207,6 +207,7 @@
       "tests/Granit.Parties.Abstractions.Tests/Granit.Parties.Abstractions.Tests.csproj",
       "tests/Granit.Parties.Endpoints.Tests/Granit.Parties.Endpoints.Tests.csproj",
       "tests/Granit.Parties.EntityFrameworkCore.Tests/Granit.Parties.EntityFrameworkCore.Tests.csproj",
+      "tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj",
       "tests/Granit.Parties.Mergeable.Tests/Granit.Parties.Mergeable.Tests.csproj",
       "tests/Granit.Parties.MultiTenancy.Tests/Granit.Parties.MultiTenancy.Tests.csproj",
       "tests/Granit.Parties.Privacy.Tests/Granit.Parties.Privacy.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -630,6 +630,7 @@
     <Project Path="tests/Granit.Parties.Endpoints.Tests/Granit.Parties.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Parties.EntityFrameworkCore.Tests/Granit.Parties.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/Granit.Parties.Mergeable.Tests/Granit.Parties.Mergeable.Tests.csproj" />
+    <Project Path="tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Parties.MultiTenancy.Tests/Granit.Parties.MultiTenancy.Tests.csproj" />
     <Project Path="tests/Granit.Parties.Privacy.Tests/Granit.Parties.Privacy.Tests.csproj" />
     <Project Path="tests/Granit.Parties.Tests/Granit.Parties.Tests.csproj" />

--- a/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
+++ b/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
@@ -10,6 +10,7 @@
     <InternalsVisibleTo Include="Granit.Parties.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.Parties.Mergeable" />
     <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests" />
+    <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Parties.Mergeable/Extensions/PartiesMergeableHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.Mergeable/Extensions/PartiesMergeableHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Mergeable;
+using Granit.Mergeable.Extensions;
 using Granit.Parties.Domain;
 using Granit.Parties.Mergeable.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,10 +17,15 @@ namespace Granit.Parties.Mergeable.Extensions;
 public static class PartiesMergeableHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Registers the per-aggregate adapter for parties. Cross-module reference rewriters
-    /// (Invoice.PartyId, Subscription.PartyId, etc.) are NOT registered here — each module
-    /// that holds a <c>PartyId</c> ships its own <c>*.Mergeable</c> package and registers
-    /// its rewriter via <c>services.AddReferenceRewriter&lt;Party, ...&gt;()</c>.
+    /// Registers the per-aggregate adapter for parties plus the two Parties-internal
+    /// reference rewriters: <see cref="PartyParentReferenceRewriter"/> (re-parents Party
+    /// children of the loser) and <see cref="PartyChildrenReferenceRewriter"/> (rewrites
+    /// the four child collections — addresses, emails, phones, external mappings — via
+    /// SQL bulk-update, with structural dedup, primary/default demotion and cap
+    /// enforcement). Cross-module rewriters (Invoice.PartyId, Subscription.PartyId, etc.)
+    /// are NOT registered here — each module that holds a <c>PartyId</c> ships its own
+    /// <c>*.Mergeable</c> package and registers its rewriter via
+    /// <c>services.AddReferenceRewriter&lt;Party, ...&gt;()</c>.
     /// </summary>
     public static IHostApplicationBuilder AddGranitPartiesMergeable(
         this IHostApplicationBuilder builder)
@@ -27,6 +33,8 @@ public static class PartiesMergeableHostApplicationBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Services.TryAddScoped<IMergeableAggregateAdapter<Party>, PartyMergeableAggregateAdapter>();
+        builder.Services.AddReferenceRewriter<Party, PartyParentReferenceRewriter>();
+        builder.Services.AddReferenceRewriter<Party, PartyChildrenReferenceRewriter>();
 
         return builder;
     }

--- a/src/Granit.Parties.Mergeable/Granit.Parties.Mergeable.csproj
+++ b/src/Granit.Parties.Mergeable/Granit.Parties.Mergeable.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests" />
+    <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests.Integration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Parties.Mergeable/Internal/PartyChildrenReferenceRewriter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyChildrenReferenceRewriter.cs
@@ -1,0 +1,257 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Mergeable;
+using Granit.Mergeable.Exceptions;
+using Granit.Parties.Domain;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Mergeable.Internal;
+
+/// <summary>
+/// SQL bulk-update rewriter for the four <see cref="Party"/> child collections —
+/// <c>PartyAddresses</c>, <c>PartyEmails</c>, <c>PartyPhones</c>, <c>PartyExternalMappings</c>.
+/// For each table:
+/// <list type="number">
+/// <item>Demote primaries / defaults that would clash with the survivor's, before any move.</item>
+/// <item>Delete the loser-side rows that are <em>structural duplicates</em> of an existing
+/// survivor row.</item>
+/// <item>Re-point the remaining loser-side rows to the survivor by rewriting the shadow FK
+/// <c>PartyId</c>.</item>
+/// <item>Verify the per-aggregate caps (<see cref="Party.MaxAddresses"/>,
+/// <see cref="Party.MaxEmails"/>, <see cref="Party.MaxPhones"/>, plus the per-provider
+/// uniqueness constraint on external mappings).</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why a SQL rewriter and not <c>survivor.Children.AddRange(loser.Children)</c>: the four
+/// child entities are mapped via <c>HasMany.WithOne().HasForeignKey("PartyId")</c> with a
+/// shadow FK and their own primary key. EF Core would either insert duplicate-PK rows or
+/// leave the shadow FK pointing at the loser if we tried the in-memory move — neither
+/// yields a consistent state. Going through bulk SQL is also significantly faster on
+/// parties with hundreds of addresses (rare but not unheard of for global retailers).
+/// </para>
+/// <para>
+/// The merge orchestrator (<see cref="IMergeService{TAggregate}"/>) runs every registered
+/// <see cref="IReferenceRewriter{TAggregate}"/> inside the same <see cref="System.Transactions.TransactionScope"/>,
+/// so any exception thrown here rolls back the entire merge atomically.
+/// </para>
+/// </remarks>
+internal sealed class PartyChildrenReferenceRewriter(
+    IDbContextFactory<PartiesDbContext> contextFactory,
+    IDataFilter dataFilter) : IReferenceRewriter<Party>
+{
+    private const string PartyIdShadowFk = "PartyId";
+
+    /// <inheritdoc />
+    public string Description => "Party.Children";
+
+    /// <inheritdoc />
+    public async Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        using IDisposable _ = dataFilter.Disable<IHasMergeTombstone>();
+
+        int total = 0;
+        total += await RewriteEmailsAsync(db, survivorId, loserId, cancellationToken).ConfigureAwait(false);
+        total += await RewritePhonesAsync(db, survivorId, loserId, cancellationToken).ConfigureAwait(false);
+        total += await RewriteAddressesAsync(db, survivorId, loserId, cancellationToken).ConfigureAwait(false);
+        total += await RewriteExternalMappingsAsync(db, survivorId, loserId, cancellationToken).ConfigureAwait(false);
+
+        await EnsureCapsAsync(db, survivorId, cancellationToken).ConfigureAwait(false);
+
+        return total;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        // Dry-run preview: count the loser-side rows that would be touched (deleted or moved)
+        // across the four child collections. Cap violations are not checked here — only the
+        // live RewriteAsync path enforces them.
+        await using PartiesDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        using IDisposable _ = dataFilter.Disable<IHasMergeTombstone>();
+
+        int total = 0;
+        total += await db.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, PartyIdShadowFk) == loserId)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+        total += await db.Set<PartyPhone>()
+            .Where(p => EF.Property<Guid>(p, PartyIdShadowFk) == loserId)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+        total += await db.Set<PartyAddress>()
+            .Where(a => EF.Property<Guid>(a, PartyIdShadowFk) == loserId)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+        total += await db.Set<PartyExternalMapping>()
+            .Where(m => EF.Property<Guid>(m, PartyIdShadowFk) == loserId)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+        return total;
+    }
+
+    private static async Task<int> RewriteEmailsAsync(
+        PartiesDbContext db, Guid survivorId, Guid loserId, CancellationToken ct)
+    {
+        // Demote loser primaries when the survivor already has one (only one IsPrimary per party).
+        bool survivorHasPrimary = await db.Set<PartyEmail>()
+            .AnyAsync(e => EF.Property<Guid>(e, PartyIdShadowFk) == survivorId && e.IsPrimary, ct)
+            .ConfigureAwait(false);
+        if (survivorHasPrimary)
+        {
+            await db.Set<PartyEmail>()
+                .Where(e => EF.Property<Guid>(e, PartyIdShadowFk) == loserId && e.IsPrimary)
+                .ExecuteUpdateAsync(s => s.SetProperty(e => e.IsPrimary, false), ct)
+                .ConfigureAwait(false);
+        }
+
+        // Structural duplicates = same Address (case-sensitive in SQL; canonicalisation lives upstream).
+        await db.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, PartyIdShadowFk) == loserId
+                        && db.Set<PartyEmail>().Any(s =>
+                            EF.Property<Guid>(s, PartyIdShadowFk) == survivorId
+                            && s.Address == e.Address))
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+
+        return await db.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, PartyIdShadowFk) == loserId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => EF.Property<Guid>(e, PartyIdShadowFk), survivorId), ct)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<int> RewritePhonesAsync(
+        PartiesDbContext db, Guid survivorId, Guid loserId, CancellationToken ct)
+    {
+        bool survivorHasPrimary = await db.Set<PartyPhone>()
+            .AnyAsync(p => EF.Property<Guid>(p, PartyIdShadowFk) == survivorId && p.IsPrimary, ct)
+            .ConfigureAwait(false);
+        if (survivorHasPrimary)
+        {
+            await db.Set<PartyPhone>()
+                .Where(p => EF.Property<Guid>(p, PartyIdShadowFk) == loserId && p.IsPrimary)
+                .ExecuteUpdateAsync(s => s.SetProperty(p => p.IsPrimary, false), ct)
+                .ConfigureAwait(false);
+        }
+
+        // Structural duplicates = same Number (canonical E.164 expected — see PhoneE164 column in dedup epic).
+        await db.Set<PartyPhone>()
+            .Where(p => EF.Property<Guid>(p, PartyIdShadowFk) == loserId
+                        && db.Set<PartyPhone>().Any(s =>
+                            EF.Property<Guid>(s, PartyIdShadowFk) == survivorId
+                            && s.Number == p.Number))
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+
+        return await db.Set<PartyPhone>()
+            .Where(p => EF.Property<Guid>(p, PartyIdShadowFk) == loserId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(p => EF.Property<Guid>(p, PartyIdShadowFk), survivorId), ct)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<int> RewriteAddressesAsync(
+        PartiesDbContext db, Guid survivorId, Guid loserId, CancellationToken ct)
+    {
+        // Demote loser defaults per AddressKind that the survivor already has a default for.
+        // Materialise once: the kind set is small (Billing, Shipping, …) so a join is overkill.
+        List<AddressKind> survivorDefaultKinds = await db.Set<PartyAddress>()
+            .Where(a => EF.Property<Guid>(a, PartyIdShadowFk) == survivorId && a.IsDefault)
+            .Select(a => a.Kind)
+            .Distinct()
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        if (survivorDefaultKinds.Count > 0)
+        {
+            await db.Set<PartyAddress>()
+                .Where(a => EF.Property<Guid>(a, PartyIdShadowFk) == loserId
+                            && a.IsDefault
+                            && survivorDefaultKinds.Contains(a.Kind))
+                .ExecuteUpdateAsync(s => s.SetProperty(a => a.IsDefault, false), ct)
+                .ConfigureAwait(false);
+        }
+
+        // Structural duplicates = same Address VO equality components (CompanyName, Line1,
+        // Line2, City, PostalCode, State, Country). Stored as owned columns on the same row.
+        await db.Set<PartyAddress>()
+            .Where(a => EF.Property<Guid>(a, PartyIdShadowFk) == loserId
+                        && db.Set<PartyAddress>().Any(s =>
+                            EF.Property<Guid>(s, PartyIdShadowFk) == survivorId
+                            && s.Value.CompanyName == a.Value.CompanyName
+                            && s.Value.Line1 == a.Value.Line1
+                            && s.Value.Line2 == a.Value.Line2
+                            && s.Value.City == a.Value.City
+                            && s.Value.PostalCode == a.Value.PostalCode
+                            && s.Value.State == a.Value.State
+                            && s.Value.Country == a.Value.Country))
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+
+        return await db.Set<PartyAddress>()
+            .Where(a => EF.Property<Guid>(a, PartyIdShadowFk) == loserId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(a => EF.Property<Guid>(a, PartyIdShadowFk), survivorId), ct)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<int> RewriteExternalMappingsAsync(
+        PartiesDbContext db, Guid survivorId, Guid loserId, CancellationToken ct)
+    {
+        // Conflict: same ProviderName on both sides but different ExternalId — the unique
+        // index on (PartyId, ProviderName) would also fail post-move, but a domain-specific
+        // exception is more actionable than a database constraint violation. Override
+        // semantics live in the endpoint layer (story #1290) — at this layer we fail fast.
+        List<string> conflictingProviders = await db.Set<PartyExternalMapping>()
+            .Where(m => EF.Property<Guid>(m, PartyIdShadowFk) == loserId
+                        && db.Set<PartyExternalMapping>().Any(s =>
+                            EF.Property<Guid>(s, PartyIdShadowFk) == survivorId
+                            && s.ProviderName == m.ProviderName
+                            && s.ExternalId != m.ExternalId))
+            .Select(m => m.ProviderName)
+            .Distinct()
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        if (conflictingProviders.Count > 0)
+        {
+            throw new MergeException(
+                $"External provider mapping conflict on: {string.Join(", ", conflictingProviders)}. "
+                + "Resolve via the merge endpoint with an explicit ExternalMappings.<provider> override.");
+        }
+
+        // Structural duplicates = same (ProviderName, ExternalId).
+        await db.Set<PartyExternalMapping>()
+            .Where(m => EF.Property<Guid>(m, PartyIdShadowFk) == loserId
+                        && db.Set<PartyExternalMapping>().Any(s =>
+                            EF.Property<Guid>(s, PartyIdShadowFk) == survivorId
+                            && s.ProviderName == m.ProviderName
+                            && s.ExternalId == m.ExternalId))
+            .ExecuteDeleteAsync(ct).ConfigureAwait(false);
+
+        return await db.Set<PartyExternalMapping>()
+            .Where(m => EF.Property<Guid>(m, PartyIdShadowFk) == loserId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(m => EF.Property<Guid>(m, PartyIdShadowFk), survivorId), ct)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task EnsureCapsAsync(PartiesDbContext db, Guid survivorId, CancellationToken ct)
+    {
+        int emailCount = await db.Set<PartyEmail>()
+            .CountAsync(e => EF.Property<Guid>(e, PartyIdShadowFk) == survivorId, ct).ConfigureAwait(false);
+        if (emailCount > Party.MaxEmails)
+        {
+            throw new MergeException($"Email cap exceeded after merge: {emailCount} > {Party.MaxEmails}.");
+        }
+
+        int phoneCount = await db.Set<PartyPhone>()
+            .CountAsync(p => EF.Property<Guid>(p, PartyIdShadowFk) == survivorId, ct).ConfigureAwait(false);
+        if (phoneCount > Party.MaxPhones)
+        {
+            throw new MergeException($"Phone cap exceeded after merge: {phoneCount} > {Party.MaxPhones}.");
+        }
+
+        int addressCount = await db.Set<PartyAddress>()
+            .CountAsync(a => EF.Property<Guid>(a, PartyIdShadowFk) == survivorId, ct).ConfigureAwait(false);
+        if (addressCount > Party.MaxAddresses)
+        {
+            throw new MergeException($"Address cap exceeded after merge: {addressCount} > {Party.MaxAddresses}.");
+        }
+    }
+}

--- a/src/Granit.Parties.Mergeable/Internal/PartyParentReferenceRewriter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyParentReferenceRewriter.cs
@@ -1,0 +1,60 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Mergeable;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Mergeable.Internal;
+
+/// <summary>
+/// Re-parents <see cref="Party"/> children of the loser onto the survivor — i.e. parties
+/// whose <see cref="Party.ParentContactId"/> equals the loser's id are redirected to the
+/// survivor. Implemented as a SQL bulk-update so the change tracker is not loaded with
+/// potentially thousands of rows and to avoid the EF shadow-FK pitfall.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The query disables the <see cref="IHasMergeTombstone"/> filter for its scope so that
+/// already-tombstoned children (rare but possible after chain merges) are still rewritten
+/// to point at the latest survivor — guaranteeing the single-hop invariant relied on by
+/// <c>PartyId.ResolveCurrentAsync</c>.
+/// </para>
+/// </remarks>
+internal sealed class PartyParentReferenceRewriter(
+    IDbContextFactory<PartiesDbContext> contextFactory,
+    IDataFilter dataFilter) : IReferenceRewriter<Party>
+{
+    /// <inheritdoc />
+    public string Description => "Party.ParentContactId";
+
+    /// <inheritdoc />
+    public async Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        using IDisposable _ = dataFilter.Disable<IHasMergeTombstone>();
+
+        var loserPartyId = PartyId.Create(loserId);
+        var survivorPartyId = PartyId.Create(survivorId);
+
+        return await db.Parties
+            .Where(p => p.ParentContactId == loserPartyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(p => p.ParentContactId, survivorPartyId), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        using IDisposable _ = dataFilter.Disable<IHasMergeTombstone>();
+
+        var loserPartyId = PartyId.Create(loserId);
+
+        return await db.Parties
+            .Where(p => p.ParentContactId == loserPartyId)
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/Granit.Parties.Mergeable.Tests.Integration.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);EF1001;EF1002</NoWarn>
+    <!-- Excluded from CI unit-test job; runs only in the integration-test job. -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Parties.Mergeable\Granit.Parties.Mergeable.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/PartyChildrenReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/PartyChildrenReferenceRewriterPostgresTests.cs
@@ -1,0 +1,254 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Mergeable.Exceptions;
+using Granit.Parties.Domain;
+using Granit.Parties.EntityFrameworkCore;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.Parties.Mergeable.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// Postgres integration tests for <see cref="PartyChildrenReferenceRewriter"/>. Exercises
+/// the bulk SQL paths (<c>ExecuteUpdateAsync</c> + <c>ExecuteDeleteAsync</c>) that the
+/// in-memory provider cannot run.
+/// </summary>
+public sealed class PartyChildrenReferenceRewriterPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
+    private TestPartiesDbContextFactory _factory = null!;
+    private PartyChildrenReferenceRewriter _sut = null!;
+
+    public PartyChildrenReferenceRewriterPostgresTests(PostgresFixture postgres)
+    {
+        _postgres = postgres;
+        _dataFilter.Disable<IHasMergeTombstone>().Returns(Substitute.For<IDisposable>());
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _factory = new TestPartiesDbContextFactory(_postgres.ConnectionString);
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        // Tables created via EnsureCreated; truncate between tests for isolation.
+        // Use the configured prefix (default "contacts_") so tests stay aligned with whatever
+        // GranitPartiesDbProperties.DbTablePrefix is set to in the future.
+        string p = GranitPartiesDbProperties.DbTablePrefix;
+        await db.Database.ExecuteSqlRawAsync(
+            $"TRUNCATE TABLE {p}external_mappings, {p}addresses, {p}emails, {p}phones, {p}parties RESTART IDENTITY CASCADE;",
+            TestContext.Current.CancellationToken);
+
+        _sut = new PartyChildrenReferenceRewriter(_factory, _dataFilter);
+    }
+
+    public ValueTask DisposeAsync() => _factory?.DisposeAsync() ?? ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task EmailDuplicate_IsDeletedFromLoser_AndUniqueIsMoved()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddEmail(Guid.NewGuid(), "shared@acme.com", isPrimary: true);
+        survivor.AddEmail(Guid.NewGuid(), "ops@acme.com", isPrimary: false);
+
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "shared@acme.com", isPrimary: false);
+        loser.AddEmail(Guid.NewGuid(), "billing@acme.com", isPrimary: false);
+
+        await SeedAsync(survivor, loser);
+
+        await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<string> survivorEmails = await db.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, "PartyId") == survivor.Id)
+            .Select(e => e.Address)
+            .OrderBy(s => s)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        survivorEmails.ShouldBe(["billing@acme.com", "ops@acme.com", "shared@acme.com"]);
+
+        int loserEmailCount = await db.Set<PartyEmail>()
+            .CountAsync(e => EF.Property<Guid>(e, "PartyId") == loser.Id, TestContext.Current.CancellationToken);
+        loserEmailCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task PrimaryEmail_OnLoser_IsDemoted_WhenSurvivorAlreadyHasOne()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddEmail(Guid.NewGuid(), "owner@acme.com", isPrimary: true);
+
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "owner-old@acme.com", isPrimary: true);
+
+        await SeedAsync(survivor, loser);
+
+        await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<PartyEmail> emails = await db.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, "PartyId") == survivor.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        emails.Count.ShouldBe(2);
+        emails.Count(e => e.IsPrimary).ShouldBe(1);
+        emails.Single(e => e.IsPrimary).Address.ShouldBe("owner@acme.com");
+    }
+
+    [Fact]
+    public async Task DefaultAddress_OnLoser_IsDemotedPerKind_WhenSurvivorHasOne()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddAddress(
+            Guid.NewGuid(),
+            AddressKind.Billing,
+            Address.Create("Rue 1", "Brussels", "1000", "BE"),
+            isDefault: true);
+
+        Party loser = NewParty("Acme L");
+        loser.AddAddress(
+            Guid.NewGuid(),
+            AddressKind.Billing,
+            Address.Create("Rue 99", "Brussels", "1000", "BE"),
+            isDefault: true);
+        loser.AddAddress(
+            Guid.NewGuid(),
+            AddressKind.Shipping,
+            Address.Create("Av Louise", "Brussels", "1050", "BE"),
+            isDefault: true);
+
+        await SeedAsync(survivor, loser);
+
+        await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<PartyAddress> addresses = await db.Set<PartyAddress>()
+            .Where(a => EF.Property<Guid>(a, "PartyId") == survivor.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        addresses.Count.ShouldBe(3);
+        addresses.Count(a => a.Kind == AddressKind.Billing && a.IsDefault).ShouldBe(1);
+        addresses.Single(a => a.Kind == AddressKind.Billing && a.IsDefault).Value.Line1.ShouldBe("Rue 1");
+        addresses.Single(a => a.Kind == AddressKind.Shipping).IsDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AddressStructuralDuplicate_IsDedupedByVoEquality()
+    {
+        var shared = Address.Create("Same St 1", "Brussels", "1000", "BE", state: "BXL");
+        Party survivor = NewParty("Acme S");
+        survivor.AddAddress(Guid.NewGuid(), AddressKind.Billing, shared);
+
+        Party loser = NewParty("Acme L");
+        loser.AddAddress(
+            Guid.NewGuid(),
+            AddressKind.Billing,
+            Address.Create("Same St 1", "Brussels", "1000", "BE", state: "BXL"));
+        loser.AddAddress(
+            Guid.NewGuid(),
+            AddressKind.Shipping,
+            Address.Create("Other St 9", "Antwerp", "2000", "BE"));
+
+        await SeedAsync(survivor, loser);
+
+        await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        int survivorAddressCount = await db.Set<PartyAddress>()
+            .CountAsync(a => EF.Property<Guid>(a, "PartyId") == survivor.Id, TestContext.Current.CancellationToken);
+        survivorAddressCount.ShouldBe(2); // 1 original + 1 unique (shipping); the duplicate billing was deleted.
+    }
+
+    [Fact]
+    public async Task ExternalMappingConflict_OnSameProvider_ThrowsMergeException()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_survivor");
+
+        Party loser = NewParty("Acme L");
+        loser.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_loser");
+
+        await SeedAsync(survivor, loser);
+
+        MergeException ex = await Should.ThrowAsync<MergeException>(() =>
+            _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("stripe");
+    }
+
+    [Fact]
+    public async Task ExternalMappingDuplicate_SameProviderAndExternalId_IsDeleted()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_same");
+
+        Party loser = NewParty("Acme L");
+        loser.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_same");
+        loser.AddExternalMapping(Guid.NewGuid(), "mollie", "cst_unique");
+
+        await SeedAsync(survivor, loser);
+
+        await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        List<PartyExternalMapping> mappings = await db.Set<PartyExternalMapping>()
+            .Where(m => EF.Property<Guid>(m, "PartyId") == survivor.Id)
+            .OrderBy(m => m.ProviderName)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        mappings.Select(m => m.ProviderName).ShouldBe(["mollie", "stripe"]);
+    }
+
+    [Fact]
+    public async Task EmailCapExceeded_AfterMerge_ThrowsMergeException()
+    {
+        // Cap is 50; survivor + loser unique emails > 50 must throw.
+        Party survivor = NewParty("Big S");
+        for (int i = 0; i < 30; i++)
+        {
+            survivor.AddEmail(Guid.NewGuid(), $"s{i}@acme.com", isPrimary: i == 0);
+        }
+        Party loser = NewParty("Big L");
+        for (int i = 0; i < 25; i++)
+        {
+            loser.AddEmail(Guid.NewGuid(), $"l{i}@acme.com", isPrimary: i == 0);
+        }
+        await SeedAsync(survivor, loser);
+
+        MergeException ex = await Should.ThrowAsync<MergeException>(() =>
+            _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("Email cap exceeded");
+    }
+
+    [Fact]
+    public async Task CountAsync_ReturnsTotalLoserChildRowCount()
+    {
+        Party survivor = NewParty("Acme S");
+        survivor.AddEmail(Guid.NewGuid(), "s@acme.com", isPrimary: true);
+
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "l1@acme.com");
+        loser.AddEmail(Guid.NewGuid(), "l2@acme.com");
+        loser.AddPhone(Guid.NewGuid(), PhoneKind.Mobile, "+3221111111");
+        loser.AddAddress(Guid.NewGuid(), AddressKind.Billing,
+            Address.Create("Rue 1", "Brussels", "1000", "BE"));
+
+        await SeedAsync(survivor, loser);
+
+        int count = await _sut.CountAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+        count.ShouldBe(4);
+    }
+
+    private async Task SeedAsync(params Party[] parties)
+    {
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Parties.AddRange(parties);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static Party NewParty(string name) =>
+        Party.Create(Guid.NewGuid(), tenantId: null, PartyKind.Company, name, "EUR");
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/PartyParentReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/PartyParentReferenceRewriterPostgresTests.cs
@@ -1,0 +1,118 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Parties.EntityFrameworkCore;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.Parties.Mergeable.Internal;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// Postgres integration tests for <see cref="PartyParentReferenceRewriter"/>. The
+/// <c>UPDATE parties SET ParentContactId = survivorId WHERE ParentContactId = loserId</c>
+/// path requires a relational provider, hence Postgres rather than the in-memory provider.
+/// </summary>
+public sealed class PartyParentReferenceRewriterPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
+    private TestPartiesDbContextFactory _factory = null!;
+    private PartyParentReferenceRewriter _sut = null!;
+
+    public PartyParentReferenceRewriterPostgresTests(PostgresFixture postgres)
+    {
+        _postgres = postgres;
+        _dataFilter.Disable<IHasMergeTombstone>().Returns(Substitute.For<IDisposable>());
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _factory = new TestPartiesDbContextFactory(_postgres.ConnectionString);
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        string p = GranitPartiesDbProperties.DbTablePrefix;
+        await db.Database.ExecuteSqlRawAsync(
+            $"TRUNCATE TABLE {p}external_mappings, {p}addresses, {p}emails, {p}phones, {p}parties RESTART IDENTITY CASCADE;",
+            TestContext.Current.CancellationToken);
+
+        _sut = new PartyParentReferenceRewriter(_factory, _dataFilter);
+    }
+
+    public ValueTask DisposeAsync() => _factory?.DisposeAsync() ?? ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task RewriteAsync_ReparentsLoserChildrenOntoSurvivor()
+    {
+        Party survivor = NewParty("Holding S");
+        Party loser = NewParty("Holding L");
+        Party child1 = NewParty("Sub 1");
+        child1.AttachToParent(PartyId.Create(loser.Id), parentTenantId: null);
+        Party child2 = NewParty("Sub 2");
+        child2.AttachToParent(PartyId.Create(loser.Id), parentTenantId: null);
+        Party unrelated = NewParty("Other Sub");
+        unrelated.AttachToParent(PartyId.Create(survivor.Id), parentTenantId: null);
+
+        await SeedAsync(survivor, loser, child1, child2, unrelated);
+
+        int rewritten = await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(2);
+
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var survivorPartyId = PartyId.Create(survivor.Id);
+        int childrenOfSurvivor = await db.Parties
+            .CountAsync(p => p.ParentContactId == survivorPartyId, TestContext.Current.CancellationToken);
+        childrenOfSurvivor.ShouldBe(3);
+
+        var loserPartyId = PartyId.Create(loser.Id);
+        int childrenOfLoser = await db.Parties
+            .CountAsync(p => p.ParentContactId == loserPartyId, TestContext.Current.CancellationToken);
+        childrenOfLoser.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RewriteAsync_ReturnsZero_WhenLoserHasNoChildren()
+    {
+        Party survivor = NewParty("S");
+        Party loser = NewParty("L");
+        await SeedAsync(survivor, loser);
+
+        int rewritten = await _sut.RewriteAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CountAsync_ReturnsLoserChildCount_WithoutMutating()
+    {
+        Party survivor = NewParty("S");
+        Party loser = NewParty("L");
+        Party c1 = NewParty("C1"); c1.AttachToParent(PartyId.Create(loser.Id), parentTenantId: null);
+        Party c2 = NewParty("C2"); c2.AttachToParent(PartyId.Create(loser.Id), parentTenantId: null);
+        await SeedAsync(survivor, loser, c1, c2);
+
+        int count = await _sut.CountAsync(survivor.Id, loser.Id, TestContext.Current.CancellationToken);
+        count.ShouldBe(2);
+
+        // Confirm CountAsync did not mutate.
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var loserPartyId = PartyId.Create(loser.Id);
+        int still = await db.Parties
+            .CountAsync(p => p.ParentContactId == loserPartyId, TestContext.Current.CancellationToken);
+        still.ShouldBe(2);
+    }
+
+    private async Task SeedAsync(params Party[] parties)
+    {
+        await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Parties.AddRange(parties);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static Party NewParty(string name) =>
+        Party.Create(Guid.NewGuid(), tenantId: null, PartyKind.Company, name, "EUR");
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,21 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// Starts a PostgreSQL 17 container once per test class and exposes the connection string.
+/// Required because the rewriters use <c>ExecuteUpdateAsync</c> / <c>ExecuteDeleteAsync</c>,
+/// which are not supported by the EF in-memory provider.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/TestPartiesDbContextFactory.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/TestPartiesDbContextFactory.cs
@@ -1,0 +1,29 @@
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// Minimal <see cref="IDbContextFactory{TContext}"/> for the integration tests — wires
+/// <see cref="PartiesDbContext"/> against the Postgres connection string from the
+/// Testcontainer fixture. No multi-tenancy / data filter wiring is required here because
+/// the rewriters explicitly disable the merge-tombstone filter on every operation.
+/// </summary>
+internal sealed class TestPartiesDbContextFactory : IDbContextFactory<PartiesDbContext>, IAsyncDisposable
+{
+    private readonly DbContextOptions<PartiesDbContext> _options;
+
+    public TestPartiesDbContextFactory(string connectionString)
+    {
+        _options = new DbContextOptionsBuilder<PartiesDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+    }
+
+    public PartiesDbContext CreateDbContext() => new(_options);
+
+    public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(new PartiesDbContext(_options));
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
@@ -1,0 +1,615 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.mergeable.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.parties": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.parties.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Mergeable.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Story M5 of the Party merge plan ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) → [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).

Two rewriters that the merge orchestrator runs in the same `TransactionScope` as the survivor mutation, so any failure rolls back atomically.

### `PartyParentReferenceRewriter`

Re-parents `Party` children whose `ParentContactId == loserId` onto the survivor via `ExecuteUpdateAsync`. Disables the `IHasMergeTombstone` filter for its scope so already-tombstoned children (rare, after chain merges) are still redirected — guarantees the single-hop invariant of `PartyId.ResolveCurrentAsync`.

### `PartyChildrenReferenceRewriter`

Bulk-rewrites the four child collections without loading them into the EF change tracker — sidesteps the shadow-FK pitfall that would hit `survivor.Children.AddRange(loser.Children)`.

| Step | What it does |
|---|---|
| 1. Demote | If survivor has a primary/default, demote loser's matching primary/default before the move (per `AddressKind` for addresses). |
| 2. Dedupe | `ExecuteDeleteAsync` the loser-side rows that are structural duplicates of a survivor row. Equality: Email by `Address`, Phone by `Number`, Address by all VO components, ExternalMapping by `(ProviderName, ExternalId)`. |
| 3. Move | `ExecuteUpdateAsync` the shadow FK `PartyId` for the rest — moves them onto the survivor. |
| 4. Cap | Verify `Party.MaxEmails`, `Party.MaxPhones`, `Party.MaxAddresses` post-rewrite — throw `MergeException` so the orchestrator rolls back. |

ExternalMappings: a same-`ProviderName`-different-`ExternalId` conflict throws `MergeException`. Override semantics belong to M9 (endpoint layer) where admin choices flow in; the rewriter has no knowledge of `MergeFieldChoices`.

### Placement deviation from issue

The issue lists `Granit.Parties.EntityFrameworkCore/Internal/` but the rewriters land in `Granit.Parties.Mergeable/Internal/` — same package as `PartyMergeableAggregateAdapter`. This matches the `Granit.{Module}.Mergeable` pattern that's coming for Invoicing / Subscriptions / CustomerBalance: every module groups its merge plumbing in one package, and `Granit.Parties.EntityFrameworkCore` stays free of `Granit.Mergeable` references.

### DI

`AddGranitPartiesMergeable` now wires both rewriters via `services.AddReferenceRewriter<Party, …>()` so the generic orchestrator discovers them automatically.

## Test plan

Postgres integration tests (in-memory provider does not support `ExecuteUpdate` / `ExecuteDelete`):

- [x] `PartyParentReferenceRewriterPostgresTests` (3): re-parents loser's children without touching unrelated ones; zero-impact when loser has no children; `CountAsync` is read-only.
- [x] `PartyChildrenReferenceRewriterPostgresTests` (8): email structural dedup + unique move; primary-email demotion; default-address per-kind demotion; address VO dedup; external-mapping conflict detection; same-`(ProviderName, ExternalId)` dedup; email cap enforcement (50); `CountAsync` row count.
- [x] All 11 integration tests pass under Testcontainers + Postgres 17.
- [x] `Granit.Parties.Tests` 155/155 (no regression).
- [x] `Granit.ArchitectureTests` 150/150.
- [x] `Granit.Mergeable*.Tests` 9 + 17 (no regression).
- [x] `dotnet format --verify-no-changes` clean.

Refs #1287
