### PR TITLE
feat(privacy-notifications): pt-BR LGPD-specific variants for 8/8 notif types

### DIFF
--- a/src/Granit.Privacy.Notifications/Templates/Privacy.LegalDocumentObsolete.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/Privacy.LegalDocumentObsolete.pt-BR.html
@@ -1,0 +1,16 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>{{ model.document_display_name }} foi atualizado — solicitamos a sua revisão</title>
+<p>Olá,</p>
+<p>Nosso <strong>{{ model.document_display_name }}</strong> foi atualizado. Para continuar usando nossos serviços, pedimos que você consulte a nova versão e confirme sua aceitação.</p>
+<p>Versão que você aceitou: <strong>{{ model.old_version }}</strong><br>
+Nova versão: <strong>{{ model.new_version }}</strong></p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/privacy/agreements/{{ model.document_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Consultar e aceitar</a>
+</p>
+<p>Enquanto você não confirmar sua aceitação, algumas funcionalidades poderão ficar indisponíveis.</p>
+{{ if privacy.controller_name }}
+<p>Esta mensagem é enviada por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>
+{{ end }}
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas sobre esta atualização? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_acknowledged.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_acknowledged.pt-BR.html
@@ -1,0 +1,15 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Recebemos sua solicitação de exclusão</title>
+<p>Olá,</p>
+<p>Recebemos sua solicitação de exclusão dos seus dados pessoais em <strong>{{ model.requested_at | date.to_string '%B %d, %Y' }}</strong>{{ if model.regulation }} sob a regulamentação <code>{{ model.regulation }}</code>{{ end }}.</p>
+<p>Este e-mail constitui o seu comprovante de recebimento. Iremos tratar sua solicitação dentro do prazo legal aplicável à sua jurisdição (15 dias sob o art. 19 da LGPD; um mês sob o art. 12.º, n.º 3, do RGPD, prorrogável em casos complexos). Você receberá um novo e-mail assim que a exclusão for executada, ou caso precisemos de informações adicionais.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.controller_name }}
+<p>Esta mensagem é enviada por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>
+{{ end }}
+{{ if privacy.dpo_email }}
+<p>Para questões relativas à proteção dos seus dados, você pode entrar em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}
+{{ if privacy.supervisory_authority_url }}
+<p style="font-size: 13px; color: #4b5563;">Caso não esteja satisfeito com o tratamento da sua solicitação, você tem o direito de apresentar reclamação à autoridade de controle competente: <a href="{{ privacy.supervisory_authority_url }}">{{ privacy.supervisory_authority_url }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_cancelled.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_cancelled.pt-BR.html
@@ -1,0 +1,9 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Sua solicitação de exclusão foi cancelada</title>
+<p>Olá,</p>
+<p>Confirmamos que sua solicitação de exclusão diferida foi cancelada em <strong>{{ model.cancelled_at | date.to_string '%B %d, %Y' }}</strong>. Seus dados pessoais serão mantidos como antes, e nenhuma ação adicional é necessária da sua parte.</p>
+<p>Você pode enviar uma nova solicitação de exclusão a qualquer momento a partir do seu painel de privacidade.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt-BR.html
@@ -1,0 +1,15 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Seus dados foram excluídos</title>
+<p>Olá,</p>
+<p>Confirmamos que seus dados pessoais foram definitivamente excluídos em <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Esta exclusão é irreversível.</p>
+<p>Este e-mail constitui o seu comprovante de conformidade. Solicitamos que você o guarde como prova do exercício do seu direito de eliminação.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.controller_name }}
+<p>Esta mensagem é enviada por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>
+{{ end }}
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Para questões relativas à proteção dos seus dados, entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}
+{{ if privacy.supervisory_authority_url }}
+<p style="font-size: 13px; color: #4b5563;">Caso não esteja satisfeito com o tratamento, você tem o direito de apresentar reclamação à autoridade de controle competente: <a href="{{ privacy.supervisory_authority_url }}">{{ privacy.supervisory_authority_url }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_deferred_confirmed.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_deferred_confirmed.pt-BR.html
@@ -1,0 +1,13 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Sua exclusão está agendada</title>
+<p>Olá,</p>
+<p>Você solicitou uma exclusão diferida dos seus dados pessoais em <strong>{{ model.requested_at | date.to_string '%B %d, %Y' }}</strong>{{ if model.regulation }} sob a regulamentação <code>{{ model.regulation }}</code>{{ end }}. A exclusão está agora agendada para <strong>{{ model.scheduled_deletion_at | date.to_string '%B %d, %Y' }}</strong>.</p>
+<p>Você pode mudar de ideia e cancelar esta exclusão a qualquer momento antes da data prevista, a partir do seu painel de privacidade:</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/privacy/deletion/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gerenciar minha solicitação</a>
+</p>
+<p>Enviaremos a você um lembrete alguns dias antes da data prevista. Sem ação da sua parte, seus dados serão excluídos definitivamente nessa data.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_reminder.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_reminder.pt-BR.html
@@ -1,0 +1,13 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Lembrete: seus dados serão excluídos em breve</title>
+<p>Olá,</p>
+<p>Este é um lembrete de que a exclusão dos seus dados pessoais que você solicitou está agendada para <strong>{{ model.scheduled_deletion_at | date.to_string '%B %d, %Y' }}</strong>.</p>
+<p>Se você não deseja mais excluir seus dados, pode cancelar sua solicitação a partir do seu painel de privacidade:</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/privacy/deletion/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gerenciar minha solicitação</a>
+</p>
+<p>Sem ação da sua parte, seus dados serão excluídos definitivamente na data prevista. Após isso, a exclusão é irreversível.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.export_failed.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.export_failed.pt-BR.html
@@ -1,0 +1,19 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Sua exportação de dados está parcialmente disponível</title>
+<p>Olá,</p>
+<p>Sua exportação de dados pessoais, solicitada em <strong>{{ model.requested_at | date.to_string '%B %d, %Y' }}</strong>{{ if model.regulation }} sob a regulamentação <code>{{ model.regulation }}</code>{{ end }}, foi gerada, mas algumas fontes de dados não responderam dentro do prazo. O arquivo contém tudo o que conseguimos coletar dentro da janela legal.</p>
+{{ if model.missing_providers_display }}
+<p>As seguintes fontes de dados não foram incluídas nesta exportação: <code>{{ model.missing_providers_display }}</code>.</p>
+{{ end }}
+<p>Você pode:</p>
+<ul>
+  <li><strong>Baixar o arquivo parcial</strong> a partir do seu painel de privacidade, ou</li>
+  <li><strong>Enviar uma nova solicitação</strong> para reiniciar as fontes ausentes.</li>
+</ul>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver minha exportação</a>
+</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.export_ready.pt-BR.html
@@ -1,0 +1,13 @@
+<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->
+<title>Sua exportação de dados pessoais está pronta</title>
+<p>Olá,</p>
+<p>Sua exportação de dados pessoais, solicitada em <strong>{{ model.requested_at | date.to_string '%B %d, %Y' }}</strong>{{ if model.regulation }} sob a regulamentação <code>{{ model.regulation }}</code>{{ end }}, está agora pronta para download.</p>
+<p>Você pode baixar seu arquivo a partir do seu painel de privacidade:</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/privacy/exports/{{ model.request_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Baixar meu arquivo</a>
+</p>
+<p>O link de download tem validade limitada por motivos de segurança. Se expirar, você pode solicitar um novo a partir da mesma página.</p>
+<p>Referência: <code>{{ model.request_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Tem dúvidas sobre seus dados? Entre em contato com nosso Encarregado pelo Tratamento de Dados Pessoais em <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/tests/Granit.Privacy.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
+++ b/tests/Granit.Privacy.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
@@ -120,6 +120,15 @@ public sealed class EmbeddedTemplatesTests
         "Templates.privacy.deletion_reminder.pt.html",
         "Templates.privacy.export_failed.pt.html",
         "Templates.privacy.export_ready.pt.html",
+        // Portuguese — Brazil (pt-BR) — LGPD-specific variant, auto-translated, review before production.
+        "Templates.Privacy.LegalDocumentObsolete.pt-BR.html",
+        "Templates.privacy.deletion_acknowledged.pt-BR.html",
+        "Templates.privacy.deletion_cancelled.pt-BR.html",
+        "Templates.privacy.deletion_confirmed.pt-BR.html",
+        "Templates.privacy.deletion_deferred_confirmed.pt-BR.html",
+        "Templates.privacy.deletion_reminder.pt-BR.html",
+        "Templates.privacy.export_failed.pt-BR.html",
+        "Templates.privacy.export_ready.pt-BR.html",
         // Swedish (sv) — auto-translated, review before production.
         "Templates.Privacy.LegalDocumentObsolete.sv.html",
         "Templates.privacy.deletion_acknowledged.sv.html",


### PR DESCRIPTION
## Summary

US #1313 (A2) of Epic #1306 — assess whether the 8 Privacy notification
templates' existing `.pt.html` variants (PT-PT, GDPR-flavoured) are sufficient
for Brazilian LGPD recipients, or whether a dedicated `.pt-BR.html` set is
warranted.

**Verdict: 8/8 warrant a dedicated `.pt-BR.html`.**

## Divergence assessment

| Template | Diverges? | Reason | Ship pt-BR? |
|----------|:---------:|--------|:-----------:|
| Privacy.LegalDocumentObsolete | yes | PT-PT clitics (`pedimos-lhe`), `Encarregado de Proteção de Dados` vs LGPD art. 41 form, `Contacte` (PT-PT) | yes |
| privacy.deletion_acknowledged | yes (material) | Hardcoded reference to **GDPR art. 12.3** (one-month deadline). LGPD art. 19 mandates **15 days**. Brazilian recipient gets the wrong deadline. | yes |
| privacy.deletion_cancelled | yes | PT-PT vocab (`Contacte`, `Dúvidas?` ok in both but PT-PT cadence) | yes |
| privacy.deletion_confirmed | yes | PT-PT clitics, `Contacte`, `direito ao apagamento` (PT-PT term, BR uses `direito de eliminação`) | yes |
| privacy.deletion_deferred_confirmed | yes | `enviar-lhe` (enclisis), `Gerir` (PT-PT) vs `Gerenciar` (BR) | yes |
| privacy.deletion_reminder | yes | PT-PT cadence, `Gerir` vs `Gerenciar` | yes |
| privacy.export_failed | yes | `Descarregar` (PT-PT) vs `Baixar` (BR), `arquivo` ambiguity, `Submeter` PT-PT preference | yes |
| privacy.export_ready | yes | `descarregar` / `transferência` (PT-PT terms for "download") vs `baixar` / `download` (BR loanword universal) | yes |

## What changed in pt-BR

1. **Brazilian vocabulary**: `descarregar` → `baixar`, `transferência` → `download`,
   `Gerir` → `Gerenciar`, `Submeter` → `Enviar`, `Contacte` → `Entre em contato`,
   `direito ao apagamento` → `direito de eliminação`.
2. **Proclitic style**: `pedimos-lhe`, `enviar-lhe`, `solicitamos-lhe` rewritten as
   `pedimos a você`, `enviar a você`, `solicitamos a você` / `solicitamos que você`.
3. **DPO term**: PT-PT `Encarregado de Proteção de Dados` → BR `Encarregado pelo
   Tratamento de Dados Pessoais` (LGPD art. 41 wording).
4. **`deletion_acknowledged`**: deadline sentence rewritten to mention **both**
   the LGPD 15-day window (art. 19) and the GDPR one-month window (art. 12.3).
   This fixes the most material divergence — a Brazilian user previously got an
   incorrect legal deadline.
5. The dynamic `{{ model.regulation }}` tag and `{{ privacy.supervisory_authority_url }}`
   setting are preserved unchanged — they continue to carry the runtime regulator
   identity (BR_LGPD vs EU_GDPR, ANPD vs CNIL/APD URLs).

## Validation

- Placeholder parity: `{{` / `}}` counts identical to `.pt.html` source on all 8 files.
- HTML tag counts identical to source on all 8 files.
- Each file carries the `<!-- AUTO-TRANSLATED (claude-opus-4-7, 2026-04-27) — REVIEW BEFORE PRODUCTION -->` marker.
- `EmbeddedTemplatesTests` updated with 8 new theory entries.

## Files added

8 new `.pt-BR.html` templates under `src/Granit.Privacy.Notifications/Templates/`.

## Test counts

- `Granit.Privacy.Notifications.Tests`: **252 → 268** passing (+16 = 8 files × 2 theories).
- `Granit.ArchitectureTests`: 150/150 passing.

## Lockfiles

0 regenerated — no package dependencies modified.

## Test plan

- [ ] Native BR pt review of the 8 `.pt-BR.html` files (review marker present)
- [ ] Verify rendering with `Regulation = "BR_LGPD"` produces correct deadline wording
- [ ] Verify `pt-PT` clients still pick up the existing `.pt.html` variant (no regression)

Closes #1313
