### PR TITLE
fix(privacy-notifications): regulation-neutral phrasing in deletion_confirmed

### DIFF
--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.cs.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.cs.html
@@ -2,7 +2,7 @@
 <title>Vaše údaje byly vymazány</title>
 <p>Dobrý den,</p>
 <p>Potvrzujeme, že Vaše osobní údaje byly trvale vymazány dne <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Tento výmaz je nevratný.</p>
-<p>Tento e-mail představuje Váš doklad o souladu s předpisy. Žádáme Vás, abyste si jej uschoval/a jako důkaz o uplatnění Vašeho práva na výmaz.</p>
+<p>Tento e-mail představuje Váš doklad o souladu s předpisy. Žádáme Vás, abyste si jej uschoval/a jako důkaz o tom, že Vaší žádosti o výmaz bylo vyhověno.</p>
 <p>Reference: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Tuto zprávu odesílá {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.de.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.de.html
@@ -2,7 +2,7 @@
 <title>Ihre Daten wurden gelöscht</title>
 <p>Guten Tag,</p>
 <p>Wir bestätigen, dass Ihre personenbezogenen Daten am <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> endgültig gelöscht wurden. Diese Löschung ist unwiderruflich.</p>
-<p>Diese E-Mail dient als Ihr Compliance-Nachweis. Bitte bewahren Sie sie als Beleg dafür auf, dass Ihrem Recht auf Löschung entsprochen wurde.</p>
+<p>Diese E-Mail dient als Ihr Compliance-Nachweis. Bitte bewahren Sie sie als Beleg dafür auf, dass Ihrer Löschungsanforderung entsprochen wurde.</p>
 <p>Referenz: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Diese Nachricht wird gesendet von {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.es.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.es.html
@@ -2,7 +2,7 @@
 <title>Sus datos han sido suprimidos</title>
 <p>Hola,</p>
 <p>Le confirmamos que sus datos personales han sido suprimidos definitivamente el <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Esta supresión es irreversible.</p>
-<p>Este correo electrónico constituye su justificante de cumplimiento. Le rogamos que lo conserve como prueba del ejercicio de su derecho de supresión.</p>
+<p>Este correo electrónico constituye su justificante de cumplimiento. Le rogamos que lo conserve como prueba de que su solicitud de eliminación ha sido atendida.</p>
 <p>Referencia: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Este mensaje es enviado por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.fr.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.fr.html
@@ -1,7 +1,7 @@
 <title>Vos données ont été supprimées</title>
 <p>Bonjour,</p>
 <p>Nous vous confirmons que vos données personnelles ont été définitivement supprimées le <strong>{{ model.executed_at | date.to_string '%d %B %Y à %H:%M UTC' }}</strong>. Cette suppression est irréversible.</p>
-<p>Cet e-mail constitue votre preuve de conformité. Nous vous invitons à le conserver comme attestation de l'exercice de votre droit à l'effacement.</p>
+<p>Cet e-mail constitue votre preuve de conformité. Nous vous invitons à le conserver comme attestation que votre demande de suppression a été honorée.</p>
 <p>Référence : <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Ce message est envoyé par {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.hi.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.hi.html
@@ -2,7 +2,7 @@
 <title>आपका डेटा हटा दिया गया है</title>
 <p>नमस्ते,</p>
 <p>हम पुष्टि करते हैं कि आपका व्यक्तिगत डेटा <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> पर स्थायी रूप से हटा दिया गया है। यह विलोपन अपरिवर्तनीय है।</p>
-<p>यह ईमेल आपकी अनुपालन रसीद है। कृपया इसे इस बात के प्रमाण के रूप में सुरक्षित रखें कि आपके विलोपन के अधिकार का सम्मान किया गया है।</p>
+<p>यह ईमेल आपकी अनुपालन रसीद है। कृपया इसे इस बात के प्रमाण के रूप में सुरक्षित रखें कि आपके विलोपन अनुरोध को पूरा किया गया है।</p>
 <p>संदर्भ: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>यह संदेश {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }} द्वारा भेजा जा रहा है।</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.html
@@ -1,7 +1,7 @@
 <title>Your data has been deleted</title>
 <p>Hi,</p>
 <p>We confirm that your personal data has been permanently deleted on <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. This deletion is irreversible.</p>
-<p>This email is your compliance receipt. Please retain it as proof that your right to erasure has been honoured.</p>
+<p>This email is your compliance receipt. Please retain it as proof that your deletion request has been honoured.</p>
 <p>Reference: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>This message is sent by {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.it.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.it.html
@@ -2,7 +2,7 @@
 <title>I Suoi dati sono stati cancellati</title>
 <p>Buongiorno,</p>
 <p>Le confermiamo che i Suoi dati personali sono stati definitivamente cancellati il <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. La cancellazione è irreversibile.</p>
-<p>Questa e-mail costituisce la Sua attestazione di conformità. La invitiamo a conservarla come prova dell'esercizio del Suo diritto alla cancellazione.</p>
+<p>Questa e-mail costituisce la Sua attestazione di conformità. La invitiamo a conservarla come prova che la Sua richiesta di cancellazione è stata onorata.</p>
 <p>Riferimento: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Questo messaggio è inviato da {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.ja.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.ja.html
@@ -2,7 +2,7 @@
 <title>お客様のデータが削除されました</title>
 <p>こんにちは。</p>
 <p>お客様の個人データが <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> に永久に削除されたことを確認いたしました。本削除は取り消すことができません。</p>
-<p>本メールはお客様のコンプライアンス受領証となります。お客様の削除権が履行された証として保管をお願いいたします。</p>
+<p>本メールはお客様のコンプライアンス受領証となります。お客様の削除のご依頼が履行された証として保管をお願いいたします。</p>
 <p>参照番号: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>本メッセージは {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }} より送信されています。</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.ko.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.ko.html
@@ -2,7 +2,7 @@
 <title>고객님의 데이터가 삭제되었습니다</title>
 <p>안녕하십니까.</p>
 <p>고객님의 개인정보가 <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> 에 영구히 삭제되었음을 확인해 드립니다. 본 삭제는 되돌릴 수 없습니다.</p>
-<p>본 이메일은 고객님의 컴플라이언스 영수증입니다. 삭제권이 이행되었음을 증명하는 자료로 보관하여 주시기 바랍니다.</p>
+<p>본 이메일은 고객님의 컴플라이언스 영수증입니다. 삭제 요청이 이행되었음을 증명하는 자료로 보관하여 주시기 바랍니다.</p>
 <p>참조번호: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>본 메시지는 {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }} 에서 발송하였습니다.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.nl.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.nl.html
@@ -2,7 +2,7 @@
 <title>Uw gegevens zijn verwijderd</title>
 <p>Hallo,</p>
 <p>Wij bevestigen dat uw persoonsgegevens definitief zijn verwijderd op <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Deze verwijdering is onomkeerbaar.</p>
-<p>Deze e-mail geldt als uw bewijs van naleving. Bewaar dit als bevestiging dat uw recht op verwijdering is gehonoreerd.</p>
+<p>Deze e-mail geldt als uw bewijs van naleving. Bewaar dit als bevestiging dat uw verzoek tot verwijdering is gehonoreerd.</p>
 <p>Referentie: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Dit bericht wordt verzonden door {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pl.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pl.html
@@ -2,7 +2,7 @@
 <title>Państwa dane zostały usunięte</title>
 <p>Dzień dobry,</p>
 <p>Potwierdzamy, że Państwa dane osobowe zostały trwale usunięte w dniu <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Usunięcie jest nieodwracalne.</p>
-<p>Niniejsza wiadomość stanowi Państwa dowód zgodności. Prosimy o jej zachowanie jako potwierdzenia realizacji prawa do usunięcia danych.</p>
+<p>Niniejsza wiadomość stanowi Państwa dowód zgodności. Prosimy o jej zachowanie jako potwierdzenia, że Państwa żądanie usunięcia danych zostało zrealizowane.</p>
 <p>Numer referencyjny: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Wiadomość ta jest wysyłana przez {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt-BR.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt-BR.html
@@ -2,7 +2,7 @@
 <title>Seus dados foram excluídos</title>
 <p>Olá,</p>
 <p>Confirmamos que seus dados pessoais foram definitivamente excluídos em <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Esta exclusão é irreversível.</p>
-<p>Este e-mail constitui o seu comprovante de conformidade. Solicitamos que você o guarde como prova do exercício do seu direito de eliminação.</p>
+<p>Este e-mail constitui o seu comprovante de conformidade. Solicitamos que você o guarde como prova de que sua solicitação de exclusão foi atendida.</p>
 <p>Referência: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Esta mensagem é enviada por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.pt.html
@@ -2,7 +2,7 @@
 <title>Os seus dados foram eliminados</title>
 <p>Olá,</p>
 <p>Confirmamos que os seus dados pessoais foram definitivamente eliminados em <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Esta eliminação é irreversível.</p>
-<p>Este e-mail constitui o seu comprovativo de conformidade. Solicitamos que o conserve como prova do exercício do seu direito ao apagamento.</p>
+<p>Este e-mail constitui o seu comprovativo de conformidade. Solicitamos que o conserve como prova de que o seu pedido de eliminação foi atendido.</p>
 <p>Referência: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Esta mensagem é enviada por {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.sv.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.sv.html
@@ -2,7 +2,7 @@
 <title>Dina uppgifter har raderats</title>
 <p>Hej,</p>
 <p>Vi bekräftar att dina personuppgifter har raderats permanent den <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>. Denna radering är oåterkallelig.</p>
-<p>Detta e-postmeddelande utgör ditt bevis på efterlevnad. Vänligen behåll det som intyg på att din rätt till radering har tillgodosetts.</p>
+<p>Detta e-postmeddelande utgör ditt bevis på efterlevnad. Vänligen behåll det som intyg på att din raderingsbegäran har tillgodosetts.</p>
 <p>Referens: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Detta meddelande skickas av {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }}.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.tr.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.tr.html
@@ -2,7 +2,7 @@
 <title>Verileriniz silindi</title>
 <p>Merhaba,</p>
 <p>Kişisel verilerinizin <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> tarihinde kalıcı olarak silindiğini onaylarız. Bu silme işlemi geri alınamaz.</p>
-<p>Bu e-posta, uyumluluk makbuzunuz niteliğindedir. Lütfen silme hakkınızın yerine getirildiğine dair belge olarak saklayınız.</p>
+<p>Bu e-posta, uyumluluk makbuzunuz niteliğindedir. Lütfen silme talebinizin yerine getirildiğine dair belge olarak saklayınız.</p>
 <p>Referans: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>Bu mesaj {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }} tarafından gönderilmektedir.</p>

--- a/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.zh.html
+++ b/src/Granit.Privacy.Notifications/Templates/privacy.deletion_confirmed.zh.html
@@ -2,7 +2,7 @@
 <title>您的数据已被删除</title>
 <p>您好,</p>
 <p>我们确认您的个人数据已于 <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong> 被永久删除。本次删除不可撤销。</p>
-<p>本邮件即您的合规凭证。请妥善保留,作为您的删除权已得到落实的证明。</p>
+<p>本邮件即您的合规凭证。请妥善保留,作为您的删除请求已得到处理的证明。</p>
 <p>参考编号: <code>{{ model.request_id }}</code></p>
 {{ if privacy.controller_name }}
 <p>本邮件由 {{ privacy.controller_name }}{{ if privacy.controller_email }} (<a href="mailto:{{ privacy.controller_email }}">{{ privacy.controller_email }}</a>){{ end }} 发送。</p>

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3142,6 +3142,7 @@
         "dependencies": {
           "Granit.Notifications.Abstractions": "[0.1.0-dev, )",
           "Granit.Privacy": "[0.1.0-dev, )",
+          "Granit.Privacy.Regulations": "[0.1.0-dev, )",
           "Granit.Templating": "[0.1.0-dev, )"
         }
       },
@@ -4440,8 +4441,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.12.5",
-        "contentHash": "yS1EgVf7a3QZ3hKN/B+Yh8kHbAvdtkDLdWf74sk3fFweLc4k9SSvMGig8k8lBK3iDXeVx9r7W44g/nBxYFIuLw==",
+        "resolved": "0.13.0",
+        "contentHash": "C7rx/q7K6cF8Z2FVCg6z0z4uIqo+cC2Ge1Yaq9ThMaODQBozJ7FNCwMxiK7JeUC9x9roUUmHUJ1aAnXkdWzjNg==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }


### PR DESCRIPTION
## Summary

Fixes #1365 — same class as #1356 (PR #1357) but cosmetic. The 16 culture
variants of `privacy.deletion_confirmed` referred to "your right to erasure
has been honoured" — GDPR Art. 17 phrasing baked into the wording regardless
of the active `Regulation`. Replaces with the regulation-neutral
"deletion request has been honoured" / per-language equivalent.

No handler, data-record, csproj or module changes. Supervisory-authority URL
remains tenant-configurable via `{{ privacy.supervisory_authority_url }}` (no
change required there — already generic English in the source bug).

## Before / after — phrase mapping per culture

| Culture | Before (GDPR-flavored) | After (neutral) |
| ------- | ---------------------- | --------------- |
| `en` (default) | your right to erasure has been honoured | your deletion request has been honoured |
| `fr` | l'exercice de votre droit à l'effacement | que votre demande de suppression a été honorée |
| `de` | Ihrem Recht auf Löschung entsprochen wurde | Ihrer Löschungsanforderung entsprochen wurde |
| `es` | el ejercicio de su derecho de supresión | que su solicitud de eliminación ha sido atendida |
| `it` | l'esercizio del Suo diritto alla cancellazione | che la Sua richiesta di cancellazione è stata onorata |
| `nl` | uw recht op verwijdering is gehonoreerd | uw verzoek tot verwijdering is gehonoreerd |
| `pt` | o exercício do seu direito ao apagamento | que o seu pedido de eliminação foi atendido |
| `pt-BR` | o exercício do seu direito de eliminação | que sua solicitação de exclusão foi atendida |
| `cs` | uplatnění Vašeho práva na výmaz | že Vaší žádosti o výmaz bylo vyhověno |
| `pl` | realizacji prawa do usunięcia danych | że Państwa żądanie usunięcia danych zostało zrealizowane |
| `sv` | din rätt till radering har tillgodosetts | din raderingsbegäran har tillgodosetts |
| `tr` | silme hakkınızın yerine getirildiğine | silme talebinizin yerine getirildiğine |
| `zh` | 您的删除权已得到落实 | 您的删除请求已得到处理 |
| `ja` | お客様の削除権が履行された | お客様の削除のご依頼が履行された |
| `ko` | 삭제권이 이행되었음을 | 삭제 요청이 이행되었음을 |
| `hi` | आपके विलोपन के अधिकार का सम्मान किया गया | आपके विलोपन अनुरोध को पूरा किया गया |

The `<!-- AUTO-TRANSLATED -->` markers (14 non-EN/FR cultures) are preserved
as-is — these are still machine translations awaiting native review.

## Verification

- `grep -E 'GDPR|RGPD|DSGVO|RODO|AVG|LGPD|Art\. 1[27]|art\. 1[27]'` over the
  16 templates → empty (no hardcoded regulation tokens).
- `grep` for "right to erasure" / per-language equivalents → empty.
- `dotnet build src/Granit.Privacy.Notifications` → 0 errors / 0 warnings.
- `dotnet test tests/Granit.Privacy.Notifications.Tests` → **271 passed / 0 failed**.
- `dotnet format src/Granit.Privacy.Notifications --verify-no-changes` → clean.
- `dotnet test tests/Granit.ArchitectureTests` → **150 passed / 0 failed**.
- Lockfile regeneration (`--force-evaluate`) refreshed `tests/Granit.ArchitectureTests/packages.lock.json`
  (transitive `Granit.Privacy.Regulations` entry + `Sep` minor bump from upstream drift); included in commit.

## Test plan

- [ ] Manual smoke: render `privacy.deletion_confirmed` for `Regulation = BR_LGPD`
  and confirm the body no longer references "right to erasure" wording.
- [ ] Visually skim each culture's `<p>compliance receipt…</p>` line to confirm
  the new phrasing reads naturally to a native speaker (10 of 16 are
  `AUTO-TRANSLATED` — review before production deploy per existing convention).
- [ ] CI green across all 6 shards.
