### PR TITLE
fix(customer-balance): add PartyId to CreditExpiredEto + user-target notification

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11429,7 +11429,7 @@
       "kind": "record",
       "project": "Granit.CustomerBalance.Notifications",
       "file": "src/Granit.CustomerBalance.Notifications/CreditExpiredNotificationType.cs",
-      "line": 38,
+      "line": 40,
       "members": []
     },
     {
@@ -11438,7 +11438,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Notifications",
       "file": "src/Granit.CustomerBalance.Notifications/CreditExpiredNotificationType.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "new",
@@ -11513,7 +11513,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Notifications",
       "file": "src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiredNotificationHandler.cs",
-      "line": 27,
+      "line": 15,
       "members": [
         {
           "name": "HandleAsync",

--- a/src/Granit.CustomerBalance.Notifications/CreditExpiredNotificationType.cs
+++ b/src/Granit.CustomerBalance.Notifications/CreditExpiredNotificationType.cs
@@ -4,12 +4,13 @@ namespace Granit.CustomerBalance.Notifications;
 
 /// <summary>
 /// Notification type for a credit that has expired and was deducted from the balance —
-/// fanned out to tenant administrators because <c>CreditExpiredEto</c> does not carry
-/// the owning party identifier (only <c>BalanceAccountId</c>).
+/// sent directly to the party (end user) who owned the balance so they are informed
+/// that value was lost from their account.
 /// </summary>
 /// <remarks>
 /// Channels: Email + InApp. <see cref="NotificationSeverity.Warning"/> — value was
-/// silently lost by the user, so admins should follow up or adjust expiration policy.
+/// silently lost by the user, so they should be made aware (and may choose to top up
+/// or contact support).
 /// </remarks>
 public sealed class CreditExpiredNotificationType
     : NotificationType<CreditExpiredNotificationData>
@@ -33,10 +34,12 @@ public sealed class CreditExpiredNotificationType
 /// </summary>
 /// <param name="BalanceAccountId">Balance account whose credit expired.</param>
 /// <param name="TenantId">Tenant owning the balance account.</param>
+/// <param name="PartyId">Party (end user) who owned the balance.</param>
 /// <param name="Amount">Amount that expired and was deducted from the balance, positive.</param>
 /// <param name="Currency">ISO 4217 currency code of the balance.</param>
 public sealed record CreditExpiredNotificationData(
     Guid BalanceAccountId,
     Guid TenantId,
+    Guid PartyId,
     decimal Amount,
     string Currency);

--- a/src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiredNotificationHandler.cs
+++ b/src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiredNotificationHandler.cs
@@ -4,25 +4,13 @@ using Granit.Notifications.Abstractions;
 namespace Granit.CustomerBalance.Notifications.Handlers;
 
 /// <summary>
-/// Handles <see cref="CreditExpiredEto"/> by fanning out a
-/// <see cref="CreditExpiredNotificationType"/> to every tenant administrator subscribed
-/// to that notification type.
+/// Handles <see cref="CreditExpiredEto"/> by sending a
+/// <see cref="CreditExpiredNotificationType"/> directly to the party (end user) who
+/// owned the balance, so they are informed that value was lost from their account.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Recipient strategy: <see cref="INotificationPublisher.PublishToSubscribersAsync{TData}"/>.
-/// Unlike <c>BalanceCreditedEto</c>, the <c>CreditExpiredEto</c> payload does not carry
-/// a <c>PartyId</c> (only <c>BalanceAccountId</c>), so we cannot directly address the
-/// owning end user. Admins opt in through the notifications admin UI and are
-/// tenant-scoped by the subscription engine — they can then follow up with the affected
-/// user or adjust the expiration policy.
-/// </para>
-/// <para>
-/// If <c>CreditExpiredEto</c> later grows a <c>PartyId</c> field, this handler should
-/// switch to <c>INotificationPublisher.PublishAsync</c> with
-/// <c>[evt.PartyId.ToString()]</c> as recipients, mirroring
-/// <see cref="CreditGrantedNotificationHandler"/>.
-/// </para>
+/// Recipient strategy: directly addressed to the owning <c>PartyId</c> — credit
+/// expiration is a per-user signal, mirroring <see cref="CreditGrantedNotificationHandler"/>.
 /// </remarks>
 public class CreditExpiredNotificationHandler
 {
@@ -31,13 +19,15 @@ public class CreditExpiredNotificationHandler
         INotificationPublisher publisher,
         CancellationToken cancellationToken)
     {
-        await publisher.PublishToSubscribersAsync(
+        await publisher.PublishAsync(
             CreditExpiredNotificationType.Instance,
             new CreditExpiredNotificationData(
                 evt.BalanceAccountId,
                 evt.TenantId,
+                evt.PartyId,
                 evt.Amount,
                 evt.Currency),
+            [evt.PartyId.ToString()],
             cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expired.fr.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expired.fr.html
@@ -1,22 +1,14 @@
-<title>Crédit expiré : {{ model.amount | math.format '0.00' }} {{ model.currency }}</title>
+<title>Votre crédit de {{ model.amount | math.format '0.00' }} {{ model.currency }} a expiré</title>
 <p>Bonjour,</p>
-<p>Un crédit promotionnel de <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
-   vient d'expirer sur le compte de solde
-   <code>{{ model.balance_account_id }}</code> et a été déduit du solde disponible.</p>
-<p>L'utilisateur concerné n'est pas notifié directement par cet e-mail — l'événement
-   d'intégration <code>CreditExpiredEto</code> ne transporte pas l'identifiant de la
-   partie propriétaire ; nous le routons donc vers les administrateurs du tenant.
-   Vous pouvez :</p>
-<ul>
-  <li><strong>Contacter le client concerné</strong> si le montant perdu est
-      significatif, ou</li>
-  <li><strong>Revoir votre politique d'expiration</strong> si les expirations sont
-      plus fréquentes que prévu.</li>
-</ul>
+<p>Nous vous informons que <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
+   de crédit promotionnel sur votre compte vient d'expirer et ont été déduits de
+   votre solde disponible.</p>
+<p>Si vous souhaitez continuer à utiliser la facturation par crédit, vous pouvez
+   recharger votre solde ou consulter votre compte à tout moment.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Examiner le solde</a>
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Consulter mon solde</a>
 </p>
-<p style="font-size: 13px; color: #4b5563;">Identifiant du solde : <code>{{ model.balance_account_id }}</code> &middot; Identifiant du tenant : <code>{{ model.tenant_id }}</code></p>
+<p style="font-size: 13px; color: #4b5563;">Identifiant du solde : <code>{{ model.balance_account_id }}</code></p>
 {{ if privacy.dpo_email }}
-<p style="font-size: 13px; color: #4b5563;">Une question ? Contactez notre équipe via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+<p style="font-size: 13px; color: #4b5563;">Une question sur vos données ? Contactez notre équipe via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
 {{ end }}

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expired.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expired.html
@@ -1,22 +1,14 @@
-<title>Credit expired: {{ model.amount | math.format '0.00' }} {{ model.currency }}</title>
+<title>Your credit of {{ model.amount | math.format '0.00' }} {{ model.currency }} has expired</title>
 <p>Hi,</p>
-<p>A promotional credit of <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
-   has just expired on balance account
-   <code>{{ model.balance_account_id }}</code> and was deducted from the available
-   balance.</p>
-<p>The owning user is not directly notified by this email — the
-   <code>CreditExpiredEto</code> integration event does not carry the owning party
-   identifier, so we route it to tenant administrators instead. You may want to:</p>
-<ul>
-  <li><strong>Reach out to the affected customer</strong> if the lost amount is
-      material, or</li>
-  <li><strong>Review your expiration policy</strong> if expirations are happening more
-      often than expected.</li>
-</ul>
+<p>We're letting you know that <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
+   of promotional credit on your account has just expired and was deducted from your
+   available balance.</p>
+<p>If you'd like to keep using credit-based billing, you can top up your balance or
+   review your account at any time.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Review balance</a>
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View my balance</a>
 </p>
-<p style="font-size: 13px; color: #4b5563;">Balance id: <code>{{ model.balance_account_id }}</code> &middot; Tenant id: <code>{{ model.tenant_id }}</code></p>
+<p style="font-size: 13px; color: #4b5563;">Balance id: <code>{{ model.balance_account_id }}</code></p>
 {{ if privacy.dpo_email }}
-<p style="font-size: 13px; color: #4b5563;">Questions? Contact our team via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+<p style="font-size: 13px; color: #4b5563;">Questions about your data? Contact our team via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
 {{ end }}

--- a/src/Granit.CustomerBalance/Events/CreditExpiredEto.cs
+++ b/src/Granit.CustomerBalance/Events/CreditExpiredEto.cs
@@ -6,5 +6,6 @@ namespace Granit.CustomerBalance.Events;
 public sealed record CreditExpiredEto(
     Guid BalanceAccountId,
     Guid TenantId,
+    Guid PartyId,
     decimal Amount,
     string Currency) : IIntegrationEvent;

--- a/src/Granit.CustomerBalance/Internal/DefaultCreditExpirationService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultCreditExpirationService.cs
@@ -70,7 +70,7 @@ internal sealed partial class DefaultCreditExpirationService(
             await accountWriter.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
 
             await eventBus.PublishAsync(
-                new CreditExpiredEto(account.Id, account.TenantId!.Value, amountToExpire, account.Currency),
+                new CreditExpiredEto(account.Id, account.TenantId!.Value, account.PartyId.Value, amountToExpire, account.Currency),
                 cancellationToken).ConfigureAwait(false);
 
             metrics.RecordExpired(account.TenantId.Value.ToString(), account.Currency);

--- a/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/CreditExpiredNotificationHandlerTests.cs
+++ b/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/CreditExpiredNotificationHandlerTests.cs
@@ -9,14 +9,16 @@ namespace Granit.CustomerBalance.Notifications.Tests.Handlers;
 public sealed class CreditExpiredNotificationHandlerTests
 {
     [Fact]
-    public async Task HandleAsync_PublishesCreditExpiredNotification_ToSubscribers()
+    public async Task HandleAsync_PublishesCreditExpiredNotification_ToOwningParty()
     {
         INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
         var balanceAccountId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
         CreditExpiredEto evt = new(
             BalanceAccountId: balanceAccountId,
             TenantId: tenantId,
+            PartyId: partyId,
             Amount: 12.50m,
             Currency: "EUR");
 
@@ -25,13 +27,15 @@ public sealed class CreditExpiredNotificationHandlerTests
             publisher,
             CancellationToken.None);
 
-        await publisher.Received(1).PublishToSubscribersAsync(
+        await publisher.Received(1).PublishAsync(
             CreditExpiredNotificationType.Instance,
             Arg.Is<CreditExpiredNotificationData>(d =>
                 d.BalanceAccountId == balanceAccountId &&
                 d.TenantId == tenantId &&
+                d.PartyId == partyId &&
                 d.Amount == 12.50m &&
                 d.Currency == "EUR"),
+            Arg.Is<IReadOnlyList<string>>(r => r.Count == 1 && r[0] == partyId.ToString()),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpirationServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpirationServiceTests.cs
@@ -123,7 +123,10 @@ public sealed class DefaultCreditExpirationServiceTests : IDisposable
         result.ShouldBe(1);
         await _accountWriter.Received(1).UpdateAsync(account, Arg.Any<CancellationToken>());
         await _eventBus.Received(1).PublishAsync(
-            Arg.Is<CreditExpiredEto>(e => e.Amount == 50m && e.Currency == "EUR"),
+            Arg.Is<CreditExpiredEto>(e =>
+                e.Amount == 50m
+                && e.Currency == "EUR"
+                && e.PartyId == account.PartyId.Value),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary

Closes #1364 (FU-6). `CreditExpiredEto` was missing `PartyId`, forcing
`customer-balance.credit_expired` to fall back to admin fan-out instead of
user-targeted delivery. This PR closes the data-model gap and retargets the
notification to the credit's owner.

## Changes

- **`CreditExpiredEto`** — added required positional `Guid PartyId` between `TenantId` and `Amount`, mirroring `BalanceCreditedEto`.
- **Producer** (`src/Granit.CustomerBalance/Internal/DefaultCreditExpirationService.cs`) — passes `account.PartyId.Value`, which was already available on `BalanceAccount`.
- **Notification handler** (`src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiredNotificationHandler.cs`) — switched from `PublishToSubscribersAsync(...)` (admin fan-out) to `PublishAsync(..., [evt.PartyId.ToString()], ...)` (user-targeted), matching `CreditGrantedNotificationHandler`.
- **Notification data** (`CreditExpiredNotificationType.cs`) — added `PartyId` to `CreditExpiredNotificationData` + updated XML doc.
- **Templates** — shifted both `customer-balance.credit_expired.html` and `.fr.html` from admin voice ("A credit owned by X has expired", admin balance link) to user voice ("Your credit has expired", `/balance/{id}` CTA).
- **Tests** — `CreditExpiredNotificationHandlerTests` now asserts `PublishAsync` with single recipient `[partyId.ToString()]`; `DefaultCreditExpirationServiceTests` asserts `e.PartyId == account.PartyId.Value`.

## In-repo consumers audit

`grep -rn "CreditExpiredEto" src tests --include="*.cs"`:

- Producer: `src/Granit.CustomerBalance/Internal/DefaultCreditExpirationService.cs` — updated.
- Consumer: `src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiredNotificationHandler.cs` — updated.
- Tests: `Granit.CustomerBalance.Tests`, `Granit.CustomerBalance.Notifications.Tests` — updated.

**No other in-repo consumers exist.**

## Before / after handler

```csharp
// BEFORE (admin fan-out)
await publisher.PublishToSubscribersAsync(
    CreditExpiredNotificationType.Instance,
    new CreditExpiredNotificationData(evt.BalanceAccountId, evt.TenantId, evt.Amount, evt.Currency),
    cancellationToken).ConfigureAwait(false);

// AFTER (user-targeted)
await publisher.PublishAsync(
    CreditExpiredNotificationType.Instance,
    new CreditExpiredNotificationData(evt.BalanceAccountId, evt.TenantId, evt.PartyId, evt.Amount, evt.Currency),
    [evt.PartyId.ToString()],
    cancellationToken).ConfigureAwait(false);
```

## Migration note (downstream apps)

This is a **breaking change to the `CreditExpiredEto` contract**. The
positional record now reads:

```csharp
public sealed record CreditExpiredEto(
    Guid BalanceAccountId,
    Guid TenantId,
    Guid PartyId,        // NEW — inserted between TenantId and Amount
    decimal Amount,
    string Currency) : IIntegrationEvent;
```

Downstream apps (other repos) that produce or consume this Eto must update
their construction sites / handlers to supply or destructure the new
positional parameter. Within `granit-dotnet` the only consumer was the
Notifications handler, which is updated in this PR.

## Verification

- `dotnet build src/Granit.CustomerBalance` — 0 warnings, 0 errors
- `dotnet build src/Granit.CustomerBalance.Notifications` — 0 warnings, 0 errors
- `dotnet test tests/Granit.CustomerBalance.Tests` — **51 / 51 passed**
- `dotnet test tests/Granit.CustomerBalance.Notifications.Tests` — **10 / 10 passed**
- `dotnet test tests/Granit.ArchitectureTests` — **150 / 150 passed**
- `dotnet format --verify-no-changes` — clean on `src/Granit.CustomerBalance`, `src/Granit.CustomerBalance.Notifications`, `tests/Granit.CustomerBalance.Tests`, `tests/Granit.CustomerBalance.Notifications.Tests`
- Lockfiles: `dotnet restore --force-evaluate` ran on all four affected projects (`src/Granit.CustomerBalance`, `src/Granit.CustomerBalance.Notifications`, `tests/Granit.CustomerBalance.Tests`, `tests/Granit.CustomerBalance.Notifications.Tests`) — no per-project lockfile drift.

## Test plan

- [x] Producer test `ExpireCreditsAsync_WithBalance_ShouldDebitAndPublishEvent` asserts `PartyId` flows through to the Eto
- [x] Handler test asserts single-recipient publish (`[partyId.ToString()]`) instead of admin fan-out
- [x] Architecture tests pass (Eto naming + Wolverine handler conventions)
- [ ] Downstream apps coordinate the breaking change at integration time (covered by migration note)
