### PR TITLE
feat(subscriptions): SubscriptionPartyReferenceRewriter (#1289)

### DIFF
--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -121,6 +121,7 @@
       "tests/Granit.Subscriptions.BackgroundJobs.Tests/Granit.Subscriptions.BackgroundJobs.Tests.csproj",
       "tests/Granit.Subscriptions.Builtin.Tests/Granit.Subscriptions.Builtin.Tests.csproj",
       "tests/Granit.Subscriptions.Endpoints.Tests/Granit.Subscriptions.Endpoints.Tests.csproj",
+      "tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Granit.Subscriptions.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Subscriptions.Features.Tests/Granit.Subscriptions.Features.Tests.csproj",
       "tests/Granit.Subscriptions.Notifications.Tests/Granit.Subscriptions.Notifications.Tests.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -315,6 +315,7 @@
         "tests/Granit.Subscriptions.BackgroundJobs.Tests",
         "tests/Granit.Subscriptions.Endpoints.Tests",
         "tests/Granit.Subscriptions.EntityFrameworkCore.Tests",
+        "tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration",
         "tests/Granit.Subscriptions.Features.Tests",
         "tests/Granit.Subscriptions.Builtin.Tests",
         "tests/Granit.Subscriptions.Notifications.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2174,6 +2174,8 @@
       "name": "Granit.Subscriptions.EntityFrameworkCore",
       "deps": [
         "Granit.Guids",
+        "Granit.Mergeable",
+        "Granit.Parties",
         "Granit.Persistence.EntityFrameworkCore",
         "Granit.Subscriptions"
       ],
@@ -43189,7 +43191,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.EntityFrameworkCore",
       "file": "src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitSubscriptionsEntityFrameworkCore",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -352,6 +352,7 @@
       "tests/Granit.Subscriptions.BackgroundJobs.Tests/Granit.Subscriptions.BackgroundJobs.Tests.csproj",
       "tests/Granit.Subscriptions.Builtin.Tests/Granit.Subscriptions.Builtin.Tests.csproj",
       "tests/Granit.Subscriptions.Endpoints.Tests/Granit.Subscriptions.Endpoints.Tests.csproj",
+      "tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Granit.Subscriptions.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Subscriptions.Features.Tests/Granit.Subscriptions.Features.Tests.csproj",
       "tests/Granit.Subscriptions.Notifications.Tests/Granit.Subscriptions.Notifications.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -234,6 +234,7 @@
       "tests/Granit.Subscriptions.BackgroundJobs.Tests/Granit.Subscriptions.BackgroundJobs.Tests.csproj",
       "tests/Granit.Subscriptions.Builtin.Tests/Granit.Subscriptions.Builtin.Tests.csproj",
       "tests/Granit.Subscriptions.Endpoints.Tests/Granit.Subscriptions.Endpoints.Tests.csproj",
+      "tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Granit.Subscriptions.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Subscriptions.Features.Tests/Granit.Subscriptions.Features.Tests.csproj",
       "tests/Granit.Subscriptions.Notifications.Tests/Granit.Subscriptions.Notifications.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -613,6 +613,7 @@
     <Project Path="tests/Granit.Subscriptions.Builtin.Tests/Granit.Subscriptions.Builtin.Tests.csproj" />
     <Project Path="tests/Granit.Subscriptions.Endpoints.Tests/Granit.Subscriptions.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Subscriptions.EntityFrameworkCore.Tests/Granit.Subscriptions.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Subscriptions.Features.Tests/Granit.Subscriptions.Features.Tests.csproj" />
     <Project Path="tests/Granit.Subscriptions.Notifications.Tests/Granit.Subscriptions.Notifications.Tests.csproj" />
     <Project Path="tests/Granit.Subscriptions.Tests/Granit.Subscriptions.Tests.csproj" />

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.Mergeable.Extensions;
+using Granit.Parties.Domain;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Granit.Subscriptions.Domain;
@@ -33,6 +35,11 @@ public static class SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtens
         builder.Services.TryAddScoped<IPricingResolver, EfPricingResolver>();
 
         builder.Services.AddScoped<IQueryableSource<Subscription>, EfSubscriptionQueryableSource>();
+
+        // Plugs Subscriptions into the Party merge orchestrator. Unconditional registration:
+        // when no IMergeService<Party> is wired up by the host (e.g. an app without merging),
+        // the rewriter just sits idle in DI at zero runtime cost.
+        builder.Services.AddReferenceRewriter<Party, SubscriptionPartyReferenceRewriter>();
 
         return builder;
     }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Granit.Subscriptions.EntityFrameworkCore.csproj
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Granit.Subscriptions.EntityFrameworkCore.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Subscriptions.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Subscriptions.EntityFrameworkCore.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
@@ -18,6 +19,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.Mergeable\Granit.Mergeable.csproj" />
+    <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Subscriptions\Granit.Subscriptions.csproj" />
   </ItemGroup>

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPartyReferenceRewriter.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionPartyReferenceRewriter.cs
@@ -1,0 +1,66 @@
+using Granit.Mergeable;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Bulk SQL rewriter that redirects <see cref="Subscription.PartyId"/> from a merged-out
+/// (loser) party onto the surviving party. Discovered automatically by the merge
+/// orchestrator (<c>EfMergeService&lt;Party&gt;</c>) via DI registration as
+/// <c>IReferenceRewriter&lt;Party&gt;</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Active subscriptions are rewritten too. The legal billing relationship transfers to
+/// the survivor: the next renewal cycle bills the survivor's payment instrument, the
+/// surviving billing address, and so on. Tax computation runs against the survivor's
+/// <c>TaxStatus</c> (which has already been resolved by <c>Party.MergeFrom</c>), so a
+/// reverse-charge or VAT-exempt loser correctly surfaces on the survivor's renewals
+/// after merge.
+/// </para>
+/// <para>
+/// Lives next to <c>SubscriptionsDbContext</c> rather than in a dedicated
+/// <c>Granit.Subscriptions.Mergeable</c> package — the rewriter is intrinsically a
+/// SQL/persistence concern and a separate package would be plumbing for plumbing's
+/// sake. <c>Granit.Subscriptions.EntityFrameworkCore</c> takes a contracts-only
+/// dependency on <c>Granit.Mergeable</c> (no runtime). Hosts that don't enable merging
+/// pay only the DI registration line; with no <c>IMergeService&lt;Party&gt;</c> wired
+/// up the rewriter is a no-op.
+/// </para>
+/// </remarks>
+internal sealed class SubscriptionPartyReferenceRewriter(
+    IDbContextFactory<SubscriptionsDbContext> contextFactory) : IReferenceRewriter<Party>
+{
+    /// <inheritdoc />
+    public string Description => "Subscription.PartyId";
+
+    /// <inheritdoc />
+    public async Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using SubscriptionsDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var loser = PartyId.Create(loserId);
+        var survivor = PartyId.Create(survivorId);
+
+        return await db.Subscriptions
+            .Where(s => s.PartyId == loser)
+            .ExecuteUpdateAsync(s => s.SetProperty(x => x.PartyId, survivor), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using SubscriptionsDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var loser = PartyId.Create(loserId);
+
+        return await db.Subscriptions
+            .Where(s => s.PartyId == loser)
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3142,6 +3142,7 @@
         "dependencies": {
           "Granit.Notifications.Abstractions": "[0.1.0-dev, )",
           "Granit.Privacy": "[0.1.0-dev, )",
+          "Granit.Privacy.Regulations": "[0.1.0-dev, )",
           "Granit.Templating": "[0.1.0-dev, )"
         }
       },
@@ -3359,6 +3360,8 @@
         "type": "Project",
         "dependencies": {
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
@@ -4440,8 +4443,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.12.5",
-        "contentHash": "yS1EgVf7a3QZ3hKN/B+Yh8kHbAvdtkDLdWf74sk3fFweLc4k9SSvMGig8k8lBK3iDXeVx9r7W44g/nBxYFIuLw==",
+        "resolved": "0.13.0",
+        "contentHash": "C7rx/q7K6cF8Z2FVCg6z0z4uIqo+cC2Ge1Yaq9ThMaODQBozJ7FNCwMxiK7JeUC9x9roUUmHUJ1aAnXkdWzjNg==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);EF1001;EF1002;EF1003</NoWarn>
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Subscriptions.EntityFrameworkCore\Granit.Subscriptions.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,19 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Starts a PostgreSQL 17 container shared by the integration tests in this assembly.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/SubscriptionPartyReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/SubscriptionPartyReferenceRewriterPostgresTests.cs
@@ -1,0 +1,120 @@
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Granit.Subscriptions.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres integration tests for <see cref="SubscriptionPartyReferenceRewriter"/>.
+/// <c>ExecuteUpdateAsync</c> requires a relational provider, so the EF in-memory
+/// provider isn't a substitute.
+/// </summary>
+public sealed class SubscriptionPartyReferenceRewriterPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestSubscriptionsDbContextFactory _factory = null!;
+    private SubscriptionPartyReferenceRewriter _sut = null!;
+
+    public SubscriptionPartyReferenceRewriterPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        _factory = new TestSubscriptionsDbContextFactory(_postgres.ConnectionString);
+        await using SubscriptionsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        // Truncate every Subscriptions table so each test starts clean. The schema is
+        // discovered through GranitSubscriptionsDbProperties so the test stays aligned with
+        // a future prefix change.
+        string p = GranitSubscriptionsDbProperties.DbTablePrefix;
+        await db.Database.ExecuteSqlRawAsync(
+            $"TRUNCATE TABLE "
+            + $"{p}subscription_external_mappings, {p}subscription_phases, {p}subscription_seats, {p}subscriptions, "
+            + $"{p}plan_external_mappings, {p}plan_feature_values, {p}pricing_tiers, {p}plan_prices, {p}plans "
+            + "RESTART IDENTITY CASCADE;",
+            TestContext.Current.CancellationToken);
+
+        _sut = new SubscriptionPartyReferenceRewriter(_factory);
+    }
+
+    public ValueTask DisposeAsync() => _factory?.DisposeAsync() ?? ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task RewriteAsync_RedirectsLoserSubscriptionsOntoSurvivor()
+    {
+        var survivorId = Guid.NewGuid();
+        var loserId = Guid.NewGuid();
+        var otherPartyId = Guid.NewGuid();
+
+        await SeedAsync(
+            NewSubscription(loserId),
+            NewSubscription(loserId),
+            NewSubscription(survivorId),
+            NewSubscription(otherPartyId));
+
+        int rewritten = await _sut.RewriteAsync(survivorId, loserId, TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(2);
+
+        await using SubscriptionsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var survivorPartyId = PartyId.Create(survivorId);
+        int survivorCount = await db.Subscriptions
+            .CountAsync(s => s.PartyId == survivorPartyId, TestContext.Current.CancellationToken);
+        survivorCount.ShouldBe(3);
+
+        var loserPartyId = PartyId.Create(loserId);
+        int loserCount = await db.Subscriptions
+            .CountAsync(s => s.PartyId == loserPartyId, TestContext.Current.CancellationToken);
+        loserCount.ShouldBe(0);
+
+        var otherPartyIdValueObject = PartyId.Create(otherPartyId);
+        int otherCount = await db.Subscriptions
+            .CountAsync(s => s.PartyId == otherPartyIdValueObject, TestContext.Current.CancellationToken);
+        otherCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RewriteAsync_ReturnsZero_WhenLoserHasNoSubscriptions()
+    {
+        int rewritten = await _sut.RewriteAsync(Guid.NewGuid(), Guid.NewGuid(), TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CountAsync_ReturnsLoserSubscriptionCount_WithoutMutating()
+    {
+        var loserId = Guid.NewGuid();
+        await SeedAsync(NewSubscription(loserId), NewSubscription(loserId));
+
+        int count = await _sut.CountAsync(Guid.NewGuid(), loserId, TestContext.Current.CancellationToken);
+        count.ShouldBe(2);
+
+        await using SubscriptionsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var loserPartyId = PartyId.Create(loserId);
+        int still = await db.Subscriptions
+            .CountAsync(s => s.PartyId == loserPartyId, TestContext.Current.CancellationToken);
+        still.ShouldBe(2);
+    }
+
+    private async Task SeedAsync(params Subscription[] subscriptions)
+    {
+        await using SubscriptionsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Subscriptions.AddRange(subscriptions);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static Subscription NewSubscription(Guid partyId)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        return Subscription.Create(
+            id: SubscriptionId.Create(Guid.NewGuid()),
+            tenantId: Guid.NewGuid(),
+            contactId: PartyId.Create(partyId),
+            planId: PlanId.Create(Guid.NewGuid()),
+            currency: "EUR",
+            period: new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));
+    }
+}

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/TestSubscriptionsDbContextFactory.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/TestSubscriptionsDbContextFactory.cs
@@ -1,0 +1,23 @@
+using Granit.Subscriptions.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Tests.Integration;
+
+internal sealed class TestSubscriptionsDbContextFactory : IDbContextFactory<SubscriptionsDbContext>, IAsyncDisposable
+{
+    private readonly DbContextOptions<SubscriptionsDbContext> _options;
+
+    public TestSubscriptionsDbContextFactory(string connectionString)
+    {
+        _options = new DbContextOptionsBuilder<SubscriptionsDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+    }
+
+    public SubscriptionsDbContext CreateDbContext() => new(_options);
+
+    public Task<SubscriptionsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(new SubscriptionsDbContext(_options));
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -2,36 +2,128 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.EntityFrameworkCore.Relational": {
+      "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "requested": "[18.*, )",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
         }
       },
-      "Microsoft.Extensions.Hosting.Abstractions": {
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
         }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -104,6 +196,174 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
       },
       "ZString": {
         "type": "Transitive",
@@ -282,6 +542,18 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.subscriptions.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Subscriptions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +580,18 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
           "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
           "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
           "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
@@ -370,6 +654,19 @@
           "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Localization": {

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -392,6 +392,13 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
@@ -408,6 +415,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.parties.abstractions": {
@@ -485,6 +504,8 @@
         "type": "Project",
         "dependencies": {
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",


### PR DESCRIPTION
## Summary

Story M7 of the Party merge plan ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) → [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).

`SubscriptionPartyReferenceRewriter` redirects `Subscription.PartyId` from a merged-out (loser) party onto the surviving party via a single `ExecuteUpdateAsync`. Discovered automatically by the merge orchestrator through DI registration as `IReferenceRewriter<Party>`.

## Placement — same as #1288

Inlined in `Granit.Subscriptions.EntityFrameworkCore.Internal/`, not in a dedicated `*.Mergeable` package. Reasoning identical to [#1358](https://github.com/granit-fx/granit-dotnet/pull/1358) — the rewriter is a SQL/persistence concern that belongs next to the `SubscriptionsDbContext` that owns the FK.

New project references on `Granit.Subscriptions.EntityFrameworkCore`:
- `Granit.Mergeable` (contracts only — `Granit` + `Microsoft.Extensions.DependencyInjection.Abstractions`, no runtime)
- `Granit.Parties` (full domain — Subscriptions previously only referenced `Granit.Parties.Abstractions` for `PartyId`, but the rewriter's `IReferenceRewriter<Party>` signature requires the `Party` type)

## Edge case — active subscriptions are rewritten too

The legal billing relationship transfers to the survivor: the next renewal cycle bills the survivor's payment instrument and addresses. Tax computation runs against the survivor's `TaxStatus` (already resolved by `Party.MergeFrom`).

## Test plan

`Granit.Subscriptions.EntityFrameworkCore.Tests.Integration` — new project, Postgres 17 via Testcontainers.

- [x] `RewriteAsync_RedirectsLoserSubscriptionsOntoSurvivor` — moves loser subscriptions onto the survivor; survivor + unrelated party subscriptions stay intact.
- [x] `RewriteAsync_ReturnsZero_WhenLoserHasNoSubscriptions` — no-op path.
- [x] `CountAsync_ReturnsLoserSubscriptionCount_WithoutMutating` — dry-run is read-only.
- [x] All 3 tests pass under Testcontainers.
- [x] `Granit.ArchitectureTests` 150/150.
- [x] `dotnet format --verify-no-changes` clean.

Refs #1289
