### PR TITLE
feat(customer-balance): BalanceAccountPartyReferenceRewriter (#1290)

### DIFF
--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -89,6 +89,7 @@
       "tests/Granit.Catalog.Tests/Granit.Catalog.Tests.csproj",
       "tests/Granit.CustomerBalance.BackgroundJobs.Tests/Granit.CustomerBalance.BackgroundJobs.Tests.csproj",
       "tests/Granit.CustomerBalance.Endpoints.Tests/Granit.CustomerBalance.Endpoints.Tests.csproj",
+      "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.CustomerBalance.Notifications.Tests/Granit.CustomerBalance.Notifications.Tests.csproj",
       "tests/Granit.CustomerBalance.Tests/Granit.CustomerBalance.Tests.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -338,6 +338,7 @@
         "tests/Granit.Payments.SepaTransfer.Tests",
         "tests/Granit.CustomerBalance.Tests",
         "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests",
+        "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration",
         "tests/Granit.CustomerBalance.Endpoints.Tests",
         "tests/Granit.CustomerBalance.BackgroundJobs.Tests",
         "tests/Granit.CustomerBalance.Notifications.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -541,6 +541,8 @@
       "name": "Granit.CustomerBalance.EntityFrameworkCore",
       "deps": [
         "Granit.CustomerBalance",
+        "Granit.Mergeable",
+        "Granit.Parties",
         "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
@@ -11123,7 +11125,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.EntityFrameworkCore",
       "file": "src/Granit.CustomerBalance.EntityFrameworkCore/Extensions/CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitCustomerBalanceEntityFrameworkCore",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -238,6 +238,7 @@
       "tests/Granit.Catalog.Tests/Granit.Catalog.Tests.csproj",
       "tests/Granit.CustomerBalance.BackgroundJobs.Tests/Granit.CustomerBalance.BackgroundJobs.Tests.csproj",
       "tests/Granit.CustomerBalance.Endpoints.Tests/Granit.CustomerBalance.Endpoints.Tests.csproj",
+      "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.CustomerBalance.Notifications.Tests/Granit.CustomerBalance.Notifications.Tests.csproj",
       "tests/Granit.CustomerBalance.Tests/Granit.CustomerBalance.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -155,6 +155,7 @@
       "tests/Granit.Catalog.Tests/Granit.Catalog.Tests.csproj",
       "tests/Granit.CustomerBalance.BackgroundJobs.Tests/Granit.CustomerBalance.BackgroundJobs.Tests.csproj",
       "tests/Granit.CustomerBalance.Endpoints.Tests/Granit.CustomerBalance.Endpoints.Tests.csproj",
+      "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.CustomerBalance.Notifications.Tests/Granit.CustomerBalance.Notifications.Tests.csproj",
       "tests/Granit.CustomerBalance.Tests/Granit.CustomerBalance.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -574,6 +574,7 @@
     <Project Path="tests/Granit.CustomerBalance.BackgroundJobs.Tests/Granit.CustomerBalance.BackgroundJobs.Tests.csproj" />
     <Project Path="tests/Granit.CustomerBalance.Endpoints.Tests/Granit.CustomerBalance.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.CustomerBalance.EntityFrameworkCore.Tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj" />
     <Project Path="tests/Granit.CustomerBalance.Notifications.Tests/Granit.CustomerBalance.Notifications.Tests.csproj" />
     <Project Path="tests/Granit.CustomerBalance.Tests/Granit.CustomerBalance.Tests.csproj" />
     <Project Path="tests/Granit.Identity.Local.Notifications.Tests/Granit.Identity.Local.Notifications.Tests.csproj" />

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Extensions/CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Extensions/CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
 using Granit.CustomerBalance.EntityFrameworkCore.Internal;
+using Granit.Mergeable.Extensions;
+using Granit.Parties.Domain;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +24,11 @@ public static class CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExte
         builder.Services.TryAddScoped<IBalanceAccountWriter>(sp => sp.GetRequiredService<EfBalanceAccountStore>());
 
         builder.Services.TryAddScoped<IBalanceTransactionReader, EfBalanceTransactionReader>();
+
+        // Plugs CustomerBalance into the Party merge orchestrator. Unconditional registration:
+        // when no IMergeService<Party> is wired up by the host, the rewriter just sits idle in
+        // DI at zero runtime cost.
+        builder.Services.AddReferenceRewriter<Party, BalanceAccountPartyReferenceRewriter>();
 
         return builder;
     }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.CustomerBalance.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
@@ -18,6 +19,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.CustomerBalance\Granit.CustomerBalance.csproj" />
+    <ProjectReference Include="..\Granit.Mergeable\Granit.Mergeable.csproj" />
+    <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountPartyReferenceRewriter.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountPartyReferenceRewriter.cs
@@ -1,0 +1,77 @@
+using Granit.CustomerBalance.Domain;
+using Granit.Mergeable;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.CustomerBalance.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Bulk SQL rewriter that redirects <see cref="BalanceAccount.PartyId"/> from a
+/// merged-out (loser) party onto the surviving party. Discovered automatically by the
+/// merge orchestrator (<c>EfMergeService&lt;Party&gt;</c>) via DI registration as
+/// <c>IReferenceRewriter&lt;Party&gt;</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only the <c>BalanceAccount.PartyId</c> column is rewritten. The downstream
+/// <c>BalanceTransaction</c> rows reference the account via <c>AccountId</c> (the
+/// account's primary key), not the party — re-pointing the account onto the survivor
+/// preserves the entire ledger history without touching individual transactions.
+/// </para>
+/// <para>
+/// <b>Cardinality caveat — same-currency collision.</b> The per-party, per-currency
+/// uniqueness constraint on <c>BalanceAccount</c> means that if loser and survivor both
+/// hold an account in the same currency, this rewriter's bulk <c>UPDATE</c> would
+/// produce two rows violating the unique index — the database surfaces the error and
+/// the orchestrator's <see cref="System.Transactions.TransactionScope"/> rolls back the
+/// entire merge. v1 deliberately lets this fail rather than silently consolidate, so
+/// the operator is forced to make the consolidation decision explicitly. Real-world
+/// consolidation (sum balances, repoint transactions, soft-delete loser account, emit
+/// audit event) is tracked as
+/// <see href="https://github.com/granit-fx/granit-dotnet/issues/1402">tech-debt #1402
+/// — IMergeConsolidator&lt;T&gt; + BalanceAccount consolidation</see>; until that lands,
+/// admins must reconcile the loser's balance off-merge and re-attempt.
+/// </para>
+/// <para>
+/// Lives next to <c>CustomerBalanceDbContext</c> rather than in a dedicated
+/// <c>Granit.CustomerBalance.Mergeable</c> package — same rationale as
+/// <c>InvoicePartyReferenceRewriter</c> (#1288) and
+/// <c>SubscriptionPartyReferenceRewriter</c> (#1289): the rewriter is a SQL/persistence
+/// concern next to the DbContext that owns the FK; a dedicated package would be
+/// plumbing for plumbing's sake.
+/// </para>
+/// </remarks>
+internal sealed class BalanceAccountPartyReferenceRewriter(
+    IDbContextFactory<CustomerBalanceDbContext> contextFactory) : IReferenceRewriter<Party>
+{
+    /// <inheritdoc />
+    public string Description => "BalanceAccount.PartyId";
+
+    /// <inheritdoc />
+    public async Task<int> RewriteAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using CustomerBalanceDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var loser = PartyId.Create(loserId);
+        var survivor = PartyId.Create(survivorId);
+
+        return await db.Accounts
+            .Where(a => a.PartyId == loser)
+            .ExecuteUpdateAsync(s => s.SetProperty(a => a.PartyId, survivor), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountAsync(Guid survivorId, Guid loserId, CancellationToken cancellationToken)
+    {
+        await using CustomerBalanceDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var loser = PartyId.Create(loserId);
+
+        return await db.Accounts
+            .Where(a => a.PartyId == loser)
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
@@ -144,6 +144,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.parties": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.parties.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1908,6 +1908,8 @@
         "type": "Project",
         "dependencies": {
           "Granit.CustomerBalance": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/BalanceAccountPartyReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/BalanceAccountPartyReferenceRewriterPostgresTests.cs
@@ -1,0 +1,134 @@
+using System.Data.Common;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.EntityFrameworkCore.Internal;
+using Granit.Parties.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres integration tests for <see cref="BalanceAccountPartyReferenceRewriter"/>.
+/// <c>ExecuteUpdateAsync</c> requires a relational provider, so the EF in-memory
+/// provider isn't a substitute.
+/// </summary>
+public sealed class BalanceAccountPartyReferenceRewriterPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestCustomerBalanceDbContextFactory _factory = null!;
+    private BalanceAccountPartyReferenceRewriter _sut = null!;
+
+    public BalanceAccountPartyReferenceRewriterPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        _factory = new TestCustomerBalanceDbContextFactory(_postgres.ConnectionString);
+        await using CustomerBalanceDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        string p = GranitCustomerBalanceDbProperties.DbTablePrefix;
+        await db.Database.ExecuteSqlRawAsync(
+            $"TRUNCATE TABLE {p}transactions, {p}accounts RESTART IDENTITY CASCADE;",
+            TestContext.Current.CancellationToken);
+
+        _sut = new BalanceAccountPartyReferenceRewriter(_factory);
+    }
+
+    public ValueTask DisposeAsync() => _factory?.DisposeAsync() ?? ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task RewriteAsync_RedirectsLoserAccountsOntoSurvivor()
+    {
+        var survivorId = Guid.NewGuid();
+        var loserId = Guid.NewGuid();
+        var otherPartyId = Guid.NewGuid();
+
+        // Distinct currencies on loser to avoid the per-currency uniqueness collision noted on
+        // the rewriter (cardinality caveat — same-currency same-survivor is documented as
+        // domain-level tech-debt for v2).
+        await SeedAsync(
+            NewAccount(loserId, "EUR"),
+            NewAccount(loserId, "USD"),
+            NewAccount(survivorId, "GBP"),
+            NewAccount(otherPartyId, "EUR"));
+
+        int rewritten = await _sut.RewriteAsync(survivorId, loserId, TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(2);
+
+        await using CustomerBalanceDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var survivorPartyId = PartyId.Create(survivorId);
+        int survivorCount = await db.Accounts
+            .CountAsync(a => a.PartyId == survivorPartyId, TestContext.Current.CancellationToken);
+        survivorCount.ShouldBe(3);
+
+        var loserPartyId = PartyId.Create(loserId);
+        int loserCount = await db.Accounts
+            .CountAsync(a => a.PartyId == loserPartyId, TestContext.Current.CancellationToken);
+        loserCount.ShouldBe(0);
+
+        var otherPartyIdValueObject = PartyId.Create(otherPartyId);
+        int otherCount = await db.Accounts
+            .CountAsync(a => a.PartyId == otherPartyIdValueObject, TestContext.Current.CancellationToken);
+        otherCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RewriteAsync_SurfacesUniqueConstraint_OnSameCurrencyCollision()
+    {
+        // Documents the v1 behaviour: when both parties have an account in the same currency,
+        // the per-(PartyId, Currency) unique index fires post-rewrite and the orchestrator's
+        // TransactionScope rolls back. Real consolidation is tech-debt #1402.
+        var survivorId = Guid.NewGuid();
+        var loserId = Guid.NewGuid();
+
+        await SeedAsync(NewAccount(survivorId, "EUR"), NewAccount(loserId, "EUR"));
+
+        // ExecuteUpdateAsync bypasses the change tracker, so the provider surfaces the unique
+        // constraint violation directly as a DbException — Npgsql.PostgresException
+        // (SqlState 23505) on PostgreSQL, Microsoft.Data.SqlClient.SqlException
+        // (Number 2627 / 2601) on SQL Server. Asserting on the common DbException base type
+        // keeps the test provider-agnostic; the contract we document is "the database
+        // surfaces an error and the orchestrator's TransactionScope rolls back", not the
+        // specific SqlState code.
+        await Should.ThrowAsync<DbException>(() =>
+            _sut.RewriteAsync(survivorId, loserId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RewriteAsync_ReturnsZero_WhenLoserHasNoAccounts()
+    {
+        int rewritten = await _sut.RewriteAsync(Guid.NewGuid(), Guid.NewGuid(), TestContext.Current.CancellationToken);
+        rewritten.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CountAsync_ReturnsLoserAccountCount_WithoutMutating()
+    {
+        var loserId = Guid.NewGuid();
+        await SeedAsync(NewAccount(loserId, "EUR"), NewAccount(loserId, "USD"));
+
+        int count = await _sut.CountAsync(Guid.NewGuid(), loserId, TestContext.Current.CancellationToken);
+        count.ShouldBe(2);
+
+        await using CustomerBalanceDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var loserPartyId = PartyId.Create(loserId);
+        int still = await db.Accounts
+            .CountAsync(a => a.PartyId == loserPartyId, TestContext.Current.CancellationToken);
+        still.ShouldBe(2);
+    }
+
+    private async Task SeedAsync(params BalanceAccount[] accounts)
+    {
+        await using CustomerBalanceDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Accounts.AddRange(accounts);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static BalanceAccount NewAccount(Guid partyId, string currency) =>
+        BalanceAccount.Create(
+            id: Guid.NewGuid(),
+            tenantId: Guid.NewGuid(),
+            contactId: PartyId.Create(partyId),
+            currency: currency);
+}

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);EF1001;EF1002;EF1003</NoWarn>
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.CustomerBalance.EntityFrameworkCore\Granit.CustomerBalance.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,17 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>Starts a PostgreSQL 17 container shared by the integration tests in this assembly.</summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/TestCustomerBalanceDbContextFactory.cs
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/TestCustomerBalanceDbContextFactory.cs
@@ -1,0 +1,23 @@
+using Granit.CustomerBalance.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration;
+
+internal sealed class TestCustomerBalanceDbContextFactory : IDbContextFactory<CustomerBalanceDbContext>, IAsyncDisposable
+{
+    private readonly DbContextOptions<CustomerBalanceDbContext> _options;
+
+    public TestCustomerBalanceDbContextFactory(string connectionString)
+    {
+        _options = new DbContextOptionsBuilder<CustomerBalanceDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+    }
+
+    public CustomerBalanceDbContext CreateDbContext() => new(_options);
+
+    public Task<CustomerBalanceDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(new CustomerBalanceDbContext(_options));
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -30,13 +30,15 @@
           "Microsoft.TestPlatform.TestHost": "18.5.0"
         }
       },
-      "NSubstitute": {
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "Direct",
-        "requested": "[5.*, )",
-        "resolved": "5.3.0",
-        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
         "dependencies": {
-          "Castle.Core": "5.1.1"
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
         }
       },
       "Shouldly": {
@@ -47,6 +49,15 @@
         "dependencies": {
           "DiffEngine": "11.3.0",
           "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
         }
       },
       "xunit.runner.visualstudio": {
@@ -64,13 +75,10 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
-      "Castle.Core": {
+      "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -79,6 +87,22 @@
         "dependencies": {
           "EmptyFiles": "4.4.0",
           "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
         }
       },
       "EmptyFiles": {
@@ -218,15 +242,32 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -234,6 +275,18 @@
         "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
         "dependencies": {
           "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
         }
       },
       "xunit.analyzers": {


### PR DESCRIPTION
## Summary

Story M8 of the Party merge plan ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) → [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).

`BalanceAccountPartyReferenceRewriter` redirects `BalanceAccount.PartyId` from a merged-out (loser) party onto the surviving party via a single `ExecuteUpdateAsync`. Discovered automatically by the merge orchestrator through DI registration as `IReferenceRewriter<Party>`.

## Placement — same as #1288 / #1289

Inlined in `Granit.CustomerBalance.EntityFrameworkCore.Internal/`, not in a dedicated `*.Mergeable` package. Same rationale as the previous PRs.

New project references on `Granit.CustomerBalance.EntityFrameworkCore`:
- `Granit.Mergeable` (contracts only — `Granit` + `Microsoft.Extensions.DependencyInjection.Abstractions`, no runtime)
- `Granit.Parties` (full domain — needed for the `Party` type in `IReferenceRewriter<Party>`)

## Cardinality caveat — same-currency collision (v1: reject)

The per-`(PartyId, Currency)` uniqueness constraint on `BalanceAccount` means that if loser and survivor each hold an account in the same currency, the bulk `UPDATE` produces two rows violating the unique index. **v1 deliberately lets the database surface the error** (orchestrator's `TransactionScope` rolls back) rather than silently consolidate balances. Real consolidation involves domain decisions — sum balances, repoint `BalanceTransaction` rows, soft-delete loser account, emit a `BalanceAccountConsolidatedFromMergeEvent` audit transaction — that an operator must opt into explicitly.

A future framework primitive `IMergeConsolidator<T>` (running aggregate-level operations before the bulk-SQL rewriters in the merge pipeline) is tracked as **tech-debt [#1402](https://github.com/granit-fx/granit-dotnet/issues/1402)**, attached as a sub-issue of the merge Epic.

Until then, admins must reconcile the loser's balance off-merge and re-attempt.

## Test plan

`Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration` — new project, Postgres 17 via Testcontainers.

- [x] `RewriteAsync_RedirectsLoserAccountsOntoSurvivor` — moves loser accounts onto the survivor; survivor + unrelated party accounts stay intact.
- [x] `RewriteAsync_SurfacesUniqueConstraint_OnSameCurrencyCollision` — documents v1 reject behaviour.
  - Asserts on `System.Data.Common.DbException` (the common base class of `Npgsql.PostgresException` and `Microsoft.Data.SqlClient.SqlException`) so the contract is provider-agnostic — same assertion would hold on SQL Server.
- [x] `RewriteAsync_ReturnsZero_WhenLoserHasNoAccounts` — no-op path.
- [x] `CountAsync_ReturnsLoserAccountCount_WithoutMutating` — dry-run is read-only.
- [x] All 4 tests pass under Testcontainers.
- [x] `Granit.ArchitectureTests` 150/150.
- [x] `dotnet format --verify-no-changes` clean.

## Out of scope

- Same-currency consolidation logic — see [#1402](https://github.com/granit-fx/granit-dotnet/issues/1402).
- SQL Server-specific integration tests — none of the merge rewriter tests run against SQL Server in this PR series. Postgres-only is the established pattern.

Refs #1290
Refs #1402
