### PR TITLE
feat(customer-balance): CreditExpiringEto + BalanceDepletedEto + notifications (#1361)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10873,6 +10873,31 @@
       "members": []
     },
     {
+      "name": "CreditExpiringScanHandler",
+      "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditExpiringScanHandler",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.BackgroundJobs",
+      "file": "src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanHandler.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(CreditExpiringScanJob _, ICreditExpiringScanService creditExpiringScanService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CreditExpiringScanJob",
+      "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditExpiringScanJob",
+      "kind": "record",
+      "project": "Granit.CustomerBalance.BackgroundJobs",
+      "file": "src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanJob.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "CustomerBalanceMetrics",
       "fqn": "Granit.CustomerBalance.Diagnostics.CustomerBalanceMetrics",
       "kind": "class",
@@ -10934,7 +10959,14 @@
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Domain/BalanceTransaction.cs",
       "line": 12,
-      "members": []
+      "members": [
+        {
+          "name": "MarkExpirationNotified",
+          "kind": "method",
+          "signature": "MarkExpirationNotified(DateTimeOffset notifiedAt)",
+          "returnType": "Guid? ReferenceId { get; private set; } public string? ReferenceType { get; private set; } public DateTimeOffset? ExpiresAt { get; private set; } public DateTimeOffset? LastExpirationNotifiedAt { get; private set; } public DateTimeOffset CreatedAt { get; private set; } internal void"
+        }
+      ]
     },
     {
       "name": "TransactionSource",
@@ -11193,12 +11225,30 @@
       "members": []
     },
     {
+      "name": "BalanceDepletedEto",
+      "fqn": "Granit.CustomerBalance.Events.BalanceDepletedEto",
+      "kind": "record",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Events/BalanceDepletedEto.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "CreditExpiredEto",
       "fqn": "Granit.CustomerBalance.Events.CreditExpiredEto",
       "kind": "record",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Events/CreditExpiredEto.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "CreditExpiringEto",
+      "fqn": "Granit.CustomerBalance.Events.CreditExpiringEto",
+      "kind": "record",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Events/CreditExpiringEto.cs",
+      "line": 23,
       "members": []
     },
     {
@@ -11248,7 +11298,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitCustomerBalance",
@@ -11391,6 +11441,28 @@
           "kind": "method",
           "signature": "GetExpiredCreditsAsync(DateTimeOffset now, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<BalanceTransaction>>"
+        },
+        {
+          "name": "GetCreditsExpiringSoonAsync",
+          "kind": "method",
+          "signature": "GetCreditsExpiringSoonAsync(DateTimeOffset now, DateTimeOffset leadTimeWindowEnd, DateTimeOffset cooldownThreshold, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BalanceTransaction>>"
+        }
+      ]
+    },
+    {
+      "name": "IBalanceTransactionWriter",
+      "fqn": "Granit.CustomerBalance.IBalanceTransactionWriter",
+      "kind": "interface",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/IBalanceTransactionWriter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "StampExpirationNotifiedAsync",
+          "kind": "method",
+          "signature": "StampExpirationNotifiedAsync(Guid creditTransactionId, DateTimeOffset notifiedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },
@@ -11411,6 +11483,22 @@
       ]
     },
     {
+      "name": "ICreditExpiringScanService",
+      "fqn": "Granit.CustomerBalance.ICreditExpiringScanService",
+      "kind": "interface",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/ICreditExpiringScanService.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
       "name": "IOverpaymentCreditService",
       "fqn": "Granit.CustomerBalance.IOverpaymentCreditService",
       "kind": "interface",
@@ -11423,6 +11511,37 @@
           "kind": "method",
           "signature": "CreditOverpaymentAsync(Guid tenantId, PartyId contactId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BalanceDepletedNotificationData",
+      "fqn": "Granit.CustomerBalance.Notifications.BalanceDepletedNotificationData",
+      "kind": "record",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/BalanceDepletedNotificationType.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "BalanceDepletedNotificationType",
+      "fqn": "Granit.CustomerBalance.Notifications.BalanceDepletedNotificationType",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/BalanceDepletedNotificationType.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "BalanceDepletedNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
         }
       ]
     },
@@ -11448,6 +11567,43 @@
           "kind": "method",
           "signature": "new()",
           "returnType": "CreditExpiredNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSeverity",
+          "kind": "property",
+          "signature": "NotificationSeverity DefaultSeverity",
+          "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "CreditExpiringNotificationData",
+      "fqn": "Granit.CustomerBalance.Notifications.CreditExpiringNotificationData",
+      "kind": "record",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/CreditExpiringNotificationType.cs",
+      "line": 46,
+      "members": []
+    },
+    {
+      "name": "CreditExpiringNotificationType",
+      "fqn": "Granit.CustomerBalance.Notifications.CreditExpiringNotificationType",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/CreditExpiringNotificationType.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "CreditExpiringNotificationType Instance ="
         },
         {
           "name": "Name",
@@ -11511,6 +11667,22 @@
       ]
     },
     {
+      "name": "BalanceDepletedNotificationHandler",
+      "fqn": "Granit.CustomerBalance.Notifications.Handlers.BalanceDepletedNotificationHandler",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/Handlers/BalanceDepletedNotificationHandler.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(BalanceDepletedEto evt, INotificationPublisher publisher, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "CreditExpiredNotificationHandler",
       "fqn": "Granit.CustomerBalance.Notifications.Handlers.CreditExpiredNotificationHandler",
       "kind": "class",
@@ -11522,6 +11694,22 @@
           "name": "HandleAsync",
           "kind": "method",
           "signature": "HandleAsync(CreditExpiredEto evt, INotificationPublisher publisher, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CreditExpiringNotificationHandler",
+      "fqn": "Granit.CustomerBalance.Notifications.Handlers.CreditExpiringNotificationHandler",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.Notifications",
+      "file": "src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiringNotificationHandler.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(CreditExpiringEto evt, INotificationPublisher publisher, IClock clock, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -11539,6 +11727,28 @@
           "kind": "method",
           "signature": "HandleAsync(BalanceCreditedEto evt, INotificationPublisher publisher, CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CustomerBalanceOptions",
+      "fqn": "Granit.CustomerBalance.Options.CustomerBalanceOptions",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Options/CustomerBalanceOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ExpirationLeadTimeDays",
+          "kind": "property",
+          "signature": "int ExpirationLeadTimeDays",
+          "returnType": "int"
+        },
+        {
+          "name": "ExpirationNotificationCooldownDays",
+          "kind": "property",
+          "signature": "int ExpirationNotificationCooldownDays",
+          "returnType": "int"
         }
       ]
     },

--- a/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanHandler.cs
+++ b/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanHandler.cs
@@ -1,0 +1,15 @@
+namespace Granit.CustomerBalance.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Handler for <see cref="CreditExpiringScanJob"/>. Delegates to
+/// <see cref="ICreditExpiringScanService"/> for the proactive
+/// "credit expiring soon" scan that emits one <c>CreditExpiringEto</c> per matching credit.
+/// </summary>
+public class CreditExpiringScanHandler
+{
+    public static async Task HandleAsync(
+        CreditExpiringScanJob _,
+        ICreditExpiringScanService creditExpiringScanService,
+        CancellationToken cancellationToken) =>
+        await creditExpiringScanService.ScanAsync(cancellationToken).ConfigureAwait(false);
+}

--- a/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanJob.cs
+++ b/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpiringScanJob.cs
@@ -1,0 +1,13 @@
+using Granit.BackgroundJobs;
+
+namespace Granit.CustomerBalance.BackgroundJobs.Jobs;
+
+/// <summary>
+/// Scans for promotional credits whose expiration is approaching (within
+/// <c>CustomerBalanceOptions.ExpirationLeadTimeDays</c>) and emits one
+/// <c>CreditExpiringEto</c> per match. Runs daily at 07:00 UTC — chosen so the user
+/// receives a "credit expiring soon" email at the start of their day, not in the middle
+/// of the night.
+/// </summary>
+[RecurringJob("0 7 * * *", "customer-balance-credit-expiring-scan")]
+public sealed record CreditExpiringScanJob : IBackgroundJob;

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Extensions/CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Extensions/CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -21,7 +21,9 @@ public static class CustomerBalanceEntityFrameworkCoreHostApplicationBuilderExte
         builder.Services.TryAddScoped<IBalanceAccountReader>(sp => sp.GetRequiredService<EfBalanceAccountStore>());
         builder.Services.TryAddScoped<IBalanceAccountWriter>(sp => sp.GetRequiredService<EfBalanceAccountStore>());
 
-        builder.Services.TryAddScoped<IBalanceTransactionReader, EfBalanceTransactionReader>();
+        builder.Services.AddScoped<EfBalanceTransactionReader>();
+        builder.Services.TryAddScoped<IBalanceTransactionReader>(sp => sp.GetRequiredService<EfBalanceTransactionReader>());
+        builder.Services.TryAddScoped<IBalanceTransactionWriter>(sp => sp.GetRequiredService<EfBalanceTransactionReader>());
 
         return builder;
     }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceTransactionConfiguration.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceTransactionConfiguration.cs
@@ -24,5 +24,10 @@ internal sealed class BalanceTransactionConfiguration : IEntityTypeConfiguration
         builder.HasIndex(e => e.ExpiresAt)
             .HasFilter($"\"Source\" = {(int)TransactionSource.Promotional} AND \"Type\" = {(int)TransactionType.Credit}")
             .HasDatabaseName($"ix_{GranitCustomerBalanceDbProperties.DbTablePrefix}transactions_expires_at");
+
+        // Dedupe stamp written by the daily expiration scanner once a CreditExpiringEto
+        // has been emitted. Nullable — only populated for promotional credits that have
+        // been alerted at least once.
+        builder.Property(e => e.LastExpirationNotifiedAt);
     }
 }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceTransactionReader.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceTransactionReader.cs
@@ -9,8 +9,10 @@ namespace Granit.CustomerBalance.EntityFrameworkCore.Internal;
 internal sealed class EfBalanceTransactionReader(
     IDbContextFactory<CustomerBalanceDbContext> contextFactory)
     : EfStoreBase<BalanceTransaction, CustomerBalanceDbContext>(contextFactory),
-      IBalanceTransactionReader
+      IBalanceTransactionReader, IBalanceTransactionWriter
 {
+    private readonly IDbContextFactory<CustomerBalanceDbContext> _contextFactory = contextFactory;
+
     public Task<IReadOnlyList<BalanceTransaction>> GetByAccountAsync(
         BalanceAccountId accountId,
         int page,
@@ -34,4 +36,36 @@ internal sealed class EfBalanceTransactionReader(
                     t.ExpiresAt != null &&
                     t.ExpiresAt <= now),
             cancellationToken);
+
+    public Task<IReadOnlyList<BalanceTransaction>> GetCreditsExpiringSoonAsync(
+        DateTimeOffset now,
+        DateTimeOffset leadTimeWindowEnd,
+        DateTimeOffset cooldownThreshold,
+        CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<BalanceTransaction>()
+                .Where(t =>
+                    t.Source == TransactionSource.Promotional &&
+                    t.Type == TransactionType.Credit &&
+                    t.ExpiresAt != null &&
+                    t.ExpiresAt > now &&
+                    t.ExpiresAt <= leadTimeWindowEnd &&
+                    (t.LastExpirationNotifiedAt == null || t.LastExpirationNotifiedAt < cooldownThreshold)),
+            cancellationToken);
+
+    public async Task StampExpirationNotifiedAsync(
+        Guid creditTransactionId,
+        DateTimeOffset notifiedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await using CustomerBalanceDbContext context = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        await context.Set<BalanceTransaction>()
+            .Where(t => t.Id == creditTransactionId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(t => t.LastExpirationNotifiedAt, notifiedAt),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Granit.CustomerBalance.Notifications/BalanceDepletedNotificationType.cs
+++ b/src/Granit.CustomerBalance.Notifications/BalanceDepletedNotificationType.cs
@@ -1,0 +1,41 @@
+using Granit.Notifications;
+
+namespace Granit.CustomerBalance.Notifications;
+
+/// <summary>
+/// Notification type for a balance account that has just been depleted to zero —
+/// sent to the party (end user) who owns the balance so they know there is no more
+/// credit available before their next charge.
+/// </summary>
+/// <remarks>
+/// Channels: Email + InApp. <see cref="NotificationSeverity.Info"/> — purely
+/// informational; the user may choose to top up but no action is strictly required.
+/// </remarks>
+public sealed class BalanceDepletedNotificationType
+    : NotificationType<BalanceDepletedNotificationData>
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly BalanceDepletedNotificationType Instance = new();
+
+    /// <inheritdoc />
+    public override string Name => "customer-balance.depleted";
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> DefaultChannels { get; } =
+        [NotificationChannels.Email, NotificationChannels.InApp];
+}
+
+/// <summary>
+/// Data payload for a balance-depleted notification.
+/// </summary>
+/// <param name="BalanceAccountId">Balance account that has just been depleted.</param>
+/// <param name="TenantId">Tenant owning the balance account.</param>
+/// <param name="PartyId">Party (end user) who owns the balance.</param>
+/// <param name="Currency">ISO 4217 currency code of the balance.</param>
+/// <param name="DepletedAt">Timestamp of the transaction that depleted the balance.</param>
+public sealed record BalanceDepletedNotificationData(
+    Guid BalanceAccountId,
+    Guid TenantId,
+    Guid PartyId,
+    string Currency,
+    DateTimeOffset DepletedAt);

--- a/src/Granit.CustomerBalance.Notifications/CreditExpiringNotificationType.cs
+++ b/src/Granit.CustomerBalance.Notifications/CreditExpiringNotificationType.cs
@@ -1,0 +1,54 @@
+using Granit.Notifications;
+
+namespace Granit.CustomerBalance.Notifications;
+
+/// <summary>
+/// Notification type for a promotional credit approaching its expiration date — sent
+/// proactively to the party (end user) who owns the balance so they can use the credit
+/// before any value is silently lost.
+/// </summary>
+/// <remarks>
+/// Channels: Email + InApp. <see cref="NotificationSeverity.Warning"/> — the user has a
+/// limited time window to act before value disappears from their account.
+/// </remarks>
+public sealed class CreditExpiringNotificationType
+    : NotificationType<CreditExpiringNotificationData>
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly CreditExpiringNotificationType Instance = new();
+
+    /// <inheritdoc />
+    public override string Name => "customer-balance.credit_expiring";
+
+    /// <inheritdoc />
+    public override NotificationSeverity DefaultSeverity => NotificationSeverity.Warning;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<string> DefaultChannels { get; } =
+        [NotificationChannels.Email, NotificationChannels.InApp];
+}
+
+/// <summary>
+/// Data payload for a "credit expiring soon" notification.
+/// </summary>
+/// <param name="BalanceAccountId">Balance account holding the credit.</param>
+/// <param name="TenantId">Tenant owning the balance account.</param>
+/// <param name="PartyId">Party (end user) who owns the balance.</param>
+/// <param name="CreditId">Identifier of the promotional credit transaction.</param>
+/// <param name="Amount">Original credited amount, positive.</param>
+/// <param name="Currency">ISO 4217 currency code of the balance.</param>
+/// <param name="ExpiresAt">Scheduled expiration timestamp of the credit.</param>
+/// <param name="DaysUntilExpiry">
+/// Whole-day countdown until <paramref name="ExpiresAt"/>, computed by the handler at
+/// dispatch time. Embedded in the data so templates render a friendly "Your credit
+/// expires in N days" header without doing date arithmetic in Scriban.
+/// </param>
+public sealed record CreditExpiringNotificationData(
+    Guid BalanceAccountId,
+    Guid TenantId,
+    Guid PartyId,
+    Guid CreditId,
+    decimal Amount,
+    string Currency,
+    DateTimeOffset ExpiresAt,
+    int DaysUntilExpiry);

--- a/src/Granit.CustomerBalance.Notifications/Handlers/BalanceDepletedNotificationHandler.cs
+++ b/src/Granit.CustomerBalance.Notifications/Handlers/BalanceDepletedNotificationHandler.cs
@@ -1,0 +1,34 @@
+using Granit.CustomerBalance.Events;
+using Granit.Notifications.Abstractions;
+
+namespace Granit.CustomerBalance.Notifications.Handlers;
+
+/// <summary>
+/// Handles <see cref="BalanceDepletedEto"/> by sending a
+/// <see cref="BalanceDepletedNotificationType"/> directly to the party (end user) who
+/// owns the balance so they know there is no more credit available before their next
+/// charge.
+/// </summary>
+/// <remarks>
+/// Recipient strategy: directly addressed to the owning <c>PartyId</c> — depletion is a
+/// per-user signal, mirroring <see cref="CreditGrantedNotificationHandler"/>.
+/// </remarks>
+public class BalanceDepletedNotificationHandler
+{
+    public static async Task HandleAsync(
+        BalanceDepletedEto evt,
+        INotificationPublisher publisher,
+        CancellationToken cancellationToken)
+    {
+        await publisher.PublishAsync(
+            BalanceDepletedNotificationType.Instance,
+            new BalanceDepletedNotificationData(
+                evt.BalanceAccountId,
+                evt.TenantId,
+                evt.PartyId,
+                evt.Currency,
+                evt.DepletedAt),
+            [evt.PartyId.ToString()],
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiringNotificationHandler.cs
+++ b/src/Granit.CustomerBalance.Notifications/Handlers/CreditExpiringNotificationHandler.cs
@@ -1,0 +1,43 @@
+using Granit.CustomerBalance.Events;
+using Granit.Notifications.Abstractions;
+using Granit.Timing;
+
+namespace Granit.CustomerBalance.Notifications.Handlers;
+
+/// <summary>
+/// Handles <see cref="CreditExpiringEto"/> by sending a
+/// <see cref="CreditExpiringNotificationType"/> directly to the party (end user) who
+/// owns the balance so they can use the credit before any value is silently lost.
+/// </summary>
+/// <remarks>
+/// Recipient strategy: directly addressed to the owning <c>PartyId</c> — credit
+/// expiration is a per-user signal, mirroring <see cref="CreditExpiredNotificationHandler"/>.
+/// The whole-day countdown <c>DaysUntilExpiry</c> is computed here using
+/// <see cref="IClock"/> rather than in the template so Scriban does not have to do date
+/// arithmetic.
+/// </remarks>
+public class CreditExpiringNotificationHandler
+{
+    public static async Task HandleAsync(
+        CreditExpiringEto evt,
+        INotificationPublisher publisher,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        int daysUntilExpiry = Math.Max(0, (int)Math.Ceiling((evt.ExpiresAt - clock.Now).TotalDays));
+
+        await publisher.PublishAsync(
+            CreditExpiringNotificationType.Instance,
+            new CreditExpiringNotificationData(
+                evt.BalanceAccountId,
+                evt.TenantId,
+                evt.PartyId,
+                evt.CreditId,
+                evt.Amount,
+                evt.Currency,
+                evt.ExpiresAt,
+                daysUntilExpiry),
+            [evt.PartyId.ToString()],
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expiring.fr.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expiring.fr.html
@@ -1,0 +1,17 @@
+<title>Votre crédit expire dans {{ model.days_until_expiry }} jour(s)</title>
+<p>Bonjour,</p>
+<p>Information importante : votre crédit de
+   <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
+   expirera le
+   <strong>{{ model.expires_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</strong>
+   (dans {{ model.days_until_expiry }} jour(s)).</p>
+<p>Ce crédit est automatiquement appliqué à vos prochaines facturations — la remise
+   apparaîtra dès votre prochaine facture. En revanche, si aucune facture n'est émise
+   avant la date d'expiration, la valeur restante sera perdue.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #b45309; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Utiliser mon crédit</a>
+</p>
+<p style="font-size: 13px; color: #4b5563;">Identifiant du solde : <code>{{ model.balance_account_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Une question sur vos données ? Contactez notre équipe via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expiring.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.credit_expiring.html
@@ -1,0 +1,17 @@
+<title>Your credit expires in {{ model.days_until_expiry }} days</title>
+<p>Hi,</p>
+<p>A heads-up: your credit of
+   <strong>{{ model.amount | math.format '0.00' }} {{ model.currency }}</strong>
+   will expire on
+   <strong>{{ model.expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>
+   ({{ model.days_until_expiry }} day(s) from now).</p>
+<p>This credit is automatically applied to your next charges, so you'll get the
+   discount as soon as you have an upcoming invoice — but if nothing is invoiced
+   before the expiration date, the remaining value will be lost.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #b45309; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Use my credit</a>
+</p>
+<p style="font-size: 13px; color: #4b5563;">Balance id: <code>{{ model.balance_account_id }}</code></p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Questions about your data? Contact our team via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.depleted.fr.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.depleted.fr.html
@@ -1,0 +1,16 @@
+<title>Votre solde est épuisé</title>
+<p>Bonjour,</p>
+<p>Votre solde en <strong>{{ model.currency }}</strong> vient d'atteindre
+   <strong>0</strong>. Vous n'avez plus de crédit disponible, donc toute prochaine
+   facturation sera prélevée sur votre moyen de paiement habituel, sans remise.</p>
+<p>Si vous souhaitez recharger votre solde ou simplement vérifier les opérations
+   passées, rendez-vous sur votre page de solde.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Voir mon solde</a>
+</p>
+<p style="font-size: 13px; color: #4b5563;">Identifiant du solde : <code>{{ model.balance_account_id }}</code></p>
+<p style="font-size: 13px; color: #4b5563;">Épuisé le :
+   {{ model.depleted_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Une question sur vos données ? Contactez notre équipe via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.depleted.html
+++ b/src/Granit.CustomerBalance.Notifications/Templates/customer-balance.depleted.html
@@ -1,0 +1,16 @@
+<title>Your balance is depleted</title>
+<p>Hi,</p>
+<p>Your <strong>{{ model.currency }}</strong> balance has just reached
+   <strong>0</strong>. You no longer have any credit available, so any upcoming charge
+   will go to your usual payment method without a discount.</p>
+<p>If you'd like to top up or simply review what was deducted, you can do so from your
+   balance page.</p>
+<p style="text-align: center; margin: 32px 0;">
+  <a href="{{ app.base_url }}/balance/{{ model.balance_account_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View my balance</a>
+</p>
+<p style="font-size: 13px; color: #4b5563;">Balance id: <code>{{ model.balance_account_id }}</code></p>
+<p style="font-size: 13px; color: #4b5563;">Depleted on:
+   {{ model.depleted_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</p>
+{{ if privacy.dpo_email }}
+<p style="font-size: 13px; color: #4b5563;">Questions about your data? Contact our team via <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
+{{ end }}

--- a/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceActivitySource.cs
+++ b/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceActivitySource.cs
@@ -14,4 +14,5 @@ internal static class CustomerBalanceActivitySource
     internal const string CreditBalance = "customer_balance.credit";
     internal const string DebitBalance = "customer_balance.debit";
     internal const string ExpireCredit = "customer_balance.expire_credit";
+    internal const string ScanExpiringCredits = "customer_balance.scan_expiring_credits";
 }

--- a/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceMetrics.cs
+++ b/src/Granit.CustomerBalance/Diagnostics/CustomerBalanceMetrics.cs
@@ -20,6 +20,7 @@ public sealed class CustomerBalanceMetrics
     private readonly Counter<long> _credited;
     private readonly Counter<long> _debited;
     private readonly Counter<long> _expired;
+    private readonly Counter<long> _expiringNotified;
 
     /// <summary>Initializes customer balance metrics using the specified meter factory.</summary>
     public CustomerBalanceMetrics(IMeterFactory meterFactory)
@@ -37,6 +38,10 @@ public sealed class CustomerBalanceMetrics
         _expired = meter.CreateCounter<long>(
             "granit.customer_balance.credit.expired",
             description: "Number of promotional credits expired.");
+
+        _expiringNotified = meter.CreateCounter<long>(
+            "granit.customer_balance.credit.expiring_notified",
+            description: "Number of CreditExpiringEto notifications emitted by the daily scanner.");
     }
 
     /// <summary>Records a credit transaction.</summary>
@@ -72,5 +77,16 @@ public sealed class CustomerBalanceMetrics
             { CurrencyTag, currency },
         };
         _expired.Add(1, tags);
+    }
+
+    /// <summary>Records a "credit expiring soon" notification emission.</summary>
+    public void RecordExpiringNotified(string? tenantId, string currency)
+    {
+        var tags = new TagList
+        {
+            { TenantIdTag, tenantId ?? GlobalTenant },
+            { CurrencyTag, currency },
+        };
+        _expiringNotified.Add(1, tags);
     }
 }

--- a/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
+++ b/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
@@ -149,9 +149,20 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
             referenceType);
 
         _transactions.Add(transaction);
+        decimal previousBalance = Balance;
         Balance -= amount;
 
         AddDistributedEvent(new BalanceDebitedEto(
             Id, TenantId!.Value, PartyId.Value, amount, Currency, referenceId, referenceType));
+
+        // Transition-driven: only emit BalanceDepletedEto when this debit moved the
+        // running total from strictly positive to exactly zero. A no-op recompute that
+        // keeps the balance at zero (or pushes it negative — a guard above prevents
+        // that anyway) does NOT re-emit.
+        if (previousBalance > 0m && Balance == 0m)
+        {
+            AddDistributedEvent(new BalanceDepletedEto(
+                Id, TenantId.Value, PartyId.Value, Currency, createdAt));
+        }
     }
 }

--- a/src/Granit.CustomerBalance/Domain/BalanceTransaction.cs
+++ b/src/Granit.CustomerBalance/Domain/BalanceTransaction.cs
@@ -67,6 +67,22 @@ public sealed class BalanceTransaction : Entity
     /// <summary>Expiration date for promotional credits. <c>null</c> if non-expiring.</summary>
     public DateTimeOffset? ExpiresAt { get; private set; }
 
+    /// <summary>
+    /// Timestamp of the last "expiration approaching" notification emitted for this credit
+    /// — populated only when this transaction is a promotional credit. Used by the
+    /// expiration scanner job to dedupe <c>CreditExpiringEto</c> emissions per credit.
+    /// </summary>
+    public DateTimeOffset? LastExpirationNotifiedAt { get; private set; }
+
     /// <summary>When this transaction was recorded.</summary>
     public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>
+    /// Records that a "credit expiring soon" notification was emitted for this credit at
+    /// the given timestamp. Called by the expiration scanner once an
+    /// <c>CreditExpiringEto</c> has been published.
+    /// </summary>
+    /// <param name="notifiedAt">Timestamp of the notification.</param>
+    internal void MarkExpirationNotified(DateTimeOffset notifiedAt) =>
+        LastExpirationNotifiedAt = notifiedAt;
 }

--- a/src/Granit.CustomerBalance/Events/BalanceDepletedEto.cs
+++ b/src/Granit.CustomerBalance/Events/BalanceDepletedEto.cs
@@ -1,0 +1,20 @@
+using Granit.Events;
+
+namespace Granit.CustomerBalance.Events;
+
+/// <summary>
+/// Published when a transaction transitions a balance account's running total from a
+/// strictly positive amount to exactly zero — transition-driven, not state-driven, so a
+/// no-op recompute that keeps the balance at zero does not re-emit the event.
+/// </summary>
+/// <param name="BalanceAccountId">Balance account that has just been depleted.</param>
+/// <param name="TenantId">Tenant owning the balance account.</param>
+/// <param name="PartyId">Party (end user) who owns the balance.</param>
+/// <param name="Currency">ISO 4217 currency code of the balance.</param>
+/// <param name="DepletedAt">Timestamp of the transaction that depleted the balance.</param>
+public sealed record BalanceDepletedEto(
+    Guid BalanceAccountId,
+    Guid TenantId,
+    Guid PartyId,
+    string Currency,
+    DateTimeOffset DepletedAt) : IIntegrationEvent;

--- a/src/Granit.CustomerBalance/Events/CreditExpiringEto.cs
+++ b/src/Granit.CustomerBalance/Events/CreditExpiringEto.cs
@@ -1,0 +1,30 @@
+using Granit.Events;
+
+namespace Granit.CustomerBalance.Events;
+
+/// <summary>
+/// Published when a promotional credit is approaching its expiration date — emitted
+/// proactively by the daily expiration scanner once the credit's <c>ExpiresAt</c> falls
+/// within the configured <c>ExpirationLeadTimeDays</c> window.
+/// </summary>
+/// <remarks>
+/// Per-credit dedupe is enforced upstream via
+/// <c>BalanceTransaction.LastExpirationNotifiedAt</c> — the scanner stamps the
+/// transaction once the Eto has been published so the same credit is not re-alerted
+/// every run during the lead-time window.
+/// </remarks>
+/// <param name="BalanceAccountId">Balance account holding the credit.</param>
+/// <param name="TenantId">Tenant owning the balance account.</param>
+/// <param name="PartyId">Party (end user) who owns the balance.</param>
+/// <param name="CreditId">Identifier of the promotional credit transaction.</param>
+/// <param name="Amount">Original credited amount, positive.</param>
+/// <param name="Currency">ISO 4217 currency code of the balance.</param>
+/// <param name="ExpiresAt">Scheduled expiration timestamp of the credit.</param>
+public sealed record CreditExpiringEto(
+    Guid BalanceAccountId,
+    Guid TenantId,
+    Guid PartyId,
+    Guid CreditId,
+    decimal Amount,
+    string Currency,
+    DateTimeOffset ExpiresAt) : IIntegrationEvent;

--- a/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Exports;
 using Granit.CustomerBalance.Internal;
+using Granit.CustomerBalance.Options;
 using Granit.CustomerBalance.Queries;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
@@ -25,6 +26,15 @@ public static class CustomerBalanceHostApplicationBuilderExtensions
         this IHostApplicationBuilder builder)
     {
         builder.Services.TryAddSingleton<CustomerBalanceMetrics>();
+
+        // Bind and validate module options at startup.
+        builder.Services
+            .AddOptions<CustomerBalanceOptions>()
+            .BindConfiguration(CustomerBalanceOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        builder.Services.TryAddTransient<ICreditExpiringScanService, DefaultCreditExpiringScanService>();
         builder.Services.TryAddTransient<ICreditExpirationService, DefaultCreditExpirationService>();
         builder.Services.TryAddTransient<IAdminCreditService, DefaultAdminCreditService>();
         builder.Services.TryAddTransient<IAdminDebitService, DefaultAdminDebitService>();

--- a/src/Granit.CustomerBalance/IBalanceTransactionReader.cs
+++ b/src/Granit.CustomerBalance/IBalanceTransactionReader.cs
@@ -17,4 +17,24 @@ public interface IBalanceTransactionReader
     Task<IReadOnlyList<BalanceTransaction>> GetExpiredCreditsAsync(
         DateTimeOffset now,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns promotional credit transactions whose <c>ExpiresAt</c> falls within the
+    /// lead-time window <c>(now, now + leadTime]</c>, filtered by the per-credit
+    /// notification cooldown (i.e. credits never alerted, or last alerted before
+    /// <paramref name="cooldownThreshold"/>).
+    /// </summary>
+    /// <param name="now">Current timestamp; the lower bound of the lead-time window (exclusive).</param>
+    /// <param name="leadTimeWindowEnd">Upper bound of the lead-time window (inclusive).</param>
+    /// <param name="cooldownThreshold">
+    /// Credits whose <c>LastExpirationNotifiedAt</c> is null OR strictly less than this
+    /// timestamp are returned. Computed by the caller as
+    /// <c>now - ExpirationNotificationCooldownDays</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<BalanceTransaction>> GetCreditsExpiringSoonAsync(
+        DateTimeOffset now,
+        DateTimeOffset leadTimeWindowEnd,
+        DateTimeOffset cooldownThreshold,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.CustomerBalance/IBalanceTransactionWriter.cs
+++ b/src/Granit.CustomerBalance/IBalanceTransactionWriter.cs
@@ -1,0 +1,21 @@
+using Granit.CustomerBalance.Domain;
+
+namespace Granit.CustomerBalance;
+
+/// <summary>Persists balance transaction changes (command side of CQRS).</summary>
+/// <remarks>
+/// Transactions are immutable except for the <c>LastExpirationNotifiedAt</c> dedupe
+/// stamp written by the expiration scanner.
+/// </remarks>
+public interface IBalanceTransactionWriter
+{
+    /// <summary>
+    /// Stamps <c>LastExpirationNotifiedAt</c> on the given promotional credit transaction
+    /// so the daily expiration scanner does not re-emit a <c>CreditExpiringEto</c> for
+    /// the same credit on its next run during the lead-time window.
+    /// </summary>
+    Task StampExpirationNotifiedAsync(
+        Guid creditTransactionId,
+        DateTimeOffset notifiedAt,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.CustomerBalance/ICreditExpiringScanService.cs
+++ b/src/Granit.CustomerBalance/ICreditExpiringScanService.cs
@@ -1,0 +1,20 @@
+namespace Granit.CustomerBalance;
+
+/// <summary>
+/// Proactive scanner that emits <c>CreditExpiringEto</c> for promotional credits whose
+/// expiration falls within the configured lead-time window. Runs daily.
+/// </summary>
+/// <remarks>
+/// Idempotent across runs: per-credit dedupe via
+/// <c>BalanceTransaction.LastExpirationNotifiedAt</c> with a configurable cooldown
+/// (<c>CustomerBalanceOptions.ExpirationNotificationCooldownDays</c>, default 7).
+/// </remarks>
+public interface ICreditExpiringScanService
+{
+    /// <summary>
+    /// Scans for promotional credits expiring within the lead-time window and emits one
+    /// <c>CreditExpiringEto</c> per match.
+    /// </summary>
+    /// <returns>Number of credits that triggered an Eto emission.</returns>
+    Task<int> ScanAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.CustomerBalance/Internal/DefaultCreditExpiringScanService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultCreditExpiringScanService.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Events;
+using Granit.CustomerBalance.Options;
+using Granit.Events;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.CustomerBalance.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="ICreditExpiringScanService"/>. Queries
+/// promotional credits expiring within the lead-time window (excluding those alerted
+/// during the cooldown window), emits one <see cref="CreditExpiringEto"/> per match,
+/// and stamps <c>BalanceTransaction.LastExpirationNotifiedAt</c> upstream so the next
+/// run does not re-alert.
+/// </summary>
+internal sealed partial class DefaultCreditExpiringScanService(
+    IBalanceTransactionReader transactionReader,
+    IBalanceTransactionWriter transactionWriter,
+    IBalanceAccountReader accountReader,
+    IDistributedEventBus eventBus,
+    IClock clock,
+    IOptions<CustomerBalanceOptions> options,
+    CustomerBalanceMetrics metrics,
+    ILogger<DefaultCreditExpiringScanService> logger) : ICreditExpiringScanService
+{
+    public async Task<int> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        using Activity? activity = CustomerBalanceActivitySource.Source
+            .StartActivity(CustomerBalanceActivitySource.ScanExpiringCredits);
+
+        DateTimeOffset now = clock.Now;
+        CustomerBalanceOptions value = options.Value;
+        DateTimeOffset windowEnd = now.AddDays(value.ExpirationLeadTimeDays);
+        DateTimeOffset cooldownThreshold = now.AddDays(-value.ExpirationNotificationCooldownDays);
+
+        Log.ScanStarted(logger, now, value.ExpirationLeadTimeDays, value.ExpirationNotificationCooldownDays);
+
+        IReadOnlyList<BalanceTransaction> candidates = await transactionReader
+            .GetCreditsExpiringSoonAsync(now, windowEnd, cooldownThreshold, cancellationToken)
+            .ConfigureAwait(false);
+
+        int processed = 0;
+
+        foreach (BalanceTransaction credit in candidates)
+        {
+            BalanceAccount? account = await accountReader
+                .GetByIdAsync(credit.BalanceAccountId, cancellationToken).ConfigureAwait(false);
+
+            if (account is null)
+            {
+                continue;
+            }
+
+            await eventBus.PublishAsync(
+                new CreditExpiringEto(
+                    account.Id,
+                    account.TenantId!.Value,
+                    account.PartyId.Value,
+                    credit.Id,
+                    credit.Amount,
+                    account.Currency,
+                    credit.ExpiresAt!.Value),
+                cancellationToken).ConfigureAwait(false);
+
+            await transactionWriter
+                .StampExpirationNotifiedAsync(credit.Id, now, cancellationToken)
+                .ConfigureAwait(false);
+
+            metrics.RecordExpiringNotified(account.TenantId.Value.ToString(), account.Currency);
+            processed++;
+        }
+
+        Log.ScanCompleted(logger, processed);
+        return processed;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information, Message = "Credit expiring scan started at {Timestamp} (leadTime={LeadTimeDays}d, cooldown={CooldownDays}d)")]
+        public static partial void ScanStarted(ILogger logger, DateTimeOffset timestamp, int leadTimeDays, int cooldownDays);
+
+        [LoggerMessage(Level = LogLevel.Information, Message = "Credit expiring scan completed, {Count} CreditExpiringEto emitted")]
+        public static partial void ScanCompleted(ILogger logger, int count);
+    }
+}

--- a/src/Granit.CustomerBalance/Options/CustomerBalanceOptions.cs
+++ b/src/Granit.CustomerBalance/Options/CustomerBalanceOptions.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Granit.CustomerBalance.Options;
+
+/// <summary>
+/// Configuration options for the Granit.CustomerBalance module.
+/// </summary>
+public sealed class CustomerBalanceOptions
+{
+    /// <summary>Section key in the configuration.</summary>
+    public const string SectionName = "CustomerBalance";
+
+    /// <summary>
+    /// Number of days before a promotional credit's expiration date at which the
+    /// "credit expiring soon" notification should be triggered by the daily scanner.
+    /// Default: 7 days. Range: 1-90.
+    /// </summary>
+    [Range(1, 90)]
+    public int ExpirationLeadTimeDays { get; set; } = 7;
+
+    /// <summary>
+    /// Minimum interval, in days, between two "credit expiring soon" notifications for
+    /// the same credit. Prevents the scanner from re-alerting the same user every run
+    /// during the lead-time window. Default: 7 days. Range: 1-30.
+    /// </summary>
+    [Range(1, 30)]
+    public int ExpirationNotificationCooldownDays { get; set; } = 7;
+}

--- a/tests/Granit.CustomerBalance.BackgroundJobs.Tests/CreditExpiringScanTests.cs
+++ b/tests/Granit.CustomerBalance.BackgroundJobs.Tests/CreditExpiringScanTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Granit.BackgroundJobs;
+using Granit.CustomerBalance.BackgroundJobs.Jobs;
+using Shouldly;
+using Xunit;
+
+namespace Granit.CustomerBalance.BackgroundJobs.Tests;
+
+public sealed class CreditExpiringScanTests
+{
+    [Fact]
+    public void CreditExpiringScanJob_ShouldImplementIBackgroundJob()
+    {
+        typeof(IBackgroundJob).IsAssignableFrom(typeof(CreditExpiringScanJob))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreditExpiringScanJob_ShouldHaveRecurringJobAttribute()
+    {
+        RecurringJobAttribute? attr = typeof(CreditExpiringScanJob)
+            .GetCustomAttribute<RecurringJobAttribute>();
+
+        attr.ShouldNotBeNull();
+        attr.Name.ShouldBe("customer-balance-credit-expiring-scan");
+        attr.CronExpression.ShouldBe("0 7 * * *");
+    }
+
+    [Fact]
+    public void CreditExpiringScanHandler_ShouldBePublicNonStatic()
+    {
+        Type handlerType = typeof(CreditExpiringScanHandler);
+
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
+    }
+
+    [Fact]
+    public void CreditExpiringScanHandler_HandleAsync_ShouldExist()
+    {
+        MethodInfo? method = typeof(CreditExpiringScanHandler)
+            .GetMethod("HandleAsync", BindingFlags.Public | BindingFlags.Static);
+
+        method.ShouldNotBeNull("HandleAsync must exist as a public static method");
+        method.ReturnType.ShouldBe(typeof(Task));
+    }
+}

--- a/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/BalanceDepletedNotificationHandlerTests.cs
+++ b/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/BalanceDepletedNotificationHandlerTests.cs
@@ -1,0 +1,41 @@
+using Granit.CustomerBalance.Events;
+using Granit.CustomerBalance.Notifications.Handlers;
+using Granit.Notifications.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Granit.CustomerBalance.Notifications.Tests.Handlers;
+
+public sealed class BalanceDepletedNotificationHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_PublishesBalanceDepletedNotification_ToOwningParty()
+    {
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+
+        var balanceAccountId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var depletedAt = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+
+        BalanceDepletedEto evt = new(
+            BalanceAccountId: balanceAccountId,
+            TenantId: tenantId,
+            PartyId: partyId,
+            Currency: "EUR",
+            DepletedAt: depletedAt);
+
+        await BalanceDepletedNotificationHandler.HandleAsync(evt, publisher, CancellationToken.None);
+
+        await publisher.Received(1).PublishAsync(
+            BalanceDepletedNotificationType.Instance,
+            Arg.Is<BalanceDepletedNotificationData>(d =>
+                d.BalanceAccountId == balanceAccountId &&
+                d.TenantId == tenantId &&
+                d.PartyId == partyId &&
+                d.Currency == "EUR" &&
+                d.DepletedAt == depletedAt),
+            Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 1 && ids[0] == partyId.ToString()),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/CreditExpiringNotificationHandlerTests.cs
+++ b/tests/Granit.CustomerBalance.Notifications.Tests/Handlers/CreditExpiringNotificationHandlerTests.cs
@@ -1,0 +1,52 @@
+using Granit.CustomerBalance.Events;
+using Granit.CustomerBalance.Notifications.Handlers;
+using Granit.Notifications.Abstractions;
+using Granit.Timing;
+using NSubstitute;
+using Xunit;
+
+namespace Granit.CustomerBalance.Notifications.Tests.Handlers;
+
+public sealed class CreditExpiringNotificationHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_PublishesCreditExpiringNotification_ToOwningParty_WithDayCountdown()
+    {
+        INotificationPublisher publisher = Substitute.For<INotificationPublisher>();
+        IClock clock = Substitute.For<IClock>();
+
+        var now = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+        clock.Now.Returns(now);
+
+        var balanceAccountId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
+        var creditId = Guid.NewGuid();
+        DateTimeOffset expiresAt = now.AddDays(5);
+
+        CreditExpiringEto evt = new(
+            BalanceAccountId: balanceAccountId,
+            TenantId: tenantId,
+            PartyId: partyId,
+            CreditId: creditId,
+            Amount: 25.00m,
+            Currency: "EUR",
+            ExpiresAt: expiresAt);
+
+        await CreditExpiringNotificationHandler.HandleAsync(evt, publisher, clock, CancellationToken.None);
+
+        await publisher.Received(1).PublishAsync(
+            CreditExpiringNotificationType.Instance,
+            Arg.Is<CreditExpiringNotificationData>(d =>
+                d.BalanceAccountId == balanceAccountId &&
+                d.TenantId == tenantId &&
+                d.PartyId == partyId &&
+                d.CreditId == creditId &&
+                d.Amount == 25.00m &&
+                d.Currency == "EUR" &&
+                d.ExpiresAt == expiresAt &&
+                d.DaysUntilExpiry == 5),
+            Arg.Is<IReadOnlyList<string>>(ids => ids.Count == 1 && ids[0] == partyId.ToString()),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.CustomerBalance.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
+++ b/tests/Granit.CustomerBalance.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
@@ -15,9 +15,13 @@ public sealed class EmbeddedTemplatesTests
         // Neutral (= EN) variant, one per notification type.
         "Templates.customer-balance.credit_granted.html",
         "Templates.customer-balance.credit_expired.html",
+        "Templates.customer-balance.credit_expiring.html",
+        "Templates.customer-balance.depleted.html",
         // French variants — the second culture we ship out of the box.
         "Templates.customer-balance.credit_granted.fr.html",
         "Templates.customer-balance.credit_expired.fr.html",
+        "Templates.customer-balance.credit_expiring.fr.html",
+        "Templates.customer-balance.depleted.fr.html",
     ];
 
     [Theory]

--- a/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
@@ -154,6 +154,47 @@ public sealed class BalanceAccountTests
     }
 
     [Fact]
+    public void Debit_TransitionFromPositiveToZero_ShouldRaiseBalanceDepletedEto()
+    {
+        BalanceAccount account = CreateAccountWithBalance(100m);
+
+        account.Debit(100m, TransactionSource.InvoiceDeduction, "Full deduction", Now, Guid.NewGuid());
+
+        account.IntegrationEvents.ShouldContain(e => e is BalanceDepletedEto);
+        BalanceDepletedEto eto = account.IntegrationEvents.OfType<BalanceDepletedEto>().Single();
+        eto.BalanceAccountId.ShouldBe(account.Id);
+        eto.PartyId.ShouldBe(account.PartyId.Value);
+        eto.Currency.ShouldBe("EUR");
+        eto.DepletedAt.ShouldBe(Now);
+    }
+
+    [Fact]
+    public void Debit_PartialFromPositive_ShouldNotRaiseBalanceDepletedEto()
+    {
+        BalanceAccount account = CreateAccountWithBalance(100m);
+
+        account.Debit(40m, TransactionSource.InvoiceDeduction, "Partial deduction", Now, Guid.NewGuid());
+
+        account.IntegrationEvents.ShouldNotContain(e => e is BalanceDepletedEto);
+    }
+
+    [Fact]
+    public void Debit_AlreadyAtZero_ShouldThrowAndNotRaiseBalanceDepletedEto()
+    {
+        // A no-op recompute that *attempts* to debit a zero balance is rejected by the
+        // invariant — the transition guard never fires, so no BalanceDepletedEto is
+        // emitted twice for the same balance.
+        BalanceAccount account = CreateAccountWithBalance(100m);
+        account.Debit(100m, TransactionSource.InvoiceDeduction, "Full deduction", Now, Guid.NewGuid());
+        account.ClearIntegrationEvents();
+
+        Should.Throw<Granit.CustomerBalance.Exceptions.InsufficientBalanceException>(() =>
+            account.Debit(0.01m, TransactionSource.InvoiceDeduction, "No-op recompute", Now, Guid.NewGuid()));
+
+        account.IntegrationEvents.ShouldNotContain(e => e is BalanceDepletedEto);
+    }
+
+    [Fact]
     public void MultipleOperations_ShouldMaintainCorrectBalance()
     {
         BalanceAccount account = CreateAccount();

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpiringScanServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpiringScanServiceTests.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics.Metrics;
+using Granit.CustomerBalance.Diagnostics;
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Events;
+using Granit.CustomerBalance.Internal;
+using Granit.CustomerBalance.Options;
+using Granit.Events;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.CustomerBalance.Tests.Internal;
+
+public sealed class DefaultCreditExpiringScanServiceTests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IBalanceTransactionReader _transactionReader = Substitute.For<IBalanceTransactionReader>();
+    private readonly IBalanceTransactionWriter _transactionWriter = Substitute.For<IBalanceTransactionWriter>();
+    private readonly IBalanceAccountReader _accountReader = Substitute.For<IBalanceAccountReader>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly Meter _meter = new("test");
+    private readonly CustomerBalanceMetrics _metrics;
+    private readonly CustomerBalanceOptions _options = new();
+    private readonly DefaultCreditExpiringScanService _sut;
+
+    public DefaultCreditExpiringScanServiceTests()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(_meter);
+        _metrics = new CustomerBalanceMetrics(meterFactory);
+
+        _clock.Now.Returns(Now);
+
+        _sut = new DefaultCreditExpiringScanService(
+            _transactionReader,
+            _transactionWriter,
+            _accountReader,
+            _eventBus,
+            _clock,
+            Microsoft.Extensions.Options.Options.Create(_options),
+            _metrics,
+            NullLogger<DefaultCreditExpiringScanService>.Instance);
+    }
+
+    public void Dispose() => _meter.Dispose();
+
+    [Fact]
+    public async Task ScanAsync_NoCandidates_ShouldReturnZero()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        _transactionReader.GetCreditsExpiringSoonAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        int result = await _sut.ScanAsync(ct);
+
+        result.ShouldBe(0);
+        await _eventBus.DidNotReceiveWithAnyArgs().PublishAsync<CreditExpiringEto>(default!, ct);
+    }
+
+    [Fact]
+    public async Task ScanAsync_CandidateInWindow_ShouldEmitEtoAndStampNotifiedAt()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var tenantId = Guid.NewGuid();
+        BalanceTransaction credit = CreateCredit(amount: 50m, expiresAt: Now.AddDays(3));
+        BalanceAccount account = CreateAccountWithBalance(credit.BalanceAccountId, tenantId, 100m);
+
+        _transactionReader.GetCreditsExpiringSoonAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+        _accountReader.GetByIdAsync(credit.BalanceAccountId, Arg.Any<CancellationToken>())
+            .Returns(account);
+
+        int result = await _sut.ScanAsync(ct);
+
+        result.ShouldBe(1);
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<CreditExpiringEto>(e =>
+                e.BalanceAccountId == account.Id &&
+                e.TenantId == tenantId &&
+                e.PartyId == account.PartyId.Value &&
+                e.CreditId == credit.Id &&
+                e.Amount == 50m &&
+                e.Currency == "EUR" &&
+                e.ExpiresAt == credit.ExpiresAt!.Value),
+            Arg.Any<CancellationToken>());
+        await _transactionWriter.Received(1).StampExpirationNotifiedAsync(
+            credit.Id, Now, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScanAsync_AccountMissing_ShouldSkipCredit()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        BalanceTransaction credit = CreateCredit(amount: 50m, expiresAt: Now.AddDays(3));
+
+        _transactionReader.GetCreditsExpiringSoonAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([credit]);
+        _accountReader.GetByIdAsync(credit.BalanceAccountId, Arg.Any<CancellationToken>())
+            .Returns((BalanceAccount?)null);
+
+        int result = await _sut.ScanAsync(ct);
+
+        result.ShouldBe(0);
+        await _transactionWriter.DidNotReceiveWithAnyArgs()
+            .StampExpirationNotifiedAsync(default, default, ct);
+    }
+
+    [Fact]
+    public async Task ScanAsync_ShouldQueryReader_WithLeadTimeAndCooldownDerivedFromOptions()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _options.ExpirationLeadTimeDays = 14;
+        _options.ExpirationNotificationCooldownDays = 5;
+
+        _transactionReader.GetCreditsExpiringSoonAsync(
+            Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.ScanAsync(ct);
+
+        await _transactionReader.Received(1).GetCreditsExpiringSoonAsync(
+            Now,
+            Now.AddDays(14),
+            Now.AddDays(-5),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static BalanceTransaction CreateCredit(decimal amount, DateTimeOffset expiresAt) =>
+        BalanceTransaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), TransactionType.Credit, amount,
+            TransactionSource.Promotional, "Promo", Now.AddDays(-30),
+            expiresAt: expiresAt);
+
+    private static BalanceAccount CreateAccountWithBalance(Guid accountId, Guid tenantId, decimal balance)
+    {
+        var account = BalanceAccount.Create(accountId, tenantId, PartyId.Create(Guid.NewGuid()), "EUR");
+        account.Credit(balance, TransactionSource.Promotional, "Setup", Now.AddDays(-15), Guid.NewGuid());
+        account.ClearIntegrationEvents();
+        return account;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1361 (FU-3). Activates the placeholder notifications shipped (handler-less)
in PR #1344 by introducing the two missing trigger Etos in `Granit.CustomerBalance`:

- **`CreditExpiringEto`** — proactive, scanner-driven. New daily background job
  (`customer-balance-credit-expiring-scan`, `0 7 * * *`) emits one Eto per
  promotional credit whose `ExpiresAt` falls within the configurable lead-time
  window. Per-credit dedupe via a new `BalanceTransaction.LastExpirationNotifiedAt`
  stamp + a configurable cooldown.
- **`BalanceDepletedEto`** — transition-driven. Hooked into `BalanceAccount.Debit`
  via a pre/post-image comparison; only fires when the running total moves from
  strictly positive to exactly zero. A no-op recompute that keeps the balance at
  zero (or any negative-rejecting attempt that throws `InsufficientBalanceException`)
  does **not** re-emit.

Both Etos carry `PartyId` so the notification handlers route directly to the
owning end user. EN + FR plain-HTML templates, mirroring the
`customer-balance.credit_granted` style from PR #1344.

## Existing structure & decisions

- **`Granit.CustomerBalance.BackgroundJobs`** already existed (shipped with the
  expiration debit scanner) — the new `CreditExpiringScanJob` /
  `CreditExpiringScanHandler` were added alongside the existing job; no new project.
- **`BalanceTransaction.LastExpirationNotifiedAt`** was added (nullable
  `DateTimeOffset?`). EF Core mapping configured in
  `BalanceTransactionConfiguration`. **No EF migration created** — this framework
  package does not ship migrations (consumer apps generate their own against their
  own DbContext bundle, mirroring the rest of the framework).
- **Transition detection for `BalanceDepletedEto`**: `previousBalance` is captured
  at the start of `BalanceAccount.Debit`, then compared to `Balance` after the
  mutation. Eto only fires when `previousBalance > 0 && Balance == 0`. The
  existing `InsufficientBalanceException` guard prevents the negative case, and
  zero-amount debits are rejected upstream by `BalanceTransaction.Create`'s
  `ThrowIfNegativeOrZero` check — the test
  `Debit_AlreadyAtZero_ShouldThrowAndNotRaiseBalanceDepletedEto` pins the no-op-
  recompute non-emission contract.
- **`CustomerBalanceOptions`** added under `Granit.CustomerBalance/Options/` with
  `[Range]`-validated `ExpirationLeadTimeDays` (default 7, range 1-90) and
  `ExpirationNotificationCooldownDays` (default 7, range 1-30). Bound via the
  standard `BindConfiguration + ValidateDataAnnotations + ValidateOnStart`
  triplet, no `GranitSettings` dependency added (matches the `Granit.Webhooks`
  pattern).
- **New writer interface** `IBalanceTransactionWriter` (one method:
  `StampExpirationNotifiedAsync`). EF implementation reuses
  `EfBalanceTransactionReader` and uses `ExecuteUpdateAsync` so the immutable-
  ledger property `private set` is preserved (no entity tracking churn).
- **Metrics**: added `granit.customer_balance.credit.expiring_notified` counter
  (with `tenant_id` + `currency` tags) wired into the scanner. The
  transition-driven `BalanceDepletedEto` does not emit a separate metric —
  consumers can derive it from the Eto stream if needed.

## Test counts

| Project | Passed |
| ------- | ------ |
| `Granit.CustomerBalance.Tests` | 58 |
| `Granit.CustomerBalance.BackgroundJobs.Tests` | 9 |
| `Granit.CustomerBalance.Notifications.Tests` | 20 |
| `Granit.CustomerBalance.EntityFrameworkCore.Tests` | 5 |
| `Granit.ArchitectureTests` | 150 |

New tests in this PR (10):
- `BalanceAccountTests`: 3 transition-emission tests for `BalanceDepletedEto`
- `DefaultCreditExpiringScanServiceTests`: 4 scanner tests (no candidates,
  emit + stamp, missing account, options propagation)
- `CreditExpiringScanTests`: 4 reflection tests (`IBackgroundJob`,
  `[RecurringJob]`, public-non-static handler, `HandleAsync` shape)
- `CreditExpiringNotificationHandlerTests` + `BalanceDepletedNotificationHandlerTests`:
  one each, recipient + payload verification

## Lockfile regen scope

`dotnet restore --force-evaluate` ran on the 4 touched src projects + 4 touched
test projects — no `packages.lock.json` drift, nothing to commit. CI shards
already include all four `Granit.CustomerBalance.*.Tests`, no
`test-shards.json` change required.

## Test plan

- [ ] CI green across all 6 shards
- [ ] Smoke-test in a consumer app: configure `CustomerBalance:ExpirationLeadTimeDays`
      to e.g. 30, seed a promotional credit expiring in 20 days, run the
      `customer-balance-credit-expiring-scan` job — expect one
      `customer-balance.credit_expiring` email + `LastExpirationNotifiedAt` set
- [ ] Smoke-test depletion: credit 100 EUR, debit 100 EUR — expect one
      `customer-balance.depleted` email; debit 0 again should throw and not
      re-emit
