### PR TITLE
feat(parties): merge admin endpoints + permission + idempotency (#1291)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1669,6 +1669,7 @@
       "name": "Granit.Parties.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Mergeable",
         "Granit.Parties",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
@@ -32286,6 +32287,15 @@
       ]
     },
     {
+      "name": "FieldConflictResponse",
+      "fqn": "Granit.Parties.Endpoints.Dtos.FieldConflictResponse",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyMergeDtos.cs",
+      "line": 55,
+      "members": []
+    },
+    {
       "name": "PartyAddressRequest",
       "fqn": "Granit.Parties.Endpoints.Dtos.PartyAddressRequest",
       "kind": "record",
@@ -32355,6 +32365,24 @@
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/Dtos/PartyResponse.cs",
       "line": 73,
+      "members": []
+    },
+    {
+      "name": "PartyMergeRequest",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyMergeRequest",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyMergeDtos.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "PartyMergeResponse",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyMergeResponse",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyMergeDtos.cs",
+      "line": 38,
       "members": []
     },
     {

--- a/src/Granit.Parties.Endpoints/Dtos/PartyMergeDtos.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyMergeDtos.cs
@@ -1,0 +1,59 @@
+using Granit.Mergeable;
+
+namespace Granit.Parties.Endpoints.Dtos;
+
+/// <summary>
+/// Body of <c>POST /parties/{survivorId}/merge</c>. Identifies the loser, carries the
+/// per-field admin overrides, and an optional reason captured in the audit log.
+/// </summary>
+/// <param name="LoserId">Id of the party to merge into the survivor (will be tombstoned).</param>
+/// <param name="Choices">Per-field admin overrides. Keys are field paths
+/// (<c>"Name"</c>, <c>"TaxStatus"</c>, <c>"Metadata.segment"</c>, …); values are
+/// <c>"Survivor"</c> or <c>"Loser"</c>. Missing keys fall back to the recommended
+/// default returned by the preview endpoint. Use an empty dictionary to defer to
+/// defaults entirely.</param>
+/// <param name="Reason">Free-form admin justification — captured in the audit log.</param>
+/// <param name="DryRun">When <c>true</c>, the orchestrator computes the conflicts and
+/// rewrite counts without committing — same shape as the preview endpoint, useful for
+/// re-validating just before committing the live merge.</param>
+public sealed record PartyMergeRequest(
+    Guid LoserId,
+    IReadOnlyDictionary<string, string>? Choices = null,
+    string? Reason = null,
+    bool DryRun = false);
+
+/// <summary>
+/// Response body for both <c>GET .../merge/preview</c> and <c>POST .../merge</c>.
+/// Mirrors <see cref="MergeResult{TAggregate}"/> in a wire-friendly shape (no aggregate
+/// payload — callers fetch the survivor via <c>GET /parties/{id}</c> after the merge).
+/// </summary>
+/// <param name="SurvivorId">The party that absorbed the loser. Always set.</param>
+/// <param name="LoserId">The tombstoned party. Always set.</param>
+/// <param name="Conflicts">Per-field scalar conflicts between survivor and loser, with
+/// the recommended winner pre-populated.</param>
+/// <param name="RewriteCounts">For each registered cross-module rewriter
+/// (<c>"Invoice.PartyId"</c>, <c>"Subscription.PartyId"</c>, …), the number of rows
+/// that were (or would be) rewritten. Powers the "what will change" preview.</param>
+/// <param name="DryRun">Whether the operation was a dry-run (no DB changes).</param>
+public sealed record PartyMergeResponse(
+    Guid SurvivorId,
+    Guid LoserId,
+    IReadOnlyList<FieldConflictResponse> Conflicts,
+    IReadOnlyDictionary<string, int> RewriteCounts,
+    bool DryRun);
+
+/// <summary>
+/// Wire shape for a single field-level conflict. <see cref="FieldConflict.SurvivorValue"/>
+/// and <see cref="FieldConflict.LoserValue"/> are <c>object?</c> in the domain — surfaced
+/// as their <c>ToString()</c> representation here so the JSON payload stays predictable
+/// regardless of the underlying type.
+/// </summary>
+/// <param name="FieldPath">Dot-separated path; e.g. <c>"Name"</c>, <c>"Metadata.segment"</c>.</param>
+/// <param name="SurvivorValue">Survivor's current value, stringified (or <c>null</c>).</param>
+/// <param name="LoserValue">Loser's current value, stringified (or <c>null</c>).</param>
+/// <param name="Default">Recommended winner — <c>"Survivor"</c> or <c>"Loser"</c>.</param>
+public sealed record FieldConflictResponse(
+    string FieldPath,
+    string? SurvivorValue,
+    string? LoserValue,
+    string Default);

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
@@ -1,0 +1,126 @@
+using Granit.Mergeable;
+using Granit.Mergeable.Exceptions;
+using Granit.Parties.Domain;
+using Granit.Parties.Endpoints.Dtos;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Granit.Parties.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the party merge admin API. Routes the admin endpoint to the
+/// generic merge orchestrator (<see cref="IMergeService{Party}"/>) and shapes the
+/// response into a wire-friendly DTO.
+/// </summary>
+internal static class PartyMergeEndpoints
+{
+    /// <summary>
+    /// Handler for <c>GET /parties/{survivorId}/merge/preview?loserId=&lt;guid&gt;</c>.
+    /// Always a dry-run — computes per-field conflicts (with default <c>WinnerSide</c>
+    /// pre-populated) and per-rewriter row counts without committing anything. Powers
+    /// the admin merge wizard's side-by-side view.
+    /// </summary>
+    public static async Task<Results<Ok<PartyMergeResponse>, ProblemHttpResult>> HandlePreviewAsync(
+        Guid survivorId,
+        [FromQuery] Guid loserId,
+        [FromServices] IMergeService<Party> mergeService,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            MergeResult<Party> result = await mergeService
+                .MergePreviewAsync(survivorId, loserId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Ok(MapResponse(survivorId, loserId, result));
+        }
+        catch (MergeException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    /// <summary>
+    /// Handler for <c>POST /parties/{survivorId}/merge</c>. Runs the live merge (or a
+    /// dry-run if <see cref="PartyMergeRequest.DryRun"/> is set) inside the orchestrator's
+    /// <see cref="System.Transactions.TransactionScope"/>. Stripe-style idempotency: when
+    /// an <c>Idempotency-Key</c> header is present, repeats with the same payload return
+    /// the cached result; repeats with a different payload return 409.
+    /// </summary>
+    /// <remarks>
+    /// HTTP status mapping:
+    /// <list type="bullet">
+    /// <item><c>422</c> — domain invariant violated (tenant / kind / currency mismatch,
+    /// archived loser, …) → <see cref="MergeException"/>.</item>
+    /// <item><c>409</c> — concurrent merge raced ahead, or idempotency key reused with a
+    /// different payload → <see cref="InvalidOperationException"/> from the orchestrator.</item>
+    /// <item><c>404</c> — survivor or loser not found.</item>
+    /// </list>
+    /// </remarks>
+    public static async Task<Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem>> HandleMergeAsync(
+        Guid survivorId,
+        PartyMergeRequest request,
+        [FromHeader(Name = "Idempotency-Key")] string? idempotencyKey,
+        [FromServices] IMergeService<Party> mergeService,
+        CancellationToken cancellationToken)
+    {
+        var orchestratorRequest = new MergeRequest(
+            SurvivorId: survivorId,
+            LoserId: request.LoserId,
+            Choices: BuildChoices(request.Choices),
+            DryRun: request.DryRun,
+            Reason: request.Reason,
+            IdempotencyKey: idempotencyKey);
+
+        try
+        {
+            MergeResult<Party> result = await mergeService
+                .MergeAsync(orchestratorRequest, cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Ok(MapResponse(survivorId, request.LoserId, result));
+        }
+        catch (MergeException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The orchestrator throws InvalidOperationException for: idempotency-key conflicts
+            // (same key, different payload), already-merged loser, optimistic-concurrency
+            // races. All map cleanly to 409.
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static MergeFieldChoices BuildChoices(IReadOnlyDictionary<string, string>? wire)
+    {
+        if (wire is null || wire.Count == 0)
+        {
+            return MergeFieldChoices.Empty;
+        }
+
+        Dictionary<string, WinnerSide> mapped = new(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, string> kv in wire)
+        {
+            // Validator already enforces "Survivor" / "Loser" — Enum.Parse here covers the
+            // happy path. An invalid value would have been rejected before reaching the
+            // handler, so a defensive fallback isn't necessary.
+            mapped[kv.Key] = Enum.Parse<WinnerSide>(kv.Value);
+        }
+        return new MergeFieldChoices(mapped);
+    }
+
+    private static PartyMergeResponse MapResponse(Guid survivorId, Guid loserId, MergeResult<Party> result) =>
+        new(
+            SurvivorId: survivorId,
+            LoserId: loserId,
+            Conflicts: result.Conflicts.Select(c => new FieldConflictResponse(
+                FieldPath: c.FieldPath,
+                SurvivorValue: c.SurvivorValue?.ToString(),
+                LoserValue: c.LoserValue?.ToString(),
+                Default: c.Default.ToString())).ToList(),
+            RewriteCounts: result.RewriteCounts,
+            DryRun: result.DryRun);
+}

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -206,6 +206,26 @@ public static class PartiesEndpointRouteBuilderExtensions
             .ProducesValidationProblem()
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
+        // ── Merge (admin tool: survivor + loser → tombstoned loser) ───
+        group.MapGet("/{survivorId:guid}/merge/preview", PartyMergeEndpoints.HandlePreviewAsync)
+            .WithName("PreviewPartyMerge")
+            .WithSummary("Previews a party merge in dry-run mode.")
+            .WithDescription("Computes per-field conflicts (with the recommended winner pre-populated) and per-rewriter row counts (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId, ...) without committing anything. Powers the admin merge wizard's side-by-side view. Returns 422 when a hard invariant is violated (tenant / kind / currency mismatch, archived loser).")
+            .Produces<PartyMergeResponse>()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .RequireAuthorization(PartiesPermissions.Parties.Merge);
+
+        group.MapPost("/{survivorId:guid}/merge", PartyMergeEndpoints.HandleMergeAsync)
+            .WithName("MergeParty")
+            .WithSummary("Merges a loser party into the survivor.")
+            .WithDescription("Survivor absorbs the loser: scalar fields resolved per the supplied choices (defaults applied to missing keys), child collections rewritten via SQL bulk-update, cross-module references (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId) redirected onto the survivor, loser tombstoned with MergedIntoId pointing at the survivor. Atomic — any failure rolls the whole transaction back. Stripe-style idempotency via the optional Idempotency-Key header (24h replay window). Returns 422 on invariant violation, 409 on concurrent merge or idempotency-key conflict, 404 when survivor or loser does not exist.")
+            .Produces<PartyMergeResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem()
+            .RequireAuthorization(PartiesPermissions.Parties.Merge);
+
         // ── vCard export (RFC 6350) ───────────────────────────────────
         group.MapGet("/{id:guid}/vcard", PartyEndpoints.HandleDownloadVCardAsync)
             .WithName("DownloadPartyVCard")

--- a/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
+++ b/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Mergeable\Granit.Mergeable.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/cs.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/cs.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/de.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/de.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en-GB.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en-GB.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/es.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/es.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr-CA.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr-CA.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Gérer les tiers (identité, adresses, e-mails, téléphones, rôles)",
   "Permission:Parties.Parties.Lifecycle": "Modifier le cycle de vie d'un tiers (suspendre, réactiver, archiver)",
   "Permission:Parties.Parties.SetTaxStatus": "Définir le statut fiscal client-spécifique (exonération, autoliquidation)",
-  "Permission:Parties.Parties.ExternalMappings": "Associer des identifiants de fournisseurs externes (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Associer des identifiants de fournisseurs externes (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/hi.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/hi.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/it.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/it.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ja.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ja.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ko.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ko.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/nl.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/nl.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pl.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pl.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt-BR.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt-BR.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/sv.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/sv.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/tr.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/tr.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/zh.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/zh.json
@@ -4,5 +4,6 @@
   "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
   "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
   "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)"
+  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
 }

--- a/src/Granit.Parties.Endpoints/Permissions/PartiesPermissionDefinitionProvider.cs
+++ b/src/Granit.Parties.Endpoints/Permissions/PartiesPermissionDefinitionProvider.cs
@@ -47,5 +47,11 @@ internal sealed class PartiesPermissionDefinitionProvider : IPermissionDefinitio
             LocalizableString.Create<PartiesEndpointsLocalizationResource>(
                 "Permission:Parties.Parties.ExternalMappings"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            PartiesPermissions.Parties.Merge,
+            LocalizableString.Create<PartiesEndpointsLocalizationResource>(
+                "Permission:Parties.Parties.Merge"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Parties.Endpoints/Permissions/PartiesPermissions.cs
+++ b/src/Granit.Parties.Endpoints/Permissions/PartiesPermissions.cs
@@ -44,5 +44,14 @@ public static class PartiesPermissions
         /// account.
         /// </summary>
         public const string ExternalMappings = "Parties.Parties.ExternalMappings";
+
+        /// <summary>
+        /// Grants the right to merge two parties (survivor + loser → tombstoned loser
+        /// with all cross-module references rewritten onto the survivor). Distinct from
+        /// <see cref="Manage"/> because the operation is irreversible at scale — finalised
+        /// invoices, subscriptions, and customer-balance accounts are all redirected, and
+        /// the un-merge endpoint is best-effort only. Default rôle: Tenant.Admin.
+        /// </summary>
+        public const string Merge = "Parties.Parties.Merge";
     }
 }

--- a/src/Granit.Parties.Endpoints/Validators/PartyMergeRequestValidator.cs
+++ b/src/Granit.Parties.Endpoints/Validators/PartyMergeRequestValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Parties.Endpoints.Validators;
+
+internal sealed class PartyMergeRequestValidator : GranitValidator<PartyMergeRequest>
+{
+    public PartyMergeRequestValidator()
+    {
+        RuleFor(x => x.LoserId).NotEmpty();
+        RuleFor(x => x.Reason).MaximumLength(1000);
+
+        // Each choice value must be either "Survivor" or "Loser" — case-sensitive for
+        // wire-format predictability. Keys (field paths) are free-form: domain-level
+        // validation lives in the orchestrator (an unknown field path becomes a no-op
+        // fall-back to the default winner).
+        RuleForEach(x => x.Choices)
+            .Must(kv => kv.Value is "Survivor" or "Loser")
+            .When(x => x.Choices is not null)
+            .WithErrorCodeAndMessage("Granit:Validation:InvalidMergeChoice");
+    }
+}

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "cs",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "Zadaná podmínka nebyla splněna pro '{PropertyName}'.",

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "de",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "Die angegebene Bedingung für '{PropertyName}' wurde nicht erfüllt.",

--- a/src/Granit.Validation/Localization/Validation/en-GB.json
+++ b/src/Granit.Validation/Localization/Validation/en-GB.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "en-GB",
   "texts": {
     "Granit:Validation:AtLeastOneMappingTarget": "At least one mapping must have a non-null target property.",

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "en",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "The specified condition was not met for '{PropertyName}'.",

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "es",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "La condición especificada para '{PropertyName}' no se ha cumplido.",

--- a/src/Granit.Validation/Localization/Validation/fr-CA.json
+++ b/src/Granit.Validation/Localization/Validation/fr-CA.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Chaque choix de fusion doit être 'Survivor' ou 'Loser'.",
   "culture": "fr-CA",
   "texts": {
     "Granit:Validation:AtLeastOneMappingTarget": "Au moins un mappage doit avoir une propriété cible non nulle.",

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Chaque choix de fusion doit être 'Survivor' ou 'Loser'.",
   "culture": "fr",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "La condition spécifiée n'a pas été remplie pour '{PropertyName}'.",

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "hi",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' के लिए निर्दिष्ट शर्त पूरी नहीं हुई।",

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "it",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "La condizione specificata per '{PropertyName}' non è stata soddisfatta.",

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "ja",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' に対する指定された条件が満たされていません。",

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "ko",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}'에 대해 지정된 조건이 충족되지 않았습니다.",

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "nl",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "Aan de opgegeven voorwaarde voor '{PropertyName}' is niet voldaan.",

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "pl",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "Określony warunek nie został spełniony dla '{PropertyName}'.",

--- a/src/Granit.Validation/Localization/Validation/pt-BR.json
+++ b/src/Granit.Validation/Localization/Validation/pt-BR.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "pt-BR",
   "texts": {
     "Granit:Validation:AtLeastOneMappingTarget": "Pelo menos um mapeamento deve ter uma propriedade de destino não nula.",

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "pt",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "A condição especificada para '{PropertyName}' não foi cumprida.",

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "sv",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "Det angivna villkoret uppfylldes inte för '{PropertyName}'.",

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "tr",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' için belirtilen koşul karşılanmadı.",

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -1,4 +1,5 @@
 {
+  "Granit:Validation:InvalidMergeChoice": "Each merge choice must be either 'Survivor' or 'Loser'.",
   "culture": "zh",
   "texts": {
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' 的指定条件未满足。",

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyMergeEndpointsTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyMergeEndpointsTests.cs
@@ -1,0 +1,177 @@
+using Granit.Mergeable;
+using Granit.Mergeable.Exceptions;
+using Granit.Parties.Domain;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Endpoints;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Endpoints.Tests.Endpoints;
+
+/// <summary>
+/// Unit tests for <see cref="PartyMergeEndpoints"/>. Substitutes the orchestrator and
+/// validates that handlers translate orchestrator outcomes into the right HTTP shape:
+/// <list type="bullet">
+/// <item><see cref="MergeException"/> → 422.</item>
+/// <item><see cref="InvalidOperationException"/> (idempotency conflict, race) → 409.</item>
+/// <item>Successful result → 200 with the wire-shaped DTO.</item>
+/// </list>
+/// </summary>
+public sealed class PartyMergeEndpointsTests
+{
+    private readonly IMergeService<Party> _mergeService = Substitute.For<IMergeService<Party>>();
+
+    // ── Preview ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Preview_ReturnsOk_WithMappedConflictsAndCounts()
+    {
+        var survivor = Guid.NewGuid();
+        var loser = Guid.NewGuid();
+        _mergeService.MergePreviewAsync(survivor, loser, Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts:
+                [
+                    new FieldConflict("Name", "Acme S", "Acme L", WinnerSide.Survivor),
+                    new FieldConflict("TaxStatus", null, "Exempt", WinnerSide.Loser),
+                ],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal)
+                {
+                    ["Invoice.PartyId"] = 17,
+                    ["Subscription.PartyId"] = 3,
+                },
+                DryRun: true));
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult> result = await PartyMergeEndpoints.HandlePreviewAsync(
+            survivor, loser, _mergeService, TestContext.Current.CancellationToken);
+
+        Ok<PartyMergeResponse> ok = result.Result.ShouldBeOfType<Ok<PartyMergeResponse>>();
+        PartyMergeResponse body = ok.Value!;
+        body.SurvivorId.ShouldBe(survivor);
+        body.LoserId.ShouldBe(loser);
+        body.DryRun.ShouldBeTrue();
+        body.Conflicts.Count.ShouldBe(2);
+        body.Conflicts[0].FieldPath.ShouldBe("Name");
+        body.Conflicts[0].SurvivorValue.ShouldBe("Acme S");
+        body.Conflicts[0].Default.ShouldBe("Survivor");
+        body.Conflicts[1].SurvivorValue.ShouldBeNull();
+        body.RewriteCounts["Invoice.PartyId"].ShouldBe(17);
+    }
+
+    [Fact]
+    public async Task Preview_Returns422_OnMergeException()
+    {
+        _mergeService.MergePreviewAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MergeException("Tenant mismatch."));
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult> result = await PartyMergeEndpoints.HandlePreviewAsync(
+            Guid.NewGuid(), Guid.NewGuid(), _mergeService, TestContext.Current.CancellationToken);
+
+        ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    // ── Live merge ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Merge_PassesIdempotencyKeyAndChoicesToOrchestrator()
+    {
+        var survivor = Guid.NewGuid();
+        var loser = Guid.NewGuid();
+        const string idempotencyKey = "req-42";
+
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal),
+                DryRun: false));
+
+        var request = new PartyMergeRequest(
+            LoserId: loser,
+            Choices: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Name"] = "Loser",
+                ["Metadata.segment"] = "Survivor",
+            },
+            Reason: "Sync duplicate",
+            DryRun: false);
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem> result = await PartyMergeEndpoints.HandleMergeAsync(
+            survivor, request, idempotencyKey, _mergeService, TestContext.Current.CancellationToken);
+
+        result.Result.ShouldBeOfType<Ok<PartyMergeResponse>>();
+
+        await _mergeService.Received(1).MergeAsync(
+            Arg.Is<MergeRequest>(r =>
+                r.SurvivorId == survivor &&
+                r.LoserId == loser &&
+                r.IdempotencyKey == "req-42" &&
+                r.Reason == "Sync duplicate" &&
+                !r.DryRun &&
+                r.Choices.Choices["Name"] == WinnerSide.Loser &&
+                r.Choices.Choices["Metadata.segment"] == WinnerSide.Survivor),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Merge_Returns422_OnMergeException()
+    {
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MergeException("Currency mismatch."));
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem> result = await PartyMergeEndpoints.HandleMergeAsync(
+            Guid.NewGuid(),
+            new PartyMergeRequest(LoserId: Guid.NewGuid()),
+            idempotencyKey: null,
+            _mergeService,
+            TestContext.Current.CancellationToken);
+
+        ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Merge_Returns409_OnInvalidOperationException()
+    {
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Loser already merged."));
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem> result = await PartyMergeEndpoints.HandleMergeAsync(
+            Guid.NewGuid(),
+            new PartyMergeRequest(LoserId: Guid.NewGuid()),
+            idempotencyKey: null,
+            _mergeService,
+            TestContext.Current.CancellationToken);
+
+        ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
+        problem.StatusCode.ShouldBe(StatusCodes.Status409Conflict);
+    }
+
+    [Fact]
+    public async Task Merge_DefaultsToEmptyChoices_WhenNoneSupplied()
+    {
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal),
+                DryRun: false));
+
+        await PartyMergeEndpoints.HandleMergeAsync(
+            Guid.NewGuid(),
+            new PartyMergeRequest(LoserId: Guid.NewGuid(), Choices: null),
+            idempotencyKey: null,
+            _mergeService,
+            TestContext.Current.CancellationToken);
+
+        await _mergeService.Received(1).MergeAsync(
+            Arg.Is<MergeRequest>(r => r.Choices.Choices.Count == 0),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Parties.Endpoints.Tests/Validators/PartyMergeRequestValidatorTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Validators/PartyMergeRequestValidatorTests.cs
@@ -1,0 +1,68 @@
+using FluentValidation.TestHelper;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Endpoints.Tests.Validators;
+
+public sealed class PartyMergeRequestValidatorTests
+{
+    private readonly PartyMergeRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_Request_Passes()
+    {
+        var request = new PartyMergeRequest(
+            LoserId: Guid.NewGuid(),
+            Choices: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Name"] = "Survivor",
+                ["TaxStatus"] = "Loser",
+            },
+            Reason: "Doublon créé par sync ERP");
+
+        _validator.TestValidate(request).IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Empty_LoserId_Fails() =>
+        _validator.TestValidate(new PartyMergeRequest(LoserId: Guid.Empty))
+            .ShouldHaveValidationErrorFor(x => x.LoserId);
+
+    [Fact]
+    public void Reason_Over_1000_Chars_Fails() =>
+        _validator.TestValidate(new PartyMergeRequest(
+            LoserId: Guid.NewGuid(),
+            Reason: new string('x', 1001)))
+            .ShouldHaveValidationErrorFor(x => x.Reason);
+
+    [Theory]
+    [InlineData("survivor")]   // wrong casing
+    [InlineData("LOSER")]
+    [InlineData("Both")]
+    [InlineData("")]
+    public void Invalid_Choice_Value_Fails(string value)
+    {
+        var request = new PartyMergeRequest(
+            LoserId: Guid.NewGuid(),
+            Choices: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Name"] = value,
+            });
+
+        _validator.TestValidate(request).IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Null_Choices_IsAllowed() =>
+        _validator.TestValidate(new PartyMergeRequest(LoserId: Guid.NewGuid(), Choices: null))
+            .IsValid.ShouldBeTrue();
+
+    [Fact]
+    public void Empty_Choices_IsAllowed() =>
+        _validator.TestValidate(new PartyMergeRequest(
+            LoserId: Guid.NewGuid(),
+            Choices: new Dictionary<string, string>(StringComparer.Ordinal)))
+            .IsValid.ShouldBeTrue();
+}

--- a/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
@@ -406,6 +406,7 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

Story M9 of the Party merge plan ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) → [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).

The admin REST API on top of the merge orchestrator: a dry-run preview, a live merge with Stripe-style idempotency, and a dedicated `Parties.Parties.Merge` permission.

## Endpoints

| Method + route | Purpose |
|---|---|
| `GET /parties/{survivorId}/merge/preview?loserId=<guid>` | Dry-run preview. Returns the per-field conflicts (with the recommended winner pre-populated) and per-rewriter row counts (`Invoice.PartyId`, `Subscription.PartyId`, `BalanceAccount.PartyId`, `Party.ParentContactId`, `Party.Children`). Powers the admin merge wizard's side-by-side view. |
| `POST /parties/{survivorId}/merge` | Live merge (or dry-run if `dryRun: true`). Body: `{ loserId, choices?, reason?, dryRun? }`. Optional header `Idempotency-Key` for replay-safety (24 h window via the framework's idempotency table). |

### HTTP status mapping

| Code | When |
|---|---|
| `200 OK` | Successful preview / merge. |
| `400 / Validation` | Schema validation failure (empty `LoserId`, oversized `Reason`, invalid choice value). |
| `409 Conflict` | Already-merged loser, idempotency key reused with a different payload, or optimistic-concurrency race — surfaced by `InvalidOperationException` from the orchestrator. |
| `422 Unprocessable Entity` | Domain invariant violated (tenant / kind / currency mismatch, archived loser) — surfaced by `MergeException`. |

### Choice wire shape

Wire format uses string values `"Survivor"` / `"Loser"` to keep the payload self-describing. The handler maps to the strongly-typed `WinnerSide` enum before forwarding to the orchestrator, so the validator catches malformed payloads at the HTTP boundary.

## Permission

- New `PartiesPermissions.Parties.Merge` constant.
- Declared in `PartiesPermissionDefinitionProvider` with `MultiTenancySides.Both`.
- **Localised across all 18 cultures** in `Granit.Parties.Endpoints/Localization/PartiesEndpoints/*.json`.
- Default rôle: Tenant.Admin (irreversible-at-scale operation — finalised invoices, subscriptions and customer-balance accounts are all redirected; un-merge is best-effort).

## Validation

- `PartyMergeRequestValidator` enforces non-empty `LoserId`, `Reason ≤ 1000` chars, `Survivor`/`Loser` choice values (case-sensitive).
- The custom `.Must(...)` rule uses `.WithErrorCodeAndMessage("Granit:Validation:InvalidMergeChoice")` per the framework convention enforced by `ValidationConventionTests`.
- New key added to all 18 `src/Granit.Validation/Localization/Validation/*.json` files.

## Test plan

- [x] `PartyMergeRequestValidatorTests` — 6 cases: valid request, empty `LoserId`, oversized `Reason`, invalid choice values (`"survivor"`/`"LOSER"`/`"Both"`/`""`), null/empty `Choices`.
- [x] `PartyMergeEndpointsTests` — 6 cases: preview maps conflicts and rewrite counts; preview surfaces 422 on `MergeException`; live merge forwards Idempotency-Key + choices; 422 on `MergeException`; 409 on `InvalidOperationException`; default empty choices when none supplied.
- [x] `Granit.Parties.Endpoints.Tests` 50/50.
- [x] `Granit.ArchitectureTests` 150/150 (notably `ValidationConventionTests` which would have caught a hardcoded `.WithMessage(...)`).
- [x] `dotnet format --verify-no-changes` clean.

## Out of scope

- `PartyMergedAuditEntry` — story M10 (#1292).
- Frontend wizard — story M12 (#1294).

Refs #1291
