### PR TITLE
feat(parties): merge endpoint records audit entry on success (#1292)

### DIFF
--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1668,6 +1668,7 @@
     {
       "name": "Granit.Parties.Endpoints",
       "deps": [
+        "Granit.Auditing",
         "Granit.Authorization",
         "Granit.Mergeable",
         "Granit.Parties",
@@ -32698,7 +32699,7 @@
       "kind": "class",
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -13,6 +13,7 @@
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authentication.ApiKeys.Endpoints/Granit.Authentication.ApiKeys.Endpoints.csproj",
       "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Granit.Authentication.ApiKeys.EntityFrameworkCore.csproj",
       "src/Granit.Authentication.ApiKeys.Notifications/Granit.Authentication.ApiKeys.Notifications.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -5,6 +5,7 @@
       "src/Granit.AI/Granit.AI.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Auditing/Granit.Auditing.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",
       "src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj",
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
@@ -2,9 +2,11 @@ using Granit.Mergeable;
 using Granit.Mergeable.Exceptions;
 using Granit.Parties.Domain;
 using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Parties.Endpoints.Endpoints;
 
@@ -13,8 +15,13 @@ namespace Granit.Parties.Endpoints.Endpoints;
 /// generic merge orchestrator (<see cref="IMergeService{Party}"/>) and shapes the
 /// response into a wire-friendly DTO.
 /// </summary>
-internal static class PartyMergeEndpoints
+internal static partial class PartyMergeEndpoints
 {
+    [LoggerMessage(EventId = 1, Level = LogLevel.Error,
+        Message = "Failed to write audit entry for Party merge: survivor={SurvivorId}, loser={LoserId}.")]
+    private static partial void LogAuditWriteFailed(
+        ILogger logger, Guid survivorId, Guid loserId, Exception exception);
+
     /// <summary>
     /// Handler for <c>GET /parties/{survivorId}/merge/preview?loserId=&lt;guid&gt;</c>.
     /// Always a dry-run — computes per-field conflicts (with default <c>WinnerSide</c>
@@ -63,6 +70,8 @@ internal static class PartyMergeEndpoints
         PartyMergeRequest request,
         [FromHeader(Name = "Idempotency-Key")] string? idempotencyKey,
         [FromServices] IMergeService<Party> mergeService,
+        [FromServices] PartyMergeAuditWriter auditWriter,
+        [FromServices] ILogger<PartyMergeRequest> logger,
         CancellationToken cancellationToken)
     {
         var orchestratorRequest = new MergeRequest(
@@ -78,6 +87,29 @@ internal static class PartyMergeEndpoints
             MergeResult<Party> result = await mergeService
                 .MergeAsync(orchestratorRequest, cancellationToken)
                 .ConfigureAwait(false);
+
+            // Audit only live merges — dry-runs are exploratory and never commit.
+            if (!result.DryRun)
+            {
+                try
+                {
+                    await auditWriter.RecordAsync(
+                        survivorId: survivorId,
+                        loserId: request.LoserId,
+                        resolvedChoices: request.Choices,
+                        rewriteCounts: result.RewriteCounts,
+                        reason: request.Reason,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // The merge already committed — losing the audit row is bad but losing
+                    // the merge would be worse. Surface the failure in logs and let
+                    // operators reconstruct the audit trail from the integration event
+                    // (PartyMergedEto via the Wolverine outbox) once that path lands.
+                    LogAuditWriteFailed(logger, survivorId, request.LoserId, ex);
+                }
+            }
 
             return TypedResults.Ok(MapResponse(survivorId, request.LoserId, result));
         }

--- a/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
+++ b/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Mergeable\Granit.Mergeable.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />

--- a/src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs
+++ b/src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs
@@ -1,12 +1,14 @@
 using Granit.Authorization;
 using Granit.DataExchange.Extensions;
 using Granit.Modularity;
+using Granit.Parties.Endpoints.Internal;
 using Granit.Parties.Endpoints.Options;
 using Granit.Parties.Exports;
 using Granit.Parties.Queries;
 using Granit.QueryEngine.Extensions;
 using Granit.Validation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Parties.Endpoints;
 
@@ -27,5 +29,10 @@ public sealed class GranitPartiesEndpointsModule : GranitModule
         // ship both a QueryDefinition and an ExportDefinition, registered together.
         context.Services.AddQueryDefinition<Domain.Party, PartyQueryDefinition>();
         context.Services.AddExportDefinition<Domain.Party, PartyExportDefinition>();
+
+        // Audit writer for the Party merge endpoint. Resolves IAuditingWriter +
+        // ICurrentUserService at runtime so hosts that haven't enabled auditing get a
+        // resolution failure at the merge call site rather than at module bootstrap.
+        context.Services.TryAddScoped<PartyMergeAuditWriter>();
     }
 }

--- a/src/Granit.Parties.Endpoints/Internal/PartyMergeAuditWriter.cs
+++ b/src/Granit.Parties.Endpoints/Internal/PartyMergeAuditWriter.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using Granit.Auditing;
+using Granit.Auditing.Domain;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Granit.Users;
+
+namespace Granit.Parties.Endpoints.Internal;
+
+/// <summary>
+/// Writes a Party-merge audit entry after a successful live merge. Captures who merged
+/// what, with which choices, what reason was given, and how many rows each cross-module
+/// rewriter touched.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why endpoint-level rather than an <c>ILocalEventHandler&lt;PartyMergedEvent&gt;</c>:
+/// the orchestrator wire-up that fires <c>PartyMergedEvent</c> is still pending (see
+/// <c>Party.RaiseMergedEvents</c> from #1286). Until that lands, a domain-event handler
+/// would never fire. Writing directly from the endpoint covers the audit need today
+/// without depending on the orchestrator change. The handler-based path remains a clean
+/// future migration: move this logic to a handler, drop the endpoint call, no schema
+/// change.
+/// </para>
+/// <para>
+/// <b>Failure semantics.</b> The audit write happens <em>after</em> the merge transaction
+/// commits, so an audit-DB outage at this exact moment loses the audit entry while
+/// keeping the merge. That's the standard trade-off the framework already accepts for
+/// post-commit handlers — the alternative (rolling back a successful merge because the
+/// audit DB is unreachable) is worse. The merge endpoint logs and continues if writing
+/// fails — the merge result is still returned to the caller.
+/// </para>
+/// </remarks>
+internal sealed class PartyMergeAuditWriter(
+    IAuditingWriter auditingWriter,
+    ICurrentUserService currentUser,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IClock clock)
+{
+    /// <summary>
+    /// Records a successful Party merge. Composes one <see cref="AuditEntry"/> with a
+    /// single <see cref="AuditEntityChange"/> on the survivor (<c>EntityType="Party"</c>,
+    /// <c>ChangeType=Modified</c>) plus four property changes that capture the merge
+    /// payload in a stable, queryable shape:
+    /// <list type="bullet">
+    /// <item><c>MergedFromId</c> — the loser id (string).</item>
+    /// <item><c>Reason</c> — the operator's free-form justification (or <c>null</c>).</item>
+    /// <item><c>ResolvedChoices</c> — JSON dictionary of every <c>fieldPath → "Survivor"|"Loser"</c>.</item>
+    /// <item><c>RewriteCounts</c> — JSON dictionary of every <c>rewriter.Description → rowsAffected</c>.</item>
+    /// </list>
+    /// </summary>
+    public async Task RecordAsync(
+        Guid survivorId,
+        Guid loserId,
+        IReadOnlyDictionary<string, string>? resolvedChoices,
+        IReadOnlyDictionary<string, int> rewriteCounts,
+        string? reason,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rewriteCounts);
+
+        AuditEntityChange change = new()
+        {
+            Id = guidGenerator.Create(),
+            EntityType = "Party",
+            EntityId = survivorId.ToString(),
+            ChangeType = AuditChangeType.Modified,
+            PropertyChanges =
+            [
+                new AuditPropertyChange
+                {
+                    Id = guidGenerator.Create(),
+                    PropertyName = "MergedFromId",
+                    OriginalValue = null,
+                    NewValue = loserId.ToString(),
+                },
+                new AuditPropertyChange
+                {
+                    Id = guidGenerator.Create(),
+                    PropertyName = "Reason",
+                    OriginalValue = null,
+                    NewValue = reason,
+                },
+                new AuditPropertyChange
+                {
+                    Id = guidGenerator.Create(),
+                    PropertyName = "ResolvedChoices",
+                    OriginalValue = null,
+                    NewValue = JsonSerializer.Serialize(
+                        resolvedChoices ?? new Dictionary<string, string>(StringComparer.Ordinal)),
+                },
+                new AuditPropertyChange
+                {
+                    Id = guidGenerator.Create(),
+                    PropertyName = "RewriteCounts",
+                    OriginalValue = null,
+                    NewValue = JsonSerializer.Serialize(rewriteCounts),
+                },
+            ],
+        };
+
+        AuditEntry entry = new()
+        {
+            Id = guidGenerator.Create(),
+            Timestamp = clock.Now,
+            UserId = currentUser.UserId ?? "system",
+            UserName = currentUser.UserName,
+            Category = AuditCategory.DataMutation,
+            TenantId = currentTenant.IsAvailable ? currentTenant.Id : null,
+            CorrelationId = System.Diagnostics.Activity.Current?.Id,
+            EntityChanges = [change],
+        };
+
+        change.AuditEntryId = entry.Id;
+        foreach (AuditPropertyChange p in change.PropertyChanges)
+        {
+            p.AuditEntityChangeId = change.Id;
+        }
+
+        await auditingWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Parties.Endpoints/packages.lock.json
+++ b/src/Granit.Parties.Endpoints/packages.lock.json
@@ -34,6 +34,16 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyMergeEndpointsTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyMergeEndpointsTests.cs
@@ -1,10 +1,19 @@
+using Granit.Auditing;
+using Granit.Auditing.Domain;
+using Granit.Guids;
 using Granit.Mergeable;
 using Granit.Mergeable.Exceptions;
+using Granit.MultiTenancy;
 using Granit.Parties.Domain;
 using Granit.Parties.Endpoints.Dtos;
 using Granit.Parties.Endpoints.Endpoints;
+using Granit.Parties.Endpoints.Internal;
+using Granit.Timing;
+using Granit.Users;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Shouldly;
@@ -24,6 +33,27 @@ namespace Granit.Parties.Endpoints.Tests.Endpoints;
 public sealed class PartyMergeEndpointsTests
 {
     private readonly IMergeService<Party> _mergeService = Substitute.For<IMergeService<Party>>();
+    private readonly IAuditingWriter _auditingWriter = Substitute.For<IAuditingWriter>();
+    private readonly ILogger<PartyMergeRequest> _logger = NullLogger<PartyMergeRequest>.Instance;
+    private readonly PartyMergeAuditWriter _auditWriter;
+
+    public PartyMergeEndpointsTests()
+    {
+        ICurrentUserService user = Substitute.For<ICurrentUserService>();
+        user.UserId.Returns("admin-1");
+        user.UserName.Returns("Admin");
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+
+        IGuidGenerator guidGen = Substitute.For<IGuidGenerator>();
+        guidGen.Create().Returns(_ => Guid.NewGuid());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(new DateTimeOffset(2026, 4, 27, 14, 0, 0, TimeSpan.Zero));
+
+        _auditWriter = new PartyMergeAuditWriter(_auditingWriter, user, tenant, guidGen, clock);
+    }
 
     // ── Preview ────────────────────────────────────────────────────────────
 
@@ -103,7 +133,7 @@ public sealed class PartyMergeEndpointsTests
             DryRun: false);
 
         Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem> result = await PartyMergeEndpoints.HandleMergeAsync(
-            survivor, request, idempotencyKey, _mergeService, TestContext.Current.CancellationToken);
+            survivor, request, idempotencyKey, _mergeService, _auditWriter, _logger, TestContext.Current.CancellationToken);
 
         result.Result.ShouldBeOfType<Ok<PartyMergeResponse>>();
 
@@ -130,6 +160,8 @@ public sealed class PartyMergeEndpointsTests
             new PartyMergeRequest(LoserId: Guid.NewGuid()),
             idempotencyKey: null,
             _mergeService,
+            _auditWriter,
+            _logger,
             TestContext.Current.CancellationToken);
 
         ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
@@ -147,6 +179,8 @@ public sealed class PartyMergeEndpointsTests
             new PartyMergeRequest(LoserId: Guid.NewGuid()),
             idempotencyKey: null,
             _mergeService,
+            _auditWriter,
+            _logger,
             TestContext.Current.CancellationToken);
 
         ProblemHttpResult problem = result.Result.ShouldBeOfType<ProblemHttpResult>();
@@ -168,10 +202,101 @@ public sealed class PartyMergeEndpointsTests
             new PartyMergeRequest(LoserId: Guid.NewGuid(), Choices: null),
             idempotencyKey: null,
             _mergeService,
+            _auditWriter,
+            _logger,
             TestContext.Current.CancellationToken);
 
         await _mergeService.Received(1).MergeAsync(
             Arg.Is<MergeRequest>(r => r.Choices.Choices.Count == 0),
             Arg.Any<CancellationToken>());
+    }
+
+    // ── Audit ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Merge_WritesAuditEntry_AfterSuccessfulLiveMerge()
+    {
+        var survivor = Guid.NewGuid();
+        var loser = Guid.NewGuid();
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal)
+                {
+                    ["Invoice.PartyId"] = 12,
+                    ["Subscription.PartyId"] = 1,
+                },
+                DryRun: false));
+
+        await PartyMergeEndpoints.HandleMergeAsync(
+            survivor,
+            new PartyMergeRequest(
+                LoserId: loser,
+                Choices: new Dictionary<string, string>(StringComparer.Ordinal) { ["Name"] = "Survivor" },
+                Reason: "Doublon CRM"),
+            idempotencyKey: "k1",
+            _mergeService,
+            _auditWriter,
+            _logger,
+            TestContext.Current.CancellationToken);
+
+        await _auditingWriter.Received(1).WriteAsync(
+            Arg.Is<AuditEntry>(e =>
+                e.Category == AuditCategory.DataMutation &&
+                e.UserId == "admin-1" &&
+                e.EntityChanges.Count == 1 &&
+                e.EntityChanges.First().EntityType == "Party" &&
+                e.EntityChanges.First().EntityId == survivor.ToString() &&
+                e.EntityChanges.First().PropertyChanges.Count == 4),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Merge_DoesNotWriteAuditEntry_WhenDryRun()
+    {
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal),
+                DryRun: true));
+
+        await PartyMergeEndpoints.HandleMergeAsync(
+            Guid.NewGuid(),
+            new PartyMergeRequest(LoserId: Guid.NewGuid(), DryRun: true),
+            idempotencyKey: null,
+            _mergeService,
+            _auditWriter,
+            _logger,
+            TestContext.Current.CancellationToken);
+
+        await _auditingWriter.DidNotReceive().WriteAsync(Arg.Any<AuditEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Merge_StillReturnsOk_WhenAuditWriteFails()
+    {
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(StringComparer.Ordinal),
+                DryRun: false));
+
+        _auditingWriter.WriteAsync(Arg.Any<AuditEntry>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Audit DB unreachable."));
+
+        Results<Ok<PartyMergeResponse>, ProblemHttpResult, ValidationProblem> result = await PartyMergeEndpoints.HandleMergeAsync(
+            Guid.NewGuid(),
+            new PartyMergeRequest(LoserId: Guid.NewGuid()),
+            idempotencyKey: null,
+            _mergeService,
+            _auditWriter,
+            _logger,
+            TestContext.Current.CancellationToken);
+
+        // Merge already committed; audit failure must not surface to the caller.
+        result.Result.ShouldBeOfType<Ok<PartyMergeResponse>>();
     }
 }

--- a/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
@@ -291,6 +291,18 @@
       "granit": {
         "type": "Project"
       },
+      "granit.auditing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -401,6 +413,7 @@
       "granit.parties.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Auditing": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Story M10 of the Party merge plan ([Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278) → [Feature #1279](https://github.com/granit-fx/granit-dotnet/issues/1279)).

The merge endpoint persists an `AuditEntry` via the existing `IAuditingWriter` pipeline whenever a **live** merge succeeds — exposing every merge to the standard audit list / filter / export tooling at no extra cost.

## Audit shape

| Layer | Field | Source |
|---|---|---|
| `AuditEntry` | `Timestamp`, `UserId`, `UserName`, `TenantId`, `CorrelationId` | `IClock`, `ICurrentUserService`, `ICurrentTenant`, `Activity.Current.Id` |
| `AuditEntry.Category` | `DataMutation` | constant |
| `AuditEntityChange` | `EntityType="Party"`, `EntityId=survivorId`, `ChangeType=Modified` | endpoint payload |
| `AuditPropertyChange[]` | `MergedFromId` → loser id | endpoint payload |
|  | `Reason` → operator's free-form justification | request body |
|  | `ResolvedChoices` → JSON dict `fieldPath → "Survivor"|"Loser"` | request body |
|  | `RewriteCounts` → JSON dict `rewriter.Description → rowsAffected` | `MergeResult.RewriteCounts` |

## Why endpoint-level (not `ILocalEventHandler<PartyMergedEvent>`)

`Party.RaiseMergedEvents` was defined in #1286 but `EfMergeService<T>` doesn't call it yet — wiring the orchestrator to actually fire the event is a separate piece of work that touches the generic merge pipeline. Writing the audit directly from the endpoint:

- Covers the audit need today without depending on the orchestrator change.
- Keeps story #1292 narrowly scoped (S effort).
- Future migration to a handler-based path is mechanical: move the same payload construction to a handler subscribed to `PartyMergedEvent` and drop the endpoint call.

## Failure semantics

The audit write happens **after** the merge transaction commits. An audit-DB outage at this exact moment loses the audit entry while keeping the merge — the alternative (rolling back a successful merge because the audit DB is unreachable) is worse. The endpoint catches and logs (`Microsoft.Extensions.Logging` via `[LoggerMessage]`); the merge result is still returned to the caller.

## Test plan

- [x] `Merge_WritesAuditEntry_AfterSuccessfulLiveMerge` — asserts UserId, Category, EntityType, EntityId, 4 property changes.
- [x] `Merge_DoesNotWriteAuditEntry_WhenDryRun` — dry-runs are exploratory and never audit.
- [x] `Merge_StillReturnsOk_WhenAuditWriteFails` — merge endpoint surfaces 200 OK even when the audit DB throws.
- [x] Existing 6 endpoint tests updated to pass through the new audit writer + ILogger parameters (no behavioural change).
- [x] `Granit.Parties.Endpoints.Tests` 53/53.
- [x] `Granit.ArchitectureTests` 150/150.
- [x] `dotnet format --verify-no-changes` clean.

## Out of scope

- Orchestrator wire-up of `Party.RaiseMergedEvents` — separate piece of work; once landed, this audit writer can be retired in favour of a handler.
- Cross-process audit visibility via `PartyMergedEto` consumers — same dependency.

Refs #1292
