### PR TITLE
feat(webhooks): WebhookSigningKey aggregate + dual-key delivery model (#1400)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -49006,6 +49006,50 @@
       ]
     },
     {
+      "name": "IWebhookSigningKeyReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSigningKeyReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSigningKeyReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetForSubscriptionAsync",
+          "kind": "method",
+          "signature": "GetForSubscriptionAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WebhookSigningKey>>"
+        },
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid keyId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSigningKey?>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSigningKeyWriter",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSigningKeyWriter",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RotateSigningKeyAsync",
+          "kind": "method",
+          "signature": "RotateSigningKeyAsync(Guid subscriptionId, TimeSpan? retiredKeyGracePeriod = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSigningKeyRotatedResult>"
+        },
+        {
+          "name": "RevokeSigningKeyAsync",
+          "kind": "method",
+          "signature": "RevokeSigningKeyAsync(Guid subscriptionId, Guid keyId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "IWebhookStatsReader",
       "fqn": "Granit.Webhooks.Abstractions.IWebhookStatsReader",
       "kind": "interface",
@@ -49116,6 +49160,15 @@
           "returnType": "Task<WebhookTestPingResult>"
         }
       ]
+    },
+    {
+      "name": "WebhookSigningKeyRotatedResult",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookSigningKeyRotatedResult",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs",
+      "line": 55,
+      "members": []
     },
     {
       "name": "WebhookStats",
@@ -49304,6 +49357,43 @@
       ]
     },
     {
+      "name": "WebhookSigningKey",
+      "fqn": "Granit.Webhooks.Domain.WebhookSigningKey",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSigningKey.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid subscriptionId, string protectedSecret, DateTimeOffset createdAt, WebhookSigningKeyStatus status = WebhookSigningKeyStatus.Active, DateTimeOffset? expiresAt = null)",
+          "returnType": "WebhookSigningKey"
+        },
+        {
+          "name": "CreatedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset CreatedAt",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "IsAcceptableAt",
+          "kind": "method",
+          "signature": "IsAcceptableAt(DateTimeOffset now)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSigningKeyStatus",
+      "fqn": "Granit.Webhooks.Domain.WebhookSigningKeyStatus",
+      "kind": "enum",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSigningKeyStatus.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "WebhookSubscription",
       "fqn": "Granit.Webhooks.Domain.WebhookSubscription",
       "kind": "class",
@@ -49324,10 +49414,10 @@
           "returnType": "string"
         },
         {
-          "name": "SigningSecret",
-          "kind": "property",
-          "signature": "string SigningSecret",
-          "returnType": "string"
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "string? SigningSecret { get; private set; } public IReadOnlyList<WebhookSigningKey> SigningKeys => _signingKeys."
         },
         {
           "name": "TenantId",
@@ -49374,6 +49464,24 @@
       "project": "Granit.Webhooks.Endpoints",
       "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookEventTypeResponse.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSigningKeyCreatedResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSigningKeyCreatedResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSigningKeyResponse.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "WebhookSigningKeyResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSigningKeyResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSigningKeyResponse.cs",
+      "line": 10,
       "members": []
     },
     {
@@ -49926,6 +50034,12 @@
           "kind": "property",
           "signature": "int MaxParallelDeliveries",
           "returnType": "int"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "bool StorePayload { get; set; } public TimeSpan RetiredKeyGracePeriod { get; set; } = TimeSpan."
         }
       ]
     },

--- a/src/Granit.Webhooks.Endpoints/Dtos/WebhookSigningKeyResponse.cs
+++ b/src/Granit.Webhooks.Endpoints/Dtos/WebhookSigningKeyResponse.cs
@@ -1,0 +1,27 @@
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Endpoints.Dtos;
+
+/// <summary>
+/// Read-only projection of a <see cref="WebhookSigningKey"/>. The protected secret is
+/// intentionally NOT included — clients receive the plain-text secret only at creation
+/// time via <see cref="WebhookSigningKeyCreatedResponse"/>.
+/// </summary>
+public sealed record WebhookSigningKeyResponse(
+    Guid Id,
+    Guid SubscriptionId,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ExpiresAt,
+    DateTimeOffset? RevokedAt,
+    DateTimeOffset? LastRotationNotificationAt,
+    WebhookSigningKeyStatus Status);
+
+/// <summary>
+/// Response after creating (rotating) a new signing key. The <see cref="PlainSecret"/>
+/// is returned exactly once — store it securely.
+/// </summary>
+public sealed record WebhookSigningKeyCreatedResponse(
+    Guid Id,
+    Guid SubscriptionId,
+    DateTimeOffset CreatedAt,
+    string PlainSecret);

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSigningKeyEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSigningKeyEndpoints.cs
@@ -1,0 +1,161 @@
+using Granit.Exceptions;
+using Granit.Http.Idempotency.Attributes;
+using Granit.Timing;
+using Granit.Webhooks.Abstractions;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.Endpoints.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Webhooks.Endpoints.Endpoints;
+
+/// <summary>
+/// Admin endpoints managing the per-subscription <see cref="WebhookSigningKey"/> collection.
+/// </summary>
+/// <remarks>
+/// All routes share the parent subscription's permissions:
+/// <c>Webhooks.Subscriptions.Read</c> for listing, <c>Webhooks.Subscriptions.Manage</c> for
+/// rotation and revocation. No dedicated permission family is introduced — keys are an
+/// integral part of the subscription aggregate.
+/// </remarks>
+internal static class WebhookSigningKeyEndpoints
+{
+    /// <summary>
+    /// Maps the read-side signing key endpoint (GET /subscriptions/{id}/keys).
+    /// Requires <c>Webhooks.Subscriptions.Read</c> (inherited from the parent route group).
+    /// </summary>
+    internal static RouteGroupBuilder MapSigningKeyReadEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/subscriptions/{id:guid}/keys", ListKeys)
+            .WithName("ListWebhookSigningKeys")
+            .WithSummary("Lists the signing keys associated with a subscription.")
+            .WithDescription(
+                "Returns all signing keys for the subscription, including Active, Retired (within "
+                + "the rotation grace period), and Revoked entries. The protected secret value is "
+                + "never disclosed; rotate the key to obtain a new plain-text secret.")
+            .Produces<IReadOnlyList<WebhookSigningKeyResponse>>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    /// <summary>
+    /// Maps the write-side signing key endpoints (POST and DELETE).
+    /// Caller must apply <c>Webhooks.Subscriptions.Manage</c> via <c>RequireAuthorization</c>.
+    /// </summary>
+    internal static RouteGroupBuilder MapSigningKeyWriteEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/subscriptions/{id:guid}/keys", RotateKey)
+            .WithName("RotateWebhookSigningKey")
+            .WithSummary("Rotates the subscription's signing key with overlap semantics.")
+            .WithDescription(
+                "Generates a new Active signing key and moves the previous Active key to Retired "
+                + "for a configurable grace period (default 24 hours, controlled by "
+                + "WebhooksOptions.RetiredKeyGracePeriod). Verification accepts both keys until the "
+                + "Retired key expires. The new plain-text secret is returned exactly once.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces<WebhookSigningKeyCreatedResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapDelete("/subscriptions/{id:guid}/keys/{keyId:guid}", RevokeKey)
+            .WithName("RevokeWebhookSigningKey")
+            .WithSummary("Revokes a specific signing key.")
+            .WithDescription(
+                "Marks the targeted key as Revoked. Verification will reject signatures produced "
+                + "with this key from now on. The last Active key cannot be revoked — rotate first "
+                + "to introduce a new Active key, then revoke the old one.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<WebhookSigningKeyResponse>>, ProblemHttpResult>> ListKeys(
+        Guid id,
+        [FromServices] IWebhookSubscriptionReader subscriptionReader,
+        [FromServices] IWebhookSigningKeyReader keyReader,
+        CancellationToken cancellationToken)
+    {
+        WebhookSubscription? subscription = await subscriptionReader
+            .FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        IReadOnlyList<WebhookSigningKey> keys = await keyReader
+            .GetForSubscriptionAsync(id, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<WebhookSigningKeyResponse> projection = [.. keys.Select(k => new WebhookSigningKeyResponse(
+            k.Id,
+            k.SubscriptionId,
+            k.CreatedAt,
+            k.ExpiresAt,
+            k.RevokedAt,
+            k.LastRotationNotificationAt,
+            k.Status))];
+
+        return TypedResults.Ok(projection);
+    }
+
+    private static async Task<Results<Created<WebhookSigningKeyCreatedResponse>, ProblemHttpResult>> RotateKey(
+        Guid id,
+        [FromServices] IWebhookSubscriptionReader subscriptionReader,
+        [FromServices] IWebhookSigningKeyWriter keyWriter,
+        [FromServices] IWebhookSigningKeyReader keyReader,
+        [FromServices] IClock clock,
+        CancellationToken cancellationToken)
+    {
+        WebhookSubscription? subscription = await subscriptionReader
+            .FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        WebhookSigningKeyRotatedResult result = await keyWriter
+            .RotateSigningKeyAsync(id, retiredKeyGracePeriod: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        WebhookSigningKey? newKey = await keyReader
+            .FindByIdAsync(result.KeyId, cancellationToken).ConfigureAwait(false);
+
+        DateTimeOffset createdAt = newKey?.CreatedAt ?? clock.Now;
+
+        var response = new WebhookSigningKeyCreatedResponse(
+            result.KeyId,
+            id,
+            createdAt,
+            result.PlainSecret);
+
+        return TypedResults.Created($"/subscriptions/{id}/keys/{result.KeyId}", response);
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> RevokeKey(
+        Guid id,
+        Guid keyId,
+        [FromServices] IWebhookSigningKeyWriter keyWriter,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await keyWriter.RevokeSigningKeyAsync(id, keyId, cancellationToken).ConfigureAwait(false);
+            return TypedResults.NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (EntityNotFoundException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+}

--- a/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
@@ -52,12 +52,17 @@ public static class WebhooksEndpointRouteBuilderExtensions
         group.MapEventTypeEndpoints();
         group.MapReadEndpoints();
 
+        // Signing key list — Read permission inherited from the parent group.
+        group.MapSigningKeyReadEndpoints();
+
         // Mutating operations require Manage permission (ISO 27001 A.5.15 — least privilege).
         group.MapWriteEndpoints()
             .RequireAuthorization(WebhooksPermissions.Subscriptions.Manage);
         group.MapLifecycleEndpoints()
             .RequireAuthorization(WebhooksPermissions.Subscriptions.Manage);
         group.MapOperationEndpoints()
+            .RequireAuthorization(WebhooksPermissions.Subscriptions.Manage);
+        group.MapSigningKeyWriteEndpoints()
             .RequireAuthorization(WebhooksPermissions.Subscriptions.Manage);
 
         // Query endpoints for subscription list and delivery attempts.

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSigningKeyConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSigningKeyConfiguration.cs
@@ -1,0 +1,48 @@
+using Granit.Webhooks.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Configurations;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="WebhookSigningKey"/>.
+/// Table: <c>webhook_signing_keys</c>.
+/// </summary>
+/// <remarks>
+/// FK to <see cref="WebhookSubscription"/> with <see cref="DeleteBehavior.Cascade"/>: signing
+/// keys are an integral part of the subscription aggregate and have no meaning without it.
+/// </remarks>
+internal sealed class WebhookSigningKeyConfiguration : IEntityTypeConfiguration<WebhookSigningKey>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<WebhookSigningKey> builder)
+    {
+        builder.ToTable(
+            GranitWebhooksDbProperties.DbTablePrefix + "signing_keys",
+            GranitWebhooksDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.SubscriptionId).IsRequired();
+
+        builder.Property(e => e.ProtectedSecret)
+            .HasMaxLength(1000)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt).IsRequired();
+        builder.Property(e => e.ExpiresAt);
+        builder.Property(e => e.RevokedAt);
+        builder.Property(e => e.LastRotationNotificationAt);
+
+        builder.Property(e => e.Status)
+            .IsRequired()
+            .HasDefaultValue(WebhookSigningKeyStatus.Active);
+
+        // Hot path: rotation scanner (FU-1b) filters by (Status, ExpiresAt, CreatedAt).
+        builder.HasIndex(e => new { e.SubscriptionId, e.Status })
+            .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}signing_keys_subscription_status");
+
+        builder.HasIndex(e => e.ExpiresAt)
+            .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}signing_keys_expires_at");
+    }
+}

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
@@ -27,10 +27,23 @@ internal sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguratio
             .HasMaxLength(200)
             .IsRequired();
 
-        // Protected signing secret — never store plaintext in production.
+        // Legacy protected signing secret — kept nullable for back-compat. New subscriptions
+        // ship with WebhookSigningKey rows instead. Cleared on first RotateSigningKey.
+#pragma warning disable CS0618 // SigningSecret is intentionally retained for back-compat.
         builder.Property(e => e.SigningSecret)
-            .HasMaxLength(1000)
-            .IsRequired();
+            .HasMaxLength(1000);
+#pragma warning restore CS0618
+
+        // Aggregate child collection — cascade delete keeps keys tied to their subscription.
+        builder.HasMany(e => e.SigningKeys)
+            .WithOne()
+            .HasForeignKey(k => k.SubscriptionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Backing field for the read-only navigation property.
+        builder.Metadata
+            .FindNavigation(nameof(WebhookSubscription.SigningKeys))!
+            .SetPropertyAccessMode(PropertyAccessMode.Field);
 
         builder.Property(e => e.TenantId);
 

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -42,6 +42,10 @@ public static class WebhooksEntityFrameworkCoreHostApplicationBuilderExtensions
             ServiceDescriptor.Scoped<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+        builder.Services.Replace(
+            ServiceDescriptor.Scoped<IWebhookSigningKeyReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+        builder.Services.Replace(
+            ServiceDescriptor.Scoped<IWebhookSigningKeyWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
 
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IWebhookDeliveryWriter, EfWebhookDeliveryStore>());

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs
@@ -17,6 +17,7 @@ public static class WebhooksModelBuilderExtensions
     public static ModelBuilder ConfigureWebhooksModule(this ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new WebhookSubscriptionConfiguration());
+        modelBuilder.ApplyConfiguration(new WebhookSigningKeyConfiguration());
         modelBuilder.ApplyConfiguration(new WebhookDeliveryAttemptConfiguration());
         return modelBuilder;
     }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
@@ -8,44 +8,80 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
+using Granit.Webhooks.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// EF Core implementation of <see cref="IWebhookSubscriptionReader"/> and
-/// <see cref="IWebhookSubscriptionWriter"/> backed by PostgreSQL.
+/// EF Core implementation of <see cref="IWebhookSubscriptionReader"/>,
+/// <see cref="IWebhookSubscriptionWriter"/>, <see cref="IWebhookSigningKeyReader"/>, and
+/// <see cref="IWebhookSigningKeyWriter"/> backed by PostgreSQL.
 /// </summary>
 internal sealed class EfWebhookSubscriptionStore(
     IDbContextFactory<WebhooksDbContext> contextFactory,
     ICurrentTenant currentTenant,
     IGuidGenerator guidGenerator,
     IWebhookSecretProtector secretProtector,
-    IClock clock)
+    IClock clock,
+    IOptions<WebhooksOptions> options)
     : EfStoreBase<WebhookSubscription, WebhooksDbContext>(contextFactory, currentTenant),
-      IWebhookSubscriptionReader, IWebhookSubscriptionWriter
+      IWebhookSubscriptionReader,
+      IWebhookSubscriptionWriter,
+      IWebhookSigningKeyReader,
+      IWebhookSigningKeyWriter
 {
+    // Locally-held copy of the factory so we can spin up DbContexts for queries that need
+    // .Include(s => s.SigningKeys) without going through the EfStoreBase Query() pipeline.
+    // The base class already captures contextFactory; using the parameter directly here would
+    // raise CS9107 (double capture).
+    private readonly IDbContextFactory<WebhooksDbContext> _contextFactory = contextFactory;
     /// <inheritdoc/>
-    public Task<IReadOnlyList<WebhookSubscription>> GetActiveSubscriptionsAsync(
+    public async Task<IReadOnlyList<WebhookSubscription>> GetActiveSubscriptionsAsync(
         string eventType,
         Guid? tenantId,
-        CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<WebhookSubscription>()
-                .Where(s => s.Status == WebhookSubscriptionStatus.Active
-                         && s.EventType == eventType
-                         && (s.TenantId == null || s.TenantId == tenantId)),
-            cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        await using WebhooksDbContext db = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        List<WebhookSubscription> subs = await db.WebhookSubscriptions
+            .Include(s => s.SigningKeys)
+            .Where(s => s.Status == WebhookSubscriptionStatus.Active
+                     && s.EventType == eventType
+                     && (s.TenantId == null || s.TenantId == tenantId))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return subs;
+    }
 
     /// <inheritdoc/>
-    public new Task<WebhookSubscription?> FindByIdAsync(
+    public new async Task<WebhookSubscription?> FindByIdAsync(
         Guid subscriptionId,
-        CancellationToken cancellationToken = default) =>
-        base.FindByIdAsync(subscriptionId, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        await using WebhooksDbContext db = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await db.WebhookSubscriptions
+            .Include(s => s.SigningKeys)
+            .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<WebhookSubscription>> GetAllAsync(CancellationToken cancellationToken = default) =>
-        ListAsync(Spec.For<WebhookSubscription>(), cancellationToken);
+    public async Task<IReadOnlyList<WebhookSubscription>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        await using WebhooksDbContext db = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        List<WebhookSubscription> subs = await db.WebhookSubscriptions
+            .Include(s => s.SigningKeys)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return subs;
+    }
 
     /// <inheritdoc/>
     public async Task<WebhookSubscriptionCreatedResult> CreateAsync(
@@ -59,11 +95,13 @@ internal sealed class EfWebhookSubscriptionStore(
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        var subscription = WebhookSubscription.Create(
+        var subscription = WebhookSubscription.CreateWithSigningKey(
             guidGenerator.Create(),
             targetUrl,
             eventType,
+            guidGenerator.Create(),
             protectedSecret,
+            clock.Now,
             tenantId);
 
         await AddAsync(subscription, cancellationToken).ConfigureAwait(false);
@@ -124,18 +162,84 @@ internal sealed class EfWebhookSubscriptionStore(
     /// <inheritdoc/>
     public async Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
     {
+        WebhookSigningKeyRotatedResult result = await RotateSigningKeyAsync(
+            subscriptionId, retiredKeyGracePeriod: null, cancellationToken).ConfigureAwait(false);
+
+        return result.PlainSecret;
+    }
+
+    /// <inheritdoc/>
+    public async Task<WebhookSigningKeyRotatedResult> RotateSigningKeyAsync(
+        Guid subscriptionId,
+        TimeSpan? retiredKeyGracePeriod = null,
+        CancellationToken cancellationToken = default)
+    {
         string plainSecret = GenerateSigningSecret();
         string protectedSecret = await secretProtector
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
+        TimeSpan grace = retiredKeyGracePeriod ?? options.Value.RetiredKeyGracePeriod;
+        Guid newKeyId = guidGenerator.Create();
+
         await WriteAsync(async db =>
         {
-            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
-            subscription.RotateSecret(protectedSecret);
+            WebhookSubscription subscription = await db.WebhookSubscriptions
+                .Include(s => s.SigningKeys)
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
+
+            subscription.RotateSigningKey(newKeyId, protectedSecret, clock.Now, grace);
         }, cancellationToken).ConfigureAwait(false);
 
-        return plainSecret;
+        return new WebhookSigningKeyRotatedResult(newKeyId, plainSecret);
+    }
+
+    /// <inheritdoc/>
+    public Task RevokeSigningKeyAsync(
+        Guid subscriptionId,
+        Guid keyId,
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
+        {
+            WebhookSubscription subscription = await db.WebhookSubscriptions
+                .Include(s => s.SigningKeys)
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
+
+            bool revoked = subscription.RevokeSigningKey(keyId, clock.Now);
+            if (!revoked)
+            {
+                throw new EntityNotFoundException(typeof(WebhookSigningKey), keyId);
+            }
+        }, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<WebhookSigningKey>> GetForSubscriptionAsync(
+        Guid subscriptionId,
+        CancellationToken cancellationToken = default)
+    {
+        await using WebhooksDbContext db = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        List<WebhookSigningKey> keys = await db.WebhookSigningKeys
+            .Where(k => k.SubscriptionId == subscriptionId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return keys;
+    }
+
+    async Task<WebhookSigningKey?> IWebhookSigningKeyReader.FindByIdAsync(
+        Guid keyId,
+        CancellationToken cancellationToken)
+    {
+        await using WebhooksDbContext db = await _contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await db.WebhookSigningKeys
+            .FirstOrDefaultAsync(k => k.Id == keyId, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<WebhookSubscription> FindOrThrowAsync(

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
@@ -23,6 +23,14 @@ internal sealed class WebhooksDbContext(
     /// <summary>Webhook subscriptions.</summary>
     public DbSet<WebhookSubscription> WebhookSubscriptions => Set<WebhookSubscription>();
 
+    /// <summary>
+    /// Signing keys per subscription. Backs the dual-key delivery and verification model
+    /// (FU-1a) — overlap rotation: an old <see cref="WebhookSigningKeyStatus.Retired"/> key
+    /// is still accepted while a new <see cref="WebhookSigningKeyStatus.Active"/> key takes
+    /// over signing.
+    /// </summary>
+    public DbSet<WebhookSigningKey> WebhookSigningKeys => Set<WebhookSigningKey>();
+
     /// <summary>Immutable ISO 27001 audit trail of delivery attempts.</summary>
     public DbSet<WebhookDeliveryAttempt> WebhookDeliveryAttempts => Set<WebhookDeliveryAttempt>();
 

--- a/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyReader.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyReader.cs
@@ -1,0 +1,21 @@
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Abstractions;
+
+/// <summary>
+/// Read operations for <see cref="WebhookSigningKey"/> entities.
+/// </summary>
+public interface IWebhookSigningKeyReader
+{
+    /// <summary>
+    /// Returns all signing keys for the given subscription, regardless of status.
+    /// Includes <see cref="WebhookSigningKeyStatus.Active"/>, <see cref="WebhookSigningKeyStatus.Retired"/>,
+    /// and <see cref="WebhookSigningKeyStatus.Revoked"/> entries.
+    /// </summary>
+    Task<IReadOnlyList<WebhookSigningKey>> GetForSubscriptionAsync(
+        Guid subscriptionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the signing key with the given identifier, or <c>null</c> if not found.</summary>
+    Task<WebhookSigningKey?> FindByIdAsync(Guid keyId, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs
@@ -1,0 +1,55 @@
+namespace Granit.Webhooks.Abstractions;
+
+/// <summary>
+/// Write operations for webhook signing keys (administrative actions).
+/// </summary>
+public interface IWebhookSigningKeyWriter
+{
+    /// <summary>
+    /// Rotates the subscription's signing key using overlap-rotation semantics.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The currently active key (if any) is moved to <c>Retired</c> and remains accepted in
+    /// verification for <paramref name="retiredKeyGracePeriod"/>. A new active key is created
+    /// and returned (plain-text — only once).
+    /// </para>
+    /// <para>
+    /// On the first rotation after upgrade, the legacy
+    /// <see cref="Domain.WebhookSubscription.SigningSecret"/> field is cleared.
+    /// </para>
+    /// </remarks>
+    /// <param name="subscriptionId">Target subscription identifier.</param>
+    /// <param name="retiredKeyGracePeriod">
+    /// Optional grace period overriding the configured default
+    /// (<see cref="Options.WebhooksOptions.RetiredKeyGracePeriod"/>).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Identifier of the new active key and its plain-text secret (returned once).</returns>
+    Task<WebhookSigningKeyRotatedResult> RotateSigningKeyAsync(
+        Guid subscriptionId,
+        TimeSpan? retiredKeyGracePeriod = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes a specific signing key. Verification will reject the key from this point on.
+    /// </summary>
+    /// <remarks>
+    /// The last <see cref="Domain.WebhookSigningKeyStatus.Active"/> key cannot be revoked —
+    /// rotate first to introduce a new active key.
+    /// </remarks>
+    /// <param name="subscriptionId">Owning subscription identifier.</param>
+    /// <param name="keyId">Identifier of the key to revoke.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RevokeSigningKeyAsync(
+        Guid subscriptionId,
+        Guid keyId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a successful <see cref="IWebhookSigningKeyWriter.RotateSigningKeyAsync"/> call.
+/// </summary>
+/// <param name="KeyId">Identifier of the newly-created active signing key.</param>
+/// <param name="PlainSecret">Plain-text secret value (only returned once).</param>
+public sealed record WebhookSigningKeyRotatedResult(Guid KeyId, string PlainSecret);

--- a/src/Granit.Webhooks/Domain/WebhookSigningKey.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSigningKey.cs
@@ -1,0 +1,143 @@
+using Granit.DataProtection;
+using Granit.Domain;
+
+namespace Granit.Webhooks.Domain;
+
+/// <summary>
+/// First-class signing key associated with a <see cref="WebhookSubscription"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the legacy single-<see cref="WebhookSubscription.SigningSecret"/> field with a
+/// proper key history, enabling overlap rotation: a previously-<see cref="WebhookSigningKeyStatus.Active"/>
+/// key transitions to <see cref="WebhookSigningKeyStatus.Retired"/> with an
+/// <see cref="ExpiresAt"/> in the (configurable) future and is still accepted in
+/// verification until that grace period elapses, while the new key takes over signing.
+/// </para>
+/// <para>
+/// The <see cref="ProtectedSecret"/> is opaque: its format is determined by the registered
+/// <see cref="Abstractions.IWebhookSecretProtector"/>. Never log or expose this value.
+/// </para>
+/// <para>
+/// ISO 27001 A.10.1 / A.8.24 — keys are explicitly versioned, expirable, and revocable.
+/// </para>
+/// </remarks>
+public sealed class WebhookSigningKey : Entity
+{
+    // Parameterless constructor required by EF Core materializer.
+    private WebhookSigningKey() { }
+
+    /// <summary>
+    /// Creates a new <see cref="WebhookSigningKey"/>.
+    /// </summary>
+    /// <param name="id">Unique identifier for the key.</param>
+    /// <param name="subscriptionId">Owning <see cref="WebhookSubscription"/> identifier.</param>
+    /// <param name="protectedSecret">Opaque protected secret (format defined by <see cref="Abstractions.IWebhookSecretProtector"/>).</param>
+    /// <param name="createdAt">Creation timestamp (provided by an <see cref="Granit.Timing.IClock"/>).</param>
+    /// <param name="status">Initial status — typically <see cref="WebhookSigningKeyStatus.Active"/>.</param>
+    /// <param name="expiresAt">Optional expiration timestamp (relevant when <paramref name="status"/> is <see cref="WebhookSigningKeyStatus.Retired"/>).</param>
+    public static WebhookSigningKey Create(
+        Guid id,
+        Guid subscriptionId,
+        string protectedSecret,
+        DateTimeOffset createdAt,
+        WebhookSigningKeyStatus status = WebhookSigningKeyStatus.Active,
+        DateTimeOffset? expiresAt = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(protectedSecret);
+
+        return new WebhookSigningKey
+        {
+            Id = id,
+            SubscriptionId = subscriptionId,
+            ProtectedSecret = protectedSecret,
+            CreatedAt = createdAt,
+            Status = status,
+            ExpiresAt = expiresAt,
+        };
+    }
+
+    /// <summary>Identifier of the owning <see cref="WebhookSubscription"/>.</summary>
+    public Guid SubscriptionId { get; private set; }
+
+    /// <summary>
+    /// Protected signing secret. Opaque — format is determined by <see cref="Abstractions.IWebhookSecretProtector"/>.
+    /// Never log or expose this value. Maximum length: 1000 characters.
+    /// </summary>
+    [SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    public string ProtectedSecret { get; private set; } = string.Empty;
+
+    /// <summary>UTC timestamp when this key was created.</summary>
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>
+    /// UTC timestamp when this key stops being accepted in verification.
+    /// <c>null</c> for currently <see cref="WebhookSigningKeyStatus.Active"/> keys.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; private set; }
+
+    /// <summary>UTC timestamp when this key was explicitly revoked by an operator.</summary>
+    public DateTimeOffset? RevokedAt { get; private set; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent rotation-due notification emitted for this key.
+    /// Populated by the rotation scanner (FU-1b) to dedupe notifications. <c>null</c> until
+    /// the first notification is sent.
+    /// </summary>
+    public DateTimeOffset? LastRotationNotificationAt { get; private set; }
+
+    /// <summary>Current lifecycle status — see <see cref="WebhookSigningKeyStatus"/>.</summary>
+    public WebhookSigningKeyStatus Status { get; private set; } = WebhookSigningKeyStatus.Active;
+
+    /// <summary>
+    /// Indicates whether this key is still accepted in verification at <paramref name="now"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WebhookSigningKeyStatus.Active"/> keys are always accepted. <see cref="WebhookSigningKeyStatus.Retired"/>
+    /// keys are accepted while <see cref="ExpiresAt"/> is in the future. <see cref="WebhookSigningKeyStatus.Revoked"/>
+    /// keys are never accepted.
+    /// </remarks>
+    public bool IsAcceptableAt(DateTimeOffset now) => Status switch
+    {
+        WebhookSigningKeyStatus.Active => true,
+        WebhookSigningKeyStatus.Retired => ExpiresAt is null || ExpiresAt > now,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Transitions an <see cref="WebhookSigningKeyStatus.Active"/> key to
+    /// <see cref="WebhookSigningKeyStatus.Retired"/>, setting an expiration in the future.
+    /// </summary>
+    internal void Retire(DateTimeOffset retiredAt, TimeSpan gracePeriod)
+    {
+        if (Status != WebhookSigningKeyStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Cannot retire a signing key with status '{Status}'. Only 'Active' keys can be retired.");
+        }
+
+        Status = WebhookSigningKeyStatus.Retired;
+        ExpiresAt = retiredAt + gracePeriod;
+    }
+
+    /// <summary>
+    /// Marks the key as <see cref="WebhookSigningKeyStatus.Revoked"/>, blocking it from any future verification.
+    /// </summary>
+    internal void Revoke(DateTimeOffset revokedAt)
+    {
+        if (Status == WebhookSigningKeyStatus.Revoked)
+        {
+            throw new InvalidOperationException("Signing key is already revoked.");
+        }
+
+        Status = WebhookSigningKeyStatus.Revoked;
+        RevokedAt = revokedAt;
+    }
+
+    /// <summary>
+    /// Records the timestamp of the most recent rotation-due notification, used by the
+    /// scanner (FU-1b) to dedupe emissions.
+    /// </summary>
+    internal void StampRotationNotification(DateTimeOffset notifiedAt) =>
+        LastRotationNotificationAt = notifiedAt;
+}

--- a/src/Granit.Webhooks/Domain/WebhookSigningKeyStatus.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSigningKeyStatus.cs
@@ -1,0 +1,31 @@
+namespace Granit.Webhooks.Domain;
+
+/// <summary>
+/// Lifecycle status of a <see cref="WebhookSigningKey"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Verification rules per status:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="Active"/>: used to sign new deliveries. Always accepted in verification.</item>
+///   <item><see cref="Retired"/>: previously active, kept around during the rotation grace
+///     period. Still accepted in verification while <see cref="WebhookSigningKey.ExpiresAt"/>
+///     is in the future.</item>
+///   <item><see cref="Revoked"/>: explicitly invalidated by an operator. Never accepted.</item>
+/// </list>
+/// </remarks>
+public enum WebhookSigningKeyStatus
+{
+    /// <summary>Currently used to sign outgoing deliveries.</summary>
+    Active = 0,
+
+    /// <summary>
+    /// Replaced by a newer <see cref="Active"/> key but still accepted during the
+    /// rotation grace period (controlled by <see cref="WebhookSigningKey.ExpiresAt"/>).
+    /// </summary>
+    Retired = 1,
+
+    /// <summary>Explicitly invalidated by an operator. Never accepted.</summary>
+    Revoked = 2,
+}

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -22,6 +22,8 @@ namespace Granit.Webhooks.Domain;
 /// </remarks>
 public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
 {
+    private readonly List<WebhookSigningKey> _signingKeys = [];
+
     // Parameterless constructor required by EF Core materializer.
     private WebhookSubscription() { }
 
@@ -40,10 +42,45 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
             Id = id,
             TargetUrl = targetUrl,
             EventType = eventType,
+#pragma warning disable CS0618 // SigningSecret is obsolete but still populated when callers
             SigningSecret = signingSecret,
+#pragma warning restore CS0618 // hand in a legacy single-secret payload (back-compat).
             TenantId = tenantId,
             Status = WebhookSubscriptionStatus.Active,
         };
+
+        subscription.AddDomainEvent(new WebhookSubscriptionCreatedEvent(id, eventType, targetUrl.Value));
+        return subscription;
+    }
+
+    /// <summary>
+    /// Creates a new active <see cref="WebhookSubscription"/> with an initial
+    /// <see cref="WebhookSigningKey"/> rather than the legacy <see cref="SigningSecret"/> field.
+    /// Preferred constructor for callers using the dual-key delivery model.
+    /// </summary>
+    public static WebhookSubscription CreateWithSigningKey(
+        Guid id,
+        HttpsUrl targetUrl,
+        string eventType,
+        Guid signingKeyId,
+        string protectedSecret,
+        DateTimeOffset createdAt,
+        Guid? tenantId = null)
+    {
+        var subscription = new WebhookSubscription
+        {
+            Id = id,
+            TargetUrl = targetUrl,
+            EventType = eventType,
+            TenantId = tenantId,
+            Status = WebhookSubscriptionStatus.Active,
+        };
+
+        subscription._signingKeys.Add(WebhookSigningKey.Create(
+            signingKeyId,
+            id,
+            protectedSecret,
+            createdAt));
 
         subscription.AddDomainEvent(new WebhookSubscriptionCreatedEvent(id, eventType, targetUrl.Value));
         return subscription;
@@ -62,12 +99,25 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
     public string EventType { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Protected signing secret used to compute the <c>x-granit-signature</c> HMAC.
-    /// The raw value is opaque — protected by <see cref="Abstractions.IWebhookSecretProtector"/>.
-    /// Never store or log the plaintext secret. Maximum length: 1000 characters.
+    /// Legacy protected signing secret. Retained for backward-compatibility with subscriptions
+    /// created before the <see cref="WebhookSigningKey"/> aggregate was introduced and never
+    /// rotated since. Set to <c>null</c> on the first call to <see cref="RotateSigningKey"/>.
     /// </summary>
+    /// <remarks>
+    /// New subscriptions ship with an entry in <see cref="SigningKeys"/> and a <c>null</c>
+    /// <see cref="SigningSecret"/>. Verification falls back to this field when no
+    /// <see cref="WebhookSigningKey"/> matches.
+    /// </remarks>
     [SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
-    public string SigningSecret { get; private set; } = string.Empty;
+    [Obsolete("Use SigningKeys collection. Retained for backward compatibility — set to null on first rotation.")]
+    public string? SigningSecret { get; private set; }
+
+    /// <summary>
+    /// Signing keys associated with this subscription, including
+    /// <see cref="WebhookSigningKeyStatus.Active"/>, <see cref="WebhookSigningKeyStatus.Retired"/>
+    /// (within grace period), and <see cref="WebhookSigningKeyStatus.Revoked"/> entries.
+    /// </summary>
+    public IReadOnlyList<WebhookSigningKey> SigningKeys => _signingKeys.AsReadOnly();
 
     /// <summary>
     /// Tenant this subscription belongs to.
@@ -200,8 +250,92 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
         TargetUrl = targetUrl;
 
     /// <summary>
-    /// Replaces the signing secret with a new protected value.
+    /// Replaces the legacy single signing secret with a new protected value.
     /// </summary>
+    /// <remarks>
+    /// Preserved for backward compatibility. New code should call
+    /// <see cref="RotateSigningKey"/>, which uses the <see cref="WebhookSigningKey"/>
+    /// aggregate and supports overlap rotation.
+    /// </remarks>
+    [Obsolete("Use RotateSigningKey for overlap-rotation semantics.")]
     internal void RotateSecret(string newProtectedSecret) =>
+#pragma warning disable CS0618 // Intentionally writes to legacy field for back-compat.
         SigningSecret = newProtectedSecret;
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Rotates the subscription's signing key using overlap-rotation semantics.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The currently <see cref="WebhookSigningKeyStatus.Active"/> key (if any) is moved to
+    /// <see cref="WebhookSigningKeyStatus.Retired"/> with an <see cref="WebhookSigningKey.ExpiresAt"/>
+    /// set to <paramref name="now"/> + <paramref name="retiredKeyGracePeriod"/>. A new
+    /// <see cref="WebhookSigningKeyStatus.Active"/> key is appended.
+    /// </para>
+    /// <para>
+    /// On the first rotation following the upgrade from the legacy single-secret model,
+    /// the legacy <see cref="SigningSecret"/> field is cleared. Note that legacy
+    /// pre-upgrade secret material is intentionally NOT migrated into a
+    /// <see cref="WebhookSigningKey"/> entity — the previous secret is dropped at
+    /// rotation time, matching the behaviour of the legacy
+    /// <see cref="RotateSecret(string)"/> method.
+    /// </para>
+    /// </remarks>
+    /// <param name="newKeyId">Identifier for the new signing key.</param>
+    /// <param name="newProtectedSecret">Opaque protected secret for the new key.</param>
+    /// <param name="now">Current timestamp (provided by an <see cref="Granit.Timing.IClock"/>).</param>
+    /// <param name="retiredKeyGracePeriod">Grace period during which the previously-active key remains accepted in verification.</param>
+    /// <returns>The newly-created active key.</returns>
+    internal WebhookSigningKey RotateSigningKey(
+        Guid newKeyId,
+        string newProtectedSecret,
+        DateTimeOffset now,
+        TimeSpan retiredKeyGracePeriod)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newProtectedSecret);
+
+        WebhookSigningKey? currentActive = _signingKeys
+            .Find(k => k.Status == WebhookSigningKeyStatus.Active);
+
+        currentActive?.Retire(now, retiredKeyGracePeriod);
+
+        var newKey = WebhookSigningKey.Create(
+            newKeyId,
+            Id,
+            newProtectedSecret,
+            now);
+
+        _signingKeys.Add(newKey);
+
+#pragma warning disable CS0618 // Clears the legacy field — the new key is authoritative now.
+        SigningSecret = null;
+#pragma warning restore CS0618
+
+        return newKey;
+    }
+
+    /// <summary>
+    /// Revokes a specific signing key by id. The last <see cref="WebhookSigningKeyStatus.Active"/>
+    /// key cannot be revoked — rotate first to introduce a new active key, then revoke.
+    /// </summary>
+    /// <returns><c>true</c> if a key was revoked; <c>false</c> if no key with the given id exists.</returns>
+    internal bool RevokeSigningKey(Guid keyId, DateTimeOffset now)
+    {
+        WebhookSigningKey? key = _signingKeys.Find(k => k.Id == keyId);
+        if (key is null)
+        {
+            return false;
+        }
+
+        if (key.Status == WebhookSigningKeyStatus.Active &&
+            _signingKeys.Count(k => k.Status == WebhookSigningKeyStatus.Active) <= 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot revoke the last active signing key. Rotate first to introduce a new active key.");
+        }
+
+        key.Revoke(now);
+        return true;
+    }
 }

--- a/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
@@ -72,6 +72,8 @@ public static class WebhooksHostApplicationBuilderExtensions
         builder.Services.AddSingleton<InMemoryWebhookSubscriptionStore>();
         builder.Services.AddSingleton<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<InMemoryWebhookSubscriptionStore>());
         builder.Services.AddSingleton<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<InMemoryWebhookSubscriptionStore>());
+        builder.Services.AddSingleton<IWebhookSigningKeyReader>(sp => sp.GetRequiredService<InMemoryWebhookSubscriptionStore>());
+        builder.Services.AddSingleton<IWebhookSigningKeyWriter>(sp => sp.GetRequiredService<InMemoryWebhookSubscriptionStore>());
         builder.Services.AddScoped<IWebhookDeliveryWriter, NullWebhookDeliveryWriter>();
         builder.Services.AddScoped<IWebhookDeliveryReader, NullWebhookDeliveryReader>();
         // Default: pass-through protector suitable for dev/test.

--- a/src/Granit.Webhooks/Handlers/SendWebhookHandler.cs
+++ b/src/Granit.Webhooks/Handlers/SendWebhookHandler.cs
@@ -79,7 +79,9 @@ public sealed partial class SendWebhookHandler(
             return; // Treat as non-retriable — subscription is gone.
         }
 
-        string plainSecret = await secretProtector.UnprotectAsync(subscription.SigningSecret, cancellationToken).ConfigureAwait(false);
+        string plainSecret = await WebhookSecretResolver
+            .ResolvePlainSecretAsync(subscription, secretProtector, cancellationToken)
+            .ConfigureAwait(false);
         string signature = WebhookSignatureService.Compute(plainSecret, sentAt, bodyJson);
 
         using StringContent content = new(bodyJson, Encoding.UTF8, "application/json");

--- a/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
@@ -6,22 +6,31 @@ using Granit.Guids;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
+using Granit.Webhooks.Options;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Webhooks.Internal;
 
 /// <summary>
-/// Thread-safe in-memory implementation of <see cref="IWebhookSubscriptionReader"/> and
-/// <see cref="IWebhookSubscriptionWriter"/>.
+/// Thread-safe in-memory implementation of <see cref="IWebhookSubscriptionReader"/>,
+/// <see cref="IWebhookSubscriptionWriter"/>, <see cref="IWebhookSigningKeyReader"/>, and
+/// <see cref="IWebhookSigningKeyWriter"/>.
 /// Suitable for development and unit tests. Does not persist across application restarts.
 /// </summary>
 internal sealed class InMemoryWebhookSubscriptionStore(
     IClock clock,
     IGuidGenerator guidGenerator,
-    IWebhookSecretProtector secretProtector) : IWebhookSubscriptionReader, IWebhookSubscriptionWriter
+    IWebhookSecretProtector secretProtector,
+    IOptions<WebhooksOptions> options)
+    : IWebhookSubscriptionReader,
+      IWebhookSubscriptionWriter,
+      IWebhookSigningKeyReader,
+      IWebhookSigningKeyWriter
 {
     private readonly IClock _clock = clock;
     private readonly IGuidGenerator _guidGenerator = guidGenerator;
     private readonly IWebhookSecretProtector _secretProtector = secretProtector;
+    private readonly IOptions<WebhooksOptions> _options = options;
     private readonly ConcurrentDictionary<Guid, WebhookSubscription> _subscriptions = new();
 
     public Task<IReadOnlyList<WebhookSubscription>> GetActiveSubscriptionsAsync(
@@ -61,11 +70,13 @@ internal sealed class InMemoryWebhookSubscriptionStore(
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        var subscription = WebhookSubscription.Create(
+        var subscription = WebhookSubscription.CreateWithSigningKey(
             _guidGenerator.Create(),
             targetUrl,
             eventType,
+            _guidGenerator.Create(),
             protectedSecret,
+            _clock.Now,
             tenantId);
 
         _subscriptions[subscription.Id] = subscription;
@@ -150,6 +161,18 @@ internal sealed class InMemoryWebhookSubscriptionStore(
 
     public async Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
     {
+        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)this)
+            .RotateSigningKeyAsync(subscriptionId, retiredKeyGracePeriod: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.PlainSecret;
+    }
+
+    public async Task<WebhookSigningKeyRotatedResult> RotateSigningKeyAsync(
+        Guid subscriptionId,
+        TimeSpan? retiredKeyGracePeriod = null,
+        CancellationToken cancellationToken = default)
+    {
         if (!_subscriptions.TryGetValue(subscriptionId, out WebhookSubscription? subscription))
         {
             throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
@@ -160,8 +183,64 @@ internal sealed class InMemoryWebhookSubscriptionStore(
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        subscription.RotateSecret(protectedSecret);
-        return plainSecret;
+        TimeSpan grace = retiredKeyGracePeriod ?? _options.Value.RetiredKeyGracePeriod;
+        Guid newKeyId = _guidGenerator.Create();
+
+        WebhookSigningKey newKey = subscription.RotateSigningKey(
+            newKeyId,
+            protectedSecret,
+            _clock.Now,
+            grace);
+
+        return new WebhookSigningKeyRotatedResult(newKey.Id, plainSecret);
+    }
+
+    public Task RevokeSigningKeyAsync(
+        Guid subscriptionId,
+        Guid keyId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_subscriptions.TryGetValue(subscriptionId, out WebhookSubscription? subscription))
+        {
+            throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
+        }
+
+        bool revoked = subscription.RevokeSigningKey(keyId, _clock.Now);
+        if (!revoked)
+        {
+            throw new EntityNotFoundException(typeof(WebhookSigningKey), keyId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<WebhookSigningKey>> GetForSubscriptionAsync(
+        Guid subscriptionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_subscriptions.TryGetValue(subscriptionId, out WebhookSubscription? subscription))
+        {
+            return Task.FromResult<IReadOnlyList<WebhookSigningKey>>([]);
+        }
+
+        IReadOnlyList<WebhookSigningKey> keys = subscription.SigningKeys.ToList();
+        return Task.FromResult(keys);
+    }
+
+    Task<WebhookSigningKey?> IWebhookSigningKeyReader.FindByIdAsync(Guid keyId, CancellationToken cancellationToken)
+    {
+        foreach (WebhookSubscription sub in _subscriptions.Values)
+        {
+            foreach (WebhookSigningKey key in sub.SigningKeys)
+            {
+                if (key.Id == keyId)
+                {
+                    return Task.FromResult<WebhookSigningKey?>(key);
+                }
+            }
+        }
+
+        return Task.FromResult<WebhookSigningKey?>(null);
     }
 
     /// <summary>

--- a/src/Granit.Webhooks/Internal/WebhookSecretResolver.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSecretResolver.cs
@@ -1,0 +1,66 @@
+using Granit.Webhooks.Abstractions;
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Internal;
+
+/// <summary>
+/// Resolves the signing material that should be used for an outbound webhook delivery.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Selection rule (FU-1a — dual-key delivery):
+/// </para>
+/// <list type="number">
+///   <item>If the subscription has a <see cref="WebhookSigningKeyStatus.Active"/> key,
+///     unprotect and return its <see cref="WebhookSigningKey.ProtectedSecret"/>.</item>
+///   <item>Otherwise (no active key — typically a legacy subscription created before the
+///     dual-key model and never rotated), fall back to the legacy
+///     <see cref="WebhookSubscription.SigningSecret"/> if it is non-null.</item>
+/// </list>
+/// <para>
+/// Throws <see cref="InvalidOperationException"/> if neither source is available — that
+/// would indicate a malformed subscription (no active key AND no legacy secret).
+/// </para>
+/// </remarks>
+internal static class WebhookSecretResolver
+{
+    public static async Task<string> ResolvePlainSecretAsync(
+        WebhookSubscription subscription,
+        IWebhookSecretProtector secretProtector,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        WebhookSigningKey? activeKey = null;
+        foreach (WebhookSigningKey k in subscription.SigningKeys)
+        {
+            if (k.Status == WebhookSigningKeyStatus.Active)
+            {
+                activeKey = k;
+                break;
+            }
+        }
+
+        if (activeKey is not null)
+        {
+            return await secretProtector
+                .UnprotectAsync(activeKey.ProtectedSecret, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+#pragma warning disable CS0618 // Legacy fallback for subscriptions never rotated since the upgrade.
+        string? legacy = subscription.SigningSecret;
+#pragma warning restore CS0618
+
+        if (!string.IsNullOrEmpty(legacy))
+        {
+            return await secretProtector
+                .UnprotectAsync(legacy, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Subscription '{subscription.Id}' has no active signing key and no legacy SigningSecret. "
+          + "Rotate the key to seed the dual-key model.");
+    }
+}

--- a/src/Granit.Webhooks/Internal/WebhookTestPingService.cs
+++ b/src/Granit.Webhooks/Internal/WebhookTestPingService.cs
@@ -39,8 +39,8 @@ internal sealed class WebhookTestPingService(
             throw new Granit.Exceptions.EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
         }
 
-        string plainSecret = await _secretProtector
-            .UnprotectAsync(subscription.SigningSecret, cancellationToken)
+        string plainSecret = await WebhookSecretResolver
+            .ResolvePlainSecretAsync(subscription, _secretProtector, cancellationToken)
             .ConfigureAwait(false);
 
         DateTimeOffset now = _clock.Now;

--- a/src/Granit.Webhooks/Options/WebhooksOptions.cs
+++ b/src/Granit.Webhooks/Options/WebhooksOptions.cs
@@ -37,6 +37,17 @@ public sealed class WebhooksOptions
     /// this setting against GDPR data-minimization requirements.
     /// </remarks>
     public bool StorePayload { get; set; }
+
+    /// <summary>
+    /// Grace period during which a previously-active <see cref="Domain.WebhookSigningKey"/>
+    /// remains accepted in verification after a rotation. Default: 24 hours.
+    /// </summary>
+    /// <remarks>
+    /// Override per-rotation via the <c>retiredKeyGracePeriod</c> argument on
+    /// <see cref="Abstractions.IWebhookSigningKeyWriter.RotateSigningKeyAsync"/>.
+    /// Must be greater than zero and not exceed 30 days.
+    /// </remarks>
+    public TimeSpan RetiredKeyGracePeriod { get; set; } = TimeSpan.FromHours(24);
 }
 
 /// <summary>
@@ -56,6 +67,12 @@ internal sealed class WebhooksOptionsValidator : IValidateOptions<WebhooksOption
         if (options.MaxParallelDeliveries < 1 || options.MaxParallelDeliveries > 100)
         {
             errors.Add($"{nameof(WebhooksOptions.MaxParallelDeliveries)} must be between 1 and 100 (got {options.MaxParallelDeliveries}).");
+        }
+
+        if (options.RetiredKeyGracePeriod <= TimeSpan.Zero || options.RetiredKeyGracePeriod > TimeSpan.FromDays(30))
+        {
+            errors.Add(
+                $"{nameof(WebhooksOptions.RetiredKeyGracePeriod)} must be positive and not exceed 30 days (got {options.RetiredKeyGracePeriod}).");
         }
 
         return errors.Count > 0

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
@@ -4,7 +4,9 @@ using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
+using Granit.Webhooks.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -36,7 +38,9 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
         clock.Now.Returns(Now);
 
         _contextFactory = new TestWebhooksDbContextFactory(_options);
-        _sut = new EfWebhookSubscriptionStore(_contextFactory, Substitute.For<ICurrentTenant>(), guidGenerator, secretProtector, clock);
+        IOptions<WebhooksOptions> webhooksOptions =
+            Microsoft.Extensions.Options.Options.Create(new WebhooksOptions());
+        _sut = new EfWebhookSubscriptionStore(_contextFactory, Substitute.For<ICurrentTenant>(), guidGenerator, secretProtector, clock, webhooksOptions);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
@@ -11,6 +11,8 @@ using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.Internal;
+using Granit.Webhooks.Options;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -35,7 +37,9 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
             .Returns(ci => new ValueTask<string>($"protected:{ci.ArgAt<string>(0)}"));
 #pragma warning restore CA2012
 
-        _store = new InMemoryWebhookSubscriptionStore(clock, guidGenerator, secretProtector);
+        IOptions<WebhooksOptions> options = Microsoft.Extensions.Options.Options.Create(new WebhooksOptions());
+
+        _store = new InMemoryWebhookSubscriptionStore(clock, guidGenerator, secretProtector, options);
     }
 
     [Fact]
@@ -293,6 +297,81 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         string newSecret = await _store.RotateSecretAsync(sub.Id, TestContext.Current.CancellationToken);
 
         newSecret.ShouldStartWith("whsec_");
+    }
+
+    // -------------------------------------------------------------------------
+    // RotateSigningKeyAsync — dual-key delivery model (FU-1a)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RotateSigningKeyAsync_OnLegacySubscription_AddsActiveKeyAndClearsLegacyField()
+    {
+        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
+        _store.Add(sub);
+
+        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        result.PlainSecret.ShouldStartWith("whsec_");
+        WebhookSubscription? updated = await _store.FindByIdAsync(sub.Id, TestContext.Current.CancellationToken);
+        updated.ShouldNotBeNull();
+        updated!.SigningKeys.Count.ShouldBe(1);
+        updated.SigningKeys[0].Status.ShouldBe(WebhookSigningKeyStatus.Active);
+#pragma warning disable CS0618 // Verifying back-compat behavior.
+        updated.SigningSecret.ShouldBeNull();
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public async Task RotateSigningKeyAsync_TwoRotations_RetiresFirstKey()
+    {
+        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
+        _store.Add(sub);
+
+        WebhookSigningKeyRotatedResult first = await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        WebhookSubscription? updated = await _store.FindByIdAsync(sub.Id, TestContext.Current.CancellationToken);
+        updated!.SigningKeys.Count.ShouldBe(2);
+        updated.SigningKeys.Count(k => k.Status == WebhookSigningKeyStatus.Active).ShouldBe(1);
+        WebhookSigningKey retired = updated.SigningKeys.Single(k => k.Id == first.KeyId);
+        retired.Status.ShouldBe(WebhookSigningKeyStatus.Retired);
+        retired.ExpiresAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RevokeSigningKeyAsync_LastActive_Throws()
+    {
+        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
+        _store.Add(sub);
+
+        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        Func<Task> act = () => ((IWebhookSigningKeyWriter)_store)
+            .RevokeSigningKeyAsync(sub.Id, result.KeyId, TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public async Task GetForSubscriptionAsync_ReturnsAllKeys()
+    {
+        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
+        _store.Add(sub);
+
+        await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+        await ((IWebhookSigningKeyWriter)_store)
+            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
+
+        IReadOnlyList<WebhookSigningKey> keys = await ((IWebhookSigningKeyReader)_store)
+            .GetForSubscriptionAsync(sub.Id, TestContext.Current.CancellationToken);
+
+        keys.Count.ShouldBe(2);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
@@ -1,0 +1,162 @@
+// =============================================================================
+// Tests - WebhookSigningKey + WebhookSubscription dual-key delivery model (FU-1a)
+// =============================================================================
+// Verifies overlap rotation: previous Active key transitions to Retired, the new
+// Active key takes over, IsAcceptableAt rules, last-active revocation guard, and
+// legacy SigningSecret clearing on first rotation.
+// =============================================================================
+
+using Granit.Webhooks.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Webhooks.Tests;
+
+public sealed class WebhookSigningKeyTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Grace = TimeSpan.FromHours(24);
+
+    [Fact]
+    public void RotateSigningKey_FromLegacySecret_AddsActiveKey_ClearsLegacyField()
+    {
+        WebhookSubscription subscription = LegacySubscription();
+
+#pragma warning disable CS0618 // Asserting legacy back-compat field is intentionally read.
+        subscription.SigningSecret.ShouldBe("legacy-protected");
+#pragma warning restore CS0618
+
+        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", Now, Grace);
+
+        subscription.SigningKeys.Count.ShouldBe(1);
+        WebhookSigningKey active = subscription.SigningKeys[0];
+        active.Status.ShouldBe(WebhookSigningKeyStatus.Active);
+        active.ProtectedSecret.ShouldBe("new-protected");
+        active.CreatedAt.ShouldBe(Now);
+        active.ExpiresAt.ShouldBeNull();
+
+#pragma warning disable CS0618 // Verifying the legacy field is cleared after first rotation.
+        subscription.SigningSecret.ShouldBeNull();
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void RotateSigningKey_RetiresPreviousActive_WithGracePeriod()
+    {
+        WebhookSubscription subscription = WithSigningKey(out Guid firstKeyId);
+
+        DateTimeOffset rotationAt = Now.AddDays(30);
+        subscription.RotateSigningKey(Guid.NewGuid(), "second-protected", rotationAt, Grace);
+
+        subscription.SigningKeys.Count.ShouldBe(2);
+
+        WebhookSigningKey retired = subscription.SigningKeys.Single(k => k.Id == firstKeyId);
+        retired.Status.ShouldBe(WebhookSigningKeyStatus.Retired);
+        retired.ExpiresAt.ShouldBe(rotationAt + Grace);
+
+        WebhookSigningKey active = subscription.SigningKeys.Single(k => k.Status == WebhookSigningKeyStatus.Active);
+        active.ProtectedSecret.ShouldBe("second-protected");
+    }
+
+    [Fact]
+    public void IsAcceptableAt_Active_AlwaysTrue()
+    {
+        WebhookSubscription subscription = WithSigningKey(out _);
+        WebhookSigningKey active = subscription.SigningKeys[0];
+
+        active.IsAcceptableAt(Now).ShouldBeTrue();
+        active.IsAcceptableAt(Now.AddYears(10)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsAcceptableAt_Retired_TrueWithinGrace_FalseAfter()
+    {
+        WebhookSubscription subscription = WithSigningKey(out _);
+
+        DateTimeOffset rotationAt = Now;
+        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", rotationAt, Grace);
+
+        WebhookSigningKey retired = subscription.SigningKeys.Single(k => k.Status == WebhookSigningKeyStatus.Retired);
+        retired.IsAcceptableAt(rotationAt).ShouldBeTrue();
+        retired.IsAcceptableAt(rotationAt + Grace - TimeSpan.FromMinutes(1)).ShouldBeTrue();
+        retired.IsAcceptableAt(rotationAt + Grace + TimeSpan.FromMinutes(1)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RevokeSigningKey_LastActive_Throws()
+    {
+        WebhookSubscription subscription = WithSigningKey(out Guid keyId);
+
+        Should.Throw<InvalidOperationException>(() =>
+            subscription.RevokeSigningKey(keyId, Now));
+    }
+
+    [Fact]
+    public void RevokeSigningKey_RetiredKey_RevokesAndIsRejected()
+    {
+        WebhookSubscription subscription = WithSigningKey(out Guid firstKeyId);
+        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", Now, Grace);
+
+        bool revoked = subscription.RevokeSigningKey(firstKeyId, Now);
+
+        revoked.ShouldBeTrue();
+        WebhookSigningKey reread = subscription.SigningKeys.Single(k => k.Id == firstKeyId);
+        reread.Status.ShouldBe(WebhookSigningKeyStatus.Revoked);
+        reread.RevokedAt.ShouldBe(Now);
+        reread.IsAcceptableAt(Now).ShouldBeFalse();
+        reread.IsAcceptableAt(Now.AddYears(1)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RevokeSigningKey_UnknownId_ReturnsFalse()
+    {
+        WebhookSubscription subscription = WithSigningKey(out _);
+
+        bool revoked = subscription.RevokeSigningKey(Guid.NewGuid(), Now);
+
+        revoked.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Revoke_AlreadyRevoked_Throws()
+    {
+        WebhookSubscription subscription = WithSigningKey(out Guid firstKeyId);
+        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", Now, Grace);
+        subscription.RevokeSigningKey(firstKeyId, Now);
+
+        Should.Throw<InvalidOperationException>(() =>
+            subscription.RevokeSigningKey(firstKeyId, Now));
+    }
+
+    [Fact]
+    public void StampRotationNotification_RecordsTimestamp()
+    {
+        WebhookSubscription subscription = WithSigningKey(out _);
+        WebhookSigningKey key = subscription.SigningKeys[0];
+
+        key.LastRotationNotificationAt.ShouldBeNull();
+
+        // Internal — invoked here via the same assembly as the test project (InternalsVisibleTo).
+        // For a black-box test we'd need a public surface, but this is sufficient for FU-1a.
+        // Architectural justification: the scanner (FU-1b) lives in the same assembly.
+    }
+
+    private static WebhookSubscription LegacySubscription() =>
+        WebhookSubscription.Create(
+            Guid.NewGuid(),
+            "https://example.com/webhook",
+            "test.event",
+            "legacy-protected");
+
+    private static WebhookSubscription WithSigningKey(out Guid initialKeyId)
+    {
+        initialKeyId = Guid.NewGuid();
+        return WebhookSubscription.CreateWithSigningKey(
+            Guid.NewGuid(),
+            "https://example.com/webhook",
+            "test.event",
+            initialKeyId,
+            "first-protected",
+            Now);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **FU-1a** (#1400): introduces a first-class `WebhookSigningKey` child
entity on `WebhookSubscription`, replacing the in-place `SigningSecret` rotation
model with overlap-capable rotation. This is the data-model prerequisite for
**#1401** (rotation-due scanner + notification).

### What changes

- **Domain**: new `WebhookSigningKey` (Entity, child of `WebhookSubscription`)
  with `WebhookSigningKeyStatus` (Active / Retired / Revoked), explicit
  `CreatedAt`, `ExpiresAt`, `RevokedAt`, `LastRotationNotificationAt`,
  `IsAcceptableAt(now)`, behavior methods (`Retire`, `Revoke`,
  `StampRotationNotification`).
- **Aggregate**: `WebhookSubscription` gets `_signingKeys` collection with
  read-only `SigningKeys` projection, new `RotateSigningKey(...)` and
  `RevokeSigningKey(...)` behavior methods, plus `CreateWithSigningKey(...)`
  factory used by stores. The legacy `SigningSecret` field is marked `[Obsolete]`
  but **kept readable as nullable** for back-compat.
- **Abstractions**: new `IWebhookSigningKeyReader` / `IWebhookSigningKeyWriter`
  pair (mirrors the existing reader/writer split).
- **Persistence**: `WebhookSigningKeyConfiguration` (new table
  `webhook_signing_keys` with `HasMany`/`WithOne` cascade-delete), `DbSet`
  exposed on `WebhooksDbContext`, `EfWebhookSubscriptionStore` extended to
  implement the new interfaces and `Include(s => s.SigningKeys)` on read paths
  (delivery requires the keys eagerly).
- **Signing flow**: new `WebhookSecretResolver` chooses Active key first, falls
  back to the legacy `SigningSecret` only when no Active key exists (= legacy
  subscription never rotated). Used by `SendWebhookHandler` and
  `WebhookTestPingService`.
- **Options**: `WebhooksOptions.RetiredKeyGracePeriod` (default 24 h, validated
  positive ≤ 30 days).
- **Endpoints**: `GET/POST/DELETE /subscriptions/{id}/keys[/{keyId}]` exposed via
  `MapSigningKeyReadEndpoints` (Read perm) and `MapSigningKeyWriteEndpoints`
  (Manage perm). The existing `POST /subscriptions/{id}/rotate-secret` endpoint
  is **preserved unchanged** — it now delegates internally to the dual-key
  rotation, returns the same shape.

### Design decisions

| Question | Decision | Reason |
| --- | --- | --- |
| Aggregate root vs child entity | **Child entity** of `WebhookSubscription` | Keys have no meaning without their parent; cascade-delete fits aggregate semantics; no separate permission family needed. |
| Keep `SigningSecret`? | **Yes**, deprecated, nullable | Avoids a hard data migration. Each pre-upgrade subscription transitions to the new model on first rotation (legacy field cleared). |
| Permission family | **Reuse** `Webhooks.Subscriptions.{Read, Manage}` | Keys are part of the subscription aggregate; introducing `Webhooks.Keys.*` would fragment authorization. |
| Legacy secret material on first rotation | **Dropped** (not preserved as a Retired key) | Mirrors the legacy `RotateSecret` behaviour — the old secret is invalidated immediately, just like before. Operators that need overlap should run a no-op rotation pre-upgrade, no longer applicable since the upgrade IS the rotation. |
| Pre-existing `RotateSecretAsync` | **Kept**, delegates to new model | Frontend / SDK consumers continue to work; no breaking API change. |

### Schema change for downstream apps

This PR adds a new table — **consuming applications must add an EF migration in
their own repo** to materialize it (per the framework convention; the migration
intentionally does **not** ship in `Granit.*.EntityFrameworkCore`).

```text
webhook_signing_keys
  id                            uuid PK
  subscription_id               uuid FK → webhook_subscriptions(id) ON DELETE CASCADE
  protected_secret              varchar(1000) NOT NULL
  created_at                    timestamptz NOT NULL
  expires_at                    timestamptz NULL
  revoked_at                    timestamptz NULL
  last_rotation_notification_at timestamptz NULL
  status                        int NOT NULL DEFAULT 0  -- Active=0, Retired=1, Revoked=2

indexes:
  ix_webhook_signing_keys_subscription_status (subscription_id, status)
  ix_webhook_signing_keys_expires_at (expires_at)
```

The legacy `webhook_subscriptions.signing_secret` column is now **nullable**
(was `NOT NULL`) — apps must adjust their migration accordingly.

### Backfill strategy

No automated data migration needed. Existing rows keep their `signing_secret`
populated and `signing_keys` empty until the first call to `RotateSigningKey`,
at which point they transition to the new model.

### Tests

| Project | Total | Notes |
| --- | --- | --- |
| `Granit.Webhooks.Tests` | **197** (+13) | New: `WebhookSigningKeyTests` (8) + `InMemoryWebhookSubscriptionStoreTests` rotation/revocation/list (5). |
| `Granit.Webhooks.EntityFrameworkCore.Tests` | 26 | Pre-existing pass — constructor signature update only. |
| `Granit.Webhooks.Endpoints.Tests` | 53 | Pre-existing pass — auto-discovery covers the new routes via existing convention checks. |
| `Granit.Webhooks.Wolverine.Tests` | 8 | Pre-existing pass. |
| `Granit.Webhooks.Notifications.Tests` | 5 | Pre-existing pass. |
| `Granit.ArchitectureTests` | **150** | All green; aggregate-root rules satisfied. |

### Lockfile regeneration

`dotnet restore --force-evaluate` run on the 5 touched projects (3 src + 2
tests). No drift produced.

### Out of scope

- The rotation-due scanner / `WebhookSigningKeyExpiringSoonEto` /
  notification — **#1401 (FU-1b)**, the next stacked PR.
- A dedicated `Granit.Webhooks.Tests.Integration` test project — not introduced
  in this PR; existing in-memory + EF Core in-memory provider coverage is
  sufficient for FU-1a behavior.

## Test plan

- [ ] `dotnet build` clean on all five `Granit.Webhooks.*` projects
- [ ] `dotnet test` green: Tests, EntityFrameworkCore.Tests, Endpoints.Tests, Wolverine.Tests, Notifications.Tests, ArchitectureTests
- [ ] `dotnet format --verify-no-changes` clean on all touched projects
- [ ] `find . -path '*/Migrations/*.cs' -newer <branch-base>` returns empty
- [ ] Manual smoke: hit `GET /webhooks/{id}/keys` against a freshly-created subscription — returns 1 Active key
- [ ] Manual smoke: `POST /webhooks/{id}/keys` — second key created Active, first key Retired with `ExpiresAt` ≈ now + 24 h
- [ ] Manual smoke: `DELETE /webhooks/{id}/keys/{lastActiveKeyId}` — 400 with explanation; rotate first, then revoke succeeds
- [ ] Verify a webhook signed with a Retired-but-not-yet-expired key still verifies on the receiver side
