### PR TITLE
fix(identity-local): inline JSON property names to avoid GRSEC003 false positive

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Internal/IdentityLocalSchemaExampleProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Internal/IdentityLocalSchemaExampleProvider.cs
@@ -10,9 +10,6 @@ namespace Granit.Identity.Local.Endpoints.Internal;
 /// </summary>
 internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvider
 {
-    private const string PasswordField = "password";
-    private const string PasswordPlaceholder = "<your-password>";
-
     /// <inheritdoc/>
     public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
         new Dictionary<Type, JsonNode>
@@ -23,7 +20,7 @@ internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvide
             [typeof(AccountLoginRequest)] = new JsonObject
             {
                 ["login"] = "alice@acme.example",
-                [PasswordField] = PasswordPlaceholder,
+                ["password"] = "<your-password>",
                 ["rememberMe"] = true,
             },
             [typeof(AccountLoginResponse)] = new JsonObject
@@ -36,7 +33,7 @@ internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvide
             [typeof(AccountRegisterRequest)] = new JsonObject
             {
                 ["email"] = "alice@acme.example",
-                [PasswordField] = PasswordPlaceholder,
+                ["password"] = "<your-password>",
                 ["firstName"] = "Alice",
                 ["lastName"] = "Martin",
             },
@@ -54,7 +51,7 @@ internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvide
             },
             [typeof(AccountTwoFactorDisableRequest)] = new JsonObject
             {
-                [PasswordField] = PasswordPlaceholder,
+                ["password"] = "<your-password>",
             },
 
             // ──── Password management ────
@@ -94,7 +91,7 @@ internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvide
             },
             [typeof(AccountDeleteRequest)] = new JsonObject
             {
-                [PasswordField] = PasswordPlaceholder,
+                ["password"] = "<your-password>",
             },
 
             // ──── Passkeys (WebAuthn) ────


### PR DESCRIPTION
## Summary

Fixes the `develop` build break introduced incidentally by PR #1414. `IdentityLocalSchemaExampleProvider` had extracted the JSON property name `"password"` into a `PasswordField` const — the const **identifier** contains the substring "password", so the `GRSEC003` hardcoded-secret analyzer flags the literal as a potential secret and the build fails with:

```
error GRSEC003: Potential hardcoded secret detected in 'PasswordField'.
Use Granit.Vault or secure configuration instead.
```

The const was a refactor for de-duplication that turned out to interact badly with the analyzer. Reverting to inline literals (`["password"] = "<your-password>"` directly in the dictionary initializer) avoids the trigger:

- The string literal `"password"` is in an indexer assignment (`[ ... ] = ...`), which is **not** one of the five target-name patterns the analyzer recognises (variable declarator, property initializer, parameter default, named argument, simple assignment).
- The placeholder value `"<your-password>"` is excluded by the analyzer's existing `<` heuristic for example markers.

## Test plan

- [x] `dotnet build src/Granit.Identity.Local.Endpoints -c Release` — 0 warnings, 0 errors.
- [x] No behaviour change — OpenAPI example payloads are byte-for-byte identical.

