### PR TITLE
feat(deps): NuGet refs for Party deduplication (FuzzySharp + SoftWx.Match + libphonenumber-csharp) (#1303)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,6 +119,11 @@
     <PackageVersion Include="Mollie.Api" Version="4.*" />
     <PackageVersion Include="Stripe.net" Version="51.*" />
   </ItemGroup>
+  <ItemGroup Label="Parties Deduplication">
+    <PackageVersion Include="FuzzySharp" Version="2.*" />
+    <PackageVersion Include="libphonenumber-csharp" Version="9.*" />
+    <PackageVersion Include="SoftWx.Match" Version="2.*" />
+  </ItemGroup>
   <ItemGroup Label="Notifications">
     <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.*" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-04-27
+Dernière mise à jour : 2026-04-28
 
 ---
 
@@ -12,8 +12,8 @@ Dernière mise à jour : 2026-04-27
 
 | Licence      | Nombre de packages |
 | ------------ | ------------------ |
-| MIT          | 87                 |
-| Apache-2.0   | 35                 |
+| MIT          | 89                 |
+| Apache-2.0   | 36                 |
 | BSD-3-Clause | 2                  |
 | BSD-2-Clause | 1                  |
 | PostgreSQL   | 1                  |
@@ -38,6 +38,7 @@ Dernière mise à jour : 2026-04-27
 | Azure.Storage.Blobs | 12.27.0 | (c) Microsoft Corporation |
 | ClosedXML | 0.105.0 | ClosedXML Contributors |
 | Cronos | 0.12.0 | Copyright (c) 2016-2025 Hangfire OU |
+| FuzzySharp | 2.0.2 | Copyright (c) Jacob Bayer |
 | Lib.Net.Http.WebPush | 3.3.1 | Copyright (c) Tomasz Pęczek |
 | MailKit | 4.16.0 | Copyright (c) 2013-2026 .NET Foundation and Contributors |
 | Mjml.Net | 4.11.0 | Copyright (c) Sebastian Stehle |
@@ -78,6 +79,7 @@ Dernière mise à jour : 2026-04-27
 | Scalar.AspNetCore | 2.14.5 | Scalar Contributors |
 | Sep | 0.13.0 | Copyright (c) 2023 nietras |
 | SmartFormat | 3.6.1 | Copyright 2011-2025 SmartFormat Project |
+| SoftWx.Match | 2.0.3 | Copyright © 2015-2018 SoftWx, Inc. |
 | StackExchange.Redis | 2.12.14 | Copyright 2014-2026 Stack Exchange, Inc. |
 | Stripe.net | 51.1.0 | Copyright (c) Stripe, Inc. |
 | Sylvan.Data.Excel | 0.5.5 | Copyright (c) Mark Pflug |
@@ -115,6 +117,7 @@ Dernière mise à jour : 2026-04-27
 | Google.Cloud.Kms.V1 | 3.24.0 | Copyright (c) Google LLC |
 | Google.Cloud.SecretManager.V1 | 2.7.0 | Copyright (c) Google LLC |
 | Google.Cloud.Storage.V1 | 4.14.0 | Copyright (c) Google LLC |
+| libphonenumber-csharp | 9.0.29 | Copyright (c) Patrick Mézard, Thomas Clegg, Google, libphonenumber contributors |
 | Magick.NET-Q8-AnyCPU | 14.13.0 | Copyright 2013-2026 Dirk Lemstra |
 | ModelContextProtocol | 1.2.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
 | ModelContextProtocol.AspNetCore | 1.2.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |


### PR DESCRIPTION
## Summary

Story [#1303](https://github.com/granit-fx/granit-dotnet/issues/1303) of [Feature #1280](https://github.com/granit-fx/granit-dotnet/issues/1280) (Party duplicate detection — 3-tier pipeline) under [Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278).

Adds three central package versions to `Directory.Packages.props`. Versions only — no project consumes them yet; the detection engine in `Granit.Parties.Deduplication` (story #1299) and the canonical-column EF interceptor (story #1297) will pick them up via `PackageReference` later.

| Package | Version | License | Purpose |
| ------- | ------- | ------- | ------- |
| FuzzySharp | `2.*` | MIT | Jaro-Winkler scoring on `Name` (Tier 3 fuzzy weighted-sum) |
| SoftWx.Match | `2.*` | MIT | Normalised Levenshtein on Address + Double Metaphone on LastName |
| libphonenumber-csharp | `9.*` | Apache-2.0 | E.164 normalisation for the canonical `PhoneE164` column (Tier 1 deterministic) |

## Note on package name

The plan and original story referenced "PhoneNumbers.NET" — that name does not exist on NuGet. The canonical .NET port of Google's libphonenumber (used by Twilio, Stripe, etc.) is published as `libphonenumber-csharp` (latest 9.0.29) under the namespace `PhoneNumbers`. The plan title was a confusion between package name and namespace. Using `libphonenumber-csharp` here.

## License compliance

All three permissive — no GPL/LGPL/AGPL/SSPL to flag. `THIRD-PARTY-NOTICES.md` updated:

- 2 MIT entries (alphabetically inserted: FuzzySharp between Cronos/Lib.Net.Http.WebPush; SoftWx.Match between SmartFormat/StackExchange.Redis)
- 1 Apache-2.0 entry (libphonenumber-csharp between Google.Cloud.Storage.V1/Magick.NET-Q8-AnyCPU)
- Summary counts bumped: MIT 87 → 89, Apache-2.0 35 → 36
- `Dernière mise à jour` bumped to 2026-04-28

## Test plan

- [x] `dotnet restore` — clean
- [x] `dotnet build src/Granit.Validation -c Release` — 0/0 (smoke test that central versioning still resolves)
- [x] `npx markdownlint-cli2 THIRD-PARTY-NOTICES.md` — clean
- [x] All three packages confirmed on nuget.org with the version ranges declared

Refs #1303
Refs #1280
