### PR TITLE
feat(parties): canonical projections for Tier-1 dedup detection (#1297)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -25439,7 +25439,7 @@
       "kind": "class",
       "project": "Granit.Mergeable.EntityFrameworkCore",
       "file": "src/Granit.Mergeable.EntityFrameworkCore/GranitMergeableEntityFrameworkCoreModule.cs",
-      "line": 11,
+      "line": 13,
       "members": []
     },
     {
@@ -32506,7 +32506,7 @@
           "name": "MarkPrimary",
           "kind": "method",
           "signature": "MarkPrimary(bool isPrimary)",
-          "returnType": "bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
+          "returnType": "string? CanonicalEmail { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
         }
       ]
     },
@@ -32591,7 +32591,7 @@
           "name": "MarkPrimary",
           "kind": "method",
           "signature": "MarkPrimary(bool isPrimary)",
-          "returnType": "bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
+          "returnType": "string? CanonicalNumber { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
         }
       ]
     },
@@ -32919,12 +32919,60 @@
       "members": []
     },
     {
+      "name": "EmailCanonicaliser",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Canonicalisation.EmailCanonicaliser",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Canonicalisation/EmailCanonicaliser.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Canonicalise",
+          "kind": "method",
+          "signature": "Canonicalise(string? email)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "PhoneCanonicaliser",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Canonicalisation.PhoneCanonicaliser",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Canonicalisation/PhoneCanonicaliser.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "Canonicalise",
+          "kind": "method",
+          "signature": "Canonicalise(string? phone)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "TaxIdCanonicaliser",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Canonicalisation.TaxIdCanonicaliser",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Canonicalisation/TaxIdCanonicaliser.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Canonicalise",
+          "kind": "method",
+          "signature": "Canonicalise(string? taxId)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
       "name": "PartiesEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Parties.EntityFrameworkCore.Extensions.PartiesEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitPartiesEntityFrameworkCore",
@@ -33346,7 +33394,7 @@
       "kind": "class",
       "project": "Granit.Parties.Mergeable",
       "file": "src/Granit.Parties.Mergeable/GranitPartiesMergeableModule.cs",
-      "line": 12,
+      "line": 19,
       "members": []
     },
     {

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 294;
+export const PACKAGE_COUNT = 300;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;

--- a/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
@@ -9,15 +9,19 @@ namespace Granit.BlobStorage.Endpoints.Internal;
 /// </summary>
 internal sealed class BlobStorageSchemaExampleProvider : ISchemaExampleProvider
 {
+    private const string ContainerNameProperty = "containerName";
+    private const string ExampleContainerName = "medical-images";
+    private const string PngContentType = "image/png";
+
     /// <inheritdoc/>
     public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
         new Dictionary<Type, JsonNode>
         {
             [typeof(BlobUploadInitiateRequest)] = new JsonObject
             {
-                ["containerName"] = "medical-images",
+                [ContainerNameProperty] = ExampleContainerName,
                 ["fileName"] = "xray-2026-04-20.png",
-                ["contentType"] = "image/png",
+                ["contentType"] = PngContentType,
                 ["sizeBytes"] = 2_458_112L,
             },
             [typeof(BlobUploadInitiateResponse)] = new JsonObject
@@ -29,30 +33,30 @@ internal sealed class BlobStorageSchemaExampleProvider : ISchemaExampleProvider
                 ["requiredHeaders"] = new JsonObject
                 {
                     ["x-ms-blob-type"] = "BlockBlob",
-                    ["content-type"] = "image/png",
+                    ["content-type"] = PngContentType,
                 },
             },
             [typeof(BlobConfirmUploadRequest)] = new JsonObject
             {
-                ["containerName"] = "medical-images",
+                [ContainerNameProperty] = ExampleContainerName,
             },
             [typeof(BlobDeleteRequest)] = new JsonObject
             {
-                ["containerName"] = "medical-images",
+                [ContainerNameProperty] = ExampleContainerName,
                 ["deletionReason"] = "GDPR Art. 17 erasure request",
             },
             [typeof(BlobDownloadUrlRequest)] = new JsonObject
             {
-                ["containerName"] = "medical-images",
+                [ContainerNameProperty] = ExampleContainerName,
                 ["fileName"] = "xray-2026-04-20.png",
             },
             [typeof(BlobDescriptorResponse)] = new JsonObject
             {
                 ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
-                ["containerName"] = "medical-images",
+                [ContainerNameProperty] = ExampleContainerName,
                 ["originalFileName"] = "xray-2026-04-20.png",
-                ["declaredContentType"] = "image/png",
-                ["verifiedContentType"] = "image/png",
+                ["declaredContentType"] = PngContentType,
+                ["verifiedContentType"] = PngContentType,
                 ["declaredSizeBytes"] = 2_458_112L,
                 ["actualSizeBytes"] = 2_458_112L,
                 ["status"] = "Validated",

--- a/src/Granit.Invoicing.Odoo/Internal/OdooInvoiceSyncProvider.cs
+++ b/src/Granit.Invoicing.Odoo/Internal/OdooInvoiceSyncProvider.cs
@@ -20,8 +20,7 @@ namespace Granit.Invoicing.Odoo.Internal;
 /// <remarks>
 /// On each sync the contact's <c>res.partner</c> is created (first time) or updated (subsequent)
 /// with the latest billing address so Odoo always reflects the address shown on the issued
-/// document. Removing the dedicated <c>OdooPartnerMapping</c> aggregate and reusing the unified
-/// <c>Party.ExternalMappings</c> closes Sonar TODO <c>audit/A3</c>.
+/// document.
 /// </remarks>
 internal sealed partial class OdooInvoiceSyncProvider(
     OdooJsonRpcClient rpcClient,

--- a/src/Granit.Mergeable.EntityFrameworkCore/Granit.Mergeable.EntityFrameworkCore.csproj
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Granit.Mergeable.EntityFrameworkCore.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Mergeable.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests.Integration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Mergeable.EntityFrameworkCore/GranitMergeableEntityFrameworkCoreModule.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/GranitMergeableEntityFrameworkCoreModule.cs
@@ -7,5 +7,7 @@ namespace Granit.Mergeable.EntityFrameworkCore;
 /// Granit module marker for the EF Core merge orchestrator package. Wired via
 /// <c>builder.AddGranitMergeableEntityFrameworkCore(...)</c>.
 /// </summary>
-[DependsOn(typeof(GranitPersistenceEntityFrameworkCoreModule))]
+[DependsOn(
+    typeof(GranitMergeableModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitMergeableEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Mergeable.EntityFrameworkCore/Internal/EfMergeService.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Internal/EfMergeService.cs
@@ -8,7 +8,7 @@ using Granit.Mergeable.Exceptions;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 
-#pragma warning disable CA1812 // Resolved by DI as the open-generic registration for IMergeService<>.
+#pragma warning disable CA1812 // Justification: resolved by DI through the open-generic registration `IMergeService<>` → `EfMergeService<>` (no direct `new` call in the codebase).
 
 namespace Granit.Mergeable.EntityFrameworkCore.Internal;
 
@@ -76,7 +76,13 @@ internal sealed class EfMergeService<TAggregate>(
                 .ConfigureAwait(false);
             if (cached is not null)
             {
-                return cached;
+                // Rehydrate Merged from the live aggregate so callers always observe
+                // result.Merged != null on a successful replay (matches the contract of
+                // a fresh live merge). The aggregate is loaded outside the orchestrator's
+                // transaction — replays are read-only by definition.
+                TAggregate? mergedSnapshot = await adapter.LoadAsync(request.SurvivorId, cancellationToken)
+                    .ConfigureAwait(false);
+                return cached with { Merged = mergedSnapshot };
             }
         }
 
@@ -223,12 +229,11 @@ internal sealed class EfMergeService<TAggregate>(
 
         if (matchByHash is not null)
         {
-            // The cached MergeResult.Merged field cannot be reconstructed from the cache (it
-            // would require deserialising the full aggregate); rely on the hash equality
-            // guarantee that a fresh load + re-run of the read-side would produce the same
-            // shape. For the v1 idempotency contract we return the cached counts/conflicts
-            // and a null Merged pointer — callers that need the survivor reload from
-            // GetByIdAsync after the merge.
+            // Cache stores only the read-side projection (conflicts + rewrite counts) — the
+            // Merged aggregate is rehydrated from the database by the caller (MergeAsync)
+            // after this method returns. Returning Merged: null here is a sentinel; the
+            // caller swaps it via `cached with { Merged = … }` so external callers always
+            // observe a populated Merged on a successful replay.
             CachedMergeResult cached = JsonSerializer.Deserialize<CachedMergeResult>(matchByHash.ResultJson)!;
             return new MergeResult<TAggregate>(
                 Merged: null,

--- a/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableConcurrencyLock.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableConcurrencyLock.cs
@@ -30,9 +30,9 @@ internal static class MergeableConcurrencyLock
     private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
 
     /// <summary>
-    /// Acquires the lock inside the active transaction. Caller MUST have an open transaction
-    /// (the orchestrator's <c>TransactionScope</c> + <c>BeginTransactionAsync</c>); released on
-    /// COMMIT/ROLLBACK.
+    /// Acquires the lock inside the active transaction. Caller MUST be inside the orchestrator's
+    /// ambient <see cref="System.Transactions.TransactionScope"/>; the underlying connection is
+    /// auto-enrolled when first opened by EF and the lock is released on COMMIT/ROLLBACK.
     /// </summary>
     public static async Task AcquireAsync(
         DbContext db,

--- a/src/Granit.Mergeable/Granit.Mergeable.csproj
+++ b/src/Granit.Mergeable/Granit.Mergeable.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Mergeable.Tests" />
-    <InternalsVisibleTo Include="Granit.Mergeable.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.Mergeable.EntityFrameworkCore.Tests" />
   </ItemGroup>
 

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -174,16 +174,15 @@ internal sealed partial class EfAggregationRunner(
 
         HashSet<string> distinct = new(StringComparer.Ordinal);
 
-        IEnumerable<string?> values = events
+        IEnumerable<string> values = events
             .Select(ev => ev.Metadata)
             .Where(metadata => !string.IsNullOrWhiteSpace(metadata))
-            .Select(metadata => TryExtractStringValue(metadata!, property));
-        foreach (string? value in values)
+            .Select(metadata => TryExtractStringValue(metadata!, property))
+            .Where(value => value is not null)
+            .Select(value => value!);
+        foreach (string value in values)
         {
-            if (value is not null)
-            {
-                distinct.Add(value);
-            }
+            distinct.Add(value);
         }
 
         return distinct.Count;

--- a/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
+++ b/src/Granit.Oidc.TokenManagement/Handlers/OnBehalfOfTokenHandler.cs
@@ -161,12 +161,9 @@ internal sealed partial class OnBehalfOfTokenHandler(
         }
 
         string host = request.RequestUri.Host;
-        foreach (string allowed in options.AllowedHosts)
+        if (options.AllowedHosts.Any(allowed => string.Equals(allowed, host, StringComparison.OrdinalIgnoreCase)))
         {
-            if (string.Equals(allowed, host, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
+            return true;
         }
 
         LogRejectedTarget(ClientName, $"host '{host}' not in AllowedHosts");

--- a/src/Granit.Oidc/Internal/TokenRequestEncoder.cs
+++ b/src/Granit.Oidc/Internal/TokenRequestEncoder.cs
@@ -57,6 +57,71 @@ internal static class TokenRequestEncoder
         return parameters;
     }
 
+    /// <summary>
+    /// Converts a <see cref="RevocationRequest"/> to a mutable parameter dictionary.
+    /// </summary>
+    internal static Dictionary<string, string> ToParameters(RevocationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, string> parameters = new()
+        {
+            [OidcConstants.Parameters.ClientId] = request.ClientId,
+            [OidcConstants.Parameters.Token] = request.Token,
+        };
+
+        if (request.TokenTypeHint is not null)
+        {
+            parameters[OidcConstants.Parameters.TokenTypeHint] = request.TokenTypeHint;
+        }
+
+        foreach (KeyValuePair<string, string> kvp in request.AdditionalParameters)
+        {
+            parameters.TryAdd(kvp.Key, kvp.Value);
+        }
+
+        return parameters;
+    }
+
+    /// <summary>
+    /// Converts a <see cref="PushedAuthorizationRequest"/> to a mutable parameter dictionary.
+    /// </summary>
+    internal static Dictionary<string, string> ToParameters(PushedAuthorizationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, string> parameters = new()
+        {
+            [OidcConstants.Parameters.ClientId] = request.ClientId,
+            [OidcConstants.Parameters.RedirectUri] = request.RedirectUri,
+            [OidcConstants.Parameters.ResponseType] = request.ResponseType,
+            [OidcConstants.Parameters.Scope] = request.Scope,
+            [OidcConstants.Parameters.State] = request.State,
+        };
+
+        if (request.CodeChallenge is not null)
+        {
+            parameters[OidcConstants.Parameters.CodeChallenge] = request.CodeChallenge;
+        }
+
+        if (request.CodeChallengeMethod is not null)
+        {
+            parameters[OidcConstants.Parameters.CodeChallengeMethod] = request.CodeChallengeMethod;
+        }
+
+        if (request.Nonce is not null)
+        {
+            parameters[OidcConstants.Parameters.Nonce] = request.Nonce;
+        }
+
+        foreach (KeyValuePair<string, string> kvp in request.AdditionalParameters)
+        {
+            parameters.TryAdd(kvp.Key, kvp.Value);
+        }
+
+        return parameters;
+    }
+
     private static void AppendGrantParameters(Dictionary<string, string> parameters, TokenRequest request)
     {
         switch (request)
@@ -137,70 +202,5 @@ internal static class TokenRequestEncoder
         {
             parameters[OidcConstants.Parameters.ActorTokenType] = exchange.ActorTokenType;
         }
-    }
-
-    /// <summary>
-    /// Converts a <see cref="RevocationRequest"/> to a mutable parameter dictionary.
-    /// </summary>
-    internal static Dictionary<string, string> ToParameters(RevocationRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        Dictionary<string, string> parameters = new()
-        {
-            [OidcConstants.Parameters.ClientId] = request.ClientId,
-            [OidcConstants.Parameters.Token] = request.Token,
-        };
-
-        if (request.TokenTypeHint is not null)
-        {
-            parameters[OidcConstants.Parameters.TokenTypeHint] = request.TokenTypeHint;
-        }
-
-        foreach (KeyValuePair<string, string> kvp in request.AdditionalParameters)
-        {
-            parameters.TryAdd(kvp.Key, kvp.Value);
-        }
-
-        return parameters;
-    }
-
-    /// <summary>
-    /// Converts a <see cref="PushedAuthorizationRequest"/> to a mutable parameter dictionary.
-    /// </summary>
-    internal static Dictionary<string, string> ToParameters(PushedAuthorizationRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        Dictionary<string, string> parameters = new()
-        {
-            [OidcConstants.Parameters.ClientId] = request.ClientId,
-            [OidcConstants.Parameters.RedirectUri] = request.RedirectUri,
-            [OidcConstants.Parameters.ResponseType] = request.ResponseType,
-            [OidcConstants.Parameters.Scope] = request.Scope,
-            [OidcConstants.Parameters.State] = request.State,
-        };
-
-        if (request.CodeChallenge is not null)
-        {
-            parameters[OidcConstants.Parameters.CodeChallenge] = request.CodeChallenge;
-        }
-
-        if (request.CodeChallengeMethod is not null)
-        {
-            parameters[OidcConstants.Parameters.CodeChallengeMethod] = request.CodeChallengeMethod;
-        }
-
-        if (request.Nonce is not null)
-        {
-            parameters[OidcConstants.Parameters.Nonce] = request.Nonce;
-        }
-
-        foreach (KeyValuePair<string, string> kvp in request.AdditionalParameters)
-        {
-            parameters.TryAdd(kvp.Key, kvp.Value);
-        }
-
-        return parameters;
     }
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/EmailCanonicaliser.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/EmailCanonicaliser.cs
@@ -1,0 +1,81 @@
+namespace Granit.Parties.EntityFrameworkCore.Canonicalisation;
+
+/// <summary>
+/// Computes the dedup-friendly canonical form of an email address. The original input is
+/// kept verbatim on <c>PartyEmail.Address</c>; the canonical form lives in the separate
+/// <c>PartyEmail.CanonicalEmail</c> column and feeds Tier-1 deterministic duplicate
+/// detection (see Epic #1280).
+/// </summary>
+/// <remarks>
+/// <para>Rules applied:</para>
+/// <list type="bullet">
+///   <item>trim + <c>ToLowerInvariant</c> on the whole address (case- and whitespace-insensitive)</item>
+///   <item>Gmail / Googlemail-specific: strip dots from the local part (<c>j.f.smith</c> ≡ <c>jfsmith</c>)</item>
+///   <item>Gmail / Googlemail-specific: strip the <c>+tag</c> suffix from the local part
+///         (<c>alice+billing@gmail.com</c> ≡ <c>alice@gmail.com</c>)</item>
+///   <item>Domain <c>googlemail.com</c> rewritten to <c>gmail.com</c> (Google treats them
+///         as the same provider for delivery)</item>
+/// </list>
+/// <para>
+/// Returns <c>null</c> for null/whitespace input or any address that does not contain
+/// exactly one <c>@</c>. Other providers (Outlook, Yahoo, ProtonMail, …) are NOT
+/// dot-stripped — only Gmail has the documented "dots are ignored" semantics. The
+/// plus-tag rule applies only to Gmail in v1; Outlook + plus-tag stripping can land
+/// later under the same canonicaliser without a schema change.
+/// </para>
+/// </remarks>
+public static class EmailCanonicaliser
+{
+    private const string GmailDomain = "gmail.com";
+    private const string GoogleMailDomain = "googlemail.com";
+
+    /// <summary>
+    /// Returns the canonical form of <paramref name="email"/>, or <c>null</c> when the
+    /// input is null/whitespace or syntactically not an address.
+    /// </summary>
+    public static string? Canonicalise(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return null;
+        }
+
+        string trimmed = email.Trim().ToLowerInvariant();
+        int at = trimmed.IndexOf('@', StringComparison.Ordinal);
+
+        // Reject input without exactly one '@' — caller is expected to have validated
+        // syntax already; an invalid address gets no canonical form, no Tier-1 hit.
+        if (at <= 0 || at != trimmed.LastIndexOf('@') || at == trimmed.Length - 1)
+        {
+            return null;
+        }
+
+        string local = trimmed[..at];
+        string domain = trimmed[(at + 1)..];
+
+        if (domain == GoogleMailDomain)
+        {
+            domain = GmailDomain;
+        }
+
+        if (domain == GmailDomain)
+        {
+            int plus = local.IndexOf('+', StringComparison.Ordinal);
+            if (plus >= 0)
+            {
+                local = local[..plus];
+            }
+
+            local = local.Replace(".", string.Empty, StringComparison.Ordinal);
+
+            // After plus-tag + dot stripping the local part may collapse to empty —
+            // treat that as "no canonical form" rather than emitting "@gmail.com".
+            if (local.Length == 0)
+            {
+                return null;
+            }
+        }
+
+        return $"{local}@{domain}";
+    }
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/PhoneCanonicaliser.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/PhoneCanonicaliser.cs
@@ -1,0 +1,56 @@
+using PhoneNumbers;
+
+namespace Granit.Parties.EntityFrameworkCore.Canonicalisation;
+
+/// <summary>
+/// Computes the E.164 canonical form (<c>+&lt;country code&gt;&lt;subscriber number&gt;</c>) of a
+/// phone number via the libphonenumber-csharp port of Google's libphonenumber. The original
+/// input is kept verbatim on <c>PartyPhone.Number</c>; the canonical form lives in the
+/// separate <c>PartyPhone.CanonicalNumber</c> column and feeds Tier-1 deterministic
+/// duplicate detection (Epic #1280).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The UI is expected to capture the country code via a dropdown so input always arrives
+/// prefixed with <c>+&lt;cc&gt;</c>. We pass <c>null</c> as the default region to libphonenumber,
+/// which means only E.164-prefixed input is accepted — domestic-format numbers (no leading
+/// <c>+</c>) cannot be unambiguously parsed without a region.
+/// </para>
+/// <para>
+/// Returns <c>null</c> when libphonenumber cannot parse the input (invalid syntax, missing
+/// country code, etc.). The verbatim <c>Number</c> column still preserves what the user
+/// typed; only the dedup key is missing in that case, so the row simply does not surface
+/// in Tier-1 lookups.
+/// </para>
+/// </remarks>
+public static class PhoneCanonicaliser
+{
+    private static readonly PhoneNumberUtil _phoneNumberUtil = PhoneNumberUtil.GetInstance();
+
+    /// <summary>
+    /// Returns the E.164 form of <paramref name="phone"/>, or <c>null</c> when the input is
+    /// null/whitespace or when libphonenumber cannot parse it as a valid number.
+    /// </summary>
+    public static string? Canonicalise(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return null;
+        }
+
+        try
+        {
+            PhoneNumber parsed = _phoneNumberUtil.Parse(phone, defaultRegion: null);
+            if (!_phoneNumberUtil.IsValidNumber(parsed))
+            {
+                return null;
+            }
+
+            return _phoneNumberUtil.Format(parsed, PhoneNumberFormat.E164);
+        }
+        catch (NumberParseException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/TaxIdCanonicaliser.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Canonicalisation/TaxIdCanonicaliser.cs
@@ -1,0 +1,48 @@
+using System.Text;
+
+namespace Granit.Parties.EntityFrameworkCore.Canonicalisation;
+
+/// <summary>
+/// Normalises a tax identifier (VAT number, business registration) to a strip-formatted
+/// upper-case form. Used by the EF Core canonicalisation interceptor to overwrite
+/// <c>Party.TaxId</c> in place — single column, no separate canonical field, because the
+/// canonical form IS the legal one (KBO/BCE, HMRC, IRS, … all accept it without separators).
+/// </summary>
+/// <remarks>
+/// <para>v1 rules (provider-agnostic):</para>
+/// <list type="bullet">
+///   <item><c>ToUpperInvariant</c></item>
+///   <item>Strip ASCII whitespace, dots, hyphens, slashes</item>
+///   <item>Trim leading / trailing whitespace</item>
+/// </list>
+/// <para>
+/// Per-country checksum / format validation (Belgian KBO mod-97, French SIRET Luhn, etc.)
+/// is deferred to a v2. The Tier-1 dedup only needs structural canonicalisation — two parties
+/// with VAT <c>"BE 0123.456.789"</c> and <c>"be0123456789"</c> must collapse to the same key.
+/// </para>
+/// </remarks>
+public static class TaxIdCanonicaliser
+{
+    /// <summary>
+    /// Returns the canonical form of <paramref name="taxId"/>, or <c>null</c> when the input
+    /// is null/whitespace, or when stripping separators leaves nothing left.
+    /// </summary>
+    public static string? Canonicalise(string? taxId)
+    {
+        if (string.IsNullOrWhiteSpace(taxId))
+        {
+            return null;
+        }
+
+        StringBuilder sb = new(taxId.Length);
+        foreach (char c in taxId)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                sb.Append(char.ToUpperInvariant(c));
+            }
+        }
+
+        return sb.Length == 0 ? null : sb.ToString();
+    }
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +26,14 @@ public static class PartiesEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.TryAddScoped<IDefaultPartySeeder, EfDefaultPartySeeder>();
 
         builder.Services.AddScoped<IQueryableSource<Domain.Party>, EfPartyQueryableSource>();
+
+        // Tier-1 deterministic duplicate detection — populate canonical projections on save.
+        // Registered as both concrete + IGranitAutoInterceptor (pattern from
+        // AuditingChangeTrackingInterceptor): the concrete registration lets unit tests
+        // resolve it; IGranitAutoInterceptor wires it onto every Granit DbContext.
+        builder.Services.AddScoped<PartyCanonicalisationInterceptor>();
+        builder.Services.AddScoped<IGranitAutoInterceptor>(sp =>
+            sp.GetRequiredService<PartyCanonicalisationInterceptor>());
 
         return builder;
     }

--- a/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
+++ b/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="libphonenumber-csharp" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyCanonicalisationInterceptor.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyCanonicalisationInterceptor.cs
@@ -1,0 +1,112 @@
+using Granit.Parties.Domain;
+using Granit.Parties.EntityFrameworkCore.Canonicalisation;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Granit.Parties.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core interceptor that populates the dedup-friendly canonical projections of party
+/// identity fields on every save:
+/// <list type="bullet">
+///   <item><see cref="PartyEmail.CanonicalEmail"/> — derived from <see cref="PartyEmail.Address"/></item>
+///   <item><see cref="PartyPhone.CanonicalNumber"/> — derived from <see cref="PartyPhone.Number"/></item>
+///   <item><see cref="Party.TaxId"/> — overwritten in place with the canonical form (single
+///         column by design — TaxId has a legal canonical shape, no display ambiguity)</item>
+/// </list>
+/// Powers Tier-1 deterministic duplicate detection (Epic #1280). Auto-wired via
+/// <see cref="IGranitAutoInterceptor"/> through the same path as <c>AuditingChangeTrackingInterceptor</c>.
+/// </summary>
+internal sealed class PartyCanonicalisationInterceptor : SaveChangesInterceptor, IGranitAutoInterceptor
+{
+    /// <inheritdoc/>
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        Apply(eventData);
+        return ValueTask.FromResult(result);
+    }
+
+    /// <inheritdoc/>
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        Apply(eventData);
+        return result;
+    }
+
+    private static void Apply(DbContextEventData eventData)
+    {
+        if (eventData.Context is null)
+        {
+            return;
+        }
+
+        foreach (EntityEntry entry in eventData.Context.ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            switch (entry.Entity)
+            {
+                case Party party:
+                    ApplyToParty(party);
+                    break;
+                case PartyEmail email:
+                    ApplyToEmail(email);
+                    break;
+                case PartyPhone phone:
+                    ApplyToPhone(phone);
+                    break;
+            }
+        }
+    }
+
+    // TaxId — single column overwritten in place. The canonical form IS the legal one
+    // (KBO/BCE, HMRC, IRS all accept it without separators), so there is no UX cost to
+    // displaying it back to the admin in the canonical shape.
+    private static void ApplyToParty(Party party)
+    {
+        if (party.TaxId is null)
+        {
+            return;
+        }
+
+        string? canonical = TaxIdCanonicaliser.Canonicalise(party.TaxId);
+        if (canonical is not null && !string.Equals(canonical, party.TaxId, StringComparison.Ordinal))
+        {
+            party.OverwriteTaxIdCanonical(canonical);
+        }
+    }
+
+    // Email — preserved verbatim on Address; canonical projected to CanonicalEmail. UX
+    // cost of overwriting Address would be too high (admin would see "alice+x@gmail.com"
+    // collapse to "alice@gmail.com" and think the system corrupted their input).
+    private static void ApplyToEmail(PartyEmail email)
+    {
+        string? canonical = EmailCanonicaliser.Canonicalise(email.Address);
+        if (!string.Equals(canonical, email.CanonicalEmail, StringComparison.Ordinal))
+        {
+            email.SetCanonicalEmail(canonical);
+        }
+    }
+
+    // Phone — preserved verbatim on Number; canonical (E.164) projected to CanonicalNumber.
+    // Same UX rationale as email: a Belgian admin recognises "+32 470 12 34 56" and would
+    // be surprised to see it rewritten as "+3247012345678".
+    private static void ApplyToPhone(PartyPhone phone)
+    {
+        string? canonical = PhoneCanonicaliser.Canonicalise(phone.Number);
+        if (!string.Equals(canonical, phone.CanonicalNumber, StringComparison.Ordinal))
+        {
+            phone.SetCanonicalNumber(canonical);
+        }
+    }
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
@@ -61,6 +61,12 @@ internal sealed class PartyConfiguration : IEntityTypeConfiguration<Party>
         builder.HasIndex(c => c.Status);
         builder.HasIndex(c => c.Roles);
         builder.HasIndex(c => c.UserId);
+
+        // Tier-1 deterministic duplicate detection (Epic #1280): TaxId is overwritten in
+        // place with its canonical (separator-stripped, upper-case) form by the
+        // PartyCanonicalisationInterceptor. Non-unique because two distinct parties may
+        // legitimately share a VAT (sole proprietor + their company, group subsidiaries).
+        builder.HasIndex(c => c.TaxId);
     }
 }
 
@@ -102,10 +108,16 @@ internal sealed class PartyEmailConfiguration : IEntityTypeConfiguration<PartyEm
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.Address).HasMaxLength(320).IsRequired();
+        builder.Property(e => e.CanonicalEmail).HasMaxLength(320);
         builder.Property(e => e.IsPrimary).IsRequired();
         builder.Property(e => e.Label).HasMaxLength(64);
 
         builder.HasIndex("PartyId", nameof(PartyEmail.IsPrimary));
+
+        // Tier-1 deterministic duplicate detection (Epic #1280): non-unique because two
+        // legitimately distinct parties may share an email (household, family). Tenant
+        // filtering happens via JOIN on the parent Party in the dedup engine.
+        builder.HasIndex(e => e.CanonicalEmail);
     }
 }
 
@@ -121,10 +133,15 @@ internal sealed class PartyPhoneConfiguration : IEntityTypeConfiguration<PartyPh
 
         builder.Property(p => p.Kind).IsRequired();
         builder.Property(p => p.Number).HasMaxLength(64).IsRequired();
+        builder.Property(p => p.CanonicalNumber).HasMaxLength(20);
         builder.Property(p => p.IsPrimary).IsRequired();
         builder.Property(p => p.Label).HasMaxLength(64);
 
         builder.HasIndex("PartyId", nameof(PartyPhone.IsPrimary));
+
+        // Tier-1 deterministic duplicate detection (Epic #1280): non-unique because two
+        // legitimately distinct parties may share a phone (family, shared landline).
+        builder.HasIndex(p => p.CanonicalNumber);
     }
 }
 

--- a/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "libphonenumber-csharp": {
+        "type": "Direct",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",

--- a/src/Granit.Parties.Mergeable/GranitPartiesMergeableModule.cs
+++ b/src/Granit.Parties.Mergeable/GranitPartiesMergeableModule.cs
@@ -1,5 +1,8 @@
+using Granit.Mergeable;
 using Granit.Mergeable.EntityFrameworkCore;
 using Granit.Modularity;
+using Granit.Parties;
+using Granit.Parties.EntityFrameworkCore;
 
 namespace Granit.Parties.Mergeable;
 
@@ -8,5 +11,9 @@ namespace Granit.Parties.Mergeable;
 /// orchestrator. Wired via <c>builder.AddGranitPartiesMergeable()</c> after
 /// <c>AddGranitPartiesEntityFrameworkCore</c> + <c>AddGranitMergeableEntityFrameworkCore</c>.
 /// </summary>
-[DependsOn(typeof(GranitMergeableEntityFrameworkCoreModule))]
+[DependsOn(
+    typeof(GranitMergeableEntityFrameworkCoreModule),
+    typeof(GranitMergeableModule),
+    typeof(GranitPartiesEntityFrameworkCoreModule),
+    typeof(GranitPartiesModule))]
 public sealed class GranitPartiesMergeableModule : GranitModule;

--- a/src/Granit.Parties.Mergeable/Internal/PartyChildrenReferenceRewriter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyChildrenReferenceRewriter.cs
@@ -15,12 +15,16 @@ namespace Granit.Parties.Mergeable.Internal;
 /// <list type="number">
 /// <item>Demote primaries / defaults that would clash with the survivor's, before any move.</item>
 /// <item>Delete the loser-side rows that are <em>structural duplicates</em> of an existing
-/// survivor row.</item>
+/// survivor row (and, for <c>PartyExternalMappings</c>, fail fast on
+/// <em>per-provider conflicts</em> — same <c>ProviderName</c> but different
+/// <c>ExternalId</c> on both sides).</item>
 /// <item>Re-point the remaining loser-side rows to the survivor by rewriting the shadow FK
 /// <c>PartyId</c>.</item>
 /// <item>Verify the per-aggregate caps (<see cref="Party.MaxAddresses"/>,
-/// <see cref="Party.MaxEmails"/>, <see cref="Party.MaxPhones"/>, plus the per-provider
-/// uniqueness constraint on external mappings).</item>
+/// <see cref="Party.MaxEmails"/>, <see cref="Party.MaxPhones"/>). External mappings have
+/// no count cap — the per-provider uniqueness constraint enforced in step 2 makes the
+/// post-merge cardinality bounded by the number of distinct providers integrated with
+/// the platform.</item>
 /// </list>
 /// </summary>
 /// <remarks>

--- a/src/Granit.Parties.Mergeable/Internal/PartyMergeableAggregateAdapter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyMergeableAggregateAdapter.cs
@@ -4,6 +4,7 @@ using Granit.Mergeable;
 using Granit.Parties.Domain;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Granit.Parties.Mergeable.Internal;
 
@@ -52,12 +53,35 @@ internal sealed class PartyMergeableAggregateAdapter(
 
         // Both sides are loaded with separate DbContexts via LoadAsync above; reattach so
         // their changes flush in this single SaveChangesAsync inside the orchestrator's
-        // ambient TransactionScope. Update() rather than Attach() because both have been
-        // mutated (survivor: scalar field merge applied; loser: tombstone applied).
-        db.Parties.Update(survivor);
-        db.Parties.Update(loser);
+        // ambient TransactionScope.
+        //
+        // NEVER call db.Parties.Update(party) here: Update cascades through the navigation
+        // graph that LoadAsync fetched via Include(...) and marks every child (Address /
+        // Email / Phone / ExternalMapping) as Modified, with the snapshot value of the
+        // shadow FK PartyId = the original loserId. SaveChanges would then issue
+        // `UPDATE … SET PartyId = loserId WHERE Id = childId` for every relocated child —
+        // undoing the bulk SQL FK rewrite already performed by PartyChildrenReferenceRewriter
+        // earlier in the same transaction. Children are owned exclusively by the bulk
+        // rewriter; the adapter only persists scalar mutations on the aggregate root itself.
+        AttachAsRootOnlyModified(db, survivor);
+        AttachAsRootOnlyModified(db, loser);
 
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AttachAsRootOnlyModified(PartiesDbContext db, Party party)
+    {
+        // Use ChangeTracker.TrackGraph to attach the in-memory graph: the root is forced
+        // Modified (so AuditedEntityInterceptor stamps ModifiedAt/By), every navigation
+        // child is forced Unchanged (no UPDATE issued) — the bulk rewriter is the sole
+        // writer for the children tables.
+        db.ChangeTracker.TrackGraph(party, node =>
+        {
+            EntityEntry entry = node.Entry;
+            entry.State = ReferenceEquals(entry.Entity, party)
+                ? EntityState.Modified
+                : EntityState.Unchanged;
+        });
     }
 
     /// <inheritdoc />
@@ -83,6 +107,17 @@ internal sealed class PartyMergeableAggregateAdapter(
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // ExecuteUpdateAsync bypasses ALL framework interceptors (audit, soft-delete,
+        // domain-event dispatcher). That is intentional here: chain-collapse only retargets
+        // an already-set tombstone pointer on rows that are themselves tombstoned and
+        // hidden by the IHasMergeTombstone query filter — they are no longer part of the
+        // user-visible audit timeline. ModifiedAt/By stay frozen at the original merge
+        // (the only event a Party.MergedIntoId pointer change reflects is the orchestrator
+        // walking the chain, never a domain mutation). Party does not implement
+        // IConcurrencyAware, so there is no stamp to regenerate. The tombstone change
+        // event is emitted by the orchestrator itself once per merge (not per hop), so
+        // skipping the interceptor pipeline here is the correct semantic.
+        //
         // The IHasMergeTombstone filter is already disabled by the IDataFilter scope above
         // — no need for a per-query IgnoreQueryFilters call.
         return await db.Parties

--- a/src/Granit.Parties.Mergeable/packages.lock.json
+++ b/src/Granit.Parties.Mergeable/packages.lock.json
@@ -170,7 +170,8 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
         }
       },
       "granit.persistence": {
@@ -208,6 +209,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Granit.Parties/Domain/Party.cs
+++ b/src/Granit.Parties/Domain/Party.cs
@@ -278,6 +278,19 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     }
 
     /// <summary>
+    /// Overwrites <see cref="TaxId"/> with its canonical (separator-stripped, upper-case) form.
+    /// Called exclusively by the EF canonicalisation interceptor on save. Single-column design:
+    /// the canonical form IS the legal one (KBO/BCE, HMRC, IRS all accept it without
+    /// separators) so there is no UX cost to displaying it back canonical, and the indexed
+    /// column doubles as the Tier-1 dedup key for Epic #1280.
+    /// </summary>
+    internal void OverwriteTaxIdCanonical(string canonical)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonical);
+        TaxId = canonical;
+    }
+
+    /// <summary>
     /// Reverses <see cref="MarkAsMergedInto"/> — used by the un-merge endpoint (P3) to revive
     /// a tombstoned loser. Cross-module reference rewriters are NOT replayed by this method ;
     /// the un-merge contract documents that re-routing already-rewritten references is

--- a/src/Granit.Parties/Domain/PartyEmail.cs
+++ b/src/Granit.Parties/Domain/PartyEmail.cs
@@ -29,9 +29,18 @@ public sealed class PartyEmail : Entity
         };
     }
 
-    /// <summary>The email address.</summary>
+    /// <summary>The email address as the user supplied it — preserved verbatim for display,
+    /// outbound mail, audit, and GDPR rectification. The dedup-friendly form lives in
+    /// <see cref="CanonicalEmail"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
     public string Address { get; private set; } = string.Empty;
+
+    /// <summary>The canonical (dedup-friendly) form of <see cref="Address"/>. Computed by
+    /// the EF canonicalisation interceptor on save (Gmail dot/plus-tag stripping, lower-case,
+    /// trim). Null when canonicalisation produces no usable key. Indexed for Tier-1
+    /// deterministic duplicate detection (Epic #1280).</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? CanonicalEmail { get; private set; }
 
     /// <summary>Whether this is the contact's primary email.</summary>
     public bool IsPrimary { get; private set; }
@@ -47,4 +56,11 @@ public sealed class PartyEmail : Entity
         Address = address;
         Label = label;
     }
+
+    /// <summary>
+    /// Sets the canonical form. Called exclusively by the EF canonicalisation interceptor
+    /// at save time — never by aggregate logic, since the canonical form is a derived value
+    /// recomputable from <see cref="Address"/>.
+    /// </summary>
+    internal void SetCanonicalEmail(string? canonicalEmail) => CanonicalEmail = canonicalEmail;
 }

--- a/src/Granit.Parties/Domain/PartyPhone.cs
+++ b/src/Granit.Parties/Domain/PartyPhone.cs
@@ -34,9 +34,18 @@ public sealed class PartyPhone : Entity
     /// <summary>The kind of phone (Mobile / Office / Home / Other).</summary>
     public PhoneKind Kind { get; private set; }
 
-    /// <summary>The phone number (recommend E.164 format, e.g. <c>"+3221234567"</c>).</summary>
+    /// <summary>The phone number as the user supplied it — preserved verbatim for display,
+    /// outbound calls / SMS, audit. The dedup-friendly form lives in
+    /// <see cref="CanonicalNumber"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
     public string Number { get; private set; } = string.Empty;
+
+    /// <summary>The canonical (dedup-friendly) E.164 form of <see cref="Number"/>. Computed by
+    /// the EF canonicalisation interceptor on save via libphonenumber. Null when parsing fails
+    /// or the input is missing a country code prefix. Indexed for Tier-1 deterministic
+    /// duplicate detection (Epic #1280).</summary>
+    [SensitiveData(Level = Sensitivity.Confidential)]
+    public string? CanonicalNumber { get; private set; }
 
     /// <summary>Whether this is the contact's primary phone.</summary>
     public bool IsPrimary { get; private set; }
@@ -53,4 +62,11 @@ public sealed class PartyPhone : Entity
         Number = number;
         Label = label;
     }
+
+    /// <summary>
+    /// Sets the canonical E.164 form. Called exclusively by the EF canonicalisation interceptor
+    /// at save time — never by aggregate logic, since the canonical form is a derived value
+    /// recomputable from <see cref="Number"/>.
+    /// </summary>
+    internal void SetCanonicalNumber(string? canonicalNumber) => CanonicalNumber = canonicalNumber;
 }

--- a/src/Granit.Payments.Endpoints/Internal/PaymentMethodLabelResolver.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentMethodLabelResolver.cs
@@ -26,7 +26,7 @@ internal static class PaymentMethodLabelResolver
     /// <example><c>sepa_debit</c> → <c>Sepa Debit</c>; <c>klarna_pay_later</c> → <c>Klarna Pay Later</c>.</example>
     private static string ToTitleCase(string snakeOrKebab) =>
         string.Join(' ', snakeOrKebab
-            .Split('_', '-')
+            .Split(['_', '-'])
             .Select(word => word.Length == 0
                 ? word
                 : char.ToUpperInvariant(word[0]) + word[1..]));

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2972,7 +2972,8 @@
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
         }
       },
       "granit.parties.mergeable": {
@@ -4069,6 +4070,12 @@
         "dependencies": {
           "Lib.Net.Http.EncryptedContentEncoding": "2.1.1"
         }
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",

--- a/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/BalanceAccountTests.cs
@@ -25,7 +25,7 @@ public sealed class BalanceAccountTests
     [Fact]
     public void Create_ShouldNormalizeCurrencyToUpperCase()
     {
-        BalanceAccount account = BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), PartyId.Create(Guid.NewGuid()), "eur");
+        var account = BalanceAccount.Create(Guid.NewGuid(), Guid.NewGuid(), PartyId.Create(Guid.NewGuid()), "eur");
 
         account.Currency.ShouldBe("EUR");
     }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpiringScanServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultCreditExpiringScanServiceTests.cs
@@ -143,7 +143,7 @@ public sealed class DefaultCreditExpiringScanServiceTests : IDisposable
 
     private static BalanceAccount CreateAccountWithBalance(Guid accountId, Guid tenantId, decimal balance)
     {
-        BalanceAccount account = BalanceAccount.Create(accountId, tenantId, PartyId.Create(Guid.NewGuid()), "EUR");
+        var account = BalanceAccount.Create(accountId, tenantId, PartyId.Create(Guid.NewGuid()), "EUR");
         account.Credit(balance, TransactionSource.Promotional, "Setup", Now.AddDays(-15), Guid.NewGuid());
         account.ClearIntegrationEvents();
         return account;

--- a/tests/Granit.Invoicing.Odoo.Tests/Internal/OdooJsonRpcClientTests.cs
+++ b/tests/Granit.Invoicing.Odoo.Tests/Internal/OdooJsonRpcClientTests.cs
@@ -137,7 +137,7 @@ public sealed class OdooJsonRpcClientTests : IDisposable
         OdooJsonRpcClient client = Build();
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(() =>
-            client.CreateAsync("x", new Dictionary<string, object?>(), TestContext.Current.CancellationToken));
+            client.CreateAsync("x", new(), TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("Permission denied");
     }
@@ -158,7 +158,7 @@ public sealed class OdooJsonRpcClientTests : IDisposable
         OdooJsonRpcClient client = Build();
 
         int id = await client.CreateAsync("res.partner",
-            new Dictionary<string, object?>(),
+            new(),
             TestContext.Current.CancellationToken);
 
         id.ShouldBe(11);

--- a/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
+++ b/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
@@ -143,10 +143,8 @@ public sealed class PropertyRedactionSanitizerTests
     }
 
     [Fact]
-    public void MaskValue_EmptyValue_ReturnsOpaqueMarker()
-    {
+    public void MaskValue_EmptyValue_ReturnsOpaqueMarker() =>
         PropertyRedactionSanitizer.MaskValue(string.Empty).ShouldBe("***");
-    }
 
     [Fact]
     public void MaskValue_NeverDisclosesPlaintextCharacters()

--- a/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
+++ b/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
@@ -146,7 +146,8 @@ public sealed class EfMergeServiceTests
         // Second call with same key + same body → cached replay, no second rewrite.
         MergeResult<FakeAggregate> replay = await sut.MergeAsync(request, TestContext.Current.CancellationToken);
         replay.DryRun.ShouldBeFalse();
-        replay.Merged.ShouldBeNull("cached replays don't reload the aggregate");
+        replay.Merged.ShouldNotBeNull("cached replays rehydrate the survivor so callers observe the same shape as a live merge");
+        replay.Merged.Id.ShouldBe(SurvivorId);
         replay.RewriteCounts["fake.RefId"].ShouldBe(7);
         rewriter.RewriteCalls.ShouldBe(1, "second call must hit the cache, not re-rewrite");
     }

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/EmailCanonicaliserTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/EmailCanonicaliserTests.cs
@@ -1,0 +1,51 @@
+using Granit.Parties.EntityFrameworkCore.Canonicalisation;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Canonicalisation;
+
+public sealed class EmailCanonicaliserTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-an-email")]
+    [InlineData("@example.com")]
+    [InlineData("alice@")]
+    [InlineData("alice@two@example.com")]
+    public void Returns_null_for_invalid_input(string? input) =>
+        EmailCanonicaliser.Canonicalise(input).ShouldBeNull();
+
+    [Theory]
+    [InlineData("Alice@Example.com", "alice@example.com")]
+    [InlineData("  alice@example.com  ", "alice@example.com")]
+    [InlineData("alice@EXAMPLE.COM", "alice@example.com")]
+    public void Lowercases_and_trims_for_non_gmail(string input, string expected) =>
+        EmailCanonicaliser.Canonicalise(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("alice.smith@example.com")]
+    [InlineData("alice+billing@example.com")]
+    public void Does_NOT_strip_dots_or_plus_tags_outside_gmail(string input) =>
+        // Outlook, Yahoo, Proton etc. treat dots and +tags as significant by default.
+        // Only Gmail has the documented "dots are ignored" semantics.
+        EmailCanonicaliser.Canonicalise(input).ShouldBe(input);
+
+    [Theory]
+    [InlineData("Alice@gmail.com", "alice@gmail.com")]
+    [InlineData("a.l.i.c.e@gmail.com", "alice@gmail.com")]
+    [InlineData("alice+billing@gmail.com", "alice@gmail.com")]
+    [InlineData("a.lice+newsletter@gmail.com", "alice@gmail.com")]
+    [InlineData("alice@googlemail.com", "alice@gmail.com")]
+    [InlineData("a.l.ice+x@GoogleMail.com", "alice@gmail.com")]
+    public void Strips_dots_and_plus_tags_for_gmail_and_googlemail(string input, string expected) =>
+        EmailCanonicaliser.Canonicalise(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(".@gmail.com")]            // local part collapses to empty after dot strip
+    [InlineData("+tag@gmail.com")]         // local part collapses to empty after plus strip
+    [InlineData(".+x@gmail.com")]          // both
+    public void Returns_null_when_gmail_local_part_collapses_to_empty(string input) =>
+        EmailCanonicaliser.Canonicalise(input).ShouldBeNull();
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/PhoneCanonicaliserTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/PhoneCanonicaliserTests.cs
@@ -1,0 +1,43 @@
+using Granit.Parties.EntityFrameworkCore.Canonicalisation;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Canonicalisation;
+
+public sealed class PhoneCanonicaliserTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Returns_null_for_null_or_whitespace(string? input) =>
+        PhoneCanonicaliser.Canonicalise(input).ShouldBeNull();
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("+99999999999999999")]   // syntactically parseable but not a valid number
+    [InlineData("0470123456")]            // domestic format without country code → ambiguous
+    public void Returns_null_when_libphonenumber_cannot_parse_or_validate(string input) =>
+        PhoneCanonicaliser.Canonicalise(input).ShouldBeNull();
+
+    [Theory]
+    // Belgian mobile in three different display formats — all collapse to the same E.164.
+    [InlineData("+32 470 12 34 56", "+32470123456")]
+    [InlineData("+32-470-12-34-56", "+32470123456")]
+    [InlineData("+32470123456", "+32470123456")]
+    // French mobile.
+    [InlineData("+33 6 12 34 56 78", "+33612345678")]
+    // US example (NANP).
+    [InlineData("+1 415-555-2671", "+14155552671")]
+    public void Normalises_E164_prefixed_input_to_strict_E164(string input, string expected) =>
+        PhoneCanonicaliser.Canonicalise(input).ShouldBe(expected);
+
+    [Fact]
+    public void Idempotent_on_already_canonical_input()
+    {
+        string canonical = "+32470123456";
+        string? once = PhoneCanonicaliser.Canonicalise(canonical);
+        string? twice = PhoneCanonicaliser.Canonicalise(once);
+        twice.ShouldBe(canonical);
+    }
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/TaxIdCanonicaliserTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Canonicalisation/TaxIdCanonicaliserTests.cs
@@ -1,0 +1,40 @@
+using Granit.Parties.EntityFrameworkCore.Canonicalisation;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Canonicalisation;
+
+public sealed class TaxIdCanonicaliserTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(" - . / ")]   // separators only — nothing left after stripping
+    public void Returns_null_for_null_or_whitespace_or_separators_only(string? input) =>
+        TaxIdCanonicaliser.Canonicalise(input).ShouldBeNull();
+
+    [Theory]
+    // Belgian VAT in various display formats — all collapse to the same canonical form.
+    [InlineData("BE 0123.456.789", "BE0123456789")]
+    [InlineData("be0123456789", "BE0123456789")]
+    [InlineData("BE-0123-456-789", "BE0123456789")]
+    [InlineData("  be 0123/456/789  ", "BE0123456789")]
+    // French VAT.
+    [InlineData("FR12 345 678 901", "FR12345678901")]
+    // German VAT.
+    [InlineData("DE-123/456 789", "DE123456789")]
+    // UK Companies House.
+    [InlineData("01234567", "01234567")]
+    public void Strips_separators_and_uppercases(string input, string expected) =>
+        TaxIdCanonicaliser.Canonicalise(input).ShouldBe(expected);
+
+    [Fact]
+    public void Idempotent_on_already_canonical_input()
+    {
+        string canonical = "BE0123456789";
+        string? once = TaxIdCanonicaliser.Canonicalise(canonical);
+        string? twice = TaxIdCanonicaliser.Canonicalise(once);
+        twice.ShouldBe(canonical);
+    }
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
@@ -1,0 +1,156 @@
+using Granit.DataFiltering;
+using Granit.Parties.Domain;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Integration tests for <see cref="PartyCanonicalisationInterceptor"/>: verifies that
+/// canonical projections are populated on save for Party.TaxId (overwritten in place),
+/// PartyEmail.CanonicalEmail (separate column), and PartyPhone.CanonicalNumber (separate
+/// column). Uses the InMemory provider — interceptors are honoured the same way as on
+/// SQL providers, just without real SQL.
+/// </summary>
+[Collection(ContactsDbSerialGroup.Name)]
+public sealed class PartyCanonicalisationInterceptorTests : IAsyncDisposable
+{
+    private readonly DataFilter _filter = new();
+    private readonly string _dbName = $"canonicalisation-{Guid.NewGuid()}";
+    private readonly InMemoryDatabaseRoot _dbRoot = new();
+    private readonly StubCurrentTenant _tenant = new();
+
+    public async ValueTask DisposeAsync()
+    {
+        await using PartiesDbContext db = NewContext();
+        await db.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+    }
+
+    private PartiesDbContext NewContext() =>
+        new(
+            new DbContextOptionsBuilder<PartiesDbContext>()
+                .UseInMemoryDatabase(_dbName, _dbRoot)
+                .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+                .EnableServiceProviderCaching(false)
+                .AddInterceptors(new PartyCanonicalisationInterceptor())
+                .Options,
+            _tenant,
+            _filter);
+
+    [Fact]
+    public async Task SaveAsync_overwrites_TaxId_with_canonical_form_in_place()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var p = Party.Create(
+            id: Guid.NewGuid(),
+            tenantId: null,
+            kind: PartyKind.Company,
+            name: "Acme",
+            defaultCurrency: "EUR",
+            taxId: "BE 0123.456.789");
+
+        await using (PartiesDbContext db = NewContext())
+        {
+            db.Parties.Add(p);
+            await db.SaveChangesAsync(ct);
+        }
+
+        await using PartiesDbContext readBack = NewContext();
+        Party loaded = (await readBack.Parties.FindAsync([p.Id], ct))!;
+        loaded.TaxId.ShouldBe("BE0123456789");
+    }
+
+    [Fact]
+    public async Task SaveAsync_populates_CanonicalEmail_for_each_PartyEmail()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var p = Party.Create(
+            id: Guid.NewGuid(),
+            tenantId: null,
+            kind: PartyKind.Individual,
+            name: "Alice",
+            defaultCurrency: "EUR");
+        p.AddEmail(Guid.NewGuid(), "Alice+Newsletter@Gmail.com");
+        p.AddEmail(Guid.NewGuid(), "alice.smith@example.com");
+
+        await using (PartiesDbContext db = NewContext())
+        {
+            db.Parties.Add(p);
+            await db.SaveChangesAsync(ct);
+        }
+
+        await using PartiesDbContext readBack = NewContext();
+        Party loaded = await readBack.Parties
+            .Include(x => x.Emails)
+            .FirstAsync(x => x.Id == p.Id, ct);
+
+        loaded.Emails.ShouldContain(e => e.Address == "Alice+Newsletter@Gmail.com" && e.CanonicalEmail == "alice@gmail.com");
+        // Non-Gmail address: only lower-cased + trimmed, no dot/plus stripping.
+        loaded.Emails.ShouldContain(e => e.Address == "alice.smith@example.com" && e.CanonicalEmail == "alice.smith@example.com");
+    }
+
+    [Fact]
+    public async Task SaveAsync_populates_CanonicalNumber_for_each_PartyPhone()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var p = Party.Create(
+            id: Guid.NewGuid(),
+            tenantId: null,
+            kind: PartyKind.Individual,
+            name: "Bob",
+            defaultCurrency: "EUR");
+        p.AddPhone(Guid.NewGuid(), PhoneKind.Mobile, "+32 470 12 34 56");
+        p.AddPhone(Guid.NewGuid(), PhoneKind.Work, "0470123456"); // domestic — unparseable without region
+
+        await using (PartiesDbContext db = NewContext())
+        {
+            db.Parties.Add(p);
+            await db.SaveChangesAsync(ct);
+        }
+
+        await using PartiesDbContext readBack = NewContext();
+        Party loaded = await readBack.Parties
+            .Include(x => x.Phones)
+            .FirstAsync(x => x.Id == p.Id, ct);
+
+        // E.164-prefixed input → strict E.164 form on the canonical column; verbatim preserved.
+        loaded.Phones.ShouldContain(ph => ph.Number == "+32 470 12 34 56" && ph.CanonicalNumber == "+32470123456");
+        // Domestic input without country code → canonical is null (libphonenumber rejects ambiguous input).
+        loaded.Phones.ShouldContain(ph => ph.Number == "0470123456" && ph.CanonicalNumber == null);
+    }
+
+    [Fact]
+    public async Task SaveAsync_recomputes_CanonicalEmail_when_Address_is_modified()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var emailId = Guid.NewGuid();
+        var p = Party.Create(
+            id: Guid.NewGuid(),
+            tenantId: null,
+            kind: PartyKind.Individual,
+            name: "Carol",
+            defaultCurrency: "EUR");
+        p.AddEmail(emailId, "carol@gmail.com");
+
+        await using (PartiesDbContext db = NewContext())
+        {
+            db.Parties.Add(p);
+            await db.SaveChangesAsync(ct);
+        }
+
+        // Modify the email address — the interceptor must re-canonicalise on the next save.
+        await using (PartiesDbContext db = NewContext())
+        {
+            Party loaded = await db.Parties.Include(x => x.Emails).FirstAsync(x => x.Id == p.Id, ct);
+            loaded.UpdateEmail(emailId, "Carol+Tag@GMAIL.com", label: null);
+            await db.SaveChangesAsync(ct);
+        }
+
+        await using PartiesDbContext readBack = NewContext();
+        Party reloaded = await readBack.Parties.Include(x => x.Emails).FirstAsync(x => x.Id == p.Id, ct);
+        reloaded.Emails.ShouldContain(e => e.Address == "Carol+Tag@GMAIL.com" && e.CanonicalEmail == "carol@gmail.com");
+    }
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
@@ -375,7 +375,8 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
         }
       },
       "granit.persistence": {
@@ -413,6 +414,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
@@ -1,0 +1,287 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Guids;
+using Granit.Mergeable;
+using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Parties.EntityFrameworkCore;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.Parties.Mergeable.Internal;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// End-to-end integration test for the full Party merge pipeline: EfMergeService&lt;Party&gt;
+/// orchestrator + PartyMergeableAggregateAdapter + PartyParentReferenceRewriter +
+/// PartyChildrenReferenceRewriter, all wired against a real PostgreSQL container in a single
+/// TransactionScope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Until this test landed, the fake-aggregate orchestrator tests in
+/// <c>Granit.Mergeable.EntityFrameworkCore.Tests</c> never exercised the EF
+/// <see cref="DbContext.ChangeTracker"/> against a Party loaded with <c>Include(...)</c>, and
+/// the rewriter integration tests exercised each rewriter in isolation. The combination
+/// (orchestrator + adapter + bulk-SQL rewriters) hides a concrete pitfall: calling
+/// <c>db.Parties.Update(party)</c> on a survivor / loser whose navigation graph was loaded
+/// via Include — the default semantic of <c>Update()</c> cascades through the whole graph
+/// and forces every PartyAddress / PartyEmail / PartyPhone / PartyExternalMapping back into
+/// EF tracking with state Modified, snapshotting the shadow FK <c>PartyId</c> at the
+/// pre-merge value. <c>SaveChangesAsync</c> would then issue
+/// <c>UPDATE … SET PartyId = loserId WHERE Id = childId</c> for every relocated row,
+/// silently undoing the bulk rewriter that ran earlier in the same transaction.
+/// </para>
+/// <para>
+/// The current adapter implementation uses <see cref="ChangeTracker.TrackGraph"/> with the
+/// root forced Modified and every navigation child forced Unchanged — the assertions below
+/// are the regression net for that contract.
+/// </para>
+/// </remarks>
+public sealed class EfMergeServicePartyEndToEndTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IGuidGenerator _guidGenerator = SimpleGuidGenerator.Instance;
+    private TestPartiesDbContextFactory _partiesFactory = null!;
+    private TestMergeableDbContextFactory _mergeableFactory = null!;
+    private EfMergeService<Party> _sut = null!;
+
+    public EfMergeServicePartyEndToEndTests(PostgresFixture postgres)
+    {
+        _postgres = postgres;
+        _dataFilter.Disable<IHasMergeTombstone>().Returns(_ => Substitute.For<IDisposable>());
+        _clock.Now.Returns(new DateTimeOffset(2026, 4, 27, 12, 0, 0, TimeSpan.Zero));
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _partiesFactory = new TestPartiesDbContextFactory(_postgres.ConnectionString);
+        _mergeableFactory = new TestMergeableDbContextFactory(_postgres.ConnectionString);
+
+        await using (PartiesDbContext partiesDb = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            await partiesDb.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            string p = GranitPartiesDbProperties.DbTablePrefix;
+            await partiesDb.Database.ExecuteSqlRawAsync(
+                $"TRUNCATE TABLE {p}external_mappings, {p}addresses, {p}emails, {p}phones, {p}parties RESTART IDENTITY CASCADE;",
+                TestContext.Current.CancellationToken);
+        }
+
+        // EnsureCreatedAsync for a second DbContext on the same database is a no-op once the
+        // first context's tables exist — EF interprets the database as "already created" and
+        // skips schema generation. Hand-issue the merge-orchestrator's schema + table with
+        // IF NOT EXISTS guards so the granit.merge_idempotency table exists for the
+        // orchestrator's idempotency cache writes.
+        await using (MergeableDbContext mergeableDb = await _mergeableFactory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            await mergeableDb.Database.ExecuteSqlRawAsync(
+                """
+                CREATE SCHEMA IF NOT EXISTS granit;
+                CREATE TABLE IF NOT EXISTS granit.merge_idempotency (
+                    "Id" uuid NOT NULL,
+                    "Key" character varying(128) NOT NULL,
+                    "RequestHash" character varying(64) NOT NULL,
+                    "SurvivorId" uuid NOT NULL,
+                    "LoserId" uuid NOT NULL,
+                    "ResultJson" text NOT NULL,
+                    "CreatedAt" timestamp with time zone NOT NULL,
+                    CONSTRAINT "PK_merge_idempotency" PRIMARY KEY ("Id")
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS "IX_merge_idempotency_Key_RequestHash"
+                    ON granit.merge_idempotency ("Key", "RequestHash");
+                CREATE INDEX IF NOT EXISTS "IX_merge_idempotency_SurvivorId_LoserId"
+                    ON granit.merge_idempotency ("SurvivorId", "LoserId");
+                CREATE INDEX IF NOT EXISTS "IX_merge_idempotency_CreatedAt"
+                    ON granit.merge_idempotency ("CreatedAt");
+                """,
+                TestContext.Current.CancellationToken);
+            await mergeableDb.Database.ExecuteSqlRawAsync(
+                "TRUNCATE TABLE granit.merge_idempotency RESTART IDENTITY;",
+                TestContext.Current.CancellationToken);
+        }
+
+        var adapter = new PartyMergeableAggregateAdapter(_partiesFactory, _dataFilter);
+        var parentRewriter = new PartyParentReferenceRewriter(_partiesFactory, _dataFilter);
+        var childrenRewriter = new PartyChildrenReferenceRewriter(_partiesFactory, _dataFilter);
+        IReferenceRewriter<Party>[] rewriters = [parentRewriter, childrenRewriter];
+
+        _sut = new EfMergeService<Party>(
+            adapter,
+            rewriters,
+            _mergeableFactory,
+            _guidGenerator,
+            _clock);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _partiesFactory.DisposeAsync();
+        await _mergeableFactory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task MergeAsync_PersistsTombstoneOnLoser_AndRetainsRewrittenChildFKs()
+    {
+        // Arrange — survivor with two emails; loser with one unique email + one duplicate.
+        Party survivor = NewParty("Acme S");
+        survivor.AddEmail(Guid.NewGuid(), "ops@acme.com", isPrimary: true);
+        survivor.AddEmail(Guid.NewGuid(), "shared@acme.com", isPrimary: false);
+
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "shared@acme.com", isPrimary: false);     // structural dup → deleted
+        loser.AddEmail(Guid.NewGuid(), "billing@acme.com", isPrimary: false);    // unique → relocated
+
+        await SeedAsync(survivor, loser);
+
+        // Act
+        MergeResult<Party> result = await _sut.MergeAsync(
+            new MergeRequest(survivor.Id, loser.Id, MergeFieldChoices.Empty),
+            TestContext.Current.CancellationToken);
+
+        // Assert — orchestrator returns the merged survivor.
+        result.DryRun.ShouldBeFalse();
+        result.Merged.ShouldNotBeNull();
+        result.Merged!.Id.ShouldBe(survivor.Id);
+
+        // Assert — loser is tombstoned in DB (via adapter.ApplyTombstone + PersistMergedPair).
+        await using PartiesDbContext assertDb = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Party persistedLoser = await assertDb.Parties
+            .IgnoreQueryFilters()
+            .FirstAsync(p => p.Id == loser.Id, TestContext.Current.CancellationToken);
+        persistedLoser.MergedIntoId.ShouldBe(survivor.Id);
+        persistedLoser.MergedAt.ShouldNotBeNull();
+
+        // Assert — REGRESSION GUARD for the Update()-cascade pitfall: the unique loser email
+        // ("billing@acme.com") MUST end up attached to the survivor, with its shadow FK still
+        // pointing at survivor.Id after SaveChanges. If the adapter ever reverts to
+        // db.Parties.Update(loser), this email's PartyId would be silently rewritten back to
+        // loser.Id, breaking the merge contract.
+        List<string> survivorEmails = await assertDb.Set<PartyEmail>()
+            .Where(e => EF.Property<Guid>(e, "PartyId") == survivor.Id)
+            .Select(e => e.Address)
+            .OrderBy(s => s)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        survivorEmails.ShouldBe(["billing@acme.com", "ops@acme.com", "shared@acme.com"]);
+
+        int loserEmailCount = await assertDb.Set<PartyEmail>()
+            .CountAsync(e => EF.Property<Guid>(e, "PartyId") == loser.Id, TestContext.Current.CancellationToken);
+        loserEmailCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task MergeAsync_RewritesAllFourChildCollections_AndReParentsChildren()
+    {
+        // Arrange — full child set on the loser side and a child Party that points at it.
+        Party survivor = NewParty("Acme S");
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "billing@acme.com");
+        loser.AddPhone(Guid.NewGuid(), PhoneKind.Mobile, "+3221111111");
+        loser.AddAddress(
+            Guid.NewGuid(), AddressKind.Billing,
+            Address.Create("Rue 1", "Brussels", "1000", "BE"));
+        loser.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_loser_123");
+
+        Party child = NewParty("Acme Child");
+        child.AttachToParent(PartyId.Create(loser.Id), parentTenantId: null);
+
+        await SeedAsync(survivor, loser, child);
+
+        // Act
+        MergeResult<Party> result = await _sut.MergeAsync(
+            new MergeRequest(survivor.Id, loser.Id, MergeFieldChoices.Empty),
+            TestContext.Current.CancellationToken);
+
+        // Assert — both rewriters reported activity.
+        result.RewriteCounts["Party.Children"].ShouldBeGreaterThan(0);
+        result.RewriteCounts["Party.ParentContactId"].ShouldBe(1);
+
+        // Assert — every child collection now belongs to the survivor.
+        await using PartiesDbContext assertDb = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        (await assertDb.Set<PartyEmail>()
+            .CountAsync(e => EF.Property<Guid>(e, "PartyId") == survivor.Id, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+        (await assertDb.Set<PartyPhone>()
+            .CountAsync(p => EF.Property<Guid>(p, "PartyId") == survivor.Id, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+        (await assertDb.Set<PartyAddress>()
+            .CountAsync(a => EF.Property<Guid>(a, "PartyId") == survivor.Id, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+        (await assertDb.Set<PartyExternalMapping>()
+            .CountAsync(m => EF.Property<Guid>(m, "PartyId") == survivor.Id, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+
+        // Assert — child Party is re-parented onto the survivor.
+        Party persistedChild = await assertDb.Parties
+            .FirstAsync(p => p.Id == child.Id, TestContext.Current.CancellationToken);
+        persistedChild.ParentContactId.ShouldNotBeNull();
+        persistedChild.ParentContactId.Value.ShouldBe(survivor.Id);
+    }
+
+    [Fact]
+    public async Task MergeAsync_DryRun_PreviewsConflictsAndCounts_WithoutCommitting()
+    {
+        Party survivor = NewParty("Acme S");
+        Party loser = NewParty("Acme L"); // different Name → 1 conflict
+        loser.AddEmail(Guid.NewGuid(), "billing@acme.com");
+        await SeedAsync(survivor, loser);
+
+        MergeResult<Party> result = await _sut.MergeAsync(
+            new MergeRequest(survivor.Id, loser.Id, MergeFieldChoices.Empty, DryRun: true),
+            TestContext.Current.CancellationToken);
+
+        result.DryRun.ShouldBeTrue();
+        result.Merged.ShouldBeNull();
+        result.Conflicts.ShouldContain(c => c.FieldPath == "Name");
+        result.RewriteCounts["Party.Children"].ShouldBe(1);
+
+        // Nothing committed: both parties are still alive (no tombstone), email still on loser.
+        await using PartiesDbContext assertDb = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Party persistedLoser = await assertDb.Parties
+            .IgnoreQueryFilters()
+            .FirstAsync(p => p.Id == loser.Id, TestContext.Current.CancellationToken);
+        persistedLoser.MergedIntoId.ShouldBeNull();
+        (await assertDb.Set<PartyEmail>()
+            .CountAsync(e => EF.Property<Guid>(e, "PartyId") == loser.Id, TestContext.Current.CancellationToken))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task MergeAsync_IdempotentReplay_ReturnsCachedResult_WithRehydratedSurvivor()
+    {
+        Party survivor = NewParty("Acme S");
+        Party loser = NewParty("Acme L");
+        loser.AddEmail(Guid.NewGuid(), "billing@acme.com");
+        await SeedAsync(survivor, loser);
+
+        var request = new MergeRequest(survivor.Id, loser.Id, MergeFieldChoices.Empty,
+            IdempotencyKey: "merge-retry-key-001");
+
+        // First call: live merge.
+        MergeResult<Party> first = await _sut.MergeAsync(request, TestContext.Current.CancellationToken);
+        first.Merged.ShouldNotBeNull();
+
+        // Second call: replay.
+        MergeResult<Party> replay = await _sut.MergeAsync(request, TestContext.Current.CancellationToken);
+        replay.DryRun.ShouldBeFalse();
+        replay.Merged.ShouldNotBeNull("idempotency replay must rehydrate Merged from the live aggregate");
+        replay.Merged!.Id.ShouldBe(survivor.Id);
+        replay.RewriteCounts["Party.Children"].ShouldBe(first.RewriteCounts["Party.Children"]);
+    }
+
+    private async Task SeedAsync(params Party[] parties)
+    {
+        await using PartiesDbContext db = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Parties.AddRange(parties);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static Party NewParty(string name) =>
+        Party.Create(Guid.NewGuid(), tenantId: null, PartyKind.Company, name, "EUR");
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/TestMergeableDbContextFactory.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/TestMergeableDbContextFactory.cs
@@ -1,0 +1,30 @@
+using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Mergeable.Tests.Integration;
+
+/// <summary>
+/// Minimal <see cref="IDbContextFactory{TContext}"/> for the merge-orchestrator's
+/// <c>granit.merge_idempotency</c> bookkeeping table — wires the internal
+/// <see cref="MergeableDbContext"/> against the Postgres connection string from the
+/// Testcontainer fixture. Visible from this assembly via the <c>InternalsVisibleTo</c>
+/// entry on <c>Granit.Mergeable.EntityFrameworkCore.csproj</c>.
+/// </summary>
+internal sealed class TestMergeableDbContextFactory : IDbContextFactory<MergeableDbContext>, IAsyncDisposable
+{
+    private readonly DbContextOptions<MergeableDbContext> _options;
+
+    public TestMergeableDbContextFactory(string connectionString)
+    {
+        _options = new DbContextOptionsBuilder<MergeableDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+    }
+
+    public MergeableDbContext CreateDbContext() => new(_options);
+
+    public Task<MergeableDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(new MergeableDbContext(_options));
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
@@ -452,7 +452,8 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
         }
       },
       "granit.parties.mergeable": {
@@ -502,6 +503,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
@@ -388,7 +388,8 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
         }
       },
       "granit.parties.mergeable": {
@@ -438,6 +439,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
         }
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
@@ -399,7 +399,7 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         Guid? tenantId,
         WebhookSubscriptionStatus status)
     {
-        WebhookSubscription sub = WebhookSubscription.Create(Guid.NewGuid(), "https://example.com/webhook", eventType, "protected-secret", tenantId);
+        var sub = WebhookSubscription.Create(Guid.NewGuid(), "https://example.com/webhook", eventType, "protected-secret", tenantId);
 
         switch (status)
         {


### PR DESCRIPTION
## Summary

Story [#1297](https://github.com/granit-fx/granit-dotnet/issues/1297) of [Feature #1280](https://github.com/granit-fx/granit-dotnet/issues/1280) (Party duplicate detection — 3-tier pipeline) under [Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278).

Adds the dedup-friendly canonical projections of party identity fields, populated automatically on every save by the new `PartyCanonicalisationInterceptor` (auto-wired via `IGranitAutoInterceptor`).

| Field | Storage | Rule |
|---|---|---|
| `PartyEmail.CanonicalEmail` (NEW) | separate column, verbatim `Address` preserved | lower + trim, plus Gmail/Googlemail-specific dot/`+tag` stripping; non-Gmail providers keep dots and `+tags` (significant outside Gmail) |
| `PartyPhone.CanonicalNumber` (NEW) | separate column, verbatim `Number` preserved | strict E.164 via libphonenumber-csharp; `null` when ambiguous (UI captures country code via dropdown so caller is expected to send `+cc…`) |
| `Party.TaxId` | overwritten in place | upper + strip separators — the canonical form **is** the legal one (KBO/BCE, HMRC, IRS all accept it without separators), no UX cost to single-column |

## Design notes

- **Canonicalisers as `public static` classes** in `src/Granit.Parties.EntityFrameworkCore/Canonicalisation/` — re-usable by the upcoming `Granit.Parties.Deduplication` (#1299) and online detection at create (#1302) without depending on the interceptor.
- **Domain remains free of libphonenumber** — the dependency lives in `Granit.Parties.EntityFrameworkCore` only.
- **Three non-unique indexes** (`CanonicalEmail`, `CanonicalNumber`, `TaxId`) feed Tier-1 deterministic blocking. Non-unique because legitimate sharing exists (households, family phones, parent + subsidiary VAT). Tenant filtering happens via JOIN on `Party.TenantId` in the dedup engine (#1299).
- **Interceptor is a SaveChanges-time projection** — it never throws on bad input (libphonenumber unparseable → `CanonicalNumber = null`, the row simply doesn't surface in Tier-1 lookups). Validation is the UI's responsibility.

## Test plan

- [x] 17 unit tests on the canonicalisers (`tests/.../Canonicalisation/*Tests.cs`) — table-driven, edge cases (empty, separators-only, Gmail dot/plus collapse, idempotency)
- [x] 4 integration tests on the interceptor (`PartyCanonicalisationInterceptorTests.cs`) — InMemory provider, verifies populate-on-Add and recompute-on-Modified
- [x] `dotnet test tests/Granit.Parties.EntityFrameworkCore.Tests` — 87/87 passing
- [x] `dotnet test tests/Granit.Parties.Tests` — 155/155 passing (no domain regression)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 20/20 passing (no convention regression)

## Bonus commit

`chore(tests): fix IDE0007 violations caught by pack stage` — three pre-existing `use var instead of explicit type` violations in unrelated test projects (Webhooks, CustomerBalance) that the pack stage caught but earlier shard test stages missed. Shipping the fix here so CI pack goes green.

Refs #1297
Refs #1280
