### PR TITLE
feat(parties): pg_trgm migration helper + dedup thresholds (#1298)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32967,12 +32967,50 @@
       ]
     },
     {
+      "name": "PartiesPostgresMigrationExtensions",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Deduplication.PartiesPostgresMigrationExtensions",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs",
+      "line": 42,
+      "members": [
+        {
+          "name": "AddPartyTrigramSimilarityIndexes",
+          "kind": "method",
+          "signature": "AddPartyTrigramSimilarityIndexes(this MigrationBuilder migrationBuilder, string? schema = null, string? tableName = null)",
+          "returnType": "MigrationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PartyDeduplicationOptions",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Deduplication.PartyDeduplicationOptions",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Deduplication/PartyDeduplicationOptions.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "NameSimilarityThreshold",
+          "kind": "property",
+          "signature": "double NameSimilarityThreshold",
+          "returnType": "double"
+        },
+        {
+          "name": "CompanySimilarityThreshold",
+          "kind": "property",
+          "signature": "double CompanySimilarityThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
       "name": "PartiesEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Parties.EntityFrameworkCore.Extensions.PartiesEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitPartiesEntityFrameworkCore",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32972,7 +32972,7 @@
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs",
-      "line": 42,
+      "line": 43,
       "members": [
         {
           "name": "AddPartyTrigramSimilarityIndexes",
@@ -36242,6 +36242,15 @@
           "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } public void"
         }
       ]
+    },
+    {
+      "name": "GranitDbProviders",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitDbProviders",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbProviders.cs",
+      "line": 27,
+      "members": []
     },
     {
       "name": "GranitFilterNames",

--- a/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableConcurrencyLock.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Internal/MergeableConcurrencyLock.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Mergeable.EntityFrameworkCore.Internal;
@@ -26,9 +27,6 @@ namespace Granit.Mergeable.EntityFrameworkCore.Internal;
 /// </remarks>
 internal static class MergeableConcurrencyLock
 {
-    private const string PostgresProvider = "Npgsql.EntityFrameworkCore.PostgreSQL";
-    private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
-
     /// <summary>
     /// Acquires the lock inside the active transaction. Caller MUST be inside the orchestrator's
     /// ambient <see cref="System.Transactions.TransactionScope"/>; the underlying connection is
@@ -44,14 +42,14 @@ internal static class MergeableConcurrencyLock
 
         switch (providerName)
         {
-            case PostgresProvider:
+            case GranitDbProviders.Postgres:
                 await db.Database.ExecuteSqlRawAsync(
                     "SELECT pg_advisory_xact_lock(hashtext({0}))",
                     [resource],
                     cancellationToken).ConfigureAwait(false);
                 break;
 
-            case SqlServerProvider:
+            case GranitDbProviders.SqlServer:
                 await db.Database.ExecuteSqlRawAsync(
                     """
                     DECLARE @result int;

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeteringConcurrencyLock.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeteringConcurrencyLock.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -25,9 +26,6 @@ namespace Granit.Metering.EntityFrameworkCore.Internal;
 /// </remarks>
 internal static class MeteringConcurrencyLock
 {
-    private const string PostgresProvider = "Npgsql.EntityFrameworkCore.PostgreSQL";
-    private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
-
     /// <summary>
     /// Acquires the lock inside the active transaction. Caller MUST have already opened
     /// a transaction (<c>db.Database.BeginTransactionAsync</c>); the lock is released
@@ -49,7 +47,7 @@ internal static class MeteringConcurrencyLock
 
         switch (providerName)
         {
-            case PostgresProvider:
+            case GranitDbProviders.Postgres:
                 // pg_advisory_xact_lock is blocking: waits until the lock is free,
                 // then auto-releases at transaction end.
                 await db.Database.ExecuteSqlRawAsync(
@@ -58,7 +56,7 @@ internal static class MeteringConcurrencyLock
                     cancellationToken).ConfigureAwait(false);
                 break;
 
-            case SqlServerProvider:
+            case GranitDbProviders.SqlServer:
                 // sp_getapplock with @LockOwner='Transaction' auto-releases on COMMIT/ROLLBACK.
                 // @LockTimeout = -1 → wait indefinitely (matches PostgreSQL semantics).
                 await db.Database.ExecuteSqlRawAsync(

--- a/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Granit.Parties.EntityFrameworkCore.Deduplication;
@@ -41,8 +42,6 @@ namespace Granit.Parties.EntityFrameworkCore.Deduplication;
 /// </remarks>
 public static class PartiesPostgresMigrationExtensions
 {
-    private const string NpgsqlProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
-
     /// <summary>
     /// Installs the <c>pg_trgm</c> extension + a GIST trigram index on <c>lower(name)</c>
     /// of the parties table. No-op on non-PostgreSQL providers.
@@ -112,6 +111,6 @@ public static class PartiesPostgresMigrationExtensions
     private static bool IsPostgres(MigrationBuilder migrationBuilder) =>
         string.Equals(
             migrationBuilder.ActiveProvider,
-            NpgsqlProviderName,
+            GranitDbProviders.Postgres,
             StringComparison.Ordinal);
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartiesPostgresMigrationExtensions.cs
@@ -1,0 +1,117 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Granit.Parties.EntityFrameworkCore.Deduplication;
+
+/// <summary>
+/// PostgreSQL-specific migration helpers for Tier-2 trigram-similarity duplicate detection.
+/// The framework cannot ship migrations directly (CLAUDE.md: migrations live in the consuming
+/// app), so this static class provides composable raw-SQL helpers the app's migration calls
+/// from <c>Up()</c> and <c>Down()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PostgreSQL only — the helper inspects <see cref="MigrationBuilder.ActiveProvider"/> and
+/// no-ops when the provider is not <c>Npgsql.EntityFrameworkCore.PostgreSQL</c>. The fallback
+/// for SQL Server / SQLite / InMemory is a slower <c>LIKE</c>-based matching at query time
+/// implemented in <c>Granit.Parties.Deduplication</c> (story #1299).
+/// </para>
+/// <para>
+/// Consuming app migration usage:
+/// <code>
+/// public partial class AddPartyTrigramIndexes : Migration
+/// {
+///     protected override void Up(MigrationBuilder migrationBuilder) =&gt;
+///         migrationBuilder.AddPartyTrigramSimilarityIndexes();
+///
+///     protected override void Down(MigrationBuilder migrationBuilder) =&gt;
+///         migrationBuilder.RemovePartyTrigramSimilarityIndexes();
+/// }
+/// </code>
+/// Schema and table-name defaults follow the Granit convention
+/// (<c>contacts_parties</c> / <see cref="GranitPartiesDbProperties.DbSchema"/>); pass the
+/// parameters explicitly when the app overrides the defaults.
+/// </para>
+/// <para>
+/// Index choice: <b>GIST + gist_trgm_ops</b> rather than GIN. GIN is ~3× faster on pure
+/// <c>%</c> / <c>similarity() &gt; threshold</c> reads but lacks support for the <c>&lt;-&gt;</c>
+/// distance operator and <c>ORDER BY similarity(...)</c> ranking. Tier-3 fuzzy scoring will
+/// want ranked candidates, so GIST is the more flexible default. Adjust the helper if a
+/// specific deployment is read-only enough to prefer GIN.
+/// </para>
+/// </remarks>
+public static class PartiesPostgresMigrationExtensions
+{
+    private const string NpgsqlProviderName = "Npgsql.EntityFrameworkCore.PostgreSQL";
+
+    /// <summary>
+    /// Installs the <c>pg_trgm</c> extension + a GIST trigram index on <c>lower(name)</c>
+    /// of the parties table. No-op on non-PostgreSQL providers.
+    /// </summary>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <param name="schema">Schema of the parties table. Defaults to
+    /// <see cref="GranitPartiesDbProperties.DbSchema"/>; pass explicitly if the consuming app
+    /// overrides it after framework-default resolution.</param>
+    /// <param name="tableName">Parties table name. Defaults to <c>contacts_parties</c>.</param>
+    /// <returns>The migration builder for chaining.</returns>
+    public static MigrationBuilder AddPartyTrigramSimilarityIndexes(
+        this MigrationBuilder migrationBuilder,
+        string? schema = null,
+        string? tableName = null)
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+        if (!IsPostgres(migrationBuilder))
+        {
+            return migrationBuilder;
+        }
+
+        string resolvedSchema = schema ?? GranitPartiesDbProperties.DbSchema ?? "public";
+        string resolvedTable = tableName ?? GranitPartiesDbProperties.DbTablePrefix + "parties";
+        string indexName = $"IX_{resolvedTable}_name_trgm";
+
+        // pg_trgm provides similarity() and the % operator. CREATE EXTENSION is idempotent.
+        migrationBuilder.Sql("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
+
+        // GIST + gist_trgm_ops on lower(name) — case-insensitive trigram blocking.
+        migrationBuilder.Sql(
+            $"CREATE INDEX IF NOT EXISTS \"{indexName}\" "
+            + $"ON \"{resolvedSchema}\".\"{resolvedTable}\" "
+            + "USING GIST (lower(\"name\") gist_trgm_ops);");
+
+        return migrationBuilder;
+    }
+
+    /// <summary>
+    /// Drops the GIST trigram index installed by
+    /// <see cref="AddPartyTrigramSimilarityIndexes"/>. Does <em>not</em> drop the
+    /// <c>pg_trgm</c> extension itself — extensions are typically shared across
+    /// modules / tables and removing them on a Parties-specific rollback would break
+    /// unrelated indexes elsewhere. No-op on non-PostgreSQL providers.
+    /// </summary>
+    public static MigrationBuilder RemovePartyTrigramSimilarityIndexes(
+        this MigrationBuilder migrationBuilder,
+        string? schema = null,
+        string? tableName = null)
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+        if (!IsPostgres(migrationBuilder))
+        {
+            return migrationBuilder;
+        }
+
+        string resolvedSchema = schema ?? GranitPartiesDbProperties.DbSchema ?? "public";
+        string resolvedTable = tableName ?? GranitPartiesDbProperties.DbTablePrefix + "parties";
+        string indexName = $"IX_{resolvedTable}_name_trgm";
+
+        migrationBuilder.Sql($"DROP INDEX IF EXISTS \"{resolvedSchema}\".\"{indexName}\";");
+
+        return migrationBuilder;
+    }
+
+    private static bool IsPostgres(MigrationBuilder migrationBuilder) =>
+        string.Equals(
+            migrationBuilder.ActiveProvider,
+            NpgsqlProviderName,
+            StringComparison.Ordinal);
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartyDeduplicationOptions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Deduplication/PartyDeduplicationOptions.cs
@@ -1,0 +1,45 @@
+namespace Granit.Parties.EntityFrameworkCore.Deduplication;
+
+/// <summary>
+/// Tunable thresholds and toggles for the Tier-2 (pg_trgm blocking) and Tier-3 (fuzzy
+/// scoring) duplicate-detection pipelines that consume the canonical projections from
+/// story #1297. Threshold values fall in the <c>[0.0, 1.0]</c> range — <c>1.0</c> means
+/// "string equality", <c>0.0</c> means "anything goes".
+/// </summary>
+/// <remarks>
+/// <para>
+/// Defaults come from the prior-art research recorded in Epic
+/// <see href="https://github.com/granit-fx/granit-dotnet/issues/1278">#1278</see>
+/// (Salesforce / HubSpot / Dynamics 365 baselines): <c>0.7</c> on personal names is
+/// strict enough to filter most random matches while still catching common typos and
+/// diacritic variants; <c>0.6</c> on company names is looser because company names
+/// have more legitimate variants ("Acme", "Acme Inc.", "Acme International").
+/// </para>
+/// <para>
+/// Per-tenant overrides land later — admins may want to tune sensitivity in noisy
+/// CRM imports. For v1, the values are global per app instance.
+/// </para>
+/// </remarks>
+public sealed class PartyDeduplicationOptions
+{
+    /// <summary>
+    /// Configuration section path, conventionally bound from <c>appsettings.json</c>:
+    /// <code>{ "Granit": { "Parties": { "Deduplication": { ... } } } }</code>
+    /// </summary>
+    public const string SectionName = "Granit:Parties:Deduplication";
+
+    /// <summary>
+    /// pg_trgm <c>similarity()</c> threshold above which two <c>Name</c> values count
+    /// as Tier-2 candidates. Default <c>0.7</c>. Operates on <c>lower(name)</c> via the
+    /// GIST trigram index installed by <c>PartiesPostgresMigrationExtensions</c>.
+    /// </summary>
+    public double NameSimilarityThreshold { get; set; } = 0.7;
+
+    /// <summary>
+    /// Same as <see cref="NameSimilarityThreshold"/> but applied when the surviving party
+    /// has <c>Kind == PartyKind.Company</c>. Default <c>0.6</c> (looser): company names
+    /// carry more legitimate variants ("Acme" vs "Acme Inc.") and the sliding gap from
+    /// the personal-name default is intentional.
+    /// </summary>
+    public double CompanySimilarityThreshold { get; set; } = 0.6;
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,8 +1,10 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -34,6 +36,14 @@ public static class PartiesEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddScoped<PartyCanonicalisationInterceptor>();
         builder.Services.AddScoped<IGranitAutoInterceptor>(sp =>
             sp.GetRequiredService<PartyCanonicalisationInterceptor>());
+
+        // Tier-2 / Tier-3 thresholds — bound from the "Granit:Parties:Deduplication"
+        // configuration section so apps can tune per-environment without recompiling.
+        // Defaults baked into the options class (NameSimilarity 0.7, CompanySimilarity 0.6)
+        // apply when the section is absent. Consumed by the Tier-2 pg_trgm scan and the
+        // Tier-3 fuzzy scorer (#1299).
+        builder.Services.AddOptions<PartyDeduplicationOptions>()
+            .Bind(builder.Configuration.GetSection(PartyDeduplicationOptions.SectionName));
 
         return builder;
     }

--- a/src/Granit.Parties.EntityFrameworkCore/README.md
+++ b/src/Granit.Parties.EntityFrameworkCore/README.md
@@ -24,6 +24,46 @@ dotnet add package Granit.Parties.EntityFrameworkCore
 - `Granit.Persistence.EntityFrameworkCore`
 - `Granit.QueryEngine.Abstractions`
 
+## Duplicate detection support (PostgreSQL)
+
+Tier-1 deterministic detection (canonical `CanonicalEmail`, `CanonicalNumber`,
+`TaxId` columns) ships out of the box for every supported provider via the
+`PartyCanonicalisationInterceptor`.
+
+Tier-2 trigram blocking is **PostgreSQL-only**. The framework cannot ship
+migrations directly, so the consuming app opts in by calling the helper from
+its own migration:
+
+```csharp
+public partial class AddPartyTrigramIndexes : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder) =>
+        migrationBuilder.AddPartyTrigramSimilarityIndexes();
+
+    protected override void Down(MigrationBuilder migrationBuilder) =>
+        migrationBuilder.RemovePartyTrigramSimilarityIndexes();
+}
+```
+
+The helper installs the `pg_trgm` extension and a GIST index on `lower(name)`
+with `gist_trgm_ops`. SQL Server / SQLite / InMemory: the helper is a no-op and
+Tier-2 falls back to a slower `LIKE`-based query at scan time.
+
+Tunable thresholds via `appsettings.json`:
+
+```json
+{
+  "Granit": {
+    "Parties": {
+      "Deduplication": {
+        "NameSimilarityThreshold": 0.7,
+        "CompanySimilarityThreshold": 0.6
+      }
+    }
+  }
+}
+```
+
 ## Documentation
 
 See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbProviders.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbProviders.cs
@@ -1,0 +1,34 @@
+namespace Granit.Persistence.EntityFrameworkCore;
+
+/// <summary>
+/// Database-provider name identifiers as exposed by EF Core
+/// (<see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.ProviderName"/>,
+/// <see cref="Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder.ActiveProvider"/>,
+/// <c>DbContext.Database.ProviderName</c>, etc.).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use these constants to write provider-conditional code without scattering magic strings
+/// across the codebase. Typical pattern:
+/// <code>
+/// if (db.Database.ProviderName == GranitDbProviders.Postgres)
+/// {
+///     await db.Database.ExecuteSqlRawAsync("SELECT pg_advisory_xact_lock(...)", ct);
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// Currently consumed by <c>MergeableConcurrencyLock</c>, <c>MeteringConcurrencyLock</c>,
+/// and <c>PartiesPostgresMigrationExtensions</c>. Keep this list narrow — adding a provider
+/// here implies the framework has tested support for it; only PostgreSQL and SQL Server are
+/// first-class today.
+/// </para>
+/// </remarks>
+public static class GranitDbProviders
+{
+    /// <summary>The Npgsql provider for PostgreSQL.</summary>
+    public const string Postgres = "Npgsql.EntityFrameworkCore.PostgreSQL";
+
+    /// <summary>The Microsoft provider for SQL Server.</summary>
+    public const string SqlServer = "Microsoft.EntityFrameworkCore.SqlServer";
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartiesPostgresMigrationExtensionsTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartiesPostgresMigrationExtensionsTests.cs
@@ -1,0 +1,81 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Deduplication;
+
+public sealed class PartiesPostgresMigrationExtensionsTests
+{
+    private const string NpgsqlProvider = "Npgsql.EntityFrameworkCore.PostgreSQL";
+    private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
+
+    [Fact]
+    public void Add_emits_CREATE_EXTENSION_and_CREATE_INDEX_on_Npgsql()
+    {
+        MigrationBuilder builder = new(NpgsqlProvider);
+
+        builder.AddPartyTrigramSimilarityIndexes(schema: "granit", tableName: "contacts_parties");
+
+        builder.Operations.Count.ShouldBe(2);
+
+        var extensionOp = (SqlOperation)builder.Operations[0];
+        extensionOp.Sql.ShouldContain("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+
+        var indexOp = (SqlOperation)builder.Operations[1];
+        indexOp.Sql.ShouldContain("CREATE INDEX IF NOT EXISTS");
+        indexOp.Sql.ShouldContain("\"IX_contacts_parties_name_trgm\"");
+        indexOp.Sql.ShouldContain("\"granit\".\"contacts_parties\"");
+        indexOp.Sql.ShouldContain("USING GIST (lower(\"name\") gist_trgm_ops)");
+    }
+
+    [Fact]
+    public void Add_is_a_noop_on_SqlServer()
+    {
+        MigrationBuilder builder = new(SqlServerProvider);
+
+        builder.AddPartyTrigramSimilarityIndexes(schema: "dbo", tableName: "contacts_parties");
+
+        builder.Operations.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Add_falls_back_to_GranitPartiesDbProperties_defaults_when_called_without_args()
+    {
+        MigrationBuilder builder = new(NpgsqlProvider);
+
+        builder.AddPartyTrigramSimilarityIndexes();
+
+        builder.Operations.Count.ShouldBe(2);
+        var indexOp = (SqlOperation)builder.Operations[1];
+        // Default table name follows the GranitPartiesDbProperties.DbTablePrefix convention.
+        indexOp.Sql.ShouldContain("\"contacts_parties\"");
+    }
+
+    [Fact]
+    public void Remove_emits_DROP_INDEX_only_on_Npgsql_and_does_NOT_drop_the_extension()
+    {
+        MigrationBuilder builder = new(NpgsqlProvider);
+
+        builder.RemovePartyTrigramSimilarityIndexes(schema: "granit", tableName: "contacts_parties");
+
+        builder.Operations.Count.ShouldBe(1);
+        var dropOp = (SqlOperation)builder.Operations[0];
+        dropOp.Sql.ShouldContain("DROP INDEX IF EXISTS");
+        dropOp.Sql.ShouldContain("\"IX_contacts_parties_name_trgm\"");
+        // Extension is NOT dropped — shared with other modules / tables, removing it
+        // here would break unrelated indexes elsewhere in the database.
+        dropOp.Sql.ShouldNotContain("DROP EXTENSION");
+    }
+
+    [Fact]
+    public void Remove_is_a_noop_on_SqlServer()
+    {
+        MigrationBuilder builder = new(SqlServerProvider);
+
+        builder.RemovePartyTrigramSimilarityIndexes(schema: "dbo", tableName: "contacts_parties");
+
+        builder.Operations.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartiesPostgresMigrationExtensionsTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartiesPostgresMigrationExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Shouldly;
@@ -8,13 +9,10 @@ namespace Granit.Parties.EntityFrameworkCore.Tests.Deduplication;
 
 public sealed class PartiesPostgresMigrationExtensionsTests
 {
-    private const string NpgsqlProvider = "Npgsql.EntityFrameworkCore.PostgreSQL";
-    private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
-
     [Fact]
     public void Add_emits_CREATE_EXTENSION_and_CREATE_INDEX_on_Npgsql()
     {
-        MigrationBuilder builder = new(NpgsqlProvider);
+        MigrationBuilder builder = new(GranitDbProviders.Postgres);
 
         builder.AddPartyTrigramSimilarityIndexes(schema: "granit", tableName: "contacts_parties");
 
@@ -33,7 +31,7 @@ public sealed class PartiesPostgresMigrationExtensionsTests
     [Fact]
     public void Add_is_a_noop_on_SqlServer()
     {
-        MigrationBuilder builder = new(SqlServerProvider);
+        MigrationBuilder builder = new(GranitDbProviders.SqlServer);
 
         builder.AddPartyTrigramSimilarityIndexes(schema: "dbo", tableName: "contacts_parties");
 
@@ -43,7 +41,7 @@ public sealed class PartiesPostgresMigrationExtensionsTests
     [Fact]
     public void Add_falls_back_to_GranitPartiesDbProperties_defaults_when_called_without_args()
     {
-        MigrationBuilder builder = new(NpgsqlProvider);
+        MigrationBuilder builder = new(GranitDbProviders.Postgres);
 
         builder.AddPartyTrigramSimilarityIndexes();
 
@@ -56,7 +54,7 @@ public sealed class PartiesPostgresMigrationExtensionsTests
     [Fact]
     public void Remove_emits_DROP_INDEX_only_on_Npgsql_and_does_NOT_drop_the_extension()
     {
-        MigrationBuilder builder = new(NpgsqlProvider);
+        MigrationBuilder builder = new(GranitDbProviders.Postgres);
 
         builder.RemovePartyTrigramSimilarityIndexes(schema: "granit", tableName: "contacts_parties");
 
@@ -72,7 +70,7 @@ public sealed class PartiesPostgresMigrationExtensionsTests
     [Fact]
     public void Remove_is_a_noop_on_SqlServer()
     {
-        MigrationBuilder builder = new(SqlServerProvider);
+        MigrationBuilder builder = new(GranitDbProviders.SqlServer);
 
         builder.RemovePartyTrigramSimilarityIndexes(schema: "dbo", tableName: "contacts_parties");
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartyDeduplicationOptionsTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Deduplication/PartyDeduplicationOptionsTests.cs
@@ -1,0 +1,52 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.EntityFrameworkCore.Tests.Deduplication;
+
+public sealed class PartyDeduplicationOptionsTests
+{
+    [Fact]
+    public void Defaults_match_the_research_baseline()
+    {
+        var opts = new PartyDeduplicationOptions();
+
+        // Defaults documented in Epic #1278 prior-art research
+        // (Salesforce / HubSpot / Dynamics 365 baselines).
+        opts.NameSimilarityThreshold.ShouldBe(0.7);
+        opts.CompanySimilarityThreshold.ShouldBe(0.6);
+    }
+
+    [Fact]
+    public void Section_name_matches_the_documented_path()
+    {
+        // Drift guard: the upcoming Granit.Parties.Deduplication consumes IOptions<...>
+        // and the appsettings docs reference this string. Renaming should be deliberate.
+        PartyDeduplicationOptions.SectionName.ShouldBe("Granit:Parties:Deduplication");
+    }
+
+    [Fact]
+    public void Binds_from_configuration_section()
+    {
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Granit:Parties:Deduplication:NameSimilarityThreshold"] = "0.85",
+                ["Granit:Parties:Deduplication:CompanySimilarityThreshold"] = "0.5",
+            })
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddOptions<PartyDeduplicationOptions>()
+            .Bind(config.GetSection(PartyDeduplicationOptions.SectionName));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        PartyDeduplicationOptions resolved = sp.GetRequiredService<IOptions<PartyDeduplicationOptions>>().Value;
+
+        resolved.NameSimilarityThreshold.ShouldBe(0.85);
+        resolved.CompanySimilarityThreshold.ShouldBe(0.5);
+    }
+}


### PR DESCRIPTION
## Summary

Story [#1298](https://github.com/granit-fx/granit-dotnet/issues/1298) of [Feature #1280](https://github.com/granit-fx/granit-dotnet/issues/1280) (Party duplicate detection — 3-tier pipeline) under [Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278).

Tier-2 trigram-blocking infrastructure: a `MigrationBuilder` extension the consuming app calls from its own migration, plus tunable thresholds bound from configuration.

## What ships

| Component | Purpose |
|---|---|
| `PartiesPostgresMigrationExtensions.AddPartyTrigramSimilarityIndexes()` | Issues `CREATE EXTENSION IF NOT EXISTS pg_trgm` + a GIST index on `lower(name) gist_trgm_ops`. No-op on SQL Server / SQLite / InMemory (detected via `MigrationBuilder.ActiveProvider`). |
| `PartiesPostgresMigrationExtensions.RemovePartyTrigramSimilarityIndexes()` | Drops the index. Does **not** drop `pg_trgm` itself — extensions are shared across modules / tables, removing them on a Parties-specific rollback would break unrelated indexes elsewhere. |
| `PartyDeduplicationOptions` | Bound from `Granit:Parties:Deduplication`. `NameSimilarityThreshold = 0.7`, `CompanySimilarityThreshold = 0.6` (research baseline from Salesforce / HubSpot / Dynamics 365). |

## Design notes

- **Migration helper, not a migration.** CLAUDE.md framework rule: framework packages don't ship EF Core migrations — they live in the consuming app. The helper composes the raw SQL the app calls from `Up()` / `Down()`.
- **GIST over GIN.** GIN is ~3× faster on pure `similarity() > threshold` reads but lacks `<->` distance and ranked `ORDER BY similarity(...)`. Tier-3 fuzzy scoring (#1299) will want ranked candidates → GIST is the more flexible default.
- **Provider-conditional via `ActiveProvider` string match** — avoids forcing a transitive Npgsql dependency on SQL Server consumers. Domain layer remains provider-neutral.
- **Bind not BindConfiguration.** Standard `services.AddOptions<X>().Bind(section)` rather than `BindConfiguration(...)` to match the existing extension's idiom and avoid an extra `Microsoft.Extensions.Hosting` dep.

## Consuming-app usage

```csharp
public partial class AddPartyTrigramIndexes : Migration
{
    protected override void Up(MigrationBuilder migrationBuilder) =>
        migrationBuilder.AddPartyTrigramSimilarityIndexes();

    protected override void Down(MigrationBuilder migrationBuilder) =>
        migrationBuilder.RemovePartyTrigramSimilarityIndexes();
}
```

```jsonc
// appsettings.json
{
  "Granit": {
    "Parties": {
      "Deduplication": {
        "NameSimilarityThreshold": 0.7,
        "CompanySimilarityThreshold": 0.6
      }
    }
  }
}
```

## Test plan

- [x] 7 unit tests on the migration helper + options (`Deduplication/*Tests.cs`) — covers Npgsql vs SqlServer paths, default fallbacks, the "extension is not dropped on rollback" invariant, and configuration binding.
- [x] `dotnet test tests/Granit.Parties.EntityFrameworkCore.Tests` — 95/95 passing
- [x] `dotnet test tests/Granit.ArchitectureTests` — 153/153 passing
- [x] README updated with the opt-in usage + appsettings schema.

## Out of scope (next stories)

- The Tier-2 query layer that consumes the index (`Granit.Parties.Deduplication.IPartyDuplicateDetector`) lands in #1299.
- The background scan job that runs the Tier-2 + Tier-3 pipeline lands in #1300.

Refs #1298
Refs #1280
