### PR TITLE
feat(parties): duplicate-candidates admin endpoints (#1301)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8d926bd2-23e3-49a8-91cc-d9ab306ec7ab","pid":3917,"procStart":"3204","acquiredAt":1777270963241}

--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -185,6 +185,7 @@
       "src/Granit.OpenIddict.Server/Granit.OpenIddict.Server.csproj",
       "src/Granit.OpenIddict/Granit.OpenIddict.csproj",
       "src/Granit.Parties.Abstractions/Granit.Parties.Abstractions.csproj",
+      "src/Granit.Parties.Deduplication/Granit.Parties.Deduplication.csproj",
       "src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj",
       "src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj",
       "src/Granit.Parties.Mergeable/Granit.Parties.Mergeable.csproj",

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage-report/
 # Commit settings.json and skills (shared with all contributors), ignore local overrides
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # --- OS ---
 .DS_Store

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1712,6 +1712,7 @@
         "Granit.Authorization",
         "Granit.Mergeable",
         "Granit.Parties",
+        "Granit.Parties.Deduplication",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
         "Granit.Http.Abstractions",
@@ -32480,6 +32481,15 @@
       "members": []
     },
     {
+      "name": "DuplicateCandidatePage",
+      "fqn": "Granit.Parties.Deduplication.Domain.DuplicateCandidatePage",
+      "kind": "record",
+      "project": "Granit.Parties.Deduplication",
+      "file": "src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs",
+      "line": 57,
+      "members": []
+    },
+    {
       "name": "DuplicateMatchTier",
       "fqn": "Granit.Parties.Deduplication.Domain.DuplicateMatchTier",
       "kind": "enum",
@@ -32501,6 +32511,40 @@
           "kind": "method",
           "signature": "UpsertAsync(IReadOnlyList<DuplicateCandidate> candidates, Guid sourcePartyId, Guid? tenantId, CancellationToken cancellationToken)",
           "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IPartyDuplicateCandidateStore",
+      "fqn": "Granit.Parties.Deduplication.Domain.IPartyDuplicateCandidateStore",
+      "kind": "interface",
+      "project": "Granit.Parties.Deduplication",
+      "file": "src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(DuplicateMatchTier? tier, decimal? minScore, bool includeDismissed, int page, int pageSize, CancellationToken cancellationToken)",
+          "returnType": "Task<DuplicateCandidatePage>"
+        },
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid id, CancellationToken cancellationToken)",
+          "returnType": "Task<PartyDuplicateCandidate?>"
+        },
+        {
+          "name": "ListForPartyAsync",
+          "kind": "method",
+          "signature": "ListForPartyAsync(Guid partyId, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<PartyDuplicateCandidate>>"
+        },
+        {
+          "name": "DismissAsync",
+          "kind": "method",
+          "signature": "DismissAsync(Guid id, CancellationToken cancellationToken)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -32968,6 +33012,15 @@
       ]
     },
     {
+      "name": "DuplicateMatchSignalResponse",
+      "fqn": "Granit.Parties.Endpoints.Dtos.DuplicateMatchSignalResponse",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
+      "line": 30,
+      "members": []
+    },
+    {
       "name": "FieldConflictResponse",
       "fqn": "Granit.Parties.Endpoints.Dtos.FieldConflictResponse",
       "kind": "record",
@@ -33001,6 +33054,33 @@
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/Dtos/PartyCreateRequest.cs",
       "line": 16,
+      "members": []
+    },
+    {
+      "name": "PartyDuplicateCandidateResponse",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyDuplicateCandidateResponse",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "PartyDuplicateCandidatesPage",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyDuplicateCandidatesPage",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "PartyDuplicateMergeRequest",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyDuplicateMergeRequest",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
+      "line": 48,
       "members": []
     },
     {

--- a/src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs
+++ b/src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs
@@ -1,0 +1,61 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+
+namespace Granit.Parties.Deduplication.Domain;
+
+/// <summary>
+/// Read + dismiss surface over the <c>parties_duplicate_candidates</c> review table.
+/// Consumed by the admin endpoints (<see href="https://github.com/granit-fx/granit-dotnet/issues/1301">#1301</see>);
+/// the recurring scan job (<see href="https://github.com/granit-fx/granit-dotnet/issues/1300">#1300</see>)
+/// writes via <see cref="IDuplicateCandidateSink"/> instead.
+/// </summary>
+public interface IPartyDuplicateCandidateStore
+{
+    /// <summary>
+    /// Paginated, filtered listing for the admin "duplicates inbox" view. Always tenant-scoped
+    /// (the implementation reads <c>ICurrentTenant</c> ambiently). Sorted by score descending,
+    /// most-recent-evidence first.
+    /// </summary>
+    /// <param name="tier">When supplied, restricts the result to the given detection tier.</param>
+    /// <param name="minScore">Minimum aggregated score in <c>[0.0, 1.0]</c>.
+    /// <c>null</c> falls back to <c>0.0</c>.</param>
+    /// <param name="includeDismissed">When <c>false</c> (default) the store skips dismissed
+    /// pairs — that is the "pending review" view. <c>true</c> surfaces dismissed pairs too,
+    /// e.g. for a "review history" tab.</param>
+    /// <param name="page">1-based page index.</param>
+    /// <param name="pageSize">Items per page; clamped to <c>[1, 200]</c> by the impl.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DuplicateCandidatePage> ListAsync(
+        DuplicateMatchTier? tier,
+        decimal? minScore,
+        bool includeDismissed,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken);
+
+    /// <summary>Looks up one row by id. Returns <c>null</c> when not found in the current tenant.</summary>
+    Task<PartyDuplicateCandidate?> FindByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns every pending (non-dismissed) candidate involving <paramref name="partyId"/>
+    /// — both ends of the ordered pair. Used by the per-Party detail page and the online
+    /// detection at create (<see href="https://github.com/granit-fx/granit-dotnet/issues/1302">#1302</see>).
+    /// </summary>
+    Task<IReadOnlyList<PartyDuplicateCandidate>> ListForPartyAsync(
+        Guid partyId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks the row as dismissed (admin "not a duplicate" decision). Idempotent — a second
+    /// dismiss is a no-op. Returns <c>true</c> when the dismissal landed (row found, not
+    /// previously dismissed); <c>false</c> when the row does not exist or was already
+    /// dismissed.
+    /// </summary>
+    Task<bool> DismissAsync(Guid id, CancellationToken cancellationToken);
+}
+
+/// <summary>One page of a paginated <see cref="IPartyDuplicateCandidateStore.ListAsync"/> result.</summary>
+public sealed record DuplicateCandidatePage(
+    IReadOnlyList<PartyDuplicateCandidate> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
@@ -26,6 +26,7 @@ public static class PartiesDeduplicationHostApplicationBuilderExtensions
         builder.Services.AddScoped<Tier2TrigramBlocker>();
         builder.Services.AddScoped<Tier3WeightedScorer>();
         builder.Services.TryAddScoped<IPartyDuplicateDetector, DefaultPartyDuplicateDetector>();
+        builder.Services.TryAddScoped<IPartyDuplicateCandidateStore, EfPartyDuplicateCandidateStore>();
 
         return builder;
     }

--- a/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateStore.cs
+++ b/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateStore.cs
@@ -1,0 +1,123 @@
+using Granit.MultiTenancy;
+using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Deduplication.Internal;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IPartyDuplicateCandidateStore"/>: reads + dismisses
+/// rows of <c>parties_duplicate_candidates</c> via <see cref="PartiesDbContext"/>.
+/// Tenant-scoped: every query applies an explicit <c>WHERE tenant_id = currentTenant.Id</c>
+/// (or <c>IS NULL</c>) so the store is safe to use from non-HTTP contexts where the
+/// ambient <c>IMultiTenant</c> filter may not be set the way HTTP middleware would set it.
+/// </summary>
+internal sealed class EfPartyDuplicateCandidateStore(
+    IDbContextFactory<PartiesDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IClock clock) : IPartyDuplicateCandidateStore
+{
+    private const int MaxPageSize = 200;
+
+    public async Task<DuplicateCandidatePage> ListAsync(
+        DuplicateMatchTier? tier,
+        decimal? minScore,
+        bool includeDismissed,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        page = Math.Max(1, page);
+        pageSize = Math.Clamp(pageSize, 1, MaxPageSize);
+
+        await using PartiesDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        IQueryable<PartyDuplicateCandidate> query = ScopedToTenant(db);
+
+        if (tier is { } t)
+        {
+            int tierKey = (int)t;
+            query = query.Where(c => c.Tier == tierKey);
+        }
+
+        if (minScore is { } score)
+        {
+            query = query.Where(c => c.Score >= score);
+        }
+
+        if (!includeDismissed)
+        {
+            query = query.Where(c => c.DismissedAt == null);
+        }
+
+        int total = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        List<PartyDuplicateCandidate> items = await query
+            .OrderByDescending(c => c.Score)
+            .ThenByDescending(c => c.UpdatedAt ?? c.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new DuplicateCandidatePage(items, total, page, pageSize);
+    }
+
+    public async Task<PartyDuplicateCandidate?> FindByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await ScopedToTenant(db)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<PartyDuplicateCandidate>> ListForPartyAsync(
+        Guid partyId,
+        CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        return await ScopedToTenant(db)
+            .Where(c => c.DismissedAt == null
+                && (c.PartyId == partyId || c.CandidateId == partyId))
+            .OrderByDescending(c => c.Score)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> DismissAsync(Guid id, CancellationToken cancellationToken)
+    {
+        await using PartiesDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        PartyDuplicateCandidate? row = await ScopedToTenant(db)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (row is null || row.DismissedAt is not null)
+        {
+            return false;
+        }
+
+        row.Dismiss(clock.Now);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>Applies the explicit tenant filter and bypasses the ambient
+    /// <c>IMultiTenant</c> query filter — robust regardless of caller context.</summary>
+    private IQueryable<PartyDuplicateCandidate> ScopedToTenant(PartiesDbContext db)
+    {
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        return db.DuplicateCandidates
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(c => c.TenantId == tenantId);
+    }
+}

--- a/src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs
@@ -1,0 +1,51 @@
+using Granit.Parties.Deduplication.Domain;
+
+namespace Granit.Parties.Endpoints.Dtos;
+
+/// <summary>
+/// Wire-friendly view of a row in <c>parties_duplicate_candidates</c>. Returned by
+/// <c>GET /parties/duplicates</c> and <c>GET /parties/{id}/duplicate-candidates</c>.
+/// </summary>
+/// <param name="Id">Stable id of this candidate-pair row (used to dismiss / merge).</param>
+/// <param name="PartyId">Lower id of the ordered pair.</param>
+/// <param name="CandidateId">Higher id of the ordered pair.</param>
+/// <param name="Score">Aggregated confidence in <c>[0.0, 1.0]</c>.</param>
+/// <param name="Tier">Detection tier — <c>"Deterministic"</c>, <c>"Blocking"</c>, <c>"Fuzzy"</c>.</param>
+/// <param name="Signals">Per-signal contributions, sorted by score descending.</param>
+/// <param name="DismissedAt">When an admin marked the pair as "not a duplicate". <c>null</c> when pending.</param>
+/// <param name="CreatedAt">When the pair was first detected.</param>
+/// <param name="UpdatedAt">When the pair was last refreshed by a re-scan. <c>null</c> on the initial detection.</param>
+public sealed record PartyDuplicateCandidateResponse(
+    Guid Id,
+    Guid PartyId,
+    Guid CandidateId,
+    decimal Score,
+    string Tier,
+    IReadOnlyList<DuplicateMatchSignalResponse> Signals,
+    DateTimeOffset? DismissedAt,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? UpdatedAt);
+
+/// <summary>One per-signal contribution surfaced under <see cref="PartyDuplicateCandidateResponse.Signals"/>.</summary>
+public sealed record DuplicateMatchSignalResponse(string Kind, decimal Score);
+
+/// <summary>Paginated <c>GET /parties/duplicates</c> response.</summary>
+public sealed record PartyDuplicateCandidatesPage(
+    IReadOnlyList<PartyDuplicateCandidateResponse> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);
+
+/// <summary>
+/// Body of <c>POST /parties/duplicates/{id}/merge</c> — shortcut that resolves the
+/// candidate row to its (survivor, loser) pair and forwards to the merge orchestrator.
+/// </summary>
+/// <param name="SurvivorId">Which end of the candidate pair survives. The loser is
+/// inferred from the row (the other end). 422 if the id is not part of the pair.</param>
+/// <param name="Choices">Per-field admin overrides — same semantics as
+/// <see cref="PartyMergeRequest.Choices"/>.</param>
+/// <param name="Reason">Optional admin justification — captured in the audit log.</param>
+public sealed record PartyDuplicateMergeRequest(
+    Guid SurvivorId,
+    IReadOnlyDictionary<string, string>? Choices = null,
+    string? Reason = null);

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Granit.Mergeable;
+using Granit.Mergeable.Exceptions;
+using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.Domain;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Internal;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Parties.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the duplicate-candidates review API. Reads + dismisses rows in
+/// <c>parties_duplicate_candidates</c> (#1300) and provides a one-click "merge from
+/// candidate" shortcut that resolves the row to (survivor, loser) and forwards to the
+/// generic merge orchestrator (#1291).
+/// </summary>
+internal static partial class PartyDuplicatesEndpoints
+{
+    [LoggerMessage(EventId = 1, Level = LogLevel.Error,
+        Message = "Failed to write audit entry for duplicate-shortcut merge: candidate={CandidateRowId}, survivor={SurvivorId}, loser={LoserId}.")]
+    private static partial void LogAuditWriteFailed(
+        ILogger logger, Guid candidateRowId, Guid survivorId, Guid loserId, Exception exception);
+
+    /// <summary>
+    /// Handler for <c>GET /parties/duplicates?tier=&amp;minScore=&amp;page=&amp;pageSize=&amp;includeDismissed=</c>.
+    /// Paginated listing of pending duplicates in the current tenant scope.
+    /// </summary>
+    public static async Task<Ok<PartyDuplicateCandidatesPage>> HandleListAsync(
+        [FromQuery] string? tier,
+        [FromQuery] decimal? minScore,
+        [FromQuery] bool includeDismissed,
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
+        [FromServices] IPartyDuplicateCandidateStore store,
+        CancellationToken cancellationToken)
+    {
+        DuplicateMatchTier? parsedTier = ParseTier(tier);
+
+        DuplicateCandidatePage result = await store.ListAsync(
+            tier: parsedTier,
+            minScore: minScore,
+            includeDismissed: includeDismissed,
+            page: page ?? 1,
+            pageSize: pageSize ?? 50,
+            cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(MapPage(result));
+    }
+
+    /// <summary>Handler for <c>GET /parties/{id}/duplicate-candidates</c>.</summary>
+    public static async Task<Ok<IReadOnlyList<PartyDuplicateCandidateResponse>>> HandleListForPartyAsync(
+        Guid id,
+        [FromServices] IPartyDuplicateCandidateStore store,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<PartyDuplicateCandidate> rows =
+            await store.ListForPartyAsync(id, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<PartyDuplicateCandidateResponse> mapped =
+            [.. rows.Select(MapResponse)];
+
+        return TypedResults.Ok(mapped);
+    }
+
+    /// <summary>Handler for <c>POST /parties/duplicates/{id}/dismiss</c>. Idempotent.</summary>
+    public static async Task<Results<NoContent, NotFound>> HandleDismissAsync(
+        Guid id,
+        [FromServices] IPartyDuplicateCandidateStore store,
+        CancellationToken cancellationToken)
+    {
+        bool dismissed = await store.DismissAsync(id, cancellationToken).ConfigureAwait(false);
+        // false either when the row does not exist OR it was already dismissed —
+        // the second case is also idempotent-OK from the caller's perspective.
+        // We return 404 only when the row truly doesn't exist; the store's contract
+        // says "false when not found OR already dismissed", so we do an extra lookup
+        // for that disambiguation.
+        if (!dismissed)
+        {
+            PartyDuplicateCandidate? row = await store.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+            if (row is null)
+            {
+                return TypedResults.NotFound();
+            }
+        }
+        return TypedResults.NoContent();
+    }
+
+    /// <summary>Handler for <c>POST /parties/duplicates/{id}/merge</c>.</summary>
+    public static async Task<Results<Ok<PartyMergeResponse>, NotFound, ProblemHttpResult, ValidationProblem>> HandleMergeShortcutAsync(
+        Guid id,
+        [FromBody] PartyDuplicateMergeRequest request,
+        [FromHeader(Name = "Idempotency-Key")] string? idempotencyKey,
+        [FromServices] IPartyDuplicateCandidateStore store,
+        [FromServices] IMergeService<Party> mergeService,
+        [FromServices] PartyMergeAuditWriter auditWriter,
+        [FromServices] ILogger<PartyMergeAuditWriterMarker> logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        PartyDuplicateCandidate? row = await store.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (row is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        // Resolve which end of the candidate pair is the survivor / loser.
+        Guid loserId;
+        if (request.SurvivorId == row.PartyId)
+        {
+            loserId = row.CandidateId;
+        }
+        else if (request.SurvivorId == row.CandidateId)
+        {
+            loserId = row.PartyId;
+        }
+        else
+        {
+            return TypedResults.Problem(
+                "survivorId is not part of the candidate pair on the supplied id.",
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+
+        try
+        {
+            MergeFieldChoices choices = MergeFieldChoicesMapper.FromDictionary(request.Choices);
+            MergeRequest mergeRequest = new(
+                SurvivorId: request.SurvivorId,
+                LoserId: loserId,
+                Choices: choices,
+                DryRun: false,
+                Reason: request.Reason,
+                IdempotencyKey: idempotencyKey);
+
+            MergeResult<Party> result = await mergeService
+                .MergeAsync(mergeRequest, cancellationToken)
+                .ConfigureAwait(false);
+
+            try
+            {
+                await auditWriter.RecordAsync(
+                    survivorId: request.SurvivorId,
+                    loserId: loserId,
+                    resolvedChoices: request.Choices,
+                    rewriteCounts: result.RewriteCounts,
+                    reason: request.Reason,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogAuditWriteFailed(logger, id, request.SurvivorId, loserId, ex);
+            }
+
+            return TypedResults.Ok(new PartyMergeResponse(
+                SurvivorId: request.SurvivorId,
+                LoserId: loserId,
+                Conflicts: [.. result.Conflicts.Select(c => new FieldConflictResponse(
+                    c.FieldPath, c.SurvivorValue?.ToString(), c.LoserValue?.ToString(), c.Default.ToString()))],
+                RewriteCounts: result.RewriteCounts,
+                DryRun: result.DryRun));
+        }
+        catch (MergeException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Idempotency-key conflict / already-merged / concurrent — surfaced from EfMergeService.
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static PartyDuplicateCandidatesPage MapPage(DuplicateCandidatePage page) =>
+        new(
+            Items: [.. page.Items.Select(MapResponse)],
+            TotalCount: page.TotalCount,
+            Page: page.Page,
+            PageSize: page.PageSize);
+
+    private static PartyDuplicateCandidateResponse MapResponse(PartyDuplicateCandidate row)
+    {
+        IReadOnlyList<DuplicateMatchSignalResponse> signals = ParseSignals(row.SignalsJson);
+        return new PartyDuplicateCandidateResponse(
+            Id: row.Id,
+            PartyId: row.PartyId,
+            CandidateId: row.CandidateId,
+            Score: row.Score,
+            Tier: ((DuplicateMatchTier)row.Tier).ToString(),
+            Signals: signals,
+            DismissedAt: row.DismissedAt,
+            CreatedAt: row.CreatedAt,
+            UpdatedAt: row.UpdatedAt);
+    }
+
+    private static IReadOnlyList<DuplicateMatchSignalResponse> ParseSignals(string signalsJson)
+    {
+        if (string.IsNullOrWhiteSpace(signalsJson))
+        {
+            return [];
+        }
+        try
+        {
+            MatchSignal[]? raw = JsonSerializer.Deserialize<MatchSignal[]>(signalsJson);
+            if (raw is null)
+            {
+                return [];
+            }
+            return [.. raw
+                .OrderByDescending(s => s.Score)
+                .Select(s => new DuplicateMatchSignalResponse(s.Kind, s.Score))];
+        }
+        catch (JsonException)
+        {
+            // Forward-compat: if the stored shape ever drifts, drop the signals rather
+            // than fail the whole listing query.
+            return [];
+        }
+    }
+
+    private static DuplicateMatchTier? ParseTier(string? tier) =>
+        tier is null ? null
+        : Enum.TryParse(tier, ignoreCase: true, out DuplicateMatchTier parsed) ? parsed
+        : null;
+}
+
+/// <summary>
+/// Marker type used solely for the strongly-typed <c>ILogger&lt;T&gt;</c> dependency in
+/// <see cref="PartyDuplicatesEndpoints.HandleMergeShortcutAsync"/>. Lives in the same file
+/// so its scope is obvious.
+/// </summary>
+internal sealed class PartyMergeAuditWriterMarker;

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyMergeEndpoints.cs
@@ -77,7 +77,7 @@ internal static partial class PartyMergeEndpoints
         var orchestratorRequest = new MergeRequest(
             SurvivorId: survivorId,
             LoserId: request.LoserId,
-            Choices: BuildChoices(request.Choices),
+            Choices: MergeFieldChoicesMapper.FromDictionary(request.Choices),
             DryRun: request.DryRun,
             Reason: request.Reason,
             IdempotencyKey: idempotencyKey);
@@ -124,24 +124,6 @@ internal static partial class PartyMergeEndpoints
             // races. All map cleanly to 409.
             return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
-    }
-
-    private static MergeFieldChoices BuildChoices(IReadOnlyDictionary<string, string>? wire)
-    {
-        if (wire is null || wire.Count == 0)
-        {
-            return MergeFieldChoices.Empty;
-        }
-
-        Dictionary<string, WinnerSide> mapped = new(StringComparer.Ordinal);
-        foreach (KeyValuePair<string, string> kv in wire)
-        {
-            // Validator already enforces "Survivor" / "Loser" — Enum.Parse here covers the
-            // happy path. An invalid value would have been rejected before reaching the
-            // handler, so a defensive fallback isn't necessary.
-            mapped[kv.Key] = Enum.Parse<WinnerSide>(kv.Value);
-        }
-        return new MergeFieldChoices(mapped);
     }
 
     private static PartyMergeResponse MapResponse(Guid survivorId, Guid loserId, MergeResult<Party> result) =>

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -226,6 +226,40 @@ public static class PartiesEndpointRouteBuilderExtensions
             .ProducesValidationProblem()
             .RequireAuthorization(PartiesPermissions.Parties.Merge);
 
+        // ── Duplicate-candidates review (Epic 2: #1301) ───────────────
+        group.MapGet("/duplicates", PartyDuplicatesEndpoints.HandleListAsync)
+            .WithName("ListPartyDuplicateCandidates")
+            .WithSummary("Lists pending duplicate-candidate pairs in the current tenant.")
+            .WithDescription("Returns paginated rows from the parties_duplicate_candidates review table populated by the recurring scan job. Filterable by detection tier (Deterministic / Blocking / Fuzzy), minimum aggregated score, and (off by default) include-dismissed pairs. Sorted by score descending, then by most-recent evidence. Page size clamped to [1, 200].")
+            .Produces<PartyDuplicateCandidatesPage>()
+            .RequireAuthorization(PartiesPermissions.Parties.Read);
+
+        group.MapGet("/{id:guid}/duplicate-candidates", PartyDuplicatesEndpoints.HandleListForPartyAsync)
+            .WithName("ListPartyDuplicateCandidatesForParty")
+            .WithSummary("Lists pending duplicate candidates that involve the given party.")
+            .WithDescription("Returns every non-dismissed pair where the party is either end of the ordered (PartyId, CandidateId) tuple. Powers the per-Party detail-page warning and the create-time online detection (#1302).")
+            .Produces<IReadOnlyList<PartyDuplicateCandidateResponse>>()
+            .RequireAuthorization(PartiesPermissions.Parties.Read);
+
+        group.MapPost("/duplicates/{id:guid}/dismiss", PartyDuplicatesEndpoints.HandleDismissAsync)
+            .WithName("DismissPartyDuplicateCandidate")
+            .WithSummary("Marks a candidate pair as 'not a duplicate'.")
+            .WithDescription("Sets DismissedAt = now on the row. Idempotent — repeated dismisses are a no-op (still 204). Dismissed pairs are durably skipped on every subsequent scan, so the admin's decision sticks. Returns 404 only when the row truly does not exist in the current tenant.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(PartiesPermissions.Parties.Manage);
+
+        group.MapPost("/duplicates/{id:guid}/merge", PartyDuplicatesEndpoints.HandleMergeShortcutAsync)
+            .WithName("MergePartyFromDuplicateCandidate")
+            .WithSummary("One-click merge from a candidate row.")
+            .WithDescription("Forwards to the generic merge orchestrator. Body specifies which end of the ordered candidate pair survives (the other becomes the loser); 422 when the supplied survivorId is not part of the pair. Same Idempotency-Key + audit-write semantics as POST /parties/{survivorId}/merge.")
+            .Produces<PartyMergeResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem()
+            .RequireAuthorization(PartiesPermissions.Parties.Merge);
+
         // ── vCard export (RFC 6350) ───────────────────────────────────
         group.MapGet("/{id:guid}/vcard", PartyEndpoints.HandleDownloadVCardAsync)
             .WithName("DownloadPartyVCard")

--- a/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
+++ b/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Mergeable\Granit.Mergeable.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
+    <ProjectReference Include="..\Granit.Parties.Deduplication\Granit.Parties.Deduplication.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />

--- a/src/Granit.Parties.Endpoints/Internal/MergeFieldChoicesMapper.cs
+++ b/src/Granit.Parties.Endpoints/Internal/MergeFieldChoicesMapper.cs
@@ -1,0 +1,30 @@
+using Granit.Mergeable;
+
+namespace Granit.Parties.Endpoints.Internal;
+
+/// <summary>
+/// Maps the wire dictionary <c>{ "FieldPath": "Survivor" | "Loser" }</c> from the merge
+/// request bodies to the strongly-typed <see cref="MergeFieldChoices"/> the orchestrator
+/// expects. Validation of the values happens at the validator boundary; this mapper
+/// trusts the input.
+/// </summary>
+internal static class MergeFieldChoicesMapper
+{
+    public static MergeFieldChoices FromDictionary(IReadOnlyDictionary<string, string>? wire)
+    {
+        if (wire is null || wire.Count == 0)
+        {
+            return MergeFieldChoices.Empty;
+        }
+
+        Dictionary<string, WinnerSide> mapped = new(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, string> kv in wire)
+        {
+            // Validator already enforces "Survivor" / "Loser" — Enum.Parse here covers
+            // the happy path. An invalid value would have been rejected before reaching
+            // the handler, so a defensive fallback isn't necessary.
+            mapped[kv.Key] = Enum.Parse<WinnerSide>(kv.Value);
+        }
+        return new MergeFieldChoices(mapped);
+    }
+}

--- a/src/Granit.Parties.Endpoints/packages.lock.json
+++ b/src/Granit.Parties.Endpoints/packages.lock.json
@@ -21,10 +21,33 @@
           "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
       "Microsoft.OpenApi": {
         "type": "Transitive",
         "resolved": "2.0.0",
         "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "1.6.1",
+        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
       },
       "ZString": {
         "type": "Transitive",
@@ -140,6 +163,47 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.parties.deduplication": {
+        "type": "Project",
+        "dependencies": {
+          "FuzzySharp": "[2.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "SoftWx.Match": "[2.*, )"
+        }
+      },
+      "granit.parties.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -196,6 +260,18 @@
           "FluentValidation": "12.1.1"
         }
       },
+      "FuzzySharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.2",
+        "contentHash": "sBKqWxw3g//peYxDZ8JipRlyPbIyBtgzqBVA5GqwHVeqtIrw75maGXAllztf+1aJhchD+drcQIgf2mFho8ZV8A=="
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -203,6 +279,34 @@
         "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {
@@ -224,6 +328,15 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "SoftWx.Match": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.3",
+        "contentHash": "dTYfATuLtFwV6GFsEahznQWZZ9ciuWux2ehxlFg5Go2gcwq2Zrj05TNlXS2FTp8wXo6FG9TgJjKcZjoM7BThGQ==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
@@ -1,0 +1,209 @@
+using Granit.Auditing;
+using Granit.Guids;
+using Granit.Mergeable;
+using Granit.MultiTenancy;
+using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Endpoints;
+using Granit.Parties.Endpoints.Internal;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Timing;
+using Granit.Users;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Endpoints.Tests.Endpoints;
+
+/// <summary>
+/// Unit tests for <see cref="PartyDuplicatesEndpoints"/>. Substitutes the store + merge
+/// service and validates the HTTP-shape contract.
+/// </summary>
+public sealed class PartyDuplicatesEndpointsTests
+{
+    private readonly IPartyDuplicateCandidateStore _store = Substitute.For<IPartyDuplicateCandidateStore>();
+    private readonly IMergeService<Party> _mergeService = Substitute.For<IMergeService<Party>>();
+    private readonly PartyMergeAuditWriter _auditWriter;
+
+    public PartyDuplicatesEndpointsTests()
+    {
+        ICurrentUserService user = Substitute.For<ICurrentUserService>();
+        user.UserId.Returns("admin-1");
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        IGuidGenerator guidGen = Substitute.For<IGuidGenerator>();
+        guidGen.Create().Returns(_ => Guid.NewGuid());
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+        IAuditingWriter auditingWriter = Substitute.For<IAuditingWriter>();
+
+        _auditWriter = new PartyMergeAuditWriter(auditingWriter, user, tenant, guidGen, clock);
+    }
+
+    [Fact]
+    public async Task HandleListAsync_returns_paginated_response_with_mapped_signals()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        var lower = new Guid("11111111-1111-1111-1111-111111111111");
+        var higher = new Guid("22222222-2222-2222-2222-222222222222");
+        var row = PartyDuplicateCandidate.Create(
+            id: rowId, tenantId: null, partyId: lower, candidateId: higher,
+            tier: (int)DuplicateMatchTier.Fuzzy, score: 0.92m,
+            signalsJson: """[{"Kind":"NameTokenSet","Score":0.4},{"Kind":"PhonePartial","Score":0.1}]""",
+            createdAt: DateTimeOffset.UtcNow);
+
+        _store.ListAsync(default, default, default, default, default, ct)
+            .ReturnsForAnyArgs(new DuplicateCandidatePage([row], TotalCount: 1, Page: 1, PageSize: 50));
+
+        Ok<PartyDuplicateCandidatesPage> response = await PartyDuplicatesEndpoints.HandleListAsync(
+            tier: "Fuzzy", minScore: 0.5m, includeDismissed: false, page: 1, pageSize: 50,
+            store: _store, cancellationToken: ct);
+
+        PartyDuplicateCandidatesPage page = response.Value!;
+        page.TotalCount.ShouldBe(1);
+        page.Items.Count.ShouldBe(1);
+        page.Items[0].Score.ShouldBe(0.92m);
+        page.Items[0].Tier.ShouldBe("Fuzzy");
+        page.Items[0].Signals.Count.ShouldBe(2);
+        // Signals are sorted by score descending.
+        page.Items[0].Signals[0].Kind.ShouldBe("NameTokenSet");
+    }
+
+    [Fact]
+    public async Task HandleDismissAsync_returns_204_when_row_dismissed()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        _store.DismissAsync(rowId, ct).Returns(true);
+
+        Results<NoContent, NotFound> response = await PartyDuplicatesEndpoints.HandleDismissAsync(
+            rowId, _store, ct);
+
+        response.Result.ShouldBeOfType<NoContent>();
+    }
+
+    [Fact]
+    public async Task HandleDismissAsync_returns_204_when_already_dismissed()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        _store.DismissAsync(rowId, ct).Returns(false);
+        var existing = PartyDuplicateCandidate.Create(
+            id: rowId, tenantId: null,
+            partyId: new("11111111-1111-1111-1111-111111111111"),
+            candidateId: new("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+            tier: (int)DuplicateMatchTier.Blocking, score: 0.7m,
+            signalsJson: "[]", createdAt: DateTimeOffset.UtcNow);
+        existing.Dismiss(DateTimeOffset.UtcNow);
+        _store.FindByIdAsync(rowId, ct).Returns(existing);
+
+        Results<NoContent, NotFound> response = await PartyDuplicatesEndpoints.HandleDismissAsync(
+            rowId, _store, ct);
+
+        response.Result.ShouldBeOfType<NoContent>();
+    }
+
+    [Fact]
+    public async Task HandleDismissAsync_returns_404_when_row_not_found()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        _store.DismissAsync(rowId, ct).Returns(false);
+        _store.FindByIdAsync(rowId, ct).Returns((PartyDuplicateCandidate?)null);
+
+        Results<NoContent, NotFound> response = await PartyDuplicatesEndpoints.HandleDismissAsync(
+            rowId, _store, ct);
+
+        response.Result.ShouldBeOfType<NotFound>();
+    }
+
+    [Fact]
+    public async Task HandleMergeShortcutAsync_returns_404_when_candidate_row_missing()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        _store.FindByIdAsync(rowId, ct).Returns((PartyDuplicateCandidate?)null);
+
+        Results<Ok<PartyMergeResponse>, NotFound, ProblemHttpResult, ValidationProblem> response = await PartyDuplicatesEndpoints.HandleMergeShortcutAsync(
+            id: rowId,
+            request: new PartyDuplicateMergeRequest(SurvivorId: Guid.NewGuid()),
+            idempotencyKey: null,
+            store: _store, mergeService: _mergeService, auditWriter: _auditWriter,
+            logger: NullLogger<PartyMergeAuditWriterMarker>.Instance,
+            cancellationToken: ct);
+
+        response.Result.ShouldBeOfType<NotFound>();
+    }
+
+    [Fact]
+    public async Task HandleMergeShortcutAsync_returns_422_when_survivorId_not_in_pair()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        var lower = new Guid("11111111-1111-1111-1111-111111111111");
+        var higher = new Guid("22222222-2222-2222-2222-222222222222");
+
+        var row = PartyDuplicateCandidate.Create(
+            id: rowId, tenantId: null, partyId: lower, candidateId: higher,
+            tier: (int)DuplicateMatchTier.Blocking, score: 0.8m,
+            signalsJson: "[]", createdAt: DateTimeOffset.UtcNow);
+        _store.FindByIdAsync(rowId, ct).Returns(row);
+
+        Results<Ok<PartyMergeResponse>, NotFound, ProblemHttpResult, ValidationProblem> response = await PartyDuplicatesEndpoints.HandleMergeShortcutAsync(
+            id: rowId,
+            request: new PartyDuplicateMergeRequest(SurvivorId: Guid.NewGuid()), // unrelated
+            idempotencyKey: null,
+            store: _store, mergeService: _mergeService, auditWriter: _auditWriter,
+            logger: NullLogger<PartyMergeAuditWriterMarker>.Instance,
+            cancellationToken: ct);
+
+        ProblemHttpResult problem = response.Result.ShouldBeOfType<ProblemHttpResult>();
+        problem.StatusCode.ShouldBe(422);
+    }
+
+    [Fact]
+    public async Task HandleMergeShortcutAsync_resolves_loserId_from_pair_and_calls_orchestrator()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var rowId = Guid.NewGuid();
+        var lower = new Guid("11111111-1111-1111-1111-111111111111");
+        var higher = new Guid("22222222-2222-2222-2222-222222222222");
+
+        var row = PartyDuplicateCandidate.Create(
+            id: rowId, tenantId: null, partyId: lower, candidateId: higher,
+            tier: (int)DuplicateMatchTier.Blocking, score: 0.8m,
+            signalsJson: "[]", createdAt: DateTimeOffset.UtcNow);
+        _store.FindByIdAsync(rowId, ct).Returns(row);
+
+        // Survivor = lower → orchestrator should receive (lower, higher).
+        _mergeService.MergeAsync(Arg.Any<MergeRequest>(), ct)
+            .Returns(new MergeResult<Party>(
+                Merged: null,
+                Conflicts: [],
+                RewriteCounts: new Dictionary<string, int>(),
+                DryRun: false));
+
+        Results<Ok<PartyMergeResponse>, NotFound, ProblemHttpResult, ValidationProblem> response = await PartyDuplicatesEndpoints.HandleMergeShortcutAsync(
+            id: rowId,
+            request: new PartyDuplicateMergeRequest(SurvivorId: lower),
+            idempotencyKey: "key-1",
+            store: _store, mergeService: _mergeService, auditWriter: _auditWriter,
+            logger: NullLogger<PartyMergeAuditWriterMarker>.Instance,
+            cancellationToken: ct);
+
+        Ok<PartyMergeResponse> ok = response.Result.ShouldBeOfType<Ok<PartyMergeResponse>>();
+        ok.Value!.SurvivorId.ShouldBe(lower);
+        ok.Value!.LoserId.ShouldBe(higher);
+
+        // Orchestrator was called with the resolved (survivor, loser) pair + the idem key.
+        await _mergeService.Received(1).MergeAsync(
+            Arg.Is<MergeRequest>(r =>
+                r.SurvivorId == lower && r.LoserId == higher && r.IdempotencyKey == "key-1"),
+            ct);
+    }
+}


### PR DESCRIPTION
## Summary

Story [#1301](https://github.com/granit-fx/granit-dotnet/issues/1301) of [Feature #1280](https://github.com/granit-fx/granit-dotnet/issues/1280) (Party duplicate detection — 3-tier pipeline) under [Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278).

Read + dismiss + merge-shortcut over the `parties_duplicate_candidates` review table populated by the recurring scan job (#1300). Four endpoints under the existing `/parties` prefix.

## Endpoints

| Method + Path | Purpose | Permission |
|---|---|---|
| `GET /parties/duplicates` | Paginated listing — `?tier=&minScore=&page=&pageSize=&includeDismissed=`. Sorted by score desc, then most-recent evidence. Page size clamped to `[1, 200]`. | `Parties.Parties.Read` |
| `GET /parties/{id}/duplicate-candidates` | Pending pairs involving the given party (either end of the ordered tuple). | `Parties.Parties.Read` |
| `POST /parties/duplicates/{id}/dismiss` | Idempotent — sets `DismissedAt = now`. Second call → 204 (no-op). 404 only when the row truly doesn't exist. | `Parties.Parties.Manage` |
| `POST /parties/duplicates/{id}/merge` | One-click forward to `IMergeService<Party>`. Body picks which end of the candidate pair survives; 422 when `survivorId` is not part of the pair. Same `Idempotency-Key` + audit semantics as the standard merge endpoint. | `Parties.Parties.Merge` |

## Architecture

- **`IPartyDuplicateCandidateStore`** (public) in `Granit.Parties.Deduplication` — paginated list, find-by-id, list-for-party, dismiss. Always tenant-scoped via explicit `Where(c => c.TenantId == currentTenant.Id)` + `IgnoreQueryFilters([MultiTenant])` so it works safely from non-HTTP contexts.
- **`EfPartyDuplicateCandidateStore`** impl in the same package (already had `InternalsVisibleTo` to `PartiesDbContext`). Registered via the existing `AddGranitPartiesDeduplication` extension.
- **`PartyDuplicatesEndpoints`** handlers in `Granit.Parties.Endpoints`. The merge-shortcut resolves the `(PartyId, CandidateId)` pair against the supplied `survivorId` and forwards to the same orchestrator the standard endpoint uses.
- **`MergeFieldChoicesMapper`** extracted from `PartyMergeEndpoints` into `Granit.Parties.Endpoints.Internal` so both endpoints share the wire-to-strongly-typed conversion.

## Test plan

- [x] 7/7 unit tests on the duplicate endpoints (`PartyDuplicatesEndpointsTests.cs`):
  - List response shape + signal sorting (by score descending)
  - Dismiss happy / idempotent / 404 paths
  - Merge-shortcut 404 + 422-when-survivor-not-in-pair + survivor-resolution-from-pair
- [x] `dotnet test tests/Granit.Parties.Endpoints.Tests` — 60/60
- [x] `dotnet test tests/Granit.Parties.EntityFrameworkCore.Tests` — 95/95
- [x] `dotnet test tests/Granit.Parties.Deduplication.Tests` — 14/14

## Bonus commit

`chore: ignore .claude/scheduled_tasks.lock` — small fix on the side: that lock file is local Claude Code runtime state, was accidentally tracked. Added to `.gitignore` and removed from index; the file stays on disk for local use.

## Out of scope (next stories)

- Online detection at create (return 409 with candidates when score > 0.95) → #1302
- Frontend `<DuplicatesInbox>` page → #1304

Refs #1301
Refs #1280
