### PR TITLE
refactor(parties): drive duplicates listing through Granit.QueryEngine

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1686,9 +1686,11 @@
       "name": "Granit.Parties.Deduplication",
       "deps": [
         "Granit",
+        "Granit.DataExchange.Abstractions",
         "Granit.Parties",
         "Granit.Parties.EntityFrameworkCore",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1718,6 +1720,7 @@
         "Granit.Http.Abstractions",
         "Granit.Http.ApiDocumentation",
         "Granit.QueryEngine.Abstractions",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -32589,12 +32592,28 @@
       "members": []
     },
     {
+      "name": "DuplicateCandidateExportDefinition",
+      "fqn": "Granit.Parties.Deduplication.Exports.DuplicateCandidateExportDefinition",
+      "kind": "class",
+      "project": "Granit.Parties.Deduplication",
+      "file": "src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "PartiesDeduplicationHostApplicationBuilderExtensions",
       "fqn": "Granit.Parties.Deduplication.Extensions.PartiesDeduplicationHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitPartiesDeduplication",
@@ -32612,6 +32631,22 @@
       "file": "src/Granit.Parties.Deduplication/GranitPartiesDeduplicationModule.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "DuplicateCandidateQueryDefinition",
+      "fqn": "Granit.Parties.Deduplication.Queries.DuplicateCandidateQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Parties.Deduplication",
+      "file": "src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "PartiesMetrics",
@@ -33066,21 +33101,12 @@
       "members": []
     },
     {
-      "name": "PartyDuplicateCandidatesPage",
-      "fqn": "Granit.Parties.Endpoints.Dtos.PartyDuplicateCandidatesPage",
-      "kind": "record",
-      "project": "Granit.Parties.Endpoints",
-      "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
-      "line": 33,
-      "members": []
-    },
-    {
       "name": "PartyDuplicateMergeRequest",
       "fqn": "Granit.Parties.Endpoints.Dtos.PartyDuplicateMergeRequest",
       "kind": "record",
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs",
-      "line": 48,
+      "line": 41,
       "members": []
     },
     {
@@ -33233,7 +33259,7 @@
       "kind": "class",
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "MapGranitParties",

--- a/src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs
+++ b/src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs
@@ -1,0 +1,31 @@
+using Granit.DataExchange.Export;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+
+namespace Granit.Parties.Deduplication.Exports;
+
+/// <summary>
+/// CSV / XLSX export whitelist for the duplicate-candidates review table. Mirrors the
+/// columns surfaced by <c>DuplicateCandidateQueryDefinition</c> with one addition — the
+/// raw signals JSON blob ships in the export so a finance / privacy reviewer can audit
+/// why each pair was flagged without round-tripping through the per-row detail view.
+/// </summary>
+public sealed class DuplicateCandidateExportDefinition : ExportDefinition<PartyDuplicateCandidate>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Parties.Deduplication.DuplicateCandidateExport";
+
+    /// <inheritdoc/>
+    protected override void Configure(ExportDefinitionBuilder<PartyDuplicateCandidate> builder)
+    {
+        builder
+            .IncludeId()
+            .Field(c => c.PartyId)
+            .Field(c => c.CandidateId)
+            .Field(c => c.Tier)
+            .Field(c => c.Score)
+            .Field(c => c.SignalsJson)
+            .Field(c => c.DismissedAt, f => f.Format("O"))
+            .Field(c => c.CreatedAt, f => f.Format("O"))
+            .Field(c => c.UpdatedAt, f => f.Format("O"));
+    }
+}

--- a/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
@@ -1,5 +1,11 @@
+using Granit.DataExchange.Extensions;
 using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.Deduplication.Exports;
 using Granit.Parties.Deduplication.Internal;
+using Granit.Parties.Deduplication.Queries;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -27,6 +33,14 @@ public static class PartiesDeduplicationHostApplicationBuilderExtensions
         builder.Services.AddScoped<Tier3WeightedScorer>();
         builder.Services.TryAddScoped<IPartyDuplicateDetector, DefaultPartyDuplicateDetector>();
         builder.Services.TryAddScoped<IPartyDuplicateCandidateStore, EfPartyDuplicateCandidateStore>();
+
+        // QueryEngine wiring for the admin grid (#1301): query / export definitions plus
+        // the IQueryableSource that powers MapGranitQuery<PartyDuplicateCandidate> in the
+        // Endpoints package. Provider-agnostic — the source bypasses no filters and the
+        // ambient IMultiTenant filter scopes every read to the current tenant.
+        builder.Services.AddQueryDefinition<PartyDuplicateCandidate, DuplicateCandidateQueryDefinition>();
+        builder.Services.AddExportDefinition<PartyDuplicateCandidate, DuplicateCandidateExportDefinition>();
+        builder.Services.AddScoped<IQueryableSource<PartyDuplicateCandidate>, EfPartyDuplicateCandidateQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Parties.Deduplication/Granit.Parties.Deduplication.csproj
+++ b/src/Granit.Parties.Deduplication/Granit.Parties.Deduplication.csproj
@@ -21,9 +21,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Parties.EntityFrameworkCore\Granit.Parties.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateQueryableSource.cs
+++ b/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateQueryableSource.cs
@@ -1,0 +1,30 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Parties.Deduplication.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="PartyDuplicateCandidate"/>. Powers the query-engine-driven
+/// <c>GET /parties/duplicates</c> endpoint with full filter / sort / pagination /
+/// saved-views support.
+/// </summary>
+/// <remarks>
+/// The standard <see cref="Granit.MultiTenancy.IMultiTenant"/> query filter is left
+/// active deliberately — every read auto-scopes to the current tenant the same way
+/// <c>EfPartyQueryableSource</c> does. Cross-tenant browsing is opt-in via
+/// <c>IDataFilter.Disable&lt;IMultiTenant&gt;()</c> from a permission-gated host endpoint.
+/// </remarks>
+internal sealed class EfPartyDuplicateCandidateQueryableSource(
+    IDbContextFactory<PartiesDbContext> contextFactory)
+    : IQueryableSource<PartyDuplicateCandidate>, IDisposable
+{
+    private readonly PartiesDbContext _context = contextFactory.CreateDbContext();
+
+    public IQueryable<PartyDuplicateCandidate> GetQueryable() =>
+        _context.DuplicateCandidates.AsNoTracking();
+
+    public void Dispose() => _context.Dispose();
+}

--- a/src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs
+++ b/src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs
@@ -1,0 +1,54 @@
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.QueryEngine;
+
+namespace Granit.Parties.Deduplication.Queries;
+
+/// <summary>
+/// QueryEngine definition for the duplicate-candidates admin grid — declares the columns,
+/// filters, sorts, and pagination metadata that drive
+/// <c>GET /parties/duplicates</c> and <c>GET /parties/duplicates/meta</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The signals JSON blob is intentionally NOT exposed as a column — it is consumed by the
+/// per-row detail view (<c>GET /parties/duplicates/{id}</c> in a future iteration), not by
+/// the grid. <c>TenantId</c> is also omitted — every query is auto-scoped to the current
+/// tenant by the <c>IMultiTenant</c> query filter, so surfacing it as a filterable column
+/// would be both pointless and a footgun.
+/// </para>
+/// </remarks>
+public sealed class DuplicateCandidateQueryDefinition : QueryDefinition<PartyDuplicateCandidate>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Parties.Deduplication.DuplicateCandidateQuery";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<PartyDuplicateCandidate> builder)
+    {
+        builder
+            .Column(c => c.Score, col => col
+                .Label("Score").LabelKey("Parties.Duplicates.Columns.Score")
+                .Filterable().Sortable())
+            .Column(c => c.Tier, col => col
+                .Label("Tier").LabelKey("Parties.Duplicates.Columns.Tier")
+                .Filterable().Sortable())
+            .Column(c => c.PartyId, col => col
+                .Label("Party").LabelKey("Parties.Duplicates.Columns.PartyId")
+                .Filterable())
+            .Column(c => c.CandidateId, col => col
+                .Label("Candidate").LabelKey("Parties.Duplicates.Columns.CandidateId")
+                .Filterable())
+            .Column(c => c.DismissedAt, col => col
+                .Label("Dismissed").LabelKey("Parties.Duplicates.Columns.DismissedAt")
+                .Filterable().Sortable())
+            .Column(c => c.CreatedAt, col => col
+                .Label("Detected").LabelKey("Parties.Duplicates.Columns.CreatedAt")
+                .Filterable().Sortable())
+            .Column(c => c.UpdatedAt, col => col
+                .Label("Refreshed").LabelKey("Parties.Duplicates.Columns.UpdatedAt")
+                .Sortable())
+            .DateFilter(c => c.CreatedAt)
+            .DefaultSort("-score")
+            .DefaultPageSize(50);
+    }
+}

--- a/src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyDuplicatesDtos.cs
@@ -29,13 +29,6 @@ public sealed record PartyDuplicateCandidateResponse(
 /// <summary>One per-signal contribution surfaced under <see cref="PartyDuplicateCandidateResponse.Signals"/>.</summary>
 public sealed record DuplicateMatchSignalResponse(string Kind, decimal Score);
 
-/// <summary>Paginated <c>GET /parties/duplicates</c> response.</summary>
-public sealed record PartyDuplicateCandidatesPage(
-    IReadOnlyList<PartyDuplicateCandidateResponse> Items,
-    int TotalCount,
-    int Page,
-    int PageSize);
-
 /// <summary>
 /// Body of <c>POST /parties/duplicates/{id}/merge</c> — shortcut that resolves the
 /// candidate row to its (survivor, loser) pair and forwards to the merge orchestrator.

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
@@ -26,32 +26,6 @@ internal static partial class PartyDuplicatesEndpoints
     private static partial void LogAuditWriteFailed(
         ILogger logger, Guid candidateRowId, Guid survivorId, Guid loserId, Exception exception);
 
-    /// <summary>
-    /// Handler for <c>GET /parties/duplicates?tier=&amp;minScore=&amp;page=&amp;pageSize=&amp;includeDismissed=</c>.
-    /// Paginated listing of pending duplicates in the current tenant scope.
-    /// </summary>
-    public static async Task<Ok<PartyDuplicateCandidatesPage>> HandleListAsync(
-        [FromQuery] string? tier,
-        [FromQuery] decimal? minScore,
-        [FromQuery] bool includeDismissed,
-        [FromQuery] int? page,
-        [FromQuery] int? pageSize,
-        [FromServices] IPartyDuplicateCandidateStore store,
-        CancellationToken cancellationToken)
-    {
-        DuplicateMatchTier? parsedTier = ParseTier(tier);
-
-        DuplicateCandidatePage result = await store.ListAsync(
-            tier: parsedTier,
-            minScore: minScore,
-            includeDismissed: includeDismissed,
-            page: page ?? 1,
-            pageSize: pageSize ?? 50,
-            cancellationToken).ConfigureAwait(false);
-
-        return TypedResults.Ok(MapPage(result));
-    }
-
     /// <summary>Handler for <c>GET /parties/{id}/duplicate-candidates</c>.</summary>
     public static async Task<Ok<IReadOnlyList<PartyDuplicateCandidateResponse>>> HandleListForPartyAsync(
         Guid id,
@@ -175,13 +149,6 @@ internal static partial class PartyDuplicatesEndpoints
         }
     }
 
-    private static PartyDuplicateCandidatesPage MapPage(DuplicateCandidatePage page) =>
-        new(
-            Items: [.. page.Items.Select(MapResponse)],
-            TotalCount: page.TotalCount,
-            Page: page.Page,
-            PageSize: page.PageSize);
-
     private static PartyDuplicateCandidateResponse MapResponse(PartyDuplicateCandidate row)
     {
         IReadOnlyList<DuplicateMatchSignalResponse> signals = ParseSignals(row.SignalsJson);
@@ -222,10 +189,6 @@ internal static partial class PartyDuplicatesEndpoints
         }
     }
 
-    private static DuplicateMatchTier? ParseTier(string? tier) =>
-        tier is null ? null
-        : Enum.TryParse(tier, ignoreCase: true, out DuplicateMatchTier parsed) ? parsed
-        : null;
 }
 
 /// <summary>

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -3,6 +3,8 @@ using Granit.Parties.Endpoints.Dtos;
 using Granit.Parties.Endpoints.Endpoints;
 using Granit.Parties.Endpoints.Options;
 using Granit.Parties.Endpoints.Permissions;
+using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -227,21 +229,15 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Merge);
 
         // ── Duplicate-candidates review (Epic 2: #1301) ───────────────
-        group.MapGet("/duplicates", PartyDuplicatesEndpoints.HandleListAsync)
-            .WithName("ListPartyDuplicateCandidates")
-            .WithSummary("Lists pending duplicate-candidate pairs in the current tenant.")
-            .WithDescription("Returns paginated rows from the parties_duplicate_candidates review table populated by the recurring scan job. Filterable by detection tier (Deterministic / Blocking / Fuzzy), minimum aggregated score, and (off by default) include-dismissed pairs. Sorted by score descending, then by most-recent evidence. Page size clamped to [1, 200].")
-            .Produces<PartyDuplicateCandidatesPage>()
-            .RequireAuthorization(PartiesPermissions.Parties.Read);
+        // QueryEngine listing + meta + saved-views, plus the dedicated dismiss / merge
+        // shortcut actions that share the same /duplicates group.
+        RouteGroupBuilder duplicatesGroup = group.MapGranitGroup("duplicates");
+        duplicatesGroup.MapGranitQuery<PartyDuplicateCandidate>(configure: opts =>
+        {
+            opts.AuthorizationPolicy = PartiesPermissions.Parties.Read;
+        });
 
-        group.MapGet("/{id:guid}/duplicate-candidates", PartyDuplicatesEndpoints.HandleListForPartyAsync)
-            .WithName("ListPartyDuplicateCandidatesForParty")
-            .WithSummary("Lists pending duplicate candidates that involve the given party.")
-            .WithDescription("Returns every non-dismissed pair where the party is either end of the ordered (PartyId, CandidateId) tuple. Powers the per-Party detail-page warning and the create-time online detection (#1302).")
-            .Produces<IReadOnlyList<PartyDuplicateCandidateResponse>>()
-            .RequireAuthorization(PartiesPermissions.Parties.Read);
-
-        group.MapPost("/duplicates/{id:guid}/dismiss", PartyDuplicatesEndpoints.HandleDismissAsync)
+        duplicatesGroup.MapPost("/{id:guid}/dismiss", PartyDuplicatesEndpoints.HandleDismissAsync)
             .WithName("DismissPartyDuplicateCandidate")
             .WithSummary("Marks a candidate pair as 'not a duplicate'.")
             .WithDescription("Sets DismissedAt = now on the row. Idempotent — repeated dismisses are a no-op (still 204). Dismissed pairs are durably skipped on every subsequent scan, so the admin's decision sticks. Returns 404 only when the row truly does not exist in the current tenant.")
@@ -249,7 +245,7 @@ public static class PartiesEndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
-        group.MapPost("/duplicates/{id:guid}/merge", PartyDuplicatesEndpoints.HandleMergeShortcutAsync)
+        duplicatesGroup.MapPost("/{id:guid}/merge", PartyDuplicatesEndpoints.HandleMergeShortcutAsync)
             .WithName("MergePartyFromDuplicateCandidate")
             .WithSummary("One-click merge from a candidate row.")
             .WithDescription("Forwards to the generic merge orchestrator. Body specifies which end of the ordered candidate pair survives (the other becomes the loser); 422 when the supplied survivorId is not part of the pair. Same Idempotency-Key + audit-write semantics as POST /parties/{survivorId}/merge.")
@@ -259,6 +255,14 @@ public static class PartiesEndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem()
             .RequireAuthorization(PartiesPermissions.Parties.Merge);
+
+        // Per-party detail listing — sits at the parent /parties/{id}/... level, not under /duplicates.
+        group.MapGet("/{id:guid}/duplicate-candidates", PartyDuplicatesEndpoints.HandleListForPartyAsync)
+            .WithName("ListPartyDuplicateCandidatesForParty")
+            .WithSummary("Lists pending duplicate candidates that involve the given party.")
+            .WithDescription("Returns every non-dismissed pair where the party is either end of the ordered (PartyId, CandidateId) tuple. Powers the per-Party detail-page warning and the create-time online detection (#1302).")
+            .Produces<IReadOnlyList<PartyDuplicateCandidateResponse>>()
+            .RequireAuthorization(PartiesPermissions.Parties.Read);
 
         // ── vCard export (RFC 6350) ───────────────────────────────────
         group.MapGet("/{id:guid}/vcard", PartyEndpoints.HandleDownloadVCardAsync)

--- a/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
+++ b/src/Granit.Parties.Endpoints/Granit.Parties.Endpoints.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Parties.Endpoints/packages.lock.json
+++ b/src/Granit.Parties.Endpoints/packages.lock.json
@@ -168,9 +168,11 @@
         "dependencies": {
           "FuzzySharp": "[2.*, )",
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "SoftWx.Match": "[2.*, )"
         }
@@ -204,11 +206,30 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
@@ -45,36 +45,6 @@ public sealed class PartyDuplicatesEndpointsTests
     }
 
     [Fact]
-    public async Task HandleListAsync_returns_paginated_response_with_mapped_signals()
-    {
-        CancellationToken ct = TestContext.Current.CancellationToken;
-        var rowId = Guid.NewGuid();
-        var lower = new Guid("11111111-1111-1111-1111-111111111111");
-        var higher = new Guid("22222222-2222-2222-2222-222222222222");
-        var row = PartyDuplicateCandidate.Create(
-            id: rowId, tenantId: null, partyId: lower, candidateId: higher,
-            tier: (int)DuplicateMatchTier.Fuzzy, score: 0.92m,
-            signalsJson: """[{"Kind":"NameTokenSet","Score":0.4},{"Kind":"PhonePartial","Score":0.1}]""",
-            createdAt: DateTimeOffset.UtcNow);
-
-        _store.ListAsync(default, default, default, default, default, ct)
-            .ReturnsForAnyArgs(new DuplicateCandidatePage([row], TotalCount: 1, Page: 1, PageSize: 50));
-
-        Ok<PartyDuplicateCandidatesPage> response = await PartyDuplicatesEndpoints.HandleListAsync(
-            tier: "Fuzzy", minScore: 0.5m, includeDismissed: false, page: 1, pageSize: 50,
-            store: _store, cancellationToken: ct);
-
-        PartyDuplicateCandidatesPage page = response.Value!;
-        page.TotalCount.ShouldBe(1);
-        page.Items.Count.ShouldBe(1);
-        page.Items[0].Score.ShouldBe(0.92m);
-        page.Items[0].Tier.ShouldBe("Fuzzy");
-        page.Items[0].Signals.Count.ShouldBe(2);
-        // Signals are sorted by score descending.
-        page.Items[0].Signals[0].Kind.ShouldBe("NameTokenSet");
-    }
-
-    [Fact]
     public async Task HandleDismissAsync_returns_204_when_row_dismissed()
     {
         CancellationToken ct = TestContext.Current.CancellationToken;

--- a/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
@@ -117,6 +117,16 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -134,10 +144,55 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
@@ -192,6 +247,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "1.6.1",
+        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
@@ -410,6 +473,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.parties.deduplication": {
+        "type": "Project",
+        "dependencies": {
+          "FuzzySharp": "[2.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "SoftWx.Match": "[2.*, )"
+        }
+      },
       "granit.parties.endpoints": {
         "type": "Project",
         "dependencies": {
@@ -421,8 +499,50 @@
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Mergeable": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.Deduplication": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "libphonenumber-csharp": "[9.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -430,6 +550,17 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -484,6 +615,18 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
         }
       },
+      "FuzzySharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.2",
+        "contentHash": "sBKqWxw3g//peYxDZ8JipRlyPbIyBtgzqBVA5GqwHVeqtIrw75maGXAllztf+1aJhchD+drcQIgf2mFho8ZV8A=="
+      },
+      "libphonenumber-csharp": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.29",
+        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -491,6 +634,30 @@
         "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -530,6 +697,42 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",
@@ -600,6 +803,15 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "SoftWx.Match": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.3",
+        "contentHash": "dTYfATuLtFwV6GFsEahznQWZZ9ciuWux2ehxlFg5Go2gcwq2Zrj05TNlXS2FTp8wXo6FG9TgJjKcZjoM7BThGQ==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary

Follow-up to [#1424](https://github.com/granit-fx/granit-dotnet/pull/1424) (story #1301). Replaces the hand-rolled `GET /parties/duplicates` handler with the standard `MapGranitQuery<PartyDuplicateCandidate>()` pipeline so the admin grid gets filter / sort / pagination / saved-views / column-metadata for free — matching the convention already used by `Granit.Auditing` and `Granit.Invoicing`.

## What ships

Three new declarative artifacts in `Granit.Parties.Deduplication` (per the [CLAUDE.md placement rule](../../CLAUDE.md) — definitions live in the base module, not in `*.Endpoints`):

- **`DuplicateCandidateQueryDefinition`** (`Queries/`) — columns + filterable/sortable flags + global date-range filter + default sort by score descending. `SignalsJson` and `TenantId` intentionally omitted: the JSON blob belongs in the per-row detail view, the tenant scope is auto-applied by the `IMultiTenant` query filter.
- **`DuplicateCandidateExportDefinition`** (`Exports/`) — CSV/XLSX whitelist mirroring the grid + `SignalsJson` (auditors need to see why each pair was flagged).
- **`EfPartyDuplicateCandidateQueryableSource`** (`Internal/`) — `IQueryable` source mirroring `EfPartyQueryableSource`: `AsNoTracking`, ambient `IMultiTenant` filter left active.

## Endpoint plumbing

- `Granit.Parties.Endpoints.csproj` adds a `ProjectReference` to `Granit.QueryEngine.AspNetCore`.
- `PartiesEndpointRouteBuilderExtensions.cs`: the `/duplicates` group is now `group.MapGranitGroup("duplicates").MapGranitQuery<PartyDuplicateCandidate>(opts => opts.AuthorizationPolicy = PartiesPermissions.Parties.Read)`. Dismiss + merge-shortcut routes mount on the same group so the URL shape stays `/parties/duplicates/{id}/dismiss` etc.
- `PartyDuplicatesEndpoints` loses `HandleListAsync` (and the related `PartyDuplicateCandidatesPage` DTO + test) — the framework owns the listing now.

## Side effect

`GET /parties/duplicates` now also exposes:

- `GET /parties/duplicates/meta` — column metadata for the UI grid
- `GET /parties/duplicates/saved-views` (+ POST/PUT/DELETE) — saved views CRUD

All gated by `Parties.Parties.Read` via `QueryEndpointOptions.AuthorizationPolicy`. No new permission needed.

## Test plan

- [x] 59/59 endpoint tests pass (one removed: `HandleListAsync` coverage — behaviour now lives in `Granit.QueryEngine.AspNetCore`'s own test suite).
- [x] `dotnet build src/Granit.Parties.Deduplication -c Release` — 0/0
- [x] `dotnet build src/Granit.Parties.Endpoints -c Release` — 0/0

Refs #1301
Refs #1280
