### PR TITLE
feat(parties): online duplicate detection on POST /parties (#1302)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33083,6 +33083,24 @@
       "members": []
     },
     {
+      "name": "PartyCreateConflictResponse",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyCreateConflictResponse",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyCreateConflictResponse.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "PartyCreateDuplicateCandidate",
+      "fqn": "Granit.Parties.Endpoints.Dtos.PartyCreateDuplicateCandidate",
+      "kind": "record",
+      "project": "Granit.Parties.Endpoints",
+      "file": "src/Granit.Parties.Endpoints/Dtos/PartyCreateConflictResponse.cs",
+      "line": 38,
+      "members": []
+    },
+    {
       "name": "PartyCreateRequest",
       "fqn": "Granit.Parties.Endpoints.Dtos.PartyCreateRequest",
       "kind": "record",

--- a/src/Granit.Parties.Endpoints/Dtos/PartyCreateConflictResponse.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyCreateConflictResponse.cs
@@ -1,0 +1,42 @@
+namespace Granit.Parties.Endpoints.Dtos;
+
+/// <summary>
+/// Body of the <c>409 Conflict</c> emitted by <c>POST /parties</c> when online duplicate
+/// detection (story <see href="https://github.com/granit-fx/granit-dotnet/issues/1302">#1302</see>)
+/// surfaces at least one Tier-1 deterministic match.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The client has two recoveries:
+/// </para>
+/// <list type="bullet">
+///   <item>Re-submit with <c>?force=true</c> to bypass the check and create the party
+///         anyway (the admin acknowledges the duplicate is intentional).</item>
+///   <item>Open the merge wizard against the suggested candidate via
+///         <c>POST /parties/{survivorId}/merge</c> after creating the new row, OR drop
+///         the create entirely and adopt the existing party.</item>
+/// </list>
+/// </remarks>
+/// <param name="Reason">Always <c>"DuplicatesDetected"</c> in v1; future detection
+/// reasons (e.g. anti-fraud blocks) would extend this enum.</param>
+/// <param name="Candidates">Detected candidates ordered by score descending. Only Tier-1
+/// (deterministic) matches are surfaced here — Tier-2 / Tier-3 do not block creation,
+/// they're deferred to the recurring background scan.</param>
+public sealed record PartyCreateConflictResponse(
+    string Reason,
+    IReadOnlyList<PartyCreateDuplicateCandidate> Candidates);
+
+/// <summary>
+/// One candidate match surfaced in <see cref="PartyCreateConflictResponse"/>. Mirrors
+/// <c>DuplicateCandidate</c> in a wire-friendly shape (string tier, primitive score).
+/// </summary>
+/// <param name="CandidateId">Existing party id that matches the create draft.</param>
+/// <param name="Score">Aggregated confidence in <c>[0.0, 1.0]</c> — always <c>1.0</c> at
+/// create time since only Tier-1 deterministic matches surface here.</param>
+/// <param name="Tier">Detection tier — currently always <c>"Deterministic"</c>.</param>
+/// <param name="Signals">Per-signal contributions (e.g. <c>"TaxIdExact"</c>).</param>
+public sealed record PartyCreateDuplicateCandidate(
+    Guid CandidateId,
+    decimal Score,
+    string Tier,
+    IReadOnlyList<DuplicateMatchSignalResponse> Signals);

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Granit.Guids;
+using Granit.Parties.Deduplication.Domain;
 using Granit.Parties.Domain;
 using Granit.Parties.Domain.ValueObjects;
 using Granit.Parties.Endpoints.Dtos;
@@ -37,12 +38,49 @@ internal static class PartyEndpoints
         return c is null ? TypedResults.NotFound() : TypedResults.Ok(c.ToResponse());
     }
 
-    public static async Task<Results<Created<PartyResponse>, ValidationProblem>> HandleCreateAsync(
+    public static async Task<Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>> HandleCreateAsync(
         PartyCreateRequest request,
+        [FromQuery] bool force,
+        [FromHeader(Name = "X-Skip-Duplicate-Check")] bool skipDuplicateCheck,
         [FromServices] IPartyWriter writer,
         [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IPartyDuplicateDetector detector,
         CancellationToken cancellationToken)
     {
+        // Online duplicate detection (story #1302). Skipped when:
+        //   ?force=true          — admin acknowledges the duplicate is intentional
+        //   X-Skip-Duplicate-Check — bulk migrations / data seeding (skip the round-trip)
+        if (!force && !skipDuplicateCheck)
+        {
+            // PartyDraft only carries fields available at create time. Emails / phones are
+            // added via the dedicated POST /parties/{id}/emails endpoints later, so the
+            // online check effectively covers the TaxId Tier-1 path; email / phone
+            // duplicates surface through the recurring scan + per-party detail endpoint.
+            PartyDraft draft = new(
+                TenantId: null, // tenant filled by interceptor; detector applies the same scope
+                Kind: request.Kind,
+                Name: request.Name,
+                TaxId: request.TaxId);
+
+            IReadOnlyList<DuplicateCandidate> hits =
+                await detector.FindCandidatesAsync(draft, cancellationToken).ConfigureAwait(false);
+
+            // Only Tier-1 (deterministic) blocks. Tier-2 / Tier-3 are surfaced through the
+            // recurring scan; blocking on a fuzzy match at create time would force admins
+            // to confirm common-name overlaps every time.
+            List<DuplicateCandidate> blocking = [.. hits.Where(h => h.Tier == DuplicateMatchTier.Deterministic)];
+            if (blocking.Count > 0)
+            {
+                return TypedResults.Conflict(new PartyCreateConflictResponse(
+                    Reason: "DuplicatesDetected",
+                    Candidates: [.. blocking.Select(h => new PartyCreateDuplicateCandidate(
+                        CandidateId: h.CandidateId.Value,
+                        Score: h.Score,
+                        Tier: h.Tier.ToString(),
+                        Signals: [.. h.Signals.Select(s => new DuplicateMatchSignalResponse(s.Kind, s.Score))]))]));
+            }
+        }
+
         var c = Party.Create(
             guidGenerator.Create(),
             tenantId: null, // tenant filled by interceptor when in tenant context

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -47,8 +47,9 @@ public static class PartiesEndpointRouteBuilderExtensions
         group.MapPost("", PartyEndpoints.HandleCreateAsync)
             .WithName("CreateContact")
             .WithSummary("Creates a new contact in the active scope.")
-            .WithDescription("Creates an Active contact in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation.")
+            .WithDescription("Creates an Active contact in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation. Online duplicate detection (#1302) intercepts before INSERT — a Tier-1 deterministic match (TaxId at create time) returns 409 with the candidates list, letting the admin choose to merge or to confirm-create with ?force=true. Bulk migrations bypass the check via the X-Skip-Duplicate-Check: true header. Tier-2 / Tier-3 fuzzy matches do NOT block at create time — they surface via the recurring scan + the duplicate-candidates inbox.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
+            .Produces<PartyCreateConflictResponse>(StatusCodes.Status409Conflict)
             .ProducesValidationProblem()
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
@@ -1,0 +1,129 @@
+using Granit.Guids;
+using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.Domain;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Parties.Endpoints.Endpoints;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Parties.Endpoints.Tests.Endpoints;
+
+/// <summary>
+/// Online duplicate-detection guard on <see cref="PartyEndpoints.HandleCreateAsync"/>
+/// (story #1302). Verifies the four behaviours that matter to clients:
+/// <list type="bullet">
+///   <item>Tier-1 hit → 409 with structured candidates body</item>
+///   <item>Only fuzzy hits → no block (defer to recurring scan)</item>
+///   <item><c>?force=true</c> → bypass</item>
+///   <item><c>X-Skip-Duplicate-Check</c> header → bypass (bulk migrations)</item>
+/// </list>
+/// </summary>
+public sealed class PartyEndpointsCreateOnlineDedupTests
+{
+    private readonly IPartyWriter _writer = Substitute.For<IPartyWriter>();
+    private readonly IPartyDuplicateDetector _detector = Substitute.For<IPartyDuplicateDetector>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly PartyCreateRequest _request;
+
+    public PartyEndpointsCreateOnlineDedupTests()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+        _request = new PartyCreateRequest(
+            Kind: PartyKind.Company,
+            Name: "Acme",
+            DefaultCurrency: "EUR",
+            TaxId: "BE0123456789");
+    }
+
+    [Fact]
+    public async Task Returns_409_when_Tier1_match_detected()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        var existingId = Guid.NewGuid();
+        _detector.FindCandidatesAsync(Arg.Any<PartyDraft>(), ct)
+            .Returns(new List<DuplicateCandidate>
+            {
+                new(PartyId.Create(existingId), 1.0m, DuplicateMatchTier.Deterministic,
+                    [new MatchSignal("TaxIdExact", 1.0m)])
+            });
+
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+            response = await PartyEndpoints.HandleCreateAsync(
+                _request, force: false, skipDuplicateCheck: false,
+                _writer, _guidGenerator, _detector, ct);
+
+        Conflict<PartyCreateConflictResponse> conflict =
+            response.Result.ShouldBeOfType<Conflict<PartyCreateConflictResponse>>();
+        conflict.Value!.Reason.ShouldBe("DuplicatesDetected");
+        conflict.Value!.Candidates.Count.ShouldBe(1);
+        conflict.Value!.Candidates[0].CandidateId.ShouldBe(existingId);
+        conflict.Value!.Candidates[0].Tier.ShouldBe("Deterministic");
+
+        // Writer NEVER called — the create was blocked.
+        await _writer.DidNotReceiveWithAnyArgs().AddAsync(default!, ct);
+    }
+
+    [Fact]
+    public async Task Does_not_block_when_only_fuzzy_matches_present()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _detector.FindCandidatesAsync(Arg.Any<PartyDraft>(), ct)
+            .Returns(new List<DuplicateCandidate>
+            {
+                new(PartyId.Create(Guid.NewGuid()), 0.85m, DuplicateMatchTier.Fuzzy,
+                    [new MatchSignal("NameTokenSet", 0.4m)])
+            });
+
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+            response = await PartyEndpoints.HandleCreateAsync(
+                _request, force: false, skipDuplicateCheck: false,
+                _writer, _guidGenerator, _detector, ct);
+
+        // Tier-3 fuzzy doesn't block — create proceeds. Recurring scan surfaces it later.
+        response.Result.ShouldBeOfType<Created<PartyResponse>>();
+        await _writer.Received(1).AddAsync(Arg.Any<Party>(), ct);
+    }
+
+    [Fact]
+    public async Task Bypasses_check_when_force_true()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        // Detector would normally block, but force=true skips the check entirely.
+        _detector.FindCandidatesAsync(Arg.Any<PartyDraft>(), ct)
+            .Returns(new List<DuplicateCandidate>
+            {
+                new(PartyId.Create(Guid.NewGuid()), 1.0m, DuplicateMatchTier.Deterministic, [])
+            });
+
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+            response = await PartyEndpoints.HandleCreateAsync(
+                _request, force: true, skipDuplicateCheck: false,
+                _writer, _guidGenerator, _detector, ct);
+
+        response.Result.ShouldBeOfType<Created<PartyResponse>>();
+        // Detector never called — short-circuited before the round-trip.
+        await _detector.DidNotReceiveWithAnyArgs().FindCandidatesAsync(default!, ct);
+    }
+
+    [Fact]
+    public async Task Bypasses_check_when_X_Skip_Duplicate_Check_header_true()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        _detector.FindCandidatesAsync(Arg.Any<PartyDraft>(), ct)
+            .Returns(new List<DuplicateCandidate>
+            {
+                new(PartyId.Create(Guid.NewGuid()), 1.0m, DuplicateMatchTier.Deterministic, [])
+            });
+
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+            response = await PartyEndpoints.HandleCreateAsync(
+                _request, force: false, skipDuplicateCheck: true,
+                _writer, _guidGenerator, _detector, ct);
+
+        response.Result.ShouldBeOfType<Created<PartyResponse>>();
+        await _detector.DidNotReceiveWithAnyArgs().FindCandidatesAsync(default!, ct);
+    }
+}


### PR DESCRIPTION
## Summary

Story [#1302](https://github.com/granit-fx/granit-dotnet/issues/1302) of [Feature #1280](https://github.com/granit-fx/granit-dotnet/issues/1280) (Party duplicate detection — 3-tier pipeline) under [Epic #1278](https://github.com/granit-fx/granit-dotnet/issues/1278).

Wires `IPartyDuplicateDetector` into `POST /parties` so an admin attempting to create a duplicate gets a structured 409 with the candidate list, rather than silently producing the row the recurring scan (#1300) would surface 24h later.

## Behaviour

| Detection result | Outcome |
|---|---|
| Tier-1 (Deterministic) match | **409 Conflict** with `PartyCreateConflictResponse` body |
| Tier-2 / Tier-3 fuzzy match | Does **not** block — deferred to the recurring scan + per-party detail endpoint. Forcing admins to confirm every Acme / Smith overlap at create time is too aggressive. |
| No match | Proceed (201 Created as before) |

## Opt-outs

- `?force=true` — admin acknowledges the duplicate is intentional (subsidiary, alias, same legal entity in two roles).
- `X-Skip-Duplicate-Check: true` — bulk migrations / data seeding; skips the detector round-trip entirely.

Both short-circuit BEFORE the detector call so neither path costs a DB hit.

## Response shape on 409

```json
{
  "reason": "DuplicatesDetected",
  "candidates": [
    {
      "candidateId": "<guid>",
      "score": 1.0,
      "tier": "Deterministic",
      "signals": [ { "kind": "TaxIdExact", "score": 1.0 } ]
    }
  ]
}
```

The client has two recoveries: re-submit with `?force=true`, OR open the merge wizard against the suggested candidate.

## Note on coverage

`PartyCreateRequest` does not carry emails / phones at create time — those land via the dedicated child endpoints (`POST /parties/{id}/emails` etc.) AFTER the row exists. So the online check effectively covers the TaxId Tier-1 path; email / phone duplicates surface through the recurring scan + the per-party detail endpoint (#1301). Acceptable for v1; would need request-shape changes to broaden.

## Test plan

- [x] 4/4 unit tests on the new behaviour:
  - Tier-1 hit → 409 + structured body + writer not called
  - Tier-3-only hit → no block
  - `?force=true` → bypass (detector not even called)
  - `X-Skip-Duplicate-Check` header → bypass
- [x] `dotnet test tests/Granit.Parties.Endpoints.Tests` — 63/63 passing

Refs #1302
Refs #1280
