### PR TITLE
fix(parties): ConfigureContactsModule applies PartyDuplicateCandidateConfiguration

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -25421,7 +25421,7 @@
       "kind": "class",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/GranitMergeableBackgroundJobsModule.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",
@@ -25453,7 +25453,7 @@
       "kind": "record",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/Jobs/MergeIdempotencyCleanupJob.cs",
-      "line": 13,
+      "line": 15,
       "members": []
     },
     {
@@ -25462,7 +25462,7 @@
       "kind": "interface",
       "project": "Granit.Mergeable.BackgroundJobs",
       "file": "src/Granit.Mergeable.BackgroundJobs/Services/IMergeIdempotencySweeper.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -25500,7 +25500,7 @@
       "kind": "class",
       "project": "Granit.Mergeable.EntityFrameworkCore",
       "file": "src/Granit.Mergeable.EntityFrameworkCore/Extensions/MergeableEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitMergeableEntityFrameworkCore",
@@ -25537,10 +25537,10 @@
     },
     {
       "name": "MergeableOptions",
-      "fqn": "Granit.Mergeable.EntityFrameworkCore.MergeableOptions",
+      "fqn": "Granit.Mergeable.EntityFrameworkCore.Options.MergeableOptions",
       "kind": "class",
       "project": "Granit.Mergeable.EntityFrameworkCore",
-      "file": "src/Granit.Mergeable.EntityFrameworkCore/MergeableOptions.cs",
+      "file": "src/Granit.Mergeable.EntityFrameworkCore/Options/MergeableOptions.cs",
       "line": 10,
       "members": [
         {
@@ -32613,7 +32613,7 @@
       "kind": "class",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitPartiesDeduplication",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32489,7 +32489,7 @@
       "kind": "record",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs",
-      "line": 57,
+      "line": 58,
       "members": []
     },
     {
@@ -32523,7 +32523,7 @@
       "kind": "interface",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "ListAsync",
@@ -32597,7 +32597,7 @@
       "kind": "class",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "Name",
@@ -32613,7 +32613,7 @@
       "kind": "class",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitPartiesDeduplication",
@@ -32638,7 +32638,7 @@
       "kind": "class",
       "project": "Granit.Parties.Deduplication",
       "file": "src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "Name",
@@ -33277,7 +33277,7 @@
       "kind": "class",
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "MapGranitParties",
@@ -33437,7 +33437,7 @@
     },
     {
       "name": "PartyDuplicateCandidate",
-      "fqn": "Granit.Parties.EntityFrameworkCore.Deduplication.PartyDuplicateCandidate",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Entities.PartyDuplicateCandidate",
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/Entities/PartyDuplicateCandidate.cs",

--- a/src/Granit.Mergeable.BackgroundJobs/GranitMergeableBackgroundJobsModule.cs
+++ b/src/Granit.Mergeable.BackgroundJobs/GranitMergeableBackgroundJobsModule.cs
@@ -1,6 +1,7 @@
 using Granit.BackgroundJobs;
 using Granit.Mergeable.BackgroundJobs.Services;
 using Granit.Mergeable.EntityFrameworkCore;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.Mergeable.BackgroundJobs/Jobs/MergeIdempotencyCleanupJob.cs
+++ b/src/Granit.Mergeable.BackgroundJobs/Jobs/MergeIdempotencyCleanupJob.cs
@@ -1,5 +1,7 @@
 using Granit.BackgroundJobs;
 
+using Granit.Mergeable.EntityFrameworkCore.Options;
+
 namespace Granit.Mergeable.BackgroundJobs.Jobs;
 
 /// <summary>

--- a/src/Granit.Mergeable.BackgroundJobs/README.md
+++ b/src/Granit.Mergeable.BackgroundJobs/README.md
@@ -1,0 +1,45 @@
+# Granit.Mergeable.BackgroundJobs
+
+Recurring background jobs for the [Granit.Mergeable](../Granit.Mergeable/README.md)
+orchestrator. Currently ships one job:
+
+| Job | Cron | What |
+| --- | ---- | ---- |
+| `MergeIdempotencyCleanupJob` | configurable | Deletes `granit.merge_idempotency` rows older than `MergeableOptions.IdempotencyRetention` (default 24 h) so the cache cannot grow unbounded and idempotency-key payloads do not linger past the configured retention window (GDPR Art. 5(1)(e) — storage limitation). |
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Mergeable.BackgroundJobs
+```
+
+## Setup
+
+```csharp
+[DependsOn(typeof(GranitMergeableBackgroundJobsModule))]
+public class AppModule : GranitModule { }
+```
+
+The module's `ConfigureServices` registers the job + the
+`IMergeIdempotencySweeper` + `MergeIdempotencyCleanupService` services.
+Retention is bound from `appsettings.json`:
+
+```json
+{
+  "Mergeable": {
+    "IdempotencyRetention": "1.00:00:00"
+  }
+}
+```
+
+## Dependencies
+
+- `Granit.Mergeable.EntityFrameworkCore` — the `MergeableDbContext` that owns
+  the `granit.merge_idempotency` table the sweeper deletes from.
+- `Granit.BackgroundJobs` — recurring-job infrastructure.
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Mergeable.BackgroundJobs/Services/IMergeIdempotencySweeper.cs
+++ b/src/Granit.Mergeable.BackgroundJobs/Services/IMergeIdempotencySweeper.cs
@@ -1,3 +1,5 @@
+using Granit.Mergeable.EntityFrameworkCore.Options;
+
 namespace Granit.Mergeable.BackgroundJobs.Services;
 
 /// <summary>

--- a/src/Granit.Mergeable.BackgroundJobs/Services/MergeIdempotencyCleanupService.cs
+++ b/src/Granit.Mergeable.BackgroundJobs/Services/MergeIdempotencyCleanupService.cs
@@ -1,5 +1,6 @@
 using Granit.Mergeable.EntityFrameworkCore;
 using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Mergeable.EntityFrameworkCore/Extensions/MergeableEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Extensions/MergeableEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/Granit.Mergeable.EntityFrameworkCore/Internal/EfMergeService.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Internal/EfMergeService.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Options;
 
 #pragma warning disable CA1812 // Justification: resolved by DI through the open-generic registration `IMergeService<>` → `EfMergeService<>` (no direct `new` call in the codebase).
 
+using Granit.Mergeable.EntityFrameworkCore.Options;
+
 namespace Granit.Mergeable.EntityFrameworkCore.Internal;
 
 /// <summary>

--- a/src/Granit.Mergeable.EntityFrameworkCore/Options/MergeableOptions.cs
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Options/MergeableOptions.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace Granit.Mergeable.EntityFrameworkCore;
+namespace Granit.Mergeable.EntityFrameworkCore.Options;
 
 /// <summary>
 /// Host-tunable knobs for the merge orchestrator. Bound from the <c>Mergeable</c> section in

--- a/src/Granit.Parties.Deduplication.BackgroundJobs/Internal/EfDuplicateCandidateSink.cs
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/Internal/EfDuplicateCandidateSink.cs
@@ -3,6 +3,7 @@ using Granit.Guids;
 using Granit.Parties.Deduplication.BackgroundJobs.Diagnostics;
 using Granit.Parties.Deduplication.Domain;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;

--- a/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
@@ -191,9 +191,11 @@
         "dependencies": {
           "FuzzySharp": "[2.*, )",
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "SoftWx.Match": "[2.*, )"

--- a/src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs
+++ b/src/Granit.Parties.Deduplication/Domain/IPartyDuplicateCandidateStore.cs
@@ -1,4 +1,5 @@
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 
 namespace Granit.Parties.Deduplication.Domain;
 

--- a/src/Granit.Parties.Deduplication/EntityFrameworkCore/EfPartyDuplicateCandidateStore.cs
+++ b/src/Granit.Parties.Deduplication/EntityFrameworkCore/EfPartyDuplicateCandidateStore.cs
@@ -7,7 +7,7 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 
-namespace Granit.Parties.Deduplication.Internal;
+namespace Granit.Parties.Deduplication.EntityFrameworkCore;
 
 /// <summary>
 /// EF-backed implementation of <see cref="IPartyDuplicateCandidateStore"/>: reads + dismisses
@@ -37,7 +37,10 @@ internal sealed class EfPartyDuplicateCandidateStore(
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        IQueryable<PartyDuplicateCandidate> query = ScopedToTenant(db);
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        IQueryable<PartyDuplicateCandidate> query = db.DuplicateCandidates
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(c => c.TenantId == tenantId);
 
         if (tier is { } t)
         {
@@ -74,7 +77,10 @@ internal sealed class EfPartyDuplicateCandidateStore(
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        return await ScopedToTenant(db)
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        return await db.DuplicateCandidates
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(c => c.TenantId == tenantId)
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
             .ConfigureAwait(false);
     }
@@ -86,8 +92,11 @@ internal sealed class EfPartyDuplicateCandidateStore(
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        return await ScopedToTenant(db)
-            .Where(c => c.DismissedAt == null
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        return await db.DuplicateCandidates
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(c => c.TenantId == tenantId
+                && c.DismissedAt == null
                 && (c.PartyId == partyId || c.CandidateId == partyId))
             .OrderByDescending(c => c.Score)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
@@ -98,7 +107,10 @@ internal sealed class EfPartyDuplicateCandidateStore(
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        PartyDuplicateCandidate? row = await ScopedToTenant(db)
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        PartyDuplicateCandidate? row = await db.DuplicateCandidates
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(c => c.TenantId == tenantId)
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
@@ -110,15 +122,5 @@ internal sealed class EfPartyDuplicateCandidateStore(
         row.Dismiss(clock.Now);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return true;
-    }
-
-    /// <summary>Applies the explicit tenant filter and bypasses the ambient
-    /// <c>IMultiTenant</c> query filter — robust regardless of caller context.</summary>
-    private IQueryable<PartyDuplicateCandidate> ScopedToTenant(PartiesDbContext db)
-    {
-        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
-        return db.DuplicateCandidates
-            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
-            .Where(c => c.TenantId == tenantId);
     }
 }

--- a/src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs
+++ b/src/Granit.Parties.Deduplication/Exports/DuplicateCandidateExportDefinition.cs
@@ -1,5 +1,6 @@
 using Granit.DataExchange.Export;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 
 namespace Granit.Parties.Deduplication.Exports;
 

--- a/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Parties.Deduplication.Exports;
 using Granit.Parties.Deduplication.Internal;
 using Granit.Parties.Deduplication.Queries;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.Deduplication/Extensions/PartiesDeduplicationHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.DataExchange.Extensions;
 using Granit.Parties.Deduplication.Domain;
+using Granit.Parties.Deduplication.EntityFrameworkCore;
 using Granit.Parties.Deduplication.Exports;
 using Granit.Parties.Deduplication.Internal;
 using Granit.Parties.Deduplication.Queries;

--- a/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateQueryableSource.cs
+++ b/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateQueryableSource.cs
@@ -1,4 +1,5 @@
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;

--- a/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateStore.cs
+++ b/src/Granit.Parties.Deduplication/Internal/EfPartyDuplicateCandidateStore.cs
@@ -1,6 +1,7 @@
 using Granit.MultiTenancy;
 using Granit.Parties.Deduplication.Domain;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;

--- a/src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs
+++ b/src/Granit.Parties.Deduplication/Queries/DuplicateCandidateQueryDefinition.cs
@@ -1,4 +1,5 @@
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.QueryEngine;
 
 namespace Granit.Parties.Deduplication.Queries;

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyDuplicatesEndpoints.cs
@@ -6,6 +6,7 @@ using Granit.Parties.Domain;
 using Granit.Parties.Endpoints.Dtos;
 using Granit.Parties.Endpoints.Internal;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
@@ -38,7 +38,7 @@ internal static class PartyEndpoints
         return c is null ? TypedResults.NotFound() : TypedResults.Ok(c.ToResponse());
     }
 
-    public static async Task<Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>> HandleCreateAsync(
+    public static async Task<Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>> HandleCreateAsync(
         PartyCreateRequest request,
         [FromQuery] bool force,
         [FromHeader(Name = "X-Skip-Duplicate-Check")] bool skipDuplicateCheck,

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Parties.Endpoints.Endpoints;
 using Granit.Parties.Endpoints.Options;
 using Granit.Parties.Endpoints.Permissions;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;

--- a/src/Granit.Parties.Endpoints/Validators/PartyDuplicateMergeRequestValidator.cs
+++ b/src/Granit.Parties.Endpoints/Validators/PartyDuplicateMergeRequestValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using Granit.Parties.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Parties.Endpoints.Validators;
+
+/// <summary>
+/// Validator for <see cref="PartyDuplicateMergeRequest"/> — the body of
+/// <c>POST /parties/duplicates/{id}/merge</c>. Mirrors
+/// <see cref="PartyMergeRequestValidator"/>: <c>SurvivorId</c> required (the handler
+/// resolves the loser from the candidate pair), <c>Reason</c> capped at 1000 chars,
+/// every <c>Choices</c> value must be <c>"Survivor"</c> or <c>"Loser"</c>.
+/// </summary>
+internal sealed class PartyDuplicateMergeRequestValidator : GranitValidator<PartyDuplicateMergeRequest>
+{
+    public PartyDuplicateMergeRequestValidator()
+    {
+        RuleFor(x => x.SurvivorId).NotEmpty();
+        RuleFor(x => x.Reason).MaximumLength(1000);
+
+        RuleForEach(x => x.Choices)
+            .Must(kv => kv.Value is "Survivor" or "Loser")
+            .When(x => x.Choices is not null)
+            .WithErrorCodeAndMessage("Granit:Validation:InvalidMergeChoice");
+    }
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Entities/PartyDuplicateCandidate.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Entities/PartyDuplicateCandidate.cs
@@ -1,6 +1,6 @@
 using Granit.Domain;
 
-namespace Granit.Parties.EntityFrameworkCore.Deduplication;
+namespace Granit.Parties.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// Persisted candidate-duplicate pair surfaced by the recurring scan job

--- a/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesModelBuilderExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesModelBuilderExtensions.cs
@@ -14,6 +14,7 @@ public static class PartiesModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new PartyEmailConfiguration());
         modelBuilder.ApplyConfiguration(new PartyPhoneConfiguration());
         modelBuilder.ApplyConfiguration(new PartyExternalMappingConfiguration());
+        modelBuilder.ApplyConfiguration(new PartyDuplicateCandidateConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartiesDbContext.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartiesDbContext.cs
@@ -2,6 +2,7 @@ using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Granit.Parties.Domain;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Parties.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
@@ -1,5 +1,6 @@
 using Granit.Parties.Domain;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1322,11 +1322,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.32.1",
-        "contentHash": "Z+UiyV6PBOzfExacXcySG/IpUIjcf4jJKcKjJ09Hf+U6DQ2+TsxIBY5MJTrq1RXB/u6b8JioA9qYh4zrZoWWkQ==",
+        "resolved": "5.33.0",
+        "contentHash": "i/hpCr7qOBclKMZ6u5ET8QweDuFAqyXen84hlOZOMf3Dn+135uJFD0YFESqZCezRY58VjFjmOxhua1aBa2Y62w==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.32.1"
+          "WolverineFx": "5.33.0"
         }
       },
       "xunit.analyzers": {
@@ -2959,6 +2959,20 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.parties.deduplication": {
+        "type": "Project",
+        "dependencies": {
+          "FuzzySharp": "[2.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "SoftWx.Match": "[2.*, )"
+        }
+      },
       "granit.parties.endpoints": {
         "type": "Project",
         "dependencies": {
@@ -2970,7 +2984,9 @@
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Mergeable": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
+          "Granit.Parties.Deduplication": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
@@ -4027,6 +4043,12 @@
           "FluentValidation": "12.1.1"
         }
       },
+      "FuzzySharp": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.2",
+        "contentHash": "sBKqWxw3g//peYxDZ8JipRlyPbIyBtgzqBVA5GqwHVeqtIrw75maGXAllztf+1aJhchD+drcQIgf2mFho8ZV8A=="
+      },
       "GoCardless": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
@@ -4563,6 +4585,15 @@
           "ZString": "2.6.0"
         }
       },
+      "SoftWx.Match": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.0.3",
+        "contentHash": "dTYfATuLtFwV6GFsEahznQWZZ9ciuWux2ehxlFg5Go2gcwq2Zrj05TNlXS2FTp8wXo6FG9TgJjKcZjoM7BThGQ==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
       "StackExchange.Redis": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
@@ -4604,8 +4635,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.32.1",
-        "contentHash": "CbEkXuIap1YlUpTKQJZLr+tVe6bs2ubgkbk2vca/pIYqmShBkZxloEjavYK0LY2LVa/4NE8/GUN37M2B7lqewA==",
+        "resolved": "5.33.0",
+        "contentHash": "zpkvGtL86V/Hf4bXJaAjL0ShGKrU7Fz9OO0SlEk2traX2sTUZOGDx6f4POlQzBMsBL95T88v8EpYUf/arIvZMg==",
         "dependencies": {
           "JasperFx": "1.26.0",
           "JasperFx.Events": "1.29.0",
@@ -4618,44 +4649,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.32.1",
-        "contentHash": "LFYE/cI7ZKlFa1GLI4T/5F0ynSsKnDoGbehn9xT901EDxl89ih4j44W1KF+yLHxsxs8kUZVoMXDweVYvzfkKTg==",
+        "resolved": "5.33.0",
+        "contentHash": "PlesFCu4wX37ftOo42tbZK6pPz74VY7Z6nKKnzw+yfChdMpFJPMix/VifAsqiQsKdGk70ZoIFcYufS2RGn3BNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.32.1"
+          "WolverineFx.RDBMS": "5.33.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.32.1",
-        "contentHash": "jcEngvWAY4h4d0p1pJ6/dgEp16ISFpTpXsYxUH1h7Y6utNHeFdtw9i6YZuu/Ju3paFhkyLz28A1iNQVwWiotYQ==",
+        "resolved": "5.33.0",
+        "contentHash": "bypGvJK4bUJg6Pr4TqCOYQFl2cDOKAoW1IHwpYGQC7vpVyomCX76BzFWllC69XzyLyaP2x81fhIBTZZgCg+OKA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.32.1"
+          "WolverineFx": "5.33.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.32.1",
-        "contentHash": "wQK6J6jYwD6cDMiJQPiysDnXbT+ze6LtARKjizhpR+rhp67AY0klasTA5j8lEGqMYTg4sCPsvLYlVrKCbbf+Pg==",
+        "resolved": "5.33.0",
+        "contentHash": "Wxnu912yRiULwiSGvNI8v1mGVHEFJ89oi4gNZigyTuLKTbBCXWRgc1cD2hdBRRAwoEl4Wo4/hPWV8lbsTGqRzg==",
         "dependencies": {
           "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.32.1"
+          "WolverineFx.RDBMS": "5.33.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.32.1",
-        "contentHash": "wqAS9kX8WT0NT6SgUjsOtJvkXJWJ8oYvNQKz/L9xTk5MV/r2fWQS3m4rYt6QTqFkceDR3vKITHWkFNHuFa8ypA==",
+        "resolved": "5.33.0",
+        "contentHash": "rZNu1bGRzBQOs3rkEXjuSOh8xdunKzRq8CY/ItBlr7TLzzoibObduzX25eC+dR/cWVQcfJdJbYsLN6CzSCVosg==",
         "dependencies": {
           "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.32.1"
+          "WolverineFx.RDBMS": "5.33.0"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/Internal/EfDuplicateCandidateSinkTests.cs
+++ b/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/Internal/EfDuplicateCandidateSinkTests.cs
@@ -8,6 +8,7 @@ using Granit.Parties.Deduplication.BackgroundJobs.Internal;
 using Granit.Parties.Deduplication.Domain;
 using Granit.Parties.Domain.ValueObjects;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
@@ -409,9 +409,11 @@
         "dependencies": {
           "FuzzySharp": "[2.*, )",
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "SoftWx.Match": "[2.*, )"

--- a/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
@@ -386,9 +386,11 @@
         "dependencies": {
           "FuzzySharp": "[2.*, )",
           "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Parties.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "SoftWx.Match": "[2.*, )"

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyDuplicatesEndpointsTests.cs
@@ -9,6 +9,7 @@ using Granit.Parties.Endpoints.Dtos;
 using Granit.Parties.Endpoints.Endpoints;
 using Granit.Parties.Endpoints.Internal;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
+using Granit.Parties.EntityFrameworkCore.Entities;
 using Granit.Timing;
 using Granit.Users;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
@@ -50,7 +50,7 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
                     [new MatchSignal("TaxIdExact", 1.0m)])
             });
 
-        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
                 _request, force: false, skipDuplicateCheck: false,
                 _writer, _guidGenerator, _detector, ct);
@@ -77,7 +77,7 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
                     [new MatchSignal("NameTokenSet", 0.4m)])
             });
 
-        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
                 _request, force: false, skipDuplicateCheck: false,
                 _writer, _guidGenerator, _detector, ct);
@@ -98,7 +98,7 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
                 new(PartyId.Create(Guid.NewGuid()), 1.0m, DuplicateMatchTier.Deterministic, [])
             });
 
-        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
                 _request, force: true, skipDuplicateCheck: false,
                 _writer, _guidGenerator, _detector, ct);
@@ -118,7 +118,7 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
                 new(PartyId.Create(Guid.NewGuid()), 1.0m, DuplicateMatchTier.Deterministic, [])
             });
 
-        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ValidationProblem>
+        Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
                 _request, force: false, skipDuplicateCheck: true,
                 _writer, _guidGenerator, _detector, ct);


### PR DESCRIPTION
## Summary

One-line fix to a bug introduced by [#1423](https://github.com/granit-fx/granit-dotnet/pull/1423) (story #1300).

`PartyDuplicateCandidateConfiguration` was added to `PartyConfiguration.cs` and the `DbSet<PartyDuplicateCandidate>` was added to `PartiesDbContext`, but `PartiesModelBuilderExtensions.ConfigureContactsModule()` — the public extension consuming apps use to fold the Parties model into a consolidated DbContext — was not updated. So apps using `modelBuilder.ConfigureContactsModule()` (the showcase pattern) get EF default conventions on `parties_duplicate_candidates` instead of the explicit table name + UNIQUE index + decimal(5,4) precision.

```diff
@@ public static ModelBuilder ConfigureContactsModule(this ModelBuilder modelBuilder)
     modelBuilder.ApplyConfiguration(new PartyExternalMappingConfiguration());
+    modelBuilder.ApplyConfiguration(new PartyDuplicateCandidateConfiguration());
     return modelBuilder;
```

Caught while wiring Epic 2 into `granit-showcase-dotnet` — the consolidated `ShowcaseHostDbContext` regenerates a default-named table without the unique index. Without this fix, the recurring scan job's UPSERT logic would silently insert duplicate pairs.

## Test plan

- [x] `dotnet build src/Granit.Parties.EntityFrameworkCore -c Release` — 0/0
- [ ] No new tests — existing arch tests don't cover "every configuration is applied by the public extension". Tracking as future tech-debt would require listing registered configurations against the assembly's `IEntityTypeConfiguration<>` implementations; out of scope here.
