### PR TITLE
fix(mergeable): import Options namespace in remaining test files

### DIFF
--- a/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
+++ b/tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs
@@ -5,6 +5,7 @@ using Granit.Mergeable;
 using Granit.Mergeable.Domain;
 using Granit.Mergeable.EntityFrameworkCore;
 using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Mergeable.Exceptions;
 using Granit.MultiTenancy;
 using Granit.Timing;
@@ -35,7 +36,7 @@ public sealed class EfMergeServiceTests
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly FakeStringEncryption _encryption = new();
     private readonly IMergeableSecretProvider _secretProvider = new FakeSecretProvider();
-    private readonly IOptions<MergeableOptions> _options = Options.Create(new MergeableOptions());
+    private readonly IOptions<MergeableOptions> _options = Microsoft.Extensions.Options.Options.Create(new MergeableOptions());
     private int _idCounter;
 
     public EfMergeServiceTests()

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
@@ -5,6 +5,7 @@ using Granit.Guids;
 using Granit.Mergeable;
 using Granit.Mergeable.EntityFrameworkCore;
 using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Parties.Domain;
 using Granit.Parties.Domain.ValueObjects;
 using Granit.Parties.EntityFrameworkCore;

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/MergeIdempotencyCleanupPostgresTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/MergeIdempotencyCleanupPostgresTests.cs
@@ -2,6 +2,7 @@ using Granit.Mergeable.BackgroundJobs.Services;
 using Granit.Mergeable.EntityFrameworkCore;
 using Granit.Mergeable.EntityFrameworkCore.Domain;
 using Granit.Mergeable.EntityFrameworkCore.Internal;
+using Granit.Mergeable.EntityFrameworkCore.Options;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;


### PR DESCRIPTION
## Summary

Three test files were still resolving `MergeableOptions` via the old unqualified
name after the arch-test fix in #1427's follow-up moved the type to
`Granit.Mergeable.EntityFrameworkCore.Options` — CI on `develop` is currently
broken with 7 `CS0246` errors.

- Add the missing `using Granit.Mergeable.EntityFrameworkCore.Options;` to:
  - `tests/Granit.Mergeable.EntityFrameworkCore.Tests/EfMergeServiceTests.cs`
  - `tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs`
  - `tests/Granit.Parties.Mergeable.Tests.Integration/MergeIdempotencyCleanupPostgresTests.cs`
- Disambiguate `Options.Create(...)` → `Microsoft.Extensions.Options.Options.Create(...)`
  in `EfMergeServiceTests` where the new namespace collides with the static class.

## Test plan

- [x] `dotnet build tests/Granit.Mergeable.EntityFrameworkCore.Tests -c Release` — green
- [x] `dotnet build tests/Granit.Parties.Mergeable.Tests.Integration -c Release` — green
- [ ] CI green on PR
