### PR TITLE
refactor(parties): finish Contacts→Parties rename across the codebase

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33513,6 +33513,30 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "ContactInfoTagName",
+          "kind": "property",
+          "signature": "string ContactInfoTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ClassificationTagName",
+          "kind": "property",
+          "signature": "string ClassificationTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "MergeTagName",
+          "kind": "property",
+          "signature": "string MergeTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "DuplicatesTagName",
+          "kind": "property",
+          "signature": "string DuplicatesTagName",
+          "returnType": "string"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11317,7 +11317,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, Guid tenantId, PartyId contactId, string currency)",
+          "signature": "Create(Guid id, Guid tenantId, PartyId partyId, string currency)",
           "returnType": "BalanceAccount"
         },
         {
@@ -11751,7 +11751,7 @@
         {
           "name": "ApplyAsync",
           "kind": "method",
-          "signature": "ApplyAsync(Guid tenantId, PartyId contactId, decimal amount, string currency, TransactionSource source, string reason, DateTimeOffset? expiresAt, CancellationToken cancellationToken = default)",
+          "signature": "ApplyAsync(Guid tenantId, PartyId partyId, decimal amount, string currency, TransactionSource source, string reason, DateTimeOffset? expiresAt, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount>"
         }
       ]
@@ -11767,7 +11767,7 @@
         {
           "name": "DebitAsync",
           "kind": "method",
-          "signature": "DebitAsync(Guid tenantId, PartyId contactId, decimal amount, string currency, string reason, Guid? referenceId = null, string? referenceType = null, CancellationToken cancellationToken = default)",
+          "signature": "DebitAsync(Guid tenantId, PartyId partyId, decimal amount, string currency, string reason, Guid? referenceId = null, string? referenceType = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount>"
         }
       ]
@@ -11787,9 +11787,9 @@
           "returnType": "Task<BalanceAccount?>"
         },
         {
-          "name": "GetByContactAndCurrencyAsync",
+          "name": "GetByPartyAndCurrencyAsync",
           "kind": "method",
-          "signature": "GetByContactAndCurrencyAsync(PartyId contactId, string currency, CancellationToken cancellationToken = default)",
+          "signature": "GetByPartyAndCurrencyAsync(PartyId partyId, string currency, CancellationToken cancellationToken = default)",
           "returnType": "Task<BalanceAccount?>"
         },
         {
@@ -11909,7 +11909,7 @@
         {
           "name": "CreditOverpaymentAsync",
           "kind": "method",
-          "signature": "CreditOverpaymentAsync(Guid tenantId, PartyId contactId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
+          "signature": "CreditOverpaymentAsync(Guid tenantId, PartyId partyId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -23509,7 +23509,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, Guid tenantId, PartyId contactId, InvoiceDocumentType documentType, string currency, CollectionMethod collectionMethod, BillingReason billingReason, CreditNoteInfo? creditNoteInfo = null, BillingPeriod? period = null)",
+          "signature": "Create(Guid id, Guid tenantId, PartyId partyId, InvoiceDocumentType documentType, string currency, CollectionMethod collectionMethod, BillingReason billingReason, CreditNoteInfo? creditNoteInfo = null, BillingPeriod? period = null)",
           "returnType": "Invoice"
         },
         {
@@ -24184,9 +24184,9 @@
           "returnType": "Task<IReadOnlyList<Invoice>>"
         },
         {
-          "name": "GetByContactAsync",
+          "name": "GetByPartyAsync",
           "kind": "method",
-          "signature": "GetByContactAsync(PartyId contactId, CancellationToken cancellationToken = default)",
+          "signature": "GetByPartyAsync(PartyId partyId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Invoice>>"
         },
         {
@@ -27285,9 +27285,9 @@
           "returnType": "string"
         },
         {
-          "name": "PartyEmail",
+          "name": "ContactEmail",
           "kind": "property",
-          "signature": "string? PartyEmail",
+          "signature": "string? ContactEmail",
           "returnType": "string?"
         },
         {
@@ -33015,7 +33015,7 @@
           "name": "AsReadOnly",
           "kind": "method",
           "signature": "AsReadOnly()",
-          "returnType": "Guid? AvatarBlobId { get; private set; } public PartyId? ParentContactId { get; private set; } public Guid? UserId { get; private set; } public PartyRoles Roles { get; private set; } public PartyStatus Status { get; private set; } public IReadOnlyList<PartyExternalMapping> ExternalMappings => _externalMappings."
+          "returnType": "Guid? AvatarBlobId { get; private set; } public PartyId? ParentPartyId { get; private set; } public Guid? UserId { get; private set; } public PartyRoles Roles { get; private set; } public PartyStatus Status { get; private set; } public IReadOnlyList<PartyExternalMapping> ExternalMappings => _externalMappings."
         },
         {
           "name": "TenantId",
@@ -34043,13 +34043,13 @@
         {
           "name": "AddAsync",
           "kind": "method",
-          "signature": "AddAsync(Party contact, CancellationToken cancellationToken = default)",
+          "signature": "AddAsync(Party party, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {
           "name": "UpdateAsync",
           "kind": "method",
-          "signature": "UpdateAsync(Party contact, CancellationToken cancellationToken = default)",
+          "signature": "UpdateAsync(Party party, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -34115,7 +34115,7 @@
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(PersonalDataDeletionRequestedEto request, IPartyReader contacts, IPartyWriter writer, IDataFilter dataFilter, IDistributedEventBus bus, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(PersonalDataDeletionRequestedEto request, IPartyReader parties, IPartyWriter writer, IDataFilter dataFilter, IDistributedEventBus bus, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -35487,7 +35487,7 @@
         {
           "name": "ListAsync",
           "kind": "method",
-          "signature": "ListAsync(Guid contactId, CancellationToken cancellationToken = default)",
+          "signature": "ListAsync(Guid partyId, CancellationToken cancellationToken = default)",
           "returnType": "string ProviderName { get; } Task<IReadOnlyList<PaymentProviderMethod>>"
         },
         {
@@ -44006,7 +44006,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(SubscriptionId id, Guid tenantId, PartyId contactId, PlanId planId, string currency, SubscriptionPeriod period, DateTimeOffset? trialEndsAt = null, Guid? planPriceId = null)",
+          "signature": "Create(SubscriptionId id, Guid tenantId, PartyId partyId, PlanId planId, string currency, SubscriptionPeriod period, DateTimeOffset? trialEndsAt = null, Guid? planPriceId = null)",
           "returnType": "Subscription"
         },
         {
@@ -45881,7 +45881,7 @@
         {
           "name": "GetRateAsync",
           "kind": "method",
-          "signature": "GetRateAsync(string countryCode, DateTimeOffset asOf, PartyId? contactId = null, CancellationToken cancellationToken = default)",
+          "signature": "GetRateAsync(string countryCode, DateTimeOffset asOf, PartyId? partyId = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<TaxRateEntry?>"
         },
         {

--- a/docs-site/src/content/docs/dotnet/business/parties.mdx
+++ b/docs-site/src/content/docs/dotnet/business/parties.mdx
@@ -26,8 +26,8 @@ abstraction in one aggregate so:
 
 - Tax / billing / payment data is captured once, referenced everywhere by `PartyId`.
 - External provider identifiers (Stripe, Mollie, Odoo, Sage, NetSuite) live on the
-  contact rather than scattered across module-specific mapping tables.
-- A single GDPR Article 17 erasure pseudonymises the contact and lets
+  party rather than scattered across module-specific mapping tables.
+- A single GDPR Article 17 erasure pseudonymises the party and lets
   downstream modules retain the row for accounting integrity.
 
 ## Package structure
@@ -78,16 +78,16 @@ graph TD
 `Party` is `IMultiTenant`. The multi-tenant filter is **always** active, even in
 host scope:
 
-- `TenantId == null` → **host-scoped** contacts (the SaaS host's tenants-as-customers, vendors, internal staff).
-- `TenantId == <tenant>` → **tenant-scoped** (a tenant's e-commerce / CRM / procurement contacts).
+- `TenantId == null` → **host-scoped** parties (the SaaS host's tenants-as-customers, vendors, internal staff).
+- `TenantId == <tenant>` → **tenant-scoped** (a tenant's e-commerce / CRM / procurement parties).
 
 Cross-scope reads must explicitly bypass the filter via
-`IDataFilter.Disable<IMultiTenant>()` — leaking a tenant's contacts into a host
+`IDataFilter.Disable<IMultiTenant>()` — leaking a tenant's parties into a host
 admin browser would be a privacy regression.
 
 ### Multi-role flags
 
-A single contact may simultaneously hold any combination of `PartyRoles`:
+A single party may simultaneously hold any combination of `PartyRoles`:
 
 ```csharp
 [Flags]
@@ -111,26 +111,26 @@ Polyglot identity — at most one mapping per provider, enforced by a unique
 `(PartyId, ProviderName)` index and defensively at the aggregate:
 
 ```csharp
-contact.AddExternalMapping(id, PartyExternalProviderNames.Stripe, "cus_NffrFeUfNV2Hib");
-contact.AddExternalMapping(id, PartyExternalProviderNames.Odoo,   "12345");
+party.AddExternalMapping(id, PartyExternalProviderNames.Stripe, "cus_NffrFeUfNV2Hib");
+party.AddExternalMapping(id, PartyExternalProviderNames.Odoo,   "12345");
 
-string? stripeId = contact.FindExternalId(PartyExternalProviderNames.Stripe);
+string? stripeId = party.FindExternalId(PartyExternalProviderNames.Stripe);
 ```
 
 The reserved `"tenant"` provider name is used by `Granit.Parties.MultiTenancy` to
-link a host-scoped contact back to its tenant.
+link a host-scoped party back to its tenant.
 
 ### Lifecycle
 
 `Active` ⇄ `Suspended`; either may transition to terminal `Archived`. Archived
-contacts are immutable. Pseudonymisation (GDPR Article 17) bypasses the
+parties are immutable. Pseudonymisation (GDPR Article 17) bypasses the
 mutability guard so erasure succeeds even on archived rows.
 
 ### Customer-specific tax classification
 
 `TaxStatus` is an owned value object capturing whether the customer is VAT-exempt
 (NGO, public body), under B2B intra-EU reverse charge, or standard. Read by
-`Granit.Tax.ITaxRateProvider` when a `contactId` is supplied — exempt /
+`Granit.Tax.ITaxRateProvider` when a `partyId` is supplied — exempt /
 reverse-charge customers yield a 0% rate regardless of country defaults.
 
 ### Merging duplicates
@@ -228,7 +228,7 @@ public class AppModule : GranitModule { }
 ```
 
 ```csharp
-builder.Services.AddGranitPrivacy(p => p.AddGranitContactsPrivacyProvider());
+builder.Services.AddGranitPrivacy(p => p.AddGranitPartiesPrivacyProvider());
 ```
 
 </TabItem>
@@ -238,15 +238,15 @@ builder.Services.AddGranitPrivacy(p => p.AddGranitContactsPrivacyProvider());
 
 ## API surface
 
-`MapGranitParties()` exposes 19 endpoints under `/contacts` (configurable via
+`MapGranitParties()` exposes 19 endpoints under `/parties` (configurable via
 `Parties:Endpoints:RoutePrefix`). All endpoints require either
 `Parties.Parties.Read` or `Parties.Parties.Manage`.
 
 | Method | Path | Permission |
 |--------|------|-----------|
-| `GET` | `/contacts` | `Read` |
+| `GET` | `/parties` | `Read` |
 | `GET` | `/parties/{id}` | `Read` |
-| `POST` | `/contacts` | `Manage` |
+| `POST` | `/parties` | `Manage` |
 | `PATCH` | `/parties/{id}` | `Manage` |
 | `POST` | `/parties/{id}/{suspend\|activate\|archive}` | `Manage` |
 | `POST` / `DELETE` | `/parties/{id}/addresses[/{addressId}]` | `Manage` |
@@ -284,9 +284,9 @@ Published via the Wolverine outbox to `Granit.Parties.Abstractions`:
 
 ## See also
 
-- [Parties — external mappings guide](/dotnet/guides/contacts-external-mappings/)
-- [Parties — tenant seeding guide](/dotnet/guides/contacts-tenant-seeding/)
-- [Parties — role handler guide](/dotnet/guides/contacts-role-handler/)
+- [Parties — external mappings guide](/dotnet/guides/parties-external-mappings/)
+- [Parties — tenant seeding guide](/dotnet/guides/parties-tenant-seeding/)
+- [Parties — role handler guide](/dotnet/guides/parties-role-handler/)
 - [Privacy — data export and erasure](/dotnet/compliance/privacy/)
 - [Multi-tenancy](/dotnet/concepts/multi-tenancy/)
 - [ADR-037 — Party merge framework](/dotnet/architecture/adr/037-party-merge-framework/)

--- a/docs-site/src/content/docs/dotnet/data/mergeable.mdx
+++ b/docs-site/src/content/docs/dotnet/data/mergeable.mdx
@@ -12,7 +12,7 @@ sidebar:
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 Multi-channel data entry produces duplicates: the same customer created twice via
-two CRM imports, a supplier mapped under two external providers, a contact captured
+two CRM imports, a supplier mapped under two external providers, a party captured
 both as an individual and as their employer. Without a merge primitive those
 duplicates corrupt every aggregate that references them — invoices issued against
 the wrong party, ledger fragmented across two balances, mappings in conflict.
@@ -482,7 +482,7 @@ the framework at build time:
 ## See also
 
 - [ADR-037 — Party merge framework](/dotnet/architecture/adr/037-party-merge-framework/) — design decisions, trade-offs, non-goals
-- [Parties — central party-management aggregate](/dotnet/business/contacts/) — the first consumer
+- [Parties — central party-management aggregate](/dotnet/business/parties/) — the first consumer
 - [Query Filters](./query-filters/) — the `MergeTombstone` filter alongside `SoftDelete`, `Active`, `MultiTenant`
 - [Persistence overview](./persistence/) — `ApplyGranitConventions` and the auto-applied column conventions
 - [Entity Lifecycle Events](./entity-lifecycle-events/) — `*Eto` integration events outbox pattern, used by `PartyMergedEto`

--- a/docs-site/src/content/docs/dotnet/guides/parties-external-mappings.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/parties-external-mappings.mdx
@@ -38,7 +38,7 @@ A `PartyExternalMapping` is a `(ProviderName, ExternalId)` pair attached to a
   | `Odoo` | Odoo `res.partner` |
   | `Sage` | Sage customer |
   | `NetSuite` | NetSuite customer |
-  | `Tenant` | Reverse-link from a host-scoped contact to the Granit tenant |
+  | `Tenant` | Reverse-link from a host-scoped party to the Granit tenant |
 
   If your provider is not on this list, add a constant in a follow-up PR rather
   than coining a string ad hoc.
@@ -54,11 +54,11 @@ A `PartyExternalMapping` is a `(ProviderName, ExternalId)` pair attached to a
 ## Reading
 
 ```csharp
-Party? contact = await contactReader.GetByIdAsync(contactId, ct);
-string? externalId = contact?.FindExternalId(PartyExternalProviderNames.Stripe);
+Party? party = await partyReader.GetByIdAsync(partyId, ct);
+string? externalId = party?.FindExternalId(PartyExternalProviderNames.Stripe);
 ```
 
-The contact may be host-scoped or tenant-scoped. When you do not know the active
+The party may be host-scoped or tenant-scoped. When you do not know the active
 scope (typical for a Wolverine handler running in some tenant context), wrap the
 read in `IDataFilter.Disable<IMultiTenant>()` — see
 `Granit.Payments.Stripe.Internal.StripePaymentMethodManager` for the canonical
@@ -69,8 +69,8 @@ pattern.
 After creating the customer in the provider:
 
 ```csharp
-contact.AddExternalMapping(guidGenerator.Create(), "stripe", customer.Id);
-await contactWriter.UpdateAsync(contact, ct);
+party.AddExternalMapping(guidGenerator.Create(), "stripe", customer.Id);
+await partyWriter.UpdateAsync(party, ct);
 ```
 
 Always go through `IGuidGenerator.Create()` (Granit framework rule) — never
@@ -96,8 +96,8 @@ minimal.
 
 - **Do not** create a new aggregate `*ProviderMapping` (Stripe / Sage / NetSuite
   / …). Use `Party.ExternalMappings`.
-- **Do not** add a `(ProviderName, TenantId)` row outside the contact aggregate.
-  Tenant ↔ contact already lives in `Party.ExternalMappings` under the
+- **Do not** add a `(ProviderName, TenantId)` row outside the party aggregate.
+  Tenant ↔ party already lives in `Party.ExternalMappings` under the
   reserved provider name `tenant` (seeded automatically by
   `Granit.Parties.MultiTenancy`).
 - **Do not** reuse an `ExternalId` across providers. Each provider lives in its

--- a/docs-site/src/content/docs/dotnet/guides/parties-role-handler.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/parties-role-handler.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 `Party.Roles` is a cheap `[Flags] int` column that reflects the actual activity of
-a contact across the platform — `Customer` if they have invoices, `Supplier` if a
+a party across the platform — `Customer` if they have invoices, `Supplier` if a
 purchase order has been issued to them, `Employee` if HR has onboarded them, etc.
 
 Granit deliberately does NOT compute these flags via cross-module joins (Odoo tried
@@ -18,7 +18,7 @@ its own integration-event handlers.
 
 ## When to add a handler
 
-Add one when your module emits an event that proves a contact is acting in a given
+Add one when your module emits an event that proves a party is acting in a given
 role. The handler converts that "first time we observed activity" signal into an
 idempotent `Party.AddRole(role)` call.
 
@@ -26,9 +26,9 @@ idempotent `Party.AddRole(role)` call.
 | --------------------------- | ----------- | --- |
 | `InvoiceCreatedEto` / `InvoiceFinalizedEto` | `PartyRoles.Customer` | Party has an invoice → they are a customer. |
 | `SubscriptionCreatedEto` | `PartyRoles.Customer` | Recurring billing relationship. |
-| `PurchaseOrderCreatedEto` | `PartyRoles.Supplier` | We bought from this contact. |
+| `PurchaseOrderCreatedEto` | `PartyRoles.Supplier` | We bought from this party. |
 | `LeadCreatedEto` | `PartyRoles.Lead` | CRM has registered a sales lead. |
-| `EmployeeOnboardedEto` | `PartyRoles.Employee` | HR onboarded this contact as staff. |
+| `EmployeeOnboardedEto` | `PartyRoles.Employee` | HR onboarded this party as staff. |
 
 ## Handler pattern
 
@@ -50,27 +50,27 @@ public class InvoiceCustomerRoleHandler
 {
     public static async Task HandleAsync(
         InvoiceCreatedEto @event,
-        IPartyReader contacts,
+        IPartyReader parties,
         IPartyWriter writer,
         IDataFilter dataFilter,
         CancellationToken cancellationToken)
     {
         // Lookup with the multi-tenant filter disabled — this handler runs in a
-        // background context where the active scope may not match the contact's.
-        Party? contact;
+        // background context where the active scope may not match the party's.
+        Party? party;
         using (dataFilter.Disable<IMultiTenant>())
         {
-            contact = await contacts
+            party = await parties
                 .GetByIdAsync(PartyId.Create(@event.PartyId), cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        if (contact is null) { return; }
+        if (party is null) { return; }
 
         // AddRole is idempotent: calling it on every event is safe.
-        if (contact.AddRole(PartyRoles.Customer))
+        if (party.AddRole(PartyRoles.Customer))
         {
-            await writer.UpdateAsync(contact, cancellationToken).ConfigureAwait(false);
+            await writer.UpdateAsync(party, cancellationToken).ConfigureAwait(false);
         }
     }
 }
@@ -80,7 +80,7 @@ The handler MUST:
 
 - Be `public class` (non-static) with a `public static HandleAsync` method — required
   for Wolverine handler discovery without taking a dependency on `WolverineFx` itself.
-- Use `IDataFilter.Disable<IMultiTenant>()` around the lookup so the contact resolves
+- Use `IDataFilter.Disable<IMultiTenant>()` around the lookup so the party resolves
   regardless of the integration-event's active scope.
 - Treat `AddRole` as idempotent. Persist only when the call returns `true` so the
   outbox does not accumulate no-op rows.
@@ -93,7 +93,7 @@ The handler MUST:
 The auto-maintenance handler does not preclude manual admin curation. The endpoint
 exposed by `Granit.Parties.Endpoints` (`POST /parties/{id}/roles`) lets a host
 operator assign or revoke roles directly — typically for legacy data backfills or
-GDPR-driven contact closures.
+GDPR-driven party closures.
 
 ## Future extension
 

--- a/docs-site/src/content/docs/dotnet/guides/parties-tenant-seeding.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/parties-tenant-seeding.mdx
@@ -1,15 +1,15 @@
 ---
-title: "Seed the default contact at tenant provisioning"
+title: "Seed the default party at tenant provisioning"
 description: Wire Granit.Parties.MultiTenancy so each new tenant automatically gets the host-scoped Party that downstream Invoicing / Subscriptions / Payments / Tax / CustomerBalance modules use as the canonical billing identity.
 sidebar:
   order: 31
-  label: Seed contact on tenant created
+  label: Seed party on tenant created
 ---
 
 Downstream modules (Invoicing, Subscriptions, Payments, Tax, CustomerBalance)
 resolve the billing identity for a tenant via `IDefaultPartyResolver`, which
 looks up the host-scoped `Party` carrying the reserved
-`PartyExternalProviderNames.Tenant` external mapping. That contact has to
+`PartyExternalProviderNames.Tenant` external mapping. That party has to
 exist before any of them can issue an invoice, charge a card, or run a tax
 calculation against the tenant.
 
@@ -35,10 +35,10 @@ seeder itself is registered by `Granit.Parties.EntityFrameworkCore` regardless.
 When `Granit.MultiTenancy` raises `TenantCreatedEvent(tenantId, name, identifier)`:
 
 1. The handler resolves `IDefaultPartySeeder` from DI.
-2. The seeder asks `IDefaultPartyResolver` whether a contact already exists
+2. The seeder asks `IDefaultPartyResolver` whether a party already exists
    for `tenantId` (via the reserved `tenant` external mapping). If yes, it
    returns the existing one — replays of the same event are no-ops.
-3. Otherwise it creates a host-scoped (`TenantId == null`) `Company` contact
+3. Otherwise it creates a host-scoped (`TenantId == null`) `Company` party
    named after the tenant, attaches the
    `PartyExternalProviderNames.Tenant = tenantId.ToString()` external mapping,
    and persists it with the multi-tenant query filter disabled (the handler
@@ -63,11 +63,11 @@ public async Task BackfillAsync(IServiceProvider sp, CancellationToken ct)
 }
 ```
 
-## Customising the seeded contact
+## Customising the seeded party
 
 Apps that need to seed extra fields (taxId, billing address, language…) should
 register their own subscriber for `TenantCreatedEvent` after the framework
-handler — read the just-created contact via `IPartyReader.GetByIdAsync`,
+handler — read the just-created party via `IPartyReader.GetByIdAsync`,
 mutate it through the aggregate's methods (`UpdateContact`, `AddAddress`, …),
 and persist with `IPartyWriter.UpdateAsync`. The seeder only ships the
 identity-level baseline so it stays composable.

--- a/src/Granit.CustomerBalance.Endpoints/Dtos/AdminCreditRequest.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Dtos/AdminCreditRequest.cs
@@ -1,6 +1,6 @@
 namespace Granit.CustomerBalance.Endpoints.Dtos;
 
-/// <summary>Request to add a manual credit to a contact's balance.</summary>
+/// <summary>Request to add a manual credit to a party's balance.</summary>
 public sealed record AdminCreditRequest(
     Guid PartyId,
     decimal Amount,

--- a/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Dtos/AdminDebitRequest.cs
@@ -1,7 +1,7 @@
 namespace Granit.CustomerBalance.Endpoints.Dtos;
 
 /// <summary>
-/// Request to debit a contact's <c>BalanceAccount</c> manually — admin tooling
+/// Request to debit a party's <c>BalanceAccount</c> manually — admin tooling
 /// for corrections, scheduled drawdowns, and non-invoice adjustments.
 /// </summary>
 /// <param name="PartyId">Party whose balance account is debited.</param>

--- a/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/GetBalanceEndpoint.cs
@@ -15,7 +15,7 @@ internal static class GetBalanceEndpoint
     internal static async Task<Results<Ok<CustomerBalanceResponse>, ProblemHttpResult>> HandleAsync(
         string currency,
         [FromServices] IBalanceAccountReader accountReader,
-        [FromServices] IDefaultPartyResolver contactResolver,
+        [FromServices] IDefaultPartyResolver partyResolver,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -24,18 +24,18 @@ internal static class GetBalanceEndpoint
             return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
-        Party? contact = await contactResolver
+        Party? party = await partyResolver
             .GetDefaultForTenantAsync(currentTenant.Id!.Value, cancellationToken)
             .ConfigureAwait(false);
 
-        if (contact is null)
+        if (party is null)
         {
             return TypedResults.Ok(new CustomerBalanceResponse(
                 Guid.Empty, currency.ToUpperInvariant(), 0m, null));
         }
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(PartyId.Create(contact.Id), currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(PartyId.Create(party.Id), currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)

--- a/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Internal/ListTransactionsEndpoint.cs
@@ -18,7 +18,7 @@ internal static class ListTransactionsEndpoint
         int pageSize,
         [FromServices] IBalanceAccountReader accountReader,
         [FromServices] IBalanceTransactionReader transactionReader,
-        [FromServices] IDefaultPartyResolver contactResolver,
+        [FromServices] IDefaultPartyResolver partyResolver,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -30,17 +30,17 @@ internal static class ListTransactionsEndpoint
             return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status422UnprocessableEntity);
         }
 
-        Party? contact = await contactResolver
+        Party? party = await partyResolver
             .GetDefaultForTenantAsync(currentTenant.Id!.Value, cancellationToken)
             .ConfigureAwait(false);
 
-        if (contact is null)
+        if (party is null)
         {
             return TypedResults.Ok<IReadOnlyList<BalanceTransactionResponse>>([]);
         }
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(PartyId.Create(contact.Id), currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(PartyId.Create(party.Id), currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountConfiguration.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/BalanceAccountConfiguration.cs
@@ -23,11 +23,11 @@ internal sealed class BalanceAccountConfiguration : IEntityTypeConfiguration<Bal
             .HasForeignKey(t => t.BalanceAccountId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        // Uniqueness is now per-(contact, currency) — a tenant can hold many balances,
-        // one per (contact, currency) pair, matching real e-commerce / multi-buyer flows.
+        // Uniqueness is now per-(party, currency) — a tenant can hold many balances,
+        // one per (party, currency) pair, matching real e-commerce / multi-buyer flows.
         builder.HasIndex(e => new { e.PartyId, e.Currency })
             .IsUnique()
-            .HasDatabaseName($"uq_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_contact_currency");
+            .HasDatabaseName($"uq_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_party_currency");
 
         builder.HasIndex(e => e.TenantId)
             .HasDatabaseName($"ix_{GranitCustomerBalanceDbProperties.DbTablePrefix}accounts_tenant");

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
@@ -19,8 +19,8 @@ internal sealed class EfBalanceAccountStore(
     public Task<BalanceAccount?> GetByIdAsync(BalanceAccountId id, CancellationToken cancellationToken = default) =>
         FindByIdAsync(id.Value, cancellationToken);
 
-    public async Task<BalanceAccount?> GetByContactAndCurrencyAsync(
-        PartyId contactId, string currency, CancellationToken cancellationToken = default)
+    public async Task<BalanceAccount?> GetByPartyAndCurrencyAsync(
+        PartyId partyId, string currency, CancellationToken cancellationToken = default)
     {
         string normalizedCurrency = currency.ToUpperInvariant();
         await using CustomerBalanceDbContext context = await _contextFactory
@@ -28,7 +28,7 @@ internal sealed class EfBalanceAccountStore(
         return await context.Accounts
             .Include(a => a.Transactions)
             .FirstOrDefaultAsync(
-                a => a.PartyId.Value == contactId.Value && a.Currency == normalizedCurrency,
+                a => a.PartyId.Value == partyId.Value && a.Currency == normalizedCurrency,
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
+++ b/src/Granit.CustomerBalance/Domain/BalanceAccount.cs
@@ -26,21 +26,21 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
 
     private BalanceAccount() { }
 
-    /// <summary>Creates a new balance account for the given contact, tenant and currency.</summary>
+    /// <summary>Creates a new balance account for the given party, tenant and currency.</summary>
     /// <param name="id">Unique account identifier.</param>
     /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
-    /// <param name="contactId">Identifier of the <c>Granit.Parties.Party</c> that owns this balance — required.</param>
+    /// <param name="partyId">Identifier of the <c>Granit.Parties.Party</c> that owns this balance — required.</param>
     /// <param name="currency">ISO 4217 currency code (e.g., "EUR").</param>
-    public static BalanceAccount Create(Guid id, Guid tenantId, PartyId contactId, string currency)
+    public static BalanceAccount Create(Guid id, Guid tenantId, PartyId partyId, string currency)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
 
         return new BalanceAccount
         {
             Id = id,
             TenantId = tenantId,
-            PartyId = contactId,
+            PartyId = partyId,
             Currency = currency.ToUpperInvariant(),
             Balance = 0m,
             ConcurrencyStamp = string.Empty,
@@ -65,7 +65,7 @@ public sealed class BalanceAccount : AuditedAggregateRoot, IConcurrencyAware, IM
     /// <summary>
     /// Identifier of the <c>Granit.Parties.Party</c> that owns this balance. The
     /// module's name finally matches its domain — a tenant can hold many balance accounts,
-    /// one per (contact, currency) tuple, so e-commerce tenants run per-buyer balances.
+    /// one per (party, currency) tuple, so e-commerce tenants run per-buyer balances.
     /// </summary>
     public PartyId PartyId { get; private set; } = null!;
 

--- a/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
+++ b/src/Granit.CustomerBalance/Handlers/OverpaymentCreditHandler.cs
@@ -5,7 +5,7 @@ using Granit.Parties.Domain.ValueObjects;
 namespace Granit.CustomerBalance.Handlers;
 
 /// <summary>
-/// Credits overpayment surplus to the contact's balance account.
+/// Credits overpayment surplus to the party's balance account.
 /// Delegates to <see cref="IOverpaymentCreditService"/>. Idempotent — Wolverine's
 /// at-least-once delivery is therefore safe.
 /// </summary>

--- a/src/Granit.CustomerBalance/IAdminCreditService.cs
+++ b/src/Granit.CustomerBalance/IAdminCreditService.cs
@@ -4,16 +4,16 @@ using Granit.Parties.Domain.ValueObjects;
 namespace Granit.CustomerBalance;
 
 /// <summary>
-/// Applies admin credits (promotional, manual adjustment) to a contact's balance account.
+/// Applies admin credits (promotional, manual adjustment) to a party's balance account.
 /// Creates the account if it does not exist for the <c>(PartyId, Currency)</c> pair.
 /// </summary>
 public interface IAdminCreditService
 {
     /// <summary>
-    /// Credits the specified amount to the contact's balance account for the given currency.
+    /// Credits the specified amount to the party's balance account for the given currency.
     /// </summary>
     /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
-    /// <param name="contactId">Party whose balance account receives the credit.</param>
+    /// <param name="partyId">Party whose balance account receives the credit.</param>
     /// <param name="amount">Amount to credit.</param>
     /// <param name="currency">ISO 4217 currency code for the balance account.</param>
     /// <param name="source">Origin of the credit (e.g., Promotional, ManualAdjustment).</param>
@@ -22,7 +22,7 @@ public interface IAdminCreditService
     /// <param name="cancellationToken"></param>
     Task<BalanceAccount> ApplyAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         decimal amount,
         string currency,
         TransactionSource source,

--- a/src/Granit.CustomerBalance/IAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/IAdminDebitService.cs
@@ -23,7 +23,7 @@ public interface IAdminDebitService
     /// for the given currency.
     /// </summary>
     /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
-    /// <param name="contactId">Party whose balance account is debited.</param>
+    /// <param name="partyId">Party whose balance account is debited.</param>
     /// <param name="amount">Amount to debit (must be positive).</param>
     /// <param name="currency">ISO 4217 currency code.</param>
     /// <param name="reason">Human-readable description (audit trail).</param>
@@ -31,11 +31,11 @@ public interface IAdminDebitService
     /// <param name="referenceType">Type of the referenced document (e.g. <c>"AdminAdjustment"</c>).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The updated <see cref="BalanceAccount"/>.</returns>
-    /// <exception cref="System.InvalidOperationException">Thrown when no account exists for the contact/currency.</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when no account exists for the party/currency.</exception>
     /// <exception cref="Exceptions.InsufficientBalanceException">Thrown when the balance is insufficient.</exception>
     Task<BalanceAccount> DebitAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         decimal amount,
         string currency,
         string reason,

--- a/src/Granit.CustomerBalance/IBalanceAccountReader.cs
+++ b/src/Granit.CustomerBalance/IBalanceAccountReader.cs
@@ -10,8 +10,8 @@ public interface IBalanceAccountReader
     /// <summary>Returns a balance account by ID, including transactions.</summary>
     Task<BalanceAccount?> GetByIdAsync(BalanceAccountId id, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns the balance account for a contact and currency.</summary>
-    Task<BalanceAccount?> GetByContactAndCurrencyAsync(PartyId contactId, string currency, CancellationToken cancellationToken = default);
+    /// <summary>Returns the balance account for a party and currency.</summary>
+    Task<BalanceAccount?> GetByPartyAndCurrencyAsync(PartyId partyId, string currency, CancellationToken cancellationToken = default);
 
     /// <summary>Returns all balance accounts for a tenant (ledger management view).</summary>
     Task<IReadOnlyList<BalanceAccount>> GetByTenantAsync(Guid tenantId, CancellationToken cancellationToken = default);

--- a/src/Granit.CustomerBalance/IOverpaymentCreditService.cs
+++ b/src/Granit.CustomerBalance/IOverpaymentCreditService.cs
@@ -3,23 +3,23 @@ using Granit.Parties.Domain.ValueObjects;
 namespace Granit.CustomerBalance;
 
 /// <summary>
-/// Credits overpayment surplus to a contact's balance account.
+/// Credits overpayment surplus to a party's balance account.
 /// Creates the account if it does not exist for the <c>(PartyId, Currency)</c> pair.
 /// </summary>
 public interface IOverpaymentCreditService
 {
     /// <summary>
-    /// Credits the overpayment amount to the contact's balance account for the given currency.
+    /// Credits the overpayment amount to the party's balance account for the given currency.
     /// </summary>
     /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation).</param>
-    /// <param name="contactId">Party whose balance account receives the credit.</param>
+    /// <param name="partyId">Party whose balance account receives the credit.</param>
     /// <param name="currency">ISO 4217 currency code for the balance account.</param>
     /// <param name="amount">Overpayment amount to credit.</param>
     /// <param name="invoiceId">Source invoice that generated the overpayment.</param>
     /// <param name="cancellationToken"></param>
     Task CreditOverpaymentAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         string currency,
         decimal amount,
         Guid invoiceId,

--- a/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
+++ b/src/Granit.CustomerBalance/Internal/CustomerBalancePrePaymentProcessor.cs
@@ -31,7 +31,7 @@ internal sealed partial class CustomerBalancePrePaymentProcessor(
             .StartActivity(CustomerBalanceActivitySource.DebitBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(PartyId.Create(eto.PartyId), eto.Currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(PartyId.Create(eto.PartyId), eto.Currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null || account.Balance <= 0)

--- a/src/Granit.CustomerBalance/Internal/DefaultAdminCreditService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultAdminCreditService.cs
@@ -23,7 +23,7 @@ internal sealed partial class DefaultAdminCreditService(
 {
     public async Task<BalanceAccount> ApplyAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         decimal amount,
         string currency,
         TransactionSource source,
@@ -31,24 +31,24 @@ internal sealed partial class DefaultAdminCreditService(
         DateTimeOffset? expiresAt,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
 
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.CreditBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(partyId, currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)
         {
-            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, contactId, currency);
+            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, partyId, currency);
             await accountWriter.AddAsync(account, cancellationToken).ConfigureAwait(false);
-            Log.AccountCreated(logger, contactId.Value, currency);
+            Log.AccountCreated(logger, partyId.Value, currency);
 
             // Reload to get tracked entity with transactions collection.
             account = (await accountReader
-                .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
+                .GetByPartyAndCurrencyAsync(partyId, currency, cancellationToken)
                 .ConfigureAwait(false))!;
         }
 
@@ -72,7 +72,7 @@ internal sealed partial class DefaultAdminCreditService(
         [LoggerMessage(Level = LogLevel.Information, Message = "Admin credit ({Source}) of {Amount} applied, new balance: {NewBalance}")]
         public static partial void AdminCredited(ILogger logger, TransactionSource source, decimal amount, decimal newBalance);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for contact {PartyId} ({Currency})")]
+        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for party {PartyId} ({Currency})")]
         public static partial void AccountCreated(ILogger logger, Guid partyId, string currency);
     }
 }

--- a/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultAdminDebitService.cs
@@ -19,7 +19,7 @@ internal sealed partial class DefaultAdminDebitService(
 {
     public async Task<BalanceAccount> DebitAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         decimal amount,
         string currency,
         string reason,
@@ -27,16 +27,16 @@ internal sealed partial class DefaultAdminDebitService(
         string? referenceType = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
 
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.DebitBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(partyId, currency, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new InvalidOperationException(
-                $"No balance account exists for contact '{contactId.Value}' in currency '{currency}'.");
+                $"No balance account exists for party '{partyId.Value}' in currency '{currency}'.");
 
         // Idempotency: if a previous ManualAdjustment debit with the same
         // referenceId already landed, return the account unchanged. Mirrors the
@@ -67,7 +67,7 @@ internal sealed partial class DefaultAdminDebitService(
             referenceType: referenceType);
 
         await accountWriter.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
-        metrics.RecordDebited(contactId.Value.ToString(), currency, TransactionSource.ManualAdjustment.ToString());
+        metrics.RecordDebited(partyId.Value.ToString(), currency, TransactionSource.ManualAdjustment.ToString());
         Log.AdminDebited(logger, amount, account.Balance);
 
         return account;

--- a/src/Granit.CustomerBalance/Internal/DefaultOverpaymentCreditService.cs
+++ b/src/Granit.CustomerBalance/Internal/DefaultOverpaymentCreditService.cs
@@ -23,30 +23,30 @@ internal sealed partial class DefaultOverpaymentCreditService(
 {
     public async Task CreditOverpaymentAsync(
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         string currency,
         decimal amount,
         Guid invoiceId,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
 
         using Activity? activity = CustomerBalanceActivitySource.Source
             .StartActivity(CustomerBalanceActivitySource.CreditBalance);
 
         BalanceAccount? account = await accountReader
-            .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
+            .GetByPartyAndCurrencyAsync(partyId, currency, cancellationToken)
             .ConfigureAwait(false);
 
         if (account is null)
         {
-            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, contactId, currency);
+            account = BalanceAccount.Create(guidGenerator.Create(), tenantId, partyId, currency);
             await accountWriter.AddAsync(account, cancellationToken).ConfigureAwait(false);
-            Log.AccountCreated(logger, contactId.Value, currency);
+            Log.AccountCreated(logger, partyId.Value, currency);
 
             // Reload to get tracked entity with transactions collection.
             account = await accountReader
-                .GetByContactAndCurrencyAsync(contactId, currency, cancellationToken)
+                .GetByPartyAndCurrencyAsync(partyId, currency, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -69,7 +69,7 @@ internal sealed partial class DefaultOverpaymentCreditService(
         [LoggerMessage(Level = LogLevel.Information, Message = "Overpayment of {Amount} credited for invoice {InvoiceId}, new balance: {NewBalance}")]
         public static partial void OverpaymentCredited(ILogger logger, Guid invoiceId, decimal amount, decimal newBalance);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for contact {PartyId} ({Currency})")]
+        [LoggerMessage(Level = LogLevel.Information, Message = "Created balance account for party {PartyId} ({Currency})")]
         public static partial void AccountCreated(ILogger logger, Guid partyId, string currency);
     }
 }

--- a/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
+++ b/src/Granit.Invoicing.Abstractions/Commands/CreateInvoiceCommand.cs
@@ -13,9 +13,9 @@ namespace Granit.Invoicing.Commands;
 /// <param name="LineItems">Line items to add to the invoice.</param>
 /// <param name="PartyId">
 ///   Optional identifier of the <c>Granit.Parties.Party</c> that holds the billing identity for this invoice.
-///   When <c>null</c>, the invoicing service resolves the tenant's default host-scoped contact via
+///   When <c>null</c>, the invoicing service resolves the tenant's default host-scoped party via
 ///   <c>IDefaultPartyResolver.GetDefaultForTenantAsync</c>. Pass an explicit value when the caller already
-///   knows the contact (admin endpoints, manually issued invoices, multi-contact tenants).
+///   knows the party (admin endpoints, manually issued invoices, multi-party tenants).
 /// </param>
 /// <param name="PeriodStart">Optional billing period start.</param>
 /// <param name="PeriodEnd">Optional billing period end.</param>

--- a/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
@@ -15,7 +15,7 @@ internal sealed class InvoicingSchemaExampleProvider : ISchemaExampleProvider
         {
             [typeof(InvoiceCreateRequest)] = new JsonObject
             {
-                ["contactId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["partyId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
                 ["documentType"] = "Invoice",
                 ["currency"] = "EUR",
                 ["collectionMethod"] = "ChargeAutomatically",
@@ -28,7 +28,7 @@ internal sealed class InvoicingSchemaExampleProvider : ISchemaExampleProvider
             [typeof(InvoiceResponse)] = new JsonObject
             {
                 ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
-                ["contactId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["partyId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
                 ["documentType"] = "Invoice",
                 ["invoiceNumber"] = "INV-2026-00042",
                 ["status"] = "Open",

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
@@ -23,10 +23,10 @@ internal sealed class EfInvoiceStore(
     public Task<IReadOnlyList<Invoice>> GetForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default) =>
         ListAsync(Spec.For<Invoice>().Where(i => i.TenantId == tenantId), cancellationToken);
 
-    public Task<IReadOnlyList<Invoice>> GetByContactAsync(
-        PartyId contactId, CancellationToken cancellationToken = default) =>
+    public Task<IReadOnlyList<Invoice>> GetByPartyAsync(
+        PartyId partyId, CancellationToken cancellationToken = default) =>
         ListAsync(
-            Spec.For<Invoice>().Where(i => i.PartyId.Value == contactId.Value),
+            Spec.For<Invoice>().Where(i => i.PartyId.Value == partyId.Value),
             cancellationToken);
 
     public Task<IReadOnlyList<Invoice>> GetOverdueAsync(DateTimeOffset now, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Invoicing.Odoo/Internal/OdooInvoiceSyncProvider.cs
+++ b/src/Granit.Invoicing.Odoo/Internal/OdooInvoiceSyncProvider.cs
@@ -14,18 +14,18 @@ namespace Granit.Invoicing.Odoo.Internal;
 /// <summary>
 /// Odoo implementation of <see cref="IInvoiceSyncProvider"/>. Maps Granit invoices to Odoo
 /// <c>account.move</c> records via JSON-RPC and stores the Odoo <c>res.partner</c> id
-/// directly on the contact through <see cref="Party.ExternalMappings"/> using the reserved
+/// directly on the party through <see cref="Party.ExternalMappings"/> using the reserved
 /// provider name <see cref="PartyExternalProviderNames.Odoo"/>.
 /// </summary>
 /// <remarks>
-/// On each sync the contact's <c>res.partner</c> is created (first time) or updated (subsequent)
+/// On each sync the party's <c>res.partner</c> is created (first time) or updated (subsequent)
 /// with the latest billing address so Odoo always reflects the address shown on the issued
 /// document.
 /// </remarks>
 internal sealed partial class OdooInvoiceSyncProvider(
     OdooJsonRpcClient rpcClient,
-    IPartyReader contactReader,
-    IPartyWriter contactWriter,
+    IPartyReader partyReader,
+    IPartyWriter partyWriter,
     IDataFilter dataFilter,
     IGuidGenerator guidGenerator,
     Microsoft.Extensions.Options.IOptions<Options.OdooOptions> options,
@@ -38,7 +38,7 @@ internal sealed partial class OdooInvoiceSyncProvider(
     public async Task<(string ProviderName, string ExternalId)> SyncAsync(
         Invoice invoice, CancellationToken cancellationToken = default)
     {
-        // 1. Ensure Odoo partner exists and is up-to-date for the invoice's contact.
+        // 1. Ensure Odoo partner exists and is up-to-date for the invoice's party.
         int partnerId = await GetOrCreatePartnerAsync(
             invoice.PartyId,
             invoice.IssuedBillingAddressSnapshot,
@@ -113,60 +113,60 @@ internal sealed partial class OdooInvoiceSyncProvider(
     }
 
     /// <summary>
-    /// Gets or creates the Odoo partner for a contact. On HIT, updates the partner
+    /// Gets or creates the Odoo partner for a party. On HIT, updates the partner
     /// with the latest billing address to keep Odoo in sync.
     /// </summary>
     private async Task<int> GetOrCreatePartnerAsync(
-        PartyId contactId,
+        PartyId partyId,
         BillingAddress? address,
         CancellationToken cancellationToken)
     {
-        Party contact = await ResolveContactAsync(contactId, cancellationToken).ConfigureAwait(false)
+        Party party = await ResolvePartyAsync(partyId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException(
-                $"Party '{contactId.Value}' not found — cannot sync the invoice to Odoo without a contact to map to a res.partner.");
+                $"Party '{partyId.Value}' not found — cannot sync the invoice to Odoo without a party to map to a res.partner.");
 
-        Dictionary<string, object?> partnerValues = MapAddressToPartner(contact, address);
+        Dictionary<string, object?> partnerValues = MapAddressToPartner(party, address);
 
-        string? existing = contact.FindExternalId(Name);
+        string? existing = party.FindExternalId(Name);
         if (existing is not null
             && int.TryParse(existing, NumberStyles.Integer, CultureInfo.InvariantCulture, out int existingPartnerId))
         {
             // HIT: refresh the partner with the latest address
             await rpcClient.UpdateAsync("res.partner", existingPartnerId, partnerValues, cancellationToken)
                 .ConfigureAwait(false);
-            Log.PartnerUpdated(logger, existingPartnerId, contact.Id);
+            Log.PartnerUpdated(logger, existingPartnerId, party.Id);
             return existingPartnerId;
         }
 
-        // MISS: create the partner in Odoo and persist the reverse-link on the contact.
+        // MISS: create the partner in Odoo and persist the reverse-link on the party.
         int partnerId = await rpcClient.CreateAsync("res.partner", partnerValues, cancellationToken)
             .ConfigureAwait(false);
 
-        contact.AddExternalMapping(guidGenerator.Create(), Name, partnerId.ToString(CultureInfo.InvariantCulture));
-        await contactWriter.UpdateAsync(contact, cancellationToken).ConfigureAwait(false);
+        party.AddExternalMapping(guidGenerator.Create(), Name, partnerId.ToString(CultureInfo.InvariantCulture));
+        await partyWriter.UpdateAsync(party, cancellationToken).ConfigureAwait(false);
 
-        Log.PartnerCreated(logger, partnerId, contact.Id);
+        Log.PartnerCreated(logger, partnerId, party.Id);
         return partnerId;
     }
 
-    private async Task<Party?> ResolveContactAsync(PartyId contactId, CancellationToken cancellationToken)
+    private async Task<Party?> ResolvePartyAsync(PartyId partyId, CancellationToken cancellationToken)
     {
-        // The contact may be host-scoped (representing a tenant) or tenant-scoped — disable
+        // The party may be host-scoped (representing a tenant) or tenant-scoped — disable
         // the multi-tenant filter so the lookup succeeds regardless of the active scope.
         using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
-        return await contactReader.GetByIdAsync(contactId, cancellationToken).ConfigureAwait(false);
+        return await partyReader.GetByIdAsync(partyId, cancellationToken).ConfigureAwait(false);
     }
 
     private static Dictionary<string, object?> MapAddressToPartner(
-        Party contact, BillingAddress? address) => new()
+        Party party, BillingAddress? address) => new()
         {
-            ["name"] = address?.CompanyName ?? contact.Name,
+            ["name"] = address?.CompanyName ?? party.Name,
             ["street"] = address?.Line1,
             ["city"] = address?.City,
             ["zip"] = address?.PostalCode,
             ["country_code"] = address?.Country,
-            ["vat"] = address?.VatNumber ?? contact.TaxId,
-            ["is_company"] = contact.Kind == PartyKind.Company,
+            ["vat"] = address?.VatNumber ?? party.TaxId,
+            ["is_company"] = party.Kind == PartyKind.Company,
         };
 
     private static partial class Log
@@ -174,10 +174,10 @@ internal sealed partial class OdooInvoiceSyncProvider(
         [LoggerMessage(Level = LogLevel.Information, Message = "Invoice {InvoiceId} synced to Odoo as account.move #{OdooId} (partner #{PartnerId})")]
         public static partial void InvoiceSynced(ILogger logger, Guid invoiceId, int odooId, int partnerId);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Odoo partner #{PartnerId} created for contact {PartyId}")]
+        [LoggerMessage(Level = LogLevel.Information, Message = "Odoo partner #{PartnerId} created for party {PartyId}")]
         public static partial void PartnerCreated(ILogger logger, int partnerId, Guid partyId);
 
-        [LoggerMessage(Level = LogLevel.Debug, Message = "Odoo partner #{PartnerId} updated for contact {PartyId}")]
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Odoo partner #{PartnerId} updated for party {PartyId}")]
         public static partial void PartnerUpdated(ILogger logger, int partnerId, Guid partyId);
     }
 }

--- a/src/Granit.Invoicing/Domain/Invoice.cs
+++ b/src/Granit.Invoicing/Domain/Invoice.cs
@@ -36,8 +36,8 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
 
     /// <summary>Creates a new invoice in Draft status.</summary>
     /// <param name="id">Unique invoice identifier.</param>
-    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="contactId"/>).</param>
-    /// <param name="contactId">Identifier of the <c>Granit.Parties.Party</c> that holds the billing identity for this invoice. Required.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="partyId"/>).</param>
+    /// <param name="partyId">Identifier of the <c>Granit.Parties.Party</c> that holds the billing identity for this invoice. Required.</param>
     /// <param name="documentType">Whether this is an invoice or a credit note.</param>
     /// <param name="currency">ISO 4217 currency code.</param>
     /// <param name="collectionMethod">How payment is collected (auto-charge or manual).</param>
@@ -47,7 +47,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     public static Invoice Create(
         Guid id,
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         InvoiceDocumentType documentType,
         string currency,
         CollectionMethod collectionMethod,
@@ -55,7 +55,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         CreditNoteInfo? creditNoteInfo = null,
         BillingPeriod? period = null)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
 
         if (documentType == InvoiceDocumentType.CreditNote && creditNoteInfo is null)
@@ -68,7 +68,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
         {
             Id = id,
             TenantId = tenantId,
-            PartyId = contactId,
+            PartyId = partyId,
             DocumentType = documentType,
             Currency = currency,
             CollectionMethod = collectionMethod,
@@ -80,7 +80,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
             PeriodEnd = period?.End,
         };
 
-        invoice.AddDomainEvent(new InvoiceCreatedEvent(id, tenantId, contactId.Value));
+        invoice.AddDomainEvent(new InvoiceCreatedEvent(id, tenantId, partyId.Value));
         return invoice;
     }
 
@@ -88,12 +88,12 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     public static Invoice CreateCreditNote(
         Guid id,
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         InvoiceId parentInvoiceId,
         string currency,
         string reason) =>
         Create(
-            id, tenantId, contactId, InvoiceDocumentType.CreditNote, currency,
+            id, tenantId, partyId, InvoiceDocumentType.CreditNote, currency,
             CollectionMethod.Auto, BillingReason.Manual,
             creditNoteInfo: new CreditNoteInfo(parentInvoiceId, reason));
 
@@ -104,7 +104,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     /// identity (legal name, addresses, external mappings) for this invoice. Required —
     /// the invoice is meaningless without a billing party. Use
     /// <c>IDefaultPartyResolver.GetDefaultForTenantAsync</c> to obtain the host-scoped
-    /// contact representing a tenant when migrating from tenant-keyed billing.
+    /// party representing a tenant when migrating from tenant-keyed billing.
     /// </summary>
     public PartyId PartyId { get; private set; } = null!;
 
@@ -127,12 +127,12 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
     public string Currency { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Immutable snapshot of the contact's billing address taken at <see cref="Finalize"/>
+    /// Immutable snapshot of the party's billing address taken at <see cref="Finalize"/>
     /// time. <c>null</c> while the invoice is still in <see cref="InvoiceStatus.Draft"/>;
     /// callers in Draft state should read the live address from
     /// <c>Granit.Parties.Domain.Party.BillingAddress</c> via <see cref="PartyId"/>.
     /// Once an invoice is finalized this snapshot must remain stable forever — the address
-    /// shown on a legal invoice cannot change retroactively even if the contact later
+    /// shown on a legal invoice cannot change retroactively even if the party later
     /// updates their billing address.
     /// </summary>
     public Granit.Parties.Domain.BillingAddress? IssuedBillingAddressSnapshot { get; private set; }
@@ -239,7 +239,7 @@ public sealed class Invoice : AuditedAggregateRoot, IWorkflowStateful, IMultiTen
 
     /// <summary>
     /// Finalizes the document (Draft → Open). Assigns the document number and snapshots
-    /// the contact's billing address into <see cref="IssuedBillingAddressSnapshot"/> so the
+    /// the party's billing address into <see cref="IssuedBillingAddressSnapshot"/> so the
     /// address shown on this legal document stays stable forever.
     /// </summary>
     /// <param name="documentNumber">Sequential document number assigned by the number generator.</param>

--- a/src/Granit.Invoicing/Dtos/TaxRequest.cs
+++ b/src/Granit.Invoicing/Dtos/TaxRequest.cs
@@ -6,9 +6,9 @@ namespace Granit.Invoicing.Dtos;
 /// <summary>Request for tax calculation.</summary>
 /// <remarks>
 /// <para>
-/// <paramref name="BuyerContactId"/> lets the calculator honour customer-level overrides
+/// <paramref name="BuyerPartyId"/> lets the calculator honour customer-level overrides
 /// (VAT exemption, intra-EU reverse charge) carried by <c>Party.TaxStatus</c>. When
-/// supplied and the contact's status yields a 0% rate, the calculator returns 0% on
+/// supplied and the party's status yields a 0% rate, the calculator returns 0% on
 /// every line; otherwise the country / standard rate applies.
 /// </para>
 /// </remarks>
@@ -16,7 +16,7 @@ public sealed record TaxRequest(
     IReadOnlyList<TaxLineItem> LineItems,
     BillingAddress SellerAddress,
     BillingAddress BuyerAddress,
-    PartyId? BuyerContactId = null);
+    PartyId? BuyerPartyId = null);
 
 /// <summary>A line item for tax calculation.</summary>
 public sealed record TaxLineItem(string Description, decimal Amount, string? TaxCode);

--- a/src/Granit.Invoicing/IInvoiceReader.cs
+++ b/src/Granit.Invoicing/IInvoiceReader.cs
@@ -12,8 +12,8 @@ public interface IInvoiceReader
     Task<IReadOnlyList<Invoice>> GetForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Invoice>> GetOverdueAsync(DateTimeOffset now, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all invoices billed to the given contact, regardless of tenant scope.</summary>
-    Task<IReadOnlyList<Invoice>> GetByContactAsync(PartyId contactId, CancellationToken cancellationToken = default);
+    /// <summary>Returns all invoices billed to the given party, regardless of tenant scope.</summary>
+    Task<IReadOnlyList<Invoice>> GetByPartyAsync(PartyId partyId, CancellationToken cancellationToken = default);
 
     /// <summary>Returns all credit notes linked to a parent invoice.</summary>
     Task<IReadOnlyList<Invoice>> GetCreditNotesForInvoiceAsync(InvoiceId parentInvoiceId, CancellationToken cancellationToken = default);

--- a/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
+++ b/src/Granit.Invoicing/Internal/DefaultInvoiceCreationService.cs
@@ -13,23 +13,23 @@ namespace Granit.Invoicing.Internal;
 
 internal sealed partial class DefaultInvoiceCreationService(
     IInvoiceWriter invoiceWriter,
-    IPartyReader contactReader,
+    IPartyReader partyReader,
     IGuidGenerator guidGenerator,
     IClock clock,
-    IDefaultPartyResolver defaultContactResolver,
+    IDefaultPartyResolver defaultPartyResolver,
     ILogger<DefaultInvoiceCreationService> logger,
     ITaxCalculator? taxCalculator = null,
     IInvoiceNumberGenerator? numberGenerator = null) : IInvoiceCreationService
 {
     public async Task CreateAsync(CreateInvoiceCommand command, CancellationToken cancellationToken = default)
     {
-        Party contact = await ResolveContactAsync(command, cancellationToken).ConfigureAwait(false);
-        var contactId = PartyId.Create(contact.Id);
+        Party party = await ResolvePartyAsync(command, cancellationToken).ConfigureAwait(false);
+        var partyId = PartyId.Create(party.Id);
 
         var invoice = Invoice.Create(
             guidGenerator.Create(),
             command.TenantId,
-            contactId,
+            partyId,
             InvoiceDocumentType.Invoice,
             command.Currency,
             command.CollectionMethod,
@@ -49,7 +49,7 @@ internal sealed partial class DefaultInvoiceCreationService(
                 productId: lineItem.ProductId));
         }
 
-        Granit.Parties.Domain.BillingAddress? billingSnapshot = contact.GetBillingAddressSnapshot();
+        Granit.Parties.Domain.BillingAddress? billingSnapshot = party.GetBillingAddressSnapshot();
 
         if (taxCalculator is not null && billingSnapshot is not null)
         {
@@ -60,7 +60,7 @@ internal sealed partial class DefaultInvoiceCreationService(
                     TaxCode: null)).ToList(),
                 SellerAddress: billingSnapshot,
                 BuyerAddress: billingSnapshot,
-                BuyerContactId: contact.Id);
+                BuyerPartyId: party.Id);
 
             TaxResult taxResult = await taxCalculator
                 .CalculateAsync(taxRequest, cancellationToken)
@@ -85,22 +85,22 @@ internal sealed partial class DefaultInvoiceCreationService(
         Log.InvoiceCreated(logger, invoice.Id, command.TenantId);
     }
 
-    private async Task<Party> ResolveContactAsync(CreateInvoiceCommand command, CancellationToken cancellationToken)
+    private async Task<Party> ResolvePartyAsync(CreateInvoiceCommand command, CancellationToken cancellationToken)
     {
         if (command.PartyId is { } explicitId)
         {
-            Party? explicitContact = await contactReader
+            Party? explicitParty = await partyReader
                 .GetByIdAsync(PartyId.Create(explicitId), cancellationToken)
                 .ConfigureAwait(false);
-            return explicitContact ?? throw new InvalidOperationException(
+            return explicitParty ?? throw new InvalidOperationException(
                 $"Party '{explicitId}' referenced by {nameof(CreateInvoiceCommand)}.{nameof(CreateInvoiceCommand.PartyId)} was not found.");
         }
 
-        Party? defaultContact = await defaultContactResolver
+        Party? defaultParty = await defaultPartyResolver
             .GetDefaultForTenantAsync(command.TenantId, cancellationToken)
             .ConfigureAwait(false);
 
-        return defaultContact ?? throw new InvalidOperationException(
+        return defaultParty ?? throw new InvalidOperationException(
             $"No default Party resolved for tenant '{command.TenantId}'. Either pass " +
             $"{nameof(CreateInvoiceCommand)}.{nameof(CreateInvoiceCommand.PartyId)} explicitly or " +
             $"seed a host-scoped Party with provider '{PartyExternalProviderNames.Tenant}' = " +

--- a/src/Granit.Mergeable/IMergeableAggregateAdapter.cs
+++ b/src/Granit.Mergeable/IMergeableAggregateAdapter.cs
@@ -61,7 +61,7 @@ public interface IMergeableAggregateAdapter<TAggregate>
     /// <param name="request">The original merge request — gives <c>Reason</c>, <c>Choices</c>, ids.</param>
     /// <param name="rewriteCounts">Counts produced by every registered <c>IReferenceRewriter&lt;TAggregate&gt;</c>,
     /// keyed by their <c>Description</c>. Adapters can extract aggregate-specific counts (e.g.
-    /// <c>Party.ParentContactId</c>) to populate richer event payloads.</param>
+    /// <c>Party.ParentPartyId</c>) to populate richer event payloads.</param>
     /// <param name="mergedAt">Merge timestamp (orchestrator-provided <c>IClock.Now</c>).</param>
     void RaiseMergedEvents(
         TAggregate survivor,

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/CreateTenantRequest.cs
@@ -5,10 +5,10 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// </summary>
 /// <param name="Name">Display name of the tenant (max 256 characters).</param>
 /// <param name="Identifier">Unique slug/subdomain identifier (max 64 characters, lowercase alphanumeric + hyphens).</param>
-/// <param name="PartyEmail">Optional contact email address.</param>
+/// <param name="ContactEmail">Optional contact email address.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code (e.g. <c>"BE"</c>, <c>"FR"</c>), or <c>null</c>.</param>
 public sealed record CreateTenantRequest(
     string Name,
     string Identifier,
-    string? PartyEmail,
+    string? ContactEmail,
     string? Jurisdiction);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -6,7 +6,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Id">Unique tenant identifier.</param>
 /// <param name="Name">Display name of the tenant.</param>
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
-/// <param name="PartyEmail">Optional contact email address.</param>
+/// <param name="ContactEmail">Optional contact email address.</param>
 /// <param name="Activated">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
@@ -14,7 +14,7 @@ public sealed record TenantResponse(
     Guid Id,
     string Name,
     string Identifier,
-    string? PartyEmail,
+    string? ContactEmail,
     bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt);

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/UpdateTenantRequest.cs
@@ -4,9 +4,9 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// Request to update an existing tenant's details.
 /// </summary>
 /// <param name="Name">New display name (max 256 characters).</param>
-/// <param name="PartyEmail">New contact email (or <c>null</c> to clear).</param>
+/// <param name="ContactEmail">New contact email (or <c>null</c> to clear).</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code (or <c>null</c> to clear).</param>
 public sealed record UpdateTenantRequest(
     string Name,
-    string? PartyEmail,
+    string? ContactEmail,
     string? Jurisdiction);

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -156,7 +156,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
         Guid id = guidGenerator.Create();
 
         await writer
-            .CreateAsync(id, body.Name, body.Identifier, body.PartyEmail, body.Jurisdiction, cancellationToken)
+            .CreateAsync(id, body.Name, body.Identifier, body.ContactEmail, body.Jurisdiction, cancellationToken)
             .ConfigureAwait(false);
 
         TenantData? tenant = await reader
@@ -179,7 +179,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
         }
 
         await writer
-            .UpdateAsync(id, body.Name, body.PartyEmail, body.Jurisdiction, cancellationToken)
+            .UpdateAsync(id, body.Name, body.ContactEmail, body.Jurisdiction, cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.NoContent();
@@ -226,7 +226,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
     // -------------------------------------------------------------------------
 
     private static TenantResponse ToResponse(TenantData data) =>
-        new(data.Id, data.Name, data.Identifier, data.PartyEmail, data.Activated, data.Jurisdiction, data.CreatedAt);
+        new(data.Id, data.Name, data.Identifier, data.ContactEmail, data.Activated, data.Jurisdiction, data.CreatedAt);
 
     private static ProblemHttpResult TenantNotFound(Guid id) =>
         TypedResults.Problem(

--- a/src/Granit.MultiTenancy.Endpoints/Validators/CreateTenantRequestValidator.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Validators/CreateTenantRequestValidator.cs
@@ -26,10 +26,10 @@ internal sealed class CreateTenantRequestValidator : GranitValidator<CreateTenan
             .MaximumLength(MaxIdentifierLength)
             .Matches(IdentifierPattern);
 
-        RuleFor(x => x.PartyEmail)
+        RuleFor(x => x.ContactEmail)
             .MaximumLength(MaxEmailLength)
             .EmailAddress()
-            .When(x => x.PartyEmail is not null);
+            .When(x => x.ContactEmail is not null);
 
         RuleFor(x => x.Jurisdiction)
             .MaximumLength(MaxJurisdictionLength)

--- a/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Validators/UpdateTenantRequestValidator.cs
@@ -19,10 +19,10 @@ internal sealed class UpdateTenantRequestValidator : GranitValidator<UpdateTenan
             .NotEmpty()
             .MaximumLength(MaxNameLength);
 
-        RuleFor(x => x.PartyEmail)
+        RuleFor(x => x.ContactEmail)
             .MaximumLength(MaxEmailLength)
             .EmailAddress()
-            .When(x => x.PartyEmail is not null);
+            .When(x => x.ContactEmail is not null);
 
         RuleFor(x => x.Jurisdiction)
             .MaximumLength(MaxJurisdictionLength)

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
@@ -166,7 +166,7 @@ internal sealed partial class EfCoreTenantStore(
     // -------------------------------------------------------------------------
 
     private static TenantData ToData(Tenant tenant) =>
-        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.PartyEmail, tenant.Activated, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
+        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.Activated, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
 
     // -------------------------------------------------------------------------
     // Logging

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
@@ -27,7 +27,7 @@ internal sealed class TenantEntityTypeConfiguration : IEntityTypeConfiguration<T
                .HasMaxLength(64)
                .IsRequired();
 
-        builder.Property(e => e.PartyEmail)
+        builder.Property(e => e.ContactEmail)
                .HasMaxLength(256);
 
         builder.Property(e => e.Jurisdiction)

--- a/src/Granit.MultiTenancy/Domain/Tenant.cs
+++ b/src/Granit.MultiTenancy/Domain/Tenant.cs
@@ -21,7 +21,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
     public string Identifier { get; private set; } = string.Empty;
 
     /// <summary>Optional contact email address (max 256 characters).</summary>
-    public string? PartyEmail { get; private set; }
+    public string? ContactEmail { get; private set; }
 
     /// <inheritdoc/>
     public string? Jurisdiction { get; private set; }
@@ -69,7 +69,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
             Id = id,
             Name = name,
             Identifier = identifier,
-            PartyEmail = contactEmail,
+            ContactEmail = contactEmail,
             Jurisdiction = jurisdiction,
             Activated = true,
         };
@@ -89,7 +89,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         Name = name;
-        PartyEmail = contactEmail;
+        ContactEmail = contactEmail;
         Jurisdiction = jurisdiction;
 
         AddDomainEvent(new TenantUpdatedEvent(Id, name, contactEmail));

--- a/src/Granit.MultiTenancy/Events/TenantUpdatedEvent.cs
+++ b/src/Granit.MultiTenancy/Events/TenantUpdatedEvent.cs
@@ -7,8 +7,8 @@ namespace Granit.MultiTenancy.Events;
 /// </summary>
 /// <param name="TenantId">The unique identifier of the tenant.</param>
 /// <param name="Name">Updated display name.</param>
-/// <param name="PartyEmail">Updated contact email (or <c>null</c>).</param>
+/// <param name="ContactEmail">Updated contact email (or <c>null</c>).</param>
 public sealed record TenantUpdatedEvent(
     Guid TenantId,
     string Name,
-    string? PartyEmail) : IDomainEvent;
+    string? ContactEmail) : IDomainEvent;

--- a/src/Granit.MultiTenancy/Exports/TenantExportDefinition.cs
+++ b/src/Granit.MultiTenancy/Exports/TenantExportDefinition.cs
@@ -13,7 +13,7 @@ public sealed class TenantExportDefinition : ExportDefinition<Tenant>
             .IncludeId()
             .Field(t => t.Name)
             .Field(t => t.Identifier)
-            .Field(t => t.PartyEmail)
+            .Field(t => t.ContactEmail)
             .Field(t => t.Jurisdiction)
             .Field(t => t.Activated)
             .Field(t => t.CustomDomain)

--- a/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
+++ b/src/Granit.MultiTenancy/Queries/TenantQueryDefinition.cs
@@ -18,14 +18,14 @@ public sealed class TenantQueryDefinition : QueryDefinition<Tenant>
         builder
             .Column(t => t.Name, c => c.Label("Name").LabelKey("MultiTenancy.Columns.Name").Filterable().Sortable())
             .Column(t => t.Identifier, c => c.Label("Identifier").LabelKey("MultiTenancy.Columns.Identifier").Filterable().Sortable())
-            .Column(t => t.PartyEmail, c => c.Label("Party Email").LabelKey("MultiTenancy.Columns.PartyEmail").Filterable())
+            .Column(t => t.ContactEmail, c => c.Label("Party Email").LabelKey("MultiTenancy.Columns.ContactEmail").Filterable())
             .Column(t => t.Jurisdiction, c => c.Label("Jurisdiction").LabelKey("MultiTenancy.Columns.Jurisdiction").Filterable().Sortable())
             .Column(t => t.Activated, c => c.Label("Activated").LabelKey("MultiTenancy.Columns.Activated").Filterable().Sortable())
             .Column(t => t.CustomDomain, c => c.Label("Custom Domain").LabelKey("MultiTenancy.Columns.CustomDomain").Filterable())
             .Column(t => t.IsDeleted, c => c.Label("Deleted").LabelKey("MultiTenancy.Columns.IsDeleted").Filterable().Sortable())
             .Column(t => t.CreatedAt, c => c.Label("Created At").LabelKey("MultiTenancy.Columns.CreatedAt").Sortable())
             .Column(t => t.ModifiedAt, c => c.Label("Modified At").LabelKey("MultiTenancy.Columns.ModifiedAt").Sortable())
-            .GlobalSearch(t => t.Name, t => t.Identifier, t => t.PartyEmail)
+            .GlobalSearch(t => t.Name, t => t.Identifier, t => t.ContactEmail)
             .DateFilter(t => t.CreatedAt)
             .DefaultSort("-createdAt")
             .DefaultPageSize(25);

--- a/src/Granit.MultiTenancy/Stores/TenantData.cs
+++ b/src/Granit.MultiTenancy/Stores/TenantData.cs
@@ -8,7 +8,7 @@ namespace Granit.MultiTenancy.Stores;
 /// <param name="Id">Unique tenant identifier.</param>
 /// <param name="Name">Display name of the tenant.</param>
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
-/// <param name="PartyEmail">Optional contact email address.</param>
+/// <param name="ContactEmail">Optional contact email address.</param>
 /// <param name="Activated">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
@@ -17,7 +17,7 @@ public sealed record TenantData(
     Guid Id,
     string Name,
     string Identifier,
-    string? PartyEmail,
+    string? ContactEmail,
     bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt,

--- a/src/Granit.Parties.Abstractions/Domain/AddressKind.cs
+++ b/src/Granit.Parties.Abstractions/Domain/AddressKind.cs
@@ -4,7 +4,7 @@ namespace Granit.Parties.Domain;
 /// The functional purpose of a <see cref="PartyAddress"/> attached to a <see cref="Party"/>.
 /// </summary>
 /// <remarks>
-/// A contact may have any number of addresses with any combination of kinds. At most one
+/// A party may have any number of addresses with any combination of kinds. At most one
 /// default address per <see cref="AddressKind"/> is enforced by the aggregate. The
 /// <see cref="Other"/> kind covers everything that doesn't fit billing or shipping —
 /// physical office, registered HQ when distinct from the billing address, returns

--- a/src/Granit.Parties.Abstractions/Domain/BillingAddress.cs
+++ b/src/Granit.Parties.Abstractions/Domain/BillingAddress.cs
@@ -13,7 +13,7 @@ namespace Granit.Parties.Domain;
 /// <remarks>
 /// Snapshotted by <c>Granit.Invoicing.Domain.Invoice.Finalize</c> into
 /// <c>Invoice.IssuedBillingAddressSnapshot</c> so that the address shown on a finalized invoice
-/// stays stable forever, even if the contact's billing address is later updated.
+/// stays stable forever, even if the party's billing address is later updated.
 /// </remarks>
 public sealed class BillingAddress : ValueObject
 {

--- a/src/Granit.Parties.Abstractions/Domain/PartyExternalProviderNames.cs
+++ b/src/Granit.Parties.Abstractions/Domain/PartyExternalProviderNames.cs
@@ -7,7 +7,7 @@ namespace Granit.Parties.Domain;
 /// External providers should consult this registry before inventing a name to avoid
 /// collisions. The list is non-exhaustive — third-party providers register their own
 /// names freely. The <see cref="Tenant"/> value is reserved for the reverse-link
-/// between a host-scoped contact and the tenant entity it represents.
+/// between a host-scoped party and the tenant entity it represents.
 /// </remarks>
 public static class PartyExternalProviderNames
 {

--- a/src/Granit.Parties.Abstractions/Domain/PartyRoles.cs
+++ b/src/Granit.Parties.Abstractions/Domain/PartyRoles.cs
@@ -1,25 +1,25 @@
 namespace Granit.Parties.Domain;
 
 /// <summary>
-/// Set of roles a <see cref="Party"/> simultaneously plays. A single contact can be a
+/// Set of roles a <see cref="Party"/> simultaneously plays. A single party can be a
 /// customer (we sell to it), a supplier (we buy from it), an employee, and a lead — all
 /// at the same time. Each downstream module filters by its relevant role flag.
 /// </summary>
 [Flags]
 public enum PartyRoles
 {
-    /// <summary>No role set. A contact in this state is technically valid (e.g. fresh import) but won't be picked up by any role-filtered query.</summary>
+    /// <summary>No role set. A party in this state is technically valid (e.g. fresh import) but won't be picked up by any role-filtered query.</summary>
     None = 0,
 
-    /// <summary>The contact is a customer of the platform / tenant. Consumed by Invoicing, Subscriptions, Payments, Tax, CustomerBalance.</summary>
+    /// <summary>The party is a customer of the platform / tenant. Consumed by Invoicing, Subscriptions, Payments, Tax, CustomerBalance.</summary>
     Customer = 1 << 0,
 
-    /// <summary>The contact is a supplier / vendor. Reserved for the future <c>Granit.Procurement</c> module.</summary>
+    /// <summary>The party is a supplier / vendor. Reserved for the future <c>Granit.Procurement</c> module.</summary>
     Supplier = 1 << 1,
 
-    /// <summary>The contact is an internal employee. Reserved for the future <c>Granit.Hr</c> module.</summary>
+    /// <summary>The party is an internal employee. Reserved for the future <c>Granit.Hr</c> module.</summary>
     Employee = 1 << 2,
 
-    /// <summary>The contact is a sales lead / prospect. Reserved for the future <c>Granit.Crm</c> module.</summary>
+    /// <summary>The party is a sales lead / prospect. Reserved for the future <c>Granit.Crm</c> module.</summary>
     Lead = 1 << 3,
 }

--- a/src/Granit.Parties.Abstractions/Domain/PartyStatus.cs
+++ b/src/Granit.Parties.Abstractions/Domain/PartyStatus.cs
@@ -9,7 +9,7 @@ namespace Granit.Parties.Domain;
 /// <item><see cref="Suspended"/> → <see cref="Archived"/></item>
 /// </list>
 /// <para>
-/// <see cref="Archived"/> is terminal: archived contacts cannot be reactivated and
+/// <see cref="Archived"/> is terminal: archived parties cannot be reactivated and
 /// can no longer be edited. The row is preserved (legal retention).
 /// </para>
 /// </remarks>

--- a/src/Granit.Parties.Abstractions/Domain/TaxStatus.cs
+++ b/src/Granit.Parties.Abstractions/Domain/TaxStatus.cs
@@ -11,9 +11,9 @@ namespace Granit.Parties.Domain;
 /// <remarks>
 /// <para>
 /// Read by <c>Granit.Tax</c>'s <c>ITaxRateProvider.GetRateAsync(...)</c> when a
-/// <c>contactId</c> is supplied: an exempt or reverse-charge contact yields a 0% rate
+/// <c>partyId</c> is supplied: an exempt or reverse-charge party yields a 0% rate
 /// regardless of the country default, with the note flag indicating which mechanism
-/// applied. Standard contacts fall back to the country / standard rate.
+/// applied. Standard parties fall back to the country / standard rate.
 /// </para>
 /// <para>
 /// Defaults to <see cref="Standard"/>. Admins opt customers in via

--- a/src/Granit.Parties.Abstractions/Events/PartyActivatedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyActivatedEto.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Integration event for contact reactivation.</summary>
+/// <summary>Integration event for party reactivation.</summary>
 public sealed record PartyActivatedEto(PartyId PartyId, Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Parties.Abstractions/Events/PartyArchivedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyArchivedEto.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Integration event for contact archival.</summary>
+/// <summary>Integration event for party archival.</summary>
 public sealed record PartyArchivedEto(PartyId PartyId, Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Parties.Abstractions/Events/PartyCreatedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyCreatedEto.cs
@@ -6,8 +6,8 @@ using Granit.Parties.Domain.ValueObjects;
 namespace Granit.Parties.Events;
 
 /// <summary>
-/// Integration event published when a new contact is created. Downstream modules consume
-/// this to react to contact creation (e.g., provision a default payment method placeholder,
+/// Integration event published when a new party is created. Downstream modules consume
+/// this to react to party creation (e.g., provision a default payment method placeholder,
 /// seed metering counters, register a new "customer" in a CRM via Wolverine outbox).
 /// </summary>
 public sealed record PartyCreatedEto(

--- a/src/Granit.Parties.Abstractions/Events/PartyExternalMappingAddedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyExternalMappingAddedEto.cs
@@ -5,7 +5,7 @@ namespace Granit.Parties.Events;
 
 /// <summary>
 /// Integration event published when a new external provider identifier is registered
-/// against a contact. Provider modules consume this to confirm side-effects of an
+/// against a party. Provider modules consume this to confirm side-effects of an
 /// external API call (e.g., a Stripe customer created and its <c>cus_xxx</c> persisted).
 /// </summary>
 public sealed record PartyExternalMappingAddedEto(

--- a/src/Granit.Parties.Abstractions/Events/PartyPersonalDataPseudonymizedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyPersonalDataPseudonymizedEto.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Integration event signalling that a contact's PII has been pseudonymised (GDPR Article 17).</summary>
+/// <summary>Integration event signalling that a party's PII has been pseudonymised (GDPR Article 17).</summary>
 public sealed record PartyPersonalDataPseudonymizedEto(PartyId PartyId, Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Parties.Abstractions/Events/PartySuspendedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartySuspendedEto.cs
@@ -4,7 +4,7 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Integration event for contact suspension.</summary>
+/// <summary>Integration event for party suspension.</summary>
 public sealed record PartySuspendedEto(
     PartyId PartyId,
     Guid? TenantId,

--- a/src/Granit.Parties.Abstractions/Events/PartyUpdatedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartyUpdatedEto.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Integration event published when a contact's billing identity is updated.</summary>
+/// <summary>Integration event published when a party's billing identity is updated.</summary>
 public sealed record PartyUpdatedEto(PartyId PartyId, Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Parties.Deduplication/Domain/PartyDraft.cs
+++ b/src/Granit.Parties.Deduplication/Domain/PartyDraft.cs
@@ -9,9 +9,9 @@ namespace Granit.Parties.Deduplication.Domain;
 /// serialisable, no domain invariants — the caller has not yet built a <c>Party</c>
 /// aggregate at the point this struct is produced.
 /// </summary>
-/// <param name="TenantId">Owning tenant; <c>null</c> for host-scoped contacts. Detection is
+/// <param name="TenantId">Owning tenant; <c>null</c> for host-scoped parties. Detection is
 /// always tenant-scoped (cross-tenant duplicates are not a thing).</param>
-/// <param name="Kind">Whether the contact is an individual, a company, or a department —
+/// <param name="Kind">Whether the party is an individual, a company, or a department —
 /// drives the choice between the two configurable similarity thresholds (Name vs Company).</param>
 /// <param name="Name">Display / legal name. Required.</param>
 /// <param name="TaxId">VAT or registration number. Optional; canonicalised before lookup.</param>

--- a/src/Granit.Parties.Endpoints/Dtos/PartyAddressRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyAddressRequest.cs
@@ -2,7 +2,7 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to add an address to a contact.</summary>
+/// <summary>Request to add an address to a party.</summary>
 public sealed record PartyAddressRequest(
     AddressKind Kind,
     string Line1,

--- a/src/Granit.Parties.Endpoints/Dtos/PartyCreateRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyCreateRequest.cs
@@ -2,7 +2,7 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to create a new contact.</summary>
+/// <summary>Request to create a new party.</summary>
 /// <param name="Kind">Individual / Company / Department.</param>
 /// <param name="Name">Display / legal name (required, max 256 chars).</param>
 /// <param name="DefaultCurrency">ISO 4217 alpha-3 currency code (required).</param>

--- a/src/Granit.Parties.Endpoints/Dtos/PartyEmailRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyEmailRequest.cs
@@ -1,4 +1,4 @@
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to add an email to a contact.</summary>
+/// <summary>Request to add an email to a party.</summary>
 public sealed record PartyEmailRequest(string Address, bool IsPrimary = false, string? Label = null);

--- a/src/Granit.Parties.Endpoints/Dtos/PartyExternalMappingRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyExternalMappingRequest.cs
@@ -1,4 +1,4 @@
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to register an external provider identifier on a contact.</summary>
+/// <summary>Request to register an external provider identifier on a party.</summary>
 public sealed record PartyExternalMappingRequest(string ProviderName, string ExternalId);

--- a/src/Granit.Parties.Endpoints/Dtos/PartyPhoneRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyPhoneRequest.cs
@@ -2,7 +2,7 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to add a phone to a contact.</summary>
+/// <summary>Request to add a phone to a party.</summary>
 public sealed record PartyPhoneRequest(
     PhoneKind Kind,
     string Number,

--- a/src/Granit.Parties.Endpoints/Dtos/PartyResponse.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyResponse.cs
@@ -2,7 +2,7 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Response shape for a single contact.</summary>
+/// <summary>Response shape for a single party.</summary>
 public sealed record PartyResponse(
     Guid Id,
     Guid? TenantId,
@@ -14,7 +14,7 @@ public sealed record PartyResponse(
     string? Website,
     string? TaxId,
     string? RegistrationNumber,
-    Guid? ParentContactId,
+    Guid? ParentPartyId,
     Guid? UserId,
     Guid? AvatarBlobId,
     PartyRoles Roles,

--- a/src/Granit.Parties.Endpoints/Dtos/PartyRoleRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyRoleRequest.cs
@@ -2,5 +2,5 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to add or remove a role flag on a contact.</summary>
+/// <summary>Request to add or remove a role flag on a party.</summary>
 public sealed record PartyRoleRequest(PartyRoles Role);

--- a/src/Granit.Parties.Endpoints/Dtos/PartySuspendRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartySuspendRequest.cs
@@ -1,4 +1,4 @@
 namespace Granit.Parties.Endpoints.Dtos;
 
-/// <summary>Request to suspend a contact.</summary>
+/// <summary>Request to suspend a party.</summary>
 public sealed record PartySuspendRequest(string? Reason = null);

--- a/src/Granit.Parties.Endpoints/Dtos/PartyTaxStatusRequest.cs
+++ b/src/Granit.Parties.Endpoints/Dtos/PartyTaxStatusRequest.cs
@@ -1,7 +1,7 @@
 namespace Granit.Parties.Endpoints.Dtos;
 
 /// <summary>
-/// Request to set a contact's customer-specific tax status — exempt, reverse-charge,
+/// Request to set a party's customer-specific tax status — exempt, reverse-charge,
 /// or standard (none of the flags set).
 /// </summary>
 /// <param name="IsExempt">VAT-exempt customer (NGO, public body, charity).</param>

--- a/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
+++ b/src/Granit.Parties.Endpoints/Endpoints/PartyEndpoints.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Granit.Parties.Endpoints.Endpoints;
 
-/// <summary>HTTP handlers for the contacts admin API. Wired by <c>PartiesEndpointRouteBuilderExtensions</c>.</summary>
+/// <summary>HTTP handlers for the parties admin API. Wired by <c>PartiesEndpointRouteBuilderExtensions</c>.</summary>
 internal static class PartyEndpoints
 {
     public static async Task<Results<Ok<IReadOnlyList<PartyListItemResponse>>, ProblemHttpResult>> HandleListAsync(
@@ -21,11 +21,11 @@ internal static class PartyEndpoints
         PartyRoles? role,
         CancellationToken cancellationToken)
     {
-        IReadOnlyList<Party> contacts = role.HasValue && role.Value != PartyRoles.None
+        IReadOnlyList<Party> parties = role.HasValue && role.Value != PartyRoles.None
             ? await reader.ListByRoleAsync(role.Value, cancellationToken).ConfigureAwait(false)
             : await reader.ListAsync(cancellationToken).ConfigureAwait(false);
 
-        return TypedResults.Ok(contacts.Select(PartyMapper.ToListItem).ToList()
+        return TypedResults.Ok(parties.Select(PartyMapper.ToListItem).ToList()
             as IReadOnlyList<PartyListItemResponse>);
     }
 

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Read);
 
         group.MapGet("/{id:guid}", PartyEndpoints.HandleGetByIdAsync)
-            .WithName("GetContactById")
+            .WithName("GetPartyById")
             .WithSummary("Returns a single party by id.")
             .WithDescription("Returns the party aggregate including all its addresses, emails, phones, and external mappings. Returns 404 if no party with that id exists in the active scope.")
             .Produces<PartyResponse>()
@@ -46,7 +46,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Create / update ───────────────────────────────────────────
         group.MapPost("", PartyEndpoints.HandleCreateAsync)
-            .WithName("CreateContact")
+            .WithName("CreateParty")
             .WithSummary("Creates a new party in the active scope.")
             .WithDescription("Creates an Active party in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation. Online duplicate detection (#1302) intercepts before INSERT — a Tier-1 deterministic match (TaxId at create time) returns 409 with the candidates list, letting the admin choose to merge or to confirm-create with ?force=true. Bulk migrations bypass the check via the X-Skip-Duplicate-Check: true header. Tier-2 / Tier-3 fuzzy matches do NOT block at create time — they surface via the recurring scan + the duplicate-candidates inbox.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
@@ -65,7 +65,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Lifecycle ─────────────────────────────────────────────────
         group.MapPost("/{id:guid}/suspend", PartyEndpoints.HandleSuspendAsync)
-            .WithName("SuspendContact")
+            .WithName("SuspendParty")
             .WithSummary("Suspends a party (idempotent; throws on Archived).")
             .WithDescription("Sets the party's status to Suspended. The aggregate is idempotent: re-suspending an already-suspended party is a no-op. Suspending an Archived party returns 409 Conflict.")
             .Produces(StatusCodes.Status204NoContent)
@@ -74,7 +74,7 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Lifecycle);
 
         group.MapPost("/{id:guid}/activate", PartyEndpoints.HandleActivateAsync)
-            .WithName("ActivateContact")
+            .WithName("ActivateParty")
             .WithSummary("Reactivates a suspended party (idempotent; throws on Archived).")
             .WithDescription("Sets the party's status back to Active. No-op if already active. Returns 409 Conflict on Archived parties.")
             .Produces(StatusCodes.Status204NoContent)
@@ -83,7 +83,7 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Lifecycle);
 
         group.MapPost("/{id:guid}/archive", PartyEndpoints.HandleArchiveAsync)
-            .WithName("ArchiveContact")
+            .WithName("ArchiveParty")
             .WithSummary("Archives a party (terminal state).")
             .WithDescription("Sets the party's status to Archived. Archived parties are immutable and can no longer be edited. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
@@ -92,7 +92,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Addresses (multi-typed: Billing / Shipping / Other) ───────
         group.MapPost("/{id:guid}/addresses", PartyEndpoints.HandleAddAddressAsync)
-            .WithName("AddContactAddress")
+            .WithName("AddPartyAddress")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Adds a typed address to a party.")
             .WithDescription("Adds a typed address. The first address of a kind is auto-promoted to default. Pass IsDefault=true to demote any existing default of the same kind.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
@@ -101,7 +102,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
         group.MapDelete("/{id:guid}/addresses/{addressId:guid}", PartyEndpoints.HandleRemoveAddressAsync)
-            .WithName("RemoveContactAddress")
+            .WithName("RemovePartyAddress")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Removes an address from a party.")
             .WithDescription("Removes an address by id. If the removed address was the default for its kind, another address of the same kind (if any) is promoted to default. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
@@ -110,7 +112,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Emails ────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/emails", PartyEndpoints.HandleAddEmailAsync)
-            .WithName("AddContactEmail")
+            .WithName("AddPartyEmail")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Adds an email to a party.")
             .WithDescription("Adds an email. The first email is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary email.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
@@ -119,7 +122,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
         group.MapDelete("/{id:guid}/emails/{emailId:guid}", PartyEndpoints.HandleRemoveEmailAsync)
-            .WithName("RemoveContactEmail")
+            .WithName("RemovePartyEmail")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Removes an email from a party.")
             .WithDescription("Removes an email by id. If the removed email was primary, another email (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
@@ -128,7 +132,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Phones (typed: Mobile / Office / Home / Other) ────────────
         group.MapPost("/{id:guid}/phones", PartyEndpoints.HandleAddPhoneAsync)
-            .WithName("AddContactPhone")
+            .WithName("AddPartyPhone")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Adds a phone number to a party.")
             .WithDescription("Adds a typed phone (Mobile / Office / Home / Other). The first phone is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary phone.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
@@ -137,7 +142,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
         group.MapDelete("/{id:guid}/phones/{phoneId:guid}", PartyEndpoints.HandleRemovePhoneAsync)
-            .WithName("RemoveContactPhone")
+            .WithName("RemovePartyPhone")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Removes a phone number from a party.")
             .WithDescription("Removes a phone by id. If the removed phone was primary, another phone (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
@@ -146,7 +152,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── External mappings (one per provider) ──────────────────────
         group.MapPost("/{id:guid}/external-mappings", PartyEndpoints.HandleAddExternalMappingAsync)
-            .WithName("AddContactExternalMapping")
+            .WithName("AddPartyExternalMapping")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Registers an external provider identifier (Stripe / Mollie / Odoo / …).")
             .WithDescription("Registers a polyglot external mapping. Returns 409 Conflict if a mapping for the same provider already exists — remove the existing one first.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
@@ -156,7 +163,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.ExternalMappings);
 
         group.MapDelete("/{id:guid}/external-mappings/{providerName}", PartyEndpoints.HandleRemoveExternalMappingAsync)
-            .WithName("RemoveContactExternalMapping")
+            .WithName("RemovePartyExternalMapping")
+            .WithTags(options.ContactInfoTagName)
             .WithSummary("Removes an external mapping.")
             .WithDescription("Removes the party's external mapping for the given provider. Idempotent — returns 204 even if no mapping existed.")
             .Produces(StatusCodes.Status204NoContent)
@@ -165,7 +173,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Roles ─────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/roles", PartyEndpoints.HandleAddRoleAsync)
-            .WithName("AddContactRole")
+            .WithName("AddPartyRole")
+            .WithTags(options.ClassificationTagName)
             .WithSummary("Adds a role flag to a party.")
             .WithDescription("Adds the requested role flag(s) to the party's Roles set. Idempotent. The standard pattern is for downstream modules to push role flags via event handlers (e.g., Invoicing adds Customer on first invoice) — this endpoint covers manual administrative overrides.")
             .Produces(StatusCodes.Status204NoContent)
@@ -174,7 +183,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
 
         group.MapDelete("/{id:guid}/roles/{role}", PartyEndpoints.HandleRemoveRoleAsync)
-            .WithName("RemoveContactRole")
+            .WithName("RemovePartyRole")
+            .WithTags(options.ClassificationTagName)
             .WithSummary("Removes a role flag from a party.")
             .WithDescription("Removes the requested role flag from the party's Roles set. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
@@ -183,7 +193,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── Tax status (customer-specific tax classification) ─────────
         group.MapPut("/{id:guid}/tax-status", PartyEndpoints.HandleSetTaxStatusAsync)
-            .WithName("SetContactTaxStatus")
+            .WithName("SetPartyTaxStatus")
+            .WithTags(options.ClassificationTagName)
             .WithSummary("Sets the party's customer-specific tax status.")
             .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the party. Read by Granit.Tax when computing rates: parties with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 422 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
             .Produces<PartyResponse>()
@@ -192,7 +203,8 @@ public static class PartiesEndpointRouteBuilderExtensions
             .RequireAuthorization(PartiesPermissions.Parties.SetTaxStatus);
 
         group.MapDelete("/{id:guid}/tax-status", PartyEndpoints.HandleClearTaxStatusAsync)
-            .WithName("ClearContactTaxStatus")
+            .WithName("ClearPartyTaxStatus")
+            .WithTags(options.ClassificationTagName)
             .WithSummary("Resets the party's tax status to the default (no special classification).")
             .WithDescription("Clears any customer-specific tax classification. Subsequent tax calculations fall back to the country / standard rate. Idempotent.")
             .Produces<PartyResponse>()
@@ -202,6 +214,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Metadata & internal notes (Stripe-style extensibility) ────
         group.MapPut("/{id:guid}/metadata", PartyEndpoints.HandleReplaceMetadataAsync)
             .WithName("ReplacePartyMetadata")
+            .WithTags(options.ClassificationTagName)
             .WithSummary("Bulk-replaces the party's metadata dictionary.")
             .WithDescription("Stripe-style customer.metadata: free-form key/value extensibility. Pass an empty object to clear. Capped at 50 entries (key ≤ 40 chars, value ≤ 500 chars). NEVER store PII here — metadata surfaces in audit logs and GDPR exports.")
             .Produces<PartyResponse>()
@@ -213,6 +226,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Merge (admin tool: survivor + loser → tombstoned loser) ───
         group.MapGet("/{survivorId:guid}/merge/preview", PartyMergeEndpoints.HandlePreviewAsync)
             .WithName("PreviewPartyMerge")
+            .WithTags(options.MergeTagName)
             .WithSummary("Previews a party merge in dry-run mode.")
             .WithDescription("Computes per-field conflicts (with the recommended winner pre-populated) and per-rewriter row counts (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId, ...) without committing anything. Powers the admin merge wizard's side-by-side view. Returns 422 when a hard invariant is violated (tenant / kind / currency mismatch, archived loser).")
             .Produces<PartyMergeResponse>()
@@ -221,6 +235,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapPost("/{survivorId:guid}/merge", PartyMergeEndpoints.HandleMergeAsync)
             .WithName("MergeParty")
+            .WithTags(options.MergeTagName)
             .WithSummary("Merges a loser party into the survivor.")
             .WithDescription("Survivor absorbs the loser: scalar fields resolved per the supplied choices (defaults applied to missing keys), child collections rewritten via SQL bulk-update, cross-module references (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId) redirected onto the survivor, loser tombstoned with MergedIntoId pointing at the survivor. Atomic — any failure rolls the whole transaction back. Stripe-style idempotency via the optional Idempotency-Key header (24h replay window). Returns 422 on invariant violation, 409 on concurrent merge or idempotency-key conflict, 404 when survivor or loser does not exist.")
             .Produces<PartyMergeResponse>()
@@ -233,7 +248,8 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Duplicate-candidates review (Epic 2: #1301) ───────────────
         // QueryEngine listing + meta + saved-views, plus the dedicated dismiss / merge
         // shortcut actions that share the same /duplicates group.
-        RouteGroupBuilder duplicatesGroup = group.MapGranitGroup("duplicates");
+        RouteGroupBuilder duplicatesGroup = group.MapGranitGroup("duplicates")
+            .WithTags(options.DuplicatesTagName);
         duplicatesGroup.MapGranitQuery<PartyDuplicateCandidate>(configure: opts =>
         {
             opts.AuthorizationPolicy = PartiesPermissions.Parties.Read;
@@ -241,6 +257,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         duplicatesGroup.MapPost("/{id:guid}/dismiss", PartyDuplicatesEndpoints.HandleDismissAsync)
             .WithName("DismissPartyDuplicateCandidate")
+            .WithTags(options.DuplicatesTagName)
             .WithSummary("Marks a candidate pair as 'not a duplicate'.")
             .WithDescription("Sets DismissedAt = now on the row. Idempotent — repeated dismisses are a no-op (still 204). Dismissed pairs are durably skipped on every subsequent scan, so the admin's decision sticks. Returns 404 only when the row truly does not exist in the current tenant.")
             .Produces(StatusCodes.Status204NoContent)
@@ -249,6 +266,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         duplicatesGroup.MapPost("/{id:guid}/merge", PartyDuplicatesEndpoints.HandleMergeShortcutAsync)
             .WithName("MergePartyFromDuplicateCandidate")
+            .WithTags(options.DuplicatesTagName)
             .WithSummary("One-click merge from a candidate row.")
             .WithDescription("Forwards to the generic merge orchestrator. Body specifies which end of the ordered candidate pair survives (the other becomes the loser); 422 when the supplied survivorId is not part of the pair. Same Idempotency-Key + audit-write semantics as POST /parties/{survivorId}/merge.")
             .Produces<PartyMergeResponse>()
@@ -261,6 +279,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // Per-party detail listing — sits at the parent /parties/{id}/... level, not under /duplicates.
         group.MapGet("/{id:guid}/duplicate-candidates", PartyDuplicatesEndpoints.HandleListForPartyAsync)
             .WithName("ListPartyDuplicateCandidatesForParty")
+            .WithTags(options.DuplicatesTagName)
             .WithSummary("Lists pending duplicate candidates that involve the given party.")
             .WithDescription("Returns every non-dismissed pair where the party is either end of the ordered (PartyId, CandidateId) tuple. Powers the per-Party detail-page warning and the create-time online detection (#1302).")
             .Produces<IReadOnlyList<PartyDuplicateCandidateResponse>>()

--- a/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Parties.Endpoints/Extensions/PartiesEndpointRouteBuilderExtensions.cs
@@ -15,10 +15,10 @@ using Microsoft.Extensions.Options;
 
 namespace Granit.Parties.Endpoints.Extensions;
 
-/// <summary>Maps the contacts admin endpoints.</summary>
+/// <summary>Maps the parties admin endpoints.</summary>
 public static class PartiesEndpointRouteBuilderExtensions
 {
-    /// <summary>Maps all contacts admin routes under the configured prefix.</summary>
+    /// <summary>Maps all parties admin routes under the configured prefix.</summary>
     public static RouteGroupBuilder MapGranitParties(this IEndpointRouteBuilder endpoints)
     {
         PartyEndpointsOptions options = endpoints.ServiceProvider
@@ -30,16 +30,16 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         // ── List & detail ─────────────────────────────────────────────
         group.MapGet("", PartyEndpoints.HandleListAsync)
-            .WithName("ListContacts")
-            .WithSummary("Lists contacts in the active scope, optionally filtered by role.")
-            .WithDescription("Returns all contacts visible in the active scope (host or tenant). When the optional 'role' query parameter is set, only contacts whose Roles flags include the requested role are returned. Requires Parties.Parties.Read.")
+            .WithName("ListParties")
+            .WithSummary("Lists parties in the active scope, optionally filtered by role.")
+            .WithDescription("Returns all parties visible in the active scope (host or tenant). When the optional 'role' query parameter is set, only parties whose Roles flags include the requested role are returned. Requires Parties.Parties.Read.")
             .Produces<IReadOnlyList<PartyListItemResponse>>()
             .RequireAuthorization(PartiesPermissions.Parties.Read);
 
         group.MapGet("/{id:guid}", PartyEndpoints.HandleGetByIdAsync)
             .WithName("GetContactById")
-            .WithSummary("Returns a single contact by id.")
-            .WithDescription("Returns the contact aggregate including all its addresses, emails, phones, and external mappings. Returns 404 if no contact with that id exists in the active scope.")
+            .WithSummary("Returns a single party by id.")
+            .WithDescription("Returns the party aggregate including all its addresses, emails, phones, and external mappings. Returns 404 if no party with that id exists in the active scope.")
             .Produces<PartyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PartiesPermissions.Parties.Read);
@@ -47,8 +47,8 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Create / update ───────────────────────────────────────────
         group.MapPost("", PartyEndpoints.HandleCreateAsync)
             .WithName("CreateContact")
-            .WithSummary("Creates a new contact in the active scope.")
-            .WithDescription("Creates an Active contact in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation. Online duplicate detection (#1302) intercepts before INSERT — a Tier-1 deterministic match (TaxId at create time) returns 409 with the candidates list, letting the admin choose to merge or to confirm-create with ?force=true. Bulk migrations bypass the check via the X-Skip-Duplicate-Check: true header. Tier-2 / Tier-3 fuzzy matches do NOT block at create time — they surface via the recurring scan + the duplicate-candidates inbox.")
+            .WithSummary("Creates a new party in the active scope.")
+            .WithDescription("Creates an Active party in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation. Online duplicate detection (#1302) intercepts before INSERT — a Tier-1 deterministic match (TaxId at create time) returns 409 with the candidates list, letting the admin choose to merge or to confirm-create with ?force=true. Bulk migrations bypass the check via the X-Skip-Duplicate-Check: true header. Tier-2 / Tier-3 fuzzy matches do NOT block at create time — they surface via the recurring scan + the duplicate-candidates inbox.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
             .Produces<PartyCreateConflictResponse>(StatusCodes.Status409Conflict)
             .ProducesValidationProblem()
@@ -56,8 +56,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapPatch("/{id:guid}", PartyEndpoints.HandleUpdateAsync)
             .WithName("UpdateIdentity")
-            .WithSummary("Updates the contact's identity (name, website, locale, timezone).")
-            .WithDescription("Updates the contact's display fields. Emails / phones / addresses live in their own child collections — see the dedicated /emails, /phones, /addresses endpoints. Currency is intentionally not editable here. Returns 404 if the contact does not exist; 400 on validation failure.")
+            .WithSummary("Updates the party's identity (name, website, locale, timezone).")
+            .WithDescription("Updates the party's display fields. Emails / phones / addresses live in their own child collections — see the dedicated /emails, /phones, /addresses endpoints. Currency is intentionally not editable here. Returns 404 if the party does not exist; 400 on validation failure.")
             .Produces<PartyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem()
@@ -66,8 +66,8 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Lifecycle ─────────────────────────────────────────────────
         group.MapPost("/{id:guid}/suspend", PartyEndpoints.HandleSuspendAsync)
             .WithName("SuspendContact")
-            .WithSummary("Suspends a contact (idempotent; throws on Archived).")
-            .WithDescription("Sets the contact's status to Suspended. The aggregate is idempotent: re-suspending an already-suspended contact is a no-op. Suspending an Archived contact returns 409 Conflict.")
+            .WithSummary("Suspends a party (idempotent; throws on Archived).")
+            .WithDescription("Sets the party's status to Suspended. The aggregate is idempotent: re-suspending an already-suspended party is a no-op. Suspending an Archived party returns 409 Conflict.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
@@ -75,8 +75,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapPost("/{id:guid}/activate", PartyEndpoints.HandleActivateAsync)
             .WithName("ActivateContact")
-            .WithSummary("Reactivates a suspended contact (idempotent; throws on Archived).")
-            .WithDescription("Sets the contact's status back to Active. No-op if already active. Returns 409 Conflict on Archived contacts.")
+            .WithSummary("Reactivates a suspended party (idempotent; throws on Archived).")
+            .WithDescription("Sets the party's status back to Active. No-op if already active. Returns 409 Conflict on Archived parties.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
@@ -84,8 +84,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapPost("/{id:guid}/archive", PartyEndpoints.HandleArchiveAsync)
             .WithName("ArchiveContact")
-            .WithSummary("Archives a contact (terminal state).")
-            .WithDescription("Sets the contact's status to Archived. Archived contacts are immutable and can no longer be edited. Idempotent.")
+            .WithSummary("Archives a party (terminal state).")
+            .WithDescription("Sets the party's status to Archived. Archived parties are immutable and can no longer be edited. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PartiesPermissions.Parties.Lifecycle);
@@ -93,7 +93,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Addresses (multi-typed: Billing / Shipping / Other) ───────
         group.MapPost("/{id:guid}/addresses", PartyEndpoints.HandleAddAddressAsync)
             .WithName("AddContactAddress")
-            .WithSummary("Adds a typed address to a contact.")
+            .WithSummary("Adds a typed address to a party.")
             .WithDescription("Adds a typed address. The first address of a kind is auto-promoted to default. Pass IsDefault=true to demote any existing default of the same kind.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -102,7 +102,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapDelete("/{id:guid}/addresses/{addressId:guid}", PartyEndpoints.HandleRemoveAddressAsync)
             .WithName("RemoveContactAddress")
-            .WithSummary("Removes an address from a contact.")
+            .WithSummary("Removes an address from a party.")
             .WithDescription("Removes an address by id. If the removed address was the default for its kind, another address of the same kind (if any) is promoted to default. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -111,7 +111,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Emails ────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/emails", PartyEndpoints.HandleAddEmailAsync)
             .WithName("AddContactEmail")
-            .WithSummary("Adds an email to a contact.")
+            .WithSummary("Adds an email to a party.")
             .WithDescription("Adds an email. The first email is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary email.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -120,7 +120,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapDelete("/{id:guid}/emails/{emailId:guid}", PartyEndpoints.HandleRemoveEmailAsync)
             .WithName("RemoveContactEmail")
-            .WithSummary("Removes an email from a contact.")
+            .WithSummary("Removes an email from a party.")
             .WithDescription("Removes an email by id. If the removed email was primary, another email (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -129,7 +129,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Phones (typed: Mobile / Office / Home / Other) ────────────
         group.MapPost("/{id:guid}/phones", PartyEndpoints.HandleAddPhoneAsync)
             .WithName("AddContactPhone")
-            .WithSummary("Adds a phone number to a contact.")
+            .WithSummary("Adds a phone number to a party.")
             .WithDescription("Adds a typed phone (Mobile / Office / Home / Other). The first phone is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary phone.")
             .Produces<PartyResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -138,7 +138,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapDelete("/{id:guid}/phones/{phoneId:guid}", PartyEndpoints.HandleRemovePhoneAsync)
             .WithName("RemoveContactPhone")
-            .WithSummary("Removes a phone number from a contact.")
+            .WithSummary("Removes a phone number from a party.")
             .WithDescription("Removes a phone by id. If the removed phone was primary, another phone (if any) is promoted to primary. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -158,7 +158,7 @@ public static class PartiesEndpointRouteBuilderExtensions
         group.MapDelete("/{id:guid}/external-mappings/{providerName}", PartyEndpoints.HandleRemoveExternalMappingAsync)
             .WithName("RemoveContactExternalMapping")
             .WithSummary("Removes an external mapping.")
-            .WithDescription("Removes the contact's external mapping for the given provider. Idempotent — returns 204 even if no mapping existed.")
+            .WithDescription("Removes the party's external mapping for the given provider. Idempotent — returns 204 even if no mapping existed.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PartiesPermissions.Parties.ExternalMappings);
@@ -166,8 +166,8 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Roles ─────────────────────────────────────────────────────
         group.MapPost("/{id:guid}/roles", PartyEndpoints.HandleAddRoleAsync)
             .WithName("AddContactRole")
-            .WithSummary("Adds a role flag to a contact.")
-            .WithDescription("Adds the requested role flag(s) to the contact's Roles set. Idempotent. The standard pattern is for downstream modules to push role flags via event handlers (e.g., Invoicing adds Customer on first invoice) — this endpoint covers manual administrative overrides.")
+            .WithSummary("Adds a role flag to a party.")
+            .WithDescription("Adds the requested role flag(s) to the party's Roles set. Idempotent. The standard pattern is for downstream modules to push role flags via event handlers (e.g., Invoicing adds Customer on first invoice) — this endpoint covers manual administrative overrides.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem()
@@ -175,8 +175,8 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapDelete("/{id:guid}/roles/{role}", PartyEndpoints.HandleRemoveRoleAsync)
             .WithName("RemoveContactRole")
-            .WithSummary("Removes a role flag from a contact.")
-            .WithDescription("Removes the requested role flag from the contact's Roles set. Idempotent.")
+            .WithSummary("Removes a role flag from a party.")
+            .WithDescription("Removes the requested role flag from the party's Roles set. Idempotent.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PartiesPermissions.Parties.Manage);
@@ -184,8 +184,8 @@ public static class PartiesEndpointRouteBuilderExtensions
         // ── Tax status (customer-specific tax classification) ─────────
         group.MapPut("/{id:guid}/tax-status", PartyEndpoints.HandleSetTaxStatusAsync)
             .WithName("SetContactTaxStatus")
-            .WithSummary("Sets the contact's customer-specific tax status.")
-            .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the contact. Read by Granit.Tax when computing rates: contacts with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 422 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
+            .WithSummary("Sets the party's customer-specific tax status.")
+            .WithDescription("Applies VAT-exempt or B2B intra-EU reverse-charge classification to the party. Read by Granit.Tax when computing rates: parties with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 422 when the request violates a domain invariant (e.g., reverse-charge without VAT number).")
             .Produces<PartyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem()
@@ -193,7 +193,7 @@ public static class PartiesEndpointRouteBuilderExtensions
 
         group.MapDelete("/{id:guid}/tax-status", PartyEndpoints.HandleClearTaxStatusAsync)
             .WithName("ClearContactTaxStatus")
-            .WithSummary("Resets the contact's tax status to the default (no special classification).")
+            .WithSummary("Resets the party's tax status to the default (no special classification).")
             .WithDescription("Clears any customer-specific tax classification. Subsequent tax calculations fall back to the country / standard rate. Idempotent.")
             .Produces<PartyResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/cs.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/cs.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "cs",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/de.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/de.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "de",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en-GB.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en-GB.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "en-GB",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/en.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "en",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/es.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/es.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "es",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr-CA.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr-CA.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
+  "culture": "fr-CA",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/fr.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Tiers",
-  "Permission:Parties.Parties.Read": "Consulter les tiers",
-  "Permission:Parties.Parties.Manage": "Gérer les tiers (identité, adresses, e-mails, téléphones, rôles)",
-  "Permission:Parties.Parties.Lifecycle": "Modifier le cycle de vie d'un tiers (suspendre, réactiver, archiver)",
-  "Permission:Parties.Parties.SetTaxStatus": "Définir le statut fiscal client-spécifique (exonération, autoliquidation)",
-  "Permission:Parties.Parties.ExternalMappings": "Associer des identifiants de fournisseurs externes (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
+  "culture": "fr",
+  "texts": {
+    "PermissionGroup:Parties": "Tiers",
+    "Permission:Parties.Parties.Read": "Consulter les tiers",
+    "Permission:Parties.Parties.Manage": "Gérer les tiers (identité, adresses, e-mails, téléphones, rôles)",
+    "Permission:Parties.Parties.Lifecycle": "Modifier le cycle de vie d'un tiers (suspendre, réactiver, archiver)",
+    "Permission:Parties.Parties.SetTaxStatus": "Définir le statut fiscal client-spécifique (exonération, autoliquidation)",
+    "Permission:Parties.Parties.ExternalMappings": "Associer des identifiants de fournisseurs externes (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Fusionner deux tiers (regrouper les doublons)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/hi.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/hi.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "hi",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/it.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/it.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "it",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ja.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ja.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "ja",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ko.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/ko.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "ko",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/nl.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/nl.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "nl",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pl.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pl.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "pl",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt-BR.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt-BR.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "pt-BR",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/pt.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "pt",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/sv.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/sv.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "sv",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/tr.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/tr.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "tr",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/zh.json
+++ b/src/Granit.Parties.Endpoints/Localization/PartiesEndpoints/zh.json
@@ -1,9 +1,12 @@
 {
-  "PermissionGroup:Parties": "Parties",
-  "Permission:Parties.Parties.Read": "Read parties",
-  "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
-  "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
-  "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
-  "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
-  "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  "culture": "zh",
+  "texts": {
+    "PermissionGroup:Parties": "Parties",
+    "Permission:Parties.Parties.Read": "Read parties",
+    "Permission:Parties.Parties.Manage": "Manage parties (identity, addresses, emails, phones, roles)",
+    "Permission:Parties.Parties.Lifecycle": "Change party lifecycle (suspend, activate, archive)",
+    "Permission:Parties.Parties.SetTaxStatus": "Set customer-specific tax status (exempt, reverse-charge)",
+    "Permission:Parties.Parties.ExternalMappings": "Register external provider identifiers (Stripe, Mollie, Odoo, ...)",
+    "Permission:Parties.Parties.Merge": "Merge two parties (consolidate duplicates)"
+  }
 }

--- a/src/Granit.Parties.Endpoints/Mapping/PartyMapper.cs
+++ b/src/Granit.Parties.Endpoints/Mapping/PartyMapper.cs
@@ -17,7 +17,7 @@ internal static class PartyMapper
         c.Website,
         c.TaxId,
         c.RegistrationNumber,
-        c.ParentContactId is { } pid ? pid.Value : null,
+        c.ParentPartyId is { } pid ? pid.Value : null,
         c.UserId,
         c.AvatarBlobId,
         c.Roles,

--- a/src/Granit.Parties.Endpoints/Options/PartyEndpointsOptions.cs
+++ b/src/Granit.Parties.Endpoints/Options/PartyEndpointsOptions.cs
@@ -9,6 +9,35 @@ public sealed class PartyEndpointsOptions
     /// <summary>Route group prefix. Default: <c>"/parties"</c>.</summary>
     public string RoutePrefix { get; set; } = "/parties";
 
-    /// <summary>OpenAPI tag name. Default: <c>"Parties"</c>.</summary>
+    /// <summary>
+    /// OpenAPI tag for the core Party CRUD + lifecycle + vCard endpoints.
+    /// Default: <c>"Parties"</c>.
+    /// </summary>
     public string TagName { get; set; } = "Parties";
+
+    /// <summary>
+    /// OpenAPI tag for the per-Party communication sub-collections — addresses,
+    /// emails, phones, external provider mappings.
+    /// Default: <c>"Parties - Contact Info"</c>.
+    /// </summary>
+    public string ContactInfoTagName { get; set; } = "Parties - Contact Info";
+
+    /// <summary>
+    /// OpenAPI tag for admin classification endpoints — roles, tax status, metadata,
+    /// internal notes.
+    /// Default: <c>"Parties - Classification"</c>.
+    /// </summary>
+    public string ClassificationTagName { get; set; } = "Parties - Classification";
+
+    /// <summary>
+    /// OpenAPI tag for the merge admin tool (preview + execute).
+    /// Default: <c>"Parties - Merge"</c>.
+    /// </summary>
+    public string MergeTagName { get; set; } = "Parties - Merge";
+
+    /// <summary>
+    /// OpenAPI tag for the duplicate-candidates review inbox.
+    /// Default: <c>"Parties - Duplicates"</c>.
+    /// </summary>
+    public string DuplicatesTagName { get; set; } = "Parties - Duplicates";
 }

--- a/src/Granit.Parties.Endpoints/Permissions/PartiesPermissionDefinitionProvider.cs
+++ b/src/Granit.Parties.Endpoints/Permissions/PartiesPermissionDefinitionProvider.cs
@@ -5,7 +5,7 @@ using Granit.Parties.Endpoints.Internal;
 
 namespace Granit.Parties.Endpoints.Permissions;
 
-/// <summary>Declares permission definitions for contacts administration endpoints.</summary>
+/// <summary>Declares permission definitions for parties administration endpoints.</summary>
 internal sealed class PartiesPermissionDefinitionProvider : IPermissionDefinitionProvider
 {
     /// <inheritdoc />
@@ -16,7 +16,7 @@ internal sealed class PartiesPermissionDefinitionProvider : IPermissionDefinitio
             LocalizableString.Create<PartiesEndpointsLocalizationResource>(
                 "PermissionGroup:Parties"));
 
-        // Visible at both host (managing host-scoped contacts e.g. tenants-as-customers)
+        // Visible at both host (managing host-scoped parties e.g. tenants-as-customers)
         // and tenant (managing the tenant's own end-customers / vendors / leads).
         group.AddPermission(
             PartiesPermissions.Parties.Read,

--- a/src/Granit.Parties.Endpoints/Permissions/PartiesPermissions.cs
+++ b/src/Granit.Parties.Endpoints/Permissions/PartiesPermissions.cs
@@ -1,15 +1,15 @@
 namespace Granit.Parties.Endpoints.Permissions;
 
-/// <summary>Permission constants for the contacts administration endpoints.</summary>
+/// <summary>Permission constants for the parties administration endpoints.</summary>
 public static class PartiesPermissions
 {
     /// <summary>Permission group name.</summary>
     public const string GroupName = "Parties";
 
-    /// <summary>Permissions for the contact resource.</summary>
+    /// <summary>Permissions for the party resource.</summary>
     public static class Parties
     {
-        /// <summary>Grants read access to contacts (list + by-id + by-external-id).</summary>
+        /// <summary>Grants read access to parties (list + by-id + by-external-id).</summary>
         public const string Read = "Parties.Parties.Read";
 
         /// <summary>

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartyResolver.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartyResolver.cs
@@ -25,9 +25,9 @@ internal sealed class EfDefaultPartyResolver(
 
         string externalId = tenantId.ToString();
 
-        // The tenant↔contact reverse-link is by definition host-scoped (TenantId == null),
+        // The tenant↔party reverse-link is by definition host-scoped (TenantId == null),
         // so always disable the multi-tenant filter — even tenant-context callers must be
-        // able to resolve their own representative host-scoped contact.
+        // able to resolve their own representative host-scoped party.
         using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartySeeder.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartySeeder.cs
@@ -10,7 +10,7 @@ namespace Granit.Parties.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IDefaultPartySeeder"/>. Creates a host-scoped
 /// <see cref="Party"/> with the reserved <see cref="PartyExternalProviderNames.Tenant"/>
 /// external mapping pointing back to the tenant identifier. Idempotent — a second call
-/// returns the contact created by the first.
+/// returns the party created by the first.
 /// </summary>
 internal sealed class EfDefaultPartySeeder(
     IDefaultPartyResolver resolver,
@@ -38,13 +38,13 @@ internal sealed class EfDefaultPartySeeder(
             return existing;
         }
 
-        var contact = Party.Create(
+        var party = Party.Create(
             id: guidGenerator.Create(),
             tenantId: null,
             kind: PartyKind.Company,
             name: tenantName,
             defaultCurrency: defaultCurrency);
-        contact.AddExternalMapping(
+        party.AddExternalMapping(
             guidGenerator.Create(),
             PartyExternalProviderNames.Tenant,
             tenantId.ToString());
@@ -56,9 +56,9 @@ internal sealed class EfDefaultPartySeeder(
         using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
         await using PartiesDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.Parties.Add(contact);
+        db.Parties.Add(party);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        return contact;
+        return party;
     }
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyQueryableSource.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyQueryableSource.cs
@@ -8,9 +8,9 @@ namespace Granit.Parties.EntityFrameworkCore.Internal;
 /// <remarks>
 /// The standard <see cref="IMultiTenant"/> query filter is intentionally left active. When no
 /// tenant context is in scope (host admin), the filter naturally restricts the result set to
-/// host-scoped contacts (<c>TenantId == null</c>) — exactly the documented invariant in
+/// host-scoped parties (<c>TenantId == null</c>) — exactly the documented invariant in
 /// <see cref="EfPartyStore"/>. Disabling the filter in that branch would expose every tenant's
-/// contacts to a host-scoped browser, which is a privacy regression. Cross-tenant browsing
+/// parties to a host-scoped browser, which is a privacy regression. Cross-tenant browsing
 /// must be opt-in via <c>IDataFilter.Disable&lt;IMultiTenant&gt;()</c> from a dedicated,
 /// permission-gated endpoint, not the default behaviour of this source.
 /// </remarks>

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyStore.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyStore.cs
@@ -28,7 +28,7 @@ internal sealed class EfPartyStore(
     /// Overrides <see cref="EfStoreBase{TEntity,TContext}.Query(TContext)"/> to keep the
     /// multi-tenant query filter active in <i>both</i> tenant and host scope. The dual-use
     /// design treats <c>TenantId == null</c> as the host's own scope (its tenants-as-customers,
-    /// vendors, internal staff) — leaking other tenants' contacts into a host browser would be
+    /// vendors, internal staff) — leaking other tenants' parties into a host browser would be
     /// a privacy regression. The standard host-mode bypass remains available explicitly via
     /// <c>IDataFilter.Disable&lt;IMultiTenant&gt;()</c>.
     /// </summary>
@@ -93,36 +93,36 @@ internal sealed class EfPartyStore(
                 .ToListAsync(cancellationToken).ConfigureAwait(false),
             cancellationToken);
 
-    async Task IPartyWriter.AddAsync(Party contact, CancellationToken cancellationToken)
+    async Task IPartyWriter.AddAsync(Party party, CancellationToken cancellationToken)
     {
-        await base.AddAsync(contact, cancellationToken).ConfigureAwait(false);
-        EmitMetrics(contact);
+        await base.AddAsync(party, cancellationToken).ConfigureAwait(false);
+        EmitMetrics(party);
     }
 
     /// <summary>
-    /// Persists a contact aggregate. <c>DbSet.Update()</c> marks the entire disconnected
+    /// Persists a party aggregate. <c>DbSet.Update()</c> marks the entire disconnected
     /// graph as Modified — including child entities (<c>PartyAddress</c>, <c>PartyEmail</c>,
     /// <c>PartyPhone</c>, <c>PartyExternalMapping</c>) freshly added in memory and not
     /// yet in the DB. We reconcile by reading existing child IDs and re-marking new ones
     /// as Added. Mirrors the workaround in <c>EfPlanWriter</c>.
     /// </summary>
-    async Task IPartyWriter.UpdateAsync(Party contact, CancellationToken cancellationToken)
+    async Task IPartyWriter.UpdateAsync(Party party, CancellationToken cancellationToken)
     {
         await WriteAsync(async db =>
         {
-            HashSet<Guid> existingAddressIds = await CollectChildIdsAsync<PartyAddress>(db, contact.Id, cancellationToken).ConfigureAwait(false);
-            HashSet<Guid> existingEmailIds = await CollectChildIdsAsync<PartyEmail>(db, contact.Id, cancellationToken).ConfigureAwait(false);
-            HashSet<Guid> existingPhoneIds = await CollectChildIdsAsync<PartyPhone>(db, contact.Id, cancellationToken).ConfigureAwait(false);
-            HashSet<Guid> existingMappingIds = await CollectChildIdsAsync<PartyExternalMapping>(db, contact.Id, cancellationToken).ConfigureAwait(false);
+            HashSet<Guid> existingAddressIds = await CollectChildIdsAsync<PartyAddress>(db, party.Id, cancellationToken).ConfigureAwait(false);
+            HashSet<Guid> existingEmailIds = await CollectChildIdsAsync<PartyEmail>(db, party.Id, cancellationToken).ConfigureAwait(false);
+            HashSet<Guid> existingPhoneIds = await CollectChildIdsAsync<PartyPhone>(db, party.Id, cancellationToken).ConfigureAwait(false);
+            HashSet<Guid> existingMappingIds = await CollectChildIdsAsync<PartyExternalMapping>(db, party.Id, cancellationToken).ConfigureAwait(false);
 
-            db.Set<Party>().Update(contact);
+            db.Set<Party>().Update(party);
 
             ReconcileNewChildren<PartyAddress>(db, existingAddressIds);
             ReconcileNewChildren<PartyEmail>(db, existingEmailIds);
             ReconcileNewChildren<PartyPhone>(db, existingPhoneIds);
             ReconcileNewChildren<PartyExternalMapping>(db, existingMappingIds);
         }, cancellationToken).ConfigureAwait(false);
-        EmitMetrics(contact);
+        EmitMetrics(party);
     }
 
     /// <summary>
@@ -132,10 +132,10 @@ internal sealed class EfPartyStore(
     /// security-relevant operation (suspend / archive / pseudonymise / external-mapping
     /// registration / tax-status change) become observable without a separate handler chain.
     /// </summary>
-    private void EmitMetrics(Party contact)
+    private void EmitMetrics(Party party)
     {
-        string? tenantId = contact.TenantId?.ToString();
-        foreach (IDomainEvent evt in contact.DomainEvents)
+        string? tenantId = party.TenantId?.ToString();
+        foreach (IDomainEvent evt in party.DomainEvents)
         {
             switch (evt)
             {
@@ -153,12 +153,12 @@ internal sealed class EfPartyStore(
     }
 
     private static async Task<HashSet<Guid>> CollectChildIdsAsync<TChild>(
-        PartiesDbContext db, Guid contactId, CancellationToken cancellationToken)
+        PartiesDbContext db, Guid partyId, CancellationToken cancellationToken)
         where TChild : class
     {
         List<Guid> ids = await db.Set<TChild>()
             .AsNoTracking()
-            .Where(e => EF.Property<Guid>(e, "PartyId") == contactId)
+            .Where(e => EF.Property<Guid>(e, "PartyId") == partyId)
             .Select(e => EF.Property<Guid>(e, "Id"))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
@@ -26,7 +26,7 @@ internal sealed class PartyConfiguration : IEntityTypeConfiguration<Party>
         builder.Property(c => c.RegistrationNumber).HasMaxLength(64);
 
         // Customer-specific tax classification — owned single-valued VO inlined into the
-        // contacts table. Defaults to TaxStatus.Standard (all flags false) on materialisation.
+        // parties table. Defaults to TaxStatus.Standard (all flags false) on materialisation.
         builder.OwnsOne(c => c.TaxStatus, ts =>
         {
             ts.Property(t => t.IsExempt).IsRequired().HasDefaultValue(false);
@@ -48,8 +48,8 @@ internal sealed class PartyConfiguration : IEntityTypeConfiguration<Party>
         // Internal notes — long free-form text bounded for DoS protection.
         builder.Property(c => c.InternalNotes).HasMaxLength(Party.MaxInternalNotesLength);
 
-        // ParentContactId is a SingleValueObject<Guid> — declare explicitly as a scalar.
-        builder.Property(c => c.ParentContactId);
+        // ParentPartyId is a SingleValueObject<Guid> — declare explicitly as a scalar.
+        builder.Property(c => c.ParentPartyId);
 
         // Child collections use HasMany (not OwnsMany) so they can be queried directly via
         // their own DbSet — required by the reconciliation logic in EfPartyStore.UpdateAsync.

--- a/src/Granit.Parties.Mergeable/Internal/PartyParentReferenceRewriter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyParentReferenceRewriter.cs
@@ -10,7 +10,7 @@ namespace Granit.Parties.Mergeable.Internal;
 
 /// <summary>
 /// Re-parents <see cref="Party"/> children of the loser onto the survivor — i.e. parties
-/// whose <see cref="Party.ParentContactId"/> equals the loser's id are redirected to the
+/// whose <see cref="Party.ParentPartyId"/> equals the loser's id are redirected to the
 /// survivor. Implemented as a SQL bulk-update so the change tracker is not loaded with
 /// potentially thousands of rows and to avoid the EF shadow-FK pitfall.
 /// </summary>
@@ -30,7 +30,7 @@ internal sealed class PartyParentReferenceRewriter(
     /// Stable description string published as the rewrite-counts map key. Adapters route on
     /// this constant to extract the reparented-children count for downstream events.
     /// </summary>
-    internal const string RewriterDescription = "Party.ParentContactId";
+    internal const string RewriterDescription = "Party.ParentPartyId";
 
     /// <inheritdoc />
     public string Description => RewriterDescription;
@@ -45,8 +45,8 @@ internal sealed class PartyParentReferenceRewriter(
         var survivorPartyId = PartyId.Create(survivorId);
 
         return await db.Parties
-            .Where(p => p.ParentContactId == loserPartyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(p => p.ParentContactId, survivorPartyId), cancellationToken)
+            .Where(p => p.ParentPartyId == loserPartyId)
+            .ExecuteUpdateAsync(s => s.SetProperty(p => p.ParentPartyId, survivorPartyId), cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -59,7 +59,7 @@ internal sealed class PartyParentReferenceRewriter(
         var loserPartyId = PartyId.Create(loserId);
 
         return await db.Parties
-            .Where(p => p.ParentContactId == loserPartyId)
+            .Where(p => p.ParentPartyId == loserPartyId)
             .CountAsync(cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Granit.Parties.MultiTenancy/Handlers/SeedDefaultPartyOnTenantCreatedHandler.cs
+++ b/src/Granit.Parties.MultiTenancy/Handlers/SeedDefaultPartyOnTenantCreatedHandler.cs
@@ -6,7 +6,7 @@ namespace Granit.Parties.MultiTenancy.Handlers;
 /// <summary>
 /// Wolverine-discovered handler that seeds the host-scoped <c>Granit.Parties.Domain.Party</c>
 /// representing every newly created tenant via <see cref="IDefaultPartySeeder"/>. Idempotent —
-/// replays of the same <see cref="TenantCreatedEvent"/> return the existing contact instead of
+/// replays of the same <see cref="TenantCreatedEvent"/> return the existing party instead of
 /// duplicating it. Runtime equivalent of the historical-data backfill the showcase / consuming
 /// app would run as a one-shot migration script.
 /// </summary>

--- a/src/Granit.Parties.Privacy/DataDeletion/PartiesPersonalDataDeletionHandler.cs
+++ b/src/Granit.Parties.Privacy/DataDeletion/PartiesPersonalDataDeletionHandler.cs
@@ -11,7 +11,7 @@ namespace Granit.Parties.Privacy.DataDeletion;
 /// <summary>
 /// Wolverine-discovered integration-event handler that fulfils the GDPR Article 17
 /// erasure obligation for the <see cref="Party"/> aggregate. Pseudonymises every PII
-/// field on the contact linked to the requesting user while preserving the row for
+/// field on the party linked to the requesting user while preserving the row for
 /// accounting integrity, then publishes a <see cref="PersonalDataDeletedEto"/> audit
 /// fragment for the privacy saga.
 /// </summary>
@@ -19,11 +19,11 @@ namespace Granit.Parties.Privacy.DataDeletion;
 /// <para>
 /// The lookup goes through the <see cref="IDataFilter"/> with the <see cref="IMultiTenant"/>
 /// filter disabled, because the deletion request is identified by user only — a single user
-/// can be linked to a host-scoped or tenant-scoped contact, and the privacy stack must
+/// can be linked to a host-scoped or tenant-scoped party, and the privacy stack must
 /// process either without leaking tenant context.
 /// </para>
 /// <para>
-/// Pseudonymisation is idempotent: if the contact has already been pseudonymised, the
+/// Pseudonymisation is idempotent: if the party has already been pseudonymised, the
 /// handler emits a <see cref="DeletionAction.Retained"/> audit record with zero affected
 /// records rather than re-publishing the domain event.
 /// </para>
@@ -36,7 +36,7 @@ public class PartiesPersonalDataDeletionHandler
 
     public static async Task HandleAsync(
         PersonalDataDeletionRequestedEto request,
-        IPartyReader contacts,
+        IPartyReader parties,
         IPartyWriter writer,
         IDataFilter dataFilter,
         IDistributedEventBus bus,
@@ -44,25 +44,25 @@ public class PartiesPersonalDataDeletionHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        Party? contact;
+        Party? party;
         using (dataFilter.Disable<IMultiTenant>())
         {
-            contact = await contacts.GetByUserIdAsync(request.UserId, cancellationToken)
+            party = await parties.GetByUserIdAsync(request.UserId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        if (contact is null)
+        if (party is null)
         {
             await bus.PublishAsync(new PersonalDataDeletedEto(
                 request.RequestId,
                 ProviderName,
                 DeletionAction.Retained,
                 AffectedRecords: 0,
-                Details: "no contact linked to user"), cancellationToken).ConfigureAwait(false);
+                Details: "no party linked to user"), cancellationToken).ConfigureAwait(false);
             return;
         }
 
-        bool changed = contact.PseudonymizePersonalData();
+        bool changed = party.PseudonymizePersonalData();
         if (!changed)
         {
             await bus.PublishAsync(new PersonalDataDeletedEto(
@@ -70,17 +70,17 @@ public class PartiesPersonalDataDeletionHandler
                 ProviderName,
                 DeletionAction.Retained,
                 AffectedRecords: 0,
-                Details: "contact already pseudonymised"), cancellationToken).ConfigureAwait(false);
+                Details: "party already pseudonymised"), cancellationToken).ConfigureAwait(false);
             return;
         }
 
-        await writer.UpdateAsync(contact, cancellationToken).ConfigureAwait(false);
+        await writer.UpdateAsync(party, cancellationToken).ConfigureAwait(false);
 
         await bus.PublishAsync(new PersonalDataDeletedEto(
             request.RequestId,
             ProviderName,
             DeletionAction.Anonymized,
             AffectedRecords: 1,
-            Details: $"contact {contact.Id} pseudonymised; row retained for accounting integrity"), cancellationToken).ConfigureAwait(false);
+            Details: $"party {party.Id} pseudonymised; row retained for accounting integrity"), cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Parties.Privacy/DataExport/PartiesPrivacyDataProvider.cs
+++ b/src/Granit.Parties.Privacy/DataExport/PartiesPrivacyDataProvider.cs
@@ -13,15 +13,15 @@ namespace Granit.Parties.Privacy.DataExport;
 /// </summary>
 /// <remarks>
 /// GDPR Article 15 requires the export to be complete regardless of the active tenant
-/// scope: a single user may be linked to a host-scoped or tenant-scoped contact and the
+/// scope: a single user may be linked to a host-scoped or tenant-scoped party and the
 /// privacy stack must locate either without leaking tenant context. The lookup therefore
 /// disables the <see cref="IMultiTenant"/> filter for the duration of the read, mirroring
-/// the deletion handler. Returns an empty buffer when no contact is linked to
+/// the deletion handler. Returns an empty buffer when no party is linked to
 /// <c>userId</c> — the privacy saga then records an <c>empty:</c> sentinel for this
 /// provider and skips blob upload.
 /// </remarks>
 public sealed class PartiesPrivacyDataProvider(
-    IPartyReader contacts,
+    IPartyReader parties,
     IDataFilter dataFilter) : IPrivacyDataProvider
 {
     /// <inheritdoc />
@@ -31,37 +31,37 @@ public sealed class PartiesPrivacyDataProvider(
     public static string ContentType => "application/json";
 
     /// <inheritdoc />
-    public static string FileName(Guid requestId) => "contacts.json";
+    public static string FileName(Guid requestId) => "parties.json";
 
     /// <inheritdoc />
     public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
     {
-        Party? contact;
+        Party? party;
         using (dataFilter.Disable<IMultiTenant>())
         {
-            contact = await contacts.GetByUserIdAsync(userId, cancellationToken).ConfigureAwait(false);
+            party = await parties.GetByUserIdAsync(userId, cancellationToken).ConfigureAwait(false);
         }
-        if (contact is null)
+        if (party is null)
         {
             return ReadOnlyMemory<byte>.Empty;
         }
 
-        ContactsExportDto dto = new(
-            PartyId: contact.Id,
-            TenantId: contact.TenantId,
-            Kind: contact.Kind.ToString(),
-            Name: contact.Name,
-            Website: contact.Website,
-            Language: contact.Language,
-            Timezone: contact.Timezone,
-            DefaultCurrency: contact.DefaultCurrency,
-            TaxId: contact.TaxId,
-            RegistrationNumber: contact.RegistrationNumber,
-            Roles: contact.Roles.ToString(),
-            Status: contact.Status.ToString(),
-            Emails: [.. contact.Emails.Select(e => new PartyEmailDto(e.Address, e.IsPrimary, e.Label))],
-            Phones: [.. contact.Phones.Select(p => new PartyPhoneDto(p.Kind.ToString(), p.Number, p.IsPrimary, p.Label))],
-            Addresses: [.. contact.Addresses.Select(a => new PartyAddressDto(
+        PartiesExportDto dto = new(
+            PartyId: party.Id,
+            TenantId: party.TenantId,
+            Kind: party.Kind.ToString(),
+            Name: party.Name,
+            Website: party.Website,
+            Language: party.Language,
+            Timezone: party.Timezone,
+            DefaultCurrency: party.DefaultCurrency,
+            TaxId: party.TaxId,
+            RegistrationNumber: party.RegistrationNumber,
+            Roles: party.Roles.ToString(),
+            Status: party.Status.ToString(),
+            Emails: [.. party.Emails.Select(e => new PartyEmailDto(e.Address, e.IsPrimary, e.Label))],
+            Phones: [.. party.Phones.Select(p => new PartyPhoneDto(p.Kind.ToString(), p.Number, p.IsPrimary, p.Label))],
+            Addresses: [.. party.Addresses.Select(a => new PartyAddressDto(
                 a.Kind.ToString(),
                 a.IsDefault,
                 a.Label,
@@ -72,7 +72,7 @@ public sealed class PartiesPrivacyDataProvider(
                 a.Value.PostalCode,
                 a.Value.Country,
                 a.Value.CompanyName))],
-            ExternalMappings: [.. contact.ExternalMappings.Select(m => new PartyExternalMappingDto(m.ProviderName, m.ExternalId))]);
+            ExternalMappings: [.. party.ExternalMappings.Select(m => new PartyExternalMappingDto(m.ProviderName, m.ExternalId))]);
 
         return JsonSerializer.SerializeToUtf8Bytes(dto, ExportJsonOptions);
     }
@@ -83,7 +83,7 @@ public sealed class PartiesPrivacyDataProvider(
     };
 }
 
-internal sealed record ContactsExportDto(
+internal sealed record PartiesExportDto(
     Guid PartyId,
     Guid? TenantId,
     string Kind,

--- a/src/Granit.Parties.Privacy/Extensions/PrivacyBuilderPartiesExtensions.cs
+++ b/src/Granit.Parties.Privacy/Extensions/PrivacyBuilderPartiesExtensions.cs
@@ -4,7 +4,7 @@ using Granit.Privacy;
 namespace Granit.Parties.Privacy.Extensions;
 
 /// <summary>
-/// <see cref="GranitPrivacyBuilder"/> extensions that register the contacts privacy provider.
+/// <see cref="GranitPrivacyBuilder"/> extensions that register the parties privacy provider.
 /// </summary>
 public static class PrivacyBuilderPartiesExtensions
 {

--- a/src/Granit.Parties.Privacy/GranitPartiesPrivacyModule.cs
+++ b/src/Granit.Parties.Privacy/GranitPartiesPrivacyModule.cs
@@ -8,8 +8,8 @@ namespace Granit.Parties.Privacy;
 
 /// <summary>
 /// Granit module that registers the <see cref="PartiesPrivacyDataProvider"/> so the
-/// contacts module participates in the privacy export scatter-gather saga, and wires
-/// the personal-data deletion handler that pseudonymises the user-linked contact on
+/// parties module participates in the privacy export scatter-gather saga, and wires
+/// the personal-data deletion handler that pseudonymises the user-linked party on
 /// Article 17 erasure.
 /// </summary>
 /// <remarks>

--- a/src/Granit.Parties.Privacy/README.md
+++ b/src/Granit.Parties.Privacy/README.md
@@ -25,7 +25,7 @@ dotnet add package Granit.Parties.Privacy
 ## Usage
 
 ```csharp
-services.AddGranitPrivacy(p => p.AddGranitContactsPrivacyProvider());
+services.AddGranitPrivacy(p => p.AddGranitPartiesPrivacyProvider());
 ```
 
 ## Documentation

--- a/src/Granit.Parties/Domain/Party.cs
+++ b/src/Granit.Parties/Domain/Party.cs
@@ -17,23 +17,23 @@ namespace Granit.Parties.Domain;
 /// <remarks>
 /// <para><b>Dual-use design.</b> Party is <see cref="IMultiTenant"/>:</para>
 /// <list type="bullet">
-/// <item><c>TenantId == null</c> ⇒ <i>host-scoped</i> (the SaaS host's contacts: tenants-as-customers, vendors, internal staff).</item>
-/// <item><c>TenantId == &lt;tenant&gt;</c> ⇒ <i>tenant-scoped</i> (a tenant's e-commerce / CRM / procurement contacts).</item>
+/// <item><c>TenantId == null</c> ⇒ <i>host-scoped</i> (the SaaS host's parties: tenants-as-customers, vendors, internal staff).</item>
+/// <item><c>TenantId == &lt;tenant&gt;</c> ⇒ <i>tenant-scoped</i> (a tenant's e-commerce / CRM / procurement parties).</item>
 /// </list>
-/// <para><b>Multi-role.</b> A single contact can simultaneously hold any combination of
+/// <para><b>Multi-role.</b> A single party can simultaneously hold any combination of
 /// <see cref="PartyRoles"/> flags (Customer + Supplier for a reseller you both buy from
 /// and sell to, Customer + Employee for staff who consume the product, etc.). Roles are
 /// queried via <see cref="HasRole"/> and added/removed individually.</para>
-/// <para><b>Hierarchy.</b> A contact may be attached to a parent via <see cref="ParentContactId"/>
+/// <para><b>Hierarchy.</b> A party may be attached to a parent via <see cref="ParentPartyId"/>
 /// — typical use cases: a Person belongs to a Company, a Department reports to a parent
 /// Company, a subsidiary is owned by a holding. Same-tenant invariant is enforced at attach
 /// time. Cycle detection is deferred to a later iteration.</para>
-/// <para><b>User linkage.</b> An Individual contact may be linked to an authenticated user
+/// <para><b>User linkage.</b> An Individual party may be linked to an authenticated user
 /// via <see cref="UserId"/> — used by self-service portals to surface "my profile". One user
-/// may link to at most one contact (uniqueness enforced by the EF configuration).</para>
+/// may link to at most one party (uniqueness enforced by the EF configuration).</para>
 /// <para><b>Lifecycle.</b> <see cref="PartyStatus.Active"/> ↔ <see cref="PartyStatus.Suspended"/>;
 /// either may transition to terminal <see cref="PartyStatus.Archived"/>. Archived
-/// contacts are immutable and cannot be reactivated.</para>
+/// parties are immutable and cannot be reactivated.</para>
 /// <para><b>External mappings.</b> Polyglot — at most one mapping per provider, enforced
 /// defensively at the aggregate and by a unique index in the EF configuration.</para>
 /// </remarks>
@@ -62,10 +62,10 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
 
     private Party() { }
 
-    /// <summary>Creates a new contact in <see cref="PartyStatus.Active"/> status.</summary>
+    /// <summary>Creates a new party in <see cref="PartyStatus.Active"/> status.</summary>
     /// <param name="id">Unique identifier.</param>
-    /// <param name="tenantId">Owning tenant identifier; <c>null</c> for host-scoped contacts.</param>
-    /// <param name="kind">Whether the contact is an individual, a company, or a department.</param>
+    /// <param name="tenantId">Owning tenant identifier; <c>null</c> for host-scoped parties.</param>
+    /// <param name="kind">Whether the party is an individual, a company, or a department.</param>
     /// <param name="name">Display / legal name (required, max 256 chars).</param>
     /// <param name="defaultCurrency">ISO 4217 alpha-3 currency code (required, exactly 3 chars).</param>
     /// <param name="roles">Initial role set (defaults to <see cref="PartyRoles.Customer"/>).</param>
@@ -103,7 +103,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
                 nameof(internalNotes));
         }
 
-        var contact = new Party
+        var party = new Party
         {
             Id = id,
             TenantId = tenantId,
@@ -120,31 +120,31 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
             Status = PartyStatus.Active,
         };
 
-        contact.AddDomainEvent(new PartyCreatedEvent(
+        party.AddDomainEvent(new PartyCreatedEvent(
             PartyId.Create(id), tenantId, kind, name, roles));
-        contact.AddDistributedEvent(new PartyCreatedEto(
-            PartyId.Create(id), tenantId, kind, name, roles, contact.DefaultCurrency));
+        party.AddDistributedEvent(new PartyCreatedEto(
+            PartyId.Create(id), tenantId, kind, name, roles, party.DefaultCurrency));
 
-        return contact;
+        return party;
     }
 
     // ── Identity ───────────────────────────────────────────────────
 
-    /// <summary>Whether the contact is an individual, a company, or a department.</summary>
+    /// <summary>Whether the party is an individual, a company, or a department.</summary>
     public PartyKind Kind { get; private set; }
 
     /// <summary>Display / legal name.</summary>
     [SensitiveData(Level = Sensitivity.Internal)]
     public string Name { get; private set; } = string.Empty;
 
-    /// <summary>Email addresses attached to this contact (multi). Mutated via <see cref="AddEmail"/>, <see cref="RemoveEmail"/>, <see cref="UpdateEmail"/>, <see cref="SetPrimaryEmail"/>.</summary>
+    /// <summary>Email addresses attached to this party (multi). Mutated via <see cref="AddEmail"/>, <see cref="RemoveEmail"/>, <see cref="UpdateEmail"/>, <see cref="SetPrimaryEmail"/>.</summary>
     public IReadOnlyList<PartyEmail> Emails => _emails.AsReadOnly();
 
     /// <summary>Primary email if any (the entry flagged <see cref="PartyEmail.IsPrimary"/>, falling back to the first).</summary>
     public PartyEmail? PrimaryEmail =>
         _emails.FirstOrDefault(e => e.IsPrimary) ?? _emails.FirstOrDefault();
 
-    /// <summary>Phone numbers attached to this contact (multi, typed). Mutated via <see cref="AddPhone"/>, <see cref="RemovePhone"/>, <see cref="UpdatePhone"/>, <see cref="SetPrimaryPhone"/>.</summary>
+    /// <summary>Phone numbers attached to this party (multi, typed). Mutated via <see cref="AddPhone"/>, <see cref="RemovePhone"/>, <see cref="UpdatePhone"/>, <see cref="SetPrimaryPhone"/>.</summary>
     public IReadOnlyList<PartyPhone> Phones => _phones.AsReadOnly();
 
     /// <summary>Primary phone if any.</summary>
@@ -163,7 +163,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     /// <summary>ISO 4217 alpha-3 currency code (always upper-case after construction).</summary>
     public string DefaultCurrency { get; private set; } = string.Empty;
 
-    // ── Tax & legal identity (contact-level, not address-level) ───
+    // ── Tax & legal identity (party-level, not address-level) ───
 
     /// <summary>International VAT identifier (e.g. <c>"BE0123456789"</c>, <c>"FR12345678901"</c>).</summary>
     [SensitiveData(Level = Sensitivity.Internal)]
@@ -176,7 +176,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     /// <summary>
     /// Customer-specific tax classification (reverse-charge, exempt, VATIN). Defaults to
     /// <see cref="TaxStatus.Standard"/>. Read by <c>Granit.Tax</c>'s <c>ITaxRateProvider</c>
-    /// when a contact is in scope so exempt / reverse-charge customers yield a 0% rate.
+    /// when a party is in scope so exempt / reverse-charge customers yield a 0% rate.
     /// Admins opt-in via <see cref="SetTaxStatus"/>.
     /// </summary>
     public TaxStatus TaxStatus { get; private set; } = TaxStatus.Standard;
@@ -344,7 +344,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     /// <c>MergeFieldChoices.Choices</c> but with defaults filled in.</param>
     /// <param name="rewriteCounts">Counts reported by every <c>IReferenceRewriter&lt;Party&gt;</c>.</param>
     /// <param name="reparentedChildrenCount">Number of child parties whose
-    /// <c>ParentContactId</c> was redirected to this survivor.</param>
+    /// <c>ParentPartyId</c> was redirected to this survivor.</param>
     internal void RaiseMergedEvents(
         PartyId loserId,
         DateTimeOffset mergedAt,
@@ -412,10 +412,10 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         AddIfDifferent(conflicts, "RegistrationNumber", RegistrationNumber, loser.RegistrationNumber);
         AddIfDifferent(conflicts, "AvatarBlobId", AvatarBlobId, loser.AvatarBlobId);
 
-        // ParentContactId — compare the unwrapped Guid? to keep the FieldConflict payload
+        // ParentPartyId — compare the unwrapped Guid? to keep the FieldConflict payload
         // primitive and JSON-friendly (the audit cache stores it).
-        AddIfDifferent(conflicts, "ParentContactId",
-            ParentContactId?.Value, loser.ParentContactId?.Value);
+        AddIfDifferent(conflicts, "ParentPartyId",
+            ParentPartyId?.Value, loser.ParentPartyId?.Value);
 
         // TaxStatus — recommend the non-Standard side when one is Standard ; otherwise
         // SurvivorWins is the safe default and the admin can override at the endpoint.
@@ -499,8 +499,8 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         RegistrationNumber = ResolveScalar(choices, "RegistrationNumber", RegistrationNumber, loser.RegistrationNumber);
         AvatarBlobId = ResolveScalar(choices, "AvatarBlobId", AvatarBlobId, loser.AvatarBlobId);
 
-        // ParentContactId — round-trip via PartyId.
-        ParentContactId = ResolveParentContactId(choices, ParentContactId, loser.ParentContactId);
+        // ParentPartyId — round-trip via PartyId.
+        ParentPartyId = ResolveParentPartyId(choices, ParentPartyId, loser.ParentPartyId);
 
         // Roles — always union ; never overridable (losing a flag is destructive).
         Roles |= loser.Roles;
@@ -552,9 +552,9 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
             ? loser
             : survivor;
 
-    private static PartyId? ResolveParentContactId(
+    private static PartyId? ResolveParentPartyId(
         MergeFieldChoices choices, PartyId? survivor, PartyId? loser) =>
-        choices.ResolveOrDefault("ParentContactId", WinnerSide.Survivor) == WinnerSide.Loser
+        choices.ResolveOrDefault("ParentPartyId", WinnerSide.Survivor) == WinnerSide.Loser
             ? loser
             : survivor;
 
@@ -608,7 +608,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // ── Addresses ─────────────────────────────────────────────────
 
     /// <summary>
-    /// All postal addresses attached to this contact. A contact may carry several
+    /// All postal addresses attached to this party. A party may carry several
     /// (billing, shipping, other) — at most one default per <see cref="AddressKind"/>.
     /// Mutated via <see cref="AddAddress"/>, <see cref="RemoveAddress"/>,
     /// <see cref="SetDefaultAddress"/>, <see cref="UpdateAddress"/>.
@@ -628,7 +628,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // ── Avatar ────────────────────────────────────────────────────
 
     /// <summary>
-    /// Soft reference to a blob in <c>Granit.BlobStorage</c> holding the contact's
+    /// Soft reference to a blob in <c>Granit.BlobStorage</c> holding the party's
     /// avatar — photo for an Individual, logo for a Company. <c>null</c> = no avatar.
     /// Set/clear via <see cref="SetAvatar"/> / <see cref="ClearAvatar"/>.
     /// </summary>
@@ -636,21 +636,21 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
 
     // ── Hierarchy ─────────────────────────────────────────────────
 
-    /// <summary>Parent contact identifier (Person→Company, subsidiary→holding, …). Same-tenant only.</summary>
-    public PartyId? ParentContactId { get; private set; }
+    /// <summary>Parent party identifier (Person→Company, subsidiary→holding, …). Same-tenant only.</summary>
+    public PartyId? ParentPartyId { get; private set; }
 
     // ── User linkage ──────────────────────────────────────────────
 
     /// <summary>
-    /// Authenticated user identifier this contact represents. Only meaningful for
-    /// <see cref="PartyKind.Individual"/>. One user → at most one contact (enforced by
+    /// Authenticated user identifier this party represents. Only meaningful for
+    /// <see cref="PartyKind.Individual"/>. One user → at most one party (enforced by
     /// a partial unique index in the EF configuration).
     /// </summary>
     public Guid? UserId { get; private set; }
 
     // ── Roles ─────────────────────────────────────────────────────
 
-    /// <summary>Set of roles this contact plays (<see cref="PartyRoles"/> flags).</summary>
+    /// <summary>Set of roles this party plays (<see cref="PartyRoles"/> flags).</summary>
     public PartyRoles Roles { get; private set; }
 
     // ── Lifecycle ─────────────────────────────────────────────────
@@ -676,7 +676,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // Lifecycle (idempotent transitions)
     // ─────────────────────────────────────────────────────────────────
 
-    /// <summary>Reactivates a suspended contact. Idempotent; throws on Archived.</summary>
+    /// <summary>Reactivates a suspended party. Idempotent; throws on Archived.</summary>
     public bool Activate()
     {
         if (Status == PartyStatus.Active) { return false; }
@@ -688,7 +688,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         return true;
     }
 
-    /// <summary>Suspends an active contact. Idempotent; throws on Archived.</summary>
+    /// <summary>Suspends an active party. Idempotent; throws on Archived.</summary>
     public bool Suspend(string? reason = null)
     {
         if (Status == PartyStatus.Suspended) { return false; }
@@ -700,7 +700,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         return true;
     }
 
-    /// <summary>Archives the contact (terminal state). Idempotent.</summary>
+    /// <summary>Archives the party (terminal state). Idempotent.</summary>
     public bool Archive()
     {
         if (Status == PartyStatus.Archived) { return false; }
@@ -712,12 +712,12 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     }
 
     /// <summary>
-    /// Pseudonymises every PII field on the contact while preserving the row for accounting
+    /// Pseudonymises every PII field on the party while preserving the row for accounting
     /// integrity (ISO 27001 / legal retention). Replaces <see cref="Name"/> with the supplied
     /// placeholder, clears all <see cref="Emails"/>, <see cref="Phones"/>, <see cref="Addresses"/>,
     /// and unlinks the user. Tax and registration identifiers and external mappings are kept
     /// because downstream finance systems still reference them. Bypasses the standard mutability
-    /// guard — GDPR Article 17 erasure must succeed even on an Archived contact.
+    /// guard — GDPR Article 17 erasure must succeed even on an Archived party.
     /// </summary>
     /// <returns><c>true</c> if any PII was actually cleared; <c>false</c> when nothing remained
     /// to pseudonymise (idempotent re-run).</returns>
@@ -750,7 +750,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Updates the contact's identity fields (name, website, locale, timezone). Emails
+    /// Updates the party's identity fields (name, website, locale, timezone). Emails
     /// and phones live in their own collections — see <see cref="AddEmail"/>,
     /// <see cref="UpdateEmail"/>, <see cref="AddPhone"/>, <see cref="UpdatePhone"/>.
     /// </summary>
@@ -780,9 +780,9 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     }
 
     /// <summary>
-    /// Returns the canonical billing-address snapshot for this contact: combines the default
+    /// Returns the canonical billing-address snapshot for this party: combines the default
     /// <see cref="AddressKind.Billing"/> entry from <see cref="Addresses"/> with the
-    /// contact-level <see cref="TaxId"/> (VAT) and falls back to <see cref="Name"/> as the
+    /// party-level <see cref="TaxId"/> (VAT) and falls back to <see cref="Name"/> as the
     /// company name when the address has none. <c>null</c> when no default billing address
     /// is registered. Used by <c>Granit.Invoicing.Domain.Invoice.Finalize</c> to capture the
     /// legal address shown on the issued document.
@@ -1094,38 +1094,38 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // Hierarchy
     // ─────────────────────────────────────────────────────────────────
 
-    /// <summary>Attaches this contact to a parent contact.</summary>
-    /// <param name="parentContactId">The parent contact's identifier.</param>
-    /// <param name="parentTenantId">The parent contact's <see cref="IMultiTenant.TenantId"/> for same-scope validation.</param>
-    public void AttachToParent(PartyId parentContactId, Guid? parentTenantId)
+    /// <summary>Attaches this party to a parent party.</summary>
+    /// <param name="parentPartyId">The parent party's identifier.</param>
+    /// <param name="parentTenantId">The parent party's <see cref="IMultiTenant.TenantId"/> for same-scope validation.</param>
+    public void AttachToParent(PartyId parentPartyId, Guid? parentTenantId)
     {
         EnsureMutable();
-        ArgumentNullException.ThrowIfNull(parentContactId);
+        ArgumentNullException.ThrowIfNull(parentPartyId);
 
-        if (parentContactId.Value == Id)
+        if (parentPartyId.Value == Id)
         {
-            throw new InvalidOperationException("A contact cannot be its own parent.");
+            throw new InvalidOperationException("A party cannot be its own parent.");
         }
 
         if (parentTenantId != TenantId)
         {
             throw new InvalidOperationException(
-                "Parent contact must live in the same tenant scope (host or specific tenant).");
+                "Parent party must live in the same tenant scope (host or specific tenant).");
         }
 
-        ParentContactId = parentContactId;
+        ParentPartyId = parentPartyId;
         AddDomainEvent(new PartyAttachedToParentEvent(
-            PartyId.Create(Id), TenantId, parentContactId));
+            PartyId.Create(Id), TenantId, parentPartyId));
     }
 
-    /// <summary>Detaches this contact from its parent. Idempotent.</summary>
+    /// <summary>Detaches this party from its parent. Idempotent.</summary>
     public bool DetachFromParent()
     {
         EnsureMutable();
-        if (ParentContactId is null) { return false; }
+        if (ParentPartyId is null) { return false; }
 
-        PartyId former = ParentContactId;
-        ParentContactId = null;
+        PartyId former = ParentPartyId;
+        ParentPartyId = null;
         AddDomainEvent(new PartyDetachedFromParentEvent(
             PartyId.Create(Id), TenantId, former));
         return true;
@@ -1136,8 +1136,8 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Links this contact to an authenticated user. Only valid for
-    /// <see cref="PartyKind.Individual"/> contacts.
+    /// Links this party to an authenticated user. Only valid for
+    /// <see cref="PartyKind.Individual"/> parties.
     /// </summary>
     public void LinkToUser(Guid userId)
     {
@@ -1149,7 +1149,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         if (Kind != PartyKind.Individual)
         {
             throw new InvalidOperationException(
-                $"Only Individual contacts can be linked to a user (this contact is {Kind}).");
+                $"Only Individual parties can be linked to a user (this party is {Kind}).");
         }
 
         UserId = userId;
@@ -1231,7 +1231,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // External mappings
     // ─────────────────────────────────────────────────────────────────
 
-    /// <summary>Registers an external provider identifier against this contact.</summary>
+    /// <summary>Registers an external provider identifier against this party.</summary>
     /// <exception cref="InvalidOperationException">A mapping for <paramref name="providerName"/> already exists.</exception>
     public void AddExternalMapping(Guid mappingId, string providerName, string externalId)
     {
@@ -1286,7 +1286,7 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
         if (Status == PartyStatus.Archived)
         {
             throw new InvalidOperationException(
-                $"Party '{Id}' is Archived. Archived contacts are immutable.");
+                $"Party '{Id}' is Archived. Archived parties are immutable.");
         }
     }
 

--- a/src/Granit.Parties/Domain/PartyAddress.cs
+++ b/src/Granit.Parties/Domain/PartyAddress.cs
@@ -3,7 +3,7 @@ using Granit.Domain;
 namespace Granit.Parties.Domain;
 
 /// <summary>
-/// A typed address attached to a <see cref="Party"/>. A contact may carry several
+/// A typed address attached to a <see cref="Party"/>. A party may carry several
 /// addresses simultaneously (one for billing, one for shipping, others for HQ /
 /// returns / branches). Exactly zero or one <see cref="IsDefault"/> entry per
 /// <see cref="AddressKind"/> is enforced by the aggregate.
@@ -12,7 +12,7 @@ public sealed class PartyAddress : Entity
 {
     private PartyAddress() { }
 
-    /// <summary>Creates a new contact address.</summary>
+    /// <summary>Creates a new party address.</summary>
     public static PartyAddress Create(
         Guid id,
         AddressKind kind,

--- a/src/Granit.Parties/Domain/PartyEmail.cs
+++ b/src/Granit.Parties/Domain/PartyEmail.cs
@@ -4,7 +4,7 @@ using Granit.Domain;
 namespace Granit.Parties.Domain;
 
 /// <summary>
-/// An email address attached to a <see cref="Party"/>. A contact may carry several
+/// An email address attached to a <see cref="Party"/>. A party may carry several
 /// emails simultaneously (personal + billing + support + …). Exactly zero or one
 /// <see cref="IsPrimary"/> entry is enforced by the aggregate.
 /// </summary>
@@ -12,7 +12,7 @@ public sealed class PartyEmail : Entity
 {
     private PartyEmail() { }
 
-    /// <summary>Creates a new contact email.</summary>
+    /// <summary>Creates a new party email.</summary>
     public static PartyEmail Create(
         Guid id,
         string address,
@@ -42,7 +42,7 @@ public sealed class PartyEmail : Entity
     [SensitiveData(Level = Sensitivity.Confidential)]
     public string? CanonicalEmail { get; private set; }
 
-    /// <summary>Whether this is the contact's primary email.</summary>
+    /// <summary>Whether this is the party's primary email.</summary>
     public bool IsPrimary { get; private set; }
 
     /// <summary>Optional user-supplied label (<c>"personal"</c>, <c>"billing"</c>, <c>"support"</c>, …).</summary>

--- a/src/Granit.Parties/Domain/PartyPhone.cs
+++ b/src/Granit.Parties/Domain/PartyPhone.cs
@@ -4,7 +4,7 @@ using Granit.Domain;
 namespace Granit.Parties.Domain;
 
 /// <summary>
-/// A phone number attached to a <see cref="Party"/>. A contact may carry several phone
+/// A phone number attached to a <see cref="Party"/>. A party may carry several phone
 /// numbers (mobile + office + home + other). Exactly zero or one <see cref="IsPrimary"/>
 /// entry is enforced by the aggregate.
 /// </summary>
@@ -12,7 +12,7 @@ public sealed class PartyPhone : Entity
 {
     private PartyPhone() { }
 
-    /// <summary>Creates a new contact phone number.</summary>
+    /// <summary>Creates a new party phone number.</summary>
     public static PartyPhone Create(
         Guid id,
         PhoneKind kind,
@@ -47,7 +47,7 @@ public sealed class PartyPhone : Entity
     [SensitiveData(Level = Sensitivity.Confidential)]
     public string? CanonicalNumber { get; private set; }
 
-    /// <summary>Whether this is the contact's primary phone.</summary>
+    /// <summary>Whether this is the party's primary phone.</summary>
     public bool IsPrimary { get; private set; }
 
     /// <summary>Optional user-supplied label.</summary>

--- a/src/Granit.Parties/Events/PartyActivatedEvent.cs
+++ b/src/Granit.Parties/Events/PartyActivatedEvent.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact transitions from <c>Suspended</c> to <c>Active</c>.</summary>
+/// <summary>Domain event raised when a party transitions from <c>Suspended</c> to <c>Active</c>.</summary>
 public sealed record PartyActivatedEvent(PartyId PartyId, Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Parties/Events/PartyArchivedEvent.cs
+++ b/src/Granit.Parties/Events/PartyArchivedEvent.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact is archived (terminal state).</summary>
+/// <summary>Domain event raised when a party is archived (terminal state).</summary>
 public sealed record PartyArchivedEvent(PartyId PartyId, Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Parties/Events/PartyAttachedToParentEvent.cs
+++ b/src/Granit.Parties/Events/PartyAttachedToParentEvent.cs
@@ -3,8 +3,8 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact is attached to a parent contact.</summary>
+/// <summary>Domain event raised when a party is attached to a parent party.</summary>
 public sealed record PartyAttachedToParentEvent(
     PartyId PartyId,
     Guid? TenantId,
-    PartyId ParentContactId) : IDomainEvent;
+    PartyId ParentPartyId) : IDomainEvent;

--- a/src/Granit.Parties/Events/PartyChildrenReparentedEvent.cs
+++ b/src/Granit.Parties/Events/PartyChildrenReparentedEvent.cs
@@ -4,7 +4,7 @@ using Granit.Parties.Domain.ValueObjects;
 namespace Granit.Parties.Events;
 
 /// <summary>
-/// Domain event raised when child parties (<c>ParentContactId == loser.Id</c>) are
+/// Domain event raised when child parties (<c>ParentPartyId == loser.Id</c>) are
 /// re-parented onto the survivor as part of a merge. Emitted by the merge orchestrator
 /// after the SQL bulk-update completes. The count is reported separately from
 /// <see cref="PartyMergedEvent.RewriteCounts"/> because re-parenting is a Parties-internal

--- a/src/Granit.Parties/Events/PartyDetachedFromParentEvent.cs
+++ b/src/Granit.Parties/Events/PartyDetachedFromParentEvent.cs
@@ -3,8 +3,8 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact is detached from its parent.</summary>
+/// <summary>Domain event raised when a party is detached from its parent.</summary>
 public sealed record PartyDetachedFromParentEvent(
     PartyId PartyId,
     Guid? TenantId,
-    PartyId FormerParentContactId) : IDomainEvent;
+    PartyId FormerParentPartyId) : IDomainEvent;

--- a/src/Granit.Parties/Events/PartyExternalMappingAddedEvent.cs
+++ b/src/Granit.Parties/Events/PartyExternalMappingAddedEvent.cs
@@ -3,7 +3,7 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when an external provider identifier is registered against a contact.</summary>
+/// <summary>Domain event raised when an external provider identifier is registered against a party.</summary>
 public sealed record PartyExternalMappingAddedEvent(
     PartyId PartyId,
     Guid? TenantId,

--- a/src/Granit.Parties/Events/PartyLinkedToUserEvent.cs
+++ b/src/Granit.Parties/Events/PartyLinkedToUserEvent.cs
@@ -3,7 +3,7 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when an Individual contact is linked to an authenticated user.</summary>
+/// <summary>Domain event raised when an Individual party is linked to an authenticated user.</summary>
 public sealed record PartyLinkedToUserEvent(
     PartyId PartyId,
     Guid? TenantId,

--- a/src/Granit.Parties/Events/PartyPersonalDataPseudonymizedEvent.cs
+++ b/src/Granit.Parties/Events/PartyPersonalDataPseudonymizedEvent.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact's PII is pseudonymised under a GDPR Article 17 erasure request.</summary>
+/// <summary>Domain event raised when a party's PII is pseudonymised under a GDPR Article 17 erasure request.</summary>
 public sealed record PartyPersonalDataPseudonymizedEvent(PartyId PartyId, Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Parties/Events/PartyRoleAddedEvent.cs
+++ b/src/Granit.Parties/Events/PartyRoleAddedEvent.cs
@@ -4,7 +4,7 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a role flag is added to a contact.</summary>
+/// <summary>Domain event raised when a role flag is added to a party.</summary>
 public sealed record PartyRoleAddedEvent(
     PartyId PartyId,
     Guid? TenantId,

--- a/src/Granit.Parties/Events/PartyRoleRemovedEvent.cs
+++ b/src/Granit.Parties/Events/PartyRoleRemovedEvent.cs
@@ -4,7 +4,7 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a role flag is removed from a contact.</summary>
+/// <summary>Domain event raised when a role flag is removed from a party.</summary>
 public sealed record PartyRoleRemovedEvent(
     PartyId PartyId,
     Guid? TenantId,

--- a/src/Granit.Parties/Events/PartySuspendedEvent.cs
+++ b/src/Granit.Parties/Events/PartySuspendedEvent.cs
@@ -3,9 +3,9 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact is suspended.</summary>
+/// <summary>Domain event raised when a party is suspended.</summary>
 /// <param name="PartyId">Party identifier.</param>
-/// <param name="TenantId">Owning tenant id, or <c>null</c> for host-scoped contacts.</param>
+/// <param name="TenantId">Owning tenant id, or <c>null</c> for host-scoped parties.</param>
 /// <param name="Reason">Optional free-text justification.</param>
 public sealed record PartySuspendedEvent(
     PartyId PartyId,

--- a/src/Granit.Parties/Events/PartyUpdatedEvent.cs
+++ b/src/Granit.Parties/Events/PartyUpdatedEvent.cs
@@ -3,5 +3,5 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Parties.Events;
 
-/// <summary>Domain event raised when a contact's identity / address / tax-identity / parent / roles are updated.</summary>
+/// <summary>Domain event raised when a party's identity / address / tax-identity / parent / roles are updated.</summary>
 public sealed record PartyUpdatedEvent(PartyId PartyId, Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Parties/Exports/PartyExportDefinition.cs
+++ b/src/Granit.Parties/Exports/PartyExportDefinition.cs
@@ -3,7 +3,7 @@ using Granit.Parties.Domain;
 
 namespace Granit.Parties.Exports;
 
-/// <summary>CSV / XLSX export whitelist for contacts.</summary>
+/// <summary>CSV / XLSX export whitelist for parties.</summary>
 public sealed class PartyExportDefinition : ExportDefinition<Party>
 {
     /// <inheritdoc/>

--- a/src/Granit.Parties/IDefaultPartyResolver.cs
+++ b/src/Granit.Parties/IDefaultPartyResolver.cs
@@ -9,14 +9,14 @@ namespace Granit.Parties;
 /// <remarks>
 /// <para>
 /// The link is the reverse mapping <c>ExternalMappings[ProviderName == "tenant"].ExternalId == tenantId</c>
-/// (constant <see cref="PartyExternalProviderNames.Tenant"/>). A host-scoped contact
+/// (constant <see cref="PartyExternalProviderNames.Tenant"/>). A host-scoped party
 /// gets this mapping at tenant-provisioning time so downstream modules (Invoicing,
 /// Subscriptions, Payments, Tax, CustomerBalance) can migrate from tenant-keyed
 /// billing references to <c>PartyId</c> without losing the tenant association.
 /// </para>
 /// <para>
 /// This resolver is the single seam used by Features 2–5 to bridge the legacy
-/// <c>tenantId</c> column to the new <c>contactId</c> FK during migration and at runtime.
+/// <c>tenantId</c> column to the new <c>partyId</c> FK during migration and at runtime.
 /// Centralising the lookup here means the convention (host-scoped + reserved provider
 /// name) lives in exactly one place.
 /// </para>
@@ -24,7 +24,7 @@ namespace Granit.Parties;
 public interface IDefaultPartyResolver
 {
     /// <summary>
-    /// Returns the host-scoped contact representing <paramref name="tenantId"/>, or
+    /// Returns the host-scoped party representing <paramref name="tenantId"/>, or
     /// <c>null</c> when no such mapping exists yet. Always queries with the multi-tenant
     /// filter disabled so the lookup succeeds regardless of the active scope.
     /// </summary>

--- a/src/Granit.Parties/IDefaultPartySeeder.cs
+++ b/src/Granit.Parties/IDefaultPartySeeder.cs
@@ -5,7 +5,7 @@ namespace Granit.Parties;
 /// <summary>
 /// Seeds a host-scoped <see cref="Party"/> that represents a tenant in the SaaS host's
 /// billing relationship. Mirrors <see cref="IDefaultPartyResolver"/>: the resolver reads
-/// the tenant ↔ contact link, the seeder creates it.
+/// the tenant ↔ party link, the seeder creates it.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -17,7 +17,7 @@ namespace Granit.Parties;
 /// </para>
 /// <para>
 /// Idempotent: calling <see cref="SeedForTenantAsync"/> a second time for the same
-/// <paramref name="tenantId"/> returns the existing contact instead of creating a
+/// <paramref name="tenantId"/> returns the existing party instead of creating a
 /// duplicate. Wolverine's at-least-once delivery is therefore safe.
 /// </para>
 /// </remarks>
@@ -29,7 +29,7 @@ public interface IDefaultPartySeeder
     /// <see cref="PartyExternalProviderNames.Tenant"/> external mapping when none exists.
     /// </summary>
     /// <param name="tenantId">Identifier of the tenant being provisioned.</param>
-    /// <param name="tenantName">Display name for the new contact (typically the tenant's name).</param>
+    /// <param name="tenantName">Display name for the new party (typically the tenant's name).</param>
     /// <param name="defaultCurrency">ISO 4217 currency code. Defaults to <c>"EUR"</c>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<Party> SeedForTenantAsync(

--- a/src/Granit.Parties/IPartyReader.cs
+++ b/src/Granit.Parties/IPartyReader.cs
@@ -6,25 +6,25 @@ namespace Granit.Parties;
 /// <summary>Reader-side abstraction for the <see cref="Party"/> aggregate (CQRS read).</summary>
 /// <remarks>
 /// All lookups honour the active tenant scope via the multi-tenant query filter — host-scoped
-/// contacts are visible only when no tenant context is active (or when the filter is bypassed
+/// parties are visible only when no tenant context is active (or when the filter is bypassed
 /// via <c>IDataFilter.Disable&lt;IMultiTenant&gt;()</c>).
 /// </remarks>
 public interface IPartyReader
 {
-    /// <summary>Returns the contact with the given identifier, or <c>null</c>.</summary>
+    /// <summary>Returns the party with the given identifier, or <c>null</c>.</summary>
     Task<Party?> GetByIdAsync(PartyId id, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns the contact carrying the given external mapping, or <c>null</c>.</summary>
+    /// <summary>Returns the party carrying the given external mapping, or <c>null</c>.</summary>
     Task<Party?> GetByExternalIdAsync(
         string providerName, string externalId, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns the contact linked to the given authenticated user, or <c>null</c>.</summary>
+    /// <summary>Returns the party linked to the given authenticated user, or <c>null</c>.</summary>
     Task<Party?> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all contacts in the active scope.</summary>
+    /// <summary>Returns all parties in the active scope.</summary>
     Task<IReadOnlyList<Party>> ListAsync(CancellationToken cancellationToken = default);
 
-    /// <summary>Returns contacts whose role set includes any of the given role flags.</summary>
+    /// <summary>Returns parties whose role set includes any of the given role flags.</summary>
     Task<IReadOnlyList<Party>> ListByRoleAsync(
         PartyRoles role, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Parties/IPartyWriter.cs
+++ b/src/Granit.Parties/IPartyWriter.cs
@@ -5,9 +5,9 @@ namespace Granit.Parties;
 /// <summary>Writer-side abstraction for the <see cref="Party"/> aggregate (CQRS write).</summary>
 public interface IPartyWriter
 {
-    /// <summary>Persists a new contact.</summary>
-    Task AddAsync(Party contact, CancellationToken cancellationToken = default);
+    /// <summary>Persists a new party.</summary>
+    Task AddAsync(Party party, CancellationToken cancellationToken = default);
 
-    /// <summary>Persists changes to an existing contact.</summary>
-    Task UpdateAsync(Party contact, CancellationToken cancellationToken = default);
+    /// <summary>Persists changes to an existing party.</summary>
+    Task UpdateAsync(Party party, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Parties/Queries/PartyQueryDefinition.cs
+++ b/src/Granit.Parties/Queries/PartyQueryDefinition.cs
@@ -4,7 +4,7 @@ using Granit.QueryEngine;
 namespace Granit.Parties.Queries;
 
 /// <summary>
-/// Query definition for the contacts admin grid — declares columns, filters, sorting,
+/// Query definition for the parties admin grid — declares columns, filters, sorting,
 /// search, and pagination metadata for the query engine.
 /// </summary>
 public sealed class PartyQueryDefinition : QueryDefinition<Party>

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
@@ -141,7 +141,7 @@ internal static class PaymentMethodEndpoints
         [FromServices] IEnumerable<IPaymentMethodManager> managers,
         [FromServices] IPaymentMethodWriter writer,
         [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IDefaultPartyResolver contactResolver,
+        [FromServices] IDefaultPartyResolver partyResolver,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -155,24 +155,24 @@ internal static class PaymentMethodEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        // Resolve the host-scoped contact representing this tenant. Future iterations may
-        // accept an explicit PartyId in the request DTO when a tenant has multiple contacts.
-        Party? contact = tenantId == Guid.Empty
+        // Resolve the host-scoped party representing this tenant. Future iterations may
+        // accept an explicit PartyId in the request DTO when a tenant has multiple parties.
+        Party? party = tenantId == Guid.Empty
             ? null
-            : await contactResolver
+            : await partyResolver
                 .GetDefaultForTenantAsync(tenantId, cancellationToken)
                 .ConfigureAwait(false);
 
-        if (contact is null)
+        if (party is null)
         {
             return TypedResults.Problem(
-                detail: "No default contact resolved for the active tenant. Provision the host-scoped Party representing this tenant before attaching a payment method (see Granit.Parties.MultiTenancy).",
+                detail: "No default party resolved for the active tenant. Provision the host-scoped Party representing this tenant before attaching a payment method (see Granit.Parties.MultiTenancy).",
                 statusCode: StatusCodes.Status409Conflict);
         }
 
         PaymentProviderMethod providerMethod = await manager
             .AttachAsync(
-                new ContractAttachRequest(contact.Id, request.Type, request.Token),
+                new ContractAttachRequest(party.Id, request.Type, request.Token),
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Granit.Payments.Mollie/Internal/MolliePaymentMethodManager.cs
+++ b/src/Granit.Payments.Mollie/Internal/MolliePaymentMethodManager.cs
@@ -17,7 +17,7 @@ internal sealed class MolliePaymentMethodManager : IPaymentMethodManager
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<PaymentProviderMethod>> ListAsync(
-        Guid contactId, CancellationToken cancellationToken = default) =>
+        Guid partyId, CancellationToken cancellationToken = default) =>
         Task.FromResult<IReadOnlyList<PaymentProviderMethod>>([]);
 
     /// <inheritdoc/>

--- a/src/Granit.Payments.Stripe/Internal/StripePaymentMethodManager.cs
+++ b/src/Granit.Payments.Stripe/Internal/StripePaymentMethodManager.cs
@@ -18,8 +18,8 @@ namespace Granit.Payments.Stripe.Internal;
 /// </summary>
 internal sealed partial class StripePaymentMethodManager(
     IStripeClient stripeClient,
-    IPartyReader contactReader,
-    IPartyWriter contactWriter,
+    IPartyReader partyReader,
+    IPartyWriter partyWriter,
     IDataFilter dataFilter,
     IGuidGenerator guidGenerator,
     ILogger<StripePaymentMethodManager> logger) : IPaymentMethodManager
@@ -31,10 +31,10 @@ internal sealed partial class StripePaymentMethodManager(
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<PaymentProviderMethod>> ListAsync(
-        Guid contactId, CancellationToken cancellationToken = default)
+        Guid partyId, CancellationToken cancellationToken = default)
     {
-        Party? contact = await ResolveContactAsync(contactId, cancellationToken).ConfigureAwait(false);
-        string? stripeCustomerId = contact?.FindExternalId(Provider);
+        Party? party = await ResolvePartyAsync(partyId, cancellationToken).ConfigureAwait(false);
+        string? stripeCustomerId = party?.FindExternalId(Provider);
 
         if (stripeCustomerId is null)
         {
@@ -92,13 +92,13 @@ internal sealed partial class StripePaymentMethodManager(
     }
 
     private async Task<string> GetOrCreateStripeCustomerAsync(
-        Guid contactId, CancellationToken cancellationToken)
+        Guid partyId, CancellationToken cancellationToken)
     {
-        Party contact = await ResolveContactAsync(contactId, cancellationToken).ConfigureAwait(false)
+        Party party = await ResolvePartyAsync(partyId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException(
-                $"Party '{contactId}' not found — cannot attach a Stripe payment method to a non-existent contact.");
+                $"Party '{partyId}' not found — cannot attach a Stripe payment method to a non-existent party.");
 
-        string? existing = contact.FindExternalId(Provider);
+        string? existing = party.FindExternalId(Provider);
         if (existing is not null)
         {
             return existing;
@@ -108,26 +108,26 @@ internal sealed partial class StripePaymentMethodManager(
         Customer customer = await service.CreateAsync(
             new CustomerCreateOptions
             {
-                Name = contact.Name,
-                Metadata = new Dictionary<string, string> { ["granit_contact_id"] = contact.Id.ToString() },
+                Name = party.Name,
+                Metadata = new Dictionary<string, string> { ["granit_party_id"] = party.Id.ToString() },
             },
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        contact.AddExternalMapping(guidGenerator.Create(), Provider, customer.Id);
-        await contactWriter.UpdateAsync(contact, cancellationToken).ConfigureAwait(false);
+        party.AddExternalMapping(guidGenerator.Create(), Provider, customer.Id);
+        await partyWriter.UpdateAsync(party, cancellationToken).ConfigureAwait(false);
 
-        Log.CustomerCreated(logger, customer.Id, contactId);
+        Log.CustomerCreated(logger, customer.Id, partyId);
 
         return customer.Id;
     }
 
-    private async Task<Party?> ResolveContactAsync(Guid contactId, CancellationToken cancellationToken)
+    private async Task<Party?> ResolvePartyAsync(Guid partyId, CancellationToken cancellationToken)
     {
-        // The contact may be host-scoped or tenant-scoped — bypass the tenant filter so a
-        // host-side payment workflow can resolve a tenant-scoped contact, and vice versa.
+        // The party may be host-scoped or tenant-scoped — bypass the tenant filter so a
+        // host-side payment workflow can resolve a tenant-scoped party, and vice versa.
         using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
-        return await contactReader
-            .GetByIdAsync(PartyId.Create(contactId), cancellationToken)
+        return await partyReader
+            .GetByIdAsync(PartyId.Create(partyId), cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -140,13 +140,13 @@ internal sealed partial class StripePaymentMethodManager(
 
     private static partial class Log
     {
-        [LoggerMessage(Level = LogLevel.Information, Message = "Stripe payment method attached: {MethodId} for contact {PartyId}")]
+        [LoggerMessage(Level = LogLevel.Information, Message = "Stripe payment method attached: {MethodId} for party {PartyId}")]
         public static partial void PaymentMethodAttached(ILogger logger, string methodId, Guid partyId);
 
         [LoggerMessage(Level = LogLevel.Information, Message = "Stripe payment method detached: {MethodId}")]
         public static partial void PaymentMethodDetached(ILogger logger, string methodId);
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Stripe customer created: {CustomerId} for contact {PartyId}")]
+        [LoggerMessage(Level = LogLevel.Information, Message = "Stripe customer created: {CustomerId} for party {PartyId}")]
         public static partial void CustomerCreated(ILogger logger, string customerId, Guid partyId);
     }
 }

--- a/src/Granit.Payments/IPaymentMethodManager.cs
+++ b/src/Granit.Payments/IPaymentMethodManager.cs
@@ -8,8 +8,8 @@ public interface IPaymentMethodManager
     /// <summary>Provider name this manager serves.</summary>
     string ProviderName { get; }
 
-    /// <summary>Lists saved payment methods for the given contact.</summary>
-    Task<IReadOnlyList<PaymentProviderMethod>> ListAsync(Guid contactId, CancellationToken cancellationToken = default);
+    /// <summary>Lists saved payment methods for the given party.</summary>
+    Task<IReadOnlyList<PaymentProviderMethod>> ListAsync(Guid partyId, CancellationToken cancellationToken = default);
 
     /// <summary>Attaches a new payment method.</summary>
     Task<PaymentProviderMethod> AttachAsync(PaymentAttachMethodRequest request, CancellationToken cancellationToken = default);

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -31,8 +31,8 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
     /// <summary>Creates a new subscription in Trial or Active status.</summary>
     /// <param name="id">Unique subscription identifier.</param>
-    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="contactId"/>).</param>
-    /// <param name="contactId">Identifier of the <c>Granit.Parties.Party</c> that holds the billing identity for this subscription. Required.</param>
+    /// <param name="tenantId">Owning tenant identifier (multi-tenant isolation, orthogonal to <paramref name="partyId"/>).</param>
+    /// <param name="partyId">Identifier of the <c>Granit.Parties.Party</c> that holds the billing identity for this subscription. Required.</param>
     /// <param name="planId">Plan the subscription is for.</param>
     /// <param name="currency">ISO 4217 currency code (e.g., "EUR").</param>
     /// <param name="period">Initial billing period boundaries.</param>
@@ -41,14 +41,14 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     public static Subscription Create(
         SubscriptionId id,
         Guid tenantId,
-        PartyId contactId,
+        PartyId partyId,
         PlanId planId,
         string currency,
         SubscriptionPeriod period,
         DateTimeOffset? trialEndsAt = null,
         Guid? planPriceId = null)
     {
-        ArgumentNullException.ThrowIfNull(contactId);
+        ArgumentNullException.ThrowIfNull(partyId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
         ArgumentNullException.ThrowIfNull(period);
 
@@ -60,7 +60,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         {
             Id = id,
             TenantId = tenantId,
-            PartyId = contactId,
+            PartyId = partyId,
             PlanId = planId,
             Currency = currency.ToUpperInvariant(),
             Status = initialStatus,
@@ -72,9 +72,9 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
             PlanPriceId = planPriceId,
         };
 
-        subscription.AddDomainEvent(new SubscriptionCreatedEvent(id, planId, tenantId, contactId.Value));
+        subscription.AddDomainEvent(new SubscriptionCreatedEvent(id, planId, tenantId, partyId.Value));
         subscription.AddDistributedEvent(new SubscriptionCreatedEto(
-            id, planId, tenantId, contactId.Value, trialEndsAt.HasValue));
+            id, planId, tenantId, partyId.Value, trialEndsAt.HasValue));
 
         return subscription;
     }
@@ -143,7 +143,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
     /// <summary>
     /// Identifier of the <c>Granit.Parties.Party</c> that holds the billing identity
     /// (legal name, addresses, payment methods) for this subscription. Required — pinned
-    /// at creation. Switching contact mid-life-cycle is not supported (would invalidate
+    /// at creation. Switching party mid-life-cycle is not supported (would invalidate
     /// the running invoice cycle); cancel + re-create instead.
     /// </summary>
     public PartyId PartyId { get; private set; } = null!;

--- a/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
+++ b/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
@@ -16,12 +16,12 @@ internal sealed class ConfigTaxRateProvider(
     public Task<TaxRateEntry?> GetRateAsync(
         string countryCode,
         DateTimeOffset asOf,
-        PartyId? contactId = null,
+        PartyId? partyId = null,
         CancellationToken cancellationToken = default)
     {
         // PartyId is honoured by the upstream EfTaxRateProvider; this provider
         // returns the country default only.
-        _ = contactId;
+        _ = partyId;
 
         string normalized = countryCode.ToUpperInvariant();
 

--- a/src/Granit.Tax.Builtin/Internal/EuVatTaxCalculator.cs
+++ b/src/Granit.Tax.Builtin/Internal/EuVatTaxCalculator.cs
@@ -61,7 +61,7 @@ internal sealed class EuVatTaxCalculator(
                 .GetRateAsync(
                     context.RateCountryCode,
                     clock.Now,
-                    request.BuyerContactId,
+                    request.BuyerPartyId,
                     cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
@@ -36,7 +36,7 @@ internal static class TaxRateEndpoints
         CancellationToken cancellationToken = default)
     {
         TaxRateEntry? rate = await rateProvider
-            .GetRateAsync(countryCode, clock.Now, contactId: null, cancellationToken)
+            .GetRateAsync(countryCode, clock.Now, partyId: null, cancellationToken)
             .ConfigureAwait(false);
 
         if (rate is null)

--- a/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
@@ -10,30 +10,30 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Tax.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// DB-backed tax rate provider. Checks the contact's <c>TaxStatus</c> first (when a
-/// <c>contactId</c> is supplied) — exempt or reverse-charge customers yield a 0% rate.
+/// DB-backed tax rate provider. Checks the party's <c>TaxStatus</c> first (when a
+/// <c>partyId</c> is supplied) — exempt or reverse-charge customers yield a 0% rate.
 /// Otherwise checks <see cref="TaxRateOverride"/> rows, then delegates to the fallback
 /// (config-based) provider if no override exists.
 /// </summary>
 internal sealed class EfTaxRateProvider(
     IDbContextFactory<TaxDbContext> contextFactory,
     ITaxRateProvider fallback,
-    IPartyReader contactReader,
+    IPartyReader partyReader,
     IDataFilter dataFilter,
     IClock clock) : ITaxRateProvider
 {
     public async Task<TaxRateEntry?> GetRateAsync(
         string countryCode,
         DateTimeOffset asOf,
-        PartyId? contactId = null,
+        PartyId? partyId = null,
         CancellationToken cancellationToken = default)
     {
         // 1. Customer-specific tax status takes absolute precedence.
-        if (contactId is not null)
+        if (partyId is not null)
         {
-            Party? contact = await ResolveContactAsync(contactId, cancellationToken)
+            Party? party = await ResolvePartyAsync(partyId, cancellationToken)
                 .ConfigureAwait(false);
-            if (contact?.TaxStatus.YieldsZeroRate == true)
+            if (party?.TaxStatus.YieldsZeroRate == true)
             {
                 return new TaxRateEntry(
                     CountryCode: countryCode,
@@ -67,17 +67,17 @@ internal sealed class EfTaxRateProvider(
         }
 
         // 3. Fallback to the config-based provider.
-        return await fallback.GetRateAsync(countryCode, asOf, contactId, cancellationToken)
+        return await fallback.GetRateAsync(countryCode, asOf, partyId, cancellationToken)
             .ConfigureAwait(false);
     }
 
-    private async Task<Party?> ResolveContactAsync(
-        PartyId contactId, CancellationToken cancellationToken)
+    private async Task<Party?> ResolvePartyAsync(
+        PartyId partyId, CancellationToken cancellationToken)
     {
-        // The contact may be host-scoped or tenant-scoped; bypass the multi-tenant filter
-        // so a host-side tax calculation can read a tenant-scoped contact's TaxStatus.
+        // The party may be host-scoped or tenant-scoped; bypass the multi-tenant filter
+        // so a host-side tax calculation can read a tenant-scoped party's TaxStatus.
         using IDisposable bypass = dataFilter.Disable<IMultiTenant>();
-        return await contactReader.GetByIdAsync(contactId, cancellationToken)
+        return await partyReader.GetByIdAsync(partyId, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Granit.Tax/ITaxRateProvider.cs
+++ b/src/Granit.Tax/ITaxRateProvider.cs
@@ -2,24 +2,24 @@ using Granit.Parties.Domain.ValueObjects;
 
 namespace Granit.Tax;
 
-/// <summary>Provides tax rates by country, date, and (optionally) contact-specific status.</summary>
+/// <summary>Provides tax rates by country, date, and (optionally) party-specific status.</summary>
 public interface ITaxRateProvider
 {
     /// <summary>
     /// Returns the tax rate for a country at a specific date, optionally honouring the
-    /// contact's <c>TaxStatus</c>. When <paramref name="contactId"/> is supplied and the
-    /// contact's status yields a 0% rate (exempt or reverse-charge), the returned entry
+    /// party's <c>TaxStatus</c>. When <paramref name="partyId"/> is supplied and the
+    /// party's status yields a 0% rate (exempt or reverse-charge), the returned entry
     /// has <c>StandardRate = 0</c> and <c>ReducedRate = 0</c> — the country and effective
     /// dates remain populated so the caller still has the jurisdiction context for the
     /// document footer (e.g. "VAT reverse-charge per Art. 196").
-    /// When <paramref name="contactId"/> is omitted (<c>null</c>), the legacy
+    /// When <paramref name="partyId"/> is omitted (<c>null</c>), the legacy
     /// country-default behaviour applies — preserves binary compatibility with consumers
     /// that have not migrated to PartyId yet.
     /// </summary>
     Task<TaxRateEntry?> GetRateAsync(
         string countryCode,
         DateTimeOffset asOf,
-        PartyId? contactId = null,
+        PartyId? partyId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Returns all currently effective tax rates.</summary>

--- a/src/Granit.Validation/Extensions/ContactValidatorExtensions.cs
+++ b/src/Granit.Validation/Extensions/ContactValidatorExtensions.cs
@@ -4,7 +4,7 @@ using FluentValidation;
 namespace Granit.Validation.Extensions;
 
 /// <summary>
-/// FluentValidation extension methods for contact and communication identifiers.
+/// FluentValidation extension methods for communication identifiers (email, phone, URL).
 /// </summary>
 public static partial class ContactValidatorExtensions
 {

--- a/tests/Granit.ArchitectureTests/CrossModulePartyIdTypingTests.cs
+++ b/tests/Granit.ArchitectureTests/CrossModulePartyIdTypingTests.cs
@@ -9,15 +9,15 @@ using Xunit;
 namespace Granit.ArchitectureTests;
 
 /// <summary>
-/// US #1245 — pin cross-module consistency: every aggregate that exposes a contact
+/// US #1245 — pin cross-module consistency: every aggregate that exposes a party
 /// reference uses the typed <see cref="PartyId"/> value object, not a bare
-/// <see cref="Guid"/> named "contactId" / "customerId". Reverting any of these to a
+/// <see cref="Guid"/> named "partyId" / "customerId". Reverting any of these to a
 /// raw <c>Guid</c> would let downstream callers pass an unrelated identifier
 /// (TenantId, UserId, …) without compile-time checks.
 /// </summary>
 public sealed class CrossModulePartyIdTypingTests
 {
-    private static readonly Type[] AggregatesCarryingContactId =
+    private static readonly Type[] AggregatesCarryingPartyId =
     [
         typeof(Invoice),
         typeof(Subscription),
@@ -28,7 +28,7 @@ public sealed class CrossModulePartyIdTypingTests
     [InlineData(typeof(Invoice))]
     [InlineData(typeof(Subscription))]
     [InlineData(typeof(BalanceAccount))]
-    public void Aggregate_ContactId_IsTypedValueObject(Type aggregateType)
+    public void Aggregate_PartyId_IsTypedValueObject(Type aggregateType)
     {
         PropertyInfo? prop = aggregateType.GetProperty("PartyId");
 
@@ -40,9 +40,9 @@ public sealed class CrossModulePartyIdTypingTests
     }
 
     [Fact]
-    public void All_5_migrated_aggregates_carry_a_typed_ContactId()
+    public void All_5_migrated_aggregates_carry_a_typed_PartyId()
     {
-        IEnumerable<string> missing = AggregatesCarryingContactId
+        IEnumerable<string> missing = AggregatesCarryingPartyId
             .Where(t => t.GetProperty("PartyId")?.PropertyType != typeof(PartyId))
             .Select(t => t.Name);
 
@@ -53,7 +53,7 @@ public sealed class CrossModulePartyIdTypingTests
     }
 
     /// <summary>
-    /// US #1245 AC: every Eto event raised by a contact-aware aggregate carries a Guid PartyId.
+    /// US #1245 AC: every Eto event raised by a party-aware aggregate carries a Guid PartyId.
     /// </summary>
     [Theory]
     [InlineData(typeof(Granit.Invoicing.Events.InvoiceFinalizedEto))]
@@ -69,7 +69,7 @@ public sealed class CrossModulePartyIdTypingTests
     [InlineData(typeof(Granit.Subscriptions.Events.SubscriptionPlanChangedEto))]
     [InlineData(typeof(Granit.CustomerBalance.Events.BalanceCreditedEto))]
     [InlineData(typeof(Granit.CustomerBalance.Events.BalanceDebitedEto))]
-    public void Eto_CarriesGuidContactId(Type etoType)
+    public void Eto_CarriesGuidPartyId(Type etoType)
     {
         PropertyInfo? prop = etoType.GetProperty("PartyId");
 

--- a/tests/Granit.ArchitectureTests/InvoicePartyIdConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/InvoicePartyIdConventionTests.cs
@@ -15,7 +15,7 @@ namespace Granit.ArchitectureTests;
 public sealed class InvoicePartyIdConventionTests
 {
     [Fact]
-    public void Invoice_ContactId_IsTypedContactIdValueObject()
+    public void Invoice_PartyId_IsTypedPartyIdValueObject()
     {
         PropertyInfo? prop = typeof(Invoice).GetProperty(nameof(Invoice.PartyId));
 

--- a/tests/Granit.ArchitectureTests/PartiesDependencyDirectionTests.cs
+++ b/tests/Granit.ArchitectureTests/PartiesDependencyDirectionTests.cs
@@ -34,14 +34,14 @@ public sealed class PartiesDependencyDirectionTests
     ];
 
     [Fact]
-    public void Contacts_module_must_not_depend_on_downstream_consumers()
+    public void Parties_module_must_not_depend_on_downstream_consumers()
     {
-        IEnumerable<IType> contactsTypes = Architecture.Types.Where(t =>
+        IEnumerable<IType> partiesTypes = Architecture.Types.Where(t =>
             t.FullName.StartsWith("Granit.Parties.", StringComparison.Ordinal)
             || string.Equals(t.Namespace.FullName, "Granit.Parties", StringComparison.Ordinal)
             || t.Namespace.FullName.StartsWith("Granit.Parties.", StringComparison.Ordinal));
 
-        var violations = contactsTypes
+        var violations = partiesTypes
             .SelectMany(t => t.Dependencies.Select(d => (Source: t, TargetFullName: d.Target.FullName)))
             .Where(pair => DownstreamConsumerNamespaces.Any(ns =>
                 pair.TargetFullName.StartsWith(ns + ".", StringComparison.Ordinal)

--- a/tests/Granit.ArchitectureTests/SubscriptionPartyIdConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SubscriptionPartyIdConventionTests.cs
@@ -15,7 +15,7 @@ namespace Granit.ArchitectureTests;
 public sealed class SubscriptionPartyIdConventionTests
 {
     [Fact]
-    public void Subscription_ContactId_IsTypedContactIdValueObject()
+    public void Subscription_PartyId_IsTypedPartyIdValueObject()
     {
         PropertyInfo? prop = typeof(Subscription).GetProperty(nameof(Subscription.PartyId));
 

--- a/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/BalanceAccountPartyReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.CustomerBalance.EntityFrameworkCore.Tests.Integration/BalanceAccountPartyReferenceRewriterPostgresTests.cs
@@ -129,6 +129,6 @@ public sealed class BalanceAccountPartyReferenceRewriterPostgresTests : IClassFi
         BalanceAccount.Create(
             id: Guid.NewGuid(),
             tenantId: Guid.NewGuid(),
-            contactId: PartyId.Create(partyId),
+            partyId: PartyId.Create(partyId),
             currency: currency);
 }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminCreditServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminCreditServiceTests.cs
@@ -51,14 +51,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, contactId, 100m, "EUR", TransactionSource.ManualAdjustment, "Test credit", null, ct);
+            tenantId, partyId, 100m, "EUR", TransactionSource.ManualAdjustment, "Test credit", null, ct);
 
         result.ShouldBe(account);
         result.Balance.ShouldBe(100m);
@@ -77,14 +77,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
 
-        var contactId = PartyId.Create(Guid.NewGuid());
+        var partyId = PartyId.Create(Guid.NewGuid());
 
-        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(null as BalanceAccount, newAccount);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, contactId, 50m, "EUR", TransactionSource.Promotional, "Welcome bonus", null, ct);
+            tenantId, partyId, 50m, "EUR", TransactionSource.Promotional, "Welcome bonus", null, ct);
 
         await _accountWriter.Received(1).AddAsync(Arg.Any<BalanceAccount>(), Arg.Any<CancellationToken>());
         await _accountWriter.Received(1).UpdateAsync(newAccount, Arg.Any<CancellationToken>());
@@ -98,14 +98,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "USD");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "USD");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "USD", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "USD", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, contactId, 200m, "USD", TransactionSource.Promotional, "Promo credit", null, ct);
+            tenantId, partyId, 200m, "USD", TransactionSource.Promotional, "Promo credit", null, ct);
 
         account.Transactions[0].Source.ShouldBe(TransactionSource.Promotional);
     }
@@ -117,15 +117,15 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
         DateTimeOffset expiresAt = Now.AddDays(30);
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, contactId, 75m, "EUR", TransactionSource.Promotional, "Limited promo", expiresAt, ct);
+            tenantId, partyId, 75m, "EUR", TransactionSource.Promotional, "Limited promo", expiresAt, ct);
 
         account.Transactions[0].ExpiresAt.ShouldBe(expiresAt);
     }
@@ -137,14 +137,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, contactId, 50m, "EUR", TransactionSource.ManualAdjustment, "Permanent credit", null, ct);
+            tenantId, partyId, 50m, "EUR", TransactionSource.ManualAdjustment, "Permanent credit", null, ct);
 
         account.Transactions[0].ExpiresAt.ShouldBeNull();
     }
@@ -156,16 +156,16 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, contactId, 100m, "EUR", TransactionSource.ManualAdjustment, "First", null, ct);
+            tenantId, partyId, 100m, "EUR", TransactionSource.ManualAdjustment, "First", null, ct);
         await _sut.ApplyAsync(
-            tenantId, contactId, 50m, "EUR", TransactionSource.Promotional, "Second", null, ct);
+            tenantId, partyId, 50m, "EUR", TransactionSource.Promotional, "Second", null, ct);
 
         account.Balance.ShouldBe(150m);
         account.Transactions.Count.ShouldBe(2);
@@ -178,14 +178,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         BalanceAccount result = await _sut.ApplyAsync(
-            tenantId, contactId, 42.50m, "EUR", TransactionSource.RefundCredit, "Refund", null, ct);
+            tenantId, partyId, 42.50m, "EUR", TransactionSource.RefundCredit, "Refund", null, ct);
 
         result.Balance.ShouldBe(42.50m);
         result.Currency.ShouldBe("EUR");
@@ -198,14 +198,14 @@ public sealed class DefaultAdminCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.ApplyAsync(
-            tenantId, contactId, 10m, "EUR", TransactionSource.ManualAdjustment, "Custom reason text", null, ct);
+            tenantId, partyId, 10m, "EUR", TransactionSource.ManualAdjustment, "Custom reason text", null, ct);
 
         account.Transactions[0].Reason.ShouldBe("Custom reason text");
     }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultAdminDebitServiceTests.cs
@@ -45,9 +45,9 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
 
     public void Dispose() => _meter.Dispose();
 
-    private BalanceAccount AccountWithBalance(Guid tenantId, PartyId contactId, string currency, decimal balance)
+    private BalanceAccount AccountWithBalance(Guid tenantId, PartyId partyId, string currency, decimal balance)
     {
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, currency);
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, currency);
         if (balance > 0m)
         {
             account.Credit(
@@ -55,7 +55,7 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
                 Now.AddDays(-1), Guid.NewGuid());
         }
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, currency, Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, currency, Arg.Any<CancellationToken>())
             .Returns(account);
         return account;
     }
@@ -65,11 +65,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, partyId, "EUR", balance: 100m);
 
         BalanceAccount result = await _sut.DebitAsync(
-            tenantId, contactId, 30m, "EUR", "Manual correction", referenceId: null, referenceType: null, ct);
+            tenantId, partyId, 30m, "EUR", "Manual correction", referenceId: null, referenceType: null, ct);
 
         result.Balance.ShouldBe(70m);
         result.Transactions.Count.ShouldBe(2);   // seed credit + this debit
@@ -84,12 +84,12 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        var partyId = PartyId.Create(Guid.NewGuid());
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns((BalanceAccount?)null);
 
         await Should.ThrowAsync<InvalidOperationException>(() =>
-            _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "x", null, null, ct));
+            _sut.DebitAsync(tenantId, partyId, 10m, "EUR", "x", null, null, ct));
 
         await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
     }
@@ -99,11 +99,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        AccountWithBalance(tenantId, contactId, "EUR", balance: 20m);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        AccountWithBalance(tenantId, partyId, "EUR", balance: 20m);
 
         await Should.ThrowAsync<InsufficientBalanceException>(() =>
-            _sut.DebitAsync(tenantId, contactId, 50m, "EUR", "x", null, null, ct));
+            _sut.DebitAsync(tenantId, partyId, 50m, "EUR", "x", null, null, ct));
 
         await _accountWriter.DidNotReceiveWithAnyArgs().UpdateAsync(default!, ct);
     }
@@ -113,17 +113,17 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
+        var partyId = PartyId.Create(Guid.NewGuid());
         var refId = Guid.NewGuid();
-        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
+        BalanceAccount account = AccountWithBalance(tenantId, partyId, "EUR", balance: 100m);
 
         // First call: real debit
-        await _sut.DebitAsync(tenantId, contactId, 30m, "EUR", "first", referenceId: refId, "AdminAdjustment", ct);
+        await _sut.DebitAsync(tenantId, partyId, 30m, "EUR", "first", referenceId: refId, "AdminAdjustment", ct);
         account.Balance.ShouldBe(70m);
 
         // Second call with the same refId: short-circuited, no second debit
         BalanceAccount second = await _sut.DebitAsync(
-            tenantId, contactId, 30m, "EUR", "retry", referenceId: refId, "AdminAdjustment", ct);
+            tenantId, partyId, 30m, "EUR", "retry", referenceId: refId, "AdminAdjustment", ct);
 
         second.Balance.ShouldBe(70m);                          // unchanged
         account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(1);
@@ -135,11 +135,11 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, partyId, "EUR", balance: 100m);
 
-        await _sut.DebitAsync(tenantId, contactId, 20m, "EUR", "a", referenceId: Guid.NewGuid(), "x", ct);
-        await _sut.DebitAsync(tenantId, contactId, 30m, "EUR", "b", referenceId: Guid.NewGuid(), "x", ct);
+        await _sut.DebitAsync(tenantId, partyId, 20m, "EUR", "a", referenceId: Guid.NewGuid(), "x", ct);
+        await _sut.DebitAsync(tenantId, partyId, 30m, "EUR", "b", referenceId: Guid.NewGuid(), "x", ct);
 
         account.Balance.ShouldBe(50m);
         account.Transactions.Count(t => t.Type == TransactionType.Debit).ShouldBe(2);
@@ -150,12 +150,12 @@ public sealed class DefaultAdminDebitServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        BalanceAccount account = AccountWithBalance(tenantId, contactId, "EUR", balance: 100m);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        BalanceAccount account = AccountWithBalance(tenantId, partyId, "EUR", balance: 100m);
 
         // No idempotency without referenceId — both debits land.
-        await _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "first", null, null, ct);
-        await _sut.DebitAsync(tenantId, contactId, 10m, "EUR", "second", null, null, ct);
+        await _sut.DebitAsync(tenantId, partyId, 10m, "EUR", "first", null, null, ct);
+        await _sut.DebitAsync(tenantId, partyId, 10m, "EUR", "second", null, null, ct);
 
         account.Balance.ShouldBe(80m);
     }

--- a/tests/Granit.CustomerBalance.Tests/Internal/DefaultOverpaymentCreditServiceTests.cs
+++ b/tests/Granit.CustomerBalance.Tests/Internal/DefaultOverpaymentCreditServiceTests.cs
@@ -51,15 +51,15 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
+        var partyId = PartyId.Create(Guid.NewGuid());
         var invoiceId = Guid.NewGuid();
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.CreditOverpaymentAsync(
-            tenantId, contactId, "EUR", 42.50m, invoiceId, ct);
+            tenantId, partyId, "EUR", 42.50m, invoiceId, ct);
 
         account.Balance.ShouldBe(42.50m);
         account.Transactions.Count.ShouldBe(1);
@@ -77,16 +77,16 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
+        var partyId = PartyId.Create(Guid.NewGuid());
         var invoiceId = Guid.NewGuid();
 
         // First call returns null (account does not exist), second call returns the newly created account.
-        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        var newAccount = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(null as BalanceAccount, newAccount);
 
         await _sut.CreditOverpaymentAsync(
-            tenantId, contactId, "EUR", 75m, invoiceId, ct);
+            tenantId, partyId, "EUR", 75m, invoiceId, ct);
 
         await _accountWriter.Received(1).AddAsync(Arg.Any<BalanceAccount>(), Arg.Any<CancellationToken>());
         await _accountWriter.Received(1).UpdateAsync(newAccount, Arg.Any<CancellationToken>());
@@ -100,14 +100,14 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "USD");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "USD");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "USD", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "USD", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.CreditOverpaymentAsync(
-            tenantId, contactId, "USD", 123.45m, Guid.NewGuid(), ct);
+            tenantId, partyId, "USD", 123.45m, Guid.NewGuid(), ct);
 
         account.Balance.ShouldBe(123.45m);
         account.Transactions[0].Reason.ShouldBe("Overpayment on invoice");
@@ -120,16 +120,16 @@ public sealed class DefaultOverpaymentCreditServiceTests : IDisposable
     {
         CancellationToken ct = TestContext.Current.CancellationToken;
         var tenantId = Guid.NewGuid();
-        var contactId = PartyId.Create(Guid.NewGuid());
-        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, contactId, "EUR");
+        var partyId = PartyId.Create(Guid.NewGuid());
+        var account = BalanceAccount.Create(Guid.NewGuid(), tenantId, partyId, "EUR");
 
-        _accountReader.GetByContactAndCurrencyAsync(contactId, "EUR", Arg.Any<CancellationToken>())
+        _accountReader.GetByPartyAndCurrencyAsync(partyId, "EUR", Arg.Any<CancellationToken>())
             .Returns(account);
 
         await _sut.CreditOverpaymentAsync(
-            tenantId, contactId, "EUR", 10m, Guid.NewGuid(), ct);
+            tenantId, partyId, "EUR", 10m, Guid.NewGuid(), ct);
         await _sut.CreditOverpaymentAsync(
-            tenantId, contactId, "EUR", 25m, Guid.NewGuid(), ct);
+            tenantId, partyId, "EUR", 25m, Guid.NewGuid(), ct);
 
         account.Balance.ShouldBe(35m);
         account.Transactions.Count.ShouldBe(2);

--- a/tests/Granit.Invoicing.Endpoints.Tests/Dtos/InvoiceResponseTests.cs
+++ b/tests/Granit.Invoicing.Endpoints.Tests/Dtos/InvoiceResponseTests.cs
@@ -9,13 +9,13 @@ namespace Granit.Invoicing.Endpoints.Tests.Dtos;
 public sealed class InvoiceResponseTests
 {
     [Fact]
-    public void FromEntity_ProjectsContactId()
+    public void FromEntity_ProjectsPartyId()
     {
-        var contactId = Guid.NewGuid();
+        var partyId = Guid.NewGuid();
         var invoice = Invoice.Create(
             id: Guid.NewGuid(),
             tenantId: Guid.NewGuid(),
-            contactId: PartyId.Create(contactId),
+            partyId: PartyId.Create(partyId),
             documentType: InvoiceDocumentType.Invoice,
             currency: "EUR",
             collectionMethod: CollectionMethod.Auto,
@@ -24,7 +24,7 @@ public sealed class InvoiceResponseTests
         var response = InvoiceResponse.FromEntity(invoice);
 
         response.Id.ShouldBe(invoice.Id);
-        response.PartyId.ShouldBe(contactId);
+        response.PartyId.ShouldBe(partyId);
         response.Currency.ShouldBe("EUR");
         response.Status.ShouldBe(InvoiceStatus.Draft.ToString());
     }

--- a/tests/Granit.Invoicing.Endpoints.Tests/Validators/InvoiceCreateRequestValidatorTests.cs
+++ b/tests/Granit.Invoicing.Endpoints.Tests/Validators/InvoiceCreateRequestValidatorTests.cs
@@ -10,8 +10,8 @@ public sealed class InvoiceCreateRequestValidatorTests
 {
     private readonly InvoiceCreateRequestValidator _sut = new();
 
-    private static InvoiceCreateRequest ValidRequest(Guid? contactId = null) => new(
-        PartyId: contactId ?? Guid.NewGuid(),
+    private static InvoiceCreateRequest ValidRequest(Guid? partyId = null) => new(
+        PartyId: partyId ?? Guid.NewGuid(),
         DocumentType: InvoiceDocumentType.Invoice,
         Currency: "EUR",
         CollectionMethod: CollectionMethod.Auto,

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/InvoicePartyReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/InvoicePartyReferenceRewriterPostgresTests.cs
@@ -127,7 +127,7 @@ public sealed class InvoicePartyReferenceRewriterPostgresTests : IClassFixture<P
         var invoice = Invoice.Create(
             id: Guid.NewGuid(),
             tenantId: Guid.NewGuid(),
-            contactId: PartyId.Create(partyId),
+            partyId: PartyId.Create(partyId),
             documentType: InvoiceDocumentType.Invoice,
             currency: "EUR",
             collectionMethod: CollectionMethod.Auto,

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/EfInvoiceStoreTests.cs
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/EfInvoiceStoreTests.cs
@@ -36,10 +36,10 @@ public sealed class EfInvoiceStoreTests : IAsyncDisposable
         await db.Database.EnsureDeletedAsync();
     }
 
-    private static Invoice NewDraftInvoice(Guid? tenantId = null, Guid? contactId = null) =>
+    private static Invoice NewDraftInvoice(Guid? tenantId = null, Guid? partyId = null) =>
         Invoice.Create(
             Guid.NewGuid(), tenantId ?? Guid.NewGuid(),
-            PartyId.Create(contactId ?? Guid.NewGuid()),
+            PartyId.Create(partyId ?? Guid.NewGuid()),
             InvoiceDocumentType.Invoice, "EUR",
             CollectionMethod.Auto, BillingReason.SubscriptionCycle);
 

--- a/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
+++ b/tests/Granit.Invoicing.Tests/Internal/DefaultInvoiceCreationServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class DefaultInvoiceCreationServiceTests
     // ======== Fixtures ========
 
     private readonly IInvoiceWriter _invoiceWriter = Substitute.For<IInvoiceWriter>();
-    private readonly IPartyReader _contactReader = Substitute.For<IPartyReader>();
+    private readonly IPartyReader _partyReader = Substitute.For<IPartyReader>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly IDefaultPartyResolver _defaultContactResolver = Substitute.For<IDefaultPartyResolver>();
@@ -35,11 +35,11 @@ public sealed class DefaultInvoiceCreationServiceTests
     public DefaultInvoiceCreationServiceTests()
     {
         _clock.Now.Returns(Now);
-        // Default behaviour: an explicit PartyId resolves to a contact with no billing address.
-        // Individual tests override this when they need a contact with an address.
+        // Default behaviour: an explicit PartyId resolves to a party with no billing address.
+        // Individual tests override this when they need a party with an address.
         var bareContact = Party.Create(
             PartyId, null, PartyKind.Company, "Test Co", "EUR");
-        _contactReader.GetByIdAsync(
+        _partyReader.GetByIdAsync(
             Arg.Any<Granit.Parties.Domain.ValueObjects.PartyId>(),
             Arg.Any<CancellationToken>())
             .Returns(bareContact);
@@ -50,7 +50,7 @@ public sealed class DefaultInvoiceCreationServiceTests
         IInvoiceNumberGenerator? numberGenerator = null) =>
         new(
             _invoiceWriter,
-            _contactReader,
+            _partyReader,
             _guidGenerator,
             _clock,
             _defaultContactResolver,

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/CreateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/CreateTenantRequestTests.cs
@@ -13,7 +13,7 @@ public sealed class CreateTenantRequestTests
 
         request.Name.ShouldBe("Acme Corp");
         request.Identifier.ShouldBe("acme-corp");
-        request.PartyEmail.ShouldBe("admin@acme.com");
+        request.ContactEmail.ShouldBe("admin@acme.com");
         request.Jurisdiction.ShouldBe("BE");
     }
 
@@ -22,6 +22,6 @@ public sealed class CreateTenantRequestTests
     {
         CreateTenantRequest request = new("Acme", "acme", null, null);
 
-        request.PartyEmail.ShouldBeNull();
+        request.ContactEmail.ShouldBeNull();
     }
 }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
@@ -17,7 +17,7 @@ public sealed class TenantResponseTests
         response.Id.ShouldBe(id);
         response.Name.ShouldBe("Acme Corp");
         response.Identifier.ShouldBe("acme-corp");
-        response.PartyEmail.ShouldBe("admin@acme.com");
+        response.ContactEmail.ShouldBe("admin@acme.com");
         response.Activated.ShouldBeTrue();
         response.Jurisdiction.ShouldBe("BE");
         response.CreatedAt.ShouldBe(createdAt);
@@ -28,6 +28,6 @@ public sealed class TenantResponseTests
     {
         TenantResponse response = new(Guid.NewGuid(), "Acme", "acme", null, true, null, DateTimeOffset.UtcNow);
 
-        response.PartyEmail.ShouldBeNull();
+        response.ContactEmail.ShouldBeNull();
     }
 }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/UpdateTenantRequestTests.cs
@@ -12,7 +12,7 @@ public sealed class UpdateTenantRequestTests
         UpdateTenantRequest request = new("Updated Name", "updated@acme.com", "FR");
 
         request.Name.ShouldBe("Updated Name");
-        request.PartyEmail.ShouldBe("updated@acme.com");
+        request.ContactEmail.ShouldBe("updated@acme.com");
         request.Jurisdiction.ShouldBe("FR");
     }
 
@@ -21,6 +21,6 @@ public sealed class UpdateTenantRequestTests
     {
         UpdateTenantRequest request = new("Acme", null, null);
 
-        request.PartyEmail.ShouldBeNull();
+        request.ContactEmail.ShouldBeNull();
     }
 }

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/CreateTenantRequestValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/CreateTenantRequestValidatorTests.cs
@@ -104,7 +104,7 @@ public sealed class CreateTenantRequestValidatorTests
         ValidationResult result = _validator.Validate(request);
 
         result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain(e => e.PropertyName == "PartyEmail");
+        result.Errors.ShouldContain(e => e.PropertyName == "ContactEmail");
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Validators/UpdateTenantRequestValidatorTests.cs
@@ -50,7 +50,7 @@ public sealed class UpdateTenantRequestValidatorTests
         ValidationResult result = _validator.Validate(request);
 
         result.IsValid.ShouldBeFalse();
-        result.Errors.ShouldContain(e => e.PropertyName == "PartyEmail");
+        result.Errors.ShouldContain(e => e.PropertyName == "ContactEmail");
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
@@ -45,7 +45,7 @@ public sealed class MultiTenancyDbContextTests
         loaded.ShouldNotBeNull();
         loaded.Name.ShouldBe("Acme Corp");
         loaded.Identifier.ShouldBe("acme-corp");
-        loaded.PartyEmail.ShouldBe("admin@acme.com");
+        loaded.ContactEmail.ShouldBe("admin@acme.com");
         loaded.Activated.ShouldBeTrue();
     }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
@@ -68,7 +68,7 @@ public sealed class TenantEntityTypeConfigurationTests
         using MultiTenancyDbContext ctx = CreateInMemory();
         IEntityType entityType = ctx.Model.FindEntityType(typeof(Tenant))!;
 
-        IProperty email = entityType.FindProperty(nameof(Tenant.PartyEmail))!;
+        IProperty email = entityType.FindProperty(nameof(Tenant.ContactEmail))!;
 
         email.GetMaxLength().ShouldBe(256);
         email.IsNullable.ShouldBeTrue();

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
@@ -24,7 +24,7 @@ public sealed class TenantTests
         tenant.Id.ShouldBe(id);
         tenant.Name.ShouldBe("Acme Corp");
         tenant.Identifier.ShouldBe("acme-corp");
-        tenant.PartyEmail.ShouldBe("admin@acme.com");
+        tenant.ContactEmail.ShouldBe("admin@acme.com");
         tenant.Activated.ShouldBeTrue();
         tenant.Jurisdiction.ShouldBeNull();
     }
@@ -42,7 +42,7 @@ public sealed class TenantTests
     {
         var tenant = Tenant.Create(Guid.NewGuid(), "Acme Corp", "acme-corp");
 
-        tenant.PartyEmail.ShouldBeNull();
+        tenant.ContactEmail.ShouldBeNull();
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public sealed class TenantTests
         tenant.UpdateDetails("New Name", "new@acme.com", null);
 
         tenant.Name.ShouldBe("New Name");
-        tenant.PartyEmail.ShouldBe("new@acme.com");
+        tenant.ContactEmail.ShouldBe("new@acme.com");
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public sealed class TenantTests
         IDomainEvent evt = tenant.DomainEvents.ShouldHaveSingleItem();
         TenantUpdatedEvent updated = evt.ShouldBeOfType<TenantUpdatedEvent>();
         updated.Name.ShouldBe("New Name");
-        updated.PartyEmail.ShouldBe("new@acme.com");
+        updated.ContactEmail.ShouldBe("new@acme.com");
     }
 
     [Fact]

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartyResolverTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartyResolverTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
 
-[Collection(ContactsDbSerialGroup.Name)]
+[Collection(PartiesDbSerialGroup.Name)]
 public sealed class EfDefaultContactResolverTests : IAsyncDisposable
 {
     private readonly DataFilter _filter = new();
@@ -42,15 +42,15 @@ public sealed class EfDefaultContactResolverTests : IAsyncDisposable
 
     private async Task<Party> SeedHostContactForTenantAsync(Guid tenantId, string name = "Tenant-as-customer")
     {
-        var contact = Party.Create(Guid.NewGuid(), null, PartyKind.Company, name, "EUR");
-        contact.AddExternalMapping(Guid.NewGuid(), PartyExternalProviderNames.Tenant, tenantId.ToString());
+        var party = Party.Create(Guid.NewGuid(), null, PartyKind.Company, name, "EUR");
+        party.AddExternalMapping(Guid.NewGuid(), PartyExternalProviderNames.Tenant, tenantId.ToString());
 
         (_, ScopedFactory factory, _) = BuildResolver(tenantId: null);
         using IDisposable bypass = _filter.Disable<IMultiTenant>();
         await using PartiesDbContext db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
-        db.Parties.Add(contact);
+        db.Parties.Add(party);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
-        return contact;
+        return party;
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public sealed class EfDefaultContactResolverTests : IAsyncDisposable
     public async Task GetDefaultForTenantAsync_TenantContextActive_StillResolvesHostScoped()
     {
         // Resolver must work even when called from inside a tenant scope (tenant code
-        // looking up its own representative host-scoped contact). The tenant filter
+        // looking up its own representative host-scoped party). The tenant filter
         // would otherwise hide the host-scoped row (TenantId == null != current tenant).
         var tenantId = Guid.NewGuid();
         Party seeded = await SeedHostContactForTenantAsync(tenantId);
@@ -98,17 +98,17 @@ public sealed class EfDefaultContactResolverTests : IAsyncDisposable
     [Fact]
     public async Task GetDefaultForTenantAsync_OtherProviderMapping_NotMatched()
     {
-        // A contact whose only external mapping is e.g. "stripe" must not be returned
+        // A party whose only external mapping is e.g. "stripe" must not be returned
         // for a tenantId that happens to equal the stripe customer id.
         var tenantId = Guid.NewGuid();
-        var contact = Party.Create(Guid.NewGuid(), null, PartyKind.Company, "Acme", "EUR");
-        contact.AddExternalMapping(
+        var party = Party.Create(Guid.NewGuid(), null, PartyKind.Company, "Acme", "EUR");
+        party.AddExternalMapping(
             Guid.NewGuid(), PartyExternalProviderNames.Stripe, tenantId.ToString());
         (_, ScopedFactory factory, _) = BuildResolver(tenantId: null);
         using (IDisposable bypass = _filter.Disable<IMultiTenant>())
         {
             await using PartiesDbContext db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
-            db.Parties.Add(contact);
+            db.Parties.Add(party);
             await db.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartySeederTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartySeederTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
 
-[Collection(ContactsDbSerialGroup.Name)]
+[Collection(PartiesDbSerialGroup.Name)]
 public sealed class EfDefaultContactSeederTests : IAsyncDisposable
 {
     private readonly DataFilter _filter = new();
@@ -78,7 +78,7 @@ public sealed class EfDefaultContactSeederTests : IAsyncDisposable
             tenantId, "Different Name", cancellationToken: TestContext.Current.CancellationToken);
 
         second.Id.ShouldBe(first.Id);
-        second.Name.ShouldBe("ACME Inc.", "the existing contact must be preserved — second call must not rename");
+        second.Name.ShouldBe("ACME Inc.", "the existing party must be preserved — second call must not rename");
     }
 
     [Fact]

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreScopeTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreScopeTests.cs
@@ -16,12 +16,12 @@ namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
 /// aggregate must back both host-scoped (<c>TenantId == null</c>) and tenant-scoped
 /// (<c>TenantId == &lt;tenant&gt;</c>) usage without consumer code branches.
 ///
-/// Three contacts are seeded with the multi-tenant filter <i>disabled</i> so each row lands
+/// Three parties are seeded with the multi-tenant filter <i>disabled</i> so each row lands
 /// at its intended scope. Subsequent reads exercise the filter under each context (tenant A,
 /// tenant B, host, no-filter) and assert that <see cref="EfPartyStore"/> honours the
 /// active scope on every query path — including <c>GetByIdAsync</c>.
 /// </summary>
-[Collection(ContactsDbSerialGroup.Name)]
+[Collection(PartiesDbSerialGroup.Name)]
 public sealed class EfContactStoreScopeTests : IAsyncDisposable
 {
     private readonly Guid _tenantA = Guid.NewGuid();
@@ -91,7 +91,7 @@ public sealed class EfContactStoreScopeTests : IAsyncDisposable
     // ── ListAsync ────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ListAsync_InTenantContext_ReturnsOnlyThatTenantsContacts()
+    public async Task ListAsync_InTenantContext_ReturnsOnlyThatTenantsParties()
     {
         await SeedAsync();
         (EfPartyStore store, _) = ScopedStore(_tenantA);
@@ -102,7 +102,7 @@ public sealed class EfContactStoreScopeTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task ListAsync_InHostContext_ReturnsOnlyHostScopedContacts()
+    public async Task ListAsync_InHostContext_ReturnsOnlyHostScopedParties()
     {
         await SeedAsync();
         (EfPartyStore store, _) = ScopedStore(tenantId: null);

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
 
-[Collection(ContactsDbSerialGroup.Name)]
+[Collection(PartiesDbSerialGroup.Name)]
 public sealed class EfContactStoreTests : IAsyncDisposable
 {
     private readonly TestFactory _factory;
@@ -239,8 +239,8 @@ public sealed class EfContactStoreTests : IAsyncDisposable
     }
 }
 
-[CollectionDefinition(ContactsDbSerialGroup.Name, DisableParallelization = true)]
-public sealed class ContactsDbSerialGroup
+[CollectionDefinition(PartiesDbSerialGroup.Name, DisableParallelization = true)]
+public sealed class PartiesDbSerialGroup
 {
     public const string Name = "Parties-Db-serial";
 }

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
@@ -15,7 +15,7 @@ namespace Granit.Parties.EntityFrameworkCore.Tests.Internal;
 /// column). Uses the InMemory provider — interceptors are honoured the same way as on
 /// SQL providers, just without real SQL.
 /// </summary>
-[Collection(ContactsDbSerialGroup.Name)]
+[Collection(PartiesDbSerialGroup.Name)]
 public sealed class PartyCanonicalisationInterceptorTests : IAsyncDisposable
 {
     private readonly DataFilter _filter = new();

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/EfMergeServicePartyEndToEndTests.cs
@@ -237,7 +237,7 @@ public sealed class EfMergeServicePartyEndToEndTests : IClassFixture<PostgresFix
 
         // Assert — both rewriters reported activity.
         result.RewriteCounts["Party.Children"].ShouldBeGreaterThan(0);
-        result.RewriteCounts["Party.ParentContactId"].ShouldBe(1);
+        result.RewriteCounts["Party.ParentPartyId"].ShouldBe(1);
 
         // Assert — every child collection now belongs to the survivor.
         await using PartiesDbContext assertDb = await _partiesFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
@@ -257,8 +257,8 @@ public sealed class EfMergeServicePartyEndToEndTests : IClassFixture<PostgresFix
         // Assert — child Party is re-parented onto the survivor.
         Party persistedChild = await assertDb.Parties
             .FirstAsync(p => p.Id == child.Id, TestContext.Current.CancellationToken);
-        persistedChild.ParentContactId.ShouldNotBeNull();
-        persistedChild.ParentContactId.Value.ShouldBe(survivor.Id);
+        persistedChild.ParentPartyId.ShouldNotBeNull();
+        persistedChild.ParentPartyId.Value.ShouldBe(survivor.Id);
     }
 
     [Fact]

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/PartyParentReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/PartyParentReferenceRewriterPostgresTests.cs
@@ -14,7 +14,7 @@ namespace Granit.Parties.Mergeable.Tests.Integration;
 
 /// <summary>
 /// Postgres integration tests for <see cref="PartyParentReferenceRewriter"/>. The
-/// <c>UPDATE parties SET ParentContactId = survivorId WHERE ParentContactId = loserId</c>
+/// <c>UPDATE parties SET ParentPartyId = survivorId WHERE ParentPartyId = loserId</c>
 /// path requires a relational provider, hence Postgres rather than the in-memory provider.
 /// </summary>
 public sealed class PartyParentReferenceRewriterPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
@@ -66,12 +66,12 @@ public sealed class PartyParentReferenceRewriterPostgresTests : IClassFixture<Po
         await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         var survivorPartyId = PartyId.Create(survivor.Id);
         int childrenOfSurvivor = await db.Parties
-            .CountAsync(p => p.ParentContactId == survivorPartyId, TestContext.Current.CancellationToken);
+            .CountAsync(p => p.ParentPartyId == survivorPartyId, TestContext.Current.CancellationToken);
         childrenOfSurvivor.ShouldBe(3);
 
         var loserPartyId = PartyId.Create(loser.Id);
         int childrenOfLoser = await db.Parties
-            .CountAsync(p => p.ParentContactId == loserPartyId, TestContext.Current.CancellationToken);
+            .CountAsync(p => p.ParentPartyId == loserPartyId, TestContext.Current.CancellationToken);
         childrenOfLoser.ShouldBe(0);
     }
 
@@ -102,7 +102,7 @@ public sealed class PartyParentReferenceRewriterPostgresTests : IClassFixture<Po
         await using PartiesDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         var loserPartyId = PartyId.Create(loser.Id);
         int still = await db.Parties
-            .CountAsync(p => p.ParentContactId == loserPartyId, TestContext.Current.CancellationToken);
+            .CountAsync(p => p.ParentPartyId == loserPartyId, TestContext.Current.CancellationToken);
         still.ShouldBe(2);
     }
 

--- a/tests/Granit.Parties.Privacy.Tests/DataDeletion/PartiesPersonalDataDeletionHandlerTests.cs
+++ b/tests/Granit.Parties.Privacy.Tests/DataDeletion/PartiesPersonalDataDeletionHandlerTests.cs
@@ -13,14 +13,14 @@ using Xunit;
 
 namespace Granit.Parties.Privacy.Tests.DataDeletion;
 
-public sealed class ContactsPersonalDataDeletionHandlerTests
+public sealed class PartiesPersonalDataDeletionHandlerTests
 {
     private readonly IPartyReader _reader = Substitute.For<IPartyReader>();
     private readonly IPartyWriter _writer = Substitute.For<IPartyWriter>();
     private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
     private readonly IDistributedEventBus _bus = Substitute.For<IDistributedEventBus>();
 
-    public ContactsPersonalDataDeletionHandlerTests()
+    public PartiesPersonalDataDeletionHandlerTests()
     {
         _dataFilter.Disable<IMultiTenant>().Returns(Substitute.For<IDisposable>());
     }
@@ -58,21 +58,21 @@ public sealed class ContactsPersonalDataDeletionHandlerTests
     public async Task HandleAsync_WithLinkedContact_PseudonymisesAndPublishesAnonymised()
     {
         PersonalDataDeletionRequestedEto request = Request();
-        var contact = Party.Create(
+        var party = Party.Create(
             Guid.NewGuid(), null, PartyKind.Individual, "Jean Dupont", "EUR");
-        contact.AddEmail(Guid.NewGuid(), "jean@example.com");
-        contact.LinkToUser(request.UserId);
+        party.AddEmail(Guid.NewGuid(), "jean@example.com");
+        party.LinkToUser(request.UserId);
 
         _reader.GetByUserIdAsync(request.UserId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+            .Returns(party);
 
         await PartiesPersonalDataDeletionHandler.HandleAsync(
             request, _reader, _writer, _dataFilter, _bus, TestContext.Current.CancellationToken);
 
-        contact.Name.ShouldBe("[deleted]");
-        contact.Emails.ShouldBeEmpty();
-        contact.UserId.ShouldBeNull();
-        await _writer.Received(1).UpdateAsync(contact, Arg.Any<CancellationToken>());
+        party.Name.ShouldBe("[deleted]");
+        party.Emails.ShouldBeEmpty();
+        party.UserId.ShouldBeNull();
+        await _writer.Received(1).UpdateAsync(party, Arg.Any<CancellationToken>());
         await _bus.Received(1).PublishAsync(
             Arg.Is<PersonalDataDeletedEto>(e =>
                 e.Action == DeletionAction.Anonymized
@@ -84,12 +84,12 @@ public sealed class ContactsPersonalDataDeletionHandlerTests
     public async Task HandleAsync_AlreadyPseudonymised_PublishesRetainedNoUpdate()
     {
         PersonalDataDeletionRequestedEto request = Request();
-        var contact = Party.Create(
+        var party = Party.Create(
             Guid.NewGuid(), null, PartyKind.Company, "[deleted]", "EUR");
         // already pseudonymised: no email, no phone, no address, no website, no user link
 
         _reader.GetByUserIdAsync(request.UserId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+            .Returns(party);
 
         await PartiesPersonalDataDeletionHandler.HandleAsync(
             request, _reader, _writer, _dataFilter, _bus, TestContext.Current.CancellationToken);

--- a/tests/Granit.Parties.Privacy.Tests/DataExport/PartiesPrivacyDataProviderTests.cs
+++ b/tests/Granit.Parties.Privacy.Tests/DataExport/PartiesPrivacyDataProviderTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Granit.Parties.Privacy.Tests.DataExport;
 
-public sealed class ContactsPrivacyDataProviderTests
+public sealed class PartiesPrivacyDataProviderTests
 {
     private readonly IPartyReader _reader = Substitute.For<IPartyReader>();
     private readonly NoopDataFilter _dataFilter = new();
@@ -32,7 +32,7 @@ public sealed class ContactsPrivacyDataProviderTests
     }
 
     [Fact]
-    public void ProviderName_IsContacts() =>
+    public void ProviderName_IsParties() =>
         PartiesPrivacyDataProvider.ProviderName.ShouldBe("parties");
 
     [Fact]
@@ -41,7 +41,7 @@ public sealed class ContactsPrivacyDataProviderTests
 
     [Fact]
     public void FileName_IsStable() =>
-        PartiesPrivacyDataProvider.FileName(Guid.NewGuid()).ShouldBe("contacts.json");
+        PartiesPrivacyDataProvider.FileName(Guid.NewGuid()).ShouldBe("parties.json");
 
     [Fact]
     public async Task ExportAsync_NoLinkedContact_ReturnsEmpty()
@@ -58,18 +58,18 @@ public sealed class ContactsPrivacyDataProviderTests
     public async Task ExportAsync_WithLinkedContact_ReturnsJsonPayload()
     {
         var userId = Guid.NewGuid();
-        var contact = Party.Create(
+        var party = Party.Create(
             Guid.NewGuid(), null, PartyKind.Individual, "Jean Dupont", "EUR",
             taxId: "BE0123456789", registrationNumber: "0123.456.789");
-        contact.AddEmail(Guid.NewGuid(), "jean@example.com");
-        contact.AddPhone(Guid.NewGuid(), PhoneKind.Mobile, "+33611223344");
-        contact.AddAddress(Guid.NewGuid(), AddressKind.Billing,
+        party.AddEmail(Guid.NewGuid(), "jean@example.com");
+        party.AddPhone(Guid.NewGuid(), PhoneKind.Mobile, "+33611223344");
+        party.AddAddress(Guid.NewGuid(), AddressKind.Billing,
             Address.Create("rue 1", "Brussels", "1000", "BE"));
-        contact.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_42");
-        contact.LinkToUser(userId);
+        party.AddExternalMapping(Guid.NewGuid(), "stripe", "cus_42");
+        party.LinkToUser(userId);
 
         _reader.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+            .Returns(party);
 
         ReadOnlyMemory<byte> result = await Sut().ExportAsync(userId, TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Parties.Tests/Architecture/PartyConventionTests.cs
+++ b/tests/Granit.Parties.Tests/Architecture/PartyConventionTests.cs
@@ -21,5 +21,5 @@ public sealed class PartyConventionTests
     [Fact]
     public void Contact_TenantIdIsNullable() =>
         typeof(Party).GetProperty(nameof(IMultiTenant.TenantId))!.PropertyType
-            .ShouldBe(typeof(Guid?), "host-scoped contacts require TenantId = null");
+            .ShouldBe(typeof(Guid?), "host-scoped parties require TenantId = null");
 }

--- a/tests/Granit.Parties.Tests/Domain/PartyTests.cs
+++ b/tests/Granit.Parties.Tests/Domain/PartyTests.cs
@@ -35,7 +35,7 @@ public sealed class PartyTests
         c.Timezone.ShouldBe("UTC");
         c.ExternalMappings.ShouldBeEmpty();
         c.UserId.ShouldBeNull();
-        c.ParentContactId.ShouldBeNull();
+        c.ParentPartyId.ShouldBeNull();
     }
 
     [Theory]
@@ -78,7 +78,7 @@ public sealed class PartyTests
     }
 
     [Fact]
-    public void Create_RaisesContactCreatedEvents()
+    public void Create_RaisesPartyCreatedEvents()
     {
         Party c = NewCompany();
 
@@ -297,7 +297,7 @@ public sealed class PartyTests
     // ── Identity & address updates ────────────────────────────────
 
     [Fact]
-    public void UpdateContact_OnActive_AppliesAndRaisesEvent()
+    public void UpdateIdentity_OnActive_AppliesAndRaisesEvent()
     {
         Party c = NewCompany();
 
@@ -309,7 +309,7 @@ public sealed class PartyTests
     }
 
     [Fact]
-    public void UpdateContact_OnArchived_Throws()
+    public void UpdateIdentity_OnArchived_Throws()
     {
         Party c = NewCompany();
         c.Archive();
@@ -497,7 +497,7 @@ public sealed class PartyTests
 
         child.AttachToParent(parentId, parentTenantId: tenantId);
 
-        child.ParentContactId.ShouldBe(parentId);
+        child.ParentPartyId.ShouldBe(parentId);
         child.DomainEvents.OfType<PartyAttachedToParentEvent>().ShouldHaveSingleItem();
     }
 
@@ -509,7 +509,7 @@ public sealed class PartyTests
 
         child.AttachToParent(parentId, parentTenantId: null);
 
-        child.ParentContactId.ShouldBe(parentId);
+        child.ParentPartyId.ShouldBe(parentId);
     }
 
     [Fact]
@@ -541,7 +541,7 @@ public sealed class PartyTests
         bool result = c.DetachFromParent();
 
         result.ShouldBeTrue();
-        c.ParentContactId.ShouldBeNull();
+        c.ParentPartyId.ShouldBeNull();
         c.DomainEvents.OfType<PartyDetachedFromParentEvent>().ShouldHaveSingleItem();
     }
 
@@ -746,12 +746,12 @@ public sealed class PartyTests
     // ── Multi-tenancy ─────────────────────────────────────────────
 
     [Fact]
-    public void Contact_HostScoped_HasNullTenantId() =>
+    public void Party_HostScoped_HasNullTenantId() =>
         Party.Create(Guid.NewGuid(), null, PartyKind.Company, "X", "EUR")
             .TenantId.ShouldBeNull();
 
     [Fact]
-    public void Contact_ImplementsIMultiTenant() =>
+    public void Party_ImplementsIMultiTenant() =>
         typeof(Party).IsAssignableTo(typeof(Granit.Domain.IMultiTenant)).ShouldBeTrue();
 
     [Fact]

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/SubscriptionPartyReferenceRewriterPostgresTests.cs
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/SubscriptionPartyReferenceRewriterPostgresTests.cs
@@ -112,7 +112,7 @@ public sealed class SubscriptionPartyReferenceRewriterPostgresTests : IClassFixt
         return Subscription.Create(
             id: SubscriptionId.Create(Guid.NewGuid()),
             tenantId: Guid.NewGuid(),
-            contactId: PartyId.Create(partyId),
+            partyId: PartyId.Create(partyId),
             planId: PlanId.Create(Guid.NewGuid()),
             currency: "EUR",
             period: new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now));

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
@@ -20,7 +20,7 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
 
     private readonly TestFactory _factory;
     private readonly ITaxRateProvider _fallback = Substitute.For<ITaxRateProvider>();
-    private readonly IPartyReader _contactReader = Substitute.For<IPartyReader>();
+    private readonly IPartyReader _partyReader = Substitute.For<IPartyReader>();
     private readonly IDataFilter _dataFilter = Substitute.For<IDataFilter>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly EfTaxRateProvider _sut;
@@ -34,7 +34,7 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
         _factory = new TestFactory(options);
         _clock.Now.Returns(Now);
         _dataFilter.Disable<Granit.Domain.IMultiTenant>().Returns(new NullDisposable());
-        _sut = new EfTaxRateProvider(_factory, _fallback, _contactReader, _dataFilter, _clock);
+        _sut = new EfTaxRateProvider(_factory, _fallback, _partyReader, _dataFilter, _clock);
     }
 
     private sealed class NullDisposable : IDisposable
@@ -160,13 +160,13 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     public async Task GetRateAsync_ContactExempt_ReturnsZeroRate_BypassingDbAndFallback()
     {
         await SeedOverrideAsync("BE", 0.21m); // would normally apply
-        var contactId = PartyId.Create(Guid.NewGuid());
-        Party contact = NewContactWithStatus(TaxStatus.Create(isExempt: true));
-        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        Party party = NewPartyWithStatus(TaxStatus.Create(isExempt: true));
+        _partyReader.GetByIdAsync(partyId, Arg.Any<CancellationToken>())
+            .Returns(party);
 
         TaxRateEntry? result = await _sut.GetRateAsync(
-            "BE", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+            "BE", Now, partyId: partyId, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.StandardRate.ShouldBe(0m);
@@ -179,13 +179,13 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     [Fact]
     public async Task GetRateAsync_ContactReverseCharge_ReturnsZeroRate()
     {
-        var contactId = PartyId.Create(Guid.NewGuid());
-        Party contact = NewContactWithStatus(TaxStatus.Create(reverseCharge: true, vatin: "BE0123456789"));
-        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        Party party = NewPartyWithStatus(TaxStatus.Create(reverseCharge: true, vatin: "BE0123456789"));
+        _partyReader.GetByIdAsync(partyId, Arg.Any<CancellationToken>())
+            .Returns(party);
 
         TaxRateEntry? result = await _sut.GetRateAsync(
-            "FR", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+            "FR", Now, partyId: partyId, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.StandardRate.ShouldBe(0m);
@@ -195,18 +195,18 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     [Fact]
     public async Task GetRateAsync_ContactStandard_DelegatesToFallback()
     {
-        var contactId = PartyId.Create(Guid.NewGuid());
-        Party contact = NewContactWithStatus(TaxStatus.Standard);
-        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
-            .Returns(contact);
+        var partyId = PartyId.Create(Guid.NewGuid());
+        Party party = NewPartyWithStatus(TaxStatus.Standard);
+        _partyReader.GetByIdAsync(partyId, Arg.Any<CancellationToken>())
+            .Returns(party);
 
         TaxRateEntry fallbackEntry = new("FR", 0.20m, EffectiveFrom: Now.AddYears(-1));
         _fallback.GetRateAsync(
-                "FR", Now, contactId, Arg.Any<CancellationToken>())
+                "FR", Now, partyId, Arg.Any<CancellationToken>())
             .Returns(fallbackEntry);
 
         TaxRateEntry? result = await _sut.GetRateAsync(
-            "FR", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+            "FR", Now, partyId: partyId, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldBe(fallbackEntry);
     }
@@ -214,19 +214,19 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     [Fact]
     public async Task GetRateAsync_ContactNotFound_FallsThroughToCountryRate()
     {
-        var contactId = PartyId.Create(Guid.NewGuid());
-        _contactReader.GetByIdAsync(contactId, Arg.Any<CancellationToken>())
+        var partyId = PartyId.Create(Guid.NewGuid());
+        _partyReader.GetByIdAsync(partyId, Arg.Any<CancellationToken>())
             .Returns((Party?)null);
         await SeedOverrideAsync("BE", 0.21m);
 
         TaxRateEntry? result = await _sut.GetRateAsync(
-            "BE", Now, contactId: contactId, cancellationToken: TestContext.Current.CancellationToken);
+            "BE", Now, partyId: partyId, cancellationToken: TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result.StandardRate.ShouldBe(0.21m);
     }
 
-    private static Party NewContactWithStatus(TaxStatus status)
+    private static Party NewPartyWithStatus(TaxStatus status)
     {
         var c = Party.Create(Guid.NewGuid(), tenantId: null, PartyKind.Company, "Test", "EUR");
         c.SetTaxStatus(status);


### PR DESCRIPTION
## Summary

Domain code, tests, and docs still carried `contact` as a synonym for `party` in
identifiers, parameter names, local variables, XML docstrings, and doc URLs.
Since we're still in dev, finish the rename so the lexicon is consistent.

### Public API

- `Party.ParentContactId` → `ParentPartyId`
- `TaxRequest.BuyerContactId` → `BuyerPartyId`
- `IInvoiceReader.GetByContactAsync` → `GetByPartyAsync`
- `IBalanceAccountReader.GetByContactAndCurrencyAsync` → `GetByPartyAndCurrencyAsync`
- Every `PartyId`/`Guid contactId` parameter → `partyId`
- Endpoint `ListContacts` → `ListParties`
- Privacy export filename `contacts.json` → `parties.json`
- BalanceAccount uniqueness index `accounts_contact_currency` → `accounts_party_currency`

### Internal naming

- `var contact` / `IPartyReader contactReader` / `ResolveContactAsync` /
  `ContactsDbSerialGroup` / `ContactsExportDto` / `Contacts*Tests` →
  `party` / `partyReader` / `ResolvePartyAsync` / `PartiesDbSerialGroup` /
  `PartiesExportDto` / `Parties*Tests`

### Botched-rename revert

`Tenant.PartyEmail` → `Tenant.ContactEmail` — "contact email" of a tenant is the
natural English sense, not the Parties module. A previous mass-rename had
incorrectly swept this field too.

### Docstrings

Sweep `contact` → `party` across `Party.cs`, all events, interfaces, DTOs,
preserving natural-English uses (`escalation contacts`, `contact info` on
`RecipientInfo`, DPO contact, controller contact, `contact-info` on
`PartyUpdatedEto`, `contact email` on Tenant).

### Docs

- Move `docs-site/.../business/contacts.mdx` → `parties.mdx`
- Move `docs-site/.../guides/contacts-{external-mappings,tenant-seeding,role-handler}.mdx`
  → `guides/parties-{...}.mdx`
- Update internal links + body content

## Test plan

- [x] `business` shard builds clean
- [x] `saas` shard builds clean
- [x] `integration` shard builds clean
- [x] `security` shard builds clean
- [x] `architecture` shard builds clean
- [ ] CI green on PR

> The 3 pre-existing architecture-test failures on develop (`Granit.Analytics`
> missing README + IPersistence wiring, from #1431) are unrelated to this PR.
