### PR TITLE
fix(analytics): satisfy *.EntityFrameworkCore architecture conventions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -90,6 +90,7 @@
       "name": "Granit.Analytics.EntityFrameworkCore",
       "deps": [
         "Granit.Analytics",
+        "Granit.Persistence.EntityFrameworkCore",
         "Granit.QueryEngine.EntityFrameworkCore"
       ],
       "framework": "net10.0"
@@ -4056,7 +4057,7 @@
       "kind": "class",
       "project": "Granit.Analytics.EntityFrameworkCore",
       "file": "src/Granit.Analytics.EntityFrameworkCore/GranitAnalyticsEntityFrameworkCoreModule.cs",
-      "line": 14,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj
+++ b/src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.EntityFrameworkCore\Granit.QueryEngine.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Analytics.EntityFrameworkCore/GranitAnalyticsEntityFrameworkCoreModule.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/GranitAnalyticsEntityFrameworkCoreModule.cs
@@ -1,5 +1,6 @@
 using Granit.Analytics.EntityFrameworkCore.Extensions;
 using Granit.Modularity;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Analytics.EntityFrameworkCore;
@@ -10,7 +11,14 @@ namespace Granit.Analytics.EntityFrameworkCore;
 /// resolve <c>IMetricExecutor&lt;TEntity, TValue&gt;</c> for any combination of
 /// entity and value type they declared a metric for.
 /// </summary>
+/// <remarks>
+/// Depends on <see cref="GranitPersistenceEntityFrameworkCoreModule"/> per the
+/// framework rule that every <c>*.EntityFrameworkCore</c> package declares the
+/// dependency — keeps the EF Core ecosystem coherent even when this package
+/// does not own a DbContext (it only consumes one through <c>IQueryEngine</c>).
+/// </remarks>
 [DependsOn(typeof(GranitAnalyticsModule))]
+[DependsOn(typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitAnalyticsEntityFrameworkCoreModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Analytics.EntityFrameworkCore/README.md
+++ b/src/Granit.Analytics.EntityFrameworkCore/README.md
@@ -1,0 +1,25 @@
+# Granit.Analytics.EntityFrameworkCore
+
+EF Core executor for `Granit.Analytics` `MetricDefinition`. Runs `Count` / `Sum` /
+`Avg` / `Min` / `Max` aggregations through the `Granit.QueryEngine` filter pipeline
+so KPIs always match grid row counts for the same filter spec, and locks the
+empty-set semantics (Sum / Count → 0, Avg / Min / Max → null) that the Analytics
+module promises.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Analytics.EntityFrameworkCore
+```
+
+## Dependencies
+
+- `Granit.Analytics`
+- `Granit.Persistence`
+- `Granit.QueryEngine.EntityFrameworkCore`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Analytics/README.md
+++ b/src/Granit.Analytics/README.md
@@ -1,0 +1,24 @@
+# Granit.Analytics
+
+Declarative Business Intelligence primitives for Granit. Pairs with `QueryDefinition`
+(lists rows) and `ExportDefinition` (extracts rows): `MetricDefinition` aggregates
+them into a single value (`Count`, `Sum`, `Avg`, `Min`, `Max`). Lightweight
+abstractions package with no EF Core dependency — execute via
+`Granit.Analytics.EntityFrameworkCore`.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Analytics
+```
+
+## Dependencies
+
+- `Granit`
+- `Granit.QueryEngine.Abstractions`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
@@ -364,6 +364,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }


### PR DESCRIPTION
## Summary

Follow-up to **#1431** (merged). The architecture-tests shard surfaced three convention violations on the new `Granit.Analytics.EntityFrameworkCore` package that the `business`/`api-data`/`saas` shards do not check:

1. **`EfCore_projects_should_reference_GranitPersistence`** — every `*.EntityFrameworkCore` csproj must reference `Granit.Persistence.EntityFrameworkCore`. Added the project reference.
2. **`EfCore_modules_should_DependOn_GranitPersistenceEntityFrameworkCoreModule`** — every `*.EntityFrameworkCore` module must declare `[DependsOn(typeof(GranitPersistenceEntityFrameworkCoreModule))]`. Added alongside the existing `GranitAnalyticsModule` dependency.
3. **`Every_src_package_should_have_a_README`** — `Granit.Analytics` and `Granit.Analytics.EntityFrameworkCore` were missing README files. Added both, matching the `Granit.QueryEngine` sibling pattern (purpose, install, dependencies, link to docs site).

The dependency on `Granit.Persistence.EntityFrameworkCore` is conventional rather than functional — the executor consumes a DbContext through `IQueryEngine`, it does not own one. The convention keeps the EF Core ecosystem coherent across the framework.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj` — 153/153 green
- [x] `dotnet build src/Granit.Analytics.EntityFrameworkCore` green
- [x] `dotnet test tests/Granit.Analytics.EntityFrameworkCore.Tests` — 16/16 green (no regression)
- [ ] CI green on PR

Part of EPIC #1366. Follows merged PR #1431.