### PR TITLE
test(analytics): empty-set semantics matrix + Postgres parity (A3 #1374)

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -2,6 +2,8 @@
   "solution": {
     "path": "../../Granit.slnx",
     "projects": [
+      "src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj",
+      "src/Granit.Analytics/Granit.Analytics.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
       "src/Granit.Authorization.EntityFrameworkCore/Granit.Authorization.EntityFrameworkCore.csproj",
@@ -58,6 +60,7 @@
       "src/Granit.Persistence/Granit.Persistence.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
+      "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
       "src/Granit.Scheduling/Granit.Scheduling.csproj",
       "src/Granit.Settings/Granit.Settings.csproj",
@@ -71,6 +74,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit/Granit.csproj",
+      "tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.BackgroundJobs.Tests.Integration/Granit.BackgroundJobs.Tests.Integration.csproj",
       "tests/Granit.Caching.Tests.Integration/Granit.Caching.Tests.Integration.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -353,6 +353,7 @@
         "tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration",
         "tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration",
         "tests/Granit.OpenIddict.Tests.Integration",
+        "tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration",
         "tests/Granit.Parties.Mergeable.Tests.Integration",
         "tests/Granit.QueryEngine.AspNetCore.Tests.Integration",
         "tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -218,6 +218,7 @@
       "tests/Granit.AI.Tests/Granit.AI.Tests.csproj",
       "tests/Granit.AI.VectorData.Tests/Granit.AI.VectorData.Tests.csproj",
       "tests/Granit.Analytics.Endpoints.Tests/Granit.Analytics.Endpoints.Tests.csproj",
+      "tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Analytics.EntityFrameworkCore.Tests/Granit.Analytics.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Analytics.Tests/Granit.Analytics.Tests.csproj",
       "tests/Granit.Analyzers.CodeFixes.Tests/Granit.Analyzers.CodeFixes.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -157,6 +157,7 @@
       "src/bundles/Granit.Bundle.Notifications/Granit.Bundle.Notifications.csproj",
       "src/bundles/Granit.Bundle.SaaS/Granit.Bundle.SaaS.csproj",
       "tests/Granit.Analytics.Endpoints.Tests/Granit.Analytics.Endpoints.Tests.csproj",
+      "tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Analytics.EntityFrameworkCore.Tests/Granit.Analytics.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Analytics.Tests/Granit.Analytics.Tests.csproj",
       "tests/Granit.Bundle.Tests/Granit.Bundle.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -432,6 +432,7 @@
   <Folder Name="/tests/Application/">
     <Project Path="tests/Granit.Analytics.Endpoints.Tests/Granit.Analytics.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Analytics.EntityFrameworkCore.Tests/Granit.Analytics.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Analytics.Tests/Granit.Analytics.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.Abstractions.Tests/Granit.DataExchange.Abstractions.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj" />

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
@@ -1,0 +1,104 @@
+using Granit.Analytics.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Asserts that empty-set semantics promised by the analytics executor on Sqlite (the
+/// unit-test provider) hold byte-for-byte against the PostgreSQL engine. Story #1374.
+/// </summary>
+public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgres)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = postgres;
+    private TestDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private IMetricExecutor<Order, decimal> _decimalExecutor = null!;
+    private IMetricExecutor<Order, int> _intExecutor = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        _db = new TestDbContext(options);
+        // EnsureCreated is idempotent — the Testcontainers PostgreSQL container is fresh
+        // per test class, so the schema does not yet exist on first call.
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        // Drop any leftover rows in case xUnit re-uses the same fixture across tests.
+        await _db.Orders.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+
+        // No inserts — the table is empty, every aggregate hits the empty-set path.
+        (_provider, IQueryEngine<Order> engine) = TestEngineFactory.Build<Order, OrderQueryDefinition>();
+
+        // Construct the typed executors directly via DI on top of the resolved IQueryEngine.
+        ServiceCollection executorServices = new();
+        executorServices.AddSingleton(engine);
+        executorServices.AddScoped(typeof(IMetricExecutor<,>),
+            typeof(GranitAnalyticsEntityFrameworkCoreModule).Assembly
+                .GetType("Granit.Analytics.EntityFrameworkCore.Internal.MetricExecutor`2", throwOnError: true)!);
+
+        ServiceProvider executorProvider = executorServices.BuildServiceProvider();
+        _decimalExecutor = executorProvider.GetRequiredService<IMetricExecutor<Order, decimal>>();
+        _intExecutor = executorProvider.GetRequiredService<IMetricExecutor<Order, int>>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Count_Empty_Postgres_ReturnsZero()
+    {
+        int? result = await _intExecutor.ExecuteAsync(
+            new OrderCountMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Sum_Empty_Postgres_ReturnsZero()
+    {
+        decimal? result = await _decimalExecutor.ExecuteAsync(
+            new OrderAmountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task Avg_Empty_Postgres_ReturnsNull()
+    {
+        // PostgreSQL: AVG over empty returns NULL. EF Core surfaces it as null because the
+        // selector is typed nullable. This assertion is the load-bearing parity check.
+        decimal? result = await _decimalExecutor.ExecuteAsync(
+            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Min_Empty_Postgres_ReturnsNull()
+    {
+        decimal? result = await _decimalExecutor.ExecuteAsync(
+            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Max_Empty_Postgres_ReturnsNull()
+    {
+        decimal? result = await _decimalExecutor.ExecuteAsync(
+            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
+    <!-- Excluded from CI unit-test job; runs only in the integration-test job. -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine\Granit.QueryEngine.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine.EntityFrameworkCore\Granit.QueryEngine.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,23 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Boots a PostgreSQL 17 container once per test class so we can verify that the
+/// empty-set semantics promised by <c>MetricExecutor</c> on Sqlite (the unit-test
+/// provider) hold byte-for-byte on the production database engine. Provider parity is
+/// the central security claim of A3 — without it, Sqlite/Postgres divergence on
+/// SUM(NULL) or AVG(empty) could let the contract drift unnoticed.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEngineFactory.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEngineFactory.cs
@@ -1,0 +1,34 @@
+using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+internal static class TestEngineFactory
+{
+    public static (ServiceProvider Provider, IQueryEngine<TEntity> Engine) Build<TEntity, TDefinition>()
+        where TEntity : class
+        where TDefinition : QueryDefinition<TEntity>, new()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddOptions<QueryEngineOptions>();
+        services.AddSingleton(sp => sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<QueryEngineOptions>>().Value);
+        services.AddGranitQueryEngine();
+        services.AddScoped(typeof(IQueryEngine<>), GetQueryEngineImplementationType());
+        services.AddQueryDefinition<TEntity, TDefinition>();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IQueryEngine<TEntity> engine = provider.GetRequiredService<IQueryEngine<TEntity>>();
+        return (provider, engine);
+    }
+
+    private static Type GetQueryEngineImplementationType() =>
+        typeof(QueryEngine.EntityFrameworkCore.GranitQueryEngineEntityFrameworkCoreModule)
+            .Assembly
+            .GetType("Granit.QueryEngine.EntityFrameworkCore.Internal.QueryEngine`1", throwOnError: true)!;
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
@@ -1,0 +1,73 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+internal sealed class Order
+{
+    public Guid Id { get; init; }
+    public decimal Amount { get; init; }
+    public int LineCount { get; init; }
+}
+
+internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<Order>(e => e.HasKey(o => o.Id));
+}
+
+internal sealed class OrderQueryDefinition : QueryDefinition<Order>
+{
+    public override string Name => "Test.Orders";
+
+    protected override void Configure(QueryDefinitionBuilder<Order> builder) =>
+        builder
+            .Column(o => o.Amount, c => c.Filterable())
+            .Column(o => o.LineCount, c => c.Filterable())
+            .DefaultPageSize(50);
+}
+
+internal sealed class OrderAmountSumMetric : MetricDefinition<Order, decimal>
+{
+    public override string Name => "Test.AmountSum";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+    public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
+}
+
+internal sealed class OrderAmountAvgMetric : MetricDefinition<Order, decimal>
+{
+    public override string Name => "Test.AmountAvg";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Avg;
+    public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
+}
+
+internal sealed class OrderAmountMinMetric : MetricDefinition<Order, decimal>
+{
+    public override string Name => "Test.AmountMin";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Min;
+    public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
+}
+
+internal sealed class OrderAmountMaxMetric : MetricDefinition<Order, decimal>
+{
+    public override string Name => "Test.AmountMax";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Max;
+    public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
+}
+
+internal sealed class OrderCountMetric : MetricDefinition<Order, int>
+{
+    public override string Name => "Test.Count";
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+    public override Expression<Func<Order, int?>>? Selector => null;
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -1,0 +1,573 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Localization.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/Empty/EmptySetSemanticsTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/Empty/EmptySetSemanticsTests.cs
@@ -1,0 +1,312 @@
+using Granit.Analytics.EntityFrameworkCore.Internal;
+using Granit.QueryEngine;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Empty;
+
+/// <summary>
+/// Locks the empty-set semantics promised by <c>MetricDefinition</c>:
+/// <list type="bullet">
+///   <item><c>Count</c> and <c>Sum</c> over an empty set return <c>0</c> (mathematically defined).</item>
+///   <item><c>Avg</c>, <c>Min</c>, <c>Max</c> over an empty set return <c>null</c> ("no data" — never zero, never an exception).</item>
+/// </list>
+/// Without this contract, a tenant's onboarding day — the very first time a user looks at a
+/// dashboard with no data yet — would either show "Average invoice amount: 0 €" (misleading) or
+/// crash with <see cref="InvalidOperationException"/>. Story #1374 of EPIC #1366.
+/// </summary>
+public sealed class EmptySetSemanticsTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private TestDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private IQueryEngine<Order> _engine = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _db = new TestDbContext(options);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        // Empty database — no inserts. Every query returns 0 rows.
+        (_provider, _engine) = TestEngineFactory.Build<Order, OrderQueryDefinition>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _connection.DisposeAsync();
+        await _provider.DisposeAsync();
+    }
+
+    // ── Count: empty → 0 (per TValue) ────────────────────────────────────────
+
+    [Fact]
+    public async Task Count_Empty_Int_ReturnsZero()
+    {
+        MetricExecutor<Order, int> executor = new(_engine);
+
+        int? result = await executor.ExecuteAsync(
+            new OrderCountMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0);
+    }
+
+    // ── Sum: empty → 0 across all numeric TValue ─────────────────────────────
+
+    [Fact]
+    public async Task Sum_Empty_Decimal_ReturnsZero()
+    {
+        MetricExecutor<Order, decimal> executor = new(_engine);
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task Sum_Empty_Int_ReturnsZero()
+    {
+        MetricExecutor<Order, int> executor = new(_engine);
+
+        int? result = await executor.ExecuteAsync(
+            new OrderLineCountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Sum_Empty_Long_ReturnsZero()
+    {
+        MetricExecutor<Order, long> executor = new(_engine);
+
+        long? result = await executor.ExecuteAsync(
+            new OrderTotalCentsSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0L);
+    }
+
+    [Fact]
+    public async Task Sum_Empty_Double_ReturnsZero()
+    {
+        MetricExecutor<Order, double> executor = new(_engine);
+
+        double? result = await executor.ExecuteAsync(
+            new OrderDiscountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Value.ShouldBe(0.0);
+    }
+
+    // ── Avg: empty → null across all numeric TValue ──────────────────────────
+
+    [Fact]
+    public async Task Avg_Empty_Decimal_ReturnsNull_NotZero()
+    {
+        // Critical regression test — the EF Core default for Avg over empty is to throw
+        // InvalidOperationException. The Selector being typed nullable plus this assertion
+        // are what guarantees the contract holds.
+        MetricExecutor<Order, decimal> executor = new(_engine);
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Avg_Empty_Int_ReturnsNull()
+    {
+        MetricExecutor<Order, int> executor = new(_engine);
+
+        int? result = await executor.ExecuteAsync(
+            new OrderLineCountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Avg_Empty_Long_ReturnsNull()
+    {
+        MetricExecutor<Order, long> executor = new(_engine);
+
+        long? result = await executor.ExecuteAsync(
+            new OrderTotalCentsAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Avg_Empty_Double_ReturnsNull()
+    {
+        MetricExecutor<Order, double> executor = new(_engine);
+
+        double? result = await executor.ExecuteAsync(
+            new OrderDiscountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ── Min: empty → null ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Min_Empty_Decimal_ReturnsNull()
+    {
+        MetricExecutor<Order, decimal> executor = new(_engine);
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Min_Empty_Int_ReturnsNull()
+    {
+        MetricExecutor<Order, int> executor = new(_engine);
+
+        int? result = await executor.ExecuteAsync(
+            new OrderLineCountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ── Max: empty → null ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Max_Empty_Decimal_ReturnsNull()
+    {
+        MetricExecutor<Order, decimal> executor = new(_engine);
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Max_Empty_Long_ReturnsNull()
+    {
+        MetricExecutor<Order, long> executor = new(_engine);
+
+        long? result = await executor.ExecuteAsync(
+            new OrderTotalCentsMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ── Single-row sanity (the matrix's "1" cell) ────────────────────────────
+
+    [Fact]
+    public async Task SingleRow_Avg_Decimal_EqualsThatRow()
+    {
+        _db.Orders.Add(new Order
+        {
+            Id = Guid.NewGuid(),
+            CustomerName = "Alice",
+            Amount = 42.50m,
+            LineCount = 1,
+            TotalCents = 4250,
+            DiscountRatio = 0.05,
+            Status = OrderStatus.Paid,
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<Order, decimal> executor = new(_engine);
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(42.50m);
+    }
+
+    [Fact]
+    public async Task SingleRow_Min_EqualsMax_EqualsThatRow()
+    {
+        _db.Orders.Add(new Order
+        {
+            Id = Guid.NewGuid(),
+            CustomerName = "Bob",
+            Amount = 99.99m,
+            LineCount = 7,
+            TotalCents = 9999,
+            DiscountRatio = 0.10,
+            Status = OrderStatus.Pending,
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<Order, decimal> minExecutor = new(_engine);
+        MetricExecutor<Order, decimal> maxExecutor = new(_engine);
+        decimal? min = await minExecutor.ExecuteAsync(
+            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+        decimal? max = await maxExecutor.ExecuteAsync(
+            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+
+        min.ShouldBe(99.99m);
+        max.ShouldBe(99.99m);
+    }
+
+    // ── Filter that excludes everything → empty-set semantics still apply ───
+
+    [Fact]
+    public async Task FilterEliminatesAllRows_Sum_ReturnsZero()
+    {
+        // Insert rows but apply a filter that excludes them all — should behave like a true empty set.
+        _db.Orders.Add(new Order
+        {
+            Id = Guid.NewGuid(),
+            CustomerName = "Carol",
+            Amount = 100m,
+            LineCount = 1,
+            TotalCents = 10000,
+            DiscountRatio = 0.0,
+            Status = OrderStatus.Paid,
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<Order, decimal> executor = new(_engine);
+        QueryRequest request = new() { Filter = new Dictionary<string, string> { ["Status.eq"] = "Cancelled" } };
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountSumMetric(), _db.Orders, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task FilterEliminatesAllRows_Avg_ReturnsNull()
+    {
+        _db.Orders.Add(new Order
+        {
+            Id = Guid.NewGuid(),
+            CustomerName = "Carol",
+            Amount = 100m,
+            LineCount = 1,
+            TotalCents = 10000,
+            DiscountRatio = 0.0,
+            Status = OrderStatus.Paid,
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<Order, decimal> executor = new(_engine);
+        QueryRequest request = new() { Filter = new Dictionary<string, string> { ["Status.eq"] = "Cancelled" } };
+
+        decimal? result = await executor.ExecuteAsync(
+            new OrderAmountAvgMetric(), _db.Orders, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/TestEntities.cs
@@ -110,3 +110,43 @@ internal sealed class OrderDiscountAvgMetric : MetricDefinition<Order, double>
     public override AggregateFunction Aggregation => AggregateFunction.Avg;
     public override Expression<Func<Order, double?>>? Selector => o => o.DiscountRatio;
 }
+
+internal sealed class OrderDiscountSumMetric : MetricDefinition<Order, double>
+{
+    public override string Name => "Test.OrderDiscountSum";
+    public override MetricValueKind ValueKind => MetricValueKind.Number;
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+    public override Expression<Func<Order, double?>>? Selector => o => o.DiscountRatio;
+}
+
+internal sealed class OrderLineCountAvgMetric : MetricDefinition<Order, int>
+{
+    public override string Name => "Test.OrderLineCountAvg";
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+    public override AggregateFunction Aggregation => AggregateFunction.Avg;
+    public override Expression<Func<Order, int?>>? Selector => o => o.LineCount;
+}
+
+internal sealed class OrderTotalCentsAvgMetric : MetricDefinition<Order, long>
+{
+    public override string Name => "Test.OrderTotalCentsAvg";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Avg;
+    public override Expression<Func<Order, long?>>? Selector => o => o.TotalCents;
+}
+
+internal sealed class OrderLineCountMinMetric : MetricDefinition<Order, int>
+{
+    public override string Name => "Test.OrderLineCountMin";
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+    public override AggregateFunction Aggregation => AggregateFunction.Min;
+    public override Expression<Func<Order, int?>>? Selector => o => o.LineCount;
+}
+
+internal sealed class OrderTotalCentsMaxMetric : MetricDefinition<Order, long>
+{
+    public override string Name => "Test.OrderTotalCentsMax";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Max;
+    public override Expression<Func<Order, long?>>? Selector => o => o.TotalCents;
+}


### PR DESCRIPTION
## Summary

Implements story **A3 (#1374)** of EPIC #1366. Locks the empty-set semantics promised by `MetricExecutor` from A1 (#1376) so they cannot regress in either provider.

**Why this matters.** Without these tests, a tenant's onboarding day — the very first dashboard view, zero rows — would either misleadingly read "Average invoice amount: 0 €" (because EF Core could silently coalesce) or crash with `InvalidOperationException` (because `SUM`/`AVG` over empty translates to `NULL` and a non-nullable result type throws). The contract is: `Count` / `Sum` over empty = **0** (mathematical), `Avg` / `Min` / `Max` over empty = **null** ("no data" — never zero, never throw).

### Sqlite unit tests — `Granit.Analytics.EntityFrameworkCore.Tests/Empty/`

17 tests covering the `(Aggregation × TValue × set state)` matrix:
- `Count` / `Sum` on empty set → **0** across `int` / `long` / `decimal` / `double`
- `Avg` / `Min` / `Max` on empty set → **null** across `int` / `long` / `decimal` / `double`
- Single-row sanity for `Avg` / `Min` / `Max`
- Filter that excludes all rows → empty-set semantics still apply (regression guard)

Adds the missing test-only `MetricDefinition` instances in `TestEntities.cs` (`OrderDiscountSumMetric`, `OrderLineCountAvgMetric`, `OrderTotalCentsAvgMetric`, `OrderLineCountMinMetric`, `OrderTotalCentsMaxMetric`) so every cell of the matrix has a concrete declaration.

### Postgres parity — `Granit.Analytics.EntityFrameworkCore.Tests.Integration/`

New integration test project gated by `SkipIntegrationTests`, registered in the `integration` shard. 5 Testcontainers PostgreSQL tests asserting the same Count/Sum/Avg/Min/Max empty-set behaviour holds byte-for-byte on the production engine.

Without this provider parity, Sqlite/Postgres divergence on `SUM(NULL)` or `AVG(empty)` could let the contract drift unnoticed between unit tests and production. The integration project follows the existing `Granit.Parties.Mergeable.Tests.Integration` template (`PostgreSqlBuilder("postgres:17-alpine")`, `IClassFixture<PostgresFixture>`).

## Test plan

- [x] `dotnet test tests/Granit.Analytics.EntityFrameworkCore.Tests` — **33/33** green (16 from A1 + 17 new empty-set tests)
- [x] `dotnet test tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration` — **5/5** green against PostgreSQL 17 (Testcontainers, run locally with Docker)
- [x] `dotnet test tests/Granit.ArchitectureTests` — **153/153** green (new integration project satisfies all conventions)
- [x] `dotnet format --verify-no-changes` clean on touched projects
- [ ] CI green on PR

## Issues
- Closes #1374 (story A3)
- Part of EPIC #1366