### PR TITLE
docs(analytics): conventions page + Analytics docs section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,23 @@ include a text-rendered channel (Email, SMS, WhatsApp, Web Push…), an `Embedde
 named `Templates.{Name}.html` is present in the same assembly. Cross-link this section
 when the test lands.
 
+### Analytics (`*MetricDefinition`) — naming, placement, period tokens
+
+Full convention lives at
+[`docs-site/.../analytics/conventions.mdx`](docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx)
+(rendered as the *Conventions* page under *Business Features → Analytics* on the docs
+site). Highlights — read the full page before adding a metric:
+
+- **Class file**: `src/Granit.{Module}/Metrics/{MetricName}MetricDefinition.cs`
+- **`Name` property**: `Granit.{Module}.{MetricName}Metric` (PascalCase, dot-separated)
+- **Formula**: `{Subset?}{Entity}{Field?}{Aggregation}` — aggregation **always last**
+  (`InvoicePaymentDelayAverageMetric`, NOT `AverageInvoicePaymentDelayMetric`); groups
+  metrics alphabetically by entity in IDE autocomplete and admin UI.
+- **Period tokens** in HTTP requests reuse DAX acronyms — `MTD`, `QTD`, `YTD`, `MAT`,
+  `PP`, `PY`, `PYC`, … — so analysts moving from Power BI find a familiar vocabulary.
+- **Localization**: `Metric:{Name}` keys mandatory in all 18 cultures of the owning
+  module.
+
 ### Declarative definitions (`*QueryDefinition`, `*ExportDefinition`) — placement (STRICT)
 
 Two declarative primitives describe how an entity is consulted (grid filter/sort) and

--- a/docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx
@@ -1,0 +1,234 @@
+---
+title: "Analytics conventions — naming, structure, localization"
+description: "Mandatory naming and structural conventions for Granit.Analytics MetricDefinition, dashboards, and period tokens. Aligned with DAX (Microsoft Power BI / Analysis Services) so analysts and their tooling reuse the same vocabulary."
+sidebar:
+  label: Conventions
+  order: 10
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+These conventions are not just style preferences — they're load-bearing for the whole
+Granit BI stack. The same metric name appears in localization JSON keys, HTTP route
+parameters, dashboard widget references, OData EntitySet aliases, and Power BI client
+measures. Drift here breaks the link between layers.
+
+<Aside type="tip" title="Inspiration">
+  Granit analytics naming follows the same Subject + Aggregation pattern as **DAX
+  measures** in Microsoft Power BI / Analysis Services. Time-period tokens reuse the
+  canonical DAX acronyms (`YTD`, `MTD`, `QTD`, `MAT`, `PY`, `PYC`, `PP`…) documented at
+  [daxpatterns.com — Standard Time-Related Calculations](https://www.daxpatterns.com/standard-time-related-calculations/).
+  The intent is alignment, not imitation: an analyst arriving with a Power BI model
+  finds a familiar vocabulary on top of Granit's OData feed.
+</Aside>
+
+## `MetricDefinition` — naming
+
+### Format
+
+| Element | Format | Example |
+| ------- | ------ | ------- |
+| File path | `src/Granit.{Module}/Metrics/{MetricName}MetricDefinition.cs` | `src/Granit.Invoicing/Metrics/UnpaidInvoiceCountMetricDefinition.cs` |
+| Class name | `{MetricName}MetricDefinition` | `UnpaidInvoiceCountMetricDefinition` |
+| `Name` property | `Granit.{Module}.{MetricName}Metric` | `"Granit.Invoicing.UnpaidInvoiceCountMetric"` |
+| Localization key | `Metric:{Name}` | `Metric:Granit.Invoicing.UnpaidInvoiceCountMetric` |
+
+The class file uses the `MetricDefinition` suffix (parallel to `QueryDefinition` /
+`ExportDefinition`); the `Name` property drops `Definition` but keeps `Metric` so the
+three primitives can be listed side-by-side in admin tools without ambiguity.
+
+### Formula
+
+`{Subset?}{Entity}{Field?}{Aggregation}` — PascalCase, no spaces, no abbreviations,
+**aggregation always at the end**.
+
+| Slot | Role | Examples |
+| ---- | ---- | -------- |
+| **Subset** (optional) | Adjective scoping the data | `Unpaid`, `Active`, `Recent`, `Orphan`, `Pending`, `Failed`, `Distinct` |
+| **Entity** | Singular noun | `Invoice`, `Subscription`, `Blob`, `Webhook`, `Job`, `Customer` |
+| **Field** (optional) | Property being aggregated, when the entity has multiple aggregable dimensions | `Amount`, `PaymentDelay`, `Duration`, `LineCount` |
+| **Aggregation** | Suffix matching the function — **always last** | `Count`, `Total`, `Average`, `Min`, `Max`, `Rate`, `Ratio` |
+
+#### Why aggregation as suffix (not prefix)
+
+Strict suffix-position groups metrics alphabetically by domain in IDE autocomplete, in
+the admin UI metric picker, and in the OpenAPI schema. Typing
+`Granit.Invoicing.Invoice` in any of these surfaces brings up `InvoiceCount`,
+`InvoiceTotal`, `InvoiceAmountAverage`, `InvoiceAmountMin`, `InvoiceAmountMax` clustered
+together by entity — far more discoverable than scattering them across `Average*`,
+`Min*`, `Max*` first letters.
+
+DAX users will recognise this as the same intuition behind `[Sales Amount Average]`
+(prefer) over `[Average Sales Amount]` — Microsoft's own measure-naming guidance for
+Analysis Services follows the same logic.
+
+### Aggregation suffix decision table
+
+| Suffix | Meaning | Maps to | Default `ValueKind` |
+| ------ | ------- | ------- | ------------------- |
+| `Count` | Number of rows matching the subset | `AggregateFunction.Count` | `Count` |
+| `Total` | Sum over a numeric field | `AggregateFunction.Sum` | `Currency` (override to `Number` for non-monetary sums) |
+| `Average` | Arithmetic mean over the named field | `AggregateFunction.Avg` | depends on the field |
+| `Min` / `Max` | Lowest / highest value of the named field | `AggregateFunction.Min` / `Max` | depends on the field |
+| `Rate` | Events per time unit | `Sum` divided by interval | `Number` (rate per second / hour…) |
+| `Ratio` | Part / total fraction | Composite (numerator / denominator) | `Percentage` |
+
+`Rate` vs `Ratio` follows DAX: a *rate* is "events per unit of time" (e.g. crash rate
+per day), a *ratio* is "part over whole" (e.g. win ratio = wins / total games). Both
+typically render as percentages, but the underlying math differs.
+
+### `IsHigherBetter` heuristic
+
+| Subset | `IsHigherBetter` |
+| ------ | ---------------- |
+| `Failed*`, `Unpaid*`, `Orphan*`, `Pending*`, `Stale*`, `Overdue*` | `false` (less is better) |
+| `Active*`, `Successful*`, `Completed*`, `Approved*`, `Distinct*Count`, `*Revenue`, `*Total` (revenue) | `true` (more is better) |
+
+Drives the green/red color of the delta arrow in the UI. Override via the property
+when the heuristic doesn't match (e.g. `*Total` for cost amounts is `false`).
+
+### Sub-modules
+
+Modules with internal sub-domains (Invoicing = Invoices + CreditNotes, Identity = Local
++ Federated, BackgroundJobs = Recurring + One-shot) use a fourth segment:
+
+```text
+Granit.Invoicing.CreditNotes.OutstandingCountMetric
+Granit.Identity.Local.LockedAccountCountMetric
+Granit.BackgroundJobs.Recurring.FailureRateMetric
+```
+
+The sub-module segment is optional — only use it when the same `Module + Entity`
+pair would otherwise collide between sub-domains.
+
+## Examples — projected on the framework's modules
+
+Notice how every entity's metrics cluster alphabetically: all `Invoice*` together, all
+`PaymentTransaction*` together. The aggregation is always the final word.
+
+| Module | Class | `Name` |
+| ------ | ----- | ------ |
+| Invoicing | `UnpaidInvoiceCountMetricDefinition` | `Granit.Invoicing.UnpaidInvoiceCountMetric` |
+| Invoicing | `UnpaidInvoiceTotalMetricDefinition` | `Granit.Invoicing.UnpaidInvoiceTotalMetric` |
+| Invoicing | `InvoicePaymentDelayAverageMetricDefinition` | `Granit.Invoicing.InvoicePaymentDelayAverageMetric` |
+| Invoicing | `InvoicePaymentDelayMaxMetricDefinition` | `Granit.Invoicing.InvoicePaymentDelayMaxMetric` |
+| Subscriptions | `MonthlyRecurringRevenueMetricDefinition` | `Granit.Subscriptions.MonthlyRecurringRevenueMetric` (canonical SaaS term — see exception below) |
+| Subscriptions | `SubscriptionChurnRateMetricDefinition` | `Granit.Subscriptions.SubscriptionChurnRateMetric` |
+| Payments | `PaymentTransactionCountMetricDefinition` | `Granit.Payments.PaymentTransactionCountMetric` |
+| Payments | `PaymentTransactionSuccessRateMetricDefinition` | `Granit.Payments.PaymentTransactionSuccessRateMetric` |
+| Privacy | `PendingErasureRequestCountMetricDefinition` | `Granit.Privacy.PendingErasureRequestCountMetric` |
+| BackgroundJobs | `FailedJobCountMetricDefinition` | `Granit.BackgroundJobs.FailedJobCountMetric` |
+| BlobStorage | `OrphanBlobCountMetricDefinition` | `Granit.BlobStorage.OrphanBlobCountMetric` |
+| Webhooks | `WebhookDeliveryFailureRateMetricDefinition` | `Granit.Webhooks.WebhookDeliveryFailureRateMetric` |
+
+### Time references in the name — when to inline, when not to
+
+The framework's principle: **time periods are query parameters, not part of the
+identity**. One `Granit.Subscriptions.RecurringRevenueMetric` answers MRR with
+`?period=mtd`, ARR with `?period=ytd&aggregation=annualize`, last-quarter
+revenue with `?period=pqc`, and so on. Adding `Monthly` / `Yearly` / `Daily` to the
+name multiplies definitions for no analytical gain.
+
+The single exception: when the time unit is part of a canonical industry name and
+the metric **always normalises to it** regardless of the query period. SaaS
+"Monthly Recurring Revenue" and "Annual Recurring Revenue" are the textbook
+examples — MRR is always the monthly equivalent of the recurring book of business
+(yearly subscription / 12, etc.) at any point in time. In those cases keep the
+domain term *and* document why in the class XML doc:
+
+```csharp
+/// <summary>
+/// Monthly Recurring Revenue (MRR) — SaaS canonical metric: the monthly-equivalent
+/// recurring book of business at the queried instant. The "Monthly" is part of the
+/// metric's identity, not a time period (see Granit conventions).
+/// </summary>
+public sealed class MonthlyRecurringRevenueMetricDefinition : MetricDefinition<Subscription, decimal> { … }
+```
+
+When in doubt, drop the time word from the name.
+
+## Period tokens — DAX-aligned
+
+The HTTP endpoint accepts named tokens for both the main `period` and the optional
+`compareTo` window. Tokens are case-insensitive and resolved server-side via
+`IClock` (never `DateTimeOffset.UtcNow`), so the same request is reproducible across
+machines and time zones.
+
+### Aggregation windows (`period`)
+
+DAX users will recognise the upper-cased acronyms — they're the same calendar
+semantics:
+
+| Token | DAX acronym | Window |
+| ----- | ----------- | ------ |
+| `today` | — | `[start of today, end of today)` |
+| `yesterday` | — | `[start of yesterday, start of today)` |
+| `last_60s` / `last_5m` | — | rolling seconds / minutes (real-time-friendly) |
+| `last_7d` | — | `[7 days ago at midnight, end of today)` |
+| `last_30d` | — | `[30 days ago at midnight, end of today)` |
+| `mtd` | **MTD** (Month-to-date) | `[1st of current month, end of today)` |
+| `qtd` | **QTD** (Quarter-to-date) | `[1st of current quarter, end of today)` |
+| `ytd` | **YTD** (Year-to-date) | `[1st of January current year, end of today)` |
+| `mat` | **MAT** (Moving Annual Total) | `[365 days ago, end of today)` — rolling 12 months. Planned. |
+
+### Comparison windows (`compareTo`)
+
+Same DAX acronyms; the framework computes the time shift:
+
+| Token | DAX acronym | Resolves to |
+| ----- | ----------- | ----------- |
+| `previous_period` | **PP** (Previous Period) | Equal-length window immediately preceding the main one — works for any main period |
+| `pm` | **PM** (Previous Month — rolling) | Same offset within the previous month. Planned. |
+| `pq` | **PQ** (Previous Quarter — rolling) | Same offset within the previous quarter. Planned. |
+| `py` | **PY** (Previous Year — rolling) | Same offset within the previous year. Planned. |
+| `pmc` | **PMC** (Previous Month Complete) | Full previous calendar month. Planned. |
+| `pqc` | **PQC** (Previous Quarter Complete) | Full previous calendar quarter. Planned. |
+| `pyc` | **PYC** (Previous Year Complete) | Full previous calendar year. Planned. |
+
+<Aside type="note" title="Why tokens, not bake-into-the-name">
+  In Power BI / DAX, time-shifted measures are physical entities — `[Sales]` and
+  `[Sales YTD]` are two different measures. Granit takes the orthogonal route: one
+  metric, multiple period evaluations at request time. So you have ONE
+  `Granit.Sales.SalesMetric`, called with `?period=ytd&compareTo=py` for the YTD vs
+  previous-year-rolling comparison, with `?period=mat&compareTo=pp` for MAT vs the
+  previous 12 months, and so on. Fewer definitions to maintain, and the comparison
+  math is centralized in `DeltaCalculator`.
+</Aside>
+
+## Localization — mandatory
+
+Every `MetricDefinition.Name` MUST have a `Metric:{Name}` key in **all 18 base /
+regional cultures** of the owning module's `Localization/` folder. This includes:
+
+- 15 base cultures: `en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi`
+- 3 regional variants: `fr-CA, en-GB, pt-BR` (only differing keys; fall through to
+  base culture for unchanged strings)
+
+Architecture test (story #1397, planned) will fail the build when a metric ships
+without complete coverage.
+
+## Permissions
+
+Metric endpoints inherit the underlying entity's read permission. A metric over
+`Invoice` is gated by `Invoicing.Invoices.Read` — never a metric-specific permission.
+Rationale: the metric exposes an aggregate of data the user could already see via the
+list endpoint; granting a separate metric permission would be a confusing layer
+without security value.
+
+## Anti-patterns
+
+- **Abbreviations**: `UnpaidInvCnt` ❌. DAX rule applies — verbose names beat clever
+  ones, especially when the same identifier surfaces in URLs and JSON keys.
+- **Mixed case in module segment**: `Granit.invoicing.UnpaidInvoiceCountMetric` ❌. The
+  module segment must match the C# module name exactly.
+- **Time intelligence baked into the name**: `Granit.Sales.SalesYTDMetric` ❌. Use the
+  `period` parameter — see the `note` callout above.
+- **Hyphens / underscores in `Name`**: `granit-invoicing-unpaid-invoice-count` ❌.
+  PascalCase + dot-separated only. Background-jobs are the exception (`-` separator)
+  because they're a different namespace category.
+- **Redundant suffixes**: `Granit.Invoicing.UnpaidInvoiceCountMetricDefinition` ❌
+  (the `Definition` suffix lives on the C# class only, not the wire identifier).
+
+## Read next
+
+- [Overview](/dotnet/business/analytics/) — Three-layer BI stack, package structure.

--- a/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
@@ -1,0 +1,126 @@
+---
+title: "Analytics — Inline KPIs, Dashboards & BI Connectivity"
+description: "Granit.Analytics ships declarative MetricDefinition primitives, composable dashboards, and an OData v4 surface for Power BI / Excel / Tableau — all multi-tenant safe and locked to the same filter pipeline as the grid endpoints."
+sidebar:
+  label: Overview
+  order: 0
+---
+
+import { Aside, FileTree } from "@astrojs/starlight/components";
+
+`Granit.Analytics` brings first-class Business Intelligence to the framework — from a
+single counter above an admin grid, to fully composable Odoo-style dashboards, to native
+Power BI / Excel / Tableau connectivity — without compromising multi-tenancy isolation,
+GDPR, or ISO 27001 audit guarantees.
+
+## Why a built-in BI layer?
+
+Every Granit-based application that needs analytics either rolls its own (hand-coded
+counters, ad-hoc SQL, no caching, no period comparison, no localization) or grants
+read-only SQL access to BI tools — a multi-tenant liability waiting to happen the day a
+custom view forgets a `WHERE tenant_id = …` clause. `Granit.Analytics` closes both gaps:
+KPIs are declared once and shared across inline displays, dashboards and external BI
+tools through a single, security-reviewed pipeline.
+
+## The three layers
+
+The framework's BI story is structured in three additive layers, each useful on its own:
+
+<FileTree>
+- Layer 1 — Inline metrics  KPIs above a list, single-value tiles
+  - Granit.Analytics  Declarative MetricDefinition base classes
+  - Granit.Analytics.EntityFrameworkCore  EF Core executor with empty-set semantics
+  - Granit.Analytics.Endpoints  POST /metrics/:name surface with FusionCache
+- Layer 2 — Composable dashboards  Drag-drop layouts, multiple widget kinds
+  - Granit.Analytics  DashboardDefinition + widget contracts (planned)
+  - Granit.Analytics.EntityFrameworkCore  Persisted Dashboard aggregate (planned)
+- Layer 3 — OData v4 connector  Power BI / Excel / Tableau native consumption
+  - Granit.Http.ODataExposure  Bridge QueryDefinition → OData EntitySet (planned)
+</FileTree>
+
+## Package structure (Layer 1, shipped)
+
+<FileTree>
+- Granit.Analytics  Abstractions — no EF Core dependency
+  - Metrics/MetricDefinition.cs  Aggregation declaration + period selector
+  - Metrics/MetricValueKind.cs  Count / Number / Currency / Percentage / Duration / Date
+  - Metrics/RefreshHint.cs  Static / Dynamic / Realtime
+  - Widgets/IWidgetSource.cs  Pull-and-future-push widget contract
+  - Widgets/WidgetPayload.cs  Snapshot envelope with sequence + emitted-at metadata
+- Granit.Analytics.EntityFrameworkCore  Concrete EF Core executor
+  - IMetricExecutor.cs  Public façade — typed per (TEntity, TValue)
+  - Internal/MetricExecutor.cs  Typed dispatch per TValue (int / long / decimal / double)
+- Granit.Analytics.Endpoints  Minimal API surface
+  - Endpoints/MetricEndpoints.cs  POST /metrics/:name
+  - Internal/MetricEndpointService.cs  FusionCache + period comparison + delta
+  - Internal/PeriodResolver.cs  today / last_30d / mtd / qtd / ytd / previous_period
+  - Permissions/AnalyticsPermissions.cs  Analytics.Metrics.Read
+</FileTree>
+
+## What you ship to declare a metric
+
+A metric is a one-class declaration in your module's `Metrics/` folder, registered once in
+`ConfigureServices`. The framework takes care of the rest — caching, multi-tenancy, period
+filtering, comparison-window math, localization, and the HTTP surface.
+
+```csharp
+// src/Granit.Invoicing/Metrics/UnpaidInvoiceCountMetricDefinition.cs
+public sealed class UnpaidInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    public override string Name => "Granit.Invoicing.UnpaidInvoiceCountMetric";
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Open;
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+    public override bool IsHigherBetter => false;  // fewer unpaid invoices = better
+}
+```
+
+Naming, casing, and structural rules are codified in the
+[Conventions](/dotnet/business/analytics/conventions/) page — they're worth reading
+before adding a metric, because the same names land in:
+
+- Localization keys (`Metric:{Name}` across 18 cultures)
+- HTTP route parameters (`POST /api/granit/analytics/metrics/{Name}`)
+- Dashboard widget references (Layer 2)
+- OData EntitySet routing (Layer 3)
+- Power BI / Excel client measure aliases
+
+<Aside type="tip" title="Power BI alignment">
+  Granit metric names follow the same Subject + Aggregation pattern as DAX measures in
+  Microsoft Power BI / Analysis Services. An analyst migrating their Power BI model on
+  top of Granit's OData feed (Layer 3) finds familiar names and semantics.
+</Aside>
+
+## Empty-set semantics — locked
+
+The contract every analytics consumer can rely on:
+
+| Aggregation | Empty set | Single row | Multi row |
+| ----------- | --------- | ---------- | --------- |
+| `Count` | `0` | `1` | rows count |
+| `Sum` | `0` (mathematical sum-of-empty) | the row's value | sum of values |
+| `Avg` / `Min` / `Max` | **`null`** ("no data") | the row's value | computed |
+
+Without this contract, a tenant's onboarding day — first dashboard view, zero rows —
+would either mislead with "Average invoice amount: 0 €" (because EF Core could silently
+coalesce) or throw `InvalidOperationException`. Locked by integration tests against both
+SQLite and PostgreSQL.
+
+## Future-proofing for real-time
+
+Layer 1 is intentionally pull-based (FusionCache TTL 60–120 s). Real-time push (WebSocket
+delta updates, ThingsBoard-style for IoT) is deferred to the
+[`granit-iot`](https://github.com/granit-fx/granit-iot) repo, where the ingestion
+pipeline (MQTT bridge, AWS IoT, TimescaleDB) already lives. The wire-format envelope
+`{ Snapshot, Sequence, EmittedAt, RefreshHint }` and the `IWidgetSource<T>` contract
+(with stub `SubscribeAsync`) are locked v1 so push transport can be added later without
+breaking pull consumers.
+
+## Read next
+
+- [Conventions](/dotnet/business/analytics/conventions/) — Naming rules, mandatory
+  metric structure, localization keys, project layout. Read this first.


### PR DESCRIPTION
## Summary

Locks the **MetricDefinition naming convention** in the docs site before A4 (#1377) instantiates the first reference metrics — without this, every module that follows would copy whatever pattern A4 happens to use, and inconsistencies become unfixable post-fact.

### `docs-site/src/content/docs/dotnet/business/analytics/`

- **`index.mdx`** — overview of the three-layer BI stack (inline metrics → composable dashboards → OData connector), package structure, locked empty-set semantics, forward-compatibility note for the `granit-iot` push transport.
- **`conventions.mdx`** — naming and structural rules:
  - **Format**: `Granit.{Module}.{MetricName}Metric` for `Name`, `{MetricName}MetricDefinition` for the class, located under `src/Granit.{Module}/Metrics/`.
  - **Formula**: `{Subset?}{Entity}{Field?}{Aggregation}` — **aggregation always last** (e.g. `InvoicePaymentDelayAverageMetric`, NOT `AverageInvoicePaymentDelayMetric`). Groups metrics alphabetically by entity in IDE autocomplete and admin UI metric pickers — analysts type `Granit.Invoicing.Invoice` and see all `Invoice*Count`, `Invoice*Total`, `Invoice*Average` clustered together.
  - **Period tokens** reuse DAX acronyms (`MTD`, `QTD`, `YTD`, `MAT`, `PP`, `PY`, `PYC`, `PMC`, `PQC`) so analysts migrating from Power BI find a familiar vocabulary on top of Granit's OData feed (Layer 3).
  - **Industry-term exception** clause: SaaS canonical names like *Monthly Recurring Revenue* (MRR) keep the time word in the identity even though our general rule is "time is a query parameter, not part of the name".
  - Anti-patterns list, `IsHigherBetter` heuristic, `Rate` vs `Ratio` distinction.

Sidebar entry under "Business Features" auto-generates from the new `analytics/` folder via Starlight's `autogenerate` directive — no `astro.config.mjs` change needed.

### `CLAUDE.md`

Adds an "Analytics (`*MetricDefinition`) — naming, placement, period tokens" section just above the existing "Declarative definitions" section, summarising the highlights (file path, formula, DAX-aligned period tokens, localization key) and pointing to the docs-site page as the single source of truth. Read-this-first style.

### Inspiration

Explicit reference to [daxpatterns.com — Standard Time-Related Calculations](https://www.daxpatterns.com/standard-time-related-calculations/) (Marco Russo / Alberto Ferrari, sqlbi.com). Strategic alignment with the future OData connector (Layer 3, story C5): consumers of Granit's `EntitySet`s through Power BI / Excel / Tableau see metric names that mentally map to DAX measures they already write.

## Test plan

- [x] `npx astro build` green — both pages render
- [x] CLAUDE.md `markdownlint-cli2` clean
- [x] Sidebar auto-generates the new "Analytics" subsection under "Business Features"
- [ ] CI green on PR

## Issues
- Lays groundwork for #1377 (A4 — Invoicing reference impl) and #1375 (A6 — docs site analytics conventions page, this PR fulfills it ahead of schedule)
- Part of EPIC #1366