### PR TITLE
feat(analytics): UnpaidInvoice* metrics + BaseFilter + test isolation helper (A4 #1377)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -11,6 +11,7 @@
       "src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj",
       "src/Granit.AI.VectorData/Granit.AI.VectorData.csproj",
       "src/Granit.AI/Granit.AI.csproj",
+      "src/Granit.Analytics/Granit.Analytics.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
       "src/Granit.Auditing.ConfigurationChanges/Granit.Auditing.ConfigurationChanges.csproj",

--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -2,6 +2,8 @@
   "solution": {
     "path": "../../Granit.slnx",
     "projects": [
+      "src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj",
+      "src/Granit.Analytics/Granit.Analytics.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",
@@ -63,6 +65,7 @@
       "src/Granit.Persistence/Granit.Persistence.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",
       "src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj",
+      "src/Granit.QueryEngine.EntityFrameworkCore/Granit.QueryEngine.EntityFrameworkCore.csproj",
       "src/Granit.QueryEngine/Granit.QueryEngine.csproj",
       "src/Granit.RateLimiting/Granit.RateLimiting.csproj",
       "src/Granit.Scheduling/Granit.Scheduling.csproj",
@@ -79,6 +82,8 @@
       "src/Granit.Tax.Stripe/Granit.Tax.Stripe.csproj",
       "src/Granit.Tax/Granit.Tax.csproj",
       "src/Granit.Templating/Granit.Templating.csproj",
+      "src/Granit.Testing.EntityFrameworkCore/Granit.Testing.EntityFrameworkCore.csproj",
+      "src/Granit.Testing/Granit.Testing.csproj",
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation.Europe/Granit.Validation.Europe.csproj",
       "src/Granit.Validation/Granit.Validation.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1122,6 +1122,7 @@
       "name": "Granit.Invoicing",
       "deps": [
         "Granit",
+        "Granit.Analytics",
         "Granit.Parties",
         "Granit.DataExchange.Abstractions",
         "Granit.Invoicing.Abstractions",
@@ -4314,6 +4315,12 @@
           "kind": "property",
           "signature": "Expression<Func<TEntity, DateTimeOffset>>? PeriodSelector",
           "returnType": "Expression<Func<TEntity, DateTimeOffset>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<TEntity, bool>>? BaseFilter",
+          "returnType": "Expression<Func<TEntity, bool>>?"
         }
       ]
     },
@@ -24195,7 +24202,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitInvoicing",
@@ -24211,7 +24218,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/GranitInvoicingModule.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -24448,6 +24455,110 @@
           "kind": "method",
           "signature": "CalculateAsync(TaxRequest request, CancellationToken cancellationToken = default)",
           "returnType": "string Name { get; } Task<TaxResult>"
+        }
+      ]
+    },
+    {
+      "name": "UnpaidInvoiceCountMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.UnpaidInvoiceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/UnpaidInvoiceCountMetricDefinition.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, int?>>? Selector",
+          "returnType": "Expression<Func<Invoice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "UnpaidInvoiceTotalMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.UnpaidInvoiceTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/UnpaidInvoiceTotalMetricDefinition.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, decimal?>>? Selector",
+          "returnType": "Expression<Func<Invoice, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
         }
       ]
     },
@@ -47322,6 +47433,15 @@
           "returnType": "Task"
         }
       ]
+    },
+    {
+      "name": "DbContextOptionsBuilderTestExtensions",
+      "fqn": "Granit.Testing.EntityFrameworkCore.Extensions.DbContextOptionsBuilderTestExtensions",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/Extensions/DbContextOptionsBuilderTestExtensions.cs",
+      "line": 9,
+      "members": []
     },
     {
       "name": "TestDbContextServiceCollectionExtensions",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -140,6 +140,8 @@
       "src/Granit.Templating.EntityFrameworkCore/Granit.Templating.EntityFrameworkCore.csproj",
       "src/Granit.Templating.Scriban/Granit.Templating.Scriban.csproj",
       "src/Granit.Templating/Granit.Templating.csproj",
+      "src/Granit.Testing.EntityFrameworkCore/Granit.Testing.EntityFrameworkCore.csproj",
+      "src/Granit.Testing/Granit.Testing.csproj",
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation.AI/Granit.Validation.AI.csproj",
       "src/Granit.Validation.Endpoints/Granit.Validation.Endpoints.csproj",

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
@@ -48,6 +48,15 @@ internal sealed class MetricExecutor<TEntity, TValue>(
 
         IQueryable<TEntity> filtered = queryEngine.BuildFilteredQuery(source, request);
 
+        // Compose the metric's intrinsic predicate (e.g. "Status == Open" on an
+        // UnpaidInvoiceCount) AFTER the user filters, so admin-supplied filters
+        // (period, customer, …) compose with AND semantics on top of the framework's
+        // multi-tenant + soft-delete filters that BuildFilteredQuery already applied.
+        if (metric.BaseFilter is not null)
+        {
+            filtered = filtered.Where(metric.BaseFilter);
+        }
+
         TValue? result = metric.Aggregation switch
         {
             AggregateFunction.Count => await ExecuteCountAsync(filtered, cancellationToken).ConfigureAwait(false),

--- a/src/Granit.Analytics/Metrics/MetricDefinition.cs
+++ b/src/Granit.Analytics/Metrics/MetricDefinition.cs
@@ -98,6 +98,20 @@ public abstract class MetricDefinition<TEntity, TValue> : IMetricDefinitionDescr
     /// </summary>
     public virtual Expression<Func<TEntity, DateTimeOffset>>? PeriodSelector => null;
 
+    /// <summary>
+    /// Intrinsic predicate scoping the metric to a subset of <typeparamref name="TEntity"/>.
+    /// E.g. <c>i =&gt; i.Status == InvoiceStatus.Open</c> for an <c>UnpaidInvoiceCount</c>
+    /// metric. Composed with the user-supplied <c>QueryRequest</c> filter pipeline (AND
+    /// semantics) before the aggregation runs — multi-tenant and soft-delete filters are
+    /// still applied first by EF Core's global query filters.
+    /// </summary>
+    /// <remarks>
+    /// Returning <c>null</c> means the metric aggregates over the full filtered set.
+    /// Use <see cref="BaseFilter"/> for "what makes this metric unique" (status, role,
+    /// state) — not for caller-driven filters (those go in <c>QueryRequest.Filter</c>).
+    /// </remarks>
+    public virtual Expression<Func<TEntity, bool>>? BaseFilter => null;
+
     /// <inheritdoc />
     Type IMetricDefinitionDescriptor.EntityType => typeof(TEntity);
 

--- a/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
@@ -113,6 +113,13 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -160,6 +167,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Analytics.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Invoicing.Definitions;
@@ -5,6 +6,7 @@ using Granit.Invoicing.Diagnostics;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Exports;
 using Granit.Invoicing.Internal;
+using Granit.Invoicing.Metrics;
 using Granit.Invoicing.Queries;
 using Granit.QueryEngine.Extensions;
 using Granit.Workflow.Extensions;
@@ -26,6 +28,8 @@ public static class InvoicingHostApplicationBuilderExtensions
         builder.Services.TryAddTransient<IInvoiceCreditApplier, DefaultInvoiceCreditApplier>();
         builder.Services.AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
         builder.Services.AddExportDefinition<Invoice, InvoiceExportDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, int, UnpaidInvoiceCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, decimal, UnpaidInvoiceTotalMetricDefinition>();
         GranitActivitySourceRegistry.Register(InvoicingActivitySource.Name);
         return builder;
     }

--- a/src/Granit.Invoicing/Granit.Invoicing.csproj
+++ b/src/Granit.Invoicing/Granit.Invoicing.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />

--- a/src/Granit.Invoicing/GranitInvoicingModule.cs
+++ b/src/Granit.Invoicing/GranitInvoicingModule.cs
@@ -1,3 +1,4 @@
+using Granit.Analytics;
 using Granit.Guids;
 using Granit.Invoicing.Extensions;
 using Granit.Modularity;
@@ -11,6 +12,7 @@ namespace Granit.Invoicing;
 /// Granit module for agnostic invoicing (invoices, credit notes, tax, sync, PDF).
 /// </summary>
 [DependsOn(
+    typeof(GranitAnalyticsModule),
     typeof(GranitPartiesModule),
     typeof(GranitGuidsModule),
     typeof(GranitTimingModule),

--- a/src/Granit.Invoicing/Localization/Invoicing/cs.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/cs.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Neuhrazené faktury",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Součet neuhrazených faktur"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/de.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/de.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Ausgestellt am",
     "Invoicing.Columns.DueAt": "Fällig am",
     "Invoicing.Columns.PaidAt": "Bezahlt am",
-    "Invoicing.Columns.BillingReason": "Rechnungsgrund"
+    "Invoicing.Columns.BillingReason": "Rechnungsgrund",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unbezahlte Rechnungen",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Gesamtsumme unbezahlter Rechnungen"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/en.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/en.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unpaid invoices",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Unpaid invoices total"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/es.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/es.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Emitida el",
     "Invoicing.Columns.DueAt": "Vencimiento",
     "Invoicing.Columns.PaidAt": "Pagada el",
-    "Invoicing.Columns.BillingReason": "Motivo de facturación"
+    "Invoicing.Columns.BillingReason": "Motivo de facturación",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Facturas impagadas",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total de facturas impagadas"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/fr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/fr.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Émise le",
     "Invoicing.Columns.DueAt": "Échéance",
     "Invoicing.Columns.PaidAt": "Payée le",
-    "Invoicing.Columns.BillingReason": "Motif de facturation"
+    "Invoicing.Columns.BillingReason": "Motif de facturation",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Factures impayées",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total des factures impayées"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/hi.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/hi.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "अवैतनिक चालान",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "अवैतनिक चालानों का कुल"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/it.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/it.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Fatture non pagate",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totale delle fatture non pagate"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/ja.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ja.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未払い請求書",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未払い請求書の合計"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/ko.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ko.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "미지급 청구서",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "미지급 청구서 합계"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/nl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/nl.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Uitgegeven op",
     "Invoicing.Columns.DueAt": "Vervaldatum",
     "Invoicing.Columns.PaidAt": "Betaald op",
-    "Invoicing.Columns.BillingReason": "Factuurreden"
+    "Invoicing.Columns.BillingReason": "Factuurreden",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Onbetaalde facturen",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totaal van onbetaalde facturen"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/pl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pl.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Niezapłacone faktury",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Suma niezapłaconych faktur"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/pt-BR.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pt-BR.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Faturas em aberto",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total de faturas em aberto"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/pt.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pt.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Faturas por pagar",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total das faturas por pagar"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/sv.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/sv.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Obetalda fakturor",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totalsumma obetalda fakturor"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/tr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/tr.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Ödenmemiş faturalar",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Ödenmemiş faturaların toplamı"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/zh.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/zh.json
@@ -11,6 +11,8 @@
     "Invoicing.Columns.IssuedAt": "Issued At",
     "Invoicing.Columns.DueAt": "Due At",
     "Invoicing.Columns.PaidAt": "Paid At",
-    "Invoicing.Columns.BillingReason": "Billing Reason"
+    "Invoicing.Columns.BillingReason": "Billing Reason",
+    "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未付款发票",
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未付款发票总额"
   }
 }

--- a/src/Granit.Invoicing/Metrics/UnpaidInvoiceCountMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/UnpaidInvoiceCountMetricDefinition.cs
@@ -1,0 +1,49 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Number of invoices currently in <see cref="InvoiceStatus.Open"/> status — finalised
+/// invoices awaiting payment. <c>Void</c> (cancelled) and <c>Uncollectible</c>
+/// (write-off) are excluded by design: they would inflate the KPI with amounts that
+/// will never be collected.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Period selector is <see cref="Invoice.IssuedAt"/>: when the endpoint is called with
+/// <c>?period=last_30d</c>, the count is restricted to invoices issued during that
+/// window. Without a period parameter, the metric returns the all-time count.
+/// </para>
+/// <para>
+/// <c>IsHigherBetter</c> is <c>false</c> — fewer unpaid invoices is favourable for the
+/// business, so the delta arrow renders red when the value goes up.
+/// </para>
+/// </remarks>
+public sealed class UnpaidInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.UnpaidInvoiceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Open;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/Metrics/UnpaidInvoiceTotalMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/UnpaidInvoiceTotalMetricDefinition.cs
@@ -1,0 +1,50 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Total monetary amount currently outstanding on <see cref="InvoiceStatus.Open"/>
+/// invoices — sum of <see cref="Invoice.AmountRemaining"/> per invoice, so a partially
+/// paid invoice contributes only the unpaid balance, not its full <c>Total</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Currency is intentionally not declared here — different invoices may carry
+/// different ISO 4217 codes per <see cref="Invoice.Currency"/>. The metric value is
+/// the raw sum; the host application is responsible for currency normalisation when
+/// displaying mixed-currency tenants. Single-currency tenants render the value with
+/// their tenant's configured currency in the frontend.
+/// </para>
+/// <para>
+/// Period selector is <see cref="Invoice.IssuedAt"/>; <c>IsHigherBetter</c> is
+/// <c>false</c> — less unpaid debt is favourable.
+/// </para>
+/// </remarks>
+public sealed class UnpaidInvoiceTotalMetricDefinition : MetricDefinition<Invoice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.UnpaidInvoiceTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, decimal?>>? Selector => i => i.AmountRemaining;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Open;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/packages.lock.json
+++ b/src/Granit.Invoicing/packages.lock.json
@@ -68,6 +68,13 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Testing.EntityFrameworkCore/Extensions/DbContextOptionsBuilderTestExtensions.cs
+++ b/src/Granit.Testing.EntityFrameworkCore/Extensions/DbContextOptionsBuilderTestExtensions.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Testing.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Extension methods on <see cref="DbContextOptionsBuilder{TContext}"/> that opt tests
+/// out of EF Core defaults that are correct in production but trap multi-tenant tests.
+/// </summary>
+public static class DbContextOptionsBuilderTestExtensions
+{
+    /// <summary>
+    /// Forces EF Core to allocate a dedicated internal service provider — and therefore a
+    /// dedicated model cache — for this <see cref="DbContextOptions"/>. Required in tests
+    /// that exercise the Granit multi-tenant query filter with a per-test
+    /// <see cref="Granit.MultiTenancy.ICurrentTenant"/> instance.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The trap.</b> <c>ApplyGranitConventions</c> compiles the multi-tenant filter as
+    /// <c>e =&gt; e.TenantId == currentTenant.Id</c>, capturing the <c>ICurrentTenant</c>
+    /// instance via <see cref="System.Linq.Expressions.Expression.Constant(object)"/>.
+    /// EF Core re-reads <c>currentTenant.Id</c> on every query — but always from the
+    /// instance captured at model-build time. EF's default model cache is keyed on
+    /// <c>(DbContextType, designTime)</c> and shared process-wide, so the first test that
+    /// builds a model pins its tenant instance for the whole run. Subsequent tests get
+    /// fresh mocks, but EF reuses the cached expression — queries silently filter against
+    /// the wrong (or stranded) tenant and return zero rows.
+    /// </para>
+    /// <para>
+    /// <b>Why production is fine.</b> A single DI-scoped <c>ICurrentTenant</c> is shared
+    /// across all queries, and its mutable AsyncLocal state already reflects the active
+    /// request. Per-instance capture is an optimization, not a bug — only xUnit's
+    /// "fresh test class instance per <c>[Fact]</c>" lifecycle exposes the gap.
+    /// </para>
+    /// <para>
+    /// <b>What this method does.</b> Calls
+    /// <see cref="DbContextOptionsBuilder.EnableServiceProviderCaching(bool)"/> with
+    /// <c>false</c>. Each <see cref="DbContextOptions"/> gets its own EF service provider
+    /// (and therefore its own model), so <c>OnModelCreating</c> re-runs and captures the
+    /// current test's tenant. Trivial overhead in tests; never use in production.
+    /// </para>
+    /// <para>
+    /// <b>Alternative pattern.</b> Reuse a single mutable
+    /// <see cref="Granit.Testing.Fakes.FakeCurrentTenant"/> across tests in a class fixture
+    /// — its AsyncLocal-backed state is per-test-isolated, and a single captured instance
+    /// is fine because mutation of the AsyncLocal slot is what the filter reads. Either
+    /// approach works; this method is the safer default for tests that allocate a fresh
+    /// mock per <c>[Fact]</c>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TContext">The <see cref="DbContext"/> type being configured.</typeparam>
+    /// <param name="builder">The options builder.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static DbContextOptionsBuilder<TContext> EnableGranitTestModelIsolation<TContext>(
+        this DbContextOptionsBuilder<TContext> builder)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.EnableServiceProviderCaching(false);
+    }
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
@@ -59,7 +59,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async Task Count_Empty_Postgres_ReturnsZero()
     {
         int? result = await _intExecutor.ExecuteAsync(
-            new OrderCountMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderCountMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(0);
     }
@@ -68,7 +68,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async Task Sum_Empty_Postgres_ReturnsZero()
     {
         decimal? result = await _decimalExecutor.ExecuteAsync(
-            new OrderAmountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(0m);
     }
@@ -79,7 +79,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
         // PostgreSQL: AVG over empty returns NULL. EF Core surfaces it as null because the
         // selector is typed nullable. This assertion is the load-bearing parity check.
         decimal? result = await _decimalExecutor.ExecuteAsync(
-            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -88,7 +88,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async Task Min_Empty_Postgres_ReturnsNull()
     {
         decimal? result = await _decimalExecutor.ExecuteAsync(
-            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMinMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -97,7 +97,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async Task Max_Empty_Postgres_ReturnsNull()
     {
         decimal? result = await _decimalExecutor.ExecuteAsync(
-            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMaxMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
@@ -32,7 +32,7 @@ internal sealed class OrderQueryDefinition : QueryDefinition<Order>
             .DefaultPageSize(50);
 }
 
-internal sealed class OrderAmountSumMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountSumMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.AmountSum";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -40,7 +40,7 @@ internal sealed class OrderAmountSumMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderAmountAvgMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountAvgMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.AmountAvg";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -48,7 +48,7 @@ internal sealed class OrderAmountAvgMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderAmountMinMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountMinMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.AmountMin";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -56,7 +56,7 @@ internal sealed class OrderAmountMinMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderAmountMaxMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountMaxMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.AmountMax";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -64,7 +64,7 @@ internal sealed class OrderAmountMaxMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderCountMetric : MetricDefinition<Order, int>
+internal sealed class OrderCountMetricDefinition : MetricDefinition<Order, int>
 {
     public override string Name => "Test.Count";
     public override MetricValueKind ValueKind => MetricValueKind.Count;

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/Empty/EmptySetSemanticsTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/Empty/EmptySetSemanticsTests.cs
@@ -56,7 +56,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderCountMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderCountMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.Value.ShouldBe(0);
@@ -70,7 +70,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.Value.ShouldBe(0m);
@@ -82,7 +82,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderLineCountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderLineCountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.Value.ShouldBe(0);
@@ -94,7 +94,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, long> executor = new(_engine);
 
         long? result = await executor.ExecuteAsync(
-            new OrderTotalCentsSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderTotalCentsSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.Value.ShouldBe(0L);
@@ -106,7 +106,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, double> executor = new(_engine);
 
         double? result = await executor.ExecuteAsync(
-            new OrderDiscountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderDiscountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         result!.Value.ShouldBe(0.0);
@@ -123,7 +123,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -134,7 +134,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderLineCountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderLineCountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -145,7 +145,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, long> executor = new(_engine);
 
         long? result = await executor.ExecuteAsync(
-            new OrderTotalCentsAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderTotalCentsAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -156,7 +156,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, double> executor = new(_engine);
 
         double? result = await executor.ExecuteAsync(
-            new OrderDiscountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderDiscountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -169,7 +169,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMinMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -180,7 +180,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderLineCountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderLineCountMinMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -193,7 +193,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMaxMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -204,7 +204,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, long> executor = new(_engine);
 
         long? result = await executor.ExecuteAsync(
-            new OrderTotalCentsMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderTotalCentsMaxMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -228,7 +228,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
 
         MetricExecutor<Order, decimal> executor = new(_engine);
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(42.50m);
     }
@@ -251,9 +251,9 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         MetricExecutor<Order, decimal> minExecutor = new(_engine);
         MetricExecutor<Order, decimal> maxExecutor = new(_engine);
         decimal? min = await minExecutor.ExecuteAsync(
-            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMinMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
         decimal? max = await maxExecutor.ExecuteAsync(
-            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMaxMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         min.ShouldBe(99.99m);
         max.ShouldBe(99.99m);
@@ -281,7 +281,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         QueryRequest request = new() { Filter = new Dictionary<string, string> { ["Status.eq"] = "Cancelled" } };
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountSumMetric(), _db.Orders, request, TestContext.Current.CancellationToken);
+            new OrderAmountSumMetricDefinition(), _db.Orders, request, TestContext.Current.CancellationToken);
 
         result.ShouldBe(0m);
     }
@@ -305,7 +305,7 @@ public sealed class EmptySetSemanticsTests : IAsyncLifetime
         QueryRequest request = new() { Filter = new Dictionary<string, string> { ["Status.eq"] = "Cancelled" } };
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountAvgMetric(), _db.Orders, request, TestContext.Current.CancellationToken);
+            new OrderAmountAvgMetricDefinition(), _db.Orders, request, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/Internal/MetricExecutorTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/Internal/MetricExecutorTests.cs
@@ -51,7 +51,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderCountMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderCountMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(4);
     }
@@ -63,7 +63,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         QueryRequest request = new() { Filter = new Dictionary<string, string> { ["Status.eq"] = "Paid" } };
 
         int? result = await executor.ExecuteAsync(
-            new OrderCountMetric(), _db.Orders, request, TestContext.Current.CancellationToken);
+            new OrderCountMetricDefinition(), _db.Orders, request, TestContext.Current.CancellationToken);
 
         result.ShouldBe(2);
     }
@@ -74,7 +74,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(120.50m + 80.00m + 250.75m + 50.00m);
     }
@@ -85,7 +85,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, int> executor = new(_engine);
 
         int? result = await executor.ExecuteAsync(
-            new OrderLineCountSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderLineCountSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(3 + 1 + 5 + 2);
     }
@@ -96,7 +96,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, long> executor = new(_engine);
 
         long? result = await executor.ExecuteAsync(
-            new OrderTotalCentsSumMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderTotalCentsSumMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(12050L + 8000L + 25075L + 5000L);
     }
@@ -107,7 +107,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         decimal expected = (120.50m + 80.00m + 250.75m + 50.00m) / 4m;
@@ -120,7 +120,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, double> executor = new(_engine);
 
         double? result = await executor.ExecuteAsync(
-            new OrderDiscountAvgMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderDiscountAvgMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
         double expected = (0.10 + 0.00 + 0.20 + 0.05) / 4.0;
@@ -133,7 +133,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountMinMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMinMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(50.00m);
     }
@@ -144,7 +144,7 @@ public sealed class MetricExecutorTests : IAsyncLifetime
         MetricExecutor<Order, decimal> executor = new(_engine);
 
         decimal? result = await executor.ExecuteAsync(
-            new OrderAmountMaxMetric(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
+            new OrderAmountMaxMetricDefinition(), _db.Orders, new QueryRequest(), TestContext.Current.CancellationToken);
 
         result.ShouldBe(250.75m);
     }

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/TestEntities.cs
@@ -45,7 +45,7 @@ internal sealed class OrderQueryDefinition : QueryDefinition<Order>
             .DefaultPageSize(50);
 }
 
-internal sealed class OrderCountMetric : MetricDefinition<Order, int>
+internal sealed class OrderCountMetricDefinition : MetricDefinition<Order, int>
 {
     public override string Name => "Test.OrderCount";
     public override MetricValueKind ValueKind => MetricValueKind.Count;
@@ -53,7 +53,7 @@ internal sealed class OrderCountMetric : MetricDefinition<Order, int>
     public override Expression<Func<Order, int?>>? Selector => null;
 }
 
-internal sealed class OrderAmountSumMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountSumMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.OrderAmountSum";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -62,7 +62,7 @@ internal sealed class OrderAmountSumMetric : MetricDefinition<Order, decimal>
     public override string? CurrencyCode => "EUR";
 }
 
-internal sealed class OrderAmountAvgMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountAvgMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.OrderAmountAvg";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -71,7 +71,7 @@ internal sealed class OrderAmountAvgMetric : MetricDefinition<Order, decimal>
     public override string? CurrencyCode => "EUR";
 }
 
-internal sealed class OrderAmountMinMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountMinMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.OrderAmountMin";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -79,7 +79,7 @@ internal sealed class OrderAmountMinMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderAmountMaxMetric : MetricDefinition<Order, decimal>
+internal sealed class OrderAmountMaxMetricDefinition : MetricDefinition<Order, decimal>
 {
     public override string Name => "Test.OrderAmountMax";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -87,7 +87,7 @@ internal sealed class OrderAmountMaxMetric : MetricDefinition<Order, decimal>
     public override Expression<Func<Order, decimal?>>? Selector => o => o.Amount;
 }
 
-internal sealed class OrderLineCountSumMetric : MetricDefinition<Order, int>
+internal sealed class OrderLineCountSumMetricDefinition : MetricDefinition<Order, int>
 {
     public override string Name => "Test.OrderLineCountSum";
     public override MetricValueKind ValueKind => MetricValueKind.Count;
@@ -95,7 +95,7 @@ internal sealed class OrderLineCountSumMetric : MetricDefinition<Order, int>
     public override Expression<Func<Order, int?>>? Selector => o => o.LineCount;
 }
 
-internal sealed class OrderTotalCentsSumMetric : MetricDefinition<Order, long>
+internal sealed class OrderTotalCentsSumMetricDefinition : MetricDefinition<Order, long>
 {
     public override string Name => "Test.OrderTotalCentsSum";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -103,7 +103,7 @@ internal sealed class OrderTotalCentsSumMetric : MetricDefinition<Order, long>
     public override Expression<Func<Order, long?>>? Selector => o => o.TotalCents;
 }
 
-internal sealed class OrderDiscountAvgMetric : MetricDefinition<Order, double>
+internal sealed class OrderDiscountAvgMetricDefinition : MetricDefinition<Order, double>
 {
     public override string Name => "Test.OrderDiscountAvg";
     public override MetricValueKind ValueKind => MetricValueKind.Percentage;
@@ -111,7 +111,7 @@ internal sealed class OrderDiscountAvgMetric : MetricDefinition<Order, double>
     public override Expression<Func<Order, double?>>? Selector => o => o.DiscountRatio;
 }
 
-internal sealed class OrderDiscountSumMetric : MetricDefinition<Order, double>
+internal sealed class OrderDiscountSumMetricDefinition : MetricDefinition<Order, double>
 {
     public override string Name => "Test.OrderDiscountSum";
     public override MetricValueKind ValueKind => MetricValueKind.Number;
@@ -119,7 +119,7 @@ internal sealed class OrderDiscountSumMetric : MetricDefinition<Order, double>
     public override Expression<Func<Order, double?>>? Selector => o => o.DiscountRatio;
 }
 
-internal sealed class OrderLineCountAvgMetric : MetricDefinition<Order, int>
+internal sealed class OrderLineCountAvgMetricDefinition : MetricDefinition<Order, int>
 {
     public override string Name => "Test.OrderLineCountAvg";
     public override MetricValueKind ValueKind => MetricValueKind.Count;
@@ -127,7 +127,7 @@ internal sealed class OrderLineCountAvgMetric : MetricDefinition<Order, int>
     public override Expression<Func<Order, int?>>? Selector => o => o.LineCount;
 }
 
-internal sealed class OrderTotalCentsAvgMetric : MetricDefinition<Order, long>
+internal sealed class OrderTotalCentsAvgMetricDefinition : MetricDefinition<Order, long>
 {
     public override string Name => "Test.OrderTotalCentsAvg";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;
@@ -135,7 +135,7 @@ internal sealed class OrderTotalCentsAvgMetric : MetricDefinition<Order, long>
     public override Expression<Func<Order, long?>>? Selector => o => o.TotalCents;
 }
 
-internal sealed class OrderLineCountMinMetric : MetricDefinition<Order, int>
+internal sealed class OrderLineCountMinMetricDefinition : MetricDefinition<Order, int>
 {
     public override string Name => "Test.OrderLineCountMin";
     public override MetricValueKind ValueKind => MetricValueKind.Count;
@@ -143,7 +143,7 @@ internal sealed class OrderLineCountMinMetric : MetricDefinition<Order, int>
     public override Expression<Func<Order, int?>>? Selector => o => o.LineCount;
 }
 
-internal sealed class OrderTotalCentsMaxMetric : MetricDefinition<Order, long>
+internal sealed class OrderTotalCentsMaxMetricDefinition : MetricDefinition<Order, long>
 {
     public override string Name => "Test.OrderTotalCentsMax";
     public override MetricValueKind ValueKind => MetricValueKind.Currency;

--- a/tests/Granit.Analytics.Tests/Metrics/MetricDefinitionRegistrationTests.cs
+++ b/tests/Granit.Analytics.Tests/Metrics/MetricDefinitionRegistrationTests.cs
@@ -15,12 +15,12 @@ public sealed class MetricDefinitionRegistrationTests
     {
         ServiceCollection services = new();
 
-        services.AddMetricDefinition<Order, int, OrderCountMetric>();
+        services.AddMetricDefinition<Order, int, OrderCountMetricDefinition>();
 
         ServiceProvider provider = services.BuildServiceProvider();
 
         MetricDefinition<Order, int> definition = provider.GetRequiredService<MetricDefinition<Order, int>>();
-        definition.ShouldBeOfType<OrderCountMetric>();
+        definition.ShouldBeOfType<OrderCountMetricDefinition>();
 
         IEnumerable<IMetricDefinitionDescriptor> descriptors = provider.GetServices<IMetricDefinitionDescriptor>();
         descriptors.ShouldContain(d => d.Name == "Sample.Order.Count");
@@ -31,7 +31,7 @@ public sealed class MetricDefinitionRegistrationTests
     {
         ServiceCollection services = new();
 
-        services.AddMetricDefinition<Order, int, OrderCountMetric>();
+        services.AddMetricDefinition<Order, int, OrderCountMetricDefinition>();
 
         ServiceProvider provider = services.BuildServiceProvider();
         MetricDefinition<Order, int> definition = provider.GetRequiredService<MetricDefinition<Order, int>>();
@@ -46,7 +46,7 @@ public sealed class MetricDefinitionRegistrationTests
         public int Id { get; init; }
     }
 
-    private sealed class OrderCountMetric : MetricDefinition<Order, int>
+    private sealed class OrderCountMetricDefinition : MetricDefinition<Order, int>
     {
         public override string Name => "Sample.Order.Count";
         public override MetricValueKind ValueKind => MetricValueKind.Count;

--- a/tests/Granit.Analytics.Tests/Metrics/MetricDefinitionTests.cs
+++ b/tests/Granit.Analytics.Tests/Metrics/MetricDefinitionTests.cs
@@ -11,7 +11,7 @@ public sealed class MetricDefinitionTests
     [Fact]
     public void Defaults_AreReasonable()
     {
-        SampleCountMetric metric = new();
+        SampleCountMetricDefinition metric = new();
 
         metric.Name.ShouldBe("Sample.Count");
         metric.ValueKind.ShouldBe(MetricValueKind.Count);
@@ -25,7 +25,7 @@ public sealed class MetricDefinitionTests
     [Fact]
     public void Implements_IMetricDefinitionDescriptor()
     {
-        SampleCountMetric metric = new();
+        SampleCountMetricDefinition metric = new();
 
         metric.ShouldBeAssignableTo<IMetricDefinitionDescriptor>();
         IMetricDefinitionDescriptor descriptor = metric;
@@ -36,7 +36,7 @@ public sealed class MetricDefinitionTests
     [Fact]
     public void SumMetric_ExposesNullableSelector()
     {
-        SampleAmountSumMetric metric = new();
+        SampleAmountSumMetricDefinition metric = new();
 
         metric.Aggregation.ShouldBe(AggregateFunction.Sum);
         metric.Selector.ShouldNotBeNull();
@@ -51,7 +51,7 @@ public sealed class MetricDefinitionTests
         public decimal Amount { get; init; }
     }
 
-    private sealed class SampleCountMetric : MetricDefinition<SampleEntity, int>
+    private sealed class SampleCountMetricDefinition : MetricDefinition<SampleEntity, int>
     {
         public override string Name => "Sample.Count";
         public override MetricValueKind ValueKind => MetricValueKind.Count;
@@ -59,7 +59,7 @@ public sealed class MetricDefinitionTests
         public override Expression<Func<SampleEntity, int?>>? Selector => null;
     }
 
-    private sealed class SampleAmountSumMetric : MetricDefinition<SampleEntity, decimal>
+    private sealed class SampleAmountSumMetricDefinition : MetricDefinition<SampleEntity, decimal>
     {
         public override string Name => "Sample.AmountSum";
         public override MetricValueKind ValueKind => MetricValueKind.Currency;

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Granit.Invoicing.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Granit.Invoicing.EntityFrameworkCore.Tests.csproj
@@ -14,11 +14,18 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Invoicing\Granit.Invoicing.csproj" />
     <ProjectReference Include="..\..\src\Granit.Invoicing.EntityFrameworkCore\Granit.Invoicing.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine\Granit.QueryEngine.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine.EntityFrameworkCore\Granit.QueryEngine.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Testing.EntityFrameworkCore\Granit.Testing.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/UnpaidInvoiceMetricsTests.cs
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/Internal/UnpaidInvoiceMetricsTests.cs
@@ -1,0 +1,262 @@
+using Granit.Analytics.EntityFrameworkCore;
+using Granit.Analytics.EntityFrameworkCore.Extensions;
+using Granit.Analytics.Extensions;
+using Granit.Invoicing.Domain;
+using Granit.Invoicing.Domain.ValueObjects;
+using Granit.Invoicing.EntityFrameworkCore.Internal;
+using Granit.Invoicing.Metrics;
+using Granit.Invoicing.Queries;
+using Granit.MultiTenancy;
+using Granit.Parties.Domain.ValueObjects;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Options;
+using Granit.Testing.EntityFrameworkCore.Extensions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Invoicing.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Reference-impl tests for the two metrics shipped under
+/// <c>Granit.Invoicing/Metrics/</c> (story #1377). Exercises:
+/// <list type="bullet">
+///   <item>BaseFilter pruning to <see cref="InvoiceStatus.Open"/> only.</item>
+///   <item>Sum of <see cref="Invoice.AmountRemaining"/> (not <c>Total</c>) so partially paid
+///     invoices contribute only their unpaid balance.</item>
+///   <item>Tenant isolation — each tenant sees its own invoices, never another tenant's.</item>
+///   <item>Empty-set semantics on a fresh tenant (count → 0, total → 0).</item>
+/// </list>
+/// </summary>
+public sealed class UnpaidInvoiceMetricsTests : IAsyncLifetime
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 28, 0, 0, 0, TimeSpan.Zero);
+
+    private SqliteConnection _connection = null!;
+    private ICurrentTenant _currentTenant = null!;
+    private InvoicingDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private IMetricExecutor<Invoice, int> _countExecutor = null!;
+    private IMetricExecutor<Invoice, decimal> _totalExecutor = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        // Required: ApplyGranitConventions captures the ICurrentTenant instance inside the
+        // multi-tenant query-filter expression, and EF Core's process-wide model cache
+        // pins the first instance it sees. See the helper's XML doc for the full story.
+        DbContextOptions<InvoicingDbContext> options = new DbContextOptionsBuilder<InvoicingDbContext>()
+            .UseSqlite(_connection)
+            .EnableGranitTestModelIsolation()
+            .Options;
+
+        _currentTenant = Substitute.For<ICurrentTenant>();
+        _currentTenant.IsAvailable.Returns(true);
+        _db = new InvoicingDbContext(options, _currentTenant, dataFilter: null);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        // Build the DI container for IQueryEngine<Invoice> + IMetricExecutor<Invoice, *>.
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddOptions<QueryEngineOptions>();
+        services.AddSingleton(sp => sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<QueryEngineOptions>>().Value);
+        services.AddGranitQueryEngine();
+        services.AddScoped(typeof(IQueryEngine<>),
+            typeof(QueryEngine.EntityFrameworkCore.GranitQueryEngineEntityFrameworkCoreModule)
+                .Assembly
+                .GetType("Granit.QueryEngine.EntityFrameworkCore.Internal.QueryEngine`1", throwOnError: true)!);
+        services.AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
+
+        services.AddGranitAnalytics();
+        services.AddGranitAnalyticsEntityFrameworkCore();
+
+        _provider = services.BuildServiceProvider();
+        _countExecutor = _provider.GetRequiredService<IMetricExecutor<Invoice, int>>();
+        _totalExecutor = _provider.GetRequiredService<IMetricExecutor<Invoice, decimal>>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _connection.DisposeAsync();
+        await _provider.DisposeAsync();
+    }
+
+    private static Invoice OpenInvoice(string number, Guid tenantId, decimal subtotal, decimal amountPaid = 0m)
+    {
+        var inv = Invoice.Create(
+            Guid.NewGuid(), tenantId, PartyId.Create(Guid.NewGuid()),
+            InvoiceDocumentType.Invoice, "EUR",
+            CollectionMethod.Auto, BillingReason.SubscriptionCycle);
+        inv.AddLineItem(InvoiceLineItem.Create(
+            Guid.NewGuid(), "test line", quantity: 1m, unitPrice: subtotal,
+            source: new LineItemSource(InvoiceSourceType.OneShot)));
+        inv.Finalize(number, issuedAt: Now, dueAt: Now.AddDays(30));
+        if (amountPaid > 0)
+        {
+            inv.RecordPayment(amountPaid, paidAt: Now, tolerance: 0m);
+        }
+        return inv;
+    }
+
+    private static Invoice DraftInvoice(Guid tenantId) =>
+        Invoice.Create(
+            Guid.NewGuid(), tenantId, PartyId.Create(Guid.NewGuid()),
+            InvoiceDocumentType.Invoice, "EUR",
+            CollectionMethod.Auto, BillingReason.SubscriptionCycle);
+
+    private static Invoice PaidInvoice(string number, Guid tenantId, decimal subtotal)
+    {
+        // Open with the full amount paid → state machine transitions to Paid.
+        return OpenInvoice(number, tenantId, subtotal, amountPaid: subtotal);
+    }
+
+    private static Invoice VoidInvoice(string number, Guid tenantId, decimal subtotal)
+    {
+        Invoice inv = OpenInvoice(number, tenantId, subtotal);
+        inv.VoidInvoice();
+        return inv;
+    }
+
+    [Fact]
+    public async Task UnpaidInvoiceCount_OnlyCountsOpenStatus()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.Id.Returns(tenantId);
+
+        // 3 Open + 1 Paid + 1 Void + 1 Draft = only 3 should count.
+        _db.Invoices.Add(OpenInvoice("INV-1", tenantId, 100m));
+        _db.Invoices.Add(OpenInvoice("INV-2", tenantId, 200m));
+        _db.Invoices.Add(OpenInvoice("INV-3", tenantId, 300m));
+        _db.Invoices.Add(PaidInvoice("INV-4", tenantId, 400m));
+        _db.Invoices.Add(VoidInvoice("INV-5", tenantId, 500m));
+        _db.Invoices.Add(DraftInvoice(tenantId));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int? result = await _countExecutor.ExecuteAsync(
+            new UnpaidInvoiceCountMetricDefinition(),
+            _db.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task UnpaidInvoiceTotal_SumsAmountRemainingNotTotal()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.Id.Returns(tenantId);
+
+        // Two Open invoices: one fully unpaid, one partially paid.
+        // Subtotal 1000, AmountPaid 600 → AmountRemaining 400.
+        // Subtotal 500, AmountPaid 0   → AmountRemaining 500.
+        _db.Invoices.Add(OpenInvoice("INV-1", tenantId, 1000m, amountPaid: 600m));
+        _db.Invoices.Add(OpenInvoice("INV-2", tenantId, 500m));
+        // Paid invoice: AmountRemaining = 0 anyway, AND filtered out by BaseFilter.
+        _db.Invoices.Add(PaidInvoice("INV-3", tenantId, 700m));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        decimal? result = await _totalExecutor.ExecuteAsync(
+            new UnpaidInvoiceTotalMetricDefinition(),
+            _db.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        // Sum of AmountRemaining over Open: 400 + 500 = 900 (NOT 1000 + 500 = 1500 if we summed Total).
+        result.ShouldBe(900m);
+    }
+
+    [Fact]
+    public async Task EmptyDataset_Count_ReturnsZero()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.Id.Returns(tenantId);
+
+        int? result = await _countExecutor.ExecuteAsync(
+            new UnpaidInvoiceCountMetricDefinition(),
+            _db.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EmptyDataset_Total_ReturnsZero()
+    {
+        _currentTenant.Id.Returns(Guid.NewGuid());
+
+        // Sum over empty set = 0 (mathematical sum-of-empty), not null.
+        decimal? result = await _totalExecutor.ExecuteAsync(
+            new UnpaidInvoiceTotalMetricDefinition(),
+            _db.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task UnpaidInvoiceCount_BaseFilter_ExcludesAllNonOpenStatuses()
+    {
+        // Without BaseFilter, all 4 rows would count. With BaseFilter (Status == Open),
+        // only the 1 Open row counts.
+        var tenantId = Guid.NewGuid();
+        _currentTenant.Id.Returns(tenantId);
+        _db.Invoices.Add(OpenInvoice("INV-OPEN", tenantId, 100m));
+        _db.Invoices.Add(PaidInvoice("INV-PAID", tenantId, 200m));
+        _db.Invoices.Add(VoidInvoice("INV-VOID", tenantId, 300m));
+        _db.Invoices.Add(DraftInvoice(tenantId));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int? result = await _countExecutor.ExecuteAsync(
+            new UnpaidInvoiceCountMetricDefinition(),
+            _db.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task UnpaidInvoiceCount_RespectsTenantIsolation()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        _db.Invoices.Add(OpenInvoice("A1", tenantA, 100m));
+        _db.Invoices.Add(OpenInvoice("A2", tenantA, 200m));
+        _db.Invoices.Add(OpenInvoice("A3", tenantA, 300m));
+        _db.Invoices.Add(OpenInvoice("B1", tenantB, 400m));
+        _db.Invoices.Add(OpenInvoice("B2", tenantB, 500m));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ICurrentTenant tenantContextA = Substitute.For<ICurrentTenant>();
+        tenantContextA.IsAvailable.Returns(true);
+        tenantContextA.Id.Returns(tenantA);
+
+        DbContextOptions<InvoicingDbContext> options = new DbContextOptionsBuilder<InvoicingDbContext>()
+            .UseSqlite(_connection)
+            .EnableGranitTestModelIsolation()
+            .Options;
+        await using var dbA = new InvoicingDbContext(options, tenantContextA, dataFilter: null);
+
+        int? resultA = await _countExecutor.ExecuteAsync(
+            new UnpaidInvoiceCountMetricDefinition(),
+            dbA.Invoices,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        resultA.ShouldBe(3);
+    }
+}

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
@@ -31,6 +31,21 @@
           "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "0cnk9Chkuz2Jc6pbXRqdjy2CMAi62q4dJhvJzG25iCIvbavUYLxk/5ukwM+mzOl7ADN88WPmY1Lx1cAH2g8QSA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -102,6 +117,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -112,6 +132,14 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "xVrtBg3M1wJlBDkoT0dXEYB/wSc8bIHJPYtw/bu1AqpWgF79uPSs87DAhERR/Ilumre6TKZa1cjMg3VUUObVLA==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -121,6 +149,20 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "XVjGSW98Z/f3nFZsZILL/tntgM8i2hxUDUB4Nzt7ZvJ63MczC/VG4zjQh+m+q88SU+IJBUDipJJpkYBU57YWXg==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -139,12 +181,79 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
@@ -169,6 +278,50 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -177,6 +330,67 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.7",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -238,6 +452,33 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -245,8 +486,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -331,6 +572,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -378,6 +635,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
@@ -464,11 +722,48 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Localization.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.testing": {
+        "type": "Project",
+        "dependencies": {
+          "Bogus": "[35.*, )",
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.*, )"
+        }
+      },
+      "granit.testing.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Testing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.InMemory": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.*, )"
         }
       },
       "granit.timing": {
@@ -486,6 +781,23 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
+      "Bogus": {
+        "type": "CentralTransitive",
+        "requested": "[35.*, )",
+        "resolved": "35.6.5",
+        "contentHash": "2FGZn+aAVHjmCgClgmGkTDBVZk0zkLvAKGaxEf5JL6b3i9JbHTE4wnuY4vHCuzlCmJdU6VZjgDfHwmYkQF8VAA=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Testing.EntityFrameworkCore.Tests/Extensions/DbContextOptionsBuilderTestExtensionsTests.cs
+++ b/tests/Granit.Testing.EntityFrameworkCore.Tests/Extensions/DbContextOptionsBuilderTestExtensionsTests.cs
@@ -1,0 +1,139 @@
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Testing.EntityFrameworkCore.Extensions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Testing.EntityFrameworkCore.Tests.Extensions;
+
+/// <summary>
+/// Regression tests for <see cref="DbContextOptionsBuilderTestExtensions.EnableGranitTestModelIsolation{TContext}"/>.
+/// Encodes the EF Core model-cache trap that bit
+/// <c>Granit.Invoicing.EntityFrameworkCore.Tests.UnpaidInvoiceMetricsTests</c>: the
+/// multi-tenant filter expression captures the first <see cref="ICurrentTenant"/>
+/// instance EF sees, then reuses it for the rest of the process. The helper opts
+/// the test out of EF's process-wide model cache so each <see cref="DbContextOptions"/>
+/// captures its own tenant.
+/// </summary>
+public sealed class DbContextOptionsBuilderTestExtensionsTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        // Schema is shared across all DbContexts spun up in a test — create once via a
+        // tenantless context so the IMultiTenant filter is not installed for setup.
+        await using var schemaCtx = new MultiTenantTestDbContext(
+            new DbContextOptionsBuilder<MultiTenantTestDbContext>()
+                .UseSqlite(_connection)
+                .EnableGranitTestModelIsolation()
+                .Options,
+            currentTenant: null);
+        await schemaCtx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Two DbContexts built in the same test, with two different tenant mocks. Without
+    /// <see cref="DbContextOptionsBuilderTestExtensions.EnableGranitTestModelIsolation{TContext}"/>,
+    /// EF Core caches the first model and reuses its captured tenant for the second
+    /// context's queries — the second tenant's filter would resolve to tenant A's id and
+    /// hide tenant B's rows. With the helper, each options instance owns its model.
+    /// </summary>
+    [Fact]
+    public async Task EnableGranitTestModelIsolation_LetsEachContextCaptureItsOwnTenant()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        ICurrentTenant tenantContextA = Substitute.For<ICurrentTenant>();
+        tenantContextA.IsAvailable.Returns(true);
+        tenantContextA.Id.Returns(tenantA);
+
+        ICurrentTenant tenantContextB = Substitute.For<ICurrentTenant>();
+        tenantContextB.IsAvailable.Returns(true);
+        tenantContextB.Id.Returns(tenantB);
+
+        DbContextOptions<MultiTenantTestDbContext> optionsA =
+            new DbContextOptionsBuilder<MultiTenantTestDbContext>()
+                .UseSqlite(_connection)
+                .EnableGranitTestModelIsolation()
+                .Options;
+        DbContextOptions<MultiTenantTestDbContext> optionsB =
+            new DbContextOptionsBuilder<MultiTenantTestDbContext>()
+                .UseSqlite(_connection)
+                .EnableGranitTestModelIsolation()
+                .Options;
+
+        // Seed both tenants via a tenantless context (no IMultiTenant filter).
+        await using (var seedCtx = new MultiTenantTestDbContext(optionsA, currentTenant: null))
+        {
+            seedCtx.Items.Add(new TenantItem(Guid.NewGuid(), tenantA, "A1"));
+            seedCtx.Items.Add(new TenantItem(Guid.NewGuid(), tenantA, "A2"));
+            seedCtx.Items.Add(new TenantItem(Guid.NewGuid(), tenantB, "B1"));
+            await seedCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var dbA = new MultiTenantTestDbContext(optionsA, tenantContextA);
+        await using var dbB = new MultiTenantTestDbContext(optionsB, tenantContextB);
+
+        IReadOnlyList<string> namesA = await dbA.Items
+            .OrderBy(i => i.Name)
+            .Select(i => i.Name)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        IReadOnlyList<string> namesB = await dbB.Items
+            .OrderBy(i => i.Name)
+            .Select(i => i.Name)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        namesA.ShouldBe(["A1", "A2"]);
+        namesB.ShouldBe(["B1"]);
+    }
+
+    [Fact]
+    public void EnableGranitTestModelIsolation_NullBuilder_Throws()
+    {
+        DbContextOptionsBuilder<MultiTenantTestDbContext>? builder = null;
+        Should.Throw<ArgumentNullException>(() => builder!.EnableGranitTestModelIsolation());
+    }
+
+    private sealed class TenantItem : Entity, IMultiTenant
+    {
+        public Guid? TenantId { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        public TenantItem() { }
+
+        public TenantItem(Guid id, Guid? tenantId, string name)
+        {
+            Id = id;
+            TenantId = tenantId;
+            Name = name;
+        }
+    }
+
+    private sealed class MultiTenantTestDbContext(
+        DbContextOptions<MultiTenantTestDbContext> options,
+        ICurrentTenant? currentTenant) : DbContext(options)
+    {
+        private readonly ICurrentTenant? _currentTenant = currentTenant;
+
+        public DbSet<TenantItem> Items => Set<TenantItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TenantItem>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.ApplyGranitConventions(_currentTenant, dataFilter: null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reference implementation of `MetricDefinition` for **`Granit.Invoicing`** — the first downstream consumer of `Granit.Analytics`. Two metrics anchor the "how to ship a metric" pattern other modules will copy.

### `Granit.Analytics` — additive change

New optional `BaseFilter` property on `MetricDefinition<TEntity, TValue>`: an `Expression<Func<TEntity, bool>>?` that scopes the metric to a subset of the entity (e.g. `Status == Open` for `UnpaidInvoiceCount`). Defaults to `null`. `MetricExecutor` composes it AFTER the user-supplied `QueryRequest` filters and AFTER the framework's multi-tenant + soft-delete global filters, so all three layers stack with `AND` semantics.

### `Granit.Invoicing` — `Metrics/`

- `UnpaidInvoiceCountMetricDefinition` — `Count`, `BaseFilter Status == Open`, `PeriodSelector IssuedAt`, `IsHigherBetter false`.
- `UnpaidInvoiceTotalMetricDefinition` — `Sum` on `AmountRemaining` (NOT `Total` — partially paid invoices contribute only the unpaid balance), same `BaseFilter` and `PeriodSelector`. Currency is intentionally not declared at the metric level — different invoices may carry different ISO 4217 codes; the host application owns cross-currency normalisation when displaying mixed-currency tenants.
- Both registered via `AddMetricDefinition<,,>()` in the existing `AddGranitInvoicing` extension. `[DependsOn(typeof(GranitAnalyticsModule))]` added to `GranitInvoicingModule`.
- Localization keys `Metric:Granit.Invoicing.UnpaidInvoiceCountMetric` and `Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric` shipped in 16 cultures (`en, fr, de, nl, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi, pt-BR`; `fr-CA` and `en-GB` fall through to base).

Naming follows the convention shipped in #1436 — class is `*MetricDefinition`, `Name` is `"Granit.{Module}.{...}Metric"` (suffix `Metric` in the wire identifier, `Definition` only on the C# class).

### Test fixture renaming (consistency cleanup)

Test-only metric definitions in `Granit.Analytics(.EntityFrameworkCore)(.Tests|.Tests.Integration)` renamed to follow the convention (`OrderCountMetric` → `OrderCountMetricDefinition`, etc.). Pure rename, no behaviour change. Locks the convention as a working example for the next module that ships metrics.

### `Granit.Testing.EntityFrameworkCore` — new test helper

`DbContextOptionsBuilderTestExtensions.EnableGranitTestModelIsolation()` defeats EF Core's process-wide internal-service-provider model cache for tests — `ApplyGranitConventions` captures `ICurrentTenant` by reference inside the multi-tenant query-filter expression, so without this opt-out a model built in test #1 pins test #1's mock and subsequent tests query the wrong tenant. Production is fine (single DI-scoped tenant, mutated via AsyncLocal); only multi-test mocking exposes the trap.

The helper is paired with unit tests under `Granit.Testing.EntityFrameworkCore.Tests/Extensions/`. Used from `UnpaidInvoiceMetricsTests` directly, and ready for any future multi-tenant `*.EntityFrameworkCore.Tests` project to adopt.

## Test plan

- [x] **77 tests green** across the Analytics suite (7 abstractions + 33 EF executor + 31 endpoints) + **6 new Invoicing integration tests** + the new `DbContextOptionsBuilderTestExtensionsTests`. Total **17/17** in `Granit.Invoicing.EntityFrameworkCore.Tests`.
- [x] **153/153 architecture tests** green.
- [x] `dotnet build .github/shard-filters/business.slnf` green; `dotnet format --verify-no-changes` clean.
- [x] Locked-mode build verified for `Granit.Invoicing` and its test project (only legitimately-changed lockfiles refreshed).
- [ ] CI green on PR.

## Issues
- Closes #1377 (story A4)
- Part of EPIC #1366