### PR TITLE
fix(openiddict): refresh Bundle + Integration lockfiles for Granit.Authentication

### DIFF
--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -490,10 +490,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authentication": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authentication.openiddict": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authentication": "[0.1.0-dev, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.SystemNetHttp": "[7.*, )"
         }
@@ -730,6 +737,7 @@
       "granit.openiddict.server": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -614,6 +614,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authentication": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -806,6 +812,7 @@
       "granit.openiddict.server": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authentication": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",


### PR DESCRIPTION
## Summary

- PR #1440 added `Granit.Authentication` as a new project reference from `Granit.Authentication.OpenIddict` and `Granit.OpenIddict.Server`, but the `Granit.Bundle.OpenIddict` and `Granit.OpenIddict.Tests.Integration` lockfiles were not regenerated.
- CI on develop fails with `NU1004: The packages lock file is inconsistent with the project dependencies` since #1440 merged.
- Regenerated both lockfiles via `dotnet restore --force-evaluate`.

## Test plan

- [x] `dotnet restore src/bundles/Granit.Bundle.OpenIddict/Granit.Bundle.OpenIddict.csproj --force-evaluate` succeeds
- [x] `dotnet restore tests/Granit.OpenIddict.Tests.Integration/Granit.OpenIddict.Tests.Integration.csproj --force-evaluate` succeeds
- [ ] CI green on this PR