### PR TITLE
docs(analytics): correct HTTP route example to follow host API-versioning convention

### DIFF
--- a/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
@@ -84,7 +84,7 @@ Naming, casing, and structural rules are codified in the
 before adding a metric, because the same names land in:
 
 - Localization keys (`Metric:{Name}` across 18 cultures)
-- HTTP route parameters (`POST /api/granit/analytics/metrics/{Name}`)
+- HTTP route parameters (`POST /api/{version}/analytics/metrics/{Name}` — exact path depends on the host's API versioning prefix)
 - Dashboard widget references (Layer 2)
 - OData EntitySet routing (Layer 3)
 - Power BI / Excel client measure aliases

--- a/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
@@ -104,7 +104,7 @@ under `src/Granit.{Module}/Metrics/`.
    the route group:
 
    ```csharp
-   app.MapGranitAnalytics();   // exposes POST /api/granit/analytics/metrics/{name}
+   app.MapGranitAnalytics();   // exposes POST /api/{version}/analytics/metrics/{name}
    ```
 
 7. **Consume from the frontend** with the `<MetricCard>` component (story
@@ -122,7 +122,10 @@ under `src/Granit.{Module}/Metrics/`.
 
 ## What the framework does for you
 
-Once registered, the metric is exposed at `POST /api/granit/analytics/metrics/{name}`
+Once registered, the metric is exposed at `POST /api/{version}/analytics/metrics/{name}`
+(the `{version}` segment is supplied by the host's `Granit.Http.ApiVersioning`
+configuration; the route prefix defaults to `analytics` and is overridable via
+`MapGranitAnalytics(opts => opts.RoutePrefix = …)`)
 and the framework pipeline guarantees the following — none of which you write
 yourself:
 


### PR DESCRIPTION
## Summary

The Analytics overview page wrote \`POST /api/granit/analytics/metrics/{Name}\`, which is not what Granit modules produce. The convention is \`/api/{version}/<prefix>/...\` where \`{version}\` is supplied by the host's \`Granit.Http.ApiVersioning\` setup and \`<prefix>\` is the module's \`RoutePrefix\` (here: \`analytics\`).

No module in the framework prepends \`granit/\` to its routes — verified across:

- \`Granit.BlobStorage.Endpoints\` → \`"blob-storage"\`
- \`Granit.Authentication.ApiKeys.Endpoints\` → \`"authentication"\`
- \`Granit.Settings.Endpoints\` → \`"settings/user"\`, \`"settings/global"\`, \`"settings/tenant"\`
- \`Granit.Identity.Local.Endpoints\` → \`"account"\`, \`"admin"\`
- \`Granit.Mcp.Server\` → \`"/mcp"\`

The runtime route prefix in \`Granit.Analytics.Endpoints\` is already \`"analytics"\` — only the doc text was wrong.

The same correction will land for \`inline-metrics.mdx\` via amendment of the still-open PR #1439 before it merges.

## Test plan

- [x] No production code touched — single doc string change
- [ ] CI green on PR

## Issues
- Part of EPIC #1366 (Analytics docs hygiene)