### PR TITLE
test(analytics): QueryDefinition <-> MetricDefinition pairing archi rule (D1 #1396)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -11,6 +11,8 @@
       "src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj",
       "src/Granit.AI.VectorData/Granit.AI.VectorData.csproj",
       "src/Granit.AI/Granit.AI.csproj",
+      "src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj",
+      "src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj",
       "src/Granit.Analytics/Granit.Analytics.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",

--- a/src/Granit.Analytics.Endpoints/Validators/MetricRequestValidator.cs
+++ b/src/Granit.Analytics.Endpoints/Validators/MetricRequestValidator.cs
@@ -1,0 +1,55 @@
+using FluentValidation;
+using Granit.Analytics.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Analytics.Endpoints.Validators;
+
+/// <summary>
+/// Validates the body of <c>POST {prefix}/metrics/{name}</c>. Period is required and must
+/// be either an absolute <c>{from, to}</c> window with <c>from &lt; to</c> or a non-empty
+/// named <c>token</c> (resolved server-side by <see cref="Internal.PeriodResolver"/>) —
+/// not both. The optional <see cref="MetricRequest.CompareTo"/> follows the same rules
+/// plus accepts the special <c>previous_period</c> token.
+/// </summary>
+internal sealed class MetricRequestValidator : GranitValidator<MetricRequest>
+{
+    public MetricRequestValidator()
+    {
+        RuleFor(x => x.Period).NotNull();
+
+        RuleFor(x => x.Period)
+            .SetValidator(new PeriodSpecValidator())
+            .When(x => x.Period is not null);
+
+        RuleFor(x => x.CompareTo!)
+            .SetValidator(new PeriodSpecValidator())
+            .When(x => x.CompareTo is not null);
+    }
+
+    private sealed class PeriodSpecValidator : GranitValidator<PeriodSpec>
+    {
+        public PeriodSpecValidator()
+        {
+            // Either Token is set (named period — possibly "previous_period" for the
+            // comparison window) or both From and To are set. Anything else is rejected.
+            RuleFor(x => x)
+                .Must(HasEitherTokenOrAbsoluteRange)
+                .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecBoundsCode");
+
+            // When the absolute form is used, From must be strictly before To.
+            RuleFor(x => x)
+                .Must(FromBeforeTo)
+                .When(x => x.Token is null && x.From.HasValue && x.To.HasValue)
+                .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecOrderingCode");
+        }
+
+        private static bool HasEitherTokenOrAbsoluteRange(PeriodSpec spec) =>
+            !string.IsNullOrWhiteSpace(spec.Token)
+                ? !spec.From.HasValue && !spec.To.HasValue
+                : spec.From.HasValue && spec.To.HasValue;
+
+        private static bool FromBeforeTo(PeriodSpec spec) =>
+            spec.From!.Value < spec.To!.Value;
+    }
+}

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' nesmí mít celkem více než {ExpectedPrecision} číslic, z toho {ExpectedScale} desetinných míst.",
     "Granit:Validation:ScheduledAction:FutureDate": "Plánované datum musí být v budoucnosti.",
     "Granit:Validation:UrlMustBeHttps": "Adresa URL musí používat HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Platné do' musí být pozdější než 'Platné od'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Platné do' musí být pozdější než 'Platné od'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Období musí být buď pojmenovaný token (např. 'last_30d') nebo obojí From a To — ne obojí, ne nic.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From musí být přísně před Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' darf insgesamt nicht mehr als {ExpectedPrecision} Ziffern haben, davon {ExpectedScale} Dezimalstellen.",
     "Granit:Validation:ScheduledAction:FutureDate": "Das geplante Datum muss in der Zukunft liegen.",
     "Granit:Validation:UrlMustBeHttps": "Die URL muss HTTPS verwenden.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Gültig bis' muss nach 'Gültig ab' liegen."
+    "Granit:Validation:ValidToAfterValidFrom": "'Gültig bis' muss nach 'Gültig ab' liegen.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Der Zeitraum muss entweder ein benanntes Token (z. B. 'last_30d') oder sowohl From als auch To enthalten — nicht beides, nicht keines.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From muss strikt vor Period.To liegen."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' must not be more than {ExpectedPrecision} digits in total, with allowance for {ExpectedScale} decimals.",
     "Granit:Validation:ScheduledAction:FutureDate": "Scheduled date must be in the future.",
     "Granit:Validation:UrlMustBeHttps": "The URL must use HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valid to' must be after 'Valid from'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Valid to' must be after 'Valid from'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Period must be either a named token (e.g. 'last_30d') or both From and To, not both or neither.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From must be strictly before Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' no debe tener más de {ExpectedPrecision} dígitos en total, de los cuales {ExpectedScale} decimales.",
     "Granit:Validation:ScheduledAction:FutureDate": "La fecha programada debe ser en el futuro.",
     "Granit:Validation:UrlMustBeHttps": "La URL debe usar HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Válido hasta' debe ser posterior a 'Válido desde'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Válido hasta' debe ser posterior a 'Válido desde'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "El período debe ser un token con nombre (ej. 'last_30d') o ambos From y To — no ambos, no ninguno.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From debe ser estrictamente anterior a Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' ne doit pas avoir plus de {ExpectedPrecision} chiffres au total, dont {ExpectedScale} décimaux.",
     "Granit:Validation:ScheduledAction:FutureDate": "La date planifiée doit être dans le futur.",
     "Granit:Validation:UrlMustBeHttps": "L'URL doit utiliser HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valide jusqu'au' doit être postérieur à 'Valide à partir du'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Valide jusqu'au' doit être postérieur à 'Valide à partir du'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "La période doit être soit un jeton nommé (ex. 'last_30d') soit From et To, pas les deux ni rien.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From doit être strictement antérieur à Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' कुल {ExpectedPrecision} अंकों से अधिक नहीं होना चाहिए, {ExpectedScale} दशमलव की अनुमति के साथ।",
     "Granit:Validation:ScheduledAction:FutureDate": "निर्धारित तिथि भविष्य में होनी चाहिए।",
     "Granit:Validation:UrlMustBeHttps": "URL को HTTPS का उपयोग करना चाहिए।",
-    "Granit:Validation:ValidToAfterValidFrom": "'मान्य तक' 'मान्य से' के बाद होना चाहिए।"
+    "Granit:Validation:ValidToAfterValidFrom": "'मान्य तक' 'मान्य से' के बाद होना चाहिए।",
+    "Granit:Validation:PeriodSpecBoundsCode": "अवधि या तो एक नामित टोकन (जैसे 'last_30d') होनी चाहिए या From और To दोनों — दोनों नहीं, कोई नहीं नहीं।",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From, Period.To से सख्ती से पहले होना चाहिए।"
   }
 }

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' non deve avere più di {ExpectedPrecision} cifre in totale, di cui {ExpectedScale} decimali.",
     "Granit:Validation:ScheduledAction:FutureDate": "La data programmata deve essere nel futuro.",
     "Granit:Validation:UrlMustBeHttps": "L'URL deve utilizzare HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valido fino a' deve essere successivo a 'Valido da'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Valido fino a' deve essere successivo a 'Valido da'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Il periodo deve essere un token denominato (es. 'last_30d') oppure entrambi From e To — non entrambi, non nessuno.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From deve essere strettamente precedente a Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' は合計 {ExpectedPrecision} 桁以内で、うち小数部は {ExpectedScale} 桁以内である必要があります。",
     "Granit:Validation:ScheduledAction:FutureDate": "スケジュール日は将来の日付である必要があります。",
     "Granit:Validation:UrlMustBeHttps": "URL は HTTPS を使用する必要があります。",
-    "Granit:Validation:ValidToAfterValidFrom": "'有効終了日' は '有効開始日' より後でなければなりません。"
+    "Granit:Validation:ValidToAfterValidFrom": "'有効終了日' は '有効開始日' より後でなければなりません。",
+    "Granit:Validation:PeriodSpecBoundsCode": "期間は名前付きトークン(例: 'last_30d')または From と To の両方である必要があります — 両方や両方なしは不可。",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From は Period.To より厳密に前である必要があります。"
   }
 }

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}'은(는) 총 {ExpectedPrecision}자리를 초과할 수 없으며 소수점 이하 {ExpectedScale}자리까지 허용됩니다.",
     "Granit:Validation:ScheduledAction:FutureDate": "예약 날짜는 미래여야 합니다.",
     "Granit:Validation:UrlMustBeHttps": "URL은 HTTPS를 사용해야 합니다.",
-    "Granit:Validation:ValidToAfterValidFrom": "'유효 종료일'은 '유효 시작일' 이후여야 합니다."
+    "Granit:Validation:ValidToAfterValidFrom": "'유효 종료일'은 '유효 시작일' 이후여야 합니다.",
+    "Granit:Validation:PeriodSpecBoundsCode": "기간은 명명된 토큰(예: 'last_30d') 또는 From과 To 둘 다여야 합니다 — 둘 다이거나 둘 다 아니어선 안 됩니다.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From은 Period.To보다 엄격히 이전이어야 합니다."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' mag niet meer dan {ExpectedPrecision} cijfers bevatten, waarvan {ExpectedScale} decimalen.",
     "Granit:Validation:ScheduledAction:FutureDate": "De geplande datum moet in de toekomst liggen.",
     "Granit:Validation:UrlMustBeHttps": "De URL moet HTTPS gebruiken.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Geldig tot' moet na 'Geldig vanaf' liggen."
+    "Granit:Validation:ValidToAfterValidFrom": "'Geldig tot' moet na 'Geldig vanaf' liggen.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Periode moet ofwel een benoemd token zijn (bijv. 'last_30d') ofwel From en To bevatten — niet beide, niet geen van beide.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From moet strikt vóór Period.To liggen."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' nie może mieć więcej niż {ExpectedPrecision} cyfr łącznie, w tym {ExpectedScale} miejsc po przecinku.",
     "Granit:Validation:ScheduledAction:FutureDate": "Zaplanowana data musi być w przyszłości.",
     "Granit:Validation:UrlMustBeHttps": "Adres URL musi używać protokołu HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Ważne do' musi być późniejsze niż 'Ważne od'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Ważne do' musi być późniejsze niż 'Ważne od'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Okres musi być albo nazwanym tokenem (np. 'last_30d'), albo zarówno From, jak i To — nie obydwoma, nie żadnym.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From musi być ściśle przed Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' não deve ter mais de {ExpectedPrecision} dígitos no total, dos quais {ExpectedScale} decimais.",
     "Granit:Validation:ScheduledAction:FutureDate": "A data agendada deve ser no futuro.",
     "Granit:Validation:UrlMustBeHttps": "A URL deve usar HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Válido até' deve ser posterior a 'Válido desde'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Válido até' deve ser posterior a 'Válido desde'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "O período deve ser um token nomeado (ex.: 'last_30d') ou ambos From e To — não ambos, não nenhum.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From deve ser estritamente anterior a Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' får inte ha fler än {ExpectedPrecision} siffror totalt, varav {ExpectedScale} decimaler.",
     "Granit:Validation:ScheduledAction:FutureDate": "Schemalagt datum måste vara i framtiden.",
     "Granit:Validation:UrlMustBeHttps": "URL:en måste använda HTTPS.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Giltig till' måste vara efter 'Giltig från'."
+    "Granit:Validation:ValidToAfterValidFrom": "'Giltig till' måste vara efter 'Giltig från'.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Perioden måste vara antingen en namngiven token (t.ex. 'last_30d') eller både From och To — inte båda, inte ingen.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From måste ligga strikt före Period.To."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' toplamda {ExpectedPrecision} basamaktan fazla olmamalı ve {ExpectedScale} ondalık basamağa izin verilmelidir.",
     "Granit:Validation:ScheduledAction:FutureDate": "Planlanan tarih gelecekte olmalıdır.",
     "Granit:Validation:UrlMustBeHttps": "URL, HTTPS kullanmalıdır.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Geçerlilik bitiş tarihi', 'Geçerlilik başlangıç tarihi'nden sonra olmalıdır."
+    "Granit:Validation:ValidToAfterValidFrom": "'Geçerlilik bitiş tarihi', 'Geçerlilik başlangıç tarihi'nden sonra olmalıdır.",
+    "Granit:Validation:PeriodSpecBoundsCode": "Dönem ya bir adlandırılmış jeton (ör. 'last_30d') ya da hem From hem To olmalıdır — ikisi birden ya da hiçbiri olmaz.",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From, Period.To'dan kesinlikle önce olmalıdır."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -76,6 +76,8 @@
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' 总共不能超过 {ExpectedPrecision} 位数字，其中允许 {ExpectedScale} 位小数。",
     "Granit:Validation:ScheduledAction:FutureDate": "计划日期必须是将来的日期。",
     "Granit:Validation:UrlMustBeHttps": "URL 必须使用 HTTPS。",
-    "Granit:Validation:ValidToAfterValidFrom": "'有效截止日期' 必须晚于 '有效起始日期'。"
+    "Granit:Validation:ValidToAfterValidFrom": "'有效截止日期' 必须晚于 '有效起始日期'。",
+    "Granit:Validation:PeriodSpecBoundsCode": "周期必须是命名令牌(如 'last_30d')或同时包含 From 和 To,不能两者皆是或都为空。",
+    "Granit:Validation:PeriodSpecOrderingCode": "Period.From 必须严格早于 Period.To。"
   }
 }

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
@@ -146,7 +146,7 @@ public static class LayerDependencyRules
     public static void IQueryableShouldNotEscapePersistenceLayer(
         ArchUnitNET.Domain.Architecture architecture)
     {
-        string[] allowedNamespaceFragments = ["EntityFrameworkCore", "QueryEngine", "Persistence", "Export", "Identity.Local", "Identity.OpenIddict"];
+        string[] allowedNamespaceFragments = ["EntityFrameworkCore", "QueryEngine", "Persistence", "Export", "Identity.Local", "Identity.OpenIddict", "Analytics"];
 
         IEnumerable<IType> violators = architecture.Types
             .Where(t => !allowedNamespaceFragments.Any(ns =>

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="..\..\src\Granit.AI.Ollama\Granit.AI.Ollama.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.OpenAI\Granit.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.VectorData\Granit.AI.VectorData.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.Endpoints\Granit.Analytics.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.ConfigurationChanges\Granit.Auditing.ConfigurationChanges.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />

--- a/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
@@ -1,0 +1,249 @@
+using System.Reflection;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces the Query ↔ Metric pairing rule from EPIC #1366 (story #1396) — every
+/// admin-visible entity that has a <see cref="QueryDefinition{TEntity}"/> SHOULD ship
+/// at least one <see cref="MetricDefinition{TEntity, TValue}"/> so the admin grid is
+/// always paired with at least one KPI tile.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework cannot mechanically distinguish "admin-visible" from "internal
+/// infrastructure" entities — the heuristic in story #1396 ("has a CRUD endpoint
+/// group") would require parsing every <c>*Endpoints</c> module's route registration,
+/// which is fragile. Instead, we invert the question: **every entity with a
+/// QueryDefinition is by default admin-visible** and must therefore be paired with a
+/// metric. Entities that are genuinely infrastructure (audit-log details, internal
+/// config rows, ephemeral cache tables) opt out via the <see cref="PairingExemptions"/>
+/// allow-list with a written justification.
+/// </para>
+/// <para>
+/// The test is enforcement-mode: failure is an error, not a warning. New
+/// QueryDefinitions that don't ship a matching MetricDefinition either:
+/// </para>
+/// <list type="number">
+///   <item>add the metric in the module's <c>Metrics/</c> folder, registered via
+///         <c>services.AddMetricDefinition&lt;TEntity, TValue, TDefinition&gt;()</c>; or</item>
+///   <item>add the entity to <see cref="PairingExemptions"/> with a one-line
+///         justification explaining why this entity has no business KPI worth
+///         exposing in the admin UI.</item>
+/// </list>
+/// <para>
+/// The companion <c>QueryExportPairingTests</c> uses the same shape for the
+/// already-codified Query ↔ Export pairing.
+/// </para>
+/// </remarks>
+public sealed class QueryMetricPairingTests
+{
+    /// <summary>
+    /// Entities exempted from the Query ↔ Metric pairing rule. Each entry MUST carry a
+    /// one-line justification (inline comment).
+    /// </summary>
+    /// <remarks>
+    /// This list is pre-populated with the current baseline at the time of D1's
+    /// introduction (EPIC #1366). Entries marked <c>[BACKLOG]</c> are admin-visible
+    /// entities that should eventually ship a metric — they are exempted today so the
+    /// rule can be enforced going forward without forcing a framework-wide retrofit.
+    /// Removing an entry from <c>[BACKLOG]</c> requires shipping at least one
+    /// MetricDefinition for that entity.
+    ///
+    /// Entries marked <c>[INFRA]</c> are genuine infrastructure / audit / internal cache
+    /// entities that have no useful KPI on the admin UI — these are permanent
+    /// exemptions.
+    /// </remarks>
+    private static readonly HashSet<string> PairingExemptions = new(StringComparer.Ordinal)
+    {
+        // ── [INFRA] permanent exemptions ────────────────────────────────────
+        // System / audit / configuration entities with no useful business KPI on the
+        // admin UI. These are not "admin-visible" in the grid-with-KPI sense — they
+        // either back tooling (saved views, exports), record auditing trails, or
+        // hold security / config state.
+
+        "Granit.AI.AIUsageRecord",                                                        // [INFRA] AI cost / audit log
+        "Granit.Auditing.Domain.AuditEntityChange",                                       // [INFRA] audit log
+        "Granit.Auditing.Domain.AuditEntry",                                              // [INFRA] audit log
+        "Granit.Authorization.Domain.PermissionGrant",                                    // [INFRA] RBAC config
+        "Granit.Authorization.Domain.RoleMetadata",                                       // [INFRA] RBAC config
+        "Granit.BackgroundJobs.Domain.BackgroundJobDefinition",                           // [INFRA] job config
+        "Granit.DataExchange.Export.Domain.ExportJob",                                    // [INFRA] transient export job
+        "Granit.DataExchange.Import.Domain.ImportJob",                                    // [INFRA] transient import job
+        "Granit.Identity.Federated.Domain.UserCacheEntry",                                // [INFRA] internal user cache
+        "Granit.Identity.Local.Domain.GranitRole",                                        // [INFRA] RBAC config
+        "Granit.Identity.Local.Domain.GranitUserGroup",                                   // [INFRA] RBAC config
+        "Granit.Localization.Domain.LocalizationOverride",                                // [INFRA] localization config
+        "Granit.Metering.Domain.MeterDefinition",                                         // [INFRA] metering config
+        "Granit.MultiTenancy.Domain.Tenant",                                              // [INFRA] platform-admin entity
+        "Granit.Notifications.Domain.NotificationPreference",                             // [INFRA] user preference config
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication",              // [INFRA] OAuth client config
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope",                    // [INFRA] OAuth scope config
+        "Granit.Parties.EntityFrameworkCore.Entities.PartyDuplicateCandidate",            // [INFRA] deduplication queue
+        "Granit.QueryEngine.SavedViews.Domain.SavedView",                                 // [INFRA] grid tooling
+        "Granit.ReferenceData.Domain.DynamicReferenceDataEntity",                         // [INFRA] reference-data config
+        "Granit.Scheduling.Domain.ScheduledAction",                                       // [INFRA] scheduling state
+        "Granit.Settings.Domain.SettingRecord",                                           // [INFRA] settings config
+        "Granit.Tax.Domain.TaxRateOverride",                                              // [INFRA] tax config
+        "Granit.Tax.TaxRateEntry",                                                        // [INFRA] tax config
+        "Granit.Timeline.Domain.TimelineEntry",                                           // [INFRA] audit log
+        "Granit.Workflow.Domain.WorkflowTransitionRecord",                                // [INFRA] workflow audit
+
+        // ── [BACKLOG] admin-visible entities awaiting their first metric ────
+        // These DO surface in admin grids and SHOULD ship at least one MetricDefinition.
+        // They are exempted here as a known-debt baseline at the time D1 (#1396)
+        // landed (post-A4 #1377). Remove an entry from this list when the matching
+        // module ships its first MetricDefinition for that entity — the rule then
+        // begins enforcing for that entity going forward.
+
+        "Granit.BlobStorage.Domain.BlobDescriptor",                                       // [BACKLOG] storage-usage KPIs
+        "Granit.Catalog.Domain.Product",                                                  // [BACKLOG] catalog count / activation
+        "Granit.CustomerBalance.Domain.BalanceAccount",                                   // [BACKLOG] balance totals
+        "Granit.CustomerBalance.Domain.BalanceTransaction",                               // [BACKLOG] credit / debit volume
+        "Granit.Metering.Domain.UsageAggregate",                                          // [BACKLOG] usage trends
+        "Granit.Notifications.Domain.UserNotification",                                   // [BACKLOG] delivery / read-rate KPIs
+        "Granit.Parties.Domain.Party",                                                    // [BACKLOG] active-party count
+        "Granit.Payments.Domain.Dispute",                                                 // [BACKLOG] open-dispute count / total
+        "Granit.Payments.Domain.PaymentMethod",                                           // [BACKLOG] active-method count
+        "Granit.Payments.Domain.PaymentTransaction",                                      // [BACKLOG] success-rate / volume
+        "Granit.Payments.Domain.Refund",                                                  // [BACKLOG] refund-volume KPIs
+        "Granit.Payments.SepaDirectDebit.Domain.Mandate",                                 // [BACKLOG] active-mandate count
+        "Granit.Subscriptions.Domain.Plan",                                               // [BACKLOG] active-plan count
+        "Granit.Subscriptions.Domain.PlanPrice",                                          // [BACKLOG] active-pricing count
+        "Granit.Subscriptions.Domain.Subscription",                                       // [BACKLOG] MRR / ARR / churn rate
+        "Granit.Webhooks.Domain.WebhookDeliveryAttempt",                                  // [BACKLOG] delivery failure rate
+        "Granit.Webhooks.Domain.WebhookSubscription",                                     // [BACKLOG] active-subscription count
+    };
+
+    [Fact]
+    public void Every_QueryDefinition_should_have_a_matching_MetricDefinition()
+    {
+        (HashSet<Type> queryEntities, HashSet<Type> metricEntities) = ScanEntities();
+
+        IEnumerable<string> queryWithoutMetric = queryEntities
+            .Where(t => !metricEntities.Contains(t) && !PairingExemptions.Contains(t.FullName!))
+            .Select(t => t.FullName!)
+            .OrderBy(s => s, StringComparer.Ordinal);
+
+        queryWithoutMetric.ShouldBeEmpty(
+            "Pairing rule (EPIC #1366 / story #1396): every entity with a QueryDefinition " +
+            "should also have at least one MetricDefinition. " +
+            "Add a `*MetricDefinition` in the same module's `Metrics/` folder, " +
+            "register it via `services.AddMetricDefinition<TEntity, TValue, TDefinition>()`, " +
+            "or add the entity to PairingExemptions with a justification " +
+            "(`[BACKLOG]` for admin-visible entities awaiting their first metric, " +
+            "`[INFRA]` for permanent exemptions on infrastructure / audit / internal cache entities).");
+    }
+
+    [Fact]
+    public void Every_MetricDefinition_should_have_a_matching_QueryDefinition()
+    {
+        // The inverse direction is strictly enforced — no exemption list. A metric
+        // without a query underneath is always a bug: the user sees "12 unpaid invoices"
+        // but cannot click through to a list of those 12 rows. Either the metric
+        // is genuinely measuring something the admin UI never lists (rare; still
+        // probably wrong) or the matching QueryDefinition is missing.
+        (HashSet<Type> queryEntities, HashSet<Type> metricEntities) = ScanEntities();
+
+        IEnumerable<string> metricWithoutQuery = metricEntities
+            .Where(t => !queryEntities.Contains(t))
+            .Select(t => t.FullName!)
+            .OrderBy(s => s, StringComparer.Ordinal);
+
+        metricWithoutQuery.ShouldBeEmpty(
+            "Pairing rule (EPIC #1366 / story #1396): every entity with a MetricDefinition " +
+            "must also have a QueryDefinition — a KPI tile is meaningless without an admin " +
+            "list to drill down into. Add the matching `*QueryDefinition` in the same " +
+            "module's `Queries/` folder and register it via " +
+            "`services.AddQueryDefinition<TEntity, TDefinition>()`. " +
+            "If the entity genuinely has no admin grid (rare), reconsider whether the " +
+            "metric belongs in this module at all.");
+    }
+
+    private static (HashSet<Type> queryEntities, HashSet<Type> metricEntities) ScanEntities()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(QueryMetricPairingTests).Assembly.Location)!;
+
+        Assembly[] assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        HashSet<Type> queryEntities = [];
+        HashSet<Type> metricEntities = [];
+
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                {
+                    continue;
+                }
+
+                Type? queryEntity = ExtractGenericArgument(type, typeof(QueryDefinition<>));
+                if (queryEntity is not null && queryEntity.FullName is not null)
+                {
+                    queryEntities.Add(queryEntity);
+                }
+
+                Type? metricEntity = ExtractMetricEntity(type);
+                if (metricEntity is not null && metricEntity.FullName is not null)
+                {
+                    metricEntities.Add(metricEntity);
+                }
+            }
+        }
+
+        return (queryEntities, metricEntities);
+    }
+
+    private static Type? ExtractGenericArgument(Type candidate, Type openGenericBase)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return cursor.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts <c>TEntity</c> from a concrete <c>MetricDefinition&lt;TEntity, TValue&gt;</c>.
+    /// MetricDefinition has two generic parameters; we only care about the entity
+    /// (presence of any metric for the entity, regardless of the value type, fulfils the
+    /// pairing rule).
+    /// </summary>
+    private static Type? ExtractMetricEntity(Type candidate)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == typeof(MetricDefinition<,>))
+            {
+                return cursor.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1490,6 +1490,28 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.analytics.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Analytics.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.architecturetests.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
+++ b/tests/Granit.Parties.Endpoints.Tests/Endpoints/PartyEndpointsCreateOnlineDedupTests.cs
@@ -52,8 +52,8 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
 
         Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
-                _request, force: false, skipDuplicateCheck: false,
-                _writer, _guidGenerator, _detector, ct);
+                _request, _writer, _guidGenerator, _detector, ct,
+                force: false, skipDuplicateCheck: false);
 
         Conflict<PartyCreateConflictResponse> conflict =
             response.Result.ShouldBeOfType<Conflict<PartyCreateConflictResponse>>();
@@ -79,8 +79,8 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
 
         Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
-                _request, force: false, skipDuplicateCheck: false,
-                _writer, _guidGenerator, _detector, ct);
+                _request, _writer, _guidGenerator, _detector, ct,
+                force: false, skipDuplicateCheck: false);
 
         // Tier-3 fuzzy doesn't block — create proceeds. Recurring scan surfaces it later.
         response.Result.ShouldBeOfType<Created<PartyResponse>>();
@@ -100,8 +100,8 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
 
         Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
-                _request, force: true, skipDuplicateCheck: false,
-                _writer, _guidGenerator, _detector, ct);
+                _request, _writer, _guidGenerator, _detector, ct,
+                force: true, skipDuplicateCheck: false);
 
         response.Result.ShouldBeOfType<Created<PartyResponse>>();
         // Detector never called — short-circuited before the round-trip.
@@ -120,8 +120,8 @@ public sealed class PartyEndpointsCreateOnlineDedupTests
 
         Results<Created<PartyResponse>, Conflict<PartyCreateConflictResponse>, ProblemHttpResult, ValidationProblem>
             response = await PartyEndpoints.HandleCreateAsync(
-                _request, force: false, skipDuplicateCheck: true,
-                _writer, _guidGenerator, _detector, ct);
+                _request, _writer, _guidGenerator, _detector, ct,
+                force: false, skipDuplicateCheck: true);
 
         response.Result.ShouldBeOfType<Created<PartyResponse>>();
         await _detector.DidNotReceiveWithAnyArgs().FindCandidatesAsync(default!, ct);


### PR DESCRIPTION
## Summary

Closes part of #1396 (Feature D — Analytics conventions and architecture enforcement).

Adds two architecture tests in `Granit.ArchitectureTests` enforcing the contract between admin-visible queries and analytics metrics:

- **Every `QueryDefinition` should have a matching `MetricDefinition`** — with a categorised exemption list:
  - `[INFRA]` (audit/config/internal cache entities — exempt by design)
  - `[BACKLOG]` (admin-visible entities still awaiting metrics — to be drained as new modules ship metrics)
- **Every `MetricDefinition` must have a matching `QueryDefinition`** — no exemption, strictly enforced. A metric without an underlying query is always a bug: the user sees a KPI but cannot drill down.

The pairing rule complements the existing `QueryDefinition` ↔ `ExportDefinition` pairing (browse + export) by adding the third facet — measure — to the same admin-grid use case.

### Side fixes required to keep CI green

- **`MetricRequestValidator`** (FluentValidation) — `ValidationConventionTests` requires every `*Request` type in `.Endpoints` to have a validator. The validator enforces `PeriodSpec` bounds (either `{from, to}` or `token`, never both) and ordering (`from < to`).
- **Localization keys** in 15 base cultures: `Granit:Validation:PeriodSpecBoundsCode`, `Granit:Validation:PeriodSpecOrderingCode`. Regional files (`fr-CA`, `en-GB`, `pt-BR`) fall through to base.
- **`LayerDependencyRules`** — added `Analytics` to the allowed-namespace fragments for `IQueryable`. `MetricRunner<,>` and `PeriodFilterBuilder` live in `Granit.Analytics.Endpoints.Internal` and intentionally compose `IQueryable` server-side before EF translation.
- **`PartyEndpointsCreateOnlineDedupTests`** — reordered named arguments to match the `HandleCreateAsync` signature change from #1441 (CS8323).

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests` — 155/155 passing (including 2 new pairing tests)
- [x] `dotnet build src/Granit.Analytics.Endpoints` — clean
- [x] `dotnet build tests/Granit.Parties.Endpoints.Tests` — CS8323 errors gone
- [x] `dotnet build tests/Granit.Analytics.EntityFrameworkCore.Tests` — clean
- [x] `dotnet format .github/shard-filters/architecture.slnf --verify-no-changes` — clean
- [ ] Full CI green