### PR TITLE
docs: replace legacy `/api/granit/...` route examples with host-mount-aware paths

### DIFF
--- a/docs-site/src/content/docs/blog/rfc-7807-problem-details-the-only-way-to-return-errors.mdx
+++ b/docs-site/src/content/docs/blog/rfc-7807-problem-details-the-only-way-to-return-errors.mdx
@@ -245,7 +245,7 @@ FluentValidation failures get special treatment. The `errors` dictionary maps fi
 }
 ```
 
-Why codes instead of messages? Because the **frontend resolves them to localized strings** via `GET /api/granit/localization`. A French user sees "Le nom est obligatoire.", a Dutch user sees "Naam is verplicht." — from the same error code. This is how you do i18n-friendly validation without duplicating messages between backend and frontend.
+Why codes instead of messages? Because the **frontend resolves them to localized strings** via `GET /api/{version}/localization`. A French user sees "Le nom est obligatoire.", a Dutch user sees "Naam is verplicht." — from the same error code. This is how you do i18n-friendly validation without duplicating messages between backend and frontend.
 
 ### Custom mappers: extend the chain
 

--- a/docs-site/src/content/docs/blog/validation-at-the-right-layer.md
+++ b/docs-site/src/content/docs/blog/validation-at-the-right-layer.md
@@ -93,7 +93,7 @@ public sealed class CreateOrderRequestValidator : GranitValidator<CreateOrderReq
 }
 ```
 
-`GranitValidator<T>` is a thin base class that emits **structured error codes** (`Granit:Validation:NotEmptyValidator`, `Granit:Validation:EmailValidator`) instead of raw English strings. The frontend resolves codes to localized messages via `GET /api/granit/localization`. No backend code change ships a French translation; no hardcoded English leaks into a German UI.
+`GranitValidator<T>` is a thin base class that emits **structured error codes** (`Granit:Validation:NotEmptyValidator`, `Granit:Validation:EmailValidator`) instead of raw English strings. The frontend resolves codes to localized messages via `GET /api/{version}/localization`. No backend code change ships a French translation; no hardcoded English leaks into a German UI.
 
 For custom rules, `WithErrorCodeAndMessage("Granit:Validation:TooManyItems")` keeps the code and the message key in sync — they are the same value. Diverging the two is the single most common cause of "validation passes but UI shows nothing", and the helper makes it impossible.
 
@@ -250,7 +250,7 @@ The async uniqueness case is the one most teams get wrong. They put it in the va
 - **Validate exactly once, at the API boundary.** Scattering checks across controllers, services, and entities produces drift, duplication, and silent gaps.
 - **`MapGranitGroup` runs validation automatically** for every endpoint in the group. No per-endpoint filter, no `IValidator<T>` injection, no boilerplate.
 - **Return `422 Unprocessable Entity`** for semantic validation failures, not `400 Bad Request`. The client can act on the difference.
-- **Use structured error codes** (`Granit:Validation:*`) instead of hardcoded strings. The frontend localizes them via `GET /api/granit/localization`.
+- **Use structured error codes** (`Granit:Validation:*`) instead of hardcoded strings. The frontend localizes them via `GET /api/{version}/localization`.
 - **OpenAPI gets the rules for free** — `maxLength`, `pattern`, `required`, etc. flow into the generated schema, so frontend code generators stay accurate.
 - **Domain invariants stay on aggregate roots.** Validation is for shape; the domain owns business rules.
 

--- a/docs-site/src/content/docs/dotnet/architecture/adr/028-unified-data-lookup.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/028-unified-data-lookup.md
@@ -101,9 +101,9 @@ Mapped once at host startup via `app.MapGranitDataLookups()`:
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/granit/lookups` | Discovery manifest of every registered source |
-| `GET` | `/api/granit/lookups/{name}` | Paginated typeahead search (`search`, `page`, `pageSize`, `scope.*`) |
-| `GET` | `/api/granit/lookups/{name}/resolve?value=…` | Single-item resolve for rehydrating a persisted FK value |
+| `GET` | `/api/{version}/lookups` | Discovery manifest of every registered source |
+| `GET` | `/api/{version}/lookups/{name}` | Paginated typeahead search (`search`, `page`, `pageSize`, `scope.*`) |
+| `GET` | `/api/{version}/lookups/{name}/resolve?value=…` | Single-item resolve for rehydrating a persisted FK value |
 
 Every response honors the `Accept-Language` header (labels projected
 server-side), the ambient `ICurrentTenant`, and the per-source

--- a/docs-site/src/content/docs/dotnet/architecture/adr/035-customer-balance-orb-credits-mapping.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/035-customer-balance-orb-credits-mapping.md
@@ -66,7 +66,7 @@ upstream tenant-management), but the operations are 1:1.
 
 ### 2. Additions to close the residual gap
 
-**`POST /api/granit/customer-balance/balance/debit`** (admin debit) —
+**`POST /api/{version}/customer-balance/balance/debit`** (admin debit) —
 allows manual drawdown for corrections, scheduled debits, and non-invoice
 adjustments. Idempotent via `(ReferenceId, Source = ManualAdjustment)`
 lookup: a previous debit with the same `ReferenceId` short-circuits the

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/data-lookup.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/data-lookup.md
@@ -40,7 +40,7 @@ flowchart LR
         Reg --> EE
     end
 
-    EP[GET /api/granit/lookups/&#123;name&#125;]
+    EP[GET /api/&#123;version&#125;/lookups/&#123;name&#125;]
     MF[FilterableField.Lookup<br/>in /meta]
 
     Reg --> EP

--- a/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
+++ b/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
@@ -30,7 +30,7 @@ no duplication between backend declarations and frontend components.
 - Granit.DataLookup.Abstractions/ Contracts: LookupDescriptor, LookupItem, LookupResult, ILookupSource, ILookupRegistry
   - Granit.DataLookup/ Runtime: scoped registry, EnumLookupSource&lt;TEnum&gt;, metrics, ActivitySource
     - Granit.DataLookup.EntityFrameworkCore QueryableLookupSource&lt;T&gt; — wraps an IQueryable with value/label selectors
-    - Granit.DataLookup.Endpoints Minimal API: /api/granit/lookups manifest, search, resolve
+    - Granit.DataLookup.Endpoints Minimal API: /api/{version}/lookups manifest, search, resolve
 </FileTree>
 
 | Package | Role | Depends on |
@@ -38,7 +38,7 @@ no duplication between backend declarations and frontend components.
 | `Granit.DataLookup.Abstractions` | Pure contracts (descriptors, DTOs, interfaces) | `Granit` |
 | `Granit.DataLookup` | `ILookupRegistry`, `EnumLookupSource<TEnum>`, metrics | `.Abstractions`, `Granit.Localization` |
 | `Granit.DataLookup.EntityFrameworkCore` | `QueryableLookupSource<T>` over `IQueryable<T>` | `Granit.DataLookup`, `Granit.Persistence` |
-| `Granit.DataLookup.Endpoints` | `/api/granit/lookups` minimal API, permissions, auth | `Granit.DataLookup`, `Granit.Authorization`, `Granit.Validation` |
+| `Granit.DataLookup.Endpoints` | `/api/{version}/lookups` minimal API, permissions, auth | `Granit.DataLookup`, `Granit.Authorization`, `Granit.Validation` |
 
 ## Canonical shapes
 
@@ -107,16 +107,20 @@ Mapped once at startup:
 ```csharp
 app.MapGranitDataLookups(opts =>
 {
-    opts.RoutePrefix = "api/granit/lookups";
     opts.TagName = "Data Lookup";
 });
 ```
 
+The default `RoutePrefix` is `"lookups"`. Mount on a versioned route group
+(`api.MapGranitDataLookups()` where `api = app.MapGroup("api/v{version:apiVersion}")`)
+to expose under `/api/{version}/lookups`, or mount on `app` directly for an unversioned
+root mount (`/lookups`).
+
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/granit/lookups` | Manifest of every registered source |
-| `GET` | `/api/granit/lookups/{name}` | Paginated search (`search`, `page`, `pageSize`, `scope.*`) |
-| `GET` | `/api/granit/lookups/{name}/resolve?value=…` | Resolve a single value for rehydration |
+| `GET` | `/api/{version}/lookups` | Manifest of every registered source |
+| `GET` | `/api/{version}/lookups/{name}` | Paginated search (`search`, `page`, `pageSize`, `scope.*`) |
+| `GET` | `/api/{version}/lookups/{name}/resolve?value=…` | Resolve a single value for rehydration |
 
 Every response honors:
 

--- a/docs-site/src/content/docs/dotnet/business/timeline.mdx
+++ b/docs-site/src/content/docs/dotnet/business/timeline.mdx
@@ -139,7 +139,7 @@ public sealed record TimelineStreamEntry
 
 ## REST API endpoints
 
-All endpoints are prefixed with `/api/granit/timeline`.
+All endpoints are prefixed with `/api/{version}/timeline`.
 
 | Method | Path | Description | Permission |
 |--------|------|-------------|------------|

--- a/docs-site/src/content/docs/dotnet/compliance/privacy/contact.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/privacy/contact.mdx
@@ -75,7 +75,7 @@ Tenant administrators can override any of the values through the `Granit.Setting
 admin API without a redeploy:
 
 ```http
-PUT /api/granit/settings/Granit.Privacy.Dpo.Email
+PUT /api/{version}/settings/Granit.Privacy.Dpo.Email
 Content-Type: application/json
 
 {

--- a/docs-site/src/content/docs/dotnet/guides/set-up-localization.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/set-up-localization.mdx
@@ -350,9 +350,9 @@ public sealed class TranslationAdminService(
 
 | Method | Route | Description |
 | --- | --- | --- |
-| `GET` | `/api/granit/localization/overrides` | List overrides by resource and culture |
-| `PUT` | `/api/granit/localization/overrides/{resource}/{culture}/{key}` | Create or update an override |
-| `DELETE` | `/api/granit/localization/overrides/{resource}/{culture}/{key}` | Remove an override |
+| `GET` | `/api/{version}/localization/overrides` | List overrides by resource and culture |
+| `PUT` | `/api/{version}/localization/overrides/{resource}/{culture}/{key}` | Create or update an override |
+| `DELETE` | `/api/{version}/localization/overrides/{resource}/{culture}/{key}` | Remove an override |
 
 ```csharp
 app.MapGranitLocalizationOverrides();

--- a/docs-site/src/content/docs/dotnet/infrastructure/scheduling.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/scheduling.mdx
@@ -214,10 +214,10 @@ schedule or the catch-up job.
 
 | Method | Route | Permission | Description |
 |--------|-------|------------|-------------|
-| GET | `/api/granit/scheduling/{id}` | `Scheduling.Actions.Read` | Get action by ID |
-| GET | `/api/granit/scheduling/query` | `Scheduling.Actions.Read` | Paginated list (QueryEngine) |
-| DELETE | `/api/granit/scheduling/{id}` | `Scheduling.Actions.Manage` | Cancel a pending action |
-| PUT | `/api/granit/scheduling/{id}/reschedule` | `Scheduling.Actions.Manage` | Reschedule to new date |
+| GET | `/api/{version}/scheduling/{id}` | `Scheduling.Actions.Read` | Get action by ID |
+| GET | `/api/{version}/scheduling/query` | `Scheduling.Actions.Read` | Paginated list (QueryEngine) |
+| DELETE | `/api/{version}/scheduling/{id}` | `Scheduling.Actions.Manage` | Cancel a pending action |
+| PUT | `/api/{version}/scheduling/{id}/reschedule` | `Scheduling.Actions.Manage` | Reschedule to new date |
 
 ## Observability
 

--- a/docs-site/src/content/docs/dotnet/saas/customer-balance.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/customer-balance.mdx
@@ -96,9 +96,9 @@ existing deduction and skips the debit — only applies the credit note.
 
 | Method | Route | Permission |
 | ------ | ----- | ---------- |
-| GET | `/api/granit/customer-balance/balance?currency=EUR` | `CustomerBalance.Accounts.Read` |
-| GET | `/api/granit/customer-balance/transactions?currency=EUR` | `CustomerBalance.Transactions.Read` |
-| POST | `/api/granit/customer-balance/credit` | `CustomerBalance.Credits.Manage` |
+| GET | `/api/{version}/customer-balance/balance?currency=EUR` | `CustomerBalance.Accounts.Read` |
+| GET | `/api/{version}/customer-balance/transactions?currency=EUR` | `CustomerBalance.Transactions.Read` |
+| POST | `/api/{version}/customer-balance/credit` | `CustomerBalance.Credits.Manage` |
 
 ## Domain services
 

--- a/docs-site/src/content/docs/dotnet/saas/invoicing.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/invoicing.mdx
@@ -217,10 +217,10 @@ Both services are registered automatically by `AddGranitInvoicing()`.
 
 | Method | Route | Permission |
 |--------|-------|------------|
-| GET | `/api/granit/invoicing/invoices` | `Invoicing.Invoices.Read` |
-| GET | `/api/granit/invoicing/invoices/{id}` | `Invoicing.Invoices.Read` |
-| GET | `/api/granit/invoicing/invoices/{id}/pdf` | `Invoicing.Invoices.Download` |
-| POST | `/api/granit/invoicing/credit-notes` | `Invoicing.CreditNotes.Manage` |
+| GET | `/api/{version}/invoicing/invoices` | `Invoicing.Invoices.Read` |
+| GET | `/api/{version}/invoicing/invoices/{id}` | `Invoicing.Invoices.Read` |
+| GET | `/api/{version}/invoicing/invoices/{id}/pdf` | `Invoicing.Invoices.Download` |
+| POST | `/api/{version}/invoicing/credit-notes` | `Invoicing.CreditNotes.Manage` |
 
 ## Notifications
 

--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -204,7 +204,7 @@ hourly buckets server-side. The global ingestion watermark is **never rewound** 
 events past `to` keep flowing through the hot path.
 
 ```http
-POST /api/granit/metering/meters/{id}/recompute
+POST /api/{version}/metering/meters/{id}/recompute
 {
   "from": "2026-04-01T00:00:00Z",
   "to":   "2026-04-15T00:00:00Z"
@@ -225,7 +225,7 @@ Same shape as `POST /events`, but the per-event age validator allows up to
 on every meter window the backfilled events touched.
 
 ```http
-POST /api/granit/metering/events/backfill
+POST /api/{version}/metering/events/backfill
 { "events": [ { meterDefinitionId, idempotencyKey, quantity, timestamp, metadata }, ... ] }
 
 → 200 BackfillUsageResponse { eventsAccepted, metersAffected, aggregatesRebuilt }
@@ -242,7 +242,7 @@ preserved (audit trail, `DeprecatedAt` + `DeprecationReason` columns); the
 auto-recompute on the affected hourly bucket follows.
 
 ```http
-POST /api/granit/metering/events/{id}/deprecate
+POST /api/{version}/metering/events/{id}/deprecate
 { "reason": "duplicate from retried client" }
 
 → 200 DeprecateEventResponse { eventId, meterDefinitionId, deprecatedAt, aggregatesRebuilt }
@@ -344,19 +344,19 @@ The legacy `Activated` column is dropped by the
 
 | Method | Route | Permission |
 |--------|-------|------------|
-| GET | `/api/granit/metering/meters` | `Metering.Meters.Read` |
-| POST | `/api/granit/metering/meters` | `Metering.Meters.Manage` |
-| PUT | `/api/granit/metering/meters/{id}` | `Metering.Meters.Manage` |
-| POST | `/api/granit/metering/meters/{id}/publish` | `Metering.Meters.Manage` |
-| POST | `/api/granit/metering/meters/{id}/archive` | `Metering.Meters.Manage` |
-| POST | `/api/granit/metering/meters/{id}/recompute` | `Metering.Meters.Manage` |
-| GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
-| GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
-| POST | `/api/granit/metering/events` | `Metering.Usage.Record` |
-| POST | `/api/granit/metering/events/backfill` | `Metering.Events.Backfill` |
-| POST | `/api/granit/metering/events/{id}/deprecate` | `Metering.Events.Manage` |
-| GET | `/api/granit/metering/meter-definitions` | `Metering.Meters.Read` |
-| GET | `/api/granit/metering/usage-aggregates` | `Metering.Usage.Read` |
+| GET | `/api/{version}/metering/meters` | `Metering.Meters.Read` |
+| POST | `/api/{version}/metering/meters` | `Metering.Meters.Manage` |
+| PUT | `/api/{version}/metering/meters/{id}` | `Metering.Meters.Manage` |
+| POST | `/api/{version}/metering/meters/{id}/publish` | `Metering.Meters.Manage` |
+| POST | `/api/{version}/metering/meters/{id}/archive` | `Metering.Meters.Manage` |
+| POST | `/api/{version}/metering/meters/{id}/recompute` | `Metering.Meters.Manage` |
+| GET | `/api/{version}/metering/usage` | `Metering.Usage.Read` |
+| GET | `/api/{version}/metering/quota/{meterId}` | `Metering.Usage.Read` |
+| POST | `/api/{version}/metering/events` | `Metering.Usage.Record` |
+| POST | `/api/{version}/metering/events/backfill` | `Metering.Events.Backfill` |
+| POST | `/api/{version}/metering/events/{id}/deprecate` | `Metering.Events.Manage` |
+| GET | `/api/{version}/metering/meter-definitions` | `Metering.Meters.Read` |
+| GET | `/api/{version}/metering/usage-aggregates` | `Metering.Usage.Read` |
 
 All usage endpoints require tenant context. `POST /events` validates that each
 `MeterDefinitionId` in the batch belongs to the current tenant and is active.
@@ -369,7 +369,7 @@ host can review usage cross-tenant.
 
 ## Idempotency model
 
-`POST /api/granit/metering/events` enforces idempotency at **two complementary
+`POST /api/{version}/metering/events` enforces idempotency at **two complementary
 layers** — neither replaces the other.
 
 ### HTTP layer — request envelope dedup

--- a/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
@@ -384,12 +384,12 @@ from retaining premium feature access through stale cache entries.
 
 | Method | Route | Permission |
 |--------|-------|------------|
-| GET | `/api/granit/subscriptions/plans` | `Subscriptions.Plans.Read` |
-| POST | `/api/granit/subscriptions/plans` | `Subscriptions.Plans.Manage` |
-| GET | `/api/granit/subscriptions/subscriptions` | `Subscriptions.Subscriptions.Read` |
-| POST | `/api/granit/subscriptions/subscriptions` | `Subscriptions.Subscriptions.Manage` |
-| GET | `/api/granit/subscriptions/seats` | `Subscriptions.Seats.Read` |
-| POST | `/api/granit/subscriptions/seats` | `Subscriptions.Seats.Manage` |
+| GET | `/api/{version}/subscriptions/plans` | `Subscriptions.Plans.Read` |
+| POST | `/api/{version}/subscriptions/plans` | `Subscriptions.Plans.Manage` |
+| GET | `/api/{version}/subscriptions/subscriptions` | `Subscriptions.Subscriptions.Read` |
+| POST | `/api/{version}/subscriptions/subscriptions` | `Subscriptions.Subscriptions.Manage` |
+| GET | `/api/{version}/subscriptions/seats` | `Subscriptions.Seats.Read` |
+| POST | `/api/{version}/subscriptions/seats` | `Subscriptions.Seats.Manage` |
 
 ## Notifications
 

--- a/docs-site/src/content/docs/dotnet/security/api-keys.mdx
+++ b/docs-site/src/content/docs/dotnet/security/api-keys.mdx
@@ -183,7 +183,7 @@ issuance and store it securely.
 All five permissions live under the `AuthenticationApiKeys` group. Localisation
 keys: `PermissionGroup:AuthenticationApiKeys` and
 `Permission:AuthenticationApiKeys.Keys.{Action}` (resolved through
-`GET /api/granit/localization`).
+`GET /api/{version}/localization`).
 
 | Permission | Action | Localisation key |
 |------------|--------|------------------|

--- a/src/Granit.CustomerBalance.Endpoints/README.md
+++ b/src/Granit.CustomerBalance.Endpoints/README.md
@@ -6,6 +6,6 @@ Minimal API endpoints for Granit.CustomerBalance.
 
 | Method | Route | Permission |
 | ------ | ----- | ---------- |
-| GET | `/api/granit/customer-balance/balance?currency=EUR` | `CustomerBalance.Accounts.Read` |
-| GET | `/api/granit/customer-balance/transactions?currency=EUR` | `CustomerBalance.Transactions.Read` |
-| POST | `/api/granit/customer-balance/credit` | `CustomerBalance.Credits.Manage` |
+| GET | `/api/{version}/customer-balance/balance?currency=EUR` | `CustomerBalance.Accounts.Read` |
+| GET | `/api/{version}/customer-balance/transactions?currency=EUR` | `CustomerBalance.Transactions.Read` |
+| POST | `/api/{version}/customer-balance/credit` | `CustomerBalance.Credits.Manage` |

--- a/src/Granit.DataLookup.Abstractions/Descriptors/LookupDescriptor.cs
+++ b/src/Granit.DataLookup.Abstractions/Descriptors/LookupDescriptor.cs
@@ -13,7 +13,7 @@ namespace Granit.DataLookup.Descriptors;
 ///     <description>
 ///     <see cref="Name"/> — resolved against the central <see cref="Registry.ILookupRegistry"/>
 ///     (recommended). The frontend issues
-///     <c>GET /api/granit/lookups/{Name}?search=&amp;scope.{key}=…</c>.
+///     <c>GET /lookups/{Name}?search=&amp;scope.{key}=…</c>.
 ///     </description>
 ///   </item>
 ///   <item>

--- a/src/Granit.DataLookup.Abstractions/Registry/IKindProviderLookupSource.cs
+++ b/src/Granit.DataLookup.Abstractions/Registry/IKindProviderLookupSource.cs
@@ -5,7 +5,7 @@ namespace Granit.DataLookup.Registry;
 
 /// <summary>
 /// Optional marker for <see cref="ILookupSource"/> implementations that want to
-/// advertise a specific <see cref="LookupKind"/> in the <c>GET /api/granit/lookups</c>
+/// advertise a specific <see cref="LookupKind"/> in the <c>GET /lookups</c>
 /// manifest. Implementations that do not implement this interface default to
 /// <see cref="LookupKind.Simple"/>.
 /// </summary>

--- a/src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs
+++ b/src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs
@@ -9,7 +9,7 @@ namespace Granit.DataLookup.Registry;
 /// <remarks>
 /// Registered at startup via <c>AddLookup*</c> extensions on <c>IServiceCollection</c>.
 /// Resolved at runtime by the lookup endpoints to dispatch
-/// <c>GET /api/granit/lookups/{name}</c> to the correct source.
+/// <c>GET /lookups/{name}</c> to the correct source.
 /// </remarks>
 public interface ILookupRegistry
 {
@@ -18,7 +18,7 @@ public interface ILookupRegistry
 
     /// <summary>
     /// Returns a manifest of every registered source for
-    /// <c>GET /api/granit/lookups</c> (for tooling and frontend discovery).
+    /// <c>GET /lookups</c> (for tooling and frontend discovery).
     /// </summary>
     IReadOnlyList<LookupManifestEntry> GetManifest();
 }

--- a/src/Granit.DataLookup.Abstractions/Registry/LookupManifestEntry.cs
+++ b/src/Granit.DataLookup.Abstractions/Registry/LookupManifestEntry.cs
@@ -4,7 +4,7 @@ namespace Granit.DataLookup.Registry;
 
 /// <summary>
 /// Public metadata about a registered lookup source — one entry per registered
-/// <see cref="Sources.ILookupSource"/> in the <c>GET /api/granit/lookups</c> manifest.
+/// <see cref="Sources.ILookupSource"/> in the <c>GET /lookups</c> manifest.
 /// </summary>
 /// <param name="Name">Registry key.</param>
 /// <param name="Kind">Kind of backing source.</param>

--- a/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs
+++ b/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs
@@ -1,5 +1,5 @@
 namespace Granit.DataLookup.Endpoints.Dtos;
 
-/// <summary>Response shape for <c>GET /api/granit/lookups</c> — discovery manifest.</summary>
+/// <summary>Response shape for <c>GET /lookups</c> — discovery manifest.</summary>
 /// <param name="Lookups">Sorted list of registered lookups.</param>
 public sealed record LookupManifestResponse(IReadOnlyList<LookupManifestEntryResponse> Lookups);

--- a/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
+++ b/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
@@ -22,7 +22,7 @@ namespace Granit.DataLookup.Endpoints.Endpoints;
 /// </remarks>
 public static class LookupEndpointHandlers
 {
-    /// <summary>GET /api/granit/lookups — returns the discovery manifest.</summary>
+    /// <summary>GET /lookups — returns the discovery manifest.</summary>
     public static Ok<LookupManifestResponse> GetManifest(
         [FromServices] ILookupRegistry registry)
     {
@@ -36,7 +36,7 @@ public static class LookupEndpointHandlers
         return TypedResults.Ok(new LookupManifestResponse(responses));
     }
 
-    /// <summary>GET /api/granit/lookups/{name} — paginated search.</summary>
+    /// <summary>GET /lookups/{name} — paginated search.</summary>
     [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Minimal-API endpoint — ASP.NET binds [FromServices]/[FromQuery] parameters explicitly; no natural domain wrapper for orthogonal request inputs and DI collaborators.")]
     public static async Task<Results<Ok<LookupResultResponse>, NotFound, ForbidHttpResult, ProblemHttpResult>> SearchAsync(
         string name,
@@ -90,7 +90,7 @@ public static class LookupEndpointHandlers
         return TypedResults.Ok(new LookupResultResponse(items, result.TotalCount, result.ContinuationToken));
     }
 
-    /// <summary>GET /api/granit/lookups/{name}/resolve?value=… — single item lookup for rehydration.</summary>
+    /// <summary>GET /lookups/{name}/resolve?value=… — single item lookup for rehydration.</summary>
     public static async Task<Results<Ok<LookupItemResponse>, NotFound, ForbidHttpResult, ProblemHttpResult>> ResolveAsync(
         string name,
         [FromQuery] string? value,

--- a/src/Granit.DataLookup.Endpoints/Granit.DataLookup.Endpoints.csproj
+++ b/src/Granit.DataLookup.Endpoints/Granit.DataLookup.Endpoints.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.DataLookup.Endpoints</PackageId>
-    <Description>Minimal API endpoints for Granit.DataLookup. Routes GET /api/granit/lookups (manifest), GET /api/granit/lookups/{name} (paginated search) and GET /api/granit/lookups/{name}/resolve (single item). Handles authorization, scope key validation and the Accept-Language header.</Description>
+    <Description>Minimal API endpoints for Granit.DataLookup. Routes GET /lookups (manifest), GET /lookups/{name} (paginated search) and GET /lookups/{name}/resolve (single item). Handles authorization, scope key validation and the Accept-Language header.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
+++ b/src/Granit.DataLookup.Endpoints/GranitDataLookupEndpointsModule.cs
@@ -9,7 +9,7 @@ namespace Granit.DataLookup.Endpoints;
 /// Granit module for Granit.DataLookup HTTP endpoints.
 /// </summary>
 /// <remarks>
-/// Exposes the <c>/api/granit/lookups</c> routes via
+/// Exposes the <c>/lookups</c> routes via
 /// <see cref="Extensions.DataLookupEndpointRouteBuilderExtensions.MapGranitDataLookups"/>.
 /// Validators are auto-discovered by <see cref="GranitValidationModule"/>; the
 /// <c>DataLookup.Lookups.Read</c> permission is contributed automatically by

--- a/src/Granit.DataLookup.Endpoints/Options/DataLookupEndpointsOptions.cs
+++ b/src/Granit.DataLookup.Endpoints/Options/DataLookupEndpointsOptions.cs
@@ -5,8 +5,8 @@ namespace Granit.DataLookup.Endpoints.Options;
 /// </summary>
 public sealed class DataLookupEndpointsOptions
 {
-    /// <summary>Route prefix under which the endpoints are mapped. Default: <c>"api/granit/lookups"</c>.</summary>
-    public string RoutePrefix { get; set; } = "api/granit/lookups";
+    /// <summary>Route prefix under which the endpoints are mapped. Default: <c>"lookups"</c>.</summary>
+    public string RoutePrefix { get; set; } = "lookups";
 
     /// <summary>OpenAPI tag applied to every endpoint in the group. Default: <c>"Data Lookup"</c>.</summary>
     public string TagName { get; set; } = "Data Lookup";

--- a/src/Granit.DataLookup.Endpoints/README.md
+++ b/src/Granit.DataLookup.Endpoints/README.md
@@ -6,9 +6,9 @@ Minimal API endpoints for **Granit.DataLookup**.
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/granit/lookups` | Manifest of every registered source. |
-| `GET` | `/api/granit/lookups/{name}` | Paginated typeahead search (`?search=`, `?page=`, `?pageSize=`, `?scope.*=`). |
-| `GET` | `/api/granit/lookups/{name}/resolve` | Resolve a single value into a `LookupItem`. |
+| `GET` | `/lookups` | Manifest of every registered source. |
+| `GET` | `/lookups/{name}` | Paginated typeahead search (`?search=`, `?page=`, `?pageSize=`, `?scope.*=`). |
+| `GET` | `/lookups/{name}/resolve` | Resolve a single value into a `LookupItem`. |
 
 Labels in every response are already localized via the `Accept-Language` header — the
 frontend never re-translates.
@@ -18,7 +18,7 @@ frontend never re-translates.
 ```csharp
 app.MapGranitDataLookups(opts =>
 {
-    opts.RoutePrefix = "api/granit/lookups"; // default
+    opts.RoutePrefix = "lookups"; // default
     opts.TagName = "Data Lookup";            // default
 });
 ```

--- a/src/Granit.Localization.Endpoints/Dtos/ApplicationLocalizationResponse.cs
+++ b/src/Granit.Localization.Endpoints/Dtos/ApplicationLocalizationResponse.cs
@@ -1,7 +1,7 @@
 namespace Granit.Localization.Endpoints.Dtos;
 
 /// <summary>
-/// Response payload for <c>GET /api/granit/localization</c>.
+/// Response payload for <c>GET /api/{version}/localization</c>.
 /// Contains all localization resources for the requested culture and the list of available languages.
 /// </summary>
 /// <param name="CultureName">The resolved culture name (e.g. "fr", "en").</param>

--- a/src/Granit.Localization.Endpoints/Dtos/SetLocalizationOverrideRequest.cs
+++ b/src/Granit.Localization.Endpoints/Dtos/SetLocalizationOverrideRequest.cs
@@ -1,7 +1,7 @@
 namespace Granit.Localization.Endpoints.Dtos;
 
 /// <summary>
-/// Request body for the <c>PUT /api/granit/localization/overrides/{resourceName}/{cultureName}/{key}</c> endpoint.
+/// Request body for the <c>PUT /api/{version}/localization/overrides/{resourceName}/{cultureName}/{key}</c> endpoint.
 /// </summary>
 /// <param name="Value">Override value for the translation key. Must not be empty.</param>
 public sealed record SetLocalizationOverrideRequest(string Value);

--- a/src/Granit.Localization.Endpoints/Granit.Localization.Endpoints.csproj
+++ b/src/Granit.Localization.Endpoints/Granit.Localization.Endpoints.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Localization.Endpoints</PackageId>
-    <Description>Minimal API endpoints for Granit localization: anonymous GET /api/granit/localization for SPA bootstrapping, and CRUD /api/granit/localization/overrides for admin management of translation overrides (requires Localization.Overrides.Manage permission).</Description>
+    <Description>Minimal API endpoints for Granit localization: anonymous GET /localization for SPA bootstrapping, and CRUD /localization/overrides for admin management of translation overrides (requires Localization.Overrides.Manage permission). Final route depends on the consumer's mount point — the host can mount under /api/v1, /api/v2, or directly on the app.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
+++ b/src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs
@@ -11,9 +11,9 @@ namespace Granit.Localization.Endpoints;
 /// <remarks>
 /// Exposes two sets of endpoints:
 /// <list type="bullet">
-/// <item><c>GET /api/granit/localization</c> — anonymous SPA bootstrapping, via
+/// <item><c>GET /api/{version}/localization</c> — anonymous SPA bootstrapping, via
 ///   <see cref="Extensions.LocalizationEndpointRouteBuilderExtensions.MapGranitLocalization"/>.</item>
-/// <item>CRUD <c>/api/granit/localization/overrides</c> — admin override management
+/// <item>CRUD <c>/api/{version}/localization/overrides</c> — admin override management
 ///   (requires <c>Localization.Overrides.Manage</c> permission), via
 ///   <see cref="Extensions.LocalizationEndpointRouteBuilderExtensions.MapGranitLocalizationOverrides"/>.</item>
 /// </list>

--- a/src/Granit.Metering.Endpoints/README.md
+++ b/src/Granit.Metering.Endpoints/README.md
@@ -6,13 +6,13 @@ Minimal API endpoints for Granit.Metering.
 
 | Method | Route | Permission |
 | ------ | ----- | ---------- |
-| GET | `/api/granit/metering/meters` | `Metering.Meters.Read` |
-| POST | `/api/granit/metering/meters` | `Metering.Meters.Manage` |
-| PUT | `/api/granit/metering/meters/{id}` | `Metering.Meters.Manage` |
-| GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
-| GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
-| GET | `/api/granit/metering/meter-definitions` (+ `/meta`, `/saved-views/*`) | `Metering.Meters.Read` |
-| GET | `/api/granit/metering/usage-aggregates` (+ `/meta`, `/saved-views/*`) | `Metering.Usage.Read` |
+| GET | `/api/{version}/metering/meters` | `Metering.Meters.Read` |
+| POST | `/api/{version}/metering/meters` | `Metering.Meters.Manage` |
+| PUT | `/api/{version}/metering/meters/{id}` | `Metering.Meters.Manage` |
+| GET | `/api/{version}/metering/usage` | `Metering.Usage.Read` |
+| GET | `/api/{version}/metering/quota/{meterId}` | `Metering.Usage.Read` |
+| GET | `/api/{version}/metering/meter-definitions` (+ `/meta`, `/saved-views/*`) | `Metering.Meters.Read` |
+| GET | `/api/{version}/metering/usage-aggregates` (+ `/meta`, `/saved-views/*`) | `Metering.Usage.Read` |
 
 The `/meter-definitions` and `/usage-aggregates` routes expose the Granit
 QueryEngine (filter, sort, group, paginate, CSV/XLSX export, saved views).

--- a/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
@@ -92,7 +92,7 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     /// <summary>
     /// Declares a data-lookup source for this column by registry name. The frontend
     /// renders a typeahead picker backed by
-    /// <c>GET /api/granit/lookups/{name}</c> instead of a free-text filter input.
+    /// <c>GET /lookups/{name}</c> instead of a free-text filter input.
     /// </summary>
     /// <remarks>
     /// Preferred form when the backing source is registered in the central

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -72,7 +72,7 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
 
         // Auto-register as a Granit.DataLookup source. Lookup name uses the kebab-case
         // "ref-{entity-name}" convention (e.g. Country → "ref-country"). Frontend picker
-        // hits GET /api/granit/lookups/ref-country with Accept-Language for localized labels.
+        // hits GET /lookups/ref-country with Accept-Language for localized labels.
         string lookupName = ReferenceDataLookupNaming.ForEntity(typeof(TEntity));
         services.AddScoped<ILookupSource>(sp => new ReferenceDataLookupSource<TEntity>(
             lookupName,

--- a/src/Granit.Tax.Endpoints/README.md
+++ b/src/Granit.Tax.Endpoints/README.md
@@ -6,7 +6,7 @@ Admin API endpoints for Granit.Tax.
 
 | Method | Route | Permission |
 | ------ | ----- | ---------- |
-| POST | `/api/granit/tax/validate` | `Tax.Validations.Execute` |
-| GET | `/api/granit/tax/rates` | `Tax.Rates.Read` |
-| GET | `/api/granit/tax/rates/{countryCode}` | `Tax.Rates.Read` |
-| POST | `/api/granit/tax/calculate` | `Tax.Validations.Execute` |
+| POST | `/api/{version}/tax/validate` | `Tax.Validations.Execute` |
+| GET | `/api/{version}/tax/rates` | `Tax.Rates.Read` |
+| GET | `/api/{version}/tax/rates/{countryCode}` | `Tax.Rates.Read` |
+| POST | `/api/{version}/tax/calculate` | `Tax.Validations.Execute` |

--- a/src/Granit.Validation/Extensions/RuleBuilderExtensions.cs
+++ b/src/Granit.Validation/Extensions/RuleBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class RuleBuilderExtensions
     /// <para>
     /// The <see cref="FluentValidationSchemaTransformer"/> emits the hint key as the
     /// <c>x-granit-pattern-hint</c> OpenAPI extension alongside the <c>pattern</c> property.
-    /// The frontend resolves the key via <c>GET /api/granit/localization</c>.
+    /// The frontend resolves the key via <c>GET /api/{version}/localization</c>.
     /// </para>
     /// <example>
     /// <code>

--- a/src/Granit.Validation/GranitValidationModule.cs
+++ b/src/Granit.Validation/GranitValidationModule.cs
@@ -21,7 +21,7 @@ namespace Granit.Validation;
 /// Registers <c>AddGranitValidation()</c>, which configures FluentValidation to
 /// emit structured error codes (<c>Granit:Validation:*</c>) instead of
 /// human-readable messages. The SPA resolves codes from its local localization
-/// dictionary served by <c>GET /api/granit/localization</c>.
+/// dictionary served by <c>GET /api/{version}/localization</c>.
 /// </para>
 /// <para>
 /// Auto-discovers all <see cref="IValidator{T}"/> implementations from loaded

--- a/src/Granit.Validation/Internal/GranitErrorCodeLanguageManager.cs
+++ b/src/Granit.Validation/Internal/GranitErrorCodeLanguageManager.cs
@@ -11,7 +11,7 @@ namespace Granit.Validation.Internal;
 /// All built-in validator messages (e.g. <c>NotEmptyValidator</c>) are replaced
 /// by codes following the convention <c>Granit:Validation:{ValidatorName}</c>.
 /// The SPA resolves codes to localized strings using the dictionary served by
-/// <c>GET /api/granit/localization</c>, which supports per-tenant overrides.
+/// <c>GET /api/{version}/localization</c>, which supports per-tenant overrides.
 /// <para>
 /// Registered globally at startup via <c>AddGranitValidation()</c>:
 /// <c>ValidatorOptions.Global.LanguageManager = new GranitErrorCodeLanguageManager()</c>.

--- a/tests/Granit.DataLookup.Endpoints.Tests/DataLookupEndpointsOptionsTests.cs
+++ b/tests/Granit.DataLookup.Endpoints.Tests/DataLookupEndpointsOptionsTests.cs
@@ -7,8 +7,8 @@ namespace Granit.DataLookup.Endpoints.Tests;
 public sealed class DataLookupEndpointsOptionsTests
 {
     [Fact]
-    public void RoutePrefix_default_is_api_granit_lookups() =>
-        new DataLookupEndpointsOptions().RoutePrefix.ShouldBe("api/granit/lookups");
+    public void RoutePrefix_default_is_lookups() =>
+        new DataLookupEndpointsOptions().RoutePrefix.ShouldBe("lookups");
 
     [Fact]
     public void TagName_default_is_data_lookup() =>


### PR DESCRIPTION
## Summary

- Replaces every legacy `/api/granit/<module>/...` route example across docs, READMEs, and C# XML doc comments. The framework convention is `/api/{version}/<module-prefix>/...` (host mounts via `app.MapGroup("api/v{version:apiVersion}")`); cross-cutting modules mounted at root use the bare `/<prefix>/...` form.
- Updates the DataLookup default `RoutePrefix` from `"api/granit/lookups"` to `"lookups"` (and the matching unit test) so the SDK default matches actual host-mount semantics.
- Corrects the showcase Program.cs comment that documented the wrong Analytics route.

Same convention fix as #1443 (analytics/index + inline-metrics), applied exhaustively across the rest of the codebase.

## Test plan

- [ ] `dotnet build src/Granit.DataLookup.Endpoints` succeeds
- [ ] `dotnet test tests/Granit.DataLookup.Endpoints.Tests` passes (RoutePrefix default test updated)
- [ ] `cd docs-site && npx astro build` produces 0 errors
- [ ] Visual spot-check on a few endpoint tables in the rendered docs site
