### PR TITLE
test(analytics): archi-enforce Metric:{Name} localization across 15 cultures (D2 #1397)

### DIFF
--- a/tests/Granit.ArchitectureTests/MetricLocalizationCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/MetricLocalizationCompletenessTests.cs
@@ -47,8 +47,14 @@ public sealed class MetricLocalizationCompletenessTests
 
         foreach (MetricDescriptor metric in metrics)
         {
-            string moduleSrcDir = Path.Combine(RepoRoot, "src", metric.OwningAssemblyName);
-            string localizationDir = Path.Combine(moduleSrcDir, "Localization");
+            if (Path.IsPathRooted(metric.OwningAssemblyName))
+            {
+                missing.Add($"{metric.Name}: owning assembly name '{metric.OwningAssemblyName}' is rooted — refusing to combine into a path.");
+                continue;
+            }
+
+            string moduleSrcDir = Path.Join(RepoRoot, "src", metric.OwningAssemblyName);
+            string localizationDir = Path.Join(moduleSrcDir, "Localization");
 
             if (!Directory.Exists(localizationDir))
             {
@@ -77,16 +83,7 @@ public sealed class MetricLocalizationCompletenessTests
     private static bool LocateKeyInCultureFiles(string localizationDir, string culture, string resourceKey)
     {
         string[] candidateFiles = Directory.GetFiles(localizationDir, $"{culture}.json", SearchOption.AllDirectories);
-
-        foreach (string file in candidateFiles)
-        {
-            if (FileContainsKey(file, resourceKey))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return candidateFiles.Any(file => FileContainsKey(file, resourceKey));
     }
 
     private static bool FileContainsKey(string filePath, string key)
@@ -102,12 +99,11 @@ public sealed class MetricLocalizationCompletenessTests
 
         // Granit localization files use either a flat root object ({ "Key": "Value" })
         // or a nested layout with the culture envelope ({ "culture": "...", "texts": { "Key": "Value" } }).
-        if (root.TryGetProperty("texts", out JsonElement texts) && texts.ValueKind == JsonValueKind.Object)
+        if (root.TryGetProperty("texts", out JsonElement texts)
+            && texts.ValueKind == JsonValueKind.Object
+            && texts.TryGetProperty(key, out _))
         {
-            if (texts.TryGetProperty(key, out _))
-            {
-                return true;
-            }
+            return true;
         }
 
         return root.TryGetProperty(key, out _);
@@ -154,7 +150,7 @@ public sealed class MetricLocalizationCompletenessTests
 
                 object instance;
                 try { instance = Activator.CreateInstance(type)!; }
-                catch (Exception)
+                catch (Exception ex) when (ex is MissingMethodException or MemberAccessException or TargetInvocationException)
                 {
                     // Definitions without a parameterless ctor are out of scope for this
                     // archi check — every shipped metric should be parameterless per the

--- a/tests/Granit.ArchitectureTests/MetricLocalizationCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/MetricLocalizationCompletenessTests.cs
@@ -1,0 +1,204 @@
+using System.Reflection;
+using System.Text.Json;
+using Granit.Analytics.Metrics;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces D2 (#1397) of the BI epic (#1366): every <see cref="MetricDefinition{TEntity, TValue}"/>
+/// MUST have a <c>Metric:{Name}</c> resource key in all 15 base cultures of its owning
+/// module's <c>Localization/</c> directory. Regional variants (<c>fr-CA</c>, <c>en-GB</c>,
+/// <c>pt-BR</c>) are exempt because they are designed to ship only differing keys and
+/// fall through to their parent culture for everything else (see
+/// <c>docs/guide/conventions/langues.md</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The single failure aggregates all (metric, culture) pairs missing a key, so a
+/// developer adding a new metric without a complete translation pack sees the entire
+/// list at once instead of one-failure-per-culture spam.
+/// </para>
+/// <para>
+/// A future <c>Dashboard:</c> companion check will be added when the first
+/// <c>DashboardDefinition</c> ships under feature B (#1382).
+/// </para>
+/// </remarks>
+public sealed class MetricLocalizationCompletenessTests
+{
+    private static readonly string[] BaseCultures =
+    [
+        "en", "fr", "nl", "de", "es", "it", "pt", "zh", "ja",
+        "pl", "tr", "ko", "sv", "cs", "hi",
+    ];
+
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Every_MetricDefinition_should_have_localization_keys_in_all_base_cultures()
+    {
+        IReadOnlyList<MetricDescriptor> metrics = ScanMetricDefinitions();
+        metrics.ShouldNotBeEmpty(
+            "No MetricDefinitions discovered — the test cannot run. " +
+            "Ensure Granit.Analytics is referenced and reference modules (Granit.Invoicing) ship at least one metric.");
+
+        List<string> missing = [];
+
+        foreach (MetricDescriptor metric in metrics)
+        {
+            string moduleSrcDir = Path.Combine(RepoRoot, "src", metric.OwningAssemblyName);
+            string localizationDir = Path.Combine(moduleSrcDir, "Localization");
+
+            if (!Directory.Exists(localizationDir))
+            {
+                missing.Add($"{metric.Name} (declared in {metric.OwningAssemblyName}): Localization/ directory not found at {Path.GetRelativePath(RepoRoot, localizationDir)}");
+                continue;
+            }
+
+            string resourceKey = $"Metric:{metric.Name}";
+
+            foreach (string culture in BaseCultures)
+            {
+                bool found = LocateKeyInCultureFiles(localizationDir, culture, resourceKey);
+                if (!found)
+                {
+                    missing.Add($"{metric.Name} -> {culture} (expected key '{resourceKey}' in src/{metric.OwningAssemblyName}/Localization/**/{culture}.json)");
+                }
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            $"D2 (#1397): every MetricDefinition must have a 'Metric:{{Name}}' key in all 15 base cultures " +
+            $"of its owning module. {missing.Count} key(s) missing:" + Environment.NewLine +
+            string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
+    }
+
+    private static bool LocateKeyInCultureFiles(string localizationDir, string culture, string resourceKey)
+    {
+        string[] candidateFiles = Directory.GetFiles(localizationDir, $"{culture}.json", SearchOption.AllDirectories);
+
+        foreach (string file in candidateFiles)
+        {
+            if (FileContainsKey(file, resourceKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool FileContainsKey(string filePath, string key)
+    {
+        using FileStream stream = File.OpenRead(filePath);
+        using var document = JsonDocument.Parse(stream);
+
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        // Granit localization files use either a flat root object ({ "Key": "Value" })
+        // or a nested layout with the culture envelope ({ "culture": "...", "texts": { "Key": "Value" } }).
+        if (root.TryGetProperty("texts", out JsonElement texts) && texts.ValueKind == JsonValueKind.Object)
+        {
+            if (texts.TryGetProperty(key, out _))
+            {
+                return true;
+            }
+        }
+
+        return root.TryGetProperty(key, out _);
+    }
+
+    private static List<MetricDescriptor> ScanMetricDefinitions()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(MetricLocalizationCompletenessTests).Assembly.Location)!;
+
+        Assembly[] assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<MetricDescriptor> metrics = [];
+
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                {
+                    continue;
+                }
+
+                if (!InheritsFromMetricDefinition(type))
+                {
+                    continue;
+                }
+
+                object instance;
+                try { instance = Activator.CreateInstance(type)!; }
+                catch (Exception)
+                {
+                    // Definitions without a parameterless ctor are out of scope for this
+                    // archi check — every shipped metric should be parameterless per the
+                    // *.Analytics canonical checklist.
+                    continue;
+                }
+
+                string metricName = (string)type.GetProperty(nameof(IMetricDefinitionDescriptor.Name))!.GetValue(instance)!;
+                metrics.Add(new MetricDescriptor(metricName, assembly.GetName().Name!));
+            }
+        }
+
+        return metrics;
+    }
+
+    private static bool InheritsFromMetricDefinition(Type candidate)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == typeof(MetricDefinition<,>))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(MetricLocalizationCompletenessTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    private sealed record MetricDescriptor(string Name, string OwningAssemblyName);
+}


### PR DESCRIPTION
## Summary

Closes #1397 (D2 of the BI epic #1366). Completes Feature D's archi-enforcement set alongside D1 (pairing) and D3/D4 (docs).

Adds `MetricLocalizationCompletenessTests` to the `architecture` shard. For every concrete `MetricDefinition` discovered via reflection, asserts a `Metric:{Name}` resource key exists in all 15 base cultures of the metric's owning module `Localization/` directory.

### Design decisions

- **Regional variants exempt by design.** `fr-CA`, `en-GB`, `pt-BR` ship only the keys that differ from their parent culture and fall through to the base for everything else (per `docs/guide/conventions/langues.md`). Including them in the strict check would force three extra files per metric for zero translation value.
- **One-shot failure message.** Rather than one assertion per culture, the test aggregates every missing `(metric, culture)` pair into a single `ShouldBeEmpty` so a contributor adding a metric without a translation pack sees the complete to-do list at once.
- **Reflection-based discovery.** Same scan pattern as `QueryMetricPairingTests` — load every non-test `Granit.*.dll` from the test bin, walk types deriving from `MetricDefinition<TEntity, TValue>`, instantiate via `Activator.CreateInstance` to read `.Name`. Definitions without a parameterless constructor are skipped (every shipped metric has one per the canonical checklist).
- **JSON shape tolerance.** Reads both flat-root (`{ "Metric:Foo": "..." }`) and culture-envelope (`{ "culture": "...", "texts": { "Metric:Foo": "..." } }`) layouts found across the framework.
- **Dashboard companion deferred.** The `Dashboard:{Name}` check will be added when the first `DashboardDefinition` ships under Feature B #1382.

### Negative-test verification

Removed `Metric:Granit.Invoicing.UnpaidInvoiceCountMetric` from `de.json` locally. The test failed with:

```text
D2 (#1397): every MetricDefinition must have a 'Metric:{Name}' key in all 15 base cultures of its owning module. 1 key(s) missing:
Granit.Invoicing.UnpaidInvoiceCountMetric -> de (expected key 'Metric:Granit.Invoicing.UnpaidInvoiceCountMetric' in src/Granit.Invoicing/Localization/**/de.json)
```

Restored, re-ran — green.

## Test plan

- [x] `dotnet build tests/Granit.ArchitectureTests` — clean
- [x] `dotnet test tests/Granit.ArchitectureTests` — 156/156 (D2 added)
- [x] Negative test: missing key → clear, actionable failure listing every (key, culture) pair
- [x] `dotnet format .github/shard-filters/architecture.slnf --verify-no-changes` — clean
- [ ] CI green