### PR TITLE
fix(docs): unblock Cloudflare Pages build (3 docs-site regressions)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -161,9 +161,9 @@ export default defineConfig({
                         { label: "Add Background Jobs", link: "/dotnet/guides/add-background-jobs/" },
                         { label: "Configure Blob Storage", link: "/dotnet/guides/configure-blob-storage/" },
                         { label: "Implement Webhooks", link: "/dotnet/guides/implement-webhooks/" },
-                        { label: "Auto-maintain Contact Roles", link: "/dotnet/guides/contacts-role-handler/" },
-                        { label: "Seed Contact on Tenant Created", link: "/dotnet/guides/contacts-tenant-seeding/" },
-                        { label: "External Mapping Contract", link: "/dotnet/guides/contacts-external-mappings/" },
+                        { label: "Auto-maintain Party Roles", link: "/dotnet/guides/parties-role-handler/" },
+                        { label: "Seed Party on Tenant Created", link: "/dotnet/guides/parties-tenant-seeding/" },
+                        { label: "External Mapping Contract", link: "/dotnet/guides/parties-external-mappings/" },
                       ],
                     },
                     {

--- a/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
@@ -143,7 +143,7 @@ yourself:
   `PeriodSelector` (here `IssuedAt`) is wrapped in a `[from, to)` predicate
   resolved server-side via `IClock` (`TimeProvider`) — never
   `DateTimeOffset.UtcNow`. Period tokens map to the canonical
-  [DAX acronyms](/dotnet/business/analytics/conventions/#period-tokens---dax-aligned)
+  [DAX acronyms](/dotnet/business/analytics/conventions/#period-tokens--dax-aligned)
   (`MTD`, `QTD`, `YTD`, …).
 - **Period comparison + delta.** If the request includes
   `compareTo: { token: 'previous_period' }`, the framework runs the metric

--- a/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
+++ b/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
@@ -30,7 +30,7 @@ no duplication between backend declarations and frontend components.
 - Granit.DataLookup.Abstractions/ Contracts: LookupDescriptor, LookupItem, LookupResult, ILookupSource, ILookupRegistry
   - Granit.DataLookup/ Runtime: scoped registry, EnumLookupSource&lt;TEnum&gt;, metrics, ActivitySource
     - Granit.DataLookup.EntityFrameworkCore QueryableLookupSource&lt;T&gt; — wraps an IQueryable with value/label selectors
-    - Granit.DataLookup.Endpoints Minimal API: /api/{version}/lookups manifest, search, resolve
+    - Granit.DataLookup.Endpoints Minimal API: /api/\{version\}/lookups manifest, search, resolve
 </FileTree>
 
 | Package | Role | Depends on |


### PR DESCRIPTION
## Summary

Cloudflare Pages was failing on every open PR after #1448 / #1432 / #1439. Three independent regressions, all in docs-site, all fixed in one shot since they share the same blast radius.

### 1. `data-lookup.mdx` — `{version}` parsed as JSX

Line 33 inside a `<FileTree>` block contained `/api/{version}/lookups`. MDX evaluates `{...}` as JSX expressions inside component children, so the build fails with:

```text
ReferenceError: version is not defined
  at _createMdxContent (.../data-lookup_*.mjs:82:80)
```

**Fix:** escape with `\{version\}`, matching the convention already in use across other FileTree blocks (e.g. `infrastructure/notifications/conventions.mdx`).

Introduced by **#1448** (host-mount-aware route examples).

### 2. `astro.config.mjs` — orphaned guide links

Three sidebar entries still point at the legacy `contacts-*` paths:

```javascript
{ label: "Auto-maintain Contact Roles", link: "/dotnet/guides/contacts-role-handler/" },
{ label: "Seed Contact on Tenant Created", link: "/dotnet/guides/contacts-tenant-seeding/" },
{ label: "External Mapping Contract", link: "/dotnet/guides/contacts-external-mappings/" },
```

But the files were renamed to `parties-*` (and labels updated) in #1432 without updating the sidebar config. The renamed pages are now orphaned in `starlight-sidebar-topics` and the build fails with:

```text
AstroUserError: Failed to find the topic for the `dotnet/guides/parties-external-mappings` page.
```

**Fix:** rewrite the three links + labels (`Contact Roles` → `Party Roles`, etc.).

Introduced by **#1432** (Contacts → Parties rename).

### 3. `inline-metrics.mdx` — broken cross-page anchor

Link `/dotnet/business/analytics/conventions/#period-tokens---dax-aligned` (three dashes) — but the actual heading slug is `period-tokens--dax-aligned` (two dashes; em-dash between spaces produces `--`, not `---`). Surfaced now that the build progresses past errors 1 and 2 and reaches `starlight-links-validator`.

**Fix:** drop one dash in the anchor.

Introduced by **#1439** (A6 inline metrics walk-through).

## Test plan

- [x] `npx astro build` — **440 pages built, 0 errors** (was: red on the first error)
- [x] All three originally-broken pages render: `data-lookup`, `parties-external-mappings`, `inline-metrics` (anchor resolves)
- [ ] Cloudflare Pages green
- [ ] Unblocks PRs #1447 (D3+D4) and #1449 (D2)