### PR TITLE
feat(analytics): DashboardDefinition declarative API + 5 widget types (B1 #1382)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4048,6 +4048,181 @@
       ]
     },
     {
+      "name": "ChartType",
+      "fqn": "Granit.Analytics.Dashboards.ChartType",
+      "kind": "enum",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 133,
+      "members": []
+    },
+    {
+      "name": "ChartWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.ChartWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 59,
+      "members": []
+    },
+    {
+      "name": "DashboardCategory",
+      "fqn": "Granit.Analytics.Dashboards.DashboardCategory",
+      "kind": "enum",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/DashboardCategory.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "DashboardDefinition",
+      "fqn": "Granit.Analytics.Dashboards.DashboardDefinition",
+      "kind": "class",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/DashboardDefinition.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Version",
+          "kind": "property",
+          "signature": "string Version",
+          "returnType": "string"
+        },
+        {
+          "name": "Layout",
+          "kind": "property",
+          "signature": "DashboardLayout Layout",
+          "returnType": "DashboardLayout"
+        }
+      ]
+    },
+    {
+      "name": "DashboardLayout",
+      "fqn": "Granit.Analytics.Dashboards.DashboardLayout",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/DashboardLayout.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(12, 80)",
+          "returnType": "DashboardLayout Default =>"
+        }
+      ]
+    },
+    {
+      "name": "IDashboardDefinitionDescriptor",
+      "fqn": "Granit.Analytics.Dashboards.IDashboardDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/IDashboardDefinitionDescriptor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IDashboardDefinitionRegistry",
+      "fqn": "Granit.Analytics.Dashboards.IDashboardDefinitionRegistry",
+      "kind": "interface",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/IDashboardDefinitionRegistry.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<IDashboardDefinitionDescriptor>"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "IDashboardDefinitionDescriptor?"
+        }
+      ]
+    },
+    {
+      "name": "KpiWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.KpiWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 37,
+      "members": []
+    },
+    {
+      "name": "MarkdownWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.MarkdownWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 125,
+      "members": []
+    },
+    {
+      "name": "PivotWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.PivotWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 104,
+      "members": []
+    },
+    {
+      "name": "TableWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.TableWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 82,
+      "members": []
+    },
+    {
+      "name": "WidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.WidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetDefinition.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "WidgetSize",
+      "fqn": "Granit.Analytics.Dashboards.WidgetSize",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/WidgetSize.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(3, 1)",
+          "returnType": "WidgetSize SmallKpi =>"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(6, 2)",
+          "returnType": "WidgetSize StandardChart =>"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(12, 1)",
+          "returnType": "WidgetSize FullWidthRow =>"
+        }
+      ]
+    },
+    {
       "name": "AnalyticsMetrics",
       "fqn": "Granit.Analytics.Diagnostics.AnalyticsMetrics",
       "kind": "class",
@@ -4255,7 +4430,7 @@
       "kind": "class",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Extensions/AnalyticsServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitAnalytics",

--- a/src/Granit.Analytics/Dashboards/DashboardCategory.cs
+++ b/src/Granit.Analytics/Dashboards/DashboardCategory.cs
@@ -1,0 +1,32 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Coarse grouping shipped on every <see cref="DashboardDefinition"/>. Drives the
+/// catalogue ordering surfaced by <see cref="IDashboardDefinitionRegistry.GetAll()"/>
+/// and the section grouping in the admin import dialog (story B5).
+/// </summary>
+/// <remarks>
+/// Categories intentionally stay broad — the goal is "where would an admin look for
+/// this dashboard", not "what schema is it under". A new category should only land
+/// when an existing one becomes a junk drawer.
+/// </remarks>
+public enum DashboardCategory
+{
+    /// <summary>Default — uncategorised. Use only when the others genuinely do not fit.</summary>
+    General = 0,
+
+    /// <summary>Invoicing, payments, subscriptions, customer balance, tax.</summary>
+    Finance = 1,
+
+    /// <summary>AI usage, blob storage, background jobs, webhooks, observability.</summary>
+    Operations = 2,
+
+    /// <summary>Identity, authorization, auditing.</summary>
+    Security = 3,
+
+    /// <summary>Privacy / GDPR (export requests, erasure, retention).</summary>
+    Compliance = 4,
+
+    /// <summary>Multi-tenancy, platform-level admin (tenant lifecycle, feature flags).</summary>
+    Platform = 5,
+}

--- a/src/Granit.Analytics/Dashboards/DashboardDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/DashboardDefinition.cs
@@ -1,0 +1,66 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Declarative dashboard catalogue entry shipped by a Granit module. Mirrors the
+/// existing declarative primitives — pure declaration, no runtime, no persistence.
+/// Pairs with <c>QueryDefinition</c> (lists rows), <c>ExportDefinition</c> (extracts
+/// rows), and <c>MetricDefinition</c> (aggregates rows) — see ADR-020 and ADR-038.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each definition is registered as a singleton via
+/// <c>services.AddDashboardDefinition&lt;TDefinition&gt;()</c>. Definitions describe
+/// the dashboard catalogue surfaced to admins; they are not the persisted dashboard.
+/// When an admin imports a definition (story B4), the framework deep-copies the
+/// definition into a new <c>Dashboard</c> aggregate (story B2). Module upgrades do
+/// NOT retro-edit imported dashboards — drift is surfaced via
+/// <see cref="Version"/> + an admin-driven re-sync action (ADR-038 §3).
+/// </para>
+/// <para>
+/// Example:
+/// <code>
+/// public sealed class InvoicingFinanceDashboard : DashboardDefinition
+/// {
+///     public override string Name =&gt; "Granit.Invoicing.FinanceOverview";
+///     public override DashboardCategory Category =&gt; DashboardCategory.Finance;
+///     public override IReadOnlyList&lt;WidgetDefinition&gt; Widgets { get; } = [
+///         new KpiWidgetDefinition("UnpaidCount", "Granit.Invoicing.UnpaidInvoiceCountMetric", Position: 0),
+///         new KpiWidgetDefinition("UnpaidTotal", "Granit.Invoicing.UnpaidInvoiceTotalMetric", Position: 1),
+///     ];
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    /// <summary>
+    /// Unique wire identifier — <c>"Granit.{Module}.{DashboardName}"</c>, PascalCase,
+    /// dot-separated. Used as the resource key for the dashboard's localized title
+    /// (<c>Dashboard:{Name}</c>) and as the import endpoint parameter
+    /// (<c>POST /dashboards/from-definition/{name}</c>).
+    /// </summary>
+    public abstract string Name { get; }
+
+    /// <summary>Catalogue grouping. Drives the section ordering in the import dialog.</summary>
+    public abstract DashboardCategory Category { get; }
+
+    /// <summary>
+    /// Whether this dashboard is mandated by the platform operator. When <c>true</c>,
+    /// imported instances cannot be deleted by tenant admins (only re-synced). Defaults
+    /// to <c>false</c> — framework modules ship suggestions, not impositions
+    /// (ADR-038 §5).
+    /// </summary>
+    public virtual bool IsSystem => false;
+
+    /// <summary>
+    /// Semver of the definition shape. Bumped when the widget set changes in a
+    /// breaking way; surfaced to admins as drift after import (ADR-038 §3).
+    /// </summary>
+    public virtual string Version => "1.0.0";
+
+    /// <summary>Grid layout configuration. Defaults to <see cref="DashboardLayout.Default"/>.</summary>
+    public virtual DashboardLayout Layout => DashboardLayout.Default;
+
+    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    public abstract IReadOnlyList<WidgetDefinition> Widgets { get; }
+}

--- a/src/Granit.Analytics/Dashboards/DashboardLayout.cs
+++ b/src/Granit.Analytics/Dashboards/DashboardLayout.cs
@@ -1,0 +1,15 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Coarse layout configuration applied to a dashboard's widget grid. Per ADR-038, the
+/// layout is intentionally minimal at the declarative level — the persisted
+/// <c>Dashboard</c> aggregate (story B2) and the frontend composer (story B5) own the
+/// fine-grained layout.
+/// </summary>
+/// <param name="Columns">Number of grid columns. Default 12 (standard responsive grid).</param>
+/// <param name="RowHeight">Row height in CSS pixels. Default 80.</param>
+public sealed record DashboardLayout(int Columns, int RowHeight)
+{
+    /// <summary>Conventional 12-column responsive grid with 80px row height.</summary>
+    public static DashboardLayout Default => new(12, 80);
+}

--- a/src/Granit.Analytics/Dashboards/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Analytics/Dashboards/IDashboardDefinitionDescriptor.cs
@@ -1,0 +1,27 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Type-erased descriptor exposed for registry lookup. Lets the registry surface every
+/// registered <see cref="DashboardDefinition"/> without each consumer needing the
+/// concrete type.
+/// </summary>
+public interface IDashboardDefinitionDescriptor
+{
+    /// <summary>Unique wire identifier, e.g. <c>"Granit.Invoicing.FinanceOverview"</c>.</summary>
+    string Name { get; }
+
+    /// <summary>Coarse grouping driving catalogue ordering.</summary>
+    DashboardCategory Category { get; }
+
+    /// <summary>Whether the dashboard is mandated by the platform operator (cannot be deleted by tenant admins).</summary>
+    bool IsSystem { get; }
+
+    /// <summary>Semver — used for drift detection between definition and persisted dashboard (story B2).</summary>
+    string Version { get; }
+
+    /// <summary>Layout configuration applied to the widget grid.</summary>
+    DashboardLayout Layout { get; }
+
+    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    IReadOnlyList<WidgetDefinition> Widgets { get; }
+}

--- a/src/Granit.Analytics/Dashboards/IDashboardDefinitionRegistry.cs
+++ b/src/Granit.Analytics/Dashboards/IDashboardDefinitionRegistry.cs
@@ -1,0 +1,22 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Read-only registry of every <see cref="DashboardDefinition"/> registered across
+/// all loaded modules. Surfaces the catalogue to the import endpoint
+/// (story B4) and the admin import dialog (story B5).
+/// </summary>
+public interface IDashboardDefinitionRegistry
+{
+    /// <summary>
+    /// Returns every registered definition, ordered by <see cref="DashboardCategory"/>
+    /// then by <see cref="DashboardDefinition.Name"/> (ordinal). Stable ordering across
+    /// processes — useful for tests and snapshot fixtures.
+    /// </summary>
+    IReadOnlyList<IDashboardDefinitionDescriptor> GetAll();
+
+    /// <summary>
+    /// Looks up a definition by its wire identifier. Returns <c>null</c> when the name
+    /// is not registered (callers translate to a 404 at the HTTP layer).
+    /// </summary>
+    IDashboardDefinitionDescriptor? Find(string name);
+}

--- a/src/Granit.Analytics/Dashboards/Internal/DashboardDefinitionRegistry.cs
+++ b/src/Granit.Analytics/Dashboards/Internal/DashboardDefinitionRegistry.cs
@@ -1,0 +1,30 @@
+namespace Granit.Analytics.Dashboards.Internal;
+
+internal sealed class DashboardDefinitionRegistry : IDashboardDefinitionRegistry
+{
+    private readonly IReadOnlyList<IDashboardDefinitionDescriptor> _ordered;
+    private readonly Dictionary<string, IDashboardDefinitionDescriptor> _byName;
+
+    public DashboardDefinitionRegistry(IEnumerable<IDashboardDefinitionDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        IDashboardDefinitionDescriptor[] snapshot = descriptors.ToArray();
+
+        // Stable ordering: category index (declared enum order, broad-to-narrow), then
+        // dashboard name. Ordinal comparison keeps test fixtures deterministic.
+        _ordered = [.. snapshot
+            .OrderBy(d => (int)d.Category)
+            .ThenBy(d => d.Name, StringComparer.Ordinal)];
+
+        _byName = snapshot.ToDictionary(d => d.Name, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<IDashboardDefinitionDescriptor> GetAll() => _ordered;
+
+    public IDashboardDefinitionDescriptor? Find(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        return _byName.TryGetValue(name, out IDashboardDefinitionDescriptor? d) ? d : null;
+    }
+}

--- a/src/Granit.Analytics/Dashboards/WidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/WidgetDefinition.cs
@@ -1,0 +1,152 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Base record for every widget shipped by a <see cref="DashboardDefinition"/>.
+/// Concrete widget kinds add their kind-specific configuration via inheritance.
+/// </summary>
+/// <param name="Slug">
+/// Widget-local identifier (PascalCase, unique within the dashboard). Used to compose
+/// localization keys (<c>Widget:{DashboardName}.{Slug}</c>) and as the stable
+/// identifier under reorder operations.
+/// </param>
+/// <param name="Position">Dense-ranked grid order — 0-based, contiguous within the dashboard.</param>
+/// <param name="Size">Width / height in grid cells.</param>
+/// <param name="RequiredPermission">
+/// Optional override of the permission gating this widget at render time. When
+/// <c>null</c>, the runtime resolves the effective permission from the underlying
+/// metric / query (ADR-038 §6).
+/// </param>
+public abstract record WidgetDefinition(
+    string Slug,
+    int Position,
+    WidgetSize Size,
+    string? RequiredPermission = null);
+
+/// <summary>
+/// A single-value KPI tile bound to a <c>MetricDefinition</c>. The most common widget
+/// kind — typically renders the metric value, an optional period delta, and a
+/// favorable / unfavorable color cue driven by <c>MetricDefinition.IsHigherBetter</c>.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="MetricName">The <c>MetricDefinition.Name</c> this KPI surfaces (e.g. <c>"Granit.Invoicing.UnpaidInvoiceCountMetric"</c>).</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.SmallKpi"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record KpiWidgetDefinition(
+    string Slug,
+    string MetricName,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.SmallKpi, RequiredPermission);
+
+/// <summary>
+/// Aggregated chart bound to a <c>QueryDefinition</c>. Unlike a KPI, a chart owns its
+/// aggregation (sum / average / count over a chosen field) so the same query can
+/// power multiple distinct charts.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this chart (e.g. <c>"Granit.Invoicing.InvoiceQuery"</c>).</param>
+/// <param name="GroupBy">Field used as the chart's category axis (e.g. <c>"IssuedAtMonth"</c>).</param>
+/// <param name="Aggregation">Reuses <see cref="AggregateFunction"/> for parity with metrics.</param>
+/// <param name="Field">Field aggregated; <c>null</c> when <see cref="Aggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="ChartType">Visual representation hint — interpreted by the frontend.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record ChartWidgetDefinition(
+    string Slug,
+    string QueryName,
+    string GroupBy,
+    AggregateFunction Aggregation,
+    string? Field,
+    ChartType ChartType,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);
+
+/// <summary>
+/// Tabular widget bound to a <c>QueryDefinition</c>. Renders a paginated grid of rows
+/// using the query's filter / sort surface.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this table.</param>
+/// <param name="VisibleColumns">Subset of the query's columns to surface, in order; <c>null</c> renders all.</param>
+/// <param name="PageSize">Default page size for the embedded grid.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record TableWidgetDefinition(
+    string Slug,
+    string QueryName,
+    IReadOnlyList<string>? VisibleColumns,
+    int PageSize,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);
+
+/// <summary>
+/// Pivot-table widget — rows × columns × value cells, classic OLAP shape.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this pivot.</param>
+/// <param name="RowFields">Fields used as row dimensions (in order).</param>
+/// <param name="ColumnFields">Fields used as column dimensions (in order).</param>
+/// <param name="ValueField">Field aggregated in each cell; <c>null</c> when <see cref="ValueAggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="ValueAggregation">Aggregation applied to <see cref="ValueField"/>.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record PivotWidgetDefinition(
+    string Slug,
+    string QueryName,
+    IReadOnlyList<string> RowFields,
+    IReadOnlyList<string> ColumnFields,
+    string? ValueField,
+    AggregateFunction ValueAggregation,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);
+
+/// <summary>
+/// Static markdown content — does not query the data layer. Used for dashboard
+/// banners, contextual notes, links to runbooks. Permission filtering does not apply
+/// (markdown is always visible to anyone who can see the dashboard).
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="ContentLocalizationKey">Localization key resolving to the markdown body (e.g. <c>"Widget:Granit.Invoicing.FinanceOverview.Banner"</c>).</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.FullWidthRow"/>.</param>
+public sealed record MarkdownWidgetDefinition(
+    string Slug,
+    string ContentLocalizationKey,
+    int Position,
+    WidgetSize? Size = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null);
+
+/// <summary>Visual hint for chart widgets, interpreted by the frontend.</summary>
+public enum ChartType
+{
+    /// <summary>Vertical bars; one bar per category.</summary>
+    Bar = 0,
+
+    /// <summary>Horizontal bars; one bar per category.</summary>
+    HorizontalBar = 1,
+
+    /// <summary>Line chart over an ordered category axis (typically time).</summary>
+    Line = 2,
+
+    /// <summary>Area chart — line chart with the area under it filled.</summary>
+    Area = 3,
+
+    /// <summary>Pie chart — proportional slices of a total.</summary>
+    Pie = 4,
+
+    /// <summary>Donut chart — pie chart with a hollow centre.</summary>
+    Donut = 5,
+}

--- a/src/Granit.Analytics/Dashboards/WidgetSize.cs
+++ b/src/Granit.Analytics/Dashboards/WidgetSize.cs
@@ -1,0 +1,21 @@
+namespace Granit.Analytics.Dashboards;
+
+/// <summary>
+/// Width / height of a widget on the dashboard grid, expressed in grid cells.
+/// The frontend grid is conventionally 12 columns wide; widget heights are typically
+/// 1–6 rows. The runtime does not enforce a maximum — the rendering layer clamps
+/// values to its viewport.
+/// </summary>
+/// <param name="Width">Grid columns occupied by the widget. Must be &gt; 0.</param>
+/// <param name="Height">Grid rows occupied by the widget. Must be &gt; 0.</param>
+public sealed record WidgetSize(int Width, int Height)
+{
+    /// <summary>A small KPI card — 3×1 (a quarter row).</summary>
+    public static WidgetSize SmallKpi => new(3, 1);
+
+    /// <summary>A standard chart — half a row, two rows tall (6×2).</summary>
+    public static WidgetSize StandardChart => new(6, 2);
+
+    /// <summary>A full-width content widget (12×1) — typical for markdown banners.</summary>
+    public static WidgetSize FullWidthRow => new(12, 1);
+}

--- a/src/Granit.Analytics/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.Analytics.Dashboards;
+using Granit.Analytics.Dashboards.Internal;
 using Granit.Analytics.Diagnostics;
 using Granit.Analytics.Metrics;
 using Granit.Diagnostics;
@@ -27,6 +29,7 @@ public static class AnalyticsServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<AnalyticsMetrics>();
+        services.TryAddSingleton<IDashboardDefinitionRegistry, DashboardDefinitionRegistry>();
         GranitActivitySourceRegistry.Register(AnalyticsActivitySource.Name);
 
         return services;
@@ -51,6 +54,25 @@ public static class AnalyticsServiceCollectionExtensions
         services.AddSingleton<MetricDefinition<TEntity, TValue>>(_ => new TDefinition());
         services.AddSingleton<IMetricDefinitionDescriptor>(sp =>
             sp.GetRequiredService<MetricDefinition<TEntity, TValue>>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a dashboard definition. Each definition is exposed as a singleton
+    /// <see cref="IDashboardDefinitionDescriptor"/> picked up by the
+    /// <see cref="IDashboardDefinitionRegistry"/> at composition time.
+    /// </summary>
+    /// <typeparam name="TDefinition">The dashboard definition implementation.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDashboardDefinition<TDefinition>(this IServiceCollection services)
+        where TDefinition : DashboardDefinition, new()
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<TDefinition>(_ => new TDefinition());
+        services.AddSingleton<IDashboardDefinitionDescriptor>(sp => sp.GetRequiredService<TDefinition>());
 
         return services;
     }

--- a/tests/Granit.Analytics.Tests/Dashboards/DashboardDefinitionRegistryTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/DashboardDefinitionRegistryTests.cs
@@ -1,0 +1,120 @@
+using Granit.Analytics.Dashboards;
+using Granit.Analytics.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards;
+
+public sealed class DashboardDefinitionRegistryTests
+{
+    [Fact]
+    public void AddDashboardDefinition_RegistersDescriptorAndConcreteType()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalytics();
+        services.AddDashboardDefinition<FinanceDashboard>();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        FinanceDashboard concrete = provider.GetRequiredService<FinanceDashboard>();
+        IEnumerable<IDashboardDefinitionDescriptor> descriptors =
+            provider.GetServices<IDashboardDefinitionDescriptor>();
+
+        descriptors.ShouldContain(concrete);
+        descriptors.Single().Name.ShouldBe("Sample.Finance");
+    }
+
+    [Fact]
+    public void GetAll_OrdersByCategoryThenName()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalytics();
+        services.AddDashboardDefinition<OperationsDashboard>();   // Operations (category=2)
+        services.AddDashboardDefinition<FinanceDashboard>();      // Finance (category=1)
+        services.AddDashboardDefinition<AlphaFinanceDashboard>(); // Finance (category=1), Alpha < Finance
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        IReadOnlyList<IDashboardDefinitionDescriptor> ordered = registry.GetAll();
+
+        ordered.Select(d => d.Name).ShouldBe([
+            "Sample.AlphaFinance",
+            "Sample.Finance",
+            "Sample.Operations",
+        ]);
+    }
+
+    [Fact]
+    public void Find_ReturnsDescriptor_WhenRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalytics();
+        services.AddDashboardDefinition<FinanceDashboard>();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        IDashboardDefinitionDescriptor? found = registry.Find("Sample.Finance");
+
+        found.ShouldNotBeNull();
+        found.Name.ShouldBe("Sample.Finance");
+    }
+
+    [Fact]
+    public void Find_ReturnsNull_WhenNotRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalytics();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        registry.Find("Sample.Missing").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Find_Throws_OnNullOrEmptyName()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalytics();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        Should.Throw<ArgumentException>(() => registry.Find(string.Empty));
+        Should.Throw<ArgumentException>(() => registry.Find(null!));
+    }
+
+    private sealed class FinanceDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Finance";
+        public override DashboardCategory Category => DashboardCategory.Finance;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new KpiWidgetDefinition("UnpaidCount", "Sample.UnpaidInvoiceCount", Position: 0),
+            new KpiWidgetDefinition("UnpaidTotal", "Sample.UnpaidInvoiceTotal", Position: 1),
+        ];
+    }
+
+    private sealed class AlphaFinanceDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.AlphaFinance";
+        public override DashboardCategory Category => DashboardCategory.Finance;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new KpiWidgetDefinition("Total", "Sample.UnpaidInvoiceTotal", Position: 0),
+        ];
+    }
+
+    private sealed class OperationsDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Operations";
+        public override DashboardCategory Category => DashboardCategory.Operations;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new MarkdownWidgetDefinition(
+                "Banner",
+                "Widget:Sample.Operations.Banner",
+                Position: 0),
+        ];
+    }
+}

--- a/tests/Granit.Analytics.Tests/Dashboards/WidgetDefinitionTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/WidgetDefinitionTests.cs
@@ -1,0 +1,93 @@
+using Granit.Analytics.Dashboards;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards;
+
+/// <summary>
+/// Smoke-level coverage of the five widget definition shapes shipped by B1. The
+/// purpose is to lock the public API (constructor positional shape, default sizes,
+/// nullable RequiredPermission), not to re-test record equality.
+/// </summary>
+public sealed class WidgetDefinitionTests
+{
+    [Fact]
+    public void Kpi_DefaultsToSmallKpiSize()
+    {
+        KpiWidgetDefinition widget = new("Slug", "Sample.Metric", Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.SmallKpi);
+        widget.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Chart_DefaultsToStandardChartSize()
+    {
+        ChartWidgetDefinition widget = new(
+            Slug: "RevenueByMonth",
+            QueryName: "Sample.InvoiceQuery",
+            GroupBy: "IssuedAtMonth",
+            Aggregation: AggregateFunction.Sum,
+            Field: "Total",
+            ChartType: ChartType.Line,
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.StandardChart);
+    }
+
+    [Fact]
+    public void Table_AllowsNullVisibleColumns_AndCustomPageSize()
+    {
+        TableWidgetDefinition widget = new(
+            Slug: "RecentInvoices",
+            QueryName: "Sample.InvoiceQuery",
+            VisibleColumns: null,
+            PageSize: 25,
+            Position: 0);
+
+        widget.VisibleColumns.ShouldBeNull();
+        widget.PageSize.ShouldBe(25);
+    }
+
+    [Fact]
+    public void Pivot_AllowsNullValueField_WhenAggregationIsCount()
+    {
+        PivotWidgetDefinition widget = new(
+            Slug: "InvoicesByCustomerByMonth",
+            QueryName: "Sample.InvoiceQuery",
+            RowFields: ["CustomerName"],
+            ColumnFields: ["IssuedAtMonth"],
+            ValueField: null,
+            ValueAggregation: AggregateFunction.Count,
+            Position: 0);
+
+        widget.ValueField.ShouldBeNull();
+        widget.ValueAggregation.ShouldBe(AggregateFunction.Count);
+    }
+
+    [Fact]
+    public void Markdown_DefaultsToFullWidthRow_AndIgnoresPermissions()
+    {
+        MarkdownWidgetDefinition widget = new(
+            Slug: "Banner",
+            ContentLocalizationKey: "Widget:Sample.Banner",
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.FullWidthRow);
+        // Markdown is always visible — permission filtering does not apply.
+        widget.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Widget_AllowsRequiredPermissionOverride()
+    {
+        KpiWidgetDefinition widget = new(
+            Slug: "RestrictedKpi",
+            MetricName: "Sample.Metric",
+            Position: 0,
+            RequiredPermission: "Custom.Composite.Read");
+
+        widget.RequiredPermission.ShouldBe("Custom.Composite.Read");
+    }
+}

--- a/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
+++ b/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
@@ -1,0 +1,192 @@
+using System.Reflection;
+using Granit.Analytics.Dashboards;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces story #1382 (B1): every widget reference inside a shipped
+/// <see cref="DashboardDefinition"/> MUST resolve at composition time.
+/// <see cref="KpiWidgetDefinition.MetricName"/> must match a registered
+/// <see cref="MetricDefinition{TEntity, TValue}"/>; the <c>QueryName</c> on
+/// chart / table / pivot widgets must match a registered
+/// <see cref="QueryDefinition{TEntity}"/>.
+/// </summary>
+/// <remarks>
+/// This catches the "the dashboard has been shipped, the metric was renamed, nobody
+/// noticed" failure mode at build time rather than at the first user-clicks-import
+/// in production. The test only enforces references for dashboards actually shipped
+/// by the framework — any new module that adds a dashboard automatically gets the
+/// check for free.
+/// </remarks>
+public sealed class DashboardWidgetReferenceTests
+{
+    [Fact]
+    public void Every_widget_reference_should_resolve_to_a_registered_metric_or_query()
+    {
+        Inventory inventory = ScanInventory();
+
+        if (inventory.Dashboards.Count == 0)
+        {
+            // No dashboards shipped yet — story B1 lands the abstractions; concrete
+            // dashboards arrive in follow-up stories. The test stays green and
+            // becomes load-bearing the moment a module ships its first dashboard.
+            return;
+        }
+
+        List<string> dangling = [];
+
+        foreach (DashboardDefinition dashboard in inventory.Dashboards)
+        {
+            foreach (WidgetDefinition widget in dashboard.Widgets)
+            {
+                switch (widget)
+                {
+                    case KpiWidgetDefinition kpi:
+                        if (!inventory.MetricNames.Contains(kpi.MetricName))
+                        {
+                            dangling.Add($"{dashboard.Name}/{kpi.Slug} -> KPI references missing metric '{kpi.MetricName}'");
+                        }
+                        break;
+
+                    case ChartWidgetDefinition chart:
+                        if (!inventory.QueryNames.Contains(chart.QueryName))
+                        {
+                            dangling.Add($"{dashboard.Name}/{chart.Slug} -> Chart references missing query '{chart.QueryName}'");
+                        }
+                        break;
+
+                    case TableWidgetDefinition table:
+                        if (!inventory.QueryNames.Contains(table.QueryName))
+                        {
+                            dangling.Add($"{dashboard.Name}/{table.Slug} -> Table references missing query '{table.QueryName}'");
+                        }
+                        break;
+
+                    case PivotWidgetDefinition pivot:
+                        if (!inventory.QueryNames.Contains(pivot.QueryName))
+                        {
+                            dangling.Add($"{dashboard.Name}/{pivot.Slug} -> Pivot references missing query '{pivot.QueryName}'");
+                        }
+                        break;
+
+                    case MarkdownWidgetDefinition:
+                        // Markdown widgets do not reference metrics or queries.
+                        break;
+                }
+            }
+        }
+
+        dangling.ShouldBeEmpty(
+            "Story #1382 (B1): every widget in a shipped DashboardDefinition must reference " +
+            "an existing MetricDefinition (KPI) or QueryDefinition (Chart, Table, Pivot). " +
+            "Dangling references almost always mean a metric / query was renamed without " +
+            "updating the dashboards that depended on it. Either fix the reference or remove " +
+            "the widget from the dashboard." + Environment.NewLine +
+            string.Join(Environment.NewLine, dangling.Order(StringComparer.Ordinal)));
+    }
+
+    private static Inventory ScanInventory()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(DashboardWidgetReferenceTests).Assembly.Location)!;
+
+        Assembly[] assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<DashboardDefinition> dashboards = [];
+        HashSet<string> metricNames = new(StringComparer.Ordinal);
+        HashSet<string> queryNames = new(StringComparer.Ordinal);
+
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                {
+                    continue;
+                }
+
+                if (typeof(DashboardDefinition).IsAssignableFrom(type))
+                {
+                    DashboardDefinition? dashboard = TryCreate<DashboardDefinition>(type);
+                    if (dashboard is not null)
+                    {
+                        dashboards.Add(dashboard);
+                    }
+
+                    continue;
+                }
+
+                if (DerivesFromOpenGeneric(type, typeof(MetricDefinition<,>)))
+                {
+                    IMetricDefinitionDescriptor? descriptor = TryCreate<IMetricDefinitionDescriptor>(type);
+                    if (descriptor is not null)
+                    {
+                        metricNames.Add(descriptor.Name);
+                    }
+
+                    continue;
+                }
+
+                if (DerivesFromOpenGeneric(type, typeof(QueryDefinition<>)))
+                {
+                    object? instance = TryCreate<object>(type);
+                    if (instance is not null)
+                    {
+                        string? name = (string?)type.GetProperty("Name", BindingFlags.Instance | BindingFlags.Public)?.GetValue(instance);
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            queryNames.Add(name);
+                        }
+                    }
+                }
+            }
+        }
+
+        return new Inventory(dashboards, metricNames, queryNames);
+    }
+
+    private static T? TryCreate<T>(Type type)
+        where T : class
+    {
+        try { return Activator.CreateInstance(type) as T; }
+        catch (Exception) { return null; }
+    }
+
+    private static bool DerivesFromOpenGeneric(Type candidate, Type openGenericBase)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed record Inventory(
+        List<DashboardDefinition> Dashboards,
+        HashSet<string> MetricNames,
+        HashSet<string> QueryNames);
+}


### PR DESCRIPTION
## Summary

Closes #1382 (B1 of the BI epic #1366). Builds on ADR-038 (merged in #1446) to ship the declarative dashboard catalogue layer in `Granit.Analytics`.

Modules declare *"I propose this dashboard with these widgets"* in code; admins import them on demand to create persisted `Dashboard` aggregates (story B2 #1383). Module upgrades surface drift via `Version`, they never silently retro-edit imported dashboards (ADR-038 §3).

### What lands in this PR

**`Granit.Analytics/Dashboards/`**

- `DashboardDefinition` abstract — `Name`, `Category`, `Version`, `IsSystem`, `Layout`, `Widgets`
- `DashboardCategory` enum — General / Finance / Operations / Security / Compliance / Platform
- `DashboardLayout` value object (Columns × RowHeight)
- `WidgetDefinition` abstract record with five sealed records:
  - `KpiWidgetDefinition` — references a `MetricDefinition` by name
  - `ChartWidgetDefinition` — references a `QueryDefinition` + owns its aggregation (so the same query powers multiple charts)
  - `TableWidgetDefinition` — references a `QueryDefinition`
  - `PivotWidgetDefinition` — references a `QueryDefinition` with row / column / value dims
  - `MarkdownWidgetDefinition` — static, no data layer (no permission filtering)
- All widgets carry `Slug` + `Position` + `Size` + optional `RequiredPermission` override (ADR-038 §6)
- `WidgetSize` value object with sensible presets (`SmallKpi`, `StandardChart`, `FullWidthRow`)
- `ChartType` enum (Bar / HorizontalBar / Line / Area / Pie / Donut)
- `IDashboardDefinitionRegistry` — `GetAll()` (ordered by category then name, ordinal), `Find(name)` (returns null on miss)
- `AddDashboardDefinition<TDefinition>()` DI extension mirroring `AddMetricDefinition<,,>()`
- `AddGranitAnalytics()` now also registers the registry as a singleton

### Tests

- **`Granit.Analytics.Tests/Dashboards/`** — 11 unit tests covering registry ordering / lookup / null-safety, DI registration of descriptor + concrete type, and the public shape of each of the five widget kinds (default sizes, optional permissions, nullable selectors)
- **`Granit.ArchitectureTests/DashboardWidgetReferenceTests`** — asserts every widget reference (`MetricName` for KPI, `QueryName` for Chart/Table/Pivot) resolves to a registered `MetricDefinition` / `QueryDefinition`. Stays green today (no framework module ships a dashboard yet); becomes **load-bearing the moment Granit.Invoicing or another module ships its first `DashboardDefinition`** — exactly the failure mode the AC asks the test to catch ("metric was renamed, dashboard reference left dangling").

### Design choices worth flagging

- **Typed widget hierarchy at the declarative level**, JSON `ConfigJson` blob at the persisted level (ADR-038 §6). The two are not in conflict — the typed records are serialised to JSON at import time. Keeps the declarative API IDE-friendly while keeping the persistence schema additive (B7 MapWidget will ship without a migration).
- **`Slug` per widget** — widget-local identifier (e.g. `"UnpaidCount"`). Used to compose stable localization keys (`Widget:{DashboardName}.{Slug}`) and to re-anchor references across reorder operations.
- **`Find` instead of `Get`** — `Get` would trip CA1716 (clashes with reserved language keywords).
- **Default `Version = "1.0.0"`** rather than mandatory abstract — reasonable starting point, modules opt in to bumping when they ship a breaking widget-set change.

### Out of scope (handled by later stories)

- Persisted `Dashboard` aggregate + EF Core configuration → **B2** (#1383)
- Per-`WidgetKind` `ConfigJson` validators on the persisted side → **B3** (#1384)
- Catalogue + import endpoints → **B4** (#1385)
- Frontend composer / read-mode rendering → **B5** (#1386)

## Test plan

- [x] `dotnet build src/Granit.Analytics` — clean, 0 warnings
- [x] `dotnet test tests/Granit.Analytics.Tests` — 18/18 passing (4 existing + 14 new)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 156/156 passing (1 new, was 155 on develop pre-D2)
- [x] `dotnet format src/Granit.Analytics --verify-no-changes` — clean
- [x] `dotnet format tests/Granit.Analytics.Tests --verify-no-changes` — clean
- [x] `dotnet format tests/Granit.ArchitectureTests --verify-no-changes` — clean
- [ ] CI green (depends on docs-fix #1450 landing first to unblock Cloudflare Pages)