### PR TITLE
feat(dashboards): split DashboardDefinition into Granit.Dashboards.Abstractions + Granit.Dashboards (B1 #1382)

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -65,6 +65,8 @@
         "tests/Granit.Analytics.Tests",
         "tests/Granit.Analytics.EntityFrameworkCore.Tests",
         "tests/Granit.Analytics.Endpoints.Tests",
+        "tests/Granit.Dashboards.Tests",
+        "tests/Granit.Dashboards.Abstractions.Tests",
         "tests/Granit.DataExchange.Abstractions.Tests",
         "tests/Granit.DataExchange.BlobStorage.Tests",
         "tests/Granit.DataExchange.Csv.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -82,6 +82,7 @@
       "name": "Granit.Analytics",
       "deps": [
         "Granit",
+        "Granit.Dashboards.Abstractions",
         "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
@@ -597,6 +598,21 @@
         "Granit.CustomerBalance",
         "Granit.Notifications.Abstractions",
         "Granit.Templating"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.Dashboards",
+      "deps": [
+        "Granit",
+        "Granit.Dashboards.Abstractions"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.Dashboards.Abstractions",
+      "deps": [
+        "Granit"
       ],
       "framework": "net10.0"
     },
@@ -4048,6 +4064,51 @@
       ]
     },
     {
+      "name": "ChartType",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.ChartType",
+      "kind": "enum",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "ChartWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.ChartWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "KpiWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "PivotWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.PivotWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "TableWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.TableWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "AnalyticsMetrics",
       "fqn": "Granit.Analytics.Diagnostics.AnalyticsMetrics",
       "kind": "class",
@@ -4271,7 +4332,7 @@
       "kind": "class",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/GranitAnalyticsModule.cs",
-      "line": 26,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -12441,6 +12502,210 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "DashboardCategory",
+      "fqn": "Granit.Dashboards.DashboardCategory",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardCategory.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "DashboardDefinition",
+      "fqn": "Granit.Dashboards.DashboardDefinition",
+      "kind": "class",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardDefinition.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Version",
+          "kind": "property",
+          "signature": "string Version",
+          "returnType": "string"
+        },
+        {
+          "name": "Layout",
+          "kind": "property",
+          "signature": "DashboardLayout Layout",
+          "returnType": "DashboardLayout"
+        }
+      ]
+    },
+    {
+      "name": "DashboardLayout",
+      "fqn": "Granit.Dashboards.DashboardLayout",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardLayout.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(12, 80)",
+          "returnType": "DashboardLayout Default =>"
+        }
+      ]
+    },
+    {
+      "name": "DashboardsServiceCollectionExtensions",
+      "fqn": "Granit.Dashboards.Extensions.DashboardsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDashboards",
+          "kind": "method",
+          "signature": "AddGranitDashboards(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDashboardsAbstractionsModule",
+      "fqn": "Granit.Dashboards.GranitDashboardsAbstractionsModule",
+      "kind": "class",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/GranitDashboardsAbstractionsModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "GranitDashboardsModule",
+      "fqn": "Granit.Dashboards.GranitDashboardsModule",
+      "kind": "class",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/GranitDashboardsModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IDashboardDefinitionDescriptor",
+      "fqn": "Granit.Dashboards.IDashboardDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IDashboardDefinitionRegistry",
+      "fqn": "Granit.Dashboards.IDashboardDefinitionRegistry",
+      "kind": "interface",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/IDashboardDefinitionRegistry.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<IDashboardDefinitionDescriptor>"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "IDashboardDefinitionDescriptor?"
+        }
+      ]
+    },
+    {
+      "name": "WidgetDefinition",
+      "fqn": "Granit.Dashboards.WidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetDefinition.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "WidgetSize",
+      "fqn": "Granit.Dashboards.WidgetSize",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetSize.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(3, 1)",
+          "returnType": "WidgetSize SmallKpi =>"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(6, 2)",
+          "returnType": "WidgetSize StandardChart =>"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(12, 1)",
+          "returnType": "WidgetSize FullWidthRow =>"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(4, 4)",
+          "returnType": "WidgetSize MediaTile =>"
+        }
+      ]
+    },
+    {
+      "name": "ImageWidgetDefinition",
+      "fqn": "Granit.Dashboards.Widgets.ImageWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MarkdownWidgetDefinition",
+      "fqn": "Granit.Dashboards.Widgets.MarkdownWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "TextStyle",
+      "fqn": "Granit.Dashboards.Widgets.TextStyle",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "TextWidgetDefinition",
+      "fqn": "Granit.Dashboards.Widgets.TextWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs",
+      "line": 13,
+      "members": []
     },
     {
       "name": "DataExchangeAIHostApplicationBuilderExtensions",

--- a/docs-site/src/content/docs/dotnet/architecture/adr/038-analytics-dashboard-definition-vs-aggregate.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/038-analytics-dashboard-definition-vs-aggregate.md
@@ -41,16 +41,39 @@ mutable counterpart on the wire. Dashboards follow the same dichotomy.
 
 ## Decision
 
-### 1. Two types, two homes
+### 1. Two types, two homes — and a dedicated package family
+
+The framework cannot host dashboards under `Granit.Analytics` because the same
+primitive will eventually power IoT real-time dashboards (gauges, camera feeds,
+alarm lights — none of which are analytics measures). Forcing `Granit.IoT` to
+depend on `Granit.Analytics` (and thus on `Granit.QueryEngine`) just to declare a
+widget would be the wrong dependency direction.
+
+The two types therefore live in a dedicated package family that mirrors the
+`QueryEngine.Abstractions` / `QueryEngine` split (ADR-020):
 
 | Concept | Type | Lives in | Mutability | Persistence |
 | ------- | ---- | -------- | ---------- | ----------- |
-| Module-shipped catalogue entry | `DashboardDefinition` | `Granit.{Module}` (base module, alongside `QueryDefinition` / `ExportDefinition`) | Immutable — code | None — assembly only |
-| Tenant-composed dashboard | `Dashboard` | `Granit.Analytics` (aggregate root) | Mutable — admin actions | `Granit.Analytics.EntityFrameworkCore` |
+| Declarative dashboard catalogue entry | `DashboardDefinition` | Per-domain — `Granit.Analytics`, future `Granit.IoT.Dashboards`, ... — declared via `Granit.Dashboards.Abstractions` | Immutable — code | None — assembly only |
+| Tenant-composed dashboard (aggregate) | `Dashboard` | `Granit.Dashboards` (aggregate root, story B2) | Mutable — admin actions | `Granit.Dashboards.EntityFrameworkCore` (story B2) |
 
-`DashboardDefinition` follows the placement rule of ADR-020: each module owns its own
-catalogue entries and registers them via `services.AddDashboardDefinition<TDef>()`.
-There is no central aggregation package.
+Package responsibilities:
+
+| Package | Contents |
+| ------- | -------- |
+| `Granit.Dashboards.Abstractions` | `DashboardDefinition`, `WidgetDefinition` (base), `DashboardLayout`, `WidgetSize`, `IDashboardDefinitionRegistry`, `DashboardCategory`. Plus presentation-only widgets shared across domains: `MarkdownWidgetDefinition`, `ImageWidgetDefinition`, `TextWidgetDefinition`. Lightweight — only consumers of contracts pull this. |
+| `Granit.Dashboards` | `IDashboardDefinitionRegistry` implementation, `AddGranitDashboards()` + `AddDashboardDefinition<TDef>()` DI extensions. Future home of the persisted `Dashboard` aggregate, import / re-sync logic, and the real-time hub for IoT live tiles. |
+| `Granit.Analytics` | Analytics-flavoured widgets: `KpiWidgetDefinition` (binds to `MetricDefinition`), `ChartWidgetDefinition` / `TableWidgetDefinition` / `PivotWidgetDefinition` (bind to `QueryDefinition`). Depends on `Granit.Dashboards.Abstractions`. |
+| `Granit.IoT.Dashboards` (future) | IoT-flavoured widgets: live sensor gauge, camera feed, alarm light. Depends on `Granit.Dashboards.Abstractions`. Will not depend on `Granit.Analytics`. |
+
+`DashboardDefinition` itself follows the placement rule of ADR-020: each module
+declares its own dashboards and registers them via
+`services.AddDashboardDefinition<TDef>()`. There is no central aggregation package.
+
+Presentation-only widgets (Markdown, Image, Text) ship in
+`Granit.Dashboards.Abstractions` because they are *domain-neutral* — a dashboard in
+any vertical may want a banner, a logo or a heading. Putting them anywhere else
+would force IoT modules to depend on Analytics for a banner.
 
 ### 2. Dashboards are *imported*, not auto-instantiated
 
@@ -258,7 +281,10 @@ widgets) and keeps reorder updates to two rows.
   the framework treats it as tenant-owned and never silently mutates it.
 - **Additive schema.** JSON `ConfigJson` + dense-ranked `Position` keeps story B7
   (`MapWidget`) and any future widget kind shippable without a migration in
-  `Granit.Analytics.EntityFrameworkCore`.
+  `Granit.Dashboards.EntityFrameworkCore`.
+- **Domain-extensible.** A new domain (IoT, observability, …) ships its own widget
+  records against `Granit.Dashboards.Abstractions` without touching `Granit.Analytics`
+  or vice versa. The dashboard runtime is the only horizontal piece.
 
 ## Consequences
 
@@ -275,7 +301,11 @@ widgets) and keeps reorder updates to two rows.
 
 - Two types instead of one — admins/devs must remember which one they are dealing
   with. Mitigated by clear naming (`Dashboard` vs `DashboardDefinition`) and by
-  putting them in the same module so IDE auto-complete keeps them adjacent.
+  shipping them in the same package family so IDE auto-complete keeps them adjacent.
+- Two new framework packages (`Granit.Dashboards.Abstractions` + `Granit.Dashboards`)
+  rather than reusing `Granit.Analytics`. Marginal — the framework already absorbs
+  the same split twice for `Granit.QueryEngine` and `Granit.DataExchange`. The
+  runtime cost is paid only by hosts that actually expose dashboards.
 - Drift between definition and persisted copy must be surfaced in the admin UI.
   Story B5 (frontend composer) is responsible for this UX. Until B5 ships, drift
   is queryable via API but not visualised.
@@ -285,15 +315,14 @@ widgets) and keeps reorder updates to two rows.
 
 ### Migration order
 
-1. **B1** (#1382) — implement `DashboardDefinition`, `WidgetDefinition`, `WidgetSize`,
-   `DashboardLayout` value objects in `Granit.Analytics`. Add
-   `services.AddDashboardDefinition<TDef>()` extension. Architecture test enforces
-   placement (base module, not `.Endpoints`).
+1. **B1** (#1382) — split `Granit.Dashboards.Abstractions` (base types + presentation
+   widgets: Markdown, Image, Text) and `Granit.Dashboards` (registry + DI).
+   Analytics-flavoured widgets (Kpi, Chart, Table, Pivot) ship in `Granit.Analytics`.
+   Architecture test enforces widget references resolve at composition time.
 2. **B2** (#1383) — implement `Dashboard` aggregate, `WidgetInstance` owned entity,
-   EF configurations, migration in `Granit.Analytics.EntityFrameworkCore`. Apply
+   EF configurations, migration in `Granit.Dashboards.EntityFrameworkCore`. Apply
    `ApplyGranitConventions` (multi-tenant + soft-delete).
-3. **B3** (#1384) — ship the five baseline widget kinds (Kpi, Chart, Table, Pivot,
-   Markdown) with per-kind `ConfigJson` validators.
+3. **B3** (#1384) — ship per-kind `ConfigJson` validators on the persisted side.
 4. **B4** (#1385) — REST endpoints (`GET /dashboards/catalog`,
    `POST /dashboards/from-definition/{name}`, full CRUD on persisted dashboards) +
    permission filtering at render time.

--- a/src/Granit.Analytics.Endpoints/packages.lock.json
+++ b/src/Granit.Analytics.Endpoints/packages.lock.json
@@ -35,6 +35,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -64,6 +65,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
@@ -90,7 +90,14 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs
@@ -1,0 +1,52 @@
+using Granit.Dashboards;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Aggregated chart bound to a <c>QueryDefinition</c>. Unlike a KPI, a chart owns its
+/// aggregation (sum / average / count over a chosen field) so the same query can
+/// power multiple distinct charts.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this chart (e.g. <c>"Granit.Invoicing.InvoiceQuery"</c>).</param>
+/// <param name="GroupBy">Field used as the chart's category axis (e.g. <c>"IssuedAtMonth"</c>).</param>
+/// <param name="Aggregation">Reuses <see cref="AggregateFunction"/> for parity with metrics.</param>
+/// <param name="Field">Field aggregated; <c>null</c> when <see cref="Aggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="ChartType">Visual representation hint — interpreted by the frontend.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record ChartWidgetDefinition(
+    string Slug,
+    string QueryName,
+    string GroupBy,
+    AggregateFunction Aggregation,
+    string? Field,
+    ChartType ChartType,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);
+
+/// <summary>Visual hint for chart widgets, interpreted by the frontend.</summary>
+public enum ChartType
+{
+    /// <summary>Vertical bars; one bar per category.</summary>
+    Bar = 0,
+
+    /// <summary>Horizontal bars; one bar per category.</summary>
+    HorizontalBar = 1,
+
+    /// <summary>Line chart over an ordered category axis (typically time).</summary>
+    Line = 2,
+
+    /// <summary>Area chart — line chart with the area under it filled.</summary>
+    Area = 3,
+
+    /// <summary>Pie chart — proportional slices of a total.</summary>
+    Pie = 4,
+
+    /// <summary>Donut chart — pie chart with a hollow centre.</summary>
+    Donut = 5,
+}

--- a/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
@@ -1,0 +1,21 @@
+using Granit.Dashboards;
+
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// A single-value KPI tile bound to a <c>MetricDefinition</c>. The most common widget
+/// kind — typically renders the metric value, an optional period delta, and a
+/// favorable / unfavorable color cue driven by <c>MetricDefinition.IsHigherBetter</c>.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="MetricName">The <c>MetricDefinition.Name</c> this KPI surfaces (e.g. <c>"Granit.Invoicing.UnpaidInvoiceCountMetric"</c>).</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.SmallKpi"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record KpiWidgetDefinition(
+    string Slug,
+    string MetricName,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.SmallKpi, RequiredPermission);

--- a/src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs
@@ -1,0 +1,28 @@
+using Granit.Dashboards;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Pivot-table widget — rows × columns × value cells, classic OLAP shape.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this pivot.</param>
+/// <param name="RowFields">Fields used as row dimensions (in order).</param>
+/// <param name="ColumnFields">Fields used as column dimensions (in order).</param>
+/// <param name="ValueField">Field aggregated in each cell; <c>null</c> when <see cref="ValueAggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="ValueAggregation">Aggregation applied to <see cref="ValueField"/>.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record PivotWidgetDefinition(
+    string Slug,
+    string QueryName,
+    IReadOnlyList<string> RowFields,
+    IReadOnlyList<string> ColumnFields,
+    string? ValueField,
+    AggregateFunction ValueAggregation,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);

--- a/src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs
@@ -1,0 +1,24 @@
+using Granit.Dashboards;
+
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Tabular widget bound to a <c>QueryDefinition</c>. Renders a paginated grid of rows
+/// using the query's filter / sort surface.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this table.</param>
+/// <param name="VisibleColumns">Subset of the query's columns to surface, in order; <c>null</c> renders all.</param>
+/// <param name="PageSize">Default page size for the embedded grid.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+public sealed record TableWidgetDefinition(
+    string Slug,
+    string QueryName,
+    IReadOnlyList<string>? VisibleColumns,
+    int PageSize,
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission);

--- a/src/Granit.Analytics/Granit.Analytics.csproj
+++ b/src/Granit.Analytics/Granit.Analytics.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Analytics</PackageId>
-    <Description>Declarative Business Intelligence primitives for Granit: MetricDefinition for inline KPIs and DashboardDefinition for composable dashboards. Pairs with QueryDefinition (lists rows) and ExportDefinition (extracts rows) — MetricDefinition aggregates them. Reference this package from any module that declares metrics; reference Granit.Analytics.EntityFrameworkCore from hosts that execute them.</Description>
+    <Description>Declarative Business Intelligence primitives for Granit: MetricDefinition for inline KPIs plus the analytics-flavoured widget catalogue (Kpi, Chart, Table, Pivot) that plugs into Granit.Dashboards.Abstractions. Pairs with QueryDefinition (lists rows) and ExportDefinition (extracts rows) — MetricDefinition aggregates them. Reference this package from any module that declares metrics or analytics dashboards; reference Granit.Analytics.EntityFrameworkCore from hosts that execute them.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Analytics/GranitAnalyticsModule.cs
+++ b/src/Granit.Analytics/GranitAnalyticsModule.cs
@@ -1,4 +1,5 @@
 using Granit.Analytics.Extensions;
+using Granit.Dashboards;
 using Granit.Modularity;
 using Granit.QueryEngine;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,9 @@ namespace Granit.Analytics;
 /// so OpenTelemetry pipelines pick them up automatically.
 /// </para>
 /// </remarks>
-[DependsOn(typeof(GranitQueryEngineAbstractionsModule))]
+[DependsOn(
+    typeof(GranitDashboardsAbstractionsModule),
+    typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitAnalyticsModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Analytics/packages.lock.json
+++ b/src/Granit.Analytics/packages.lock.json
@@ -11,6 +11,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Dashboards.Abstractions/DashboardCategory.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardCategory.cs
@@ -1,0 +1,35 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Coarse grouping shipped on every <see cref="DashboardDefinition"/>. Drives the
+/// catalogue ordering surfaced by <see cref="IDashboardDefinitionRegistry.GetAll()"/>
+/// and the section grouping in the admin import dialog.
+/// </summary>
+/// <remarks>
+/// Categories intentionally stay broad — the goal is "where would an admin look for
+/// this dashboard", not "what schema is it under". A new category should only land
+/// when an existing one becomes a junk drawer.
+/// </remarks>
+public enum DashboardCategory
+{
+    /// <summary>Default — uncategorised. Use only when the others genuinely do not fit.</summary>
+    General = 0,
+
+    /// <summary>Invoicing, payments, subscriptions, customer balance, tax.</summary>
+    Finance = 1,
+
+    /// <summary>AI usage, blob storage, background jobs, webhooks, observability.</summary>
+    Operations = 2,
+
+    /// <summary>Identity, authorization, auditing.</summary>
+    Security = 3,
+
+    /// <summary>Privacy / GDPR (export requests, erasure, retention).</summary>
+    Compliance = 4,
+
+    /// <summary>Multi-tenancy, platform-level admin (tenant lifecycle, feature flags).</summary>
+    Platform = 5,
+
+    /// <summary>IoT / real-time telemetry — sensors, alarms, video feeds.</summary>
+    Iot = 6,
+}

--- a/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
@@ -1,0 +1,67 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Declarative dashboard catalogue entry shipped by a Granit module. Mirrors the
+/// existing declarative primitives — pure declaration, no runtime, no persistence.
+/// Pairs with <c>QueryDefinition</c> (lists rows), <c>ExportDefinition</c> (extracts
+/// rows), and <c>MetricDefinition</c> (aggregates rows) — see ADR-020 and ADR-038.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each definition is registered as a singleton via
+/// <c>services.AddDashboardDefinition&lt;TDefinition&gt;()</c>. Definitions describe
+/// the dashboard catalogue surfaced to admins; they are not the persisted dashboard.
+/// When an admin imports a definition (story B4), the framework deep-copies the
+/// definition into a new <c>Dashboard</c> aggregate (story B2). Module upgrades do
+/// NOT retro-edit imported dashboards — drift is surfaced via
+/// <see cref="Version"/> + an admin-driven re-sync action (ADR-038 §3).
+/// </para>
+/// <para>
+/// Example (analytics dashboard combining a KPI from <c>Granit.Analytics</c> and a
+/// presentation-only widget from this package):
+/// <code>
+/// public sealed class InvoicingFinanceDashboard : DashboardDefinition
+/// {
+///     public override string Name =&gt; "Granit.Invoicing.FinanceOverview";
+///     public override DashboardCategory Category =&gt; DashboardCategory.Finance;
+///     public override IReadOnlyList&lt;WidgetDefinition&gt; Widgets { get; } = [
+///         new MarkdownWidgetDefinition("Banner", "Widget:Granit.Invoicing.FinanceOverview.Banner", Position: 0),
+///         new KpiWidgetDefinition("UnpaidCount", "Granit.Invoicing.UnpaidInvoiceCountMetric", Position: 1),
+///     ];
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    /// <summary>
+    /// Unique wire identifier — <c>"Granit.{Module}.{DashboardName}"</c>, PascalCase,
+    /// dot-separated. Used as the resource key for the dashboard's localized title
+    /// (<c>Dashboard:{Name}</c>) and as the import endpoint parameter
+    /// (<c>POST /dashboards/from-definition/{name}</c>).
+    /// </summary>
+    public abstract string Name { get; }
+
+    /// <summary>Catalogue grouping. Drives the section ordering in the import dialog.</summary>
+    public abstract DashboardCategory Category { get; }
+
+    /// <summary>
+    /// Whether this dashboard is mandated by the platform operator. When <c>true</c>,
+    /// imported instances cannot be deleted by tenant admins (only re-synced). Defaults
+    /// to <c>false</c> — framework modules ship suggestions, not impositions
+    /// (ADR-038 §5).
+    /// </summary>
+    public virtual bool IsSystem => false;
+
+    /// <summary>
+    /// Semver of the definition shape. Bumped when the widget set changes in a
+    /// breaking way; surfaced to admins as drift after import (ADR-038 §3).
+    /// </summary>
+    public virtual string Version => "1.0.0";
+
+    /// <summary>Grid layout configuration. Defaults to <see cref="DashboardLayout.Default"/>.</summary>
+    public virtual DashboardLayout Layout => DashboardLayout.Default;
+
+    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    public abstract IReadOnlyList<WidgetDefinition> Widgets { get; }
+}

--- a/src/Granit.Dashboards.Abstractions/DashboardLayout.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardLayout.cs
@@ -1,0 +1,15 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Coarse layout configuration applied to a dashboard's widget grid. Per ADR-038, the
+/// layout is intentionally minimal at the declarative level — the persisted
+/// <c>Dashboard</c> aggregate (story B2) and the frontend composer (story B5) own the
+/// fine-grained layout.
+/// </summary>
+/// <param name="Columns">Number of grid columns. Default 12 (standard responsive grid).</param>
+/// <param name="RowHeight">Row height in CSS pixels. Default 80.</param>
+public sealed record DashboardLayout(int Columns, int RowHeight)
+{
+    /// <summary>Conventional 12-column responsive grid with 80px row height.</summary>
+    public static DashboardLayout Default => new(12, 80);
+}

--- a/src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj
+++ b/src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Dashboards.Abstractions</PackageId>
+    <Description>Inter-module contracts for Granit.Dashboards: declarative DashboardDefinition base class, WidgetDefinition record hierarchy, layout/size value objects, registry interface, and presentation-only widgets (Markdown, Image, Text). Reference this package from any module that declares dashboards or widgets (Granit.Analytics, future Granit.IoT, ...); reference Granit.Dashboards only from hosts that execute, persist, or expose them.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Dashboards.Abstractions.Tests" />
+    <InternalsVisibleTo Include="Granit.Dashboards" />
+    <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit\Granit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Dashboards.Abstractions/GranitDashboardsAbstractionsModule.cs
+++ b/src/Granit.Dashboards.Abstractions/GranitDashboardsAbstractionsModule.cs
@@ -1,0 +1,19 @@
+using Granit.Modularity;
+
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Granit module for the dashboard contracts. Hosts only the declarative primitives
+/// (<see cref="DashboardDefinition"/>, <see cref="WidgetDefinition"/>, layout / size
+/// value objects, registry interface) plus the presentation-only widgets
+/// (<see cref="Widgets.MarkdownWidgetDefinition"/>, <see cref="Widgets.ImageWidgetDefinition"/>,
+/// <see cref="Widgets.TextWidgetDefinition"/>).
+/// </summary>
+/// <remarks>
+/// This module has no service registrations — it exists so that consumer modules
+/// (Granit.Analytics, future Granit.IoT.Dashboards, ...) can declare
+/// <c>[DependsOn(typeof(GranitDashboardsAbstractionsModule))]</c> without pulling in
+/// the registry / persistence / endpoints runtime that lives in
+/// <c>Granit.Dashboards</c>.
+/// </remarks>
+public sealed class GranitDashboardsAbstractionsModule : GranitModule;

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -1,0 +1,27 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Type-erased descriptor exposed for registry lookup. Lets the registry surface every
+/// registered <see cref="DashboardDefinition"/> without each consumer needing the
+/// concrete type.
+/// </summary>
+public interface IDashboardDefinitionDescriptor
+{
+    /// <summary>Unique wire identifier, e.g. <c>"Granit.Invoicing.FinanceOverview"</c>.</summary>
+    string Name { get; }
+
+    /// <summary>Coarse grouping driving catalogue ordering.</summary>
+    DashboardCategory Category { get; }
+
+    /// <summary>Whether the dashboard is mandated by the platform operator (cannot be deleted by tenant admins).</summary>
+    bool IsSystem { get; }
+
+    /// <summary>Semver — used for drift detection between definition and persisted dashboard.</summary>
+    string Version { get; }
+
+    /// <summary>Layout configuration applied to the widget grid.</summary>
+    DashboardLayout Layout { get; }
+
+    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    IReadOnlyList<WidgetDefinition> Widgets { get; }
+}

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionRegistry.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionRegistry.cs
@@ -1,0 +1,22 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Read-only registry of every <see cref="DashboardDefinition"/> registered across
+/// all loaded modules. Surfaces the catalogue to the import endpoint
+/// (story B4) and the admin import dialog (story B5).
+/// </summary>
+public interface IDashboardDefinitionRegistry
+{
+    /// <summary>
+    /// Returns every registered definition, ordered by <see cref="DashboardCategory"/>
+    /// then by <see cref="DashboardDefinition.Name"/> (ordinal). Stable ordering across
+    /// processes — useful for tests and snapshot fixtures.
+    /// </summary>
+    IReadOnlyList<IDashboardDefinitionDescriptor> GetAll();
+
+    /// <summary>
+    /// Looks up a definition by its wire identifier. Returns <c>null</c> when the name
+    /// is not registered (callers translate to a 404 at the HTTP layer).
+    /// </summary>
+    IDashboardDefinitionDescriptor? Find(string name);
+}

--- a/src/Granit.Dashboards.Abstractions/README.md
+++ b/src/Granit.Dashboards.Abstractions/README.md
@@ -1,0 +1,25 @@
+# Granit.Dashboards.Abstractions
+
+Inter-module contracts for `Granit.Dashboards`: `DashboardDefinition` declarative base
+class, `WidgetDefinition` record hierarchy, layout / size value objects, registry
+interface, and the three presentation-only widgets (`MarkdownWidgetDefinition`,
+`ImageWidgetDefinition`, `TextWidgetDefinition`). Reference this package from any
+module that declares dashboards or widgets (`Granit.Analytics`, future
+`Granit.IoT.Dashboards`, ...); reference `Granit.Dashboards` only from hosts that
+execute, persist, or expose them.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Dashboards.Abstractions
+```
+
+## Dependencies
+
+- `Granit`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
@@ -1,0 +1,27 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Base record for every widget shipped by a <see cref="DashboardDefinition"/>.
+/// Concrete widget kinds add their kind-specific configuration via inheritance — see
+/// <c>Granit.Dashboards.Abstractions</c> for presentation-only widgets, and per-domain
+/// packages (e.g. <c>Granit.Analytics</c>, future <c>Granit.IoT.Dashboards</c>) for
+/// data-bound widgets.
+/// </summary>
+/// <param name="Slug">
+/// Widget-local identifier (PascalCase, unique within the dashboard). Used to compose
+/// localization keys (<c>Widget:{DashboardName}.{Slug}</c>) and as the stable
+/// identifier under reorder operations.
+/// </param>
+/// <param name="Position">Dense-ranked grid order — 0-based, contiguous within the dashboard.</param>
+/// <param name="Size">Width / height in grid cells.</param>
+/// <param name="RequiredPermission">
+/// Optional override of the permission gating this widget at render time. When
+/// <c>null</c>, the runtime resolves the effective permission from the underlying
+/// data source (metric / query / IoT topic) — see ADR-038 §6.
+/// Presentation-only widgets ignore this field.
+/// </param>
+public abstract record WidgetDefinition(
+    string Slug,
+    int Position,
+    WidgetSize Size,
+    string? RequiredPermission = null);

--- a/src/Granit.Dashboards.Abstractions/WidgetSize.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetSize.cs
@@ -1,0 +1,24 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Width / height of a widget on the dashboard grid, expressed in grid cells.
+/// The frontend grid is conventionally 12 columns wide; widget heights are typically
+/// 1–6 rows. The runtime does not enforce a maximum — the rendering layer clamps
+/// values to its viewport.
+/// </summary>
+/// <param name="Width">Grid columns occupied by the widget. Must be &gt; 0.</param>
+/// <param name="Height">Grid rows occupied by the widget. Must be &gt; 0.</param>
+public sealed record WidgetSize(int Width, int Height)
+{
+    /// <summary>A small KPI card — 3×1 (a quarter row).</summary>
+    public static WidgetSize SmallKpi => new(3, 1);
+
+    /// <summary>A standard chart — half a row, two rows tall (6×2).</summary>
+    public static WidgetSize StandardChart => new(6, 2);
+
+    /// <summary>A full-width content widget (12×1) — typical for markdown banners.</summary>
+    public static WidgetSize FullWidthRow => new(12, 1);
+
+    /// <summary>A square media tile (4×4) — typical default for image / video widgets.</summary>
+    public static WidgetSize MediaTile => new(4, 4);
+}

--- a/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
@@ -1,0 +1,19 @@
+namespace Granit.Dashboards.Widgets;
+
+/// <summary>
+/// Static image tile — typically a logo, illustration, or contextual photo. The
+/// source can be an inline URL (CDN, public asset) or a Granit blob reference
+/// resolved at render time by the frontend.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="Source">URL or blob reference (e.g. <c>"blob:logo-banner"</c>, <c>"https://cdn..."</c>).</param>
+/// <param name="AltLocalizationKey">Localization key for the alt text (accessibility).</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.MediaTile"/>.</param>
+public sealed record ImageWidgetDefinition(
+    string Slug,
+    string Source,
+    string AltLocalizationKey,
+    int Position,
+    WidgetSize? Size = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile, RequiredPermission: null);

--- a/src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs
@@ -1,0 +1,17 @@
+namespace Granit.Dashboards.Widgets;
+
+/// <summary>
+/// Static markdown content — does not query the data layer. Used for dashboard
+/// banners, contextual notes, links to runbooks. Permission filtering does not apply
+/// (markdown is always visible to anyone who can see the dashboard).
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="ContentLocalizationKey">Localization key resolving to the markdown body (e.g. <c>"Widget:Granit.Invoicing.FinanceOverview.Banner"</c>).</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.FullWidthRow"/>.</param>
+public sealed record MarkdownWidgetDefinition(
+    string Slug,
+    string ContentLocalizationKey,
+    int Position,
+    WidgetSize? Size = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null);

--- a/src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs
@@ -1,0 +1,35 @@
+namespace Granit.Dashboards.Widgets;
+
+/// <summary>
+/// Plain text tile — short label or heading without markdown formatting. Lighter
+/// alternative to <see cref="MarkdownWidgetDefinition"/> for stable interface labels
+/// (page titles, section headers) where markdown rendering would be overkill.
+/// </summary>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="ContentLocalizationKey">Localization key for the text body.</param>
+/// <param name="Style">Visual style hint — interpreted by the frontend.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.FullWidthRow"/>.</param>
+public sealed record TextWidgetDefinition(
+    string Slug,
+    string ContentLocalizationKey,
+    TextStyle Style,
+    int Position,
+    WidgetSize? Size = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null);
+
+/// <summary>Visual style hint for <see cref="TextWidgetDefinition"/>.</summary>
+public enum TextStyle
+{
+    /// <summary>Default body-text size and weight.</summary>
+    Body = 0,
+
+    /// <summary>Page-level heading (h1).</summary>
+    Heading = 1,
+
+    /// <summary>Section subheading (h2 / h3).</summary>
+    Subheading = 2,
+
+    /// <summary>Smaller, secondary caption text.</summary>
+    Caption = 3,
+}

--- a/src/Granit.Dashboards.Abstractions/packages.lock.json
+++ b/src/Granit.Dashboards.Abstractions/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "granit": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+using Granit.Dashboards.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Dashboards.Extensions;
+
+/// <summary>
+/// Extension methods for registering <c>Granit.Dashboards</c> services and shipped
+/// dashboard definitions.
+/// </summary>
+public static class DashboardsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="IDashboardDefinitionRegistry"/> that surfaces every
+    /// registered <see cref="DashboardDefinition"/> across loaded modules.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitDashboards(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IDashboardDefinitionRegistry, DashboardDefinitionRegistry>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a dashboard definition. Each definition is exposed as a singleton
+    /// <see cref="IDashboardDefinitionDescriptor"/> picked up by the
+    /// <see cref="IDashboardDefinitionRegistry"/> at composition time.
+    /// </summary>
+    /// <typeparam name="TDefinition">The dashboard definition implementation.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDashboardDefinition<TDefinition>(this IServiceCollection services)
+        where TDefinition : DashboardDefinition, new()
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<TDefinition>(_ => new TDefinition());
+        services.AddSingleton<IDashboardDefinitionDescriptor>(sp => sp.GetRequiredService<TDefinition>());
+
+        return services;
+    }
+}

--- a/src/Granit.Dashboards/Granit.Dashboards.csproj
+++ b/src/Granit.Dashboards/Granit.Dashboards.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Dashboards</PackageId>
+    <Description>Dashboard composition runtime for Granit. Hosts the IDashboardDefinitionRegistry implementation and the AddDashboardDefinition&lt;T&gt;() DI extension. Future home of the persisted Dashboard aggregate, import/re-sync logic, and real-time hub. Reference Granit.Dashboards.Abstractions to declare dashboards or widgets; reference this package only from hosts that execute, persist, or expose them.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Dashboards/GranitDashboardsModule.cs
+++ b/src/Granit.Dashboards/GranitDashboardsModule.cs
@@ -1,0 +1,25 @@
+using Granit.Dashboards.Extensions;
+using Granit.Modularity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Granit module for the dashboard runtime. Registers the
+/// <see cref="IDashboardDefinitionRegistry"/> and provides the
+/// <c>AddDashboardDefinition&lt;TDefinition&gt;()</c> DI extension.
+/// </summary>
+/// <remarks>
+/// Per-domain widget catalogues live in their own modules (Granit.Analytics ships
+/// KPI / Chart / Table / Pivot widgets; future Granit.IoT.Dashboards will ship
+/// gauge / camera / alarm widgets). Persistence (<c>Dashboard</c> aggregate) and
+/// HTTP endpoints will land in <c>Granit.Dashboards.EntityFrameworkCore</c> /
+/// <c>Granit.Dashboards.Endpoints</c> in subsequent stories.
+/// </remarks>
+[DependsOn(typeof(GranitDashboardsAbstractionsModule))]
+public sealed class GranitDashboardsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitDashboards();
+}

--- a/src/Granit.Dashboards/Internal/DashboardDefinitionRegistry.cs
+++ b/src/Granit.Dashboards/Internal/DashboardDefinitionRegistry.cs
@@ -1,0 +1,30 @@
+namespace Granit.Dashboards.Internal;
+
+internal sealed class DashboardDefinitionRegistry : IDashboardDefinitionRegistry
+{
+    private readonly IReadOnlyList<IDashboardDefinitionDescriptor> _ordered;
+    private readonly Dictionary<string, IDashboardDefinitionDescriptor> _byName;
+
+    public DashboardDefinitionRegistry(IEnumerable<IDashboardDefinitionDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        IDashboardDefinitionDescriptor[] snapshot = descriptors.ToArray();
+
+        // Stable ordering: category index (declared enum order, broad-to-narrow), then
+        // dashboard name. Ordinal comparison keeps test fixtures deterministic.
+        _ordered = [.. snapshot
+            .OrderBy(d => (int)d.Category)
+            .ThenBy(d => d.Name, StringComparer.Ordinal)];
+
+        _byName = snapshot.ToDictionary(d => d.Name, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<IDashboardDefinitionDescriptor> GetAll() => _ordered;
+
+    public IDashboardDefinitionDescriptor? Find(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        return _byName.TryGetValue(name, out IDashboardDefinitionDescriptor? d) ? d : null;
+    }
+}

--- a/src/Granit.Dashboards/README.md
+++ b/src/Granit.Dashboards/README.md
@@ -1,0 +1,27 @@
+# Granit.Dashboards
+
+Dashboard composition runtime for Granit. Hosts the
+`IDashboardDefinitionRegistry` implementation and the
+`AddDashboardDefinition<T>()` DI extension. Future home of the persisted `Dashboard`
+aggregate, import / re-sync logic, and the real-time hub for IoT-style live tiles.
+
+Reference [Granit.Dashboards.Abstractions](../Granit.Dashboards.Abstractions/) to
+declare dashboards or widgets; reference this package only from hosts that execute,
+persist, or expose them.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Dashboards
+```
+
+## Dependencies
+
+- `Granit`
+- `Granit.Dashboards.Abstractions`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Dashboards/packages.lock.json
+++ b/src/Granit.Dashboards/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
@@ -59,6 +59,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -91,6 +92,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Builtin/packages.lock.json
+++ b/src/Granit.Invoicing.Builtin/packages.lock.json
@@ -59,6 +59,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -77,6 +78,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Endpoints/packages.lock.json
+++ b/src/Granit.Invoicing.Endpoints/packages.lock.json
@@ -38,6 +38,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -58,6 +59,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
@@ -117,6 +117,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -135,6 +136,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Notifications/packages.lock.json
+++ b/src/Granit.Invoicing.Notifications/packages.lock.json
@@ -59,6 +59,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -77,6 +78,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Odoo/packages.lock.json
+++ b/src/Granit.Invoicing.Odoo/packages.lock.json
@@ -230,6 +230,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -248,6 +249,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing/packages.lock.json
+++ b/src/Granit.Invoicing/packages.lock.json
@@ -72,6 +72,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -90,6 +91,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Tax.Builtin/packages.lock.json
+++ b/src/Granit.Tax.Builtin/packages.lock.json
@@ -235,6 +235,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -253,6 +254,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Tax.Stripe/packages.lock.json
+++ b/src/Granit.Tax.Stripe/packages.lock.json
@@ -264,6 +264,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -282,6 +283,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -210,15 +210,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -329,6 +329,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -377,6 +378,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
@@ -122,8 +122,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -220,15 +220,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -363,6 +363,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -373,6 +374,12 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
@@ -38,11 +38,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "Shouldly": {
@@ -96,8 +96,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -221,15 +221,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -357,6 +357,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -367,6 +368,12 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
@@ -1,0 +1,82 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards;
+
+/// <summary>
+/// Smoke-level coverage of the four analytics widget definition shapes shipped by
+/// <c>Granit.Analytics</c>. The purpose is to lock the public API (default sizes,
+/// nullable selectors, optional permission overrides), not to re-test record equality.
+/// </summary>
+public sealed class AnalyticsWidgetDefinitionTests
+{
+    [Fact]
+    public void Kpi_DefaultsToSmallKpiSize()
+    {
+        KpiWidgetDefinition widget = new("UnpaidCount", "Sample.UnpaidInvoiceCountMetric", Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.SmallKpi);
+        widget.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Kpi_AllowsRequiredPermissionOverride()
+    {
+        KpiWidgetDefinition widget = new(
+            Slug: "RestrictedKpi",
+            MetricName: "Sample.Metric",
+            Position: 0,
+            RequiredPermission: "Custom.Composite.Read");
+
+        widget.RequiredPermission.ShouldBe("Custom.Composite.Read");
+    }
+
+    [Fact]
+    public void Chart_DefaultsToStandardChartSize()
+    {
+        ChartWidgetDefinition widget = new(
+            Slug: "RevenueByMonth",
+            QueryName: "Sample.InvoiceQuery",
+            GroupBy: "IssuedAtMonth",
+            Aggregation: AggregateFunction.Sum,
+            Field: "Total",
+            ChartType: ChartType.Line,
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.StandardChart);
+        widget.ChartType.ShouldBe(ChartType.Line);
+    }
+
+    [Fact]
+    public void Table_AllowsNullVisibleColumns_AndCustomPageSize()
+    {
+        TableWidgetDefinition widget = new(
+            Slug: "RecentInvoices",
+            QueryName: "Sample.InvoiceQuery",
+            VisibleColumns: null,
+            PageSize: 25,
+            Position: 0);
+
+        widget.VisibleColumns.ShouldBeNull();
+        widget.PageSize.ShouldBe(25);
+    }
+
+    [Fact]
+    public void Pivot_AllowsNullValueField_WhenAggregationIsCount()
+    {
+        PivotWidgetDefinition widget = new(
+            Slug: "InvoicesByCustomerByMonth",
+            QueryName: "Sample.InvoiceQuery",
+            RowFields: ["CustomerName"],
+            ColumnFields: ["IssuedAtMonth"],
+            ValueField: null,
+            ValueAggregation: AggregateFunction.Count,
+            Position: 0);
+
+        widget.ValueField.ShouldBeNull();
+        widget.ValueAggregation.ShouldBe(AggregateFunction.Count);
+    }
+}

--- a/tests/Granit.Analytics.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -133,15 +133,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -247,7 +247,14 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.datalookup.abstractions": {

--- a/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
+++ b/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces story #1382 (B1): every widget reference inside a shipped
+/// <see cref="DashboardDefinition"/> MUST resolve at composition time.
+/// <see cref="KpiWidgetDefinition.MetricName"/> must match a registered
+/// <see cref="MetricDefinition{TEntity, TValue}"/>; the <c>QueryName</c> on
+/// chart / table / pivot widgets must match a registered
+/// <see cref="QueryDefinition{TEntity}"/>. Presentation-only widgets
+/// (<c>Markdown</c>, <c>Image</c>, <c>Text</c>) are not data-bound and skipped.
+/// </summary>
+/// <remarks>
+/// This catches the "dashboard shipped, metric was renamed, nobody noticed" failure
+/// mode at build time rather than at the first user-clicks-import in production.
+/// The test only enforces references for dashboards actually shipped by the
+/// framework — any new module that adds a dashboard automatically gets the check
+/// for free.
+/// </remarks>
+public sealed class DashboardWidgetReferenceTests
+{
+    [Fact]
+    public void Every_widget_reference_should_resolve_to_a_registered_metric_or_query()
+    {
+        Inventory inventory = ScanInventory();
+
+        if (inventory.Dashboards.Count == 0)
+        {
+            // No dashboards shipped yet — story B1 lands the abstractions; concrete
+            // dashboards arrive in follow-up stories. The test stays green and
+            // becomes load-bearing the moment a module ships its first dashboard.
+            return;
+        }
+
+        List<string> dangling = [];
+
+        foreach (DashboardDefinition dashboard in inventory.Dashboards)
+        {
+            foreach (WidgetDefinition widget in dashboard.Widgets)
+            {
+                switch (widget)
+                {
+                    case KpiWidgetDefinition kpi
+                        when !inventory.MetricNames.Contains(kpi.MetricName):
+                        dangling.Add($"{dashboard.Name}/{kpi.Slug} -> KPI references missing metric '{kpi.MetricName}'");
+                        break;
+
+                    case ChartWidgetDefinition chart
+                        when !inventory.QueryNames.Contains(chart.QueryName):
+                        dangling.Add($"{dashboard.Name}/{chart.Slug} -> Chart references missing query '{chart.QueryName}'");
+                        break;
+
+                    case TableWidgetDefinition table
+                        when !inventory.QueryNames.Contains(table.QueryName):
+                        dangling.Add($"{dashboard.Name}/{table.Slug} -> Table references missing query '{table.QueryName}'");
+                        break;
+
+                    case PivotWidgetDefinition pivot
+                        when !inventory.QueryNames.Contains(pivot.QueryName):
+                        dangling.Add($"{dashboard.Name}/{pivot.Slug} -> Pivot references missing query '{pivot.QueryName}'");
+                        break;
+                }
+            }
+        }
+
+        dangling.ShouldBeEmpty(
+            "Story #1382 (B1): every widget in a shipped DashboardDefinition must reference " +
+            "an existing MetricDefinition (KPI) or QueryDefinition (Chart, Table, Pivot). " +
+            "Dangling references almost always mean a metric / query was renamed without " +
+            "updating the dashboards that depended on it. Either fix the reference or remove " +
+            "the widget from the dashboard." + Environment.NewLine +
+            string.Join(Environment.NewLine, dangling.Order(StringComparer.Ordinal)));
+    }
+
+    private static Inventory ScanInventory()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(DashboardWidgetReferenceTests).Assembly.Location)!;
+
+        Assembly[] assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<DashboardDefinition> dashboards = [];
+        HashSet<string> metricNames = new(StringComparer.Ordinal);
+        HashSet<string> queryNames = new(StringComparer.Ordinal);
+
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                {
+                    continue;
+                }
+
+                if (typeof(DashboardDefinition).IsAssignableFrom(type))
+                {
+                    DashboardDefinition? dashboard = TryCreate<DashboardDefinition>(type);
+                    if (dashboard is not null)
+                    {
+                        dashboards.Add(dashboard);
+                    }
+
+                    continue;
+                }
+
+                if (DerivesFromOpenGeneric(type, typeof(MetricDefinition<,>)))
+                {
+                    IMetricDefinitionDescriptor? descriptor = TryCreate<IMetricDefinitionDescriptor>(type);
+                    if (descriptor is not null)
+                    {
+                        metricNames.Add(descriptor.Name);
+                    }
+
+                    continue;
+                }
+
+                if (DerivesFromOpenGeneric(type, typeof(QueryDefinition<>)))
+                {
+                    object? instance = TryCreate<object>(type);
+                    if (instance is not null)
+                    {
+                        string? name = (string?)type.GetProperty("Name", BindingFlags.Instance | BindingFlags.Public)?.GetValue(instance);
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            queryNames.Add(name);
+                        }
+                    }
+                }
+            }
+        }
+
+        return new Inventory(dashboards, metricNames, queryNames);
+    }
+
+    private static T? TryCreate<T>(Type type)
+        where T : class
+    {
+        try { return Activator.CreateInstance(type) as T; }
+        catch (Exception) { return null; }
+    }
+
+    private static bool DerivesFromOpenGeneric(Type candidate, Type openGenericBase)
+    {
+        for (Type? cursor = candidate.BaseType; cursor is not null; cursor = cursor.BaseType)
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed record Inventory(
+        List<DashboardDefinition> Dashboards,
+        HashSet<string> MetricNames,
+        HashSet<string> QueryNames);
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -44,6 +44,8 @@
     <ProjectReference Include="..\..\src\Granit.Analytics.Endpoints\Granit.Analytics.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.ConfigurationChanges\Granit.Auditing.ConfigurationChanges.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.EntityFrameworkCore\Granit.Auditing.EntityFrameworkCore.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "Shouldly": {
@@ -561,8 +561,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Data.SqlClient": {
         "type": "Transitive",
@@ -816,15 +816,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1487,6 +1487,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -1948,6 +1949,19 @@
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange": {

--- a/tests/Granit.Dashboards.Abstractions.Tests/Granit.Dashboards.Abstractions.Tests.csproj
+++ b/tests/Granit.Dashboards.Abstractions.Tests/Granit.Dashboards.Abstractions.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Dashboards.Abstractions.Tests/GranitDashboardsAbstractionsModuleTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/GranitDashboardsAbstractionsModuleTests.cs
@@ -1,0 +1,27 @@
+using Granit.Dashboards;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+public sealed class GranitDashboardsAbstractionsModuleTests
+{
+    [Fact]
+    public void Module_IsGranitModule()
+    {
+        GranitDashboardsAbstractionsModule module = new();
+
+        module.ShouldBeAssignableTo<GranitModule>();
+    }
+
+    [Fact]
+    public void Module_HasNoServiceRegistrations()
+    {
+        // Pure contracts module — exists for [DependsOn] composition only. The DI
+        // surface for dashboards lives in the runtime package (Granit.Dashboards).
+        GranitDashboardsAbstractionsModule module = new();
+
+        module.ShouldNotBeNull();
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Abstractions.Tests/packages.lock.json
@@ -1,0 +1,232 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Dashboards.Tests/DashboardDefinitionRegistryTests.cs
+++ b/tests/Granit.Dashboards.Tests/DashboardDefinitionRegistryTests.cs
@@ -1,0 +1,120 @@
+using Granit.Dashboards.Extensions;
+using Granit.Dashboards.Widgets;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Tests;
+
+public sealed class DashboardDefinitionRegistryTests
+{
+    [Fact]
+    public void AddDashboardDefinition_RegistersDescriptorAndConcreteType()
+    {
+        ServiceCollection services = new();
+        services.AddGranitDashboards();
+        services.AddDashboardDefinition<MarkdownOnlyDashboard>();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        MarkdownOnlyDashboard concrete = provider.GetRequiredService<MarkdownOnlyDashboard>();
+        IEnumerable<IDashboardDefinitionDescriptor> descriptors =
+            provider.GetServices<IDashboardDefinitionDescriptor>();
+
+        descriptors.ShouldContain(concrete);
+        descriptors.Single().Name.ShouldBe("Sample.MarkdownOnly");
+    }
+
+    [Fact]
+    public void GetAll_OrdersByCategoryThenName()
+    {
+        ServiceCollection services = new();
+        services.AddGranitDashboards();
+        services.AddDashboardDefinition<OperationsDashboard>(); // Operations (category=2)
+        services.AddDashboardDefinition<MarkdownOnlyDashboard>(); // General (category=0)
+        services.AddDashboardDefinition<AlphaGeneralDashboard>(); // General (category=0)
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        IReadOnlyList<IDashboardDefinitionDescriptor> ordered = registry.GetAll();
+
+        ordered.Select(d => d.Name).ShouldBe([
+            "Sample.AlphaGeneral",
+            "Sample.MarkdownOnly",
+            "Sample.Operations",
+        ]);
+    }
+
+    [Fact]
+    public void Find_ReturnsDescriptor_WhenRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddGranitDashboards();
+        services.AddDashboardDefinition<MarkdownOnlyDashboard>();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        IDashboardDefinitionDescriptor? found = registry.Find("Sample.MarkdownOnly");
+
+        found.ShouldNotBeNull();
+        found.Name.ShouldBe("Sample.MarkdownOnly");
+    }
+
+    [Fact]
+    public void Find_ReturnsNull_WhenNotRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddGranitDashboards();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        registry.Find("Sample.Missing").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Find_Throws_OnNullOrEmptyName()
+    {
+        ServiceCollection services = new();
+        services.AddGranitDashboards();
+
+        IDashboardDefinitionRegistry registry =
+            services.BuildServiceProvider().GetRequiredService<IDashboardDefinitionRegistry>();
+
+        Should.Throw<ArgumentException>(() => registry.Find(string.Empty));
+        Should.Throw<ArgumentException>(() => registry.Find(null!));
+    }
+
+    private sealed class MarkdownOnlyDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.MarkdownOnly";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new MarkdownWidgetDefinition("Banner", "Widget:Sample.MarkdownOnly.Banner", Position: 0),
+        ];
+    }
+
+    private sealed class AlphaGeneralDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.AlphaGeneral";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new TextWidgetDefinition("Title", "Widget:Sample.AlphaGeneral.Title", TextStyle.Heading, Position: 0),
+        ];
+    }
+
+    private sealed class OperationsDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Operations";
+        public override DashboardCategory Category => DashboardCategory.Operations;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [
+            new ImageWidgetDefinition(
+                "Logo",
+                Source: "https://cdn.example.com/logo.png",
+                AltLocalizationKey: "Widget:Sample.Operations.Logo.Alt",
+                Position: 0),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Tests/Granit.Dashboards.Tests.csproj
+++ b/tests/Granit.Dashboards.Tests/Granit.Dashboards.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Dashboards\Granit.Dashboards.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Dashboards.Tests/Widgets/PresentationWidgetTests.cs
+++ b/tests/Granit.Dashboards.Tests/Widgets/PresentationWidgetTests.cs
@@ -1,0 +1,51 @@
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Tests.Widgets;
+
+/// <summary>
+/// Locks the public shape of the three presentation-only widgets shipped by
+/// <c>Granit.Dashboards.Abstractions</c>. Permission filtering does not apply to
+/// these widgets — they are always visible to anyone who can see the dashboard.
+/// </summary>
+public sealed class PresentationWidgetTests
+{
+    [Fact]
+    public void Markdown_DefaultsToFullWidthRow_AndIgnoresPermissions()
+    {
+        MarkdownWidgetDefinition widget = new(
+            Slug: "Banner",
+            ContentLocalizationKey: "Widget:Sample.Banner",
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.FullWidthRow);
+        widget.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Image_DefaultsToMediaTile_AndIgnoresPermissions()
+    {
+        ImageWidgetDefinition widget = new(
+            Slug: "Logo",
+            Source: "https://cdn.example.com/logo.png",
+            AltLocalizationKey: "Widget:Sample.Logo.Alt",
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.MediaTile);
+        widget.RequiredPermission.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Text_DefaultsToFullWidthRow_AndCarriesStyle()
+    {
+        TextWidgetDefinition widget = new(
+            Slug: "Title",
+            ContentLocalizationKey: "Widget:Sample.Title",
+            Style: TextStyle.Heading,
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.FullWidthRow);
+        widget.Style.ShouldBe(TextStyle.Heading);
+    }
+}

--- a/tests/Granit.Dashboards.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Tests/packages.lock.json
@@ -1,0 +1,261 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -172,15 +172,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -291,6 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -323,6 +324,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -172,15 +172,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -291,6 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -309,6 +310,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -34,11 +34,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -130,8 +130,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -399,15 +399,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -518,6 +518,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -544,6 +545,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
@@ -122,8 +122,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -229,15 +229,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -377,6 +377,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -395,6 +396,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
@@ -49,11 +49,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -129,8 +129,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -430,15 +430,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -576,6 +576,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -603,6 +604,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -172,15 +172,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -291,6 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -309,6 +310,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -300,15 +300,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -448,6 +448,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -466,6 +467,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -172,15 +172,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -291,6 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -309,6 +310,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Tax.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Builtin.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -305,15 +305,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -453,6 +453,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -471,6 +472,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Tax.Stripe.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Stripe.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.5.0",
-        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.0",
-          "Microsoft.TestPlatform.TestHost": "18.5.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -300,15 +300,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.0",
-        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -462,6 +462,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -480,6 +481,12 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {


### PR DESCRIPTION
## Summary

Closes #1382. Replaces **#1451** (closed) with the corrected architecture surfaced during review: the declarative dashboard primitive must not live under `Granit.Analytics` — future real-time IoT dashboards (gauges, camera feeds, alarm lights) cannot reasonably take a transitive dependency on `Granit.QueryEngine` just to declare a widget.

The split mirrors the established Granit pattern (`QueryEngine.Abstractions` / `DataExchange.Abstractions`): a lightweight Abstractions package carries the contracts + presentation-only widgets; the runtime package hosts the registry and the future `Dashboard` aggregate / persistence / endpoints / real-time hub.

### Package architecture

| Package | Contents |
| --- | --- |
| **`Granit.Dashboards.Abstractions`** (new) | `DashboardDefinition`, `WidgetDefinition` (base), `DashboardLayout`, `WidgetSize`, `IDashboardDefinitionRegistry`, `DashboardCategory`. Plus presentation-only widgets shared across all domains: **`MarkdownWidgetDefinition`**, **`ImageWidgetDefinition`**, **`TextWidgetDefinition`**. |
| **`Granit.Dashboards`** (new) | `DashboardDefinitionRegistry` impl, `AddGranitDashboards()` + `AddDashboardDefinition<TDef>()` DI extensions. Future home of the persisted `Dashboard` aggregate, import / re-sync logic, and the real-time hub for IoT live tiles. |
| **`Granit.Analytics`** (updated) | KPI / Chart / Table / Pivot widgets. Now `[DependsOn(GranitDashboardsAbstractionsModule, GranitQueryEngineAbstractionsModule)]`. |
| `Granit.IoT.Dashboards` (future) | Will ship gauge / camera / alarm widgets against `Granit.Dashboards.Abstractions` without touching `Granit.Analytics`. |

### Tests

- **`Granit.Dashboards.Abstractions.Tests`** — module class assertions (2/2)
- **`Granit.Dashboards.Tests`** — registry ordering / lookup / null-safety + the three presentation widget shapes (8/8)
- **`Granit.Analytics.Tests`** — five analytics widget shapes locking the public API (12/12 total)
- **`Granit.ArchitectureTests/DashboardWidgetReferenceTests`** — every KPI / Chart / Table / Pivot reference must resolve to a registered metric / query at build time. Stays green today; load-bearing the moment any module ships its first dashboard. **156/156** archi green.

### Plumbing

- `README.md` for both new packages (DoD + archi test)
- `test-shards.json`: `Dashboards.*.Tests` in the **`business`** shard; `.slnf` filters regenerated via `scripts/generate-shard-filters.py`
- `packages.lock.json` refreshed for every project transitively depending on `Granit.Analytics` (`Invoicing.*` + `Tax.*` + their `.Tests`) to absorb the new transitive ref to `Granit.Dashboards.Abstractions`

### ADR-038 amended

- §1 *Two types, two homes* expanded into a three-package family with explicit dependency direction (analytics widgets → Abstractions, IoT widgets → Abstractions)
- Migration order rewritten: B2 now lands persistence in **`Granit.Dashboards.EntityFrameworkCore`**, not `Granit.Analytics.EntityFrameworkCore`
- Consequences updated with the *domain-extensible* property as the load-bearing rationale

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Abstractions src/Granit.Dashboards src/Granit.Analytics` — clean
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 2/2
- [x] `dotnet test tests/Granit.Dashboards.Tests` — 8/8
- [x] `dotnet test tests/Granit.Analytics.Tests` — 12/12
- [x] `dotnet test tests/Granit.ArchitectureTests` — 156/156
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet format .github/shard-filters/architecture.slnf --verify-no-changes` — clean
- [x] `npx markdownlint-cli2 docs-site/.../038-*.md` — clean
- [x] All `packages.lock.json` regenerated (`dotnet restore --force-evaluate`)
- [ ] CI green (depends on docs-fix #1450 landing first to unblock Cloudflare Pages)