### PR TITLE
feat(dashboards): wire-format hardening (P1.1 polymorphism + P1.2 ImageFit + P1.4 responsive + P3.1 + P3.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4072,6 +4072,22 @@
       ]
     },
     {
+      "name": "AnalyticsWidgetSerialization",
+      "fqn": "Granit.Analytics.Dashboards.Json.AnalyticsWidgetSerialization",
+      "kind": "class",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddAnalyticsWidgets",
+          "kind": "method",
+          "signature": "AddAnalyticsWidgets(this JsonSerializerOptions options)",
+          "returnType": "JsonSerializerOptions"
+        }
+      ]
+    },
+    {
       "name": "ChartType",
       "fqn": "Granit.Analytics.Dashboards.Widgets.ChartType",
       "kind": "enum",
@@ -12512,6 +12528,15 @@
       ]
     },
     {
+      "name": "DashboardBreakpoint",
+      "fqn": "Granit.Dashboards.DashboardBreakpoint",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardLayout.cs",
+      "line": 40,
+      "members": []
+    },
+    {
       "name": "DashboardCategory",
       "fqn": "Granit.Dashboards.DashboardCategory",
       "kind": "enum",
@@ -12554,7 +12579,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/DashboardLayout.cs",
-      "line": 11,
+      "line": 24,
       "members": [
         {
           "name": "new",
@@ -12563,6 +12588,15 @@
           "returnType": "DashboardLayout Default =>"
         }
       ]
+    },
+    {
+      "name": "DashboardLayoutOverride",
+      "fqn": "Granit.Dashboards.DashboardLayoutOverride",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardLayout.cs",
+      "line": 71,
+      "members": []
     },
     {
       "name": "Dashboard",
@@ -12783,7 +12817,7 @@
       "kind": "class",
       "project": "Granit.Dashboards",
       "file": "src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDashboards",
@@ -12824,7 +12858,7 @@
       "kind": "interface",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs",
-      "line": 8,
+      "line": 23,
       "members": []
     },
     {
@@ -12850,12 +12884,37 @@
       ]
     },
     {
+      "name": "WidgetDefinitionPolymorphism",
+      "fqn": "Granit.Dashboards.Json.WidgetDefinitionPolymorphism",
+      "kind": "class",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Json/WidgetDefinitionPolymorphism.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IVariableSubstituter",
+      "fqn": "Granit.Dashboards.Templating.IVariableSubstituter",
+      "kind": "interface",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Templating/IVariableSubstituter.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Substitute",
+          "kind": "method",
+          "signature": "Substitute(string? input, IReadOnlyDictionary<string, object?> context)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
       "name": "WidgetDefinition",
       "fqn": "Granit.Dashboards.WidgetDefinition",
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/WidgetDefinition.cs",
-      "line": 23,
+      "line": 39,
       "members": []
     },
     {
@@ -12893,12 +12952,21 @@
       ]
     },
     {
+      "name": "ImageFit",
+      "fqn": "Granit.Dashboards.Widgets.ImageFit",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs",
+      "line": 28,
+      "members": []
+    },
+    {
       "name": "ImageWidgetDefinition",
       "fqn": "Granit.Dashboards.Widgets.ImageWidgetDefinition",
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs",
-      "line": 13,
+      "line": 18,
       "members": []
     },
     {

--- a/src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs
+++ b/src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards.Json;
+
+namespace Granit.Analytics.Dashboards.Json;
+
+/// <summary>
+/// Convenience helpers wiring the four analytics-flavoured widget kinds
+/// (<see cref="KpiWidgetDefinition"/>, <see cref="ChartWidgetDefinition"/>,
+/// <see cref="TableWidgetDefinition"/>, <see cref="PivotWidgetDefinition"/>) into
+/// the JSON polymorphism chain shared by the dashboards stack.
+/// </summary>
+/// <remarks>
+/// Hosts that expose dashboard endpoints call
+/// <see cref="AddAnalyticsWidgets(JsonSerializerOptions)"/> once on their shared
+/// <see cref="JsonSerializerOptions"/> at startup. The discriminators (<c>"kpi"</c>,
+/// <c>"chart"</c>, <c>"table"</c>, <c>"pivot"</c>) become the contract surfaced to
+/// frontends and stay stable across module upgrades.
+/// </remarks>
+public static class AnalyticsWidgetSerialization
+{
+    /// <summary>Registers the four analytics widget kinds on the supplied options.</summary>
+    /// <param name="options">Target serializer options.</param>
+    /// <returns>The same <paramref name="options"/> for chaining.</returns>
+    public static JsonSerializerOptions AddAnalyticsWidgets(this JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.AddDerivedType<KpiWidgetDefinition>("kpi");
+        options.AddDerivedType<ChartWidgetDefinition>("chart");
+        options.AddDerivedType<TableWidgetDefinition>("table");
+        options.AddDerivedType<PivotWidgetDefinition>("pivot");
+
+        return options;
+    }
+}

--- a/src/Granit.Dashboards.Abstractions/DashboardLayout.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardLayout.cs
@@ -1,15 +1,76 @@
 namespace Granit.Dashboards;
 
 /// <summary>
-/// Coarse layout configuration applied to a dashboard's widget grid. Per ADR-038, the
-/// layout is intentionally minimal at the declarative level — the persisted
-/// <c>Dashboard</c> aggregate (story B2) and the frontend composer (story B5) own the
-/// fine-grained layout.
+/// Layout configuration for a dashboard's widget grid. Carries a base configuration
+/// applied at every viewport plus optional per-breakpoint overrides — same model
+/// ThingsBoard ships, scaled down to one grid (the dual-pane container is deferred
+/// to v2 — see ADR-038).
 /// </summary>
-/// <param name="Columns">Number of grid columns. Default 12 (standard responsive grid).</param>
-/// <param name="RowHeight">Row height in CSS pixels. Default 80.</param>
-public sealed record DashboardLayout(int Columns, int RowHeight)
+/// <param name="Columns">Number of grid columns at the base viewport. Default 12.</param>
+/// <param name="RowHeight">Row height in CSS pixels at the base viewport. Default 80.</param>
+/// <param name="WidgetSizes">
+/// Per-widget size overrides keyed by <c>WidgetDefinition.Slug</c>. <c>null</c> = use
+/// the widget's default <c>Size</c> from its definition.
+/// </param>
+/// <param name="WidgetOrder">
+/// Optional Slug ordering — when present, overrides the widget's <c>Position</c> for
+/// this layout. Widgets not listed are appended in declared <c>Position</c> order.
+/// </param>
+/// <param name="Breakpoints">
+/// Per-breakpoint overrides. Each entry is a partial layout merged onto the base when
+/// the viewport hits the corresponding <see cref="DashboardBreakpoint"/>. Missing
+/// breakpoints fall through to the base.
+/// </param>
+public sealed record DashboardLayout(
+    int Columns,
+    int RowHeight,
+    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
+    IReadOnlyList<string>? WidgetOrder = null,
+    IReadOnlyDictionary<DashboardBreakpoint, DashboardLayoutOverride>? Breakpoints = null)
 {
-    /// <summary>Conventional 12-column responsive grid with 80px row height.</summary>
+    /// <summary>Conventional 12-column responsive grid with 80px row height and no overrides.</summary>
     public static DashboardLayout Default => new(12, 80);
 }
+
+/// <summary>
+/// Tailwind / Bootstrap-style viewport breakpoints. The <see cref="DashboardLayout.Breakpoints"/>
+/// dictionary lets a dashboard ship a different layout per breakpoint without forking
+/// the widget pool.
+/// </summary>
+public enum DashboardBreakpoint
+{
+    /// <summary>Extra-small (mobile portrait).</summary>
+    Xs = 0,
+
+    /// <summary>Small (mobile landscape, small tablets).</summary>
+    Sm = 1,
+
+    /// <summary>Medium (tablets, narrow desktops).</summary>
+    Md = 2,
+
+    /// <summary>Large (desktops).</summary>
+    Lg = 3,
+
+    /// <summary>Extra-large (wide desktops, large monitors).</summary>
+    Xl = 4,
+}
+
+/// <summary>
+/// Partial layout — merged onto the base <see cref="DashboardLayout"/> when a viewport
+/// hits the matching <see cref="DashboardBreakpoint"/>. Every field is nullable so
+/// overrides stay scoped to what actually changes per breakpoint.
+/// </summary>
+/// <param name="Columns">Override the base column count at this breakpoint.</param>
+/// <param name="RowHeight">Override the base row height at this breakpoint.</param>
+/// <param name="WidgetSizes">Per-widget size overrides keyed by <c>WidgetDefinition.Slug</c>.</param>
+/// <param name="WidgetOrder">Override the widget order at this breakpoint.</param>
+/// <param name="HiddenWidgets">
+/// Slugs to hide at this breakpoint. The widgets remain in the pool — only the layout
+/// drops them, which keeps state intact when the viewport flips back.
+/// </param>
+public sealed record DashboardLayoutOverride(
+    int? Columns = null,
+    int? RowHeight = null,
+    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
+    IReadOnlyList<string>? WidgetOrder = null,
+    IReadOnlySet<string>? HiddenWidgets = null);

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -5,6 +5,21 @@ namespace Granit.Dashboards;
 /// registered <see cref="DashboardDefinition"/> without each consumer needing the
 /// concrete type.
 /// </summary>
+/// <remarks>
+/// User-facing strings are not on the descriptor — they are resolved from
+/// localization keys composed off the descriptor's <see cref="Name"/>:
+///
+/// <list type="bullet">
+///   <item><c>Dashboard:{Name}</c> — display title (required, ships in all 18 cultures).</item>
+///   <item><c>Dashboard:{Name}.Description</c> — secondary description shown in the
+///         catalogue / import dialog (optional). Modules ship the keys for their
+///         default cultures; tenants override them via <c>Granit.Localization.Overrides</c>.</item>
+///   <item><c>Widget:{Name}.{Slug}</c> — per-widget content (markdown body, image alt
+///         text, plain text body, KPI title, ...). The exact key is on each widget's
+///         <c>*LocalizationKey</c> property — this convention exists so the catalogue
+///         can pre-fetch them in one batch.</item>
+/// </list>
+/// </remarks>
 public interface IDashboardDefinitionDescriptor
 {
     /// <summary>Unique wire identifier, e.g. <c>"Granit.Invoicing.FinanceOverview"</c>.</summary>

--- a/src/Granit.Dashboards.Abstractions/Json/WidgetDefinitionPolymorphism.cs
+++ b/src/Granit.Dashboards.Abstractions/Json/WidgetDefinitionPolymorphism.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Granit.Dashboards.Json;
+
+/// <summary>
+/// Helpers to extend <see cref="WidgetDefinition"/>'s polymorphic JSON contract from
+/// downstream packages — the three presentation-only widgets (Markdown, Image, Text)
+/// are registered via <see cref="System.Text.Json.Serialization.JsonDerivedTypeAttribute"/>
+/// directly on the base record, but data-bound widget kinds shipped by domain modules
+/// (<c>Granit.Analytics</c>, future <c>Granit.IoT.Dashboards</c>, ...) cannot back-reference
+/// the abstractions package. Those modules call
+/// <see cref="AddDerivedType{TWidget}(JsonSerializerOptions, string)"/> at registration time
+/// to extend the polymorphism chain without inverting the dependency direction.
+/// </summary>
+public static class WidgetDefinitionPolymorphism
+{
+    /// <summary>
+    /// Adds a <see cref="WidgetDefinition"/>-derived type to the polymorphic JSON contract
+    /// on the supplied <paramref name="options"/>. The discriminator string travels on the
+    /// wire; pick a stable, lowercase, kebab-friendly tag (e.g. <c>"kpi"</c>, <c>"chart"</c>,
+    /// <c>"iot.gauge"</c>).
+    /// </summary>
+    /// <typeparam name="TWidget">A concrete <see cref="WidgetDefinition"/>-derived type.</typeparam>
+    /// <param name="options">Target serializer options — typically the host's shared
+    /// <c>JsonSerializerOptions</c>.</param>
+    /// <param name="discriminator">Stable type tag emitted on the wire under the
+    /// <c>"type"</c> property name.</param>
+    public static JsonSerializerOptions AddDerivedType<TWidget>(
+        this JsonSerializerOptions options,
+        string discriminator)
+        where TWidget : WidgetDefinition
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(discriminator);
+
+        options.TypeInfoResolver = (options.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver())
+            .WithAddedModifier(typeInfo =>
+            {
+                if (typeInfo.Type != typeof(WidgetDefinition))
+                {
+                    return;
+                }
+
+                typeInfo.PolymorphismOptions ??= new JsonPolymorphismOptions
+                {
+                    TypeDiscriminatorPropertyName = "type",
+                };
+
+                typeInfo.PolymorphismOptions.DerivedTypes.Add(
+                    new JsonDerivedType(typeof(TWidget), discriminator));
+            });
+
+        return options;
+    }
+}

--- a/src/Granit.Dashboards.Abstractions/Templating/IVariableSubstituter.cs
+++ b/src/Granit.Dashboards.Abstractions/Templating/IVariableSubstituter.cs
@@ -1,0 +1,35 @@
+namespace Granit.Dashboards.Templating;
+
+/// <summary>
+/// Resolves <c>${variable}</c> placeholders in declarative dashboard strings (widget
+/// titles, action params, filter values, ...) against a typed context. Implementations
+/// MUST stay limited to literal variable lookup — no expression syntax, no scripting,
+/// no piping. Anything more sophisticated belongs in the data pipeline (metric
+/// definition, query) rather than a input literal.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Composition order recognised by <see cref="DefaultVariableSubstituter"/> (later wins):
+/// state parameters, resolved entity aliases (story P2.3), the active dashboard time
+/// window, the row data when invoked from a row-click action, and the series data
+/// when invoked from a chart series-click action. Consumers compose the dictionary
+/// at dispatch time.
+/// </para>
+/// <para>
+/// Unknown variables resolve to an empty string AND surface a structured log warning;
+/// the substituter never throws so a typo in a input degrades visibly without
+/// breaking the dashboard render.
+/// </para>
+/// </remarks>
+public interface IVariableSubstituter
+{
+    /// <summary>
+    /// Substitutes <c>${variable}</c> placeholders in <paramref name="input"/>
+    /// against <paramref name="context"/>. Lookups are case-sensitive.
+    /// </summary>
+    /// <param name="input">The input string. <c>null</c> returns <c>null</c>; empty returns empty.</param>
+    /// <param name="context">Variable name → value lookup. Values are formatted via
+    /// <see cref="object.ToString"/>; <c>null</c> values render as empty.</param>
+    /// <returns>The resolved string.</returns>
+    string? Substitute(string? input, IReadOnlyDictionary<string, object?> context);
+}

--- a/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using Granit.Dashboards.Widgets;
+
 namespace Granit.Dashboards;
 
 /// <summary>
@@ -20,6 +23,19 @@ namespace Granit.Dashboards;
 /// data source (metric / query / IoT topic) — see ADR-038 §6.
 /// Presentation-only widgets ignore this field.
 /// </param>
+/// <remarks>
+/// JSON polymorphism uses a stable <c>"type"</c> discriminator with short tags
+/// (<c>"markdown"</c>, <c>"image"</c>, <c>"text"</c>, <c>"kpi"</c>, ...). The three
+/// presentation-only kinds are registered here via <see cref="JsonDerivedTypeAttribute"/>;
+/// data-bound kinds defined in downstream packages (<c>Granit.Analytics</c>,
+/// <c>Granit.IoT.Dashboards</c>, ...) extend the chain at runtime through
+/// <see cref="WidgetDefinitionPolymorphism.AddDerivedType{TWidget}"/>. Avoids leaking
+/// CLR type names into the wire format.
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(MarkdownWidgetDefinition), "markdown")]
+[JsonDerivedType(typeof(ImageWidgetDefinition), "image")]
+[JsonDerivedType(typeof(TextWidgetDefinition), "text")]
 public abstract record WidgetDefinition(
     string Slug,
     int Position,

--- a/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
@@ -10,10 +10,30 @@ namespace Granit.Dashboards.Widgets;
 /// <param name="AltLocalizationKey">Localization key for the alt text (accessibility).</param>
 /// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
 /// <param name="Size">Defaults to <see cref="WidgetSize.MediaTile"/>.</param>
+/// <param name="Fit">
+/// How the image fills the cell. Defaults to <see cref="ImageFit.Contain"/>
+/// (preserves aspect, letterboxes) — the right call for logos. Use
+/// <see cref="ImageFit.Cover"/> for banner photos that should fill the tile.
+/// </param>
 public sealed record ImageWidgetDefinition(
     string Slug,
     string Source,
     string AltLocalizationKey,
     int Position,
-    WidgetSize? Size = null)
+    WidgetSize? Size = null,
+    ImageFit Fit = ImageFit.Contain)
     : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile, RequiredPermission: null);
+
+/// <summary>How an <see cref="ImageWidgetDefinition"/> fills its grid cell.</summary>
+public enum ImageFit
+{
+    /// <summary>Preserve aspect ratio, letterbox to fit. Right for logos.</summary>
+    Contain = 0,
+
+    /// <summary>Fill the cell, crop to maintain aspect. Right for banner photos.</summary>
+    Cover = 1,
+
+    /// <summary>Stretch to fill (rarely correct — distorts the image).</summary>
+    Fill = 2,
+}
+

--- a/src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards/Extensions/DashboardsServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Granit.Dashboards.Internal;
+using Granit.Dashboards.Internal.Templating;
+using Granit.Dashboards.Templating;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -21,6 +23,7 @@ public static class DashboardsServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<IDashboardDefinitionRegistry, DashboardDefinitionRegistry>();
+        services.TryAddSingleton<IVariableSubstituter, DefaultVariableSubstituter>();
 
         return services;
     }

--- a/src/Granit.Dashboards/Internal/Templating/DefaultVariableSubstituter.cs
+++ b/src/Granit.Dashboards/Internal/Templating/DefaultVariableSubstituter.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using Granit.Dashboards.Templating;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Dashboards.Internal.Templating;
+
+/// <summary>
+/// Default <see cref="IVariableSubstituter"/> implementation: pure regex-driven
+/// <c>${variable}</c> replacement, no scripting. Unknown variables log a warning
+/// and resolve to empty.
+/// </summary>
+internal sealed partial class DefaultVariableSubstituter(
+    ILogger<DefaultVariableSubstituter> logger) : IVariableSubstituter
+{
+    // ${name} where name is any non-`}` characters. Bounded to avoid backtracking.
+    [GeneratedRegex(@"\$\{(?<name>[^}]+)\}", RegexOptions.None, matchTimeoutMilliseconds: 200)]
+    private static partial Regex VariableRegex();
+
+    public string? Substitute(string? input, IReadOnlyDictionary<string, object?> context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        return VariableRegex().Replace(input, match =>
+        {
+            string name = match.Groups["name"].Value;
+            if (context.TryGetValue(name, out object? value))
+            {
+                return value?.ToString() ?? string.Empty;
+            }
+
+            LogUnknownVariable(name);
+            return string.Empty;
+        });
+    }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning,
+        Message = "Variable '{VariableName}' is not present in the substitution context — replaced with empty.")]
+    private partial void LogUnknownVariable(string variableName);
+}

--- a/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using Granit.Analytics.Dashboards.Json;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards.Json;
+
+/// <summary>
+/// Exercises the round-trip for the four analytics widgets registered via
+/// <see cref="AnalyticsWidgetSerialization.AddAnalyticsWidgets"/> — the wire format
+/// must surface the canonical short discriminators (<c>"kpi"</c>, <c>"chart"</c>,
+/// <c>"table"</c>, <c>"pivot"</c>) and survive a serialize / deserialize cycle.
+/// </summary>
+public sealed class AnalyticsWidgetSerializationTests
+{
+    private static JsonSerializerOptions NewOptions()
+    {
+        JsonSerializerOptions options = new();
+        options.AddAnalyticsWidgets();
+        return options;
+    }
+
+    [Fact]
+    public void Kpi_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new KpiWidgetDefinition(
+            "UnpaidCount", "Granit.Invoicing.UnpaidInvoiceCountMetric", Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"kpi\"");
+        json.ShouldNotContain("$type");
+    }
+
+    [Fact]
+    public void Chart_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new ChartWidgetDefinition(
+            Slug: "RevenueByMonth",
+            QueryName: "Granit.Invoicing.InvoiceQuery",
+            GroupBy: "IssuedAtMonth",
+            Aggregation: AggregateFunction.Sum,
+            Field: "Total",
+            ChartType: ChartType.Line,
+            Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"chart\"");
+    }
+
+    [Fact]
+    public void Table_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new TableWidgetDefinition(
+            "RecentInvoices", "Granit.Invoicing.InvoiceQuery", VisibleColumns: null,
+            PageSize: 25, Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"table\"");
+    }
+
+    [Fact]
+    public void Pivot_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new PivotWidgetDefinition(
+            "InvoicesByCustomerByMonth", "Granit.Invoicing.InvoiceQuery",
+            RowFields: ["CustomerName"], ColumnFields: ["IssuedAtMonth"],
+            ValueField: null, ValueAggregation: AggregateFunction.Count, Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"pivot\"");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesAllFourAnalyticsWidgetTypes()
+    {
+        JsonSerializerOptions options = NewOptions();
+
+        WidgetDefinition[] originals =
+        [
+            new KpiWidgetDefinition("Kpi", "M1", Position: 0),
+            new ChartWidgetDefinition("Chart", "Q1", "g", AggregateFunction.Sum, "f", ChartType.Bar, Position: 1),
+            new TableWidgetDefinition("Table", "Q1", null, 25, Position: 2),
+            new PivotWidgetDefinition("Pivot", "Q1", ["r"], ["c"], null, AggregateFunction.Count, Position: 3),
+        ];
+
+        foreach (WidgetDefinition original in originals)
+        {
+            string json = JsonSerializer.Serialize(original, options);
+            WidgetDefinition? decoded = JsonSerializer.Deserialize<WidgetDefinition>(json, options);
+
+            decoded.ShouldNotBeNull();
+            decoded.GetType().ShouldBe(original.GetType());
+        }
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardLayoutTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardLayoutTests.cs
@@ -1,0 +1,69 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the responsive layout shape (P1.4): base layout + per-breakpoint overrides
+/// + per-widget size dictionary + ordered slug list + hidden-widgets set. Records
+/// stay POCO — the merge logic itself lives in the frontend.
+/// </summary>
+public sealed class DashboardLayoutTests
+{
+    [Fact]
+    public void Default_ProvidesA12ColumnGrid()
+    {
+        DashboardLayout layout = DashboardLayout.Default;
+
+        layout.Columns.ShouldBe(12);
+        layout.RowHeight.ShouldBe(80);
+        layout.WidgetSizes.ShouldBeNull();
+        layout.WidgetOrder.ShouldBeNull();
+        layout.Breakpoints.ShouldBeNull();
+    }
+
+    [Fact]
+    public void With_BreakpointOverride_PreservesBaseFields()
+    {
+        Dictionary<DashboardBreakpoint, DashboardLayoutOverride> breakpoints = new()
+        {
+            [DashboardBreakpoint.Xs] = new(
+                Columns: 4,
+                WidgetSizes: new Dictionary<string, WidgetSize>
+                {
+                    ["UnpaidCount"] = new(4, 1),
+                },
+                HiddenWidgets: new HashSet<string> { "Banner" }),
+        };
+
+        DashboardLayout layout = DashboardLayout.Default with { Breakpoints = breakpoints };
+
+        layout.Columns.ShouldBe(12);
+        layout.Breakpoints.ShouldNotBeNull();
+        layout.Breakpoints[DashboardBreakpoint.Xs].Columns.ShouldBe(4);
+        layout.Breakpoints[DashboardBreakpoint.Xs].HiddenWidgets!.ShouldContain("Banner");
+    }
+
+    [Fact]
+    public void Override_AllFieldsNullable_KeepsScopedToWhatChanges()
+    {
+        DashboardLayoutOverride empty = new();
+
+        empty.Columns.ShouldBeNull();
+        empty.RowHeight.ShouldBeNull();
+        empty.WidgetSizes.ShouldBeNull();
+        empty.WidgetOrder.ShouldBeNull();
+        empty.HiddenWidgets.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Breakpoint_EnumOrderingIsStable()
+    {
+        // The frontend may sort breakpoints by enum value to apply overrides progressively.
+        ((int)DashboardBreakpoint.Xs).ShouldBe(0);
+        ((int)DashboardBreakpoint.Sm).ShouldBe(1);
+        ((int)DashboardBreakpoint.Md).ShouldBe(2);
+        ((int)DashboardBreakpoint.Lg).ShouldBe(3);
+        ((int)DashboardBreakpoint.Xl).ShouldBe(4);
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/Widgets/ImageWidgetDefinitionTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/Widgets/ImageWidgetDefinitionTests.cs
@@ -1,0 +1,37 @@
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests.Widgets;
+
+public sealed class ImageWidgetDefinitionTests
+{
+    [Fact]
+    public void Fit_DefaultsToContain()
+    {
+        ImageWidgetDefinition widget = new(
+            "Logo", "https://cdn.example/logo.png", "Widget:Sample.Logo.Alt", Position: 0);
+
+        widget.Fit.ShouldBe(ImageFit.Contain);
+    }
+
+    [Fact]
+    public void Fit_AllowsCoverForBannerPhotos()
+    {
+        ImageWidgetDefinition widget = new(
+            "Banner", "blob:hero", "Widget:Sample.Banner.Alt", Position: 0,
+            Fit: ImageFit.Cover);
+
+        widget.Fit.ShouldBe(ImageFit.Cover);
+    }
+
+    [Fact]
+    public void Fit_EnumOrderingIsStable()
+    {
+        // Wire format stability — values land in JSON as integers when no
+        // converter is set, so the ordering must not drift.
+        ((int)ImageFit.Contain).ShouldBe(0);
+        ((int)ImageFit.Cover).ShouldBe(1);
+        ((int)ImageFit.Fill).ShouldBe(2);
+    }
+}

--- a/tests/Granit.Dashboards.Tests/Json/WidgetDefinitionPolymorphismTests.cs
+++ b/tests/Granit.Dashboards.Tests/Json/WidgetDefinitionPolymorphismTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Granit.Dashboards.Json;
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Tests.Json;
+
+/// <summary>
+/// Locks the wire format for <see cref="WidgetDefinition"/> polymorphism — the discriminator
+/// property is <c>"type"</c>, the three abstractions widgets carry stable short tags
+/// (<c>"markdown"</c>, <c>"image"</c>, <c>"text"</c>), and downstream packages can extend the
+/// chain at runtime via <see cref="WidgetDefinitionPolymorphism.AddDerivedType{TWidget}"/>.
+/// </summary>
+public sealed class WidgetDefinitionPolymorphismTests
+{
+    [Fact]
+    public void Markdown_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new MarkdownWidgetDefinition(
+            "Banner", "Widget:Sample.Banner", Position: 0);
+
+        string json = JsonSerializer.Serialize(widget);
+
+        json.ShouldContain("\"type\":\"markdown\"");
+        json.ShouldNotContain("$type"); // legacy CLR-typed shape banished
+    }
+
+    [Fact]
+    public void Image_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new ImageWidgetDefinition(
+            "Logo", "https://cdn.example/logo.png", "Widget:Sample.Logo.Alt", Position: 0);
+
+        string json = JsonSerializer.Serialize(widget);
+
+        json.ShouldContain("\"type\":\"image\"");
+    }
+
+    [Fact]
+    public void Text_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new TextWidgetDefinition(
+            "Title", "Widget:Sample.Title", TextStyle.Heading, Position: 0);
+
+        string json = JsonSerializer.Serialize(widget);
+
+        json.ShouldContain("\"type\":\"text\"");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesConcreteType_ForAllAbstractionsWidgets()
+    {
+        WidgetDefinition[] originals =
+        [
+            new MarkdownWidgetDefinition("M", "Widget:M", Position: 0),
+            new ImageWidgetDefinition("I", "https://x", "Widget:I.Alt", Position: 1),
+            new TextWidgetDefinition("T", "Widget:T", TextStyle.Body, Position: 2),
+        ];
+
+        foreach (WidgetDefinition original in originals)
+        {
+            string json = JsonSerializer.Serialize(original);
+            WidgetDefinition? decoded = JsonSerializer.Deserialize<WidgetDefinition>(json);
+
+            decoded.ShouldNotBeNull();
+            decoded.GetType().ShouldBe(original.GetType());
+            decoded.Slug.ShouldBe(original.Slug);
+        }
+    }
+
+    [Fact]
+    public void RuntimeDerivedType_IsRoundTrippable()
+    {
+        // Simulates the Granit.Analytics registration path: a downstream package
+        // extends the chain on a fresh JsonSerializerOptions.
+        JsonSerializerOptions options = new();
+        options.AddDerivedType<RuntimeRegisteredWidget>("test-widget");
+
+        WidgetDefinition widget = new RuntimeRegisteredWidget("Custom", Position: 0);
+        string json = JsonSerializer.Serialize(widget, options);
+        WidgetDefinition? decoded = JsonSerializer.Deserialize<WidgetDefinition>(json, options);
+
+        json.ShouldContain("\"type\":\"test-widget\"");
+        decoded.ShouldBeOfType<RuntimeRegisteredWidget>();
+    }
+
+    [Fact]
+    public void AddDerivedType_RejectsNullOptions()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((JsonSerializerOptions)null!).AddDerivedType<RuntimeRegisteredWidget>("x"));
+    }
+
+    [Fact]
+    public void AddDerivedType_RejectsEmptyDiscriminator()
+    {
+        JsonSerializerOptions options = new();
+        Should.Throw<ArgumentException>(() => options.AddDerivedType<RuntimeRegisteredWidget>(string.Empty));
+    }
+
+    private sealed record RuntimeRegisteredWidget(string Slug, int Position)
+        : WidgetDefinition(Slug, Position, WidgetSize.SmallKpi, RequiredPermission: null);
+}

--- a/tests/Granit.Dashboards.Tests/Templating/DefaultVariableSubstituterTests.cs
+++ b/tests/Granit.Dashboards.Tests/Templating/DefaultVariableSubstituterTests.cs
@@ -1,0 +1,126 @@
+using Granit.Dashboards.Extensions;
+using Granit.Dashboards.Templating;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Tests.Templating;
+
+/// <summary>
+/// Locks the <see cref="IVariableSubstituter"/> contract: <c>${var}</c> only, no
+/// expressions, no scripting. Unknown variables become empty strings (warning
+/// logged) — never throw.
+/// </summary>
+public sealed class DefaultVariableSubstituterTests
+{
+    private static IVariableSubstituter NewSubstituter()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>),
+            typeof(Microsoft.Extensions.Logging.Abstractions.NullLogger<>));
+        services.AddGranitDashboards();
+        return services.BuildServiceProvider().GetRequiredService<IVariableSubstituter>();
+    }
+
+    [Fact]
+    public void Substitute_ReplacesKnownVariable()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        Dictionary<string, object?> context = new()
+        {
+            ["entityName"] = "Acme Corp",
+        };
+
+        string? result = substituter.Substitute("Customer ${entityName} — invoices unpaid", context);
+
+        result.ShouldBe("Customer Acme Corp — invoices unpaid");
+    }
+
+    [Fact]
+    public void Substitute_ReplacesMultipleVariables()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        Dictionary<string, object?> context = new()
+        {
+            ["customer"] = "Acme",
+            ["count"] = 12,
+        };
+
+        string? result = substituter.Substitute("${customer}: ${count} unpaid", context);
+
+        result.ShouldBe("Acme: 12 unpaid");
+    }
+
+    [Fact]
+    public void Substitute_UnknownVariable_BecomesEmpty_DoesNotThrow()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        Dictionary<string, object?> context = [];
+
+        string? result = substituter.Substitute("Hello ${missing}!", context);
+
+        result.ShouldBe("Hello !");
+    }
+
+    [Fact]
+    public void Substitute_NullValue_BecomesEmpty()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        Dictionary<string, object?> context = new()
+        {
+            ["maybe"] = null,
+        };
+
+        string? result = substituter.Substitute("[${maybe}]", context);
+
+        result.ShouldBe("[]");
+    }
+
+    [Fact]
+    public void Substitute_NullInput_ReturnsNull()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        substituter.Substitute(null, new Dictionary<string, object?>()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Substitute_EmptyInput_ReturnsEmpty()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        substituter.Substitute(string.Empty, new Dictionary<string, object?>()).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Substitute_NoPlaceholders_PassesThrough()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        substituter.Substitute("plain string", new Dictionary<string, object?>()).ShouldBe("plain string");
+    }
+
+    [Fact]
+    public void Substitute_DoesNotEvaluateExpressions()
+    {
+        // The contract explicitly bans any syntax beyond literal lookup.
+        // ${1+1} is not "math" — it's a literal variable name "1+1" that won't be in any context.
+        IVariableSubstituter substituter = NewSubstituter();
+
+        string? result = substituter.Substitute("${1+1}", new Dictionary<string, object?>());
+
+        result.ShouldBe(string.Empty); // unknown variable, no eval
+    }
+
+    [Fact]
+    public void Substitute_CaseSensitive()
+    {
+        IVariableSubstituter substituter = NewSubstituter();
+        Dictionary<string, object?> context = new()
+        {
+            ["Name"] = "Acme",
+        };
+
+        substituter.Substitute("${name}", context).ShouldBe(string.Empty); // lowercase miss
+        substituter.Substitute("${Name}", context).ShouldBe("Acme");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the proposals from [`granit-front/docs/dashboards-architecture-proposals.md`](../granit-front/docs/dashboards-architecture-proposals.md) that align the backend wire format with the frontend type-safe consumer before B3/B4 ship endpoints. P1 priorities + P3 quality-of-life — load-bearing now because B2 just merged with persistence.

**P1.3 (DashboardTimeWindow) is deferred** — it would force `Granit.Dashboards.Abstractions` to depend on `Granit.Analytics.Endpoints` (where `PeriodSpec` lives today). Clean fix needs `PeriodSpec` to move to a neutral location first; tracked separately.

## P1.1 — JSON polymorphism (urgent)

`WidgetDefinition` was about to persist with the System.Text.Json default `$type` shape (full CLR type name + assembly). This PR pins a stable wire format **before** any dashboard is serialised in the wild.

```csharp
[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
[JsonDerivedType(typeof(MarkdownWidgetDefinition), "markdown")]
[JsonDerivedType(typeof(ImageWidgetDefinition), "image")]
[JsonDerivedType(typeof(TextWidgetDefinition), "text")]
public abstract record WidgetDefinition(...);
```

The three Abstractions-shipped widgets get `[JsonDerivedType]` directly. Data-bound widgets shipped by domain modules (Analytics today, future IoT.Dashboards) cannot back-reference Abstractions, so the chain extends at runtime via:

```csharp
public static JsonSerializerOptions AddDerivedType<TWidget>(this JsonSerializerOptions options, string discriminator)
    where TWidget : WidgetDefinition;
```

`Granit.Analytics` ships `AddAnalyticsWidgets()` registering `kpi` / `chart` / `table` / `pivot`. Hosts call it once on their shared `JsonSerializerOptions`.

## P1.2 — ImageFit

`ImageWidgetDefinition.Fit: ImageFit = Contain`. Three values (Contain / Cover / Fill). Solves the "logo wants letterbox, banner wants crop" dichotomy without preprocessing.

## P1.4 — Responsive layouts

`DashboardLayout` carries the base grid + optional `Breakpoints: IReadOnlyDictionary<DashboardBreakpoint, DashboardLayoutOverride>` map. Every field on the override is nullable — overrides stay scoped to what differs at each viewport. Dual-pane (`main` / `right`) deferred to v2 per ADR-038.

```csharp
public sealed record DashboardLayout(
    int Columns, int RowHeight,
    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
    IReadOnlyList<string>? WidgetOrder = null,
    IReadOnlyDictionary<DashboardBreakpoint, DashboardLayoutOverride>? Breakpoints = null);

public enum DashboardBreakpoint { Xs, Sm, Md, Lg, Xl }

public sealed record DashboardLayoutOverride(
    int? Columns = null,
    int? RowHeight = null,
    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
    IReadOnlyList<string>? WidgetOrder = null,
    IReadOnlySet<string>? HiddenWidgets = null);
```

Records stay POCO — the merge logic lives in `<Dashboard>` on the frontend.

## P3.1 — Localization key conventions

Documented on `IDashboardDefinitionDescriptor` (remarks): the three keys composed off `Name` are `Dashboard:{Name}`, `Dashboard:{Name}.Description`, `Widget:{Name}.{Slug}`. No code change — contractual clarity so consumers don't reinvent.

## P3.3 — `${variable}` substituter

`IVariableSubstituter` contract in Abstractions, `DefaultVariableSubstituter` (internal) in `Granit.Dashboards`. Pure regex-driven literal lookup: `${name}`. **Explicitly rejects** any expression syntax (no `${1+1}`, no pipes, no conditionals). Unknown variables → empty string + `LoggerMessage` warning, never throws. `GeneratedRegex` with bounded timeout, `[LoggerMessage]` for the warning. Wired into `AddGranitDashboards` via `TryAddSingleton<IVariableSubstituter, DefaultVariableSubstituter>`.

## Tests — 50 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Tests/Json/WidgetDefinitionPolymorphismTests` | 7 | discriminator per kind + round-trip + runtime-derived path + null/empty guards |
| `Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests` | 5 | same shape for the four analytics widgets via `AddAnalyticsWidgets()` |
| `Granit.Dashboards.Abstractions.Tests/DashboardLayoutTests` | 4 | base/override shape + breakpoint enum stability |
| `Granit.Dashboards.Abstractions.Tests/Widgets/ImageWidgetDefinitionTests` | 3 | `Fit` default/override + enum stability |
| `Granit.Dashboards.Tests/Templating/DefaultVariableSubstituterTests` | 9 | happy path, unknown var, null/empty input, **no-eval contract**, case sensitivity |

Architecture suite stays at **157/157**.

## Test plan

- [x] `dotnet build` clean on all touched packages
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 9/9
- [x] `dotnet test tests/Granit.Dashboards.Tests` — 24/24
- [x] `dotnet test tests/Granit.Analytics.Tests` — 17/17
- [x] `dotnet test tests/Granit.ArchitectureTests` — 157/157
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed (`--force-evaluate`)
- [ ] CI green