### PR TITLE
refactor(analytics): extract PeriodSpec into new Granit.Analytics.Abstractions package

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -63,6 +63,7 @@
         "tests/Granit.Parties.Privacy.Tests",
         "tests/Granit.Parties.Tests",
         "tests/Granit.Analytics.Tests",
+        "tests/Granit.Analytics.Abstractions.Tests",
         "tests/Granit.Analytics.EntityFrameworkCore.Tests",
         "tests/Granit.Analytics.Endpoints.Tests",
         "tests/Granit.Dashboards.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -82,8 +82,16 @@
       "name": "Granit.Analytics",
       "deps": [
         "Granit",
+        "Granit.Analytics.Abstractions",
         "Granit.Dashboards.Abstractions",
         "Granit.QueryEngine.Abstractions"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.Analytics.Abstractions",
+      "deps": [
+        "Granit"
       ],
       "framework": "net10.0"
     },
@@ -4162,15 +4170,6 @@
       "members": []
     },
     {
-      "name": "PeriodSpec",
-      "fqn": "Granit.Analytics.Endpoints.Dtos.PeriodSpec",
-      "kind": "record",
-      "project": "Granit.Analytics.Endpoints",
-      "file": "src/Granit.Analytics.Endpoints/Dtos/PeriodSpec.cs",
-      "line": 16,
-      "members": []
-    },
-    {
       "name": "AnalyticsEndpointRouteBuilderExtensions",
       "fqn": "Granit.Analytics.Endpoints.Extensions.AnalyticsEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -4335,6 +4334,15 @@
       ]
     },
     {
+      "name": "GranitAnalyticsAbstractionsModule",
+      "fqn": "Granit.Analytics.GranitAnalyticsAbstractionsModule",
+      "kind": "class",
+      "project": "Granit.Analytics.Abstractions",
+      "file": "src/Granit.Analytics.Abstractions/GranitAnalyticsAbstractionsModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "GranitAnalyticsModule",
       "fqn": "Granit.Analytics.GranitAnalyticsModule",
       "kind": "class",
@@ -4415,6 +4423,15 @@
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Metrics/RefreshHint.cs",
       "line": 15,
+      "members": []
+    },
+    {
+      "name": "PeriodSpec",
+      "fqn": "Granit.Analytics.PeriodSpec",
+      "kind": "record",
+      "project": "Granit.Analytics.Abstractions",
+      "file": "src/Granit.Analytics.Abstractions/PeriodSpec.cs",
+      "line": 22,
       "members": []
     },
     {

--- a/src/Granit.Analytics.Abstractions/Granit.Analytics.Abstractions.csproj
+++ b/src/Granit.Analytics.Abstractions/Granit.Analytics.Abstractions.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Analytics.Abstractions</PackageId>
+    <Description>Inter-module contracts for Granit.Analytics: PeriodSpec (token-or-absolute time window) shared between metric requests and dashboard time windows. Reference this package from any module that needs to describe a time window without pulling the full analytics runtime.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Analytics.Abstractions.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics" />
+    <InternalsVisibleTo Include="Granit.Analytics.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics.EntityFrameworkCore" />
+    <InternalsVisibleTo Include="Granit.Analytics.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit\Granit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Analytics.Abstractions/GranitAnalyticsAbstractionsModule.cs
+++ b/src/Granit.Analytics.Abstractions/GranitAnalyticsAbstractionsModule.cs
@@ -1,0 +1,16 @@
+using Granit.Modularity;
+
+namespace Granit.Analytics;
+
+/// <summary>
+/// Granit module for the analytics contracts shared between modules. Hosts only the
+/// declarative primitives that need to be reused across the framework — currently
+/// <see cref="PeriodSpec"/>; future analytics abstractions land here as they get
+/// extracted from the runtime package.
+/// </summary>
+/// <remarks>
+/// This module has no service registrations — it exists so consumer modules can
+/// declare <c>[DependsOn(typeof(GranitAnalyticsAbstractionsModule))]</c> without
+/// pulling the full Granit.Analytics runtime.
+/// </remarks>
+public sealed class GranitAnalyticsAbstractionsModule : GranitModule;

--- a/src/Granit.Analytics.Abstractions/PeriodSpec.cs
+++ b/src/Granit.Analytics.Abstractions/PeriodSpec.cs
@@ -1,4 +1,4 @@
-namespace Granit.Analytics.Endpoints.Dtos;
+namespace Granit.Analytics;
 
 /// <summary>
 /// A time window — either explicit (<see cref="From"/> / <see cref="To"/>) or named
@@ -13,6 +13,12 @@ namespace Granit.Analytics.Endpoints.Dtos;
 /// <c>ytd</c> (year-to-date), <c>previous_period</c> (only valid for the comparison
 /// window — refers to the period of equal length immediately preceding the main one).
 /// </param>
+/// <remarks>
+/// Lives in <c>Granit.Analytics.Abstractions</c> rather than the HTTP DTOs package so
+/// modules outside the analytics HTTP surface (notably <c>Granit.Dashboards.Abstractions</c>
+/// for the upcoming <c>DashboardTimeWindow</c> primitive in P1.3) can reuse the same
+/// time-window model without taking a dependency on the analytics HTTP layer.
+/// </remarks>
 public sealed record PeriodSpec(
     DateTimeOffset? From = null,
     DateTimeOffset? To = null,

--- a/src/Granit.Analytics.Abstractions/README.md
+++ b/src/Granit.Analytics.Abstractions/README.md
@@ -1,0 +1,27 @@
+# Granit.Analytics.Abstractions
+
+Inter-module contracts for `Granit.Analytics`. Currently hosts `PeriodSpec` (the
+token-or-absolute time window backing `MetricRequest.Period`), shared between
+the analytics HTTP layer and the upcoming dashboard time-window primitive
+(`DashboardTimeWindow` in `Granit.Dashboards.Abstractions`, P1.3 follow-up).
+
+Reference [Granit.Analytics](../Granit.Analytics/) for the runtime
+(`MetricDefinition`, executors, ...). This package stays minimal so consumers
+that only need the shared contracts (cross-module DTOs, dashboard layer) don't
+pull the analytics runtime.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Analytics.Abstractions
+```
+
+## Dependencies
+
+- `Granit`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Analytics.Abstractions/packages.lock.json
+++ b/src/Granit.Analytics.Abstractions/packages.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "granit": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Granit.Analytics.Endpoints/packages.lock.json
+++ b/src/Granit.Analytics.Endpoints/packages.lock.json
@@ -35,8 +35,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.entityframeworkcore": {

--- a/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
@@ -90,8 +90,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.abstractions": {

--- a/src/Granit.Analytics/Granit.Analytics.csproj
+++ b/src/Granit.Analytics/Granit.Analytics.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Analytics.Abstractions\Granit.Analytics.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Granit.Analytics/packages.lock.json
+++ b/src/Granit.Analytics/packages.lock.json
@@ -11,6 +11,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dashboards.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
@@ -59,8 +59,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.backgroundjobs": {

--- a/src/Granit.Invoicing.Builtin/packages.lock.json
+++ b/src/Granit.Invoicing.Builtin/packages.lock.json
@@ -59,8 +59,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Invoicing.Endpoints/packages.lock.json
+++ b/src/Granit.Invoicing.Endpoints/packages.lock.json
@@ -38,8 +38,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.authorization": {

--- a/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
@@ -117,8 +117,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Invoicing.Notifications/packages.lock.json
+++ b/src/Granit.Invoicing.Notifications/packages.lock.json
@@ -59,8 +59,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Invoicing.Odoo/packages.lock.json
+++ b/src/Granit.Invoicing.Odoo/packages.lock.json
@@ -230,8 +230,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Invoicing/packages.lock.json
+++ b/src/Granit.Invoicing/packages.lock.json
@@ -72,8 +72,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Tax.Builtin/packages.lock.json
+++ b/src/Granit.Tax.Builtin/packages.lock.json
@@ -235,8 +235,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/src/Granit.Tax.Stripe/packages.lock.json
+++ b/src/Granit.Tax.Stripe/packages.lock.json
@@ -264,8 +264,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Analytics.Abstractions.Tests/Granit.Analytics.Abstractions.Tests.csproj
+++ b/tests/Granit.Analytics.Abstractions.Tests/Granit.Analytics.Abstractions.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Analytics.Abstractions\Granit.Analytics.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Analytics.Abstractions.Tests/PeriodSpecTests.cs
+++ b/tests/Granit.Analytics.Abstractions.Tests/PeriodSpecTests.cs
@@ -1,0 +1,63 @@
+using Granit.Analytics;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape of <see cref="PeriodSpec"/> as it crosses the boundary
+/// between the analytics HTTP layer (where it backs <c>MetricRequest.Period</c>) and
+/// the dashboards stack (where it will back the upcoming <c>DashboardTimeWindow</c>
+/// — story P1.3 follow-up). The record is record-equality only — no behaviour to
+/// validate beyond constructibility and the module class hosting the contract.
+/// </summary>
+public sealed class PeriodSpecTests
+{
+    [Fact]
+    public void Module_IsGranitModule()
+        => new GranitAnalyticsAbstractionsModule().ShouldBeAssignableTo<GranitModule>();
+
+    [Fact]
+    public void DefaultConstruction_LeavesAllFieldsNull()
+    {
+        PeriodSpec spec = new();
+
+        spec.From.ShouldBeNull();
+        spec.To.ShouldBeNull();
+        spec.Token.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TokenForm_CarriesNamedPeriod()
+    {
+        PeriodSpec spec = new(Token: "mtd");
+
+        spec.Token.ShouldBe("mtd");
+        spec.From.ShouldBeNull();
+        spec.To.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AbsoluteForm_CarriesFromAndTo()
+    {
+        DateTimeOffset from = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset to = new(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+
+        PeriodSpec spec = new(From: from, To: to);
+
+        spec.From.ShouldBe(from);
+        spec.To.ShouldBe(to);
+        spec.Token.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RecordEquality_HoldsByValue()
+    {
+        PeriodSpec a = new(Token: "ytd");
+        PeriodSpec b = new(Token: "ytd");
+
+        a.ShouldBe(b);
+        a.GetHashCode().ShouldBe(b.GetHashCode());
+    }
+}

--- a/tests/Granit.Analytics.Abstractions.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Abstractions.Tests/packages.lock.json
@@ -30,15 +30,6 @@
           "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
-      "NSubstitute": {
-        "type": "Direct",
-        "requested": "[5.*, )",
-        "resolved": "5.3.0",
-        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
-        "dependencies": {
-          "Castle.Core": "5.1.1"
-        }
-      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.*, )",
@@ -62,14 +53,6 @@
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
           "xunit.v3.mtp-v1": "[3.2.2]"
-        }
-      },
-      "Castle.Core": {
-        "type": "Transitive",
-        "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "DiffEngine": {
@@ -160,11 +143,6 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
-      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -243,38 +221,10 @@
       "granit": {
         "type": "Project"
       },
-      "granit.analytics": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
-          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
-        }
-      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.dashboards.abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.datalookup.abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.queryengine.abstractions": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -329,8 +329,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.endpoints": {

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
@@ -357,8 +357,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.entityframeworkcore": {

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\..\src\Granit.AI.OpenAI\Granit.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.VectorData\Granit.AI.VectorData.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.Abstractions\Granit.Analytics.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics.Endpoints\Granit.Analytics.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1487,8 +1487,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.endpoints": {


### PR DESCRIPTION
## Summary

Unblocks the deferred **P1.3 (DashboardTimeWindow)** proposal from #1454. P1.3 wraps the existing `PeriodSpec`, but couldn't land while `PeriodSpec` lived in `Granit.Analytics.Endpoints/Dtos/` — `Granit.Dashboards.Abstractions` can't take a transitive dependency on the analytics HTTP layer (cycle risk plus wrong-direction dep on a runtime / HTTP package).

This refactor mirrors the established Granit pattern (`QueryEngine.Abstractions` / `DataExchange.Abstractions` / `Dashboards.Abstractions`): a lightweight `*.Abstractions` package for cross-module contracts; runtime stays in the parent.

## Changes

### New package `Granit.Analytics.Abstractions`

- `Granit.Analytics.Abstractions.csproj` (Apache-2.0, IsPackable, only depends on `Granit`)
- `GranitAnalyticsAbstractionsModule` — no DI registrations, exists for `[DependsOn]` composition
- **`PeriodSpec`** moved here from `Granit.Analytics.Endpoints/Dtos/`. Namespace `Granit.Analytics.Endpoints.Dtos` → **`Granit.Analytics`**.
- `README.md`

### Wiring

- `Granit.Analytics` now `<ProjectReference>`s `Granit.Analytics.Abstractions`. `Granit.Analytics.Endpoints` and `Granit.Analytics.EntityFrameworkCore` inherit it transitively — no extra `<ProjectReference>` needed in their csproj.
- Consumers (`MetricRequest`, `PeriodResolver`, `MetricRequestValidator`) need no `using Granit.Analytics;` — the namespace is a parent of `Granit.Analytics.Endpoints.*`, so the C# compiler resolves `PeriodSpec` automatically.

### Tests

- New `Granit.Analytics.Abstractions.Tests` — 5 tests (module class assertion, record shape, default construction, token form, absolute form, record equality).
- `Granit.Analytics.Endpoints.Tests` — 31/31, no test changes required (record name + members unchanged).
- Architecture suite — **157/157** (`.csproj` reference added).

### Plumbing

- `test-shards.json`: `Granit.Analytics.Abstractions.Tests` added to **business** shard. `.slnf` filters regenerated via `scripts/generate-shard-filters.py`.
- `packages.lock.json` refreshed (`--force-evaluate`) for every project transitively depending on `Granit.Analytics`: `Invoicing.*`, `Tax.*`, and their `.Tests` counterparts.

## Why now (and not as part of #1454)

#1454 deliberately deferred P1.3 because the package-direction question warranted its own conversation. This PR settles that: `PeriodSpec` becomes the canonical "time window" primitive of the framework, reachable from anywhere a contract needs to express a token-or-absolute period.

## Follow-up

A short PR brings `DashboardTimeWindow` to `Granit.Dashboards.Abstractions`:

```csharp
using Granit.Analytics; // PeriodSpec — now safely reachable

public sealed record DashboardTimeWindow(
    PeriodSpec Period,
    TimeWindowKind Kind = TimeWindowKind.History,
    PeriodSpec? CompareTo = null,
    TimeSpan? Aggregation = null);
```

Plus the `TimeWindowOverride` field on `WidgetDefinition`. ETA: ~1 hour after this lands.

## Test plan

- [x] `dotnet build src/Granit.Analytics.Abstractions src/Granit.Analytics src/Granit.Analytics.Endpoints src/Granit.Analytics.EntityFrameworkCore` — all clean
- [x] `dotnet test tests/Granit.Analytics.Abstractions.Tests` — 5/5
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests` — 31/31 (no changes needed)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 157/157
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed
- [ ] CI green