### PR TITLE
test(dashboards): archi-enforce Dashboard:{Name} localization across 15 cultures (D2 #1397 followup)

### DIFF
--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -363,8 +363,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.entityframeworkcore": {

--- a/tests/Granit.ArchitectureTests/DashboardLocalizationCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/DashboardLocalizationCompletenessTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using System.Text.Json;
+using Granit.Dashboards;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Companion to <see cref="MetricLocalizationCompletenessTests"/> — completes the D2
+/// (#1397) coverage by extending the same archi rule to <see cref="DashboardDefinition"/>
+/// instances. Every concrete dashboard MUST have a <c>Dashboard:{Name}</c> resource
+/// key in all 15 base cultures of its owning module's <c>Localization/</c> directory.
+/// Regional variants (<c>fr-CA</c>, <c>en-GB</c>, <c>pt-BR</c>) are exempt by design —
+/// they ship only differing keys and fall through to their parent culture.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stays trivially green today (no framework module ships a <c>DashboardDefinition</c>
+/// yet). Becomes load-bearing the moment <c>Granit.Invoicing</c> or any other module
+/// ships its first dashboard — which is the whole point of pinning the rule before
+/// the first instance ships, not after.
+/// </para>
+/// <para>
+/// Failure aggregates every missing (dashboard, culture) pair into a single message
+/// — same UX as the metric companion.
+/// </para>
+/// </remarks>
+public sealed class DashboardLocalizationCompletenessTests
+{
+    private static readonly string[] BaseCultures =
+    [
+        "en", "fr", "nl", "de", "es", "it", "pt", "zh", "ja",
+        "pl", "tr", "ko", "sv", "cs", "hi",
+    ];
+
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Every_DashboardDefinition_should_have_localization_keys_in_all_base_cultures()
+    {
+        IReadOnlyList<DashboardDescriptor> dashboards = ScanDashboardDefinitions();
+
+        if (dashboards.Count == 0)
+        {
+            // Pinned-empty: no DashboardDefinition has shipped yet (B6+ stories
+            // bring the first ones). The rule is in place ahead of time so the
+            // first dashboard PR fails CI loudly if it forgets the keys.
+            return;
+        }
+
+        List<string> missing = [];
+
+        foreach (DashboardDescriptor dashboard in dashboards)
+        {
+            string moduleSrcDir = Path.Combine(RepoRoot, "src", dashboard.OwningAssemblyName);
+            string localizationDir = Path.Combine(moduleSrcDir, "Localization");
+
+            if (!Directory.Exists(localizationDir))
+            {
+                missing.Add($"{dashboard.Name} (declared in {dashboard.OwningAssemblyName}): Localization/ directory not found at {Path.GetRelativePath(RepoRoot, localizationDir)}");
+                continue;
+            }
+
+            string resourceKey = $"Dashboard:{dashboard.Name}";
+
+            foreach (string culture in BaseCultures)
+            {
+                if (!LocateKeyInCultureFiles(localizationDir, culture, resourceKey))
+                {
+                    missing.Add($"{dashboard.Name} -> {culture} (expected key '{resourceKey}' in src/{dashboard.OwningAssemblyName}/Localization/**/{culture}.json)");
+                }
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            $"D2 (#1397): every DashboardDefinition must have a 'Dashboard:{{Name}}' key in all 15 base cultures " +
+            $"of its owning module. {missing.Count} key(s) missing:" + Environment.NewLine +
+            string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
+    }
+
+    private static bool LocateKeyInCultureFiles(string localizationDir, string culture, string resourceKey)
+    {
+        string[] candidateFiles = Directory.GetFiles(localizationDir, $"{culture}.json", SearchOption.AllDirectories);
+
+        foreach (string file in candidateFiles)
+        {
+            if (FileContainsKey(file, resourceKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool FileContainsKey(string filePath, string key)
+    {
+        using FileStream stream = File.OpenRead(filePath);
+        using var document = JsonDocument.Parse(stream);
+
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (root.TryGetProperty("texts", out JsonElement texts)
+            && texts.ValueKind == JsonValueKind.Object
+            && texts.TryGetProperty(key, out _))
+        {
+            return true;
+        }
+
+        return root.TryGetProperty(key, out _);
+    }
+
+    private static List<DashboardDescriptor> ScanDashboardDefinitions()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(DashboardLocalizationCompletenessTests).Assembly.Location)!;
+
+        Assembly[] assemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<DashboardDescriptor> dashboards = [];
+
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || !type.IsClass)
+                {
+                    continue;
+                }
+
+                if (!typeof(DashboardDefinition).IsAssignableFrom(type))
+                {
+                    continue;
+                }
+
+                DashboardDefinition? instance;
+                try { instance = Activator.CreateInstance(type) as DashboardDefinition; }
+                catch (Exception ex) when (ex is MissingMethodException or MemberAccessException or TargetInvocationException)
+                {
+                    // Definitions without a parameterless ctor are out of scope for this
+                    // archi check — every shipped dashboard should be parameterless per
+                    // the *.Dashboards canonical placement rules.
+                    continue;
+                }
+
+                if (instance is null)
+                {
+                    continue;
+                }
+
+                dashboards.Add(new DashboardDescriptor(instance.Name, assembly.GetName().Name!));
+            }
+        }
+
+        return dashboards;
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(DashboardLocalizationCompletenessTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    private sealed record DashboardDescriptor(string Name, string OwningAssemblyName);
+}

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
@@ -291,8 +291,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.backgroundjobs": {

--- a/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
@@ -291,8 +291,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -518,8 +518,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.authorization": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -377,8 +377,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
@@ -576,8 +576,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.entityframeworkcore": {

--- a/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
@@ -291,8 +291,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
@@ -448,8 +448,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Invoicing.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Tests/packages.lock.json
@@ -291,8 +291,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Tax.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Builtin.Tests/packages.lock.json
@@ -453,8 +453,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {

--- a/tests/Granit.Tax.Stripe.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Stripe.Tests/packages.lock.json
@@ -462,8 +462,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {


### PR DESCRIPTION
## Summary

Companion to `MetricLocalizationCompletenessTests`. The original D2 issue (#1397) asked for the same rule on **both** `Metric:` and `Dashboard:` keys; the metrics version shipped in the original D2 PR (#1449), but `DashboardDefinition` didn't yet exist — so the dashboard side was deferred. Now that B1 (#1452) shipped the declarative `DashboardDefinition` API and the localization key convention is documented in `IDashboardDefinitionDescriptor` (#1454), the companion can land.

`DashboardLocalizationCompletenessTests` scans every concrete `DashboardDefinition` via reflection and asserts a `Dashboard:{Name}` resource key exists in all 15 base cultures of the dashboard's owning module `Localization/` directory. Regional variants (`fr-CA`, `en-GB`, `pt-BR`) are exempt by design — they ship only differing keys and fall through to their parent culture.

### Why now (and not later)

- Stays trivially green today — no framework module ships a `DashboardDefinition` yet (B6+ stories bring the first ones).
- Becomes **load-bearing the moment a module ships its first dashboard** — exactly when you want the rule, not after.
- Closes the loop on the original D2 issue's intent before any dashboard PR forgets the keys.

Failure aggregates every missing `(dashboard, culture)` pair into a single message — same UX as the metric companion.

### Plumbing

- Architecture suite **158/158** (was 157, +1).
- Lockfile drift correction for `Invoicing.*` and `Tax.*` test projects transitively depending on `Granit.Analytics` after #1455 introduced `Granit.Analytics.Abstractions`. Picked up by my local `dotnet build` since `--force-evaluate` only refreshes the projects you point at.

## Test plan

- [x] `dotnet build tests/Granit.ArchitectureTests` — clean
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "FullyQualifiedName~DashboardLocalizationCompletenessTests"` — 1/1
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format .github/shard-filters/architecture.slnf --verify-no-changes` — clean
- [ ] CI green