### PR TITLE
feat(dashboards): per-instance config overrides on WidgetInstance (P3.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12834,9 +12834,36 @@
           "name": "Create",
           "kind": "method",
           "signature": "Create(Guid id, Guid dashboardId, string widgetType, int position, int width, int height, string titleLocalizationKey, string configJson, string? metricName = null, string? queryName = null, string? requiredPermission = null)",
-          "returnType": "string? RequiredPermission { get; private set; } internal WidgetInstance"
+          "returnType": "string? RequiredPermission { get; private set; } public WidgetInstanceConfig? Overrides { get; private set; } internal WidgetInstance"
         }
       ]
+    },
+    {
+      "name": "WidgetInstanceConfig",
+      "fqn": "Granit.Dashboards.Domain.WidgetInstanceConfig",
+      "kind": "record",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "WidgetThreshold",
+      "fqn": "Granit.Dashboards.Domain.WidgetThreshold",
+      "kind": "record",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs",
+      "line": 49,
+      "members": []
+    },
+    {
+      "name": "WidgetThresholdOperator",
+      "fqn": "Granit.Dashboards.Domain.WidgetThresholdOperator",
+      "kind": "enum",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs",
+      "line": 55,
+      "members": []
     },
     {
       "name": "DashboardsEntityFrameworkCoreHostApplicationBuilderExtensions",

--- a/src/Granit.Dashboards.EntityFrameworkCore/Configurations/WidgetInstanceConfiguration.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Configurations/WidgetInstanceConfiguration.cs
@@ -1,6 +1,9 @@
+using System.Text.Json;
 using Granit.Dashboards.Domain;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Dashboards.EntityFrameworkCore.Configurations;
 
@@ -41,6 +44,24 @@ internal sealed class WidgetInstanceConfiguration : IEntityTypeConfiguration<Wid
             .IsRequired();
 
         builder.Property(w => w.RequiredPermission).HasMaxLength(200);
+
+        // Per-instance overrides (P3.2) — persisted as a JSON string. JSON keeps the
+        // schema additive when new override fields ship; same trade-off as ConfigJson
+        // and intentionally not OwnsOne(...).ToJson() since the override record carries
+        // a nullable list of thresholds which round-trips more reliably as a single
+        // serialised payload.
+        ValueConverter<WidgetInstanceConfig?, string?> overridesConverter = new(
+            v => v == null ? null : JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
+            v => string.IsNullOrEmpty(v) ? null : JsonSerializer.Deserialize<WidgetInstanceConfig>(v, JsonSerializerOptions.Default));
+
+        ValueComparer<WidgetInstanceConfig?> overridesComparer = new(
+            (l, r) => Equals(l, r),
+            v => v == null ? 0 : v.GetHashCode(),
+            v => v);
+
+        builder.Property(w => w.Overrides)
+            .HasColumnName("overrides_json")
+            .HasConversion(overridesConverter, overridesComparer);
 
         // Index supports the typical "list widgets for this dashboard, ordered by position" query.
         builder.HasIndex(w => new { w.DashboardId, w.Position })

--- a/src/Granit.Dashboards/Domain/WidgetInstance.cs
+++ b/src/Granit.Dashboards/Domain/WidgetInstance.cs
@@ -62,6 +62,15 @@ public sealed class WidgetInstance : Entity
     /// </summary>
     public string? RequiredPermission { get; private set; }
 
+    /// <summary>
+    /// Per-instance presentation overrides applied on top of the imported config —
+    /// title, colour, unit, decimals, threshold rules. <c>null</c> = the widget renders
+    /// strictly from <see cref="ConfigJson"/> + the data source's declared formatting.
+    /// Mutated through <see cref="ApplyOverrides(WidgetInstanceConfig?)"/>.
+    /// See P3.2 of the dashboards-architecture-proposals roadmap.
+    /// </summary>
+    public WidgetInstanceConfig? Overrides { get; private set; }
+
     /// <summary>Creates a new <see cref="WidgetInstance"/>. Called only by <see cref="Dashboard"/>.</summary>
     internal static WidgetInstance Create(
         Guid id,
@@ -140,4 +149,10 @@ public sealed class WidgetInstance : Entity
         ArgumentException.ThrowIfNullOrWhiteSpace(configJson);
         ConfigJson = configJson;
     }
+
+    /// <summary>
+    /// Applies (or clears) the per-instance presentation overrides. Pass <c>null</c>
+    /// to revert to the imported defaults.
+    /// </summary>
+    public void ApplyOverrides(WidgetInstanceConfig? overrides) => Overrides = overrides;
 }

--- a/src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs
+++ b/src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs
@@ -1,0 +1,65 @@
+namespace Granit.Dashboards.Domain;
+
+/// <summary>
+/// Per-instance overrides applied on top of a <see cref="WidgetInstance"/>'s default
+/// rendering. P3.2 of the dashboards-architecture-proposals roadmap — separates the
+/// "what was imported from the definition" config (carried inline on the aggregate)
+/// from the "what the admin tweaked at runtime" overrides.
+/// </summary>
+/// <param name="TitleLocalizationKeyOverride">
+/// Replacement localization key for the widget title. <c>null</c> = honour the
+/// imported <see cref="WidgetInstance.TitleLocalizationKey"/>.
+/// </param>
+/// <param name="ColorOverride">
+/// Hex colour the frontend applies to the widget's primary visual (KPI value, chart
+/// accent, ...). <c>null</c> = use the active theme palette.
+/// </param>
+/// <param name="UnitOverride">
+/// Unit suffix (e.g. <c>"€"</c>, <c>"kWh"</c>, <c>"°C"</c>). When prefixed with
+/// <c>Unit:</c>, resolved via i18n. <c>null</c> = the data source's declared unit
+/// (or none).
+/// </param>
+/// <param name="DecimalsOverride">
+/// Number of decimal places for numeric formatting. <c>null</c> = the data source's
+/// default (typically 2 for currency, 0 for counts).
+/// </param>
+/// <param name="Thresholds">
+/// Optional value thresholds applied for conditional colouring (e.g. a KPI turns red
+/// when below a target). Evaluated left-to-right; the first matching threshold's
+/// colour wins. <c>null</c> or empty = no threshold-based colouring.
+/// </param>
+/// <remarks>
+/// Persisted as a JSON column on the <see cref="WidgetInstance"/> row so the schema
+/// stays additive when new override fields ship — same rationale as
+/// <see cref="WidgetInstance.ConfigJson"/>.
+/// </remarks>
+public sealed record WidgetInstanceConfig(
+    string? TitleLocalizationKeyOverride = null,
+    string? ColorOverride = null,
+    string? UnitOverride = null,
+    int? DecimalsOverride = null,
+    IReadOnlyList<WidgetThreshold>? Thresholds = null);
+
+/// <summary>
+/// Threshold rule for conditional colouring of a widget's primary value.
+/// </summary>
+/// <param name="Value">The numeric threshold the data point is compared against.</param>
+/// <param name="Color">Hex colour applied when the rule matches.</param>
+/// <param name="Operator">Comparison operator — see <see cref="WidgetThresholdOperator"/>.</param>
+public sealed record WidgetThreshold(
+    decimal Value,
+    string Color,
+    WidgetThresholdOperator Operator);
+
+/// <summary>Comparison operator used by <see cref="WidgetThreshold"/>.</summary>
+public enum WidgetThresholdOperator
+{
+    /// <summary>Match when the data point is greater than or equal to the threshold.</summary>
+    GreaterThanOrEqual = 0,
+
+    /// <summary>Match when the data point is less than or equal to the threshold.</summary>
+    LessThanOrEqual = 1,
+
+    /// <summary>Match when the data point equals the threshold (within reasonable tolerance).</summary>
+    Equal = 2,
+}

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/WidgetInstanceOverridesTests.cs
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/WidgetInstanceOverridesTests.cs
@@ -1,0 +1,83 @@
+using Granit.Dashboards.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Tests.Domain;
+
+/// <summary>
+/// Locks the public shape of <see cref="WidgetInstanceConfig"/> + the
+/// <see cref="WidgetInstance.ApplyOverrides"/> behaviour. Pure in-memory tests —
+/// the persistence round-trip is covered separately by
+/// <c>DashboardPersistenceRoundTripTests</c>.
+/// </summary>
+public sealed class WidgetInstanceOverridesTests
+{
+    [Fact]
+    public void NewWidget_HasNoOverrides()
+    {
+        WidgetInstance widget = NewWidget();
+        widget.Overrides.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ApplyOverrides_StoresPayload()
+    {
+        WidgetInstance widget = NewWidget();
+        var overrides = new WidgetInstanceConfig(
+            TitleLocalizationKeyOverride: "Widget:Custom.Title",
+            ColorOverride: "#ff5500",
+            UnitOverride: "€",
+            DecimalsOverride: 2,
+            Thresholds: [new WidgetThreshold(100m, "#cc0000", WidgetThresholdOperator.GreaterThanOrEqual)]);
+
+        widget.ApplyOverrides(overrides);
+
+        widget.Overrides.ShouldBe(overrides);
+        widget.Overrides!.Thresholds.ShouldNotBeNull();
+        widget.Overrides.Thresholds.Count.ShouldBe(1);
+        widget.Overrides.Thresholds[0].Operator.ShouldBe(WidgetThresholdOperator.GreaterThanOrEqual);
+    }
+
+    [Fact]
+    public void ApplyOverrides_WithNull_ClearsExistingOverrides()
+    {
+        WidgetInstance widget = NewWidget();
+        widget.ApplyOverrides(new WidgetInstanceConfig(ColorOverride: "#000000"));
+        widget.Overrides.ShouldNotBeNull();
+
+        widget.ApplyOverrides(null);
+
+        widget.Overrides.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WidgetThresholdOperator_EnumOrderingIsStable()
+    {
+        // Wire format stability — JSON serializes enums as integers when no converter
+        // is set. The operator semantics MUST not drift across releases.
+        ((int)WidgetThresholdOperator.GreaterThanOrEqual).ShouldBe(0);
+        ((int)WidgetThresholdOperator.LessThanOrEqual).ShouldBe(1);
+        ((int)WidgetThresholdOperator.Equal).ShouldBe(2);
+    }
+
+    [Fact]
+    public void WidgetInstanceConfig_AllFieldsNullable_RemainsScopedToWhatChanges()
+    {
+        var empty = new WidgetInstanceConfig();
+
+        empty.TitleLocalizationKeyOverride.ShouldBeNull();
+        empty.ColorOverride.ShouldBeNull();
+        empty.UnitOverride.ShouldBeNull();
+        empty.DecimalsOverride.ShouldBeNull();
+        empty.Thresholds.ShouldBeNull();
+    }
+
+    private static WidgetInstance NewWidget()
+    {
+        var dashboard = Dashboard.Create(
+            Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        return dashboard.AddWidget(
+            Guid.NewGuid(), "Kpi", 0, 3, 1,
+            "Widget:Sample.Slug", "{}", metricName: "Sample.Metric");
+    }
+}

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Persistence/WidgetInstanceOverridesPersistenceTests.cs
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Persistence/WidgetInstanceOverridesPersistenceTests.cs
@@ -1,0 +1,138 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Tests.Persistence;
+
+/// <summary>
+/// SQLite-backed round-trip for the JSON-persisted <see cref="WidgetInstanceConfig"/>
+/// overrides on <see cref="WidgetInstance"/> rows. Confirms the value converter
+/// serialises and deserialises every field, including the nested
+/// <see cref="WidgetThreshold"/> list and the operator enum.
+/// </summary>
+public sealed class WidgetInstanceOverridesPersistenceTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext ctx = NewContext();
+        await ctx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+        => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task RoundTrip_PreservesAllOverrideFields()
+    {
+        var dashboardId = Guid.NewGuid();
+        var widgetId = Guid.NewGuid();
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            var dashboard = Dashboard.Create(dashboardId, "Finance", DashboardCategory.Finance);
+            WidgetInstance widget = dashboard.AddWidget(
+                widgetId, "Kpi", 0, 3, 1,
+                "Widget:Sample.Kpi", "{}", metricName: "Sample.Metric");
+            widget.ApplyOverrides(new WidgetInstanceConfig(
+                TitleLocalizationKeyOverride: "Widget:Custom.Override.Title",
+                ColorOverride: "#ff5500",
+                UnitOverride: "€",
+                DecimalsOverride: 2,
+                Thresholds:
+                [
+                    new WidgetThreshold(100m, "#cc0000", WidgetThresholdOperator.GreaterThanOrEqual),
+                    new WidgetThreshold(50m, "#ffaa00", WidgetThresholdOperator.LessThanOrEqual),
+                ]));
+            ctx.Dashboards.Add(dashboard);
+            await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            Dashboard loaded = await ctx.Dashboards
+                .Include(d => d.Widgets)
+                .SingleAsync(d => d.Id == dashboardId, TestContext.Current.CancellationToken);
+
+            WidgetInstance widget = loaded.Widgets.Single(w => w.Id == widgetId);
+            widget.Overrides.ShouldNotBeNull();
+            widget.Overrides.TitleLocalizationKeyOverride.ShouldBe("Widget:Custom.Override.Title");
+            widget.Overrides.ColorOverride.ShouldBe("#ff5500");
+            widget.Overrides.UnitOverride.ShouldBe("€");
+            widget.Overrides.DecimalsOverride.ShouldBe(2);
+            widget.Overrides.Thresholds.ShouldNotBeNull();
+            widget.Overrides.Thresholds.Count.ShouldBe(2);
+            widget.Overrides.Thresholds[0].Operator.ShouldBe(WidgetThresholdOperator.GreaterThanOrEqual);
+            widget.Overrides.Thresholds[0].Value.ShouldBe(100m);
+            widget.Overrides.Thresholds[1].Operator.ShouldBe(WidgetThresholdOperator.LessThanOrEqual);
+        }
+    }
+
+    [Fact]
+    public async Task NoOverrides_PersistsAsNullColumn()
+    {
+        var dashboardId = Guid.NewGuid();
+        var widgetId = Guid.NewGuid();
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            var dashboard = Dashboard.Create(dashboardId, "Finance", DashboardCategory.Finance);
+            dashboard.AddWidget(widgetId, "Markdown", 0, 12, 1, "Widget:S.Banner", "{}");
+            ctx.Dashboards.Add(dashboard);
+            await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            WidgetInstance widget = await ctx.WidgetInstances
+                .SingleAsync(w => w.Id == widgetId, TestContext.Current.CancellationToken);
+            widget.Overrides.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task ApplyOverrides_ThenClear_PersistsAsNull()
+    {
+        var dashboardId = Guid.NewGuid();
+        var widgetId = Guid.NewGuid();
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            var dashboard = Dashboard.Create(dashboardId, "Finance", DashboardCategory.Finance);
+            WidgetInstance widget = dashboard.AddWidget(widgetId, "Kpi", 0, 3, 1, "Widget:K", "{}", metricName: "M");
+            widget.ApplyOverrides(new WidgetInstanceConfig(ColorOverride: "#000000"));
+            ctx.Dashboards.Add(dashboard);
+            await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            WidgetInstance widget = await ctx.WidgetInstances
+                .SingleAsync(w => w.Id == widgetId, TestContext.Current.CancellationToken);
+            widget.ApplyOverrides(null);
+            await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            WidgetInstance widget = await ctx.WidgetInstances
+                .SingleAsync(w => w.Id == widgetId, TestContext.Current.CancellationToken);
+            widget.Overrides.ShouldBeNull();
+        }
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+}

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/packages.lock.json
@@ -353,6 +353,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.dashboards": {
         "type": "Project",
         "dependencies": {
@@ -363,7 +369,8 @@
       "granit.dashboards.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.entityframeworkcore": {


### PR DESCRIPTION
## Summary

Implements **P3.2** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). Separates two concerns currently conflated on `WidgetInstance`:

- **Imported config** (carried inline on the aggregate via `ConfigJson` + `MetricName` + `QueryName` + `Position` + `Width` + `Height`): values pinned at the moment the admin imported a `DashboardDefinition`.
- **Runtime overrides** (the new `Overrides` JSON payload): tweaks the admin applies after import — title, colour, unit, decimals, threshold rules.

The split lets the catalogue's "re-sync from definition" flow cleanly reset the imported half while preserving the admin's overrides.

## What lands

### `Granit.Dashboards/Domain/WidgetInstanceConfig.cs`

```csharp
public sealed record WidgetInstanceConfig(
    string? TitleLocalizationKeyOverride = null,
    string? ColorOverride = null,
    string? UnitOverride = null,
    int? DecimalsOverride = null,
    IReadOnlyList<WidgetThreshold>? Thresholds = null);

public sealed record WidgetThreshold(
    decimal Value,
    string Color,
    WidgetThresholdOperator Operator);

public enum WidgetThresholdOperator { GreaterThanOrEqual, LessThanOrEqual, Equal }
```

The proposal sketched stringly-typed operators (`">="` / `"<="` / `"=="`); promoted to a typed enum here for the same reasons every other framework enum is — wire format stability + IDE autocomplete + no parsing boilerplate.

### `WidgetInstance` aggregate

- New `Overrides: WidgetInstanceConfig?` read-only public field
- New `ApplyOverrides(WidgetInstanceConfig?)` behaviour method — apply or clear in one step (passing `null` reverts to imported defaults)

### `WidgetInstanceConfiguration` (EF Core)

- `Overrides` persists as JSON string column `overrides_json` via a `System.Text.Json` `ValueConverter` + identity `ValueComparer`
- JSON keeps the schema additive when new override fields ship — same trade-off as `ConfigJson`. Not `OwnsOne(...).ToJson()` because the override record carries a nullable list of thresholds that round-trips more reliably as a single serialised payload.
- **No migration shipped** — Granit framework convention forbids migrations in framework packages; consuming hosts pick up the new column when they run `dotnet ef migrations add` against their own DbContext.

## Tests — 8 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.EntityFrameworkCore.Tests/Domain/WidgetInstanceOverridesTests` | 5 | Public shape, `ApplyOverrides` set/clear, threshold operator enum stability |
| `Granit.Dashboards.EntityFrameworkCore.Tests/Persistence/WidgetInstanceOverridesPersistenceTests` | 3 | SQLite round-trip with all fields + nested threshold list, no-overrides null column, apply-then-clear cycle |

Total `Granit.Dashboards.EntityFrameworkCore.Tests`: **21/21** (13 existing + 8 new). Architecture suite: **158/158**.

## Test plan

- [x] `dotnet build src/Granit.Dashboards src/Granit.Dashboards.EntityFrameworkCore` — clean
- [x] `dotnet test tests/Granit.Dashboards.EntityFrameworkCore.Tests` — 21/21
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed
- [ ] CI green