### PR TITLE
feat(dashboards): WidgetAction declarative click-handlers (P1.5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4102,7 +4102,7 @@
       "kind": "enum",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs",
-      "line": 35,
+      "line": 37,
       "members": []
     },
     {
@@ -4111,7 +4111,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs",
-      "line": 21,
+      "line": 22,
       "members": []
     },
     {
@@ -4120,7 +4120,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs",
-      "line": 16,
+      "line": 17,
       "members": []
     },
     {
@@ -4129,7 +4129,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs",
-      "line": 19,
+      "line": 20,
       "members": []
     },
     {
@@ -4138,7 +4138,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs",
-      "line": 17,
+      "line": 18,
       "members": []
     },
     {
@@ -13022,12 +13022,39 @@
       "members": []
     },
     {
+      "name": "WidgetAction",
+      "fqn": "Granit.Dashboards.WidgetAction",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetAction.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "WidgetActionKind",
+      "fqn": "Granit.Dashboards.WidgetActionKind",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetAction.cs",
+      "line": 51,
+      "members": []
+    },
+    {
+      "name": "WidgetActionTrigger",
+      "fqn": "Granit.Dashboards.WidgetActionTrigger",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetAction.cs",
+      "line": 35,
+      "members": []
+    },
+    {
       "name": "WidgetDefinition",
       "fqn": "Granit.Dashboards.WidgetDefinition",
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/WidgetDefinition.cs",
-      "line": 47,
+      "line": 55,
       "members": []
     },
     {
@@ -13070,7 +13097,7 @@
       "kind": "enum",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs",
-      "line": 28,
+      "line": 30,
       "members": []
     },
     {
@@ -13079,7 +13106,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -13088,7 +13115,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs",
-      "line": 12,
+      "line": 13,
       "members": []
     },
     {
@@ -13097,7 +13124,7 @@
       "kind": "enum",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs",
-      "line": 22,
+      "line": 24,
       "members": []
     },
     {
@@ -13106,7 +13133,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {

--- a/src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/ChartWidgetDefinition.cs
@@ -18,6 +18,7 @@ namespace Granit.Analytics.Dashboards.Widgets;
 /// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
 /// <param name="TimeWindowOverride">See <see cref="WidgetDefinition.TimeWindowOverride"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record ChartWidgetDefinition(
     string Slug,
     string QueryName,
@@ -28,8 +29,9 @@ public sealed record ChartWidgetDefinition(
     int Position,
     WidgetSize? Size = null,
     string? RequiredPermission = null,
-    DashboardTimeWindow? TimeWindowOverride = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride);
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride, Actions);
 
 /// <summary>Visual hint for chart widgets, interpreted by the frontend.</summary>
 public enum ChartType

--- a/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
@@ -13,11 +13,13 @@ namespace Granit.Analytics.Dashboards.Widgets;
 /// <param name="Size">Defaults to <see cref="WidgetSize.SmallKpi"/>.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
 /// <param name="TimeWindowOverride">See <see cref="WidgetDefinition.TimeWindowOverride"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record KpiWidgetDefinition(
     string Slug,
     string MetricName,
     int Position,
     WidgetSize? Size = null,
     string? RequiredPermission = null,
-    DashboardTimeWindow? TimeWindowOverride = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.SmallKpi, RequiredPermission, TimeWindowOverride);
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.SmallKpi, RequiredPermission, TimeWindowOverride, Actions);

--- a/src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/PivotWidgetDefinition.cs
@@ -16,6 +16,7 @@ namespace Granit.Analytics.Dashboards.Widgets;
 /// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
 /// <param name="TimeWindowOverride">See <see cref="WidgetDefinition.TimeWindowOverride"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record PivotWidgetDefinition(
     string Slug,
     string QueryName,
@@ -26,5 +27,6 @@ public sealed record PivotWidgetDefinition(
     int Position,
     WidgetSize? Size = null,
     string? RequiredPermission = null,
-    DashboardTimeWindow? TimeWindowOverride = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride);
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride, Actions);

--- a/src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/TableWidgetDefinition.cs
@@ -14,6 +14,7 @@ namespace Granit.Analytics.Dashboards.Widgets;
 /// <param name="Size">Defaults to <see cref="WidgetSize.StandardChart"/>.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
 /// <param name="TimeWindowOverride">See <see cref="WidgetDefinition.TimeWindowOverride"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record TableWidgetDefinition(
     string Slug,
     string QueryName,
@@ -22,5 +23,6 @@ public sealed record TableWidgetDefinition(
     int Position,
     WidgetSize? Size = null,
     string? RequiredPermission = null,
-    DashboardTimeWindow? TimeWindowOverride = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride);
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.StandardChart, RequiredPermission, TimeWindowOverride, Actions);

--- a/src/Granit.Dashboards.Abstractions/WidgetAction.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetAction.cs
@@ -1,0 +1,71 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Declarative click-handler descriptor attached to a <see cref="WidgetDefinition"/>.
+/// No code injection, no expression evaluation — only a typed
+/// (<see cref="WidgetActionTrigger"/>, <see cref="WidgetActionKind"/>, target,
+/// optional params) tuple that the frontend dispatches to a known handler.
+/// See P1.5 of the dashboards-architecture-proposals roadmap.
+/// </summary>
+/// <param name="Trigger">What user gesture fires the action.</param>
+/// <param name="Kind">What kind of dispatch the frontend should perform.</param>
+/// <param name="Target">
+/// Target identifier. Interpretation depends on <see cref="Kind"/>:
+/// <list type="bullet">
+///   <item><see cref="WidgetActionKind.Navigate"/> — frontend route (e.g. <c>"/invoicing?status=unpaid"</c>).</item>
+///   <item><see cref="WidgetActionKind.OpenDashboardView"/> — a view name on the same dashboard (story P2.1).</item>
+///   <item><see cref="WidgetActionKind.OpenDashboard"/> — a <c>Dashboard.Name</c>.</item>
+///   <item><see cref="WidgetActionKind.ExportData"/> — an <c>ExportDefinition.Name</c>.</item>
+///   <item><see cref="WidgetActionKind.OpenDetail"/> — a side-drawer name (typically the row's full detail).</item>
+/// </list>
+/// </param>
+/// <param name="Params">
+/// Static parameters merged with the dynamic data row at dispatch time. Values may
+/// reference variables resolved by <c>IVariableSubstituter</c> (P3.3) — for example
+/// <c>{"customerId": "${row.customerId}", "status": "unpaid"}</c>. <c>null</c> = no
+/// extra parameters beyond the row data itself.
+/// </param>
+public sealed record WidgetAction(
+    WidgetActionTrigger Trigger,
+    WidgetActionKind Kind,
+    string Target,
+    IReadOnlyDictionary<string, string>? Params = null);
+
+/// <summary>What user gesture fires a <see cref="WidgetAction"/>.</summary>
+public enum WidgetActionTrigger
+{
+    /// <summary>Clicking the widget body or KPI value.</summary>
+    Click = 0,
+
+    /// <summary>Clicking a row inside a Table / Pivot widget.</summary>
+    RowClick = 1,
+
+    /// <summary>Clicking a series segment inside a Chart widget (a bar, a line point, a slice).</summary>
+    SeriesClick = 2,
+
+    /// <summary>Clicking a legend item inside a Chart widget.</summary>
+    LegendClick = 3,
+}
+
+/// <summary>Type of dispatch the frontend performs when a <see cref="WidgetAction"/> fires.</summary>
+public enum WidgetActionKind
+{
+    /// <summary>Frontend route navigation (preserves dashboard context if possible).</summary>
+    Navigate = 0,
+
+    /// <summary>
+    /// Switch to another <c>view</c> of the current dashboard — see story P2.1
+    /// (Views, intra-dashboard navigation; renamed from "DashboardState" to avoid
+    /// the clash with the persisted <c>Dashboard.Status</c> field).
+    /// </summary>
+    OpenDashboardView = 1,
+
+    /// <summary>Navigate to another full <see cref="DashboardDefinition"/> by name.</summary>
+    OpenDashboard = 2,
+
+    /// <summary>Trigger an export via <c>Granit.DataExchange</c> (target = <c>ExportDefinition.Name</c>).</summary>
+    ExportData = 3,
+
+    /// <summary>Open a side drawer with the row's full detail (typical for table widgets).</summary>
+    OpenDetail = 4,
+}

--- a/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetDefinition.cs
@@ -31,6 +31,14 @@ namespace Granit.Dashboards;
 /// peers (e.g. a year-to-date KPI next to last-30-days widgets).
 /// Presentation-only widgets ignore this field.
 /// </param>
+/// <param name="Actions">
+/// Declarative click-handler descriptors. Each <see cref="WidgetAction"/> binds a
+/// trigger (click / row-click / series-click / legend-click) to a typed dispatch kind
+/// (navigate / open view / open dashboard / export / open detail) plus an optional
+/// param map. The frontend dispatches them — no code injection, no expression
+/// evaluation; values may reference variables resolved by <c>IVariableSubstituter</c>
+/// (P3.3). <c>null</c> = the widget has no actions wired.
+/// </param>
 /// <remarks>
 /// JSON polymorphism uses a stable <c>"type"</c> discriminator with short tags
 /// (<c>"markdown"</c>, <c>"image"</c>, <c>"text"</c>, <c>"kpi"</c>, ...). The three
@@ -49,4 +57,5 @@ public abstract record WidgetDefinition(
     int Position,
     WidgetSize Size,
     string? RequiredPermission = null,
-    DashboardTimeWindow? TimeWindowOverride = null);
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null);

--- a/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/ImageWidgetDefinition.cs
@@ -15,14 +15,16 @@ namespace Granit.Dashboards.Widgets;
 /// (preserves aspect, letterboxes) — the right call for logos. Use
 /// <see cref="ImageFit.Cover"/> for banner photos that should fill the tile.
 /// </param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record ImageWidgetDefinition(
     string Slug,
     string Source,
     string AltLocalizationKey,
     int Position,
     WidgetSize? Size = null,
-    ImageFit Fit = ImageFit.Contain)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile, RequiredPermission: null);
+    ImageFit Fit = ImageFit.Contain,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile, RequiredPermission: null, TimeWindowOverride: null, Actions);
 
 /// <summary>How an <see cref="ImageWidgetDefinition"/> fills its grid cell.</summary>
 public enum ImageFit

--- a/src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/MarkdownWidgetDefinition.cs
@@ -9,9 +9,11 @@ namespace Granit.Dashboards.Widgets;
 /// <param name="ContentLocalizationKey">Localization key resolving to the markdown body (e.g. <c>"Widget:Granit.Invoicing.FinanceOverview.Banner"</c>).</param>
 /// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
 /// <param name="Size">Defaults to <see cref="WidgetSize.FullWidthRow"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record MarkdownWidgetDefinition(
     string Slug,
     string ContentLocalizationKey,
     int Position,
-    WidgetSize? Size = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null);
+    WidgetSize? Size = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null, TimeWindowOverride: null, Actions);

--- a/src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/Widgets/TextWidgetDefinition.cs
@@ -10,13 +10,15 @@ namespace Granit.Dashboards.Widgets;
 /// <param name="Style">Visual style hint — interpreted by the frontend.</param>
 /// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
 /// <param name="Size">Defaults to <see cref="WidgetSize.FullWidthRow"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record TextWidgetDefinition(
     string Slug,
     string ContentLocalizationKey,
     TextStyle Style,
     int Position,
-    WidgetSize? Size = null)
-    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null);
+    WidgetSize? Size = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.FullWidthRow, RequiredPermission: null, TimeWindowOverride: null, Actions);
 
 /// <summary>Visual style hint for <see cref="TextWidgetDefinition"/>.</summary>
 public enum TextStyle

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetActionsTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetActionsTests.cs
@@ -1,0 +1,82 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards;
+
+/// <summary>
+/// Locks the propagation of <see cref="WidgetDefinition.Actions"/> through the four
+/// data-bound analytics widgets. Default = <c>null</c>; explicit value travels
+/// through the base record correctly.
+/// </summary>
+public sealed class AnalyticsWidgetActionsTests
+{
+    private static readonly WidgetAction[] OneClickAction =
+    [
+        new(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/invoicing?status=unpaid"),
+    ];
+
+    [Fact]
+    public void Kpi_DefaultsToNoActions()
+        => new KpiWidgetDefinition("K", "M", Position: 0).Actions.ShouldBeNull();
+
+    [Fact]
+    public void Kpi_AcceptsActions()
+    {
+        KpiWidgetDefinition widget = new(
+            "UnpaidCount", "Sample.Metric", Position: 0, Actions: OneClickAction);
+
+        widget.Actions.ShouldBe(OneClickAction);
+    }
+
+    [Fact]
+    public void Chart_AcceptsSeriesClickAction()
+    {
+        WidgetAction[] actions =
+        [
+            new(WidgetActionTrigger.SeriesClick, WidgetActionKind.OpenDetail, "Drawer",
+                Params: new Dictionary<string, string> { ["seriesValue"] = "${series.name}" }),
+        ];
+
+        ChartWidgetDefinition widget = new(
+            "RevenueByMonth", "Sample.Q", "g", AggregateFunction.Sum, "f", ChartType.Bar,
+            Position: 0, Actions: actions);
+
+        widget.Actions.ShouldBe(actions);
+        widget.Actions![0].Trigger.ShouldBe(WidgetActionTrigger.SeriesClick);
+        widget.Actions[0].Params!["seriesValue"].ShouldBe("${series.name}");
+    }
+
+    [Fact]
+    public void Table_AcceptsRowClickAction()
+    {
+        WidgetAction[] actions =
+        [
+            new(WidgetActionTrigger.RowClick, WidgetActionKind.OpenDetail, "InvoiceDrawer",
+                Params: new Dictionary<string, string> { ["invoiceId"] = "${row.id}" }),
+        ];
+
+        TableWidgetDefinition widget = new(
+            "RecentInvoices", "Sample.Q", null, 25, Position: 0, Actions: actions);
+
+        widget.Actions.ShouldBe(actions);
+    }
+
+    [Fact]
+    public void Pivot_AcceptsActions()
+    {
+        WidgetAction[] actions =
+        [
+            new(WidgetActionTrigger.Click, WidgetActionKind.ExportData, "Granit.Invoicing.InvoiceExport"),
+        ];
+
+        PivotWidgetDefinition widget = new(
+            "InvoicesByCustomerByMonth", "Sample.Q", ["r"], ["c"], null, AggregateFunction.Count,
+            Position: 0, Actions: actions);
+
+        widget.Actions.ShouldBe(actions);
+        widget.Actions![0].Kind.ShouldBe(WidgetActionKind.ExportData);
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/WidgetActionTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/WidgetActionTests.cs
@@ -1,0 +1,75 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape of <see cref="WidgetAction"/> + the two enums (P1.5).
+/// Records stay POCO — the dispatch itself is frontend logic. These tests pin the
+/// wire format so the typescript discriminated unions on <c>granit-front</c> have a
+/// stable contract.
+/// </summary>
+public sealed class WidgetActionTests
+{
+    [Fact]
+    public void Construction_DefaultsParamsToNull()
+    {
+        WidgetAction action = new(
+            WidgetActionTrigger.Click,
+            WidgetActionKind.Navigate,
+            Target: "/invoicing?status=unpaid");
+
+        action.Trigger.ShouldBe(WidgetActionTrigger.Click);
+        action.Kind.ShouldBe(WidgetActionKind.Navigate);
+        action.Target.ShouldBe("/invoicing?status=unpaid");
+        action.Params.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Construction_AcceptsParamsDictionary()
+    {
+        WidgetAction action = new(
+            WidgetActionTrigger.RowClick,
+            WidgetActionKind.OpenDetail,
+            Target: "InvoiceDrawer",
+            Params: new Dictionary<string, string>
+            {
+                ["invoiceId"] = "${row.id}",
+                ["mode"] = "readonly",
+            });
+
+        action.Params.ShouldNotBeNull();
+        action.Params.Count.ShouldBe(2);
+        action.Params["invoiceId"].ShouldBe("${row.id}");
+        action.Params["mode"].ShouldBe("readonly");
+    }
+
+    [Fact]
+    public void Trigger_EnumOrderingIsStable()
+    {
+        // Wire format stability — the four trigger values pin the contract.
+        ((int)WidgetActionTrigger.Click).ShouldBe(0);
+        ((int)WidgetActionTrigger.RowClick).ShouldBe(1);
+        ((int)WidgetActionTrigger.SeriesClick).ShouldBe(2);
+        ((int)WidgetActionTrigger.LegendClick).ShouldBe(3);
+    }
+
+    [Fact]
+    public void Kind_EnumOrderingIsStable()
+    {
+        ((int)WidgetActionKind.Navigate).ShouldBe(0);
+        ((int)WidgetActionKind.OpenDashboardView).ShouldBe(1);
+        ((int)WidgetActionKind.OpenDashboard).ShouldBe(2);
+        ((int)WidgetActionKind.ExportData).ShouldBe(3);
+        ((int)WidgetActionKind.OpenDetail).ShouldBe(4);
+    }
+
+    [Fact]
+    public void RecordEquality_HoldsByValue()
+    {
+        WidgetAction a = new(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/x");
+        WidgetAction b = new(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/x");
+
+        a.ShouldBe(b);
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/Widgets/WidgetDefinitionActionsPropagationTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/Widgets/WidgetDefinitionActionsPropagationTests.cs
@@ -1,0 +1,56 @@
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests.Widgets;
+
+/// <summary>
+/// Confirms the <see cref="WidgetDefinition.Actions"/> field propagates through the
+/// three presentation widgets. Default = <c>null</c> (no actions). Explicit value
+/// is preserved by record equality and round-trips through the base.
+/// </summary>
+public sealed class WidgetDefinitionActionsPropagationTests
+{
+    [Fact]
+    public void Markdown_DefaultsToNoActions()
+        => new MarkdownWidgetDefinition("M", "Widget:M", Position: 0).Actions.ShouldBeNull();
+
+    [Fact]
+    public void Image_DefaultsToNoActions()
+        => new ImageWidgetDefinition("I", "https://x", "Widget:I.Alt", Position: 0).Actions.ShouldBeNull();
+
+    [Fact]
+    public void Text_DefaultsToNoActions()
+        => new TextWidgetDefinition("T", "Widget:T", TextStyle.Body, Position: 0).Actions.ShouldBeNull();
+
+    [Fact]
+    public void Markdown_ExposesActionsForBannerLinks()
+    {
+        WidgetAction[] actions =
+        [
+            new(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/docs/onboarding"),
+        ];
+
+        MarkdownWidgetDefinition widget = new(
+            "Banner", "Widget:Banner", Position: 0, Actions: actions);
+
+        widget.Actions.ShouldNotBeNull();
+        widget.Actions.Count.ShouldBe(1);
+        widget.Actions[0].Kind.ShouldBe(WidgetActionKind.Navigate);
+    }
+
+    [Fact]
+    public void Image_ExposesActions_ForLogoLinks()
+    {
+        WidgetAction[] actions =
+        [
+            new(WidgetActionTrigger.Click, WidgetActionKind.OpenDashboard, "Granit.Invoicing.FinanceOverview"),
+        ];
+
+        ImageWidgetDefinition widget = new(
+            "Logo", "blob:logo", "Widget:Logo.Alt", Position: 0, Actions: actions);
+
+        widget.Actions.ShouldNotBeNull();
+        widget.Actions[0].Target.ShouldBe("Granit.Invoicing.FinanceOverview");
+    }
+}


### PR DESCRIPTION
## Summary

Implements **P1.5** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). Widgets gain a declarative actions surface — typed click handlers dispatched by the frontend, **zero code injection, zero expression evaluation**.

Builds on top of P1.3 (TimeWindow) and P3.3 (`${variable}` substituter): action params can reference `${row.x}` / `${series.x}` / `${alias.x}` placeholders resolved at dispatch time by `IVariableSubstituter`.

## What lands

### `Granit.Dashboards.Abstractions/WidgetAction.cs`

```csharp
public sealed record WidgetAction(
    WidgetActionTrigger Trigger,
    WidgetActionKind Kind,
    string Target,
    IReadOnlyDictionary<string, string>? Params = null);

public enum WidgetActionTrigger { Click, RowClick, SeriesClick, LegendClick }

public enum WidgetActionKind
{
    Navigate,            // frontend route
    OpenDashboardView,   // switch view within current dashboard (P2.1; renamed from "DashboardState" to avoid clashing with Dashboard.Status)
    OpenDashboard,       // full DashboardDefinition by name
    ExportData,          // ExportDefinition by name
    OpenDetail,          // side drawer
}
```

### `WidgetDefinition` base + 7 derived records

- Base record gains optional `Actions: IReadOnlyList<WidgetAction>?` field.
- All seven widget records propagate the field: **Markdown / Image / Text + Kpi / Chart / Table / Pivot**. Defaults to `null` on every record.

## Tests — 15 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Abstractions.Tests/WidgetActionTests` | 5 | Record shape, enum ordering stability for both Trigger and Kind, params dictionary, record equality |
| `Granit.Dashboards.Abstractions.Tests/Widgets/WidgetDefinitionActionsPropagationTests` | 5 | Defaults + explicit values across the three presentation widgets |
| `Granit.Analytics.Tests/Dashboards/AnalyticsWidgetActionsTests` | 5 | Defaults + trigger/kind variants across the four data-bound widgets, including `${row.id}` / `${series.name}` param-template patterns that pair with P3.3 |

Architecture suite stays at **158/158**. Total dashboards-stack tests: 77 (was 62, +15).

## Wire format

With P1.1 polymorphism + P1.5 actions, the frontend's TypeScript discriminated unions on **`WidgetDefinition` AND its actions surface** are both stable contracts now.

## Test plan

- [x] `dotnet build` — clean across Dashboards.Abstractions + Analytics + Dashboards
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 26/26
- [x] `dotnet test tests/Granit.Analytics.Tests` — 27/27
- [x] `dotnet test tests/Granit.Dashboards.Tests` — 24/24 (no impact)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [ ] CI green