### PR TITLE
feat(dashboards): dashboard-scoped filters with toolbar opt-in (P2.5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12601,8 +12601,50 @@
           "kind": "property",
           "signature": "DashboardTimeWindow? DefaultTimeWindow",
           "returnType": "DashboardTimeWindow?"
+        },
+        {
+          "name": "Widgets",
+          "kind": "property",
+          "signature": "IReadOnlyList<WidgetDefinition> Widgets",
+          "returnType": "IReadOnlyList<WidgetDefinition>"
         }
       ]
+    },
+    {
+      "name": "DashboardFilter",
+      "fqn": "Granit.Dashboards.DashboardFilter",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardFilter.cs",
+      "line": 50,
+      "members": []
+    },
+    {
+      "name": "DashboardFilterClause",
+      "fqn": "Granit.Dashboards.DashboardFilterClause",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardFilter.cs",
+      "line": 67,
+      "members": []
+    },
+    {
+      "name": "DashboardFilterOperation",
+      "fqn": "Granit.Dashboards.DashboardFilterOperation",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardFilter.cs",
+      "line": 110,
+      "members": []
+    },
+    {
+      "name": "DashboardFilterOperator",
+      "fqn": "Granit.Dashboards.DashboardFilterOperator",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardFilter.cs",
+      "line": 79,
+      "members": []
     },
     {
       "name": "DashboardLayout",

--- a/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
@@ -72,4 +72,12 @@ public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
 
     /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
     public abstract IReadOnlyList<WidgetDefinition> Widgets { get; }
+
+    /// <summary>
+    /// Dashboard-scoped filters. Each filter may be referenced by name from a widget's
+    /// data source; toolbar-exposed filters (<see cref="DashboardFilter.Editable"/>
+    /// = <c>true</c>) become user-editable controls above the grid. <c>null</c> = the
+    /// dashboard has no filters beyond what individual widgets carry.
+    /// </summary>
+    public virtual IReadOnlyList<DashboardFilter>? Filters => null;
 }

--- a/src/Granit.Dashboards.Abstractions/DashboardFilter.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardFilter.cs
@@ -1,0 +1,117 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Dashboard-scoped filter applied to data-bound widgets that opt in. P2.5 of the
+/// dashboards-architecture-proposals roadmap — distinct from per-datasource filters
+/// a widget may carry internally:
+/// </summary>
+/// <list type="bullet">
+///   <item><b>Per-widget filter</b> (today): "this chart only ever shows unpaid invoices".
+///         Lives inside the widget's data source.</item>
+///   <item><b>Dashboard filter</b> (here): "this whole dashboard is now scoped to
+///         March 2026" / "Customer = X". Shared across many widgets, optionally
+///         user-editable from a toolbar control above the grid.</item>
+/// </list>
+/// <remarks>
+/// <para>
+/// Toolbar-exposed filters (<see cref="Editable"/> = <c>true</c>) become user-driven
+/// controls; the frontend renders the appropriate input widget (date picker, lookup,
+/// text, ...) based on the clause shape, and propagates value changes through
+/// <c>DashboardContext</c> to refetch every widget that references this filter by
+/// <see cref="Name"/>.
+/// </para>
+/// <para>
+/// Non-editable filters apply silently — useful for "current user", "current tenant"
+/// scoping that should never become a user-toggleable control.
+/// </para>
+/// </remarks>
+/// <param name="Name">
+/// Filter identifier referenced from a data source's <c>DashboardFilters</c> list.
+/// PascalCase, unique within the dashboard (e.g. <c>"CurrentCustomer"</c>,
+/// <c>"DateRange"</c>, <c>"Severity"</c>).
+/// </param>
+/// <param name="LabelLocalizationKey">
+/// Localization key for the toolbar label when <see cref="Editable"/> is <c>true</c>.
+/// Resolved by the standard Granit localization stack.
+/// </param>
+/// <param name="Clauses">
+/// One or more clauses combined by <see cref="Operation"/>. Static values are encoded
+/// as their string representation; <c>${variable}</c> references resolve via
+/// <c>IVariableSubstituter</c> at query-build time against state params and aliases.
+/// </param>
+/// <param name="Operation">
+/// How clauses combine — <see cref="DashboardFilterOperation.And"/> (every clause must
+/// match) or <see cref="DashboardFilterOperation.Or"/>. Defaults to <c>And</c>.
+/// </param>
+/// <param name="Editable">
+/// When <c>true</c>, the filter is rendered as a toolbar control above the grid; end
+/// users can change its value at runtime. Defaults to <c>false</c> — silent application.
+/// </param>
+public sealed record DashboardFilter(
+    string Name,
+    string LabelLocalizationKey,
+    IReadOnlyList<DashboardFilterClause> Clauses,
+    DashboardFilterOperation Operation = DashboardFilterOperation.And,
+    bool Editable = false);
+
+/// <summary>
+/// Single clause inside a <see cref="DashboardFilter"/>.
+/// </summary>
+/// <param name="Field">Field path (e.g. <c>"customer.id"</c>, <c>"issuedAt"</c>, <c>"status"</c>).</param>
+/// <param name="Op">Comparison operator — see <see cref="DashboardFilterOperator"/>.</param>
+/// <param name="Value">
+/// Static value (string-encoded for JSON parity with the QueryEngine wire format) or a
+/// <c>${variable}</c> placeholder resolved at query-build time. <c>null</c> is valid
+/// for operators that test for absence (combined with negation upstream).
+/// </param>
+public sealed record DashboardFilterClause(
+    string Field,
+    DashboardFilterOperator Op,
+    string? Value);
+
+/// <summary>Comparison operator used by <see cref="DashboardFilterClause"/>.</summary>
+/// <remarks>
+/// Names match the OData / Granit.QueryEngine wire vocabulary (<c>eq</c>, <c>ne</c>,
+/// <c>gt</c>, <c>gte</c>, <c>lt</c>, <c>lte</c>, <c>in</c>, <c>contains</c>,
+/// <c>startswith</c>) so frontend code consuming dashboard filters can reuse the same
+/// operator dictionary already used for grid query strings.
+/// </remarks>
+public enum DashboardFilterOperator
+{
+    /// <summary>Equal.</summary>
+    Eq = 0,
+
+    /// <summary>Not equal.</summary>
+    Ne = 1,
+
+    /// <summary>Greater than.</summary>
+    Gt = 2,
+
+    /// <summary>Greater than or equal.</summary>
+    Gte = 3,
+
+    /// <summary>Less than.</summary>
+    Lt = 4,
+
+    /// <summary>Less than or equal.</summary>
+    Lte = 5,
+
+    /// <summary>Value belongs to a comma-separated set (encoded inside <see cref="DashboardFilterClause.Value"/>).</summary>
+    In = 6,
+
+    /// <summary>String contains the value (case-sensitive).</summary>
+    Contains = 7,
+
+    /// <summary>String starts with the value (case-sensitive).</summary>
+    StartsWith = 8,
+}
+
+/// <summary>How a <see cref="DashboardFilter"/>'s clauses combine.</summary>
+public enum DashboardFilterOperation
+{
+    /// <summary>Every clause must match. The default — narrowest scope.</summary>
+    And = 0,
+
+    /// <summary>At least one clause must match.</summary>
+    Or = 1,
+}

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -47,4 +47,13 @@ public interface IDashboardDefinitionDescriptor
 
     /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
     IReadOnlyList<WidgetDefinition> Widgets { get; }
+
+    /// <summary>
+    /// Dashboard-scoped filters declared by this dashboard. Each filter is referenced
+    /// by name from a widget's data source; toolbar-exposed filters
+    /// (<see cref="DashboardFilter.Editable"/> = <c>true</c>) become user-editable
+    /// controls above the widget grid. <c>null</c> = the dashboard has no filters
+    /// beyond what individual widgets carry.
+    /// </summary>
+    IReadOnlyList<DashboardFilter>? Filters { get; }
 }

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionFiltersTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionFiltersTests.cs
@@ -1,0 +1,56 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Confirms <see cref="DashboardDefinition.Filters"/> default behaviour and that a
+/// concrete dashboard can override it to ship dashboard-scoped filter sets.
+/// </summary>
+public sealed class DashboardDefinitionFiltersTests
+{
+    [Fact]
+    public void Default_ReturnsNull()
+        => new EmptyDashboard().Filters.ShouldBeNull();
+
+    [Fact]
+    public void Override_SurfacesFiltersOnTheDescriptor()
+    {
+        IDashboardDefinitionDescriptor d = new FilteredDashboard();
+
+        d.Filters.ShouldNotBeNull();
+        d.Filters.Count.ShouldBe(2);
+        d.Filters.ShouldContain(f => f.Name == "CurrentCustomer" && !f.Editable);
+        d.Filters.ShouldContain(f => f.Name == "DateRange" && f.Editable);
+    }
+
+    private sealed class EmptyDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Empty";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+    }
+
+    private sealed class FilteredDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Filtered";
+        public override DashboardCategory Category => DashboardCategory.Finance;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+
+        public override IReadOnlyList<DashboardFilter>? Filters { get; } =
+        [
+            new DashboardFilter(
+                "CurrentCustomer",
+                "Dashboard:Sample.Filtered.Filters.Customer",
+                [new DashboardFilterClause("customer.id", DashboardFilterOperator.Eq, "${entityId}")]),
+            new DashboardFilter(
+                "DateRange",
+                "Dashboard:Sample.Filtered.Filters.DateRange",
+                [
+                    new DashboardFilterClause("issuedAt", DashboardFilterOperator.Gte, "2026-01-01"),
+                    new DashboardFilterClause("issuedAt", DashboardFilterOperator.Lt, "2027-01-01"),
+                ],
+                Editable: true),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardFilterTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardFilterTests.cs
@@ -1,0 +1,102 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape of <see cref="DashboardFilter"/> + clause + the two enums
+/// (P2.5). Pin the wire format — operator names match the OData / Granit.QueryEngine
+/// vocabulary so downstream JSON consumers can reuse the same dictionary.
+/// </summary>
+public sealed class DashboardFilterTests
+{
+    [Fact]
+    public void Construction_DefaultsAndOperationAndNotEditable()
+    {
+        DashboardFilter filter = new(
+            Name: "CurrentCustomer",
+            LabelLocalizationKey: "Dashboard:Sample.Filters.Customer",
+            Clauses:
+            [
+                new DashboardFilterClause("customer.id", DashboardFilterOperator.Eq, "${entityId}"),
+            ]);
+
+        filter.Operation.ShouldBe(DashboardFilterOperation.And);
+        filter.Editable.ShouldBeFalse();
+        filter.Clauses.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Editable_OptIn_ForToolbarSurfacing()
+    {
+        DashboardFilter filter = new(
+            Name: "DateRange",
+            LabelLocalizationKey: "Dashboard:Sample.Filters.DateRange",
+            Clauses:
+            [
+                new DashboardFilterClause("issuedAt", DashboardFilterOperator.Gte, "2026-01-01"),
+                new DashboardFilterClause("issuedAt", DashboardFilterOperator.Lt, "2027-01-01"),
+            ],
+            Editable: true);
+
+        filter.Editable.ShouldBeTrue();
+        filter.Clauses.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Operation_OrCombinesClausesPermissively()
+    {
+        DashboardFilter filter = new(
+            Name: "OpenOrEscalated",
+            LabelLocalizationKey: "Dashboard:Sample.Filters.Status",
+            Clauses:
+            [
+                new DashboardFilterClause("status", DashboardFilterOperator.Eq, "open"),
+                new DashboardFilterClause("status", DashboardFilterOperator.Eq, "escalated"),
+            ],
+            Operation: DashboardFilterOperation.Or);
+
+        filter.Operation.ShouldBe(DashboardFilterOperation.Or);
+    }
+
+    [Fact]
+    public void Clause_AcceptsNullValue_ForAbsenceOperators()
+    {
+        DashboardFilterClause clause = new("archivedAt", DashboardFilterOperator.Eq, null);
+
+        clause.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Operator_EnumOrderingIsStable()
+    {
+        // Wire format stability — operator integers travel in JSON when no converter
+        // is set. Names match OData / Granit.QueryEngine vocabulary; the integer
+        // ordering pins the contract for both producers (server) and consumers (front).
+        ((int)DashboardFilterOperator.Eq).ShouldBe(0);
+        ((int)DashboardFilterOperator.Ne).ShouldBe(1);
+        ((int)DashboardFilterOperator.Gt).ShouldBe(2);
+        ((int)DashboardFilterOperator.Gte).ShouldBe(3);
+        ((int)DashboardFilterOperator.Lt).ShouldBe(4);
+        ((int)DashboardFilterOperator.Lte).ShouldBe(5);
+        ((int)DashboardFilterOperator.In).ShouldBe(6);
+        ((int)DashboardFilterOperator.Contains).ShouldBe(7);
+        ((int)DashboardFilterOperator.StartsWith).ShouldBe(8);
+    }
+
+    [Fact]
+    public void Operation_EnumOrderingIsStable()
+    {
+        ((int)DashboardFilterOperation.And).ShouldBe(0);
+        ((int)DashboardFilterOperation.Or).ShouldBe(1);
+    }
+
+    [Fact]
+    public void RecordEquality_HoldsByValue()
+    {
+        DashboardFilterClause c1 = new("status", DashboardFilterOperator.Eq, "open");
+        DashboardFilterClause c2 = new("status", DashboardFilterOperator.Eq, "open");
+
+        c1.ShouldBe(c2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **P2.5** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). Distinct from per-datasource filters a widget may carry internally — those stay widget-local. Dashboard filters are **shared across many widgets**, named, optionally surfaced as user-editable toolbar controls above the grid.

Use cases:

- **Finance dashboard**: a single `Customer = X` filter all 12 widgets respect (unpaid invoices, revenue, payments, …).
- **IoT dashboard**: `Site = Plant 3` narrows every device-bound widget to one location.
- **Audit dashboard**: `Severity >= Warning` trims noise across every audit-event widget.

## What lands

### `Granit.Dashboards.Abstractions/DashboardFilter.cs`

```csharp
public sealed record DashboardFilter(
    string Name,
    string LabelLocalizationKey,
    IReadOnlyList<DashboardFilterClause> Clauses,
    DashboardFilterOperation Operation = DashboardFilterOperation.And,
    bool Editable = false);

public sealed record DashboardFilterClause(
    string Field,
    DashboardFilterOperator Op,
    string? Value);

public enum DashboardFilterOperator
{
    Eq, Ne, Gt, Gte, Lt, Lte, In, Contains, StartsWith
}

public enum DashboardFilterOperation { And, Or }
```

- `Value` is **string-typed** for JSON parity with the QueryEngine wire format; `${variable}` references resolve via `IVariableSubstituter` (P3.3) at query-build time against state params + aliases.
- Operator names match the OData / `Granit.QueryEngine` vocabulary so frontend code consuming dashboard filters reuses the same operator dictionary it already uses for grid query strings.

### `DashboardDefinition.Filters`

- New `virtual IReadOnlyList<DashboardFilter>? Filters => null;`
- Surfaced through `IDashboardDefinitionDescriptor.Filters` so the catalogue endpoint can pre-fetch them.

### Toolbar UX (frontend, future)

- `Editable = true` → frontend renders an input control above the grid (date picker, lookup, text, … based on the clause shape). Value lives in `DashboardContext`; changes invalidate every widget that references this filter by name.
- `Editable = false` (default) → silent application. Useful for "current user", "current tenant" scoping that should never become a user-toggleable control.

## Tests — 8 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Abstractions.Tests/DashboardFilterTests` | 6 | Defaults (And + non-editable), opt-in `Editable`, `Or` operation, null-value clause for absence operators, operator + operation enum ordering stability, record equality |
| `Granit.Dashboards.Abstractions.Tests/DashboardDefinitionFiltersTests` | 2 | `null` default, override surfaces filters through the descriptor |

`Granit.Dashboards.Abstractions.Tests`: **35/35** (was 27, +8). Architecture suite: **158/158**.

## No lockfile drift

Additive within an existing package — no `<ProjectReference>` change, no transitive impact on the test tree. (Memory: any *.Abstractions ProjectReference change requires `dotnet restore Granit.slnx --force-evaluate`, but this PR doesn't trigger that path.)

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Abstractions src/Granit.Dashboards` — clean
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 35/35
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [ ] CI green