### PR TITLE
feat(dashboards): named views for intra-dashboard navigation (P2.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12607,6 +12607,18 @@
           "kind": "property",
           "signature": "IReadOnlyList<WidgetDefinition> Widgets",
           "returnType": "IReadOnlyList<WidgetDefinition>"
+        },
+        {
+          "name": "DefaultView",
+          "kind": "property",
+          "signature": "string? DefaultView",
+          "returnType": "string?"
+        },
+        {
+          "name": "Filters",
+          "kind": "property",
+          "signature": "IReadOnlyList<DashboardFilter>? Filters",
+          "returnType": "IReadOnlyList<DashboardFilter>?"
         }
       ]
     },
@@ -12716,6 +12728,15 @@
           "returnType": "DashboardTimeWindow RealtimeLast5Minutes =>"
         }
       ]
+    },
+    {
+      "name": "DashboardView",
+      "fqn": "Granit.Dashboards.DashboardView",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardView.cs",
+      "line": 43,
+      "members": []
     },
     {
       "name": "Dashboard",

--- a/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
@@ -70,8 +70,30 @@ public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
     /// </summary>
     public virtual DashboardTimeWindow? DefaultTimeWindow => null;
 
-    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    /// <summary>
+    /// Widgets shipped by this dashboard, in declared order. For single-view
+    /// dashboards this is the rendered list. For multi-view dashboards
+    /// (<see cref="Views"/> non-null), the runtime renders the active view's
+    /// widgets and treats this property as the entry-view fallback used only when
+    /// <see cref="DefaultView"/> is <c>null</c> and <see cref="Views"/> is empty.
+    /// </summary>
     public abstract IReadOnlyList<WidgetDefinition> Widgets { get; }
+
+    /// <summary>
+    /// Named views — separate widget arrangements within the same dashboard, sharing
+    /// time window, entity aliases and filters but each shipping its own widget pool
+    /// and optional layout override. <c>null</c> (default) = single-view dashboard
+    /// rendering <see cref="Widgets"/>. See P2.1 of the dashboards-architecture-proposals
+    /// roadmap.
+    /// </summary>
+    public virtual IReadOnlyList<DashboardView>? Views => null;
+
+    /// <summary>
+    /// Entry-view name when <see cref="Views"/> is non-null. <c>null</c> = the
+    /// runtime falls back to the first view in <see cref="Views"/>. Ignored for
+    /// single-view dashboards (where <see cref="Views"/> is null).
+    /// </summary>
+    public virtual string? DefaultView => null;
 
     /// <summary>
     /// Dashboard-scoped filters. Each filter may be referenced by name from a widget's

--- a/src/Granit.Dashboards.Abstractions/DashboardView.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardView.cs
@@ -1,0 +1,47 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Named view of a dashboard — a separate widget arrangement within the same
+/// <see cref="DashboardDefinition"/>. Views share the dashboard-level
+/// <c>TimeWindow</c>, entity aliases (story P2.3) and breadcrumb context, but each
+/// view ships its own widget pool and optional layout override. P2.1 of the
+/// dashboards-architecture-proposals roadmap — renamed from "DashboardState" to
+/// avoid the clash with <c>Dashboard.Status</c> (Draft / Published / Archived).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Single-view dashboards leave <see cref="DashboardDefinition.Views"/> as
+/// <c>null</c> and ship their widgets via the inherited <c>Widgets</c> property —
+/// the existing default. Multi-view dashboards override <c>Views</c> with one or
+/// more <see cref="DashboardView"/> entries and the runtime renders the entry
+/// named by <see cref="DashboardDefinition.DefaultView"/> (or the first view if
+/// <c>DefaultView</c> is <c>null</c>).
+/// </para>
+/// <para>
+/// View transitions are triggered by widget actions
+/// (<c>WidgetActionKind.OpenDashboardView</c>) and reflected in the URL as
+/// <c>/dashboards/{Name}/view/{viewName}</c>. Entity aliases that resolve from
+/// the active view's parameters (story P2.3 / <c>StateEntityResolver</c>) re-fire
+/// at every view transition.
+/// </para>
+/// </remarks>
+/// <param name="Name">
+/// View identifier, unique within the dashboard. Lowercase, dot-separated for sub-views
+/// (e.g. <c>"list"</c>, <c>"detail"</c>, <c>"history.heatmap"</c>). Used in URLs.
+/// </param>
+/// <param name="Widgets">Widgets shipped by this view, in declared order.</param>
+/// <param name="Layout">
+/// Layout override scoped to this view. <c>null</c> = inherit the dashboard's
+/// <see cref="DashboardDefinition.Layout"/>. Per-breakpoint overrides on
+/// <see cref="DashboardLayout"/> (P1.4) compose normally.
+/// </param>
+/// <param name="DisplayNameLocalizationKey">
+/// Localization key for the view's display label, used in breadcrumbs and the
+/// view-switcher control. Defaults to the convention
+/// <c>Dashboard:{DashboardName}.View.{ViewName}</c> when <c>null</c>.
+/// </param>
+public sealed record DashboardView(
+    string Name,
+    IReadOnlyList<WidgetDefinition> Widgets,
+    DashboardLayout? Layout = null,
+    string? DisplayNameLocalizationKey = null);

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -45,8 +45,19 @@ public interface IDashboardDefinitionDescriptor
     /// </summary>
     DashboardTimeWindow? DefaultTimeWindow { get; }
 
-    /// <summary>Widgets shipped by this dashboard, in declared order.</summary>
+    /// <summary>Widgets shipped by this dashboard, in declared order (single-view dashboards).</summary>
     IReadOnlyList<WidgetDefinition> Widgets { get; }
+
+    /// <summary>
+    /// Named views — separate widget arrangements within the same dashboard. <c>null</c>
+    /// = single-view dashboard rendering <see cref="Widgets"/>. See P2.1.
+    /// </summary>
+    IReadOnlyList<DashboardView>? Views { get; }
+
+    /// <summary>
+    /// Entry-view name when <see cref="Views"/> is non-null. <c>null</c> = first view.
+    /// </summary>
+    string? DefaultView { get; }
 
     /// <summary>
     /// Dashboard-scoped filters declared by this dashboard. Each filter is referenced

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionViewsTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionViewsTests.cs
@@ -1,0 +1,73 @@
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Confirms that <see cref="DashboardDefinition.Views"/> + <c>DefaultView</c>
+/// surface correctly through the descriptor and default to <c>null</c>
+/// (single-view backward compat).
+/// </summary>
+public sealed class DashboardDefinitionViewsTests
+{
+    [Fact]
+    public void SingleView_HasNoViewsAndNoDefault()
+    {
+        IDashboardDefinitionDescriptor d = new SingleViewDashboard();
+
+        d.Views.ShouldBeNull();
+        d.DefaultView.ShouldBeNull();
+        d.Widgets.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void MultiView_SurfacesViewsThroughDescriptor()
+    {
+        IDashboardDefinitionDescriptor d = new MultiViewDashboard();
+
+        d.Views.ShouldNotBeNull();
+        d.Views.Count.ShouldBe(2);
+        d.Views.ShouldContain(v => v.Name == "list");
+        d.Views.ShouldContain(v => v.Name == "detail");
+        d.DefaultView.ShouldBe("list");
+    }
+
+    [Fact]
+    public void MultiView_LeavesWidgetsEmpty_ByConvention()
+    {
+        // Multi-view dashboards delegate widget lists to each named view; the
+        // top-level Widgets property stays empty by convention.
+        IDashboardDefinitionDescriptor d = new MultiViewDashboard();
+
+        d.Widgets.ShouldBeEmpty();
+    }
+
+    private sealed class SingleViewDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.SingleView";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+        [
+            new MarkdownWidgetDefinition("Banner", "Widget:Sample.SingleView.Banner", Position: 0),
+        ];
+    }
+
+    private sealed class MultiViewDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.MultiView";
+        public override DashboardCategory Category => DashboardCategory.Operations;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+        public override string? DefaultView => "list";
+
+        public override IReadOnlyList<DashboardView>? Views { get; } =
+        [
+            new DashboardView(
+                "list",
+                [new MarkdownWidgetDefinition("Header", "Widget:Sample.MultiView.list.Header", Position: 0)]),
+            new DashboardView(
+                "detail",
+                [new MarkdownWidgetDefinition("Body", "Widget:Sample.MultiView.detail.Body", Position: 0)]),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardViewTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardViewTests.cs
@@ -1,0 +1,71 @@
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape of <see cref="DashboardView"/> (P2.1) — record carrying
+/// a name, a widget list, and optional layout / display name overrides. The
+/// rename from "DashboardState" to "DashboardView" is enforced by the type's
+/// existence (the old name is gone from the API).
+/// </summary>
+public sealed class DashboardViewTests
+{
+    [Fact]
+    public void Construction_DefaultsLayoutAndLabelToNull()
+    {
+        DashboardView view = new(
+            Name: "list",
+            Widgets:
+            [
+                new MarkdownWidgetDefinition("Heading", "Widget:S.list.Heading", Position: 0),
+            ]);
+
+        view.Name.ShouldBe("list");
+        view.Widgets.Count.ShouldBe(1);
+        view.Layout.ShouldBeNull();
+        view.DisplayNameLocalizationKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public void View_AcceptsLayoutOverrideAndDisplayKey()
+    {
+        DashboardLayout layout = new(Columns: 16, RowHeight: 64);
+
+        DashboardView view = new(
+            "detail",
+            [new MarkdownWidgetDefinition("Body", "Widget:S.detail.Body", Position: 0)],
+            Layout: layout,
+            DisplayNameLocalizationKey: "Dashboard:Sample.View.detail");
+
+        view.Layout.ShouldBe(layout);
+        view.DisplayNameLocalizationKey.ShouldBe("Dashboard:Sample.View.detail");
+    }
+
+    [Fact]
+    public void DottedSubViewName_SupportsHistoryHeatmap()
+    {
+        // The proposal documents dot-separated names for sub-views (e.g. "history.heatmap").
+        // No URL parsing here — just lock that the record accepts the canonical form.
+        DashboardView view = new(
+            "history.heatmap",
+            [new TextWidgetDefinition("T", "Widget:S.h.T", TextStyle.Heading, Position: 0)]);
+
+        view.Name.ShouldBe("history.heatmap");
+    }
+
+    [Fact]
+    public void RecordEquality_HoldsByValue()
+    {
+        WidgetDefinition[] widgets =
+        [
+            new MarkdownWidgetDefinition("X", "Widget:X", Position: 0),
+        ];
+
+        DashboardView a = new("v", widgets);
+        DashboardView b = new("v", widgets);
+
+        a.ShouldBe(b);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **P2.1** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). A dashboard becomes a navigable container with multiple internal views — `list` / `detail` / `history.heatmap` / ... — each shipping its own widget pool while sharing the dashboard-level `TimeWindow`, entity aliases (P2.3), filters (P2.5) and breadcrumb context. ThingsBoard's killer drill-down feature, scoped down to one container.

## Naming — `DashboardView`, not `DashboardState`

The proposal's original "DashboardState" was renamed during my earlier review feedback to avoid the clash with the persisted `Dashboard.Status` field shipped in B2 (`Draft` / `Published` / `Archived`). The `WidgetActionKind.OpenDashboardView` enum value already shipped under the new name in P1.5 (#1459); this PR completes the rename across the surface.

## What lands

### `Granit.Dashboards.Abstractions/DashboardView.cs`

```csharp
public sealed record DashboardView(
    string Name,
    IReadOnlyList<WidgetDefinition> Widgets,
    DashboardLayout? Layout = null,
    string? DisplayNameLocalizationKey = null);
```

- `Layout` is optional — null inherits the dashboard's. Per-breakpoint overrides from P1.4 compose normally.
- `DisplayNameLocalizationKey` defaults via convention `Dashboard:{DashboardName}.View.{ViewName}`.

### `DashboardDefinition` + `IDashboardDefinitionDescriptor`

- New `Views: IReadOnlyList<DashboardView>?` virtual (default `null` = single-view backward compat).
- New `DefaultView: string?` virtual (default `null` = first view when `Views` is non-null).
- Both surfaced through the descriptor for catalogue / endpoint use.

### Two modes by convention

| Mode | `Views` | `Widgets` | Rendered |
| --- | --- | --- | --- |
| Single-view (today) | `null` | the rendered list | `Widgets` |
| Multi-view (P2.1) | non-null | empty by convention | named `DefaultView`'s `Widgets` |

URL convention (B4 implementation): `/dashboards/{Name}/view/{viewName}`.

### Mobile layout — dropped

The proposal sketched a separate `MobileLayout? : DashboardLayout?` on each view. Dropped — `DashboardLayout` already carries per-breakpoint overrides since P1.4 (#1454). One responsive ladder per layout, not two parallel ones.

## Tests — 7 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Abstractions.Tests/DashboardViewTests` | 4 | Defaults, layout + display-key overrides, dot-separated sub-view names, record equality |
| `Granit.Dashboards.Abstractions.Tests/DashboardDefinitionViewsTests` | 3 | Single-view default, multi-view surface through descriptor, multi-view convention with empty top-level `Widgets` |

`Granit.Dashboards.Abstractions.Tests`: **42/42** (was 35, +7). Architecture suite: **158/158**.

## No lockfile drift

Additive within the existing package — no `<ProjectReference>` change.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Abstractions src/Granit.Dashboards` — clean
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 42/42
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` shard
- [ ] CI green