### PR TITLE
feat(dashboards): entity aliases for parameterised dashboards (P2.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12619,6 +12619,12 @@
           "kind": "property",
           "signature": "IReadOnlyList<DashboardFilter>? Filters",
           "returnType": "IReadOnlyList<DashboardFilter>?"
+        },
+        {
+          "name": "Aliases",
+          "kind": "property",
+          "signature": "IReadOnlyList<EntityAlias>? Aliases",
+          "returnType": "IReadOnlyList<EntityAlias>?"
         }
       ]
     },
@@ -12929,6 +12935,24 @@
       "members": []
     },
     {
+      "name": "EntityAlias",
+      "fqn": "Granit.Dashboards.EntityAlias",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAlias.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "EntityAliasResolver",
+      "fqn": "Granit.Dashboards.EntityAliasResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 24,
+      "members": []
+    },
+    {
       "name": "DashboardsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Dashboards.EntityFrameworkCore.Extensions.DashboardsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -13060,6 +13084,24 @@
       "members": []
     },
     {
+      "name": "RouteParamResolver",
+      "fqn": "Granit.Dashboards.RouteParamResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "StaticEntityResolver",
+      "fqn": "Granit.Dashboards.StaticEntityResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 66,
+      "members": []
+    },
+    {
       "name": "IVariableSubstituter",
       "fqn": "Granit.Dashboards.Templating.IVariableSubstituter",
       "kind": "interface",
@@ -13076,12 +13118,39 @@
       ]
     },
     {
+      "name": "TenantContextResolver",
+      "fqn": "Granit.Dashboards.TenantContextResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 48,
+      "members": []
+    },
+    {
       "name": "TimeWindowKind",
       "fqn": "Granit.Dashboards.TimeWindowKind",
       "kind": "enum",
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/DashboardTimeWindow.cs",
       "line": 56,
+      "members": []
+    },
+    {
+      "name": "UserSelectionResolver",
+      "fqn": "Granit.Dashboards.UserSelectionResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 57,
+      "members": []
+    },
+    {
+      "name": "ViewEntityResolver",
+      "fqn": "Granit.Dashboards.ViewEntityResolver",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
+      "line": 42,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
@@ -102,4 +102,13 @@ public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
     /// dashboard has no filters beyond what individual widgets carry.
     /// </summary>
     public virtual IReadOnlyList<DashboardFilter>? Filters => null;
+
+    /// <summary>
+    /// Named entity bindings declared by this dashboard. Each alias is resolved at
+    /// render time by its <see cref="EntityAliasResolver"/> (route param, view entity,
+    /// tenant context, user selection, static). Data sources (story P2.2) reference
+    /// aliases by name to scope their queries. <c>null</c> = the dashboard does not
+    /// take entity parameters.
+    /// </summary>
+    public virtual IReadOnlyList<EntityAlias>? Aliases => null;
 }

--- a/src/Granit.Dashboards.Abstractions/EntityAlias.cs
+++ b/src/Granit.Dashboards.Abstractions/EntityAlias.cs
@@ -1,0 +1,27 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Named entity binding declared by a <see cref="DashboardDefinition"/> and resolved
+/// at render time by a registered <see cref="EntityAliasResolver"/>. Lets the same
+/// dashboard render against different entities (a single Customer, a chosen Device,
+/// the current Tenant, ...) without duplicating the definition. P2.3 of the
+/// dashboards-architecture-proposals roadmap.
+/// </summary>
+/// <param name="Name">
+/// Alias identifier referenced from data sources (e.g. <c>"currentCustomer"</c>,
+/// <c>"selectedDevice"</c>). Camel-case, unique within the dashboard.
+/// </param>
+/// <param name="EntityType">
+/// Logical type the alias resolves to (<c>"Customer"</c>, <c>"Device"</c>,
+/// <c>"Invoice"</c>, ...). Used by the runtime to route to the right
+/// <see cref="EntityAliasResolver"/> implementation when the resolver kind is
+/// generic (e.g. <c>UserSelectionResolver</c> picks the lookup typed against
+/// the entity type).
+/// </param>
+/// <param name="Resolver">
+/// Resolution strategy — see <see cref="EntityAliasResolver"/>'s five derived kinds.
+/// </param>
+public sealed record EntityAlias(
+    string Name,
+    string EntityType,
+    EntityAliasResolver Resolver);

--- a/src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs
+++ b/src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace Granit.Dashboards;
+
+/// <summary>
+/// How an <see cref="EntityAlias"/> resolves to a concrete entity at render time.
+/// Five base kinds shipped today; <c>RelationGraphResolver</c> (TB-style traversal)
+/// is intentionally deferred to its own ADR — it requires a relation registry that
+/// the framework does not have yet, and the four resolvers below cover every
+/// applicative use case present in the current backlog.
+/// </summary>
+/// <remarks>
+/// JSON polymorphism uses the <c>"kind"</c> discriminator with short kebab tags
+/// (<c>route-param</c>, <c>view-entity</c>, <c>tenant-context</c>,
+/// <c>user-selection</c>, <c>static</c>). Stable wire format — same approach as
+/// <see cref="WidgetDefinition"/>'s <c>"type"</c> discriminator.
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(RouteParamResolver), "route-param")]
+[JsonDerivedType(typeof(ViewEntityResolver), "view-entity")]
+[JsonDerivedType(typeof(TenantContextResolver), "tenant-context")]
+[JsonDerivedType(typeof(UserSelectionResolver), "user-selection")]
+[JsonDerivedType(typeof(StaticEntityResolver), "static")]
+public abstract record EntityAliasResolver;
+
+/// <summary>
+/// Pulls the entity id from a URL / route parameter — typical for "open this
+/// dashboard for entity X" patterns where the parent route owns the binding.
+/// </summary>
+/// <param name="ParamName">Route parameter name (e.g. <c>"id"</c>, <c>"customerId"</c>).</param>
+public sealed record RouteParamResolver(string ParamName) : EntityAliasResolver;
+
+/// <summary>
+/// Pulls the entity id from the active <see cref="DashboardView"/>'s parameters
+/// — the bridge between the view stack (P2.1) and aliases. When a row click in a
+/// list view pushes a new view onto the stack with <c>entityId</c> in its params,
+/// the alias re-resolves automatically and downstream widgets re-fetch with the
+/// new entity. Renamed from the proposal's <c>StateEntityResolver</c> per the
+/// agreed States → Views rename.
+/// </summary>
+/// <param name="ParamName">Slot name in the view's params dictionary. Defaults to <c>"entityId"</c>.</param>
+public sealed record ViewEntityResolver(string ParamName = "entityId") : EntityAliasResolver;
+
+/// <summary>
+/// Resolves to the current authenticated tenant — single entity. Carries no
+/// payload; the runtime reads <c>ICurrentTenant</c> at render time.
+/// </summary>
+public sealed record TenantContextResolver : EntityAliasResolver;
+
+/// <summary>
+/// Renders a picker; the user selects one (or many) entities at runtime. Backs
+/// "scope this dashboard to a customer of my choosing" patterns without forcing
+/// the caller to encode the entity id in the URL.
+/// </summary>
+/// <param name="LookupName">Granit.DataLookup name backing the picker.</param>
+/// <param name="MultiSelect">When <c>true</c>, the picker accepts a multi-selection set.</param>
+public sealed record UserSelectionResolver(
+    string LookupName,
+    bool MultiSelect = false) : EntityAliasResolver;
+
+/// <summary>
+/// Hard-coded entity reference. Mostly for testing or "global" widgets pinned to
+/// a known operator-level entity.
+/// </summary>
+/// <param name="EntityId">Stringified entity identifier.</param>
+public sealed record StaticEntityResolver(string EntityId) : EntityAliasResolver;

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -67,4 +67,9 @@ public interface IDashboardDefinitionDescriptor
     /// beyond what individual widgets carry.
     /// </summary>
     IReadOnlyList<DashboardFilter>? Filters { get; }
+
+    /// <summary>
+    /// Named entity bindings — see <see cref="DashboardDefinition.Aliases"/>.
+    /// </summary>
+    IReadOnlyList<EntityAlias>? Aliases { get; }
 }

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionAliasesTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardDefinitionAliasesTests.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Confirms <see cref="DashboardDefinition.Aliases"/> default and override paths
+/// surface through <see cref="IDashboardDefinitionDescriptor"/>.
+/// </summary>
+public sealed class DashboardDefinitionAliasesTests
+{
+    [Fact]
+    public void Default_ReturnsNull()
+        => new EmptyDashboard().Aliases.ShouldBeNull();
+
+    [Fact]
+    public void Override_SurfacesAliasesThroughDescriptor()
+    {
+        IDashboardDefinitionDescriptor d = new ParameterizedDashboard();
+
+        d.Aliases.ShouldNotBeNull();
+        d.Aliases.Count.ShouldBe(2);
+        d.Aliases.ShouldContain(a => a.Name == "currentCustomer" && a.EntityType == "Customer"
+            && a.Resolver is RouteParamResolver);
+        d.Aliases.ShouldContain(a => a.Name == "tenant" && a.Resolver is TenantContextResolver);
+    }
+
+    private sealed class EmptyDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Empty";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+    }
+
+    private sealed class ParameterizedDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Parameterized";
+        public override DashboardCategory Category => DashboardCategory.Operations;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+
+        public override IReadOnlyList<EntityAlias>? Aliases { get; } =
+        [
+            new EntityAlias("currentCustomer", "Customer", new RouteParamResolver("customerId")),
+            new EntityAlias("tenant",          "Tenant",   new TenantContextResolver()),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/EntityAliasTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/EntityAliasTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape and JSON wire format of <see cref="EntityAlias"/> +
+/// the five <see cref="EntityAliasResolver"/> derived kinds (P2.3). Pinning the
+/// kebab discriminators is the load-bearing assertion — the frontend's
+/// TypeScript discriminated union mirrors them 1:1.
+/// </summary>
+public sealed class EntityAliasTests
+{
+    [Fact]
+    public void RouteParamResolver_SerializesWithKebabDiscriminator()
+    {
+        EntityAliasResolver resolver = new RouteParamResolver("customerId");
+        string json = JsonSerializer.Serialize(resolver);
+
+        json.ShouldContain("\"kind\":\"route-param\"");
+        json.ShouldNotContain("$type");
+
+        EntityAliasResolver? decoded = JsonSerializer.Deserialize<EntityAliasResolver>(json);
+        decoded.ShouldBeOfType<RouteParamResolver>();
+        ((RouteParamResolver)decoded!).ParamName.ShouldBe("customerId");
+    }
+
+    [Fact]
+    public void ViewEntityResolver_DefaultsParamNameToEntityId()
+    {
+        ViewEntityResolver resolver = new();
+
+        resolver.ParamName.ShouldBe("entityId");
+
+        string json = JsonSerializer.Serialize<EntityAliasResolver>(resolver);
+        json.ShouldContain("\"kind\":\"view-entity\"");
+    }
+
+    [Fact]
+    public void ViewEntityResolver_OverridesParamName()
+    {
+        EntityAliasResolver resolver = new ViewEntityResolver("deviceId");
+
+        EntityAliasResolver? decoded = JsonSerializer.Deserialize<EntityAliasResolver>(
+            JsonSerializer.Serialize(resolver));
+
+        decoded.ShouldBeOfType<ViewEntityResolver>();
+        ((ViewEntityResolver)decoded!).ParamName.ShouldBe("deviceId");
+    }
+
+    [Fact]
+    public void TenantContextResolver_CarriesNoPayload()
+    {
+        EntityAliasResolver resolver = new TenantContextResolver();
+        string json = JsonSerializer.Serialize(resolver);
+
+        json.ShouldContain("\"kind\":\"tenant-context\"");
+
+        EntityAliasResolver? decoded = JsonSerializer.Deserialize<EntityAliasResolver>(json);
+        decoded.ShouldBeOfType<TenantContextResolver>();
+    }
+
+    [Fact]
+    public void UserSelectionResolver_CarriesLookupNameAndMultiSelectFlag()
+    {
+        EntityAliasResolver resolver = new UserSelectionResolver("Granit.Customers", MultiSelect: true);
+
+        string json = JsonSerializer.Serialize(resolver);
+        json.ShouldContain("\"kind\":\"user-selection\"");
+
+        EntityAliasResolver? decoded = JsonSerializer.Deserialize<EntityAliasResolver>(json);
+        UserSelectionResolver typed = decoded.ShouldBeOfType<UserSelectionResolver>();
+        typed.LookupName.ShouldBe("Granit.Customers");
+        typed.MultiSelect.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StaticEntityResolver_CarriesEntityId()
+    {
+        EntityAliasResolver resolver = new StaticEntityResolver("global-tenant-id");
+
+        string json = JsonSerializer.Serialize(resolver);
+        json.ShouldContain("\"kind\":\"static\"");
+
+        EntityAliasResolver? decoded = JsonSerializer.Deserialize<EntityAliasResolver>(json);
+        ((StaticEntityResolver)decoded!).EntityId.ShouldBe("global-tenant-id");
+    }
+
+    [Fact]
+    public void Alias_CarriesNameAndEntityTypeAlongsideResolver()
+    {
+        EntityAlias alias = new(
+            Name: "currentDevice",
+            EntityType: "Device",
+            Resolver: new RouteParamResolver("deviceId"));
+
+        alias.Name.ShouldBe("currentDevice");
+        alias.EntityType.ShouldBe("Device");
+        alias.Resolver.ShouldBeOfType<RouteParamResolver>();
+    }
+
+    [Fact]
+    public void Alias_RoundTripsThroughJson_PreservingResolverKind()
+    {
+        EntityAlias[] originals =
+        [
+            new("currentCustomer", "Customer", new RouteParamResolver("customerId")),
+            new("activeDevice",   "Device",   new ViewEntityResolver()),
+            new("tenant",         "Tenant",   new TenantContextResolver()),
+            new("targetCustomer", "Customer", new UserSelectionResolver("Granit.Customers")),
+            new("hardCoded",      "Site",     new StaticEntityResolver("plant-3")),
+        ];
+
+        foreach (EntityAlias alias in originals)
+        {
+            string json = JsonSerializer.Serialize(alias);
+            EntityAlias? decoded = JsonSerializer.Deserialize<EntityAlias>(json);
+
+            decoded.ShouldNotBeNull();
+            decoded.Resolver.GetType().ShouldBe(alias.Resolver.GetType());
+            decoded.Name.ShouldBe(alias.Name);
+            decoded.EntityType.ShouldBe(alias.EntityType);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **P2.3** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). Lets the same `DashboardDefinition` render against different entities (a chosen Customer, the current Device, the authenticated Tenant, …) without duplicating the definition.

**5 resolver kinds shipped** — `RelationGraphResolver` is intentionally deferred to its own ADR per my earlier review feedback (it requires a relation registry the framework does not have yet, and the four covered below handle every applicative use case in the current backlog).

## What lands

### `Granit.Dashboards.Abstractions/EntityAlias.cs` + `EntityAliasResolver.cs`

```csharp
public sealed record EntityAlias(
    string Name,
    string EntityType,
    EntityAliasResolver Resolver);

[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
[JsonDerivedType(typeof(RouteParamResolver), "route-param")]
[JsonDerivedType(typeof(ViewEntityResolver), "view-entity")]
[JsonDerivedType(typeof(TenantContextResolver), "tenant-context")]
[JsonDerivedType(typeof(UserSelectionResolver), "user-selection")]
[JsonDerivedType(typeof(StaticEntityResolver), "static")]
public abstract record EntityAliasResolver;

public sealed record RouteParamResolver(string ParamName) : EntityAliasResolver;
public sealed record ViewEntityResolver(string ParamName = "entityId") : EntityAliasResolver;
public sealed record TenantContextResolver : EntityAliasResolver;
public sealed record UserSelectionResolver(string LookupName, bool MultiSelect = false) : EntityAliasResolver;
public sealed record StaticEntityResolver(string EntityId) : EntityAliasResolver;
```

`StateEntityResolver` (proposal name) → `ViewEntityResolver` here, per the same States → Views rename agreed in P1.5 / P2.1.

### `DashboardDefinition.Aliases`

- New `virtual IReadOnlyList<EntityAlias>? Aliases => null;`
- Surfaced through `IDashboardDefinitionDescriptor`.

### Wire format pinned

Same approach as `WidgetDefinition`'s `"type"` discriminator from P1.1 (#1454) — kebab tags, no `$type`, frontend TypeScript discriminated union mirrors them 1:1.

## Tests — 10 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Abstractions.Tests/EntityAliasTests` | 8 | JSON serialisation per resolver kind, kebab discriminator pinned, default `ParamName` on `ViewEntityResolver`, `TenantContextResolver` no-payload, full round-trip across all five kinds |
| `Granit.Dashboards.Abstractions.Tests/DashboardDefinitionAliasesTests` | 2 | `null` default, override surfaces aliases through the descriptor |

`Granit.Dashboards.Abstractions.Tests`: **52/52** (was 42, +10). Architecture suite: **158/158**.

## No lockfile drift

Additive within an existing package — no `<ProjectReference>` change.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Abstractions src/Granit.Dashboards` — clean
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 52/52
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` shard
- [ ] CI green