### PR TITLE
feat(dashboards): Datasource abstraction + KpiWidgetDefinition migration (P2.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -621,7 +621,8 @@
       "name": "Granit.Dashboards.Abstractions",
       "deps": [
         "Granit",
-        "Granit.Analytics.Abstractions"
+        "Granit.Analytics.Abstractions",
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -4120,7 +4121,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs",
-      "line": 17,
+      "line": 26,
       "members": []
     },
     {
@@ -12745,6 +12746,43 @@
       "members": []
     },
     {
+      "name": "DataKeyFormat",
+      "fqn": "Granit.Dashboards.DataKeyFormat",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DataKeyFormat.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "Datasource",
+      "fqn": "Granit.Dashboards.Datasource",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Datasource.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Metric",
+          "kind": "method",
+          "signature": "Metric(string metricName)",
+          "returnType": "MetricDatasource"
+        },
+        {
+          "name": "QueryAggregate",
+          "kind": "method",
+          "signature": "QueryAggregate(string queryName, AggregateFunction aggregation, string? field = null, IReadOnlyList<DataKeyFormat>? keyFormats = null)",
+          "returnType": "QueryAggregateDatasource"
+        },
+        {
+          "name": "Telemetry",
+          "kind": "method",
+          "signature": "Telemetry(string entityAlias, string telemetryKey, TelemetryAggregation aggregation = TelemetryAggregation.Last, IReadOnlyList<DataKeyFormat>? keyFormats = null)",
+          "returnType": "TelemetryDatasource"
+        }
+      ]
+    },
+    {
       "name": "Dashboard",
       "fqn": "Granit.Dashboards.Domain.Dashboard",
       "kind": "class",
@@ -13084,6 +13122,24 @@
       "members": []
     },
     {
+      "name": "MetricDatasource",
+      "fqn": "Granit.Dashboards.MetricDatasource",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Datasource.cs",
+      "line": 54,
+      "members": []
+    },
+    {
+      "name": "QueryAggregateDatasource",
+      "fqn": "Granit.Dashboards.QueryAggregateDatasource",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Datasource.cs",
+      "line": 68,
+      "members": []
+    },
+    {
       "name": "RouteParamResolver",
       "fqn": "Granit.Dashboards.RouteParamResolver",
       "kind": "record",
@@ -13099,6 +13155,24 @@
       "project": "Granit.Dashboards.Abstractions",
       "file": "src/Granit.Dashboards.Abstractions/EntityAliasResolver.cs",
       "line": 66,
+      "members": []
+    },
+    {
+      "name": "TelemetryAggregation",
+      "fqn": "Granit.Dashboards.TelemetryAggregation",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Datasource.cs",
+      "line": 92,
+      "members": []
+    },
+    {
+      "name": "TelemetryDatasource",
+      "fqn": "Granit.Dashboards.TelemetryDatasource",
+      "kind": "record",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/Datasource.cs",
+      "line": 85,
       "members": []
     },
     {

--- a/src/Granit.Analytics.Endpoints/packages.lock.json
+++ b/src/Granit.Analytics.Endpoints/packages.lock.json
@@ -78,7 +78,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Analytics.EntityFrameworkCore/packages.lock.json
@@ -105,7 +105,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs
@@ -3,12 +3,21 @@ using Granit.Dashboards;
 namespace Granit.Analytics.Dashboards.Widgets;
 
 /// <summary>
-/// A single-value KPI tile bound to a <c>MetricDefinition</c>. The most common widget
-/// kind — typically renders the metric value, an optional period delta, and a
-/// favorable / unfavorable color cue driven by <c>MetricDefinition.IsHigherBetter</c>.
+/// A single-value KPI tile. The most common widget kind — typically renders the
+/// value, an optional period delta, and a favorable / unfavorable color cue
+/// driven by <c>MetricDefinition.IsHigherBetter</c> when bound via
+/// <see cref="MetricDatasource"/>.
 /// </summary>
 /// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
-/// <param name="MetricName">The <c>MetricDefinition.Name</c> this KPI surfaces (e.g. <c>"Granit.Invoicing.UnpaidInvoiceCountMetric"</c>).</param>
+/// <param name="Datasource">
+/// Data binding for the KPI value — typically a <see cref="MetricDatasource"/>
+/// (analytics dashboards), <see cref="QueryAggregateDatasource"/> (ad-hoc admin
+/// pages reusing the same widget), or <see cref="TelemetryDatasource"/> (IoT
+/// gauge). P2.2 of the dashboards-architecture-proposals roadmap — replaces the
+/// previous <c>MetricName</c> string field. Use <c>Datasource.Metric(...)</c> /
+/// <c>Datasource.QueryAggregate(...)</c> / <c>Datasource.Telemetry(...)</c>
+/// factories for compact call sites.
+/// </param>
 /// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
 /// <param name="Size">Defaults to <see cref="WidgetSize.SmallKpi"/>.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
@@ -16,7 +25,7 @@ namespace Granit.Analytics.Dashboards.Widgets;
 /// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
 public sealed record KpiWidgetDefinition(
     string Slug,
-    string MetricName,
+    Datasource Datasource,
     int Position,
     WidgetSize? Size = null,
     string? RequiredPermission = null,

--- a/src/Granit.Analytics/packages.lock.json
+++ b/src/Granit.Analytics/packages.lock.json
@@ -21,7 +21,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.datalookup.abstractions": {

--- a/src/Granit.Dashboards.Abstractions/DataKeyFormat.cs
+++ b/src/Granit.Dashboards.Abstractions/DataKeyFormat.cs
@@ -1,0 +1,35 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Per-series presentation hints attached to a <see cref="Datasource"/> rather
+/// than to the consuming widget. P2.2 of the dashboards-architecture-proposals
+/// roadmap. The same chart widget can be reused with different data shapes —
+/// a "Revenue by Region" chart and a "Revenue by Product" chart are the same
+/// <c>ChartWidgetDefinition</c> with different datasources — so colours and
+/// units belong to the data binding, not the visual.
+/// </summary>
+/// <param name="Key">
+/// Series identifier — matches the group-by value (chart) or the field name
+/// (multi-series KPI / pivot).
+/// </param>
+/// <param name="LabelLocalizationKey">
+/// Localization key for the display label (legend, tooltip). <c>null</c> = the
+/// frontend falls back to <see cref="Key"/>.
+/// </param>
+/// <param name="Color">
+/// Hex colour override. <c>null</c> = the active theme palette by series index.
+/// </param>
+/// <param name="Unit">
+/// Unit suffix (e.g. <c>"€"</c>, <c>"kWh"</c>, <c>"°C"</c>). When prefixed with
+/// <c>Unit:</c>, resolved via i18n. <c>null</c> = no unit suffix.
+/// </param>
+/// <param name="Decimals">
+/// Decimal places for numeric formatting. <c>null</c> = the widget's default
+/// (typically 0 for counts, 2 for currency).
+/// </param>
+public sealed record DataKeyFormat(
+    string Key,
+    string? LabelLocalizationKey = null,
+    string? Color = null,
+    string? Unit = null,
+    int? Decimals = null);

--- a/src/Granit.Dashboards.Abstractions/Datasource.cs
+++ b/src/Granit.Dashboards.Abstractions/Datasource.cs
@@ -1,0 +1,111 @@
+using System.Text.Json.Serialization;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Abstract data binding for a widget — decouples a widget from how its data
+/// arrives. P2.2 of the dashboards-architecture-proposals roadmap. The same
+/// "Daily Active Users" KPI tile can be backed by a metric (<see cref="MetricDatasource"/>)
+/// on the analytics dashboard, by a query aggregate
+/// (<see cref="QueryAggregateDatasource"/>) on an ad-hoc admin page, or by a
+/// telemetry stream (<see cref="TelemetryDatasource"/>) on an IoT dashboard —
+/// same widget shape, different source.
+/// </summary>
+/// <remarks>
+/// JSON polymorphism uses the <c>"kind"</c> discriminator with kebab tags
+/// (<c>metric</c>, <c>query-aggregate</c>, <c>iot-telemetry</c>). Stable wire
+/// format — same approach as <see cref="WidgetDefinition"/>'s <c>"type"</c>
+/// discriminator (P1.1) and <see cref="EntityAliasResolver"/>'s <c>"kind"</c>
+/// (P2.3). Static factories (<see cref="Metric(string)"/>, <see cref="QueryAggregate"/>,
+/// <see cref="Telemetry"/>) keep call sites compact.
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(MetricDatasource), "metric")]
+[JsonDerivedType(typeof(QueryAggregateDatasource), "query-aggregate")]
+[JsonDerivedType(typeof(TelemetryDatasource), "iot-telemetry")]
+public abstract record Datasource
+{
+    /// <summary>Convenience factory for <see cref="MetricDatasource"/>.</summary>
+    public static MetricDatasource Metric(string metricName) => new(metricName);
+
+    /// <summary>Convenience factory for <see cref="QueryAggregateDatasource"/>.</summary>
+    public static QueryAggregateDatasource QueryAggregate(
+        string queryName,
+        AggregateFunction aggregation,
+        string? field = null,
+        IReadOnlyList<DataKeyFormat>? keyFormats = null)
+        => new(queryName, aggregation, field, keyFormats);
+
+    /// <summary>Convenience factory for <see cref="TelemetryDatasource"/>.</summary>
+    public static TelemetryDatasource Telemetry(
+        string entityAlias,
+        string telemetryKey,
+        TelemetryAggregation aggregation = TelemetryAggregation.Last,
+        IReadOnlyList<DataKeyFormat>? keyFormats = null)
+        => new(entityAlias, telemetryKey, aggregation, keyFormats);
+}
+
+/// <summary>
+/// Bound to a registered <c>MetricDefinition</c> by name. The metric's own
+/// aggregation, base filter and period selector apply — no extra knobs.
+/// </summary>
+/// <param name="MetricName">Wire identifier of the metric (e.g. <c>"Granit.Invoicing.UnpaidInvoiceCountMetric"</c>).</param>
+public sealed record MetricDatasource(string MetricName) : Datasource;
+
+/// <summary>
+/// Bound to a registered <c>QueryDefinition</c> by name; applies an aggregation
+/// over a chosen field (<c>null</c> field = <see cref="AggregateFunction.Count"/>).
+/// </summary>
+/// <param name="QueryName">Wire identifier of the query (e.g. <c>"Granit.Invoicing.InvoiceQuery"</c>).</param>
+/// <param name="Aggregation">Aggregation function applied to <paramref name="Field"/>.</param>
+/// <param name="Field">Field aggregated; <c>null</c> when aggregation is Count.</param>
+/// <param name="KeyFormats">
+/// Per-series presentation hints. When the consuming widget renders multiple
+/// series (e.g. a chart with a group-by), each entry's <see cref="DataKeyFormat.Key"/>
+/// matches a series identifier. <c>null</c> = use the active theme palette.
+/// </param>
+public sealed record QueryAggregateDatasource(
+    string QueryName,
+    AggregateFunction Aggregation,
+    string? Field = null,
+    IReadOnlyList<DataKeyFormat>? KeyFormats = null) : Datasource;
+
+/// <summary>
+/// Bound to live telemetry pushed from the runtime (IoT). Resolves the entity
+/// at render time via the dashboard's <see cref="EntityAlias"/> bindings.
+/// </summary>
+/// <param name="EntityAlias">Entity alias name (see story P2.3) — resolves to a device id at render time.</param>
+/// <param name="TelemetryKey">Telemetry key (e.g. <c>"temperature"</c>, <c>"pressure"</c>, <c>"rpm"</c>).</param>
+/// <param name="Aggregation">
+/// Aggregation applied over the dashboard's <c>TimeWindow</c>.
+/// Defaults to <see cref="TelemetryAggregation.Last"/> — the most-recent reading.
+/// </param>
+/// <param name="KeyFormats">Per-series presentation hints (see <see cref="QueryAggregateDatasource.KeyFormats"/>).</param>
+public sealed record TelemetryDatasource(
+    string EntityAlias,
+    string TelemetryKey,
+    TelemetryAggregation Aggregation = TelemetryAggregation.Last,
+    IReadOnlyList<DataKeyFormat>? KeyFormats = null) : Datasource;
+
+/// <summary>Aggregation kinds for live telemetry streams.</summary>
+public enum TelemetryAggregation
+{
+    /// <summary>Most-recent reading. The default — typical for instantaneous gauges.</summary>
+    Last = 0,
+
+    /// <summary>Arithmetic mean over the dashboard's time window.</summary>
+    Avg = 1,
+
+    /// <summary>Sum of values in the window — useful for cumulative measurements.</summary>
+    Sum = 2,
+
+    /// <summary>Lowest value in the window.</summary>
+    Min = 3,
+
+    /// <summary>Highest value in the window.</summary>
+    Max = 4,
+
+    /// <summary>Number of readings in the window — useful for rate-of-events checks.</summary>
+    Count = 5,
+}

--- a/src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj
+++ b/src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Analytics.Abstractions\Granit.Analytics.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Dashboards.Abstractions/packages.lock.json
+++ b/src/Granit.Dashboards.Abstractions/packages.lock.json
@@ -16,6 +16,19 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
       }
     }
   }

--- a/src/Granit.Dashboards.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Dashboards.EntityFrameworkCore/packages.lock.json
@@ -116,7 +116,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.datalookup.abstractions": {

--- a/src/Granit.Dashboards/packages.lock.json
+++ b/src/Granit.Dashboards/packages.lock.json
@@ -21,7 +21,21 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       }
     }

--- a/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Invoicing.BackgroundJobs/packages.lock.json
@@ -105,7 +105,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Builtin/packages.lock.json
+++ b/src/Granit.Invoicing.Builtin/packages.lock.json
@@ -91,7 +91,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Endpoints/packages.lock.json
+++ b/src/Granit.Invoicing.Endpoints/packages.lock.json
@@ -72,7 +72,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Invoicing.EntityFrameworkCore/packages.lock.json
@@ -149,7 +149,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Notifications/packages.lock.json
+++ b/src/Granit.Invoicing.Notifications/packages.lock.json
@@ -91,7 +91,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing.Odoo/packages.lock.json
+++ b/src/Granit.Invoicing.Odoo/packages.lock.json
@@ -262,7 +262,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Invoicing/packages.lock.json
+++ b/src/Granit.Invoicing/packages.lock.json
@@ -104,7 +104,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Tax.Builtin/packages.lock.json
+++ b/src/Granit.Tax.Builtin/packages.lock.json
@@ -267,7 +267,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.Tax.Stripe/packages.lock.json
+++ b/src/Granit.Tax.Stripe/packages.lock.json
@@ -296,7 +296,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -391,7 +391,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -387,7 +387,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/packages.lock.json
@@ -381,7 +381,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetActionsTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetActionsTests.cs
@@ -20,13 +20,13 @@ public sealed class AnalyticsWidgetActionsTests
 
     [Fact]
     public void Kpi_DefaultsToNoActions()
-        => new KpiWidgetDefinition("K", "M", Position: 0).Actions.ShouldBeNull();
+        => new KpiWidgetDefinition("K", Datasource.Metric("M"), Position: 0).Actions.ShouldBeNull();
 
     [Fact]
     public void Kpi_AcceptsActions()
     {
         KpiWidgetDefinition widget = new(
-            "UnpaidCount", "Sample.Metric", Position: 0, Actions: OneClickAction);
+            "UnpaidCount", Datasource.Metric("Sample.Metric"), Position: 0, Actions: OneClickAction);
 
         widget.Actions.ShouldBe(OneClickAction);
     }

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
@@ -16,10 +16,12 @@ public sealed class AnalyticsWidgetDefinitionTests
     [Fact]
     public void Kpi_DefaultsToSmallKpiSize()
     {
-        KpiWidgetDefinition widget = new("UnpaidCount", "Sample.UnpaidInvoiceCountMetric", Position: 0);
+        KpiWidgetDefinition widget = new(
+            "UnpaidCount", Datasource.Metric("Sample.UnpaidInvoiceCountMetric"), Position: 0);
 
         widget.Size.ShouldBe(WidgetSize.SmallKpi);
         widget.RequiredPermission.ShouldBeNull();
+        widget.Datasource.ShouldBeOfType<MetricDatasource>();
     }
 
     [Fact]
@@ -27,7 +29,7 @@ public sealed class AnalyticsWidgetDefinitionTests
     {
         KpiWidgetDefinition widget = new(
             Slug: "RestrictedKpi",
-            MetricName: "Sample.Metric",
+            Datasource: Datasource.Metric("Sample.Metric"),
             Position: 0,
             RequiredPermission: "Custom.Composite.Read");
 

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetTimeWindowOverrideTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetTimeWindowOverrideTests.cs
@@ -18,7 +18,7 @@ public sealed class AnalyticsWidgetTimeWindowOverrideTests
     public void Kpi_AcceptsTimeWindowOverride()
     {
         KpiWidgetDefinition widget = new(
-            "YtdKpi", "Sample.Metric", Position: 0,
+            "YtdKpi", Datasource.Metric("Sample.Metric"), Position: 0,
             TimeWindowOverride: DashboardTimeWindow.Ytd);
 
         widget.TimeWindowOverride.ShouldBe(DashboardTimeWindow.Ytd);
@@ -59,7 +59,7 @@ public sealed class AnalyticsWidgetTimeWindowOverrideTests
     [Fact]
     public void Kpi_DefaultsToNullOverride()
     {
-        KpiWidgetDefinition widget = new("DefaultKpi", "Sample.Metric", Position: 0);
+        KpiWidgetDefinition widget = new("DefaultKpi", Datasource.Metric("Sample.Metric"), Position: 0);
 
         widget.TimeWindowOverride.ShouldBeNull();
     }

--- a/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
@@ -27,7 +27,7 @@ public sealed class AnalyticsWidgetSerializationTests
     public void Kpi_SerializesWithStableDiscriminator()
     {
         WidgetDefinition widget = new KpiWidgetDefinition(
-            "UnpaidCount", "Granit.Invoicing.UnpaidInvoiceCountMetric", Position: 0);
+            "UnpaidCount", Datasource.Metric("Granit.Invoicing.UnpaidInvoiceCountMetric"), Position: 0);
 
         string json = JsonSerializer.Serialize(widget, NewOptions());
 
@@ -84,7 +84,7 @@ public sealed class AnalyticsWidgetSerializationTests
 
         WidgetDefinition[] originals =
         [
-            new KpiWidgetDefinition("Kpi", "M1", Position: 0),
+            new KpiWidgetDefinition("Kpi", Datasource.Metric("M1"), Position: 0),
             new ChartWidgetDefinition("Chart", "Q1", "g", AggregateFunction.Sum, "f", ChartType.Bar, Position: 1),
             new TableWidgetDefinition("Table", "Q1", null, 25, Position: 2),
             new PivotWidgetDefinition("Pivot", "Q1", ["r"], ["c"], null, AggregateFunction.Count, Position: 3),

--- a/tests/Granit.Analytics.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Tests/packages.lock.json
@@ -262,7 +262,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.datalookup.abstractions": {

--- a/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
+++ b/tests/Granit.ArchitectureTests/DashboardWidgetReferenceTests.cs
@@ -47,9 +47,19 @@ public sealed class DashboardWidgetReferenceTests
             {
                 switch (widget)
                 {
-                    case KpiWidgetDefinition kpi
-                        when !inventory.MetricNames.Contains(kpi.MetricName):
-                        dangling.Add($"{dashboard.Name}/{kpi.Slug} -> KPI references missing metric '{kpi.MetricName}'");
+                    case KpiWidgetDefinition kpi:
+                        // P2.2: Kpi binds to a Datasource — Metric / QueryAggregate
+                        // are validated; TelemetryDatasource is skipped (no
+                        // compile-time inventory of telemetry keys).
+                        switch (kpi.Datasource)
+                        {
+                            case MetricDatasource md when !inventory.MetricNames.Contains(md.MetricName):
+                                dangling.Add($"{dashboard.Name}/{kpi.Slug} -> KPI MetricDatasource references missing metric '{md.MetricName}'");
+                                break;
+                            case QueryAggregateDatasource qa when !inventory.QueryNames.Contains(qa.QueryName):
+                                dangling.Add($"{dashboard.Name}/{kpi.Slug} -> KPI QueryAggregateDatasource references missing query '{qa.QueryName}'");
+                                break;
+                        }
                         break;
 
                     case ChartWidgetDefinition chart

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1969,7 +1969,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.entityframeworkcore": {

--- a/tests/Granit.Dashboards.Abstractions.Tests/DatasourceTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DatasourceTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Locks the public shape and JSON wire format of <see cref="Datasource"/> + the
+/// three derived kinds (P2.2). Pinning the kebab discriminators is the
+/// load-bearing assertion — the frontend's TypeScript discriminated union
+/// mirrors them 1:1.
+/// </summary>
+public sealed class DatasourceTests
+{
+    [Fact]
+    public void MetricDatasource_SerializesWithKebabDiscriminator()
+    {
+        Datasource ds = new MetricDatasource("Granit.Invoicing.UnpaidInvoiceCountMetric");
+        string json = JsonSerializer.Serialize(ds);
+
+        json.ShouldContain("\"kind\":\"metric\"");
+        json.ShouldNotContain("$type");
+
+        Datasource? decoded = JsonSerializer.Deserialize<Datasource>(json);
+        decoded.ShouldBeOfType<MetricDatasource>();
+        ((MetricDatasource)decoded!).MetricName.ShouldBe("Granit.Invoicing.UnpaidInvoiceCountMetric");
+    }
+
+    [Fact]
+    public void QueryAggregateDatasource_SerializesWithFieldAndAggregation()
+    {
+        Datasource ds = new QueryAggregateDatasource(
+            "Granit.Invoicing.InvoiceQuery", AggregateFunction.Sum, "Total");
+
+        string json = JsonSerializer.Serialize(ds);
+        json.ShouldContain("\"kind\":\"query-aggregate\"");
+
+        Datasource? decoded = JsonSerializer.Deserialize<Datasource>(json);
+        QueryAggregateDatasource typed = decoded.ShouldBeOfType<QueryAggregateDatasource>();
+        typed.QueryName.ShouldBe("Granit.Invoicing.InvoiceQuery");
+        typed.Aggregation.ShouldBe(AggregateFunction.Sum);
+        typed.Field.ShouldBe("Total");
+        typed.KeyFormats.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TelemetryDatasource_DefaultsToLastAggregation()
+    {
+        TelemetryDatasource ds = new("currentDevice", "temperature");
+
+        ds.Aggregation.ShouldBe(TelemetryAggregation.Last);
+
+        string json = JsonSerializer.Serialize<Datasource>(ds);
+        json.ShouldContain("\"kind\":\"iot-telemetry\"");
+    }
+
+    [Fact]
+    public void Factory_Metric_ProducesMetricDatasource()
+    {
+        MetricDatasource ds = Datasource.Metric("Sample.Metric");
+
+        ds.MetricName.ShouldBe("Sample.Metric");
+    }
+
+    [Fact]
+    public void Factory_QueryAggregate_AcceptsKeyFormats()
+    {
+        QueryAggregateDatasource ds = Datasource.QueryAggregate(
+            "Sample.Q",
+            AggregateFunction.Avg,
+            field: "amount",
+            keyFormats:
+            [
+                new DataKeyFormat("paid", Color: "#00aa00", Unit: "€"),
+                new DataKeyFormat("unpaid", Color: "#cc0000", Unit: "€"),
+            ]);
+
+        ds.KeyFormats.ShouldNotBeNull();
+        ds.KeyFormats.Count.ShouldBe(2);
+        ds.KeyFormats[0].Color.ShouldBe("#00aa00");
+    }
+
+    [Fact]
+    public void Factory_Telemetry_PassesEntityAliasAndKey()
+    {
+        TelemetryDatasource ds = Datasource.Telemetry(
+            entityAlias: "currentDevice",
+            telemetryKey: "rpm",
+            aggregation: TelemetryAggregation.Avg);
+
+        ds.EntityAlias.ShouldBe("currentDevice");
+        ds.TelemetryKey.ShouldBe("rpm");
+        ds.Aggregation.ShouldBe(TelemetryAggregation.Avg);
+    }
+
+    [Fact]
+    public void TelemetryAggregation_EnumOrderingIsStable()
+    {
+        ((int)TelemetryAggregation.Last).ShouldBe(0);
+        ((int)TelemetryAggregation.Avg).ShouldBe(1);
+        ((int)TelemetryAggregation.Sum).ShouldBe(2);
+        ((int)TelemetryAggregation.Min).ShouldBe(3);
+        ((int)TelemetryAggregation.Max).ShouldBe(4);
+        ((int)TelemetryAggregation.Count).ShouldBe(5);
+    }
+
+    [Fact]
+    public void Datasource_RoundTripsThroughJson_PreservingKind()
+    {
+        Datasource[] originals =
+        [
+            new MetricDatasource("M1"),
+            new QueryAggregateDatasource("Q1", AggregateFunction.Count, null),
+            new TelemetryDatasource("alias1", "key1"),
+        ];
+
+        foreach (Datasource original in originals)
+        {
+            string json = JsonSerializer.Serialize(original);
+            Datasource? decoded = JsonSerializer.Deserialize<Datasource>(json);
+
+            decoded.ShouldNotBeNull();
+            decoded.GetType().ShouldBe(original.GetType());
+        }
+    }
+
+    [Fact]
+    public void DataKeyFormat_AllOptionalFieldsDefaultToNull()
+    {
+        DataKeyFormat fmt = new("series-1");
+
+        fmt.Key.ShouldBe("series-1");
+        fmt.LabelLocalizationKey.ShouldBeNull();
+        fmt.Color.ShouldBeNull();
+        fmt.Unit.ShouldBeNull();
+        fmt.Decimals.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Dashboards.Abstractions.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Abstractions.Tests/packages.lock.json
@@ -231,7 +231,21 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       }
     }

--- a/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.BackgroundJobs.Tests/packages.lock.json
@@ -337,7 +337,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Builtin.Tests/packages.lock.json
@@ -323,7 +323,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -558,7 +558,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -409,7 +409,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.EntityFrameworkCore.Tests/packages.lock.json
@@ -617,7 +617,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Notifications.Tests/packages.lock.json
@@ -323,7 +323,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Odoo.Tests/packages.lock.json
@@ -480,7 +480,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Invoicing.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Tests/packages.lock.json
@@ -323,7 +323,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Tax.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Builtin.Tests/packages.lock.json
@@ -485,7 +485,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.Tax.Stripe.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Stripe.Tests/packages.lock.json
@@ -494,7 +494,8 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Granit.Analytics.Abstractions": "[0.1.0-dev, )"
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {


### PR DESCRIPTION
## Summary

Implements **P2.2** of the [dashboards-architecture-proposals roadmap](../granit-front/docs/dashboards-architecture-proposals.md). The same KPI tile can now be backed by a metric (analytics dashboards), a query aggregate (ad-hoc admin pages reusing the widget), or a live telemetry stream (IoT gauges) — same widget shape, different source. Decouples widgets from how their data arrives.

## ⚠ Breaking change — `KpiWidgetDefinition.MetricName` → `Datasource Datasource`

```csharp
// Before
new KpiWidgetDefinition("UnpaidCount", "Granit.Invoicing.UnpaidInvoiceCountMetric", Position: 0)

// After — pick the right factory for your source
new KpiWidgetDefinition("UnpaidCount",
    Datasource.Metric("Granit.Invoicing.UnpaidInvoiceCountMetric"),
    Position: 0)
```

Migration is intentional and **limited to KPI**. Chart / Table / Pivot KEEP `string QueryName` directly — they are inherently query-bound and a Datasource layer would add ceremony without flexibility. `QueryAggregateDatasource` ships with `KeyFormats` for the future Chart migration when a story justifies multi-series formatting.

## What lands

### `Granit.Dashboards.Abstractions/Datasource.cs`

```csharp
[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
[JsonDerivedType(typeof(MetricDatasource), "metric")]
[JsonDerivedType(typeof(QueryAggregateDatasource), "query-aggregate")]
[JsonDerivedType(typeof(TelemetryDatasource), "iot-telemetry")]
public abstract record Datasource
{
    public static MetricDatasource Metric(string metricName);
    public static QueryAggregateDatasource QueryAggregate(string queryName, AggregateFunction aggregation, ...);
    public static TelemetryDatasource Telemetry(string entityAlias, string telemetryKey, ...);
}
```

- `TelemetryAggregation` enum (Last default / Avg / Sum / Min / Max / Count).
- `DataKeyFormat` record (Key, LabelLocalizationKey, Color, Unit, Decimals) for per-series presentation hints attached to the **datasource** rather than the widget — "Revenue by Region" and "Revenue by Product" are the same Chart with different datasources; colors / units belong to the data binding, not the visual.
- `Granit.Dashboards.Abstractions` now `<ProjectReference>`s `Granit.QueryEngine.Abstractions` for `AggregateFunction` reuse (no enum duplication).

### `Granit.ArchitectureTests/DashboardWidgetReferenceTests`

Updated to navigate the KPI `Datasource`:
- `MetricDatasource` / `QueryAggregateDatasource` references are validated against the inventory.
- `TelemetryDatasource` references are skipped (no compile-time inventory of telemetry keys).

## Tests — 10 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Abstractions.Tests/DatasourceTests` | 10 | Discriminator per kind, factory methods, `TelemetryAggregation` enum stability, full JSON round-trip across the three kinds, `DataKeyFormat` default shape |

Three existing `Granit.Analytics.Tests` files migrated to the new `Kpi` shape via `Datasource.Metric(...)` (8 call sites). Behaviour preserved.

`Granit.Dashboards.Abstractions.Tests`: **61/61** (was 52, +9). `Granit.Analytics.Tests`: **27/27**. Architecture suite: **158/158**.

## Lockfile drift handled

40 `packages.lock.json` refreshed via `dotnet restore Granit.slnx --force-evaluate` per the `feedback_lockfile_global_force_evaluate` memory — `Dashboards.Abstractions` added a transitive dep on `QueryEngine.Abstractions`, propagated through every project that references `Dashboards.Abstractions` (test projects across the framework).

## Test plan

- [x] `dotnet build` — clean across Dashboards.Abstractions / Analytics / Dashboards
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 61/61
- [x] `dotnet test tests/Granit.Analytics.Tests` — 27/27
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed globally
- [ ] CI green