### PR TITLE
feat(dashboards): catalog endpoint — GET /dashboards/catalog (B4-read prep)

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -69,6 +69,7 @@
         "tests/Granit.Dashboards.Tests",
         "tests/Granit.Dashboards.Abstractions.Tests",
         "tests/Granit.Dashboards.EntityFrameworkCore.Tests",
+        "tests/Granit.Dashboards.Endpoints.Tests",
         "tests/Granit.DataExchange.Abstractions.Tests",
         "tests/Granit.DataExchange.BlobStorage.Tests",
         "tests/Granit.DataExchange.Csv.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -627,6 +627,16 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Dashboards.Endpoints",
+      "deps": [
+        "Granit.Dashboards",
+        "Granit.Authorization",
+        "Granit.Http.Abstractions",
+        "Granit.Validation"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Dashboards.EntityFrameworkCore",
       "deps": [
         "Granit.Dashboards",
@@ -12970,6 +12980,80 @@
       "project": "Granit.Dashboards",
       "file": "src/Granit.Dashboards/Domain/WidgetInstanceConfig.cs",
       "line": 55,
+      "members": []
+    },
+    {
+      "name": "DashboardCatalogEntryResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardCatalogEntryResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardCatalogEntryResponse.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "DashboardsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Dashboards.Endpoints.Extensions.DashboardsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitDashboards",
+          "kind": "method",
+          "signature": "MapGranitDashboards(this IEndpointRouteBuilder endpoints, Action<DashboardsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDashboardsEndpointsModule",
+      "fqn": "Granit.Dashboards.Endpoints.GranitDashboardsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "DashboardsEndpointsOptions",
+      "fqn": "Granit.Dashboards.Endpoints.Options.DashboardsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Options/DashboardsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "CatalogTagName",
+          "kind": "property",
+          "signature": "string CatalogTagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Catalog",
+      "fqn": "Granit.Dashboards.Endpoints.Permissions.Catalog",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DashboardsPermissions",
+      "fqn": "Granit.Dashboards.Endpoints.Permissions.DashboardsPermissions",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs",
+      "line": 6,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardCatalogEntryResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardCatalogEntryResponse.cs
@@ -1,0 +1,25 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Response payload for a single entry in <c>GET /dashboards/catalog</c>. Mirrors
+/// the relevant subset of <see cref="IDashboardDefinitionDescriptor"/> on the wire,
+/// stripping framework internals (the registry, type-erased descriptors) so the
+/// frontend has a predictable shape to consume.
+/// </summary>
+/// <param name="Name">Wire identifier — e.g. <c>"Granit.Invoicing.FinanceOverview"</c>.</param>
+/// <param name="Category">Coarse grouping — see <see cref="DashboardCategory"/>.</param>
+/// <param name="IsSystem">When <c>true</c>, imported instances cannot be deleted by tenant admins (only re-synced).</param>
+/// <param name="Version">Semver of the definition shape — used by the drift-detection UI.</param>
+/// <param name="WidgetCount">Number of widgets shipped by this dashboard (single-view) or by its default view (multi-view).</param>
+/// <param name="HasViews">Whether the dashboard ships multiple named views (P2.1).</param>
+/// <param name="HasAliases">Whether the dashboard takes entity parameters (P2.3).</param>
+/// <param name="HasFilters">Whether the dashboard ships toolbar / silent filters (P2.5).</param>
+public sealed record DashboardCatalogEntryResponse(
+    string Name,
+    DashboardCategory Category,
+    bool IsSystem,
+    string Version,
+    int WidgetCount,
+    bool HasViews,
+    bool HasAliases,
+    bool HasFilters);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardCatalogEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardCatalogEndpoints.cs
@@ -1,0 +1,45 @@
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the dashboard catalogue read surface.
+/// </summary>
+internal static class DashboardCatalogEndpoints
+{
+    /// <summary>
+    /// Maps <c>GET /catalog</c> on the supplied route group. Returns every registered
+    /// <see cref="DashboardDefinition"/> projected through <see cref="DashboardCatalogEntryResponse"/>,
+    /// optionally filtered by <see cref="DashboardCategory"/>. Ordering matches the
+    /// registry's stable ordering (category, then name).
+    /// </summary>
+    public static RouteGroupBuilder MapCatalogEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/catalog", ListCatalog)
+            .WithName("ListGranitDashboardCatalog")
+            .WithSummary("Lists every registered DashboardDefinition.")
+            .WithDescription(
+                "Returns the full dashboard catalogue surfaced by IDashboardDefinitionRegistry. "
+                + "Each entry carries the wire identifier, category, version, widget count and "
+                + "feature flags (HasViews / HasAliases / HasFilters) that the frontend uses to "
+                + "decide how to render the import dialog. Optionally filters by ?category=... "
+                + "to narrow to a specific section.")
+            .RequireAuthorization(DashboardsPermissions.Catalog.Read)
+            .Produces<IReadOnlyList<DashboardCatalogEntryResponse>>();
+
+        return group;
+    }
+
+    private static Ok<IReadOnlyList<DashboardCatalogEntryResponse>> ListCatalog(
+        [FromServices] IDashboardDefinitionRegistry registry,
+        [FromQuery] DashboardCategory? category)
+        => TypedResults.Ok(DashboardCatalogProjection.Project(registry.GetAll(), category));
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,38 @@
+using Granit.Dashboards.Endpoints.Endpoints;
+using Granit.Dashboards.Endpoints.Options;
+using Granit.Validation.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for registering Granit.Dashboards HTTP endpoints.
+/// </summary>
+public static class DashboardsEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the Granit.Dashboards endpoints onto <paramref name="endpoints"/>. Today
+    /// ships the read-only catalogue endpoint; the import / CRUD endpoints land on
+    /// the same route group in subsequent stories.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="DashboardsEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    public static RouteGroupBuilder MapGranitDashboards(
+        this IEndpointRouteBuilder endpoints,
+        Action<DashboardsEndpointsOptions>? configure = null)
+    {
+        DashboardsEndpointsOptions options = new();
+        configure?.Invoke(options);
+
+        RouteGroupBuilder group = endpoints
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.CatalogTagName);
+
+        group.MapCatalogEndpoints();
+
+        return group;
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
+++ b/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Dashboards.Endpoints</PackageId>
+    <Description>Minimal API endpoints for Granit.Dashboards. Ships the read-only catalogue endpoint (GET /dashboards/catalog) surfacing every registered DashboardDefinition, with permission gating and per-host route prefix configuration. Future: import / CRUD endpoints, real-time hub.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs
+++ b/src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs
@@ -1,0 +1,18 @@
+using Granit.Authorization;
+using Granit.Modularity;
+using Granit.Validation;
+
+namespace Granit.Dashboards.Endpoints;
+
+/// <summary>
+/// Granit module for the Granit.Dashboards HTTP endpoints.
+/// </summary>
+/// <remarks>
+/// Wires the read-only catalogue endpoint today; the import / CRUD endpoints
+/// land in subsequent stories on top of the same module.
+/// </remarks>
+[DependsOn(
+    typeof(GranitDashboardsModule),
+    typeof(GranitAuthorizationModule),
+    typeof(GranitValidationModule))]
+public sealed class GranitDashboardsEndpointsModule : GranitModule;

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardCatalogProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardCatalogProjection.cs
@@ -1,0 +1,48 @@
+using Granit.Dashboards.Endpoints.Dtos;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Maps <see cref="IDashboardDefinitionDescriptor"/> instances to the wire shape
+/// (<see cref="DashboardCatalogEntryResponse"/>) and applies the
+/// <c>?category=</c> filter. Extracted to its own class so the projection logic
+/// is unit-testable without the full WebApplication harness.
+/// </summary>
+internal static class DashboardCatalogProjection
+{
+    public static IReadOnlyList<DashboardCatalogEntryResponse> Project(
+        IEnumerable<IDashboardDefinitionDescriptor> descriptors,
+        DashboardCategory? category)
+    {
+        IEnumerable<IDashboardDefinitionDescriptor> filtered = category.HasValue
+            ? descriptors.Where(d => d.Category == category.Value)
+            : descriptors;
+
+        return [.. filtered.Select(ToResponse)];
+    }
+
+    public static DashboardCatalogEntryResponse ToResponse(IDashboardDefinitionDescriptor d)
+    {
+        // Multi-view dashboards expose the entry-view's widget count rather than
+        // the top-level (which is empty by convention). Falls back to the first
+        // view when DefaultView is null.
+        int widgetCount = d.Views is { Count: > 0 } views
+            ? (FindEntryView(views, d.DefaultView)?.Widgets.Count ?? 0)
+            : d.Widgets.Count;
+
+        return new DashboardCatalogEntryResponse(
+            Name: d.Name,
+            Category: d.Category,
+            IsSystem: d.IsSystem,
+            Version: d.Version,
+            WidgetCount: widgetCount,
+            HasViews: d.Views is { Count: > 0 },
+            HasAliases: d.Aliases is { Count: > 0 },
+            HasFilters: d.Filters is { Count: > 0 });
+    }
+
+    private static DashboardView? FindEntryView(IReadOnlyList<DashboardView> views, string? defaultView)
+        => defaultView is null
+            ? views.Count > 0 ? views[0] : null
+            : views.FirstOrDefault(v => v.Name == defaultView) ?? (views.Count > 0 ? views[0] : null);
+}

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardsEndpointsLocalizationResource.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardsEndpointsLocalizationResource.cs
@@ -1,0 +1,11 @@
+using Granit.Localization;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Marker class for the <c>DashboardsEndpoints</c> localization resource.
+/// JSON files: <c>Localization/DashboardsEndpoints/{culture}.json</c>, embedded in this assembly.
+/// Auto-discovered by <see cref="LocalizationResourceNameAttribute"/>.
+/// </summary>
+[LocalizationResourceName("DashboardsEndpoints", DefaultCulture = "en")]
+internal sealed class DashboardsEndpointsLocalizationResource;

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
@@ -1,0 +1,7 @@
+{
+  "culture": "cs",
+  "texts": {
+    "PermissionGroup:Dashboards": "Dashboardy",
+    "Permission:Dashboards.Catalog.Read": "Procházet katalog dashboardů (zobrazit seznam všech registrovaných DashboardDefinition)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
@@ -1,0 +1,7 @@
+{
+  "culture": "de",
+  "texts": {
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Permission:Dashboards.Catalog.Read": "Den Dashboard-Katalog durchsuchen (alle registrierten DashboardDefinitions auflisten)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en-GB.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
@@ -1,0 +1,7 @@
+{
+  "culture": "en",
+  "texts": {
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Permission:Dashboards.Catalog.Read": "Browse the dashboard catalogue (list every registered DashboardDefinition)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
@@ -1,0 +1,7 @@
+{
+  "culture": "es",
+  "texts": {
+    "PermissionGroup:Dashboards": "Paneles",
+    "Permission:Dashboards.Catalog.Read": "Explorar el catálogo de paneles (listar todas las DashboardDefinition registradas)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr-CA.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
@@ -1,0 +1,7 @@
+{
+  "culture": "fr",
+  "texts": {
+    "PermissionGroup:Dashboards": "Tableaux de bord",
+    "Permission:Dashboards.Catalog.Read": "Parcourir le catalogue des tableaux de bord (lister chaque DashboardDefinition enregistrée)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
@@ -1,0 +1,7 @@
+{
+  "culture": "hi",
+  "texts": {
+    "PermissionGroup:Dashboards": "डैशबोर्ड",
+    "Permission:Dashboards.Catalog.Read": "डैशबोर्ड कैटलॉग देखें (सभी पंजीकृत DashboardDefinition की सूची बनाएँ)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
@@ -1,0 +1,7 @@
+{
+  "culture": "it",
+  "texts": {
+    "PermissionGroup:Dashboards": "Dashboard",
+    "Permission:Dashboards.Catalog.Read": "Sfogliare il catalogo dei dashboard (elencare ogni DashboardDefinition registrata)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
@@ -1,0 +1,7 @@
+{
+  "culture": "ja",
+  "texts": {
+    "PermissionGroup:Dashboards": "ダッシュボード",
+    "Permission:Dashboards.Catalog.Read": "ダッシュボードカタログを参照する（登録済みの DashboardDefinition をすべて一覧表示）"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
@@ -1,0 +1,7 @@
+{
+  "culture": "ko",
+  "texts": {
+    "PermissionGroup:Dashboards": "대시보드",
+    "Permission:Dashboards.Catalog.Read": "대시보드 카탈로그 탐색(등록된 모든 DashboardDefinition 나열)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
@@ -1,0 +1,7 @@
+{
+  "culture": "nl",
+  "texts": {
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Permission:Dashboards.Catalog.Read": "Door de dashboard-catalogus bladeren (alle geregistreerde DashboardDefinitions weergeven)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
@@ -1,0 +1,7 @@
+{
+  "culture": "pl",
+  "texts": {
+    "PermissionGroup:Dashboards": "Pulpity",
+    "Permission:Dashboards.Catalog.Read": "Przeglądanie katalogu pulpitów (lista wszystkich zarejestrowanych DashboardDefinition)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt-BR.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
@@ -1,0 +1,7 @@
+{
+  "culture": "pt",
+  "texts": {
+    "PermissionGroup:Dashboards": "Painéis",
+    "Permission:Dashboards.Catalog.Read": "Navegar pelo catálogo de painéis (listar todas as DashboardDefinition registadas)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
@@ -1,0 +1,7 @@
+{
+  "culture": "sv",
+  "texts": {
+    "PermissionGroup:Dashboards": "Instrumentpaneler",
+    "Permission:Dashboards.Catalog.Read": "Bläddra i instrumentpanelskatalogen (lista alla registrerade DashboardDefinition)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
@@ -1,0 +1,7 @@
+{
+  "culture": "tr",
+  "texts": {
+    "PermissionGroup:Dashboards": "Panolar",
+    "Permission:Dashboards.Catalog.Read": "Pano kataloğunu görüntüleme (kayıtlı her DashboardDefinition'ı listeleme)"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
@@ -1,0 +1,7 @@
+{
+  "culture": "zh",
+  "texts": {
+    "PermissionGroup:Dashboards": "仪表板",
+    "Permission:Dashboards.Catalog.Read": "浏览仪表板目录（列出每个已注册的 DashboardDefinition）"
+  }
+}

--- a/src/Granit.Dashboards.Endpoints/Options/DashboardsEndpointsOptions.cs
+++ b/src/Granit.Dashboards.Endpoints/Options/DashboardsEndpointsOptions.cs
@@ -1,0 +1,23 @@
+namespace Granit.Dashboards.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the Granit.Dashboards endpoint surface.
+/// </summary>
+public sealed class DashboardsEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "DashboardsEndpoints";
+
+    /// <summary>
+    /// Route prefix for dashboards endpoints. Default: <c>"dashboards"</c>
+    /// → final route <c>/dashboards/catalog</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "dashboards";
+
+    /// <summary>
+    /// OpenAPI tag for the dashboards endpoints. Per CLAUDE.md sub-tag convention
+    /// (<c>&lt;Module&gt; - &lt;SubGroup&gt;</c>) the catalogue gets its own subgroup
+    /// to keep room for the upcoming import / CRUD endpoints.
+    /// </summary>
+    public string CatalogTagName { get; set; } = "Dashboards - Catalogue";
+}

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
@@ -1,0 +1,27 @@
+using Granit.Authorization;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Localization;
+using Granit.MultiTenancy;
+
+namespace Granit.Dashboards.Endpoints.Permissions;
+
+/// <summary>
+/// Declares the <c>Dashboards.*</c> permissions in the Granit RBAC system.
+/// </summary>
+internal sealed class DashboardsPermissionDefinitionProvider : IPermissionDefinitionProvider
+{
+    /// <inheritdoc />
+    public void DefinePermissions(IPermissionDefinitionContext context)
+    {
+        PermissionGroup group = context.AddGroup(
+            DashboardsPermissions.GroupName,
+            LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
+                "PermissionGroup:Dashboards"));
+
+        group.AddPermission(
+            DashboardsPermissions.Catalog.Read,
+            LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
+                "Permission:Dashboards.Catalog.Read"),
+            MultiTenancySides.Both);
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
@@ -1,0 +1,17 @@
+namespace Granit.Dashboards.Endpoints.Permissions;
+
+/// <summary>
+/// Permission constants for Granit.Dashboards endpoints.
+/// </summary>
+public static class DashboardsPermissions
+{
+    /// <summary>Permission group name (matches the localization key prefix).</summary>
+    public const string GroupName = "Dashboards";
+
+    /// <summary>Permissions on the dashboard catalogue endpoint.</summary>
+    public static class Catalog
+    {
+        /// <summary>Grants read access to the dashboard catalogue (list every registered DashboardDefinition).</summary>
+        public const string Read = "Dashboards.Catalog.Read";
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/README.md
+++ b/src/Granit.Dashboards.Endpoints/README.md
@@ -1,0 +1,40 @@
+# Granit.Dashboards.Endpoints
+
+Minimal API endpoints for `Granit.Dashboards`. Today ships the read-only
+catalogue endpoint:
+
+```text
+GET /{prefix}/catalog?category={category}
+```
+
+…surfacing every registered `DashboardDefinition` through the
+`IDashboardDefinitionRegistry`. Each entry carries the wire identifier, category,
+version, widget count, and feature flags (`HasViews` / `HasAliases` /
+`HasFilters`) the frontend uses to drive the import dialog.
+
+Permission gating: `Dashboards.Catalog.Read`. Localized in all 18 cultures.
+
+The import / CRUD endpoints land on the same route group in subsequent stories.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Dashboards.Endpoints
+```
+
+```csharp
+app.MapGranitDashboards(options => options.RoutePrefix = "dashboards");
+```
+
+## Dependencies
+
+- `Granit.Dashboards`
+- `Granit.Authorization`
+- `Granit.Http.Abstractions`
+- `Granit.Validation`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Dashboards.Endpoints/packages.lock.json
+++ b/src/Granit.Dashboards.Endpoints/packages.lock.json
@@ -1,0 +1,184 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.abstractions": {
+        "type": "Project"
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards\Granit.Dashboards.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Endpoints\Granit.Dashboards.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.ConfigurationChanges\Granit.Auditing.ConfigurationChanges.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1973,6 +1973,15 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.dashboards.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
       "granit.dashboards.entityframeworkcore": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Endpoints\Granit.Dashboards.Endpoints.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Dashboards.Endpoints.Tests/GranitDashboardsEndpointsModuleTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/GranitDashboardsEndpointsModuleTests.cs
@@ -1,0 +1,13 @@
+using Granit.Dashboards.Endpoints;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests;
+
+public sealed class GranitDashboardsEndpointsModuleTests
+{
+    [Fact]
+    public void Module_IsGranitModule()
+        => new GranitDashboardsEndpointsModule().ShouldBeAssignableTo<GranitModule>();
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardCatalogProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardCatalogProjectionTests.cs
@@ -1,0 +1,177 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Locks the projection logic backing <c>GET /catalog</c>: descriptor → wire DTO,
+/// optional category filter, multi-view widget-count rule, feature-flag fields.
+/// Pure in-memory — no WebApplication harness, no auth.
+/// </summary>
+public sealed class DashboardCatalogProjectionTests
+{
+    [Fact]
+    public void Project_ReturnsAllDescriptors_WhenCategoryNull()
+    {
+        IDashboardDefinitionDescriptor[] sources =
+        [
+            new TopFinanceDashboard(),
+            new SmallOpsDashboard(),
+        ];
+
+        IReadOnlyList<DashboardCatalogEntryResponse> result =
+            DashboardCatalogProjection.Project(sources, category: null);
+
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Project_FiltersByCategory()
+    {
+        IDashboardDefinitionDescriptor[] sources =
+        [
+            new TopFinanceDashboard(),
+            new SmallOpsDashboard(),
+        ];
+
+        IReadOnlyList<DashboardCatalogEntryResponse> result =
+            DashboardCatalogProjection.Project(sources, DashboardCategory.Finance);
+
+        result.Count.ShouldBe(1);
+        result[0].Name.ShouldBe("Sample.Finance.Top");
+    }
+
+    [Fact]
+    public void Project_SingleViewDashboard_ReportsWidgetsCount()
+    {
+        DashboardCatalogEntryResponse entry =
+            DashboardCatalogProjection.ToResponse(new TopFinanceDashboard());
+
+        entry.WidgetCount.ShouldBe(1);
+        entry.HasViews.ShouldBeFalse();
+        entry.HasAliases.ShouldBeFalse();
+        entry.HasFilters.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Project_MultiViewDashboard_ReportsEntryViewWidgetCount()
+    {
+        DashboardCatalogEntryResponse entry =
+            DashboardCatalogProjection.ToResponse(new MultiViewDeviceDashboard());
+
+        entry.HasViews.ShouldBeTrue();
+        // Default view "list" has 2 widgets; "detail" has 1. Projection picks "list".
+        entry.WidgetCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Project_MultiViewDashboard_NullDefaultView_FallsBackToFirstView()
+    {
+        DashboardCatalogEntryResponse entry =
+            DashboardCatalogProjection.ToResponse(new MultiViewWithoutDefaultDashboard());
+
+        entry.HasViews.ShouldBeTrue();
+        // No DefaultView → first view ("list") wins, with 1 widget.
+        entry.WidgetCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Project_SurfacesFeatureFlags()
+    {
+        DashboardCatalogEntryResponse entry =
+            DashboardCatalogProjection.ToResponse(new RichDashboard());
+
+        entry.HasViews.ShouldBeTrue();
+        entry.HasAliases.ShouldBeTrue();
+        entry.HasFilters.ShouldBeTrue();
+        entry.IsSystem.ShouldBeTrue();
+        entry.Version.ShouldBe("2.0.0");
+    }
+
+    private sealed class TopFinanceDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Finance.Top";
+        public override DashboardCategory Category => DashboardCategory.Finance;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+        [
+            new MarkdownWidgetDefinition("Banner", "Widget:Banner", Position: 0),
+        ];
+    }
+
+    private sealed class SmallOpsDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Ops.Small";
+        public override DashboardCategory Category => DashboardCategory.Operations;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+    }
+
+    private sealed class MultiViewDeviceDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Devices.MultiView";
+        public override DashboardCategory Category => DashboardCategory.Iot;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+        public override string? DefaultView => "list";
+        public override IReadOnlyList<DashboardView>? Views { get; } =
+        [
+            new DashboardView("list",
+            [
+                new TextWidgetDefinition("Title", "Widget:Title", TextStyle.Heading, Position: 0),
+                new MarkdownWidgetDefinition("Description", "Widget:Description", Position: 1),
+            ]),
+            new DashboardView("detail",
+            [
+                new MarkdownWidgetDefinition("DetailBody", "Widget:DetailBody", Position: 0),
+            ]),
+        ];
+    }
+
+    private sealed class MultiViewWithoutDefaultDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Devices.NoDefault";
+        public override DashboardCategory Category => DashboardCategory.Iot;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+        public override IReadOnlyList<DashboardView>? Views { get; } =
+        [
+            new DashboardView("list",
+            [
+                new MarkdownWidgetDefinition("OnlyOne", "Widget:OnlyOne", Position: 0),
+            ]),
+            new DashboardView("detail",
+            [
+                new MarkdownWidgetDefinition("Body", "Widget:Body", Position: 0),
+                new TextWidgetDefinition("T", "Widget:T", TextStyle.Body, Position: 1),
+            ]),
+        ];
+    }
+
+    private sealed class RichDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Rich";
+        public override DashboardCategory Category => DashboardCategory.Compliance;
+        public override bool IsSystem => true;
+        public override string Version => "2.0.0";
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+        public override IReadOnlyList<DashboardView>? Views { get; } =
+        [
+            new DashboardView("default",
+            [
+                new MarkdownWidgetDefinition("X", "Widget:X", Position: 0),
+            ]),
+        ];
+        public override IReadOnlyList<EntityAlias>? Aliases { get; } =
+        [
+            new EntityAlias("currentTenant", "Tenant", new TenantContextResolver()),
+        ];
+        public override IReadOnlyList<DashboardFilter>? Filters { get; } =
+        [
+            new DashboardFilter(
+                "Severity",
+                "Dashboard:Sample.Rich.Filter.Severity",
+                [new DashboardFilterClause("severity", DashboardFilterOperator.Gte, "warning")]),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Permissions/DashboardsPermissionsTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Permissions/DashboardsPermissionsTests.cs
@@ -1,0 +1,28 @@
+using Granit.Dashboards.Endpoints.Permissions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Permissions;
+
+/// <summary>
+/// Locks the canonical permission constants and the
+/// <c>[Group].[Resource].[Action]</c> three-segment shape required by the
+/// framework's permission convention archi tests.
+/// </summary>
+public sealed class DashboardsPermissionsTests
+{
+    [Fact]
+    public void Group_IsDashboards()
+        => DashboardsPermissions.GroupName.ShouldBe("Dashboards");
+
+    [Fact]
+    public void Catalog_Read_FollowsThreeSegmentFormat()
+        => DashboardsPermissions.Catalog.Read.ShouldBe("Dashboards.Catalog.Read");
+
+    [Fact]
+    public void Catalog_Read_HasExactlyThreeDots()
+    {
+        // Three-segment format = exactly two dots between segments.
+        DashboardsPermissions.Catalog.Read.Split('.').Length.ShouldBe(3);
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
@@ -1,0 +1,549 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.abstractions": {
+        "type": "Project"
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First HTTP surface for `Granit.Dashboards`. Read-only catalogue endpoint exposing every registered `DashboardDefinition` through `IDashboardDefinitionRegistry` — gives the frontend something to call against the persistence layer that landed in B2 (#1453) before the full B4 import / CRUD endpoints ship.

```text
GET /{prefix}/catalog?category={category}
```

Permission: `Dashboards.Catalog.Read`. Localized in all 18 cultures.

## What lands

### New package — `Granit.Dashboards.Endpoints`

- `DashboardsEndpointsOptions` — `RoutePrefix` (default `"dashboards"`), `CatalogTagName` (follows the `Module - SubGroup` convention from CLAUDE.md).
- `GranitDashboardsEndpointsModule` with `[DependsOn(GranitDashboardsModule, GranitAuthorizationModule, GranitValidationModule)]`.
- `DashboardsPermissions.Catalog.Read` — three-segment per the framework permission convention.
- `DashboardsPermissionDefinitionProvider` — auto-discovered.
- `DashboardCatalogEntryResponse` DTO — `Name` / `Category` / `IsSystem` / `Version` / `WidgetCount` / `HasViews` / `HasAliases` / `HasFilters`. Stripped to the wire-stable fields the import dialog needs; the deeper widget tree is reachable via later endpoints (B4-write).
- `DashboardCatalogProjection` (internal) — testable in isolation, handles the single-view vs multi-view widget-count rule (multi-view dashboards report the entry view's widget count rather than the empty top-level `Widgets` list).
- `DashboardCatalogEndpoints` — `MapGet("/catalog", ...)` + `WithName` / `WithSummary` / `WithDescription` / `Produces` (the 5 OpenAPI fields per CLAUDE.md endpoint-metadata convention).
- `MapGranitDashboards(this IEndpointRouteBuilder, configure?)` DI extension — composes the route group via `MapGranitGroup` (auto FluentValidation pipeline) and tags the OpenAPI output.
- README + 18 `Localization` JSON files (15 base + 3 regional fall-through).

## Tests — 10 new

| Project | Tests | Covers |
| --- | --- | --- |
| `Granit.Dashboards.Endpoints.Tests/Internal/DashboardCatalogProjectionTests` | 6 | List-all, category filter, single-view widget count, multi-view default-view widget count, multi-view null-`DefaultView` fallback to first view, feature-flag surface |
| `Granit.Dashboards.Endpoints.Tests/Permissions/DashboardsPermissionsTests` | 3 | Group constant, `Catalog.Read` constant, three-segment archi shape |
| `Granit.Dashboards.Endpoints.Tests/GranitDashboardsEndpointsModuleTests` | 1 | Module class is a `GranitModule` |

Architecture suite stays at **158/158** (permission convention + isolated DbContext + validation rules all pass against the new package).

## Plumbing

- `test-shards.json`: `tests/Granit.Dashboards.Endpoints.Tests` added to the **business** shard. `.slnf` filters regenerated.
- `tests/Granit.ArchitectureTests` references the new endpoints package.
- **36 packages.lock.json refreshed** via `dotnet restore Granit.slnx --force-evaluate` per the `feedback_lockfile_global_force_evaluate` memory.

## What's next (separate PRs)

- **B4-write** — `POST /dashboards/from-definition/{name}` (import deep-copy), full CRUD on persisted `Dashboard` aggregate, per-widget permission filtering at render time.
- **P2.4 SSE** — `IMetricStreamProducer` + per-metric / per-dashboard multiplexed streams. Its own dedicated ticket.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` — clean
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 10/10
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed globally
- [ ] CI green