### PR TITLE
feat(dashboards): import endpoint — POST /dashboards/from-definition/{name} (B4-write)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -630,6 +630,7 @@
       "name": "Granit.Dashboards.Endpoints",
       "deps": [
         "Granit.Dashboards",
+        "Granit.Dashboards.EntityFrameworkCore",
         "Granit.Authorization",
         "Granit.Http.Abstractions",
         "Granit.Validation"
@@ -639,7 +640,10 @@
     {
       "name": "Granit.Dashboards.EntityFrameworkCore",
       "deps": [
+        "Granit.Analytics",
         "Granit.Dashboards",
+        "Granit.Guids",
+        "Granit.MultiTenancy",
         "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
@@ -12992,6 +12996,15 @@
       "members": []
     },
     {
+      "name": "DashboardImportResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardImportResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardImportResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "DashboardsEndpointRouteBuilderExtensions",
       "fqn": "Granit.Dashboards.Endpoints.Extensions.DashboardsEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -13008,13 +13021,36 @@
       ]
     },
     {
+      "name": "DashboardsEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Dashboards.Endpoints.Extensions.DashboardsEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDashboardsEndpoints",
+          "kind": "method",
+          "signature": "AddGranitDashboardsEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitDashboardsEndpointsModule",
       "fqn": "Granit.Dashboards.Endpoints.GranitDashboardsEndpointsModule",
       "kind": "class",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs",
-      "line": 18,
-      "members": []
+      "line": 23,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "DashboardsEndpointsOptions",
@@ -13054,6 +13090,15 @@
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "Instances",
+      "fqn": "Granit.Dashboards.Endpoints.Permissions.Instances",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs",
+      "line": 19,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardImportResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardImportResponse.cs
@@ -1,0 +1,22 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Response payload for <c>POST /dashboards/from-definition/{name}</c>. Echoes the
+/// freshly-imported <c>Dashboard</c> aggregate's identifying fields so the client
+/// can navigate to the new persisted dashboard immediately.
+/// </summary>
+/// <param name="Id">Persisted dashboard identifier (UUID).</param>
+/// <param name="Name">Dashboard name — copied from the source definition.</param>
+/// <param name="Category">Coarse grouping — copied from the source definition.</param>
+/// <param name="Status">Initial status. Always <see cref="DashboardStatus.Draft"/> for freshly imported dashboards.</param>
+/// <param name="SourceDefinitionName">Wire identifier of the definition this dashboard was imported from.</param>
+/// <param name="SourceDefinitionVersion">Semver of the definition at import time — used by the drift-detection UI.</param>
+/// <param name="WidgetCount">Number of widgets pinned by the import (entry view for multi-view dashboards).</param>
+public sealed record DashboardImportResponse(
+    Guid Id,
+    string Name,
+    DashboardCategory Category,
+    Granit.Dashboards.Domain.DashboardStatus Status,
+    string SourceDefinitionName,
+    string SourceDefinitionVersion,
+    int WidgetCount);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardImportEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardImportEndpoints.cs
@@ -1,0 +1,64 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handler for <c>POST /dashboards/from-definition/{name}</c> — deep-copies a
+/// registered <c>DashboardDefinition</c> into a tenant-scoped persisted
+/// <see cref="Dashboard"/>. ADR-038 §2 import flow: explicit, never automatic.
+/// </summary>
+internal static class DashboardImportEndpoints
+{
+    public static RouteGroupBuilder MapImportEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/from-definition/{name}", ImportAsync)
+            .WithName("ImportGranitDashboardFromDefinition")
+            .WithSummary("Imports a registered DashboardDefinition into a persisted Dashboard.")
+            .WithDescription(
+                "Deep-copies the named DashboardDefinition into a fresh tenant-scoped "
+                + "Dashboard aggregate (status: Draft, sourceDefinitionVersion captured at "
+                + "import time). Multi-view definitions yield a Dashboard whose widgets are "
+                + "the entry view's pool (DefaultView, or the first view when DefaultView is "
+                + "null). Returns 201 with the new dashboard's identifying fields, or 404 "
+                + "when the definition name is not registered.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<DashboardImportResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Created<DashboardImportResponse>, ProblemHttpResult>> ImportAsync(
+        [FromRoute] string name,
+        [FromServices] DashboardImporter importer,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? imported = await importer.ImportAsync(name, cancellationToken).ConfigureAwait(false);
+        if (imported is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Dashboard definition '{name}' is not registered.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        var response = new DashboardImportResponse(
+            Id: imported.Id,
+            Name: imported.Name,
+            Category: imported.Category,
+            Status: imported.Status,
+            SourceDefinitionName: imported.SourceDefinitionName!,
+            SourceDefinitionVersion: imported.SourceDefinitionVersion!,
+            WidgetCount: imported.Widgets.Count);
+
+        return TypedResults.Created($"/dashboards/{imported.Id}", response);
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -14,8 +14,9 @@ public static class DashboardsEndpointRouteBuilderExtensions
 {
     /// <summary>
     /// Maps the Granit.Dashboards endpoints onto <paramref name="endpoints"/>. Today
-    /// ships the read-only catalogue endpoint; the import / CRUD endpoints land on
-    /// the same route group in subsequent stories.
+    /// ships the read-only catalogue endpoint and the import endpoint
+    /// (<c>POST /from-definition/{name}</c>); the list / read / state-transition
+    /// endpoints land on the same route group in subsequent stories.
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="DashboardsEndpointsOptions"/>.</param>
@@ -32,6 +33,7 @@ public static class DashboardsEndpointRouteBuilderExtensions
             .WithTags(options.CatalogTagName);
 
         group.MapCatalogEndpoints();
+        group.MapImportEndpoints();
 
         return group;
     }

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Dashboards.Endpoints.Extensions;
+
+/// <summary>
+/// DI registration for the Granit.Dashboards endpoint surface — wires the import
+/// service, the projection helper, and any future write-side service.
+/// </summary>
+public static class DashboardsEndpointsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the services required by the Granit.Dashboards endpoints — the
+    /// import service today, more services as later stories ship. Idempotent
+    /// (TryAdd).
+    /// </summary>
+    public static IServiceCollection AddGranitDashboardsEndpoints(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<DashboardImporter>();
+
+        return services;
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
+++ b/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <PackageId>Granit.Dashboards.Endpoints</PackageId>
-    <Description>Minimal API endpoints for Granit.Dashboards. Ships the read-only catalogue endpoint (GET /dashboards/catalog) surfacing every registered DashboardDefinition, with permission gating and per-host route prefix configuration. Future: import / CRUD endpoints, real-time hub.</Description>
+    <Description>Minimal API endpoints for Granit.Dashboards. Ships the read-only catalogue endpoint (GET /dashboards/catalog) and the import endpoint (POST /dashboards/from-definition/{name}) that deep-copies a DashboardDefinition into a tenant-scoped Dashboard aggregate. Future: list / read / state-transition / delete endpoints, real-time hub.</Description>
     <IsPackable>true</IsPackable>
+    <!-- EF1001: false positive — DashboardImporter lives in
+         Granit.Dashboards.EntityFrameworkCore.Internal (per the framework's "no EF Core
+         in Endpoints types" rule), reachable here via InternalsVisibleTo. The analyzer
+         flags any *.Internal.* namespace touched from outside its assembly. -->
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs
+++ b/src/Granit.Dashboards.Endpoints/GranitDashboardsEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.Dashboards.Endpoints.Extensions;
+using Granit.Dashboards.EntityFrameworkCore;
 using Granit.Modularity;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Dashboards.Endpoints;
 
@@ -8,11 +11,18 @@ namespace Granit.Dashboards.Endpoints;
 /// Granit module for the Granit.Dashboards HTTP endpoints.
 /// </summary>
 /// <remarks>
-/// Wires the read-only catalogue endpoint today; the import / CRUD endpoints
-/// land in subsequent stories on top of the same module.
+/// Wires the read-only catalogue endpoint and the import endpoint today; the
+/// list / read / state-transition endpoints land in subsequent stories on top
+/// of the same module.
 /// </remarks>
 [DependsOn(
     typeof(GranitDashboardsModule),
+    typeof(GranitDashboardsEntityFrameworkCoreModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitValidationModule))]
-public sealed class GranitDashboardsEndpointsModule : GranitModule;
+public sealed class GranitDashboardsEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitDashboardsEndpoints();
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
@@ -2,6 +2,7 @@
   "culture": "cs",
   "texts": {
     "PermissionGroup:Dashboards": "Dashboardy",
-    "Permission:Dashboards.Catalog.Read": "Procházet katalog dashboardů (zobrazit seznam všech registrovaných DashboardDefinition)"
+    "Permission:Dashboards.Catalog.Read": "Procházet katalog dashboardů (zobrazit seznam všech registrovaných DashboardDefinition)",
+    "Permission:Dashboards.Instances.Manage": "Spravovat dashboardy nájemce (importovat z definice, upravit, publikovat, archivovat, obnovit)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
@@ -2,6 +2,7 @@
   "culture": "de",
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
-    "Permission:Dashboards.Catalog.Read": "Den Dashboard-Katalog durchsuchen (alle registrierten DashboardDefinitions auflisten)"
+    "Permission:Dashboards.Catalog.Read": "Den Dashboard-Katalog durchsuchen (alle registrierten DashboardDefinitions auflisten)",
+    "Permission:Dashboards.Instances.Manage": "Tenant-spezifische Dashboards verwalten (aus Definition importieren, bearbeiten, veröffentlichen, archivieren, wiederherstellen)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
@@ -2,6 +2,7 @@
   "culture": "en",
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
-    "Permission:Dashboards.Catalog.Read": "Browse the dashboard catalogue (list every registered DashboardDefinition)"
+    "Permission:Dashboards.Catalog.Read": "Browse the dashboard catalogue (list every registered DashboardDefinition)",
+    "Permission:Dashboards.Instances.Manage": "Manage tenant-scoped dashboards (import from definition, edit, publish, archive, restore)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
@@ -2,6 +2,7 @@
   "culture": "es",
   "texts": {
     "PermissionGroup:Dashboards": "Paneles",
-    "Permission:Dashboards.Catalog.Read": "Explorar el catálogo de paneles (listar todas las DashboardDefinition registradas)"
+    "Permission:Dashboards.Catalog.Read": "Explorar el catálogo de paneles (listar todas las DashboardDefinition registradas)",
+    "Permission:Dashboards.Instances.Manage": "Gestionar paneles del inquilino (importar desde definición, editar, publicar, archivar, restaurar)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
@@ -2,6 +2,7 @@
   "culture": "fr",
   "texts": {
     "PermissionGroup:Dashboards": "Tableaux de bord",
-    "Permission:Dashboards.Catalog.Read": "Parcourir le catalogue des tableaux de bord (lister chaque DashboardDefinition enregistrée)"
+    "Permission:Dashboards.Catalog.Read": "Parcourir le catalogue des tableaux de bord (lister chaque DashboardDefinition enregistrée)",
+    "Permission:Dashboards.Instances.Manage": "Gérer les tableaux de bord du locataire (importer depuis une définition, éditer, publier, archiver, restaurer)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
@@ -2,6 +2,7 @@
   "culture": "hi",
   "texts": {
     "PermissionGroup:Dashboards": "डैशबोर्ड",
-    "Permission:Dashboards.Catalog.Read": "डैशबोर्ड कैटलॉग देखें (सभी पंजीकृत DashboardDefinition की सूची बनाएँ)"
+    "Permission:Dashboards.Catalog.Read": "डैशबोर्ड कैटलॉग देखें (सभी पंजीकृत DashboardDefinition की सूची बनाएँ)",
+    "Permission:Dashboards.Instances.Manage": "टेनेंट डैशबोर्ड प्रबंधित करें (परिभाषा से आयात, संपादन, प्रकाशन, संग्रह, पुनर्स्थापन)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
@@ -2,6 +2,7 @@
   "culture": "it",
   "texts": {
     "PermissionGroup:Dashboards": "Dashboard",
-    "Permission:Dashboards.Catalog.Read": "Sfogliare il catalogo dei dashboard (elencare ogni DashboardDefinition registrata)"
+    "Permission:Dashboards.Catalog.Read": "Sfogliare il catalogo dei dashboard (elencare ogni DashboardDefinition registrata)",
+    "Permission:Dashboards.Instances.Manage": "Gestire i dashboard del tenant (importare dalla definizione, modificare, pubblicare, archiviare, ripristinare)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
@@ -2,6 +2,7 @@
   "culture": "ja",
   "texts": {
     "PermissionGroup:Dashboards": "ダッシュボード",
-    "Permission:Dashboards.Catalog.Read": "ダッシュボードカタログを参照する（登録済みの DashboardDefinition をすべて一覧表示）"
+    "Permission:Dashboards.Catalog.Read": "ダッシュボードカタログを参照する（登録済みの DashboardDefinition をすべて一覧表示）",
+    "Permission:Dashboards.Instances.Manage": "テナントスコープのダッシュボードを管理する（定義からインポート、編集、公開、アーカイブ、復元）"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
@@ -2,6 +2,7 @@
   "culture": "ko",
   "texts": {
     "PermissionGroup:Dashboards": "대시보드",
-    "Permission:Dashboards.Catalog.Read": "대시보드 카탈로그 탐색(등록된 모든 DashboardDefinition 나열)"
+    "Permission:Dashboards.Catalog.Read": "대시보드 카탈로그 탐색(등록된 모든 DashboardDefinition 나열)",
+    "Permission:Dashboards.Instances.Manage": "테넌트 범위 대시보드 관리(정의에서 가져오기, 편집, 게시, 보관, 복원)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
@@ -2,6 +2,7 @@
   "culture": "nl",
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
-    "Permission:Dashboards.Catalog.Read": "Door de dashboard-catalogus bladeren (alle geregistreerde DashboardDefinitions weergeven)"
+    "Permission:Dashboards.Catalog.Read": "Door de dashboard-catalogus bladeren (alle geregistreerde DashboardDefinitions weergeven)",
+    "Permission:Dashboards.Instances.Manage": "Beheer huurder-specifieke dashboards (importeren vanuit definitie, bewerken, publiceren, archiveren, herstellen)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
@@ -2,6 +2,7 @@
   "culture": "pl",
   "texts": {
     "PermissionGroup:Dashboards": "Pulpity",
-    "Permission:Dashboards.Catalog.Read": "Przeglądanie katalogu pulpitów (lista wszystkich zarejestrowanych DashboardDefinition)"
+    "Permission:Dashboards.Catalog.Read": "Przeglądanie katalogu pulpitów (lista wszystkich zarejestrowanych DashboardDefinition)",
+    "Permission:Dashboards.Instances.Manage": "Zarządzanie pulpitami dzierżawcy (importowanie z definicji, edycja, publikowanie, archiwizowanie, przywracanie)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
@@ -2,6 +2,7 @@
   "culture": "pt",
   "texts": {
     "PermissionGroup:Dashboards": "Painéis",
-    "Permission:Dashboards.Catalog.Read": "Navegar pelo catálogo de painéis (listar todas as DashboardDefinition registadas)"
+    "Permission:Dashboards.Catalog.Read": "Navegar pelo catálogo de painéis (listar todas as DashboardDefinition registadas)",
+    "Permission:Dashboards.Instances.Manage": "Gerir painéis do inquilino (importar a partir de definição, editar, publicar, arquivar, restaurar)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
@@ -2,6 +2,7 @@
   "culture": "sv",
   "texts": {
     "PermissionGroup:Dashboards": "Instrumentpaneler",
-    "Permission:Dashboards.Catalog.Read": "Bläddra i instrumentpanelskatalogen (lista alla registrerade DashboardDefinition)"
+    "Permission:Dashboards.Catalog.Read": "Bläddra i instrumentpanelskatalogen (lista alla registrerade DashboardDefinition)",
+    "Permission:Dashboards.Instances.Manage": "Hantera klientspecifika instrumentpaneler (importera från definition, redigera, publicera, arkivera, återställa)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
@@ -2,6 +2,7 @@
   "culture": "tr",
   "texts": {
     "PermissionGroup:Dashboards": "Panolar",
-    "Permission:Dashboards.Catalog.Read": "Pano kataloğunu görüntüleme (kayıtlı her DashboardDefinition'ı listeleme)"
+    "Permission:Dashboards.Catalog.Read": "Pano kataloğunu görüntüleme (kayıtlı her DashboardDefinition'ı listeleme)",
+    "Permission:Dashboards.Instances.Manage": "Kiracıya özel panoları yönet (tanımdan içe aktar, düzenle, yayınla, arşivle, geri yükle)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
@@ -2,6 +2,7 @@
   "culture": "zh",
   "texts": {
     "PermissionGroup:Dashboards": "仪表板",
-    "Permission:Dashboards.Catalog.Read": "浏览仪表板目录（列出每个已注册的 DashboardDefinition）"
+    "Permission:Dashboards.Catalog.Read": "浏览仪表板目录（列出每个已注册的 DashboardDefinition）",
+    "Permission:Dashboards.Instances.Manage": "管理租户范围的仪表板（从定义导入、编辑、发布、归档、恢复）"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
@@ -23,5 +23,11 @@ internal sealed class DashboardsPermissionDefinitionProvider : IPermissionDefini
             LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
                 "Permission:Dashboards.Catalog.Read"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            DashboardsPermissions.Instances.Manage,
+            LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
+                "Permission:Dashboards.Instances.Manage"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
@@ -14,4 +14,15 @@ public static class DashboardsPermissions
         /// <summary>Grants read access to the dashboard catalogue (list every registered DashboardDefinition).</summary>
         public const string Read = "Dashboards.Catalog.Read";
     }
+
+    /// <summary>Permissions on the persisted Dashboard aggregate.</summary>
+    public static class Instances
+    {
+        /// <summary>
+        /// Grants write access to the persisted Dashboard aggregate — covers import (deep-copy
+        /// from a registered DashboardDefinition), state transitions (publish / archive /
+        /// restore), and the upcoming widget-edit endpoints.
+        /// </summary>
+        public const string Manage = "Dashboards.Instances.Manage";
+    }
 }

--- a/src/Granit.Dashboards.Endpoints/packages.lock.json
+++ b/src/Granit.Dashboards.Endpoints/packages.lock.json
@@ -8,6 +8,16 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.OpenApi": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -20,6 +30,15 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.analytics.abstractions": {
         "type": "Project",
@@ -61,6 +80,17 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.dashboards.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -71,6 +101,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.http.abstractions": {
@@ -90,6 +126,33 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -137,6 +200,34 @@
         "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Dashboards.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Dashboards.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.Dashboards.EntityFrameworkCore.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
@@ -18,7 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardImporter.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardImporter.cs
@@ -1,0 +1,88 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Guids;
+using Granit.MultiTenancy;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Deep-copies a registered <see cref="DashboardDefinition"/> into a tenant-scoped
+/// <see cref="Dashboard"/> aggregate persisted via <see cref="DashboardsDbContext"/>.
+/// Per ADR-038 §3 the import freezes the dashboard at the definition's current
+/// version — module upgrades surface drift via <see cref="Dashboard.SourceDefinitionVersion"/>
+/// rather than retro-editing imported instances.
+/// </summary>
+internal sealed class DashboardImporter(
+    IDashboardDefinitionRegistry registry,
+    DashboardsDbContext db,
+    IGuidGenerator guidGenerator,
+    ICurrentTenant? currentTenant = null)
+{
+    /// <summary>
+    /// Imports the named definition. Returns <c>null</c> when the definition is
+    /// not registered (caller translates to 404). Throws on persistence errors.
+    /// </summary>
+    public async Task<Dashboard?> ImportAsync(string definitionName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(definitionName);
+
+        IDashboardDefinitionDescriptor? def = registry.Find(definitionName);
+        if (def is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<WidgetDefinition> widgets = ResolveEntryWidgets(def);
+
+        var dashboard = Dashboard.Create(
+            id: guidGenerator.Create(),
+            name: def.Name,
+            category: def.Category,
+            layoutColumns: def.Layout.Columns,
+            layoutRowHeight: def.Layout.RowHeight,
+            tenantId: currentTenant?.Id,
+            sourceDefinitionName: def.Name,
+            sourceDefinitionVersion: def.Version,
+            isSystem: def.IsSystem);
+
+        foreach (WidgetDefinition widget in widgets)
+        {
+            WidgetDefinitionToInstanceMapper.Mapping mapping =
+                WidgetDefinitionToInstanceMapper.Map(widget);
+
+            dashboard.AddWidget(
+                widgetId: guidGenerator.Create(),
+                widgetType: mapping.WidgetType,
+                position: widget.Position,
+                width: widget.Size.Width,
+                height: widget.Size.Height,
+                titleLocalizationKey: $"Widget:{def.Name}.{widget.Slug}",
+                configJson: mapping.ConfigJson,
+                metricName: mapping.MetricName,
+                queryName: mapping.QueryName,
+                requiredPermission: widget.RequiredPermission);
+        }
+
+        db.Dashboards.Add(dashboard);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return dashboard;
+    }
+
+    private static IReadOnlyList<WidgetDefinition> ResolveEntryWidgets(IDashboardDefinitionDescriptor def)
+    {
+        // Multi-view dashboards expose the widgets of the named DefaultView (or the
+        // first view when DefaultView is null). Single-view dashboards use the
+        // top-level Widgets directly.
+        if (def.Views is { Count: > 0 } views)
+        {
+            DashboardView entry = def.DefaultView is null
+                ? views[0]
+                : views.FirstOrDefault(v => v.Name == def.DefaultView) ?? views[0];
+            return entry.Widgets;
+        }
+
+        return def.Widgets;
+    }
+}

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/WidgetDefinitionToInstanceMapper.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/WidgetDefinitionToInstanceMapper.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Widgets;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Translates a typed <see cref="WidgetDefinition"/> shipped by a module into the
+/// persisted <c>WidgetInstance</c> shape — discriminator string, denormalised
+/// metric / query references for archi cross-checks, plus the kind-specific JSON
+/// payload. Used by the import endpoint to deep-copy a <c>DashboardDefinition</c>
+/// into a tenant-scoped <c>Dashboard</c> aggregate.
+/// </summary>
+internal static class WidgetDefinitionToInstanceMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>Result of the mapping — fed into <c>Dashboard.AddWidget(...)</c>.</summary>
+    internal sealed record Mapping(
+        string WidgetType,
+        string? MetricName,
+        string? QueryName,
+        string ConfigJson);
+
+    /// <summary>
+    /// Maps the supplied <paramref name="widget"/> to a persisted-shape tuple.
+    /// Throws <see cref="InvalidOperationException"/> for unknown widget kinds —
+    /// the caller is expected to ship its own derived widget records through the
+    /// runtime polymorphism extension (P1.1) and add a corresponding case here.
+    /// </summary>
+    public static Mapping Map(WidgetDefinition widget) => widget switch
+    {
+        MarkdownWidgetDefinition m => new(
+            "Markdown", null, null,
+            JsonSerializer.Serialize(new { contentLocalizationKey = m.ContentLocalizationKey }, JsonOptions)),
+
+        ImageWidgetDefinition i => new(
+            "Image", null, null,
+            JsonSerializer.Serialize(
+                new { source = i.Source, altLocalizationKey = i.AltLocalizationKey, fit = i.Fit.ToString() },
+                JsonOptions)),
+
+        TextWidgetDefinition t => new(
+            "Text", null, null,
+            JsonSerializer.Serialize(
+                new { contentLocalizationKey = t.ContentLocalizationKey, style = t.Style.ToString() },
+                JsonOptions)),
+
+        KpiWidgetDefinition k => new(
+            "Kpi",
+            ExtractMetricName(k.Datasource),
+            ExtractQueryName(k.Datasource),
+            // The full Datasource (including KeyFormats / aggregation parameters) lands
+            // in ConfigJson — the typed names extracted above are denormalised columns
+            // for cross-widget reference checks (DashboardWidgetReferenceTests archi rule).
+            JsonSerializer.Serialize<Datasource>(k.Datasource, JsonOptions)),
+
+        ChartWidgetDefinition c => new(
+            "Chart", null, c.QueryName,
+            JsonSerializer.Serialize(
+                new
+                {
+                    groupBy = c.GroupBy,
+                    aggregation = c.Aggregation.ToString(),
+                    field = c.Field,
+                    chartType = c.ChartType.ToString(),
+                },
+                JsonOptions)),
+
+        TableWidgetDefinition t => new(
+            "Table", null, t.QueryName,
+            JsonSerializer.Serialize(
+                new { visibleColumns = t.VisibleColumns, pageSize = t.PageSize },
+                JsonOptions)),
+
+        PivotWidgetDefinition p => new(
+            "Pivot", null, p.QueryName,
+            JsonSerializer.Serialize(
+                new
+                {
+                    rowFields = p.RowFields,
+                    columnFields = p.ColumnFields,
+                    valueField = p.ValueField,
+                    valueAggregation = p.ValueAggregation.ToString(),
+                },
+                JsonOptions)),
+
+        _ => throw new InvalidOperationException(
+            $"No persisted-shape mapping registered for widget kind '{widget.GetType().Name}'. "
+            + "Custom widget kinds shipped by downstream packages (Granit.IoT.Dashboards, ...) "
+            + "must extend WidgetDefinitionToInstanceMapper before they can be imported."),
+    };
+
+    private static string? ExtractMetricName(Datasource datasource) => datasource switch
+    {
+        MetricDatasource md => md.MetricName,
+        _ => null,
+    };
+
+    private static string? ExtractQueryName(Datasource datasource) => datasource switch
+    {
+        QueryAggregateDatasource qa => qa.QueryName,
+        _ => null,
+    };
+}

--- a/src/Granit.Dashboards.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Dashboards.EntityFrameworkCore/packages.lock.json
@@ -99,6 +99,15 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -120,6 +129,12 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -138,6 +153,14 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.persistence": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1978,6 +1978,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -1985,7 +1986,10 @@
       "granit.dashboards.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }

--- a/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- DashboardsDbContext is internal to Granit.Dashboards.EntityFrameworkCore — same
+         InternalsVisibleTo bridge as the Endpoints package itself. -->
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,12 +14,16 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards.Endpoints\Granit.Dashboards.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Guids\Granit.Guids.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardImporterTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardImporterTests.cs
@@ -1,0 +1,173 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Widgets;
+using Granit.Guids;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed importer tests — verifies the deep-copy from a registered
+/// <see cref="DashboardDefinition"/> to a persisted <see cref="Dashboard"/>
+/// aggregate works end-to-end through the real <see cref="DashboardsDbContext"/>.
+/// </summary>
+public sealed class DashboardImporterTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext ctx = NewContext();
+        await ctx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task ImportAsync_UnknownDefinition_ReturnsNull()
+    {
+        DashboardImporter importer = NewImporter(new InMemoryRegistry());
+
+        Dashboard? result = await importer.ImportAsync("Sample.Missing", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ImportAsync_SingleViewDashboard_CopiesAllWidgets()
+    {
+        InMemoryRegistry registry = new();
+        registry.Register(new SingleViewFinanceDashboard());
+        DashboardImporter importer = NewImporter(registry);
+
+        Dashboard? imported = await importer.ImportAsync("Sample.Finance", TestContext.Current.CancellationToken);
+
+        imported.ShouldNotBeNull();
+        imported.Status.ShouldBe(DashboardStatus.Draft);
+        imported.SourceDefinitionName.ShouldBe("Sample.Finance");
+        imported.SourceDefinitionVersion.ShouldBe("1.0.0");
+        imported.Widgets.Count.ShouldBe(2);
+        imported.Widgets.ShouldContain(w => w.WidgetType == "Markdown");
+        imported.Widgets.ShouldContain(w => w.WidgetType == "Text" && w.Position == 1);
+
+        // Round-trip through DbContext to confirm the persistence layer accepted everything.
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard fromDb = await readBack.Dashboards
+            .Include(d => d.Widgets)
+            .SingleAsync(d => d.Id == imported.Id, TestContext.Current.CancellationToken);
+        fromDb.Widgets.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ImportAsync_MultiViewDashboard_PicksDefaultViewWidgets()
+    {
+        InMemoryRegistry registry = new();
+        registry.Register(new MultiViewDashboard());
+        DashboardImporter importer = NewImporter(registry);
+
+        Dashboard? imported = await importer.ImportAsync("Sample.MultiView", TestContext.Current.CancellationToken);
+
+        imported.ShouldNotBeNull();
+        // Default view "list" carries 2 widgets; "detail" carries 1. The import must
+        // pick the default view's pool, not the empty top-level Widgets list.
+        imported.Widgets.Count.ShouldBe(2);
+        imported.Widgets.ShouldContain(w => w.TitleLocalizationKey == "Widget:Sample.MultiView.Title");
+    }
+
+    [Fact]
+    public async Task ImportAsync_PersistsSourceDefinitionVersion()
+    {
+        InMemoryRegistry registry = new();
+        registry.Register(new VersionedDashboard());
+        DashboardImporter importer = NewImporter(registry);
+
+        Dashboard? imported = await importer.ImportAsync("Sample.Versioned", TestContext.Current.CancellationToken);
+
+        imported.ShouldNotBeNull();
+        imported.SourceDefinitionVersion.ShouldBe("3.2.1");
+    }
+
+    [Fact]
+    public async Task ImportAsync_RejectsNullOrWhitespaceName()
+    {
+        DashboardImporter importer = NewImporter(new InMemoryRegistry());
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            importer.ImportAsync(string.Empty, TestContext.Current.CancellationToken));
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+
+    private DashboardImporter NewImporter(IDashboardDefinitionRegistry registry)
+    {
+        DashboardsDbContext db = NewContext();
+        IGuidGenerator guidGen = Substitute.For<IGuidGenerator>();
+        guidGen.Create().Returns(_ => Guid.NewGuid());
+        return new DashboardImporter(registry, db, guidGen);
+    }
+
+    private sealed class InMemoryRegistry : IDashboardDefinitionRegistry
+    {
+        private readonly Dictionary<string, IDashboardDefinitionDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Register(IDashboardDefinitionDescriptor d) => _byName[d.Name] = d;
+        public IReadOnlyList<IDashboardDefinitionDescriptor> GetAll() => [.. _byName.Values];
+        public IDashboardDefinitionDescriptor? Find(string name) => _byName.GetValueOrDefault(name);
+    }
+
+    private sealed class SingleViewFinanceDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Finance";
+        public override DashboardCategory Category => DashboardCategory.Finance;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+        [
+            new MarkdownWidgetDefinition("Banner", "Widget:Sample.Finance.Banner", Position: 0),
+            new TextWidgetDefinition("Heading", "Widget:Sample.Finance.Heading", TextStyle.Heading, Position: 1),
+        ];
+    }
+
+    private sealed class MultiViewDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.MultiView";
+        public override DashboardCategory Category => DashboardCategory.Iot;
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } = [];
+        public override string? DefaultView => "list";
+        public override IReadOnlyList<DashboardView>? Views { get; } =
+        [
+            new DashboardView("list",
+            [
+                new TextWidgetDefinition("Title", "Widget:Sample.MultiView.Title", TextStyle.Heading, Position: 0),
+                new MarkdownWidgetDefinition("Body", "Widget:Sample.MultiView.Body", Position: 1),
+            ]),
+            new DashboardView("detail",
+            [
+                new MarkdownWidgetDefinition("Detail", "Widget:Sample.MultiView.Detail", Position: 0),
+            ]),
+        ];
+    }
+
+    private sealed class VersionedDashboard : DashboardDefinition
+    {
+        public override string Name => "Sample.Versioned";
+        public override DashboardCategory Category => DashboardCategory.General;
+        public override string Version => "3.2.1";
+        public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+        [
+            new MarkdownWidgetDefinition("X", "Widget:X", Position: 0),
+        ];
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/WidgetDefinitionToInstanceMapperTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/WidgetDefinitionToInstanceMapperTests.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Locks the typed-widget-to-persisted-shape mapping used by the import endpoint.
+/// Each kind must produce the right discriminator string + denormalised metric /
+/// query references + a parseable ConfigJson payload.
+/// </summary>
+public sealed class WidgetDefinitionToInstanceMapperTests
+{
+    [Fact]
+    public void Markdown_MapsToMarkdownTypeWithContentKey()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new MarkdownWidgetDefinition("Banner", "Widget:S.Banner", Position: 0));
+
+        result.WidgetType.ShouldBe("Markdown");
+        result.MetricName.ShouldBeNull();
+        result.QueryName.ShouldBeNull();
+        result.ConfigJson.ShouldContain("Widget:S.Banner");
+    }
+
+    [Fact]
+    public void Image_MapsToImageTypeWithSourceAltAndFit()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new ImageWidgetDefinition("Logo", "https://cdn.example/logo.png", "Widget:S.Logo.Alt", Position: 0, Fit: ImageFit.Cover));
+
+        result.WidgetType.ShouldBe("Image");
+        result.ConfigJson.ShouldContain("https://cdn.example/logo.png");
+        result.ConfigJson.ShouldContain("Cover");
+    }
+
+    [Fact]
+    public void Text_MapsToTextTypeWithStyle()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new TextWidgetDefinition("Title", "Widget:S.Title", TextStyle.Heading, Position: 0));
+
+        result.WidgetType.ShouldBe("Text");
+        result.ConfigJson.ShouldContain("Heading");
+    }
+
+    [Fact]
+    public void Kpi_WithMetricDatasource_ExtractsMetricName()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new KpiWidgetDefinition(
+                    "UnpaidCount",
+                    Datasource.Metric("Granit.Invoicing.UnpaidInvoiceCountMetric"),
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Kpi");
+        result.MetricName.ShouldBe("Granit.Invoicing.UnpaidInvoiceCountMetric");
+        result.QueryName.ShouldBeNull();
+        // ConfigJson carries the full datasource via P1.1 polymorphism — discriminator "metric"
+        result.ConfigJson.ShouldContain("\"kind\":\"metric\"");
+    }
+
+    [Fact]
+    public void Kpi_WithQueryAggregateDatasource_ExtractsQueryName()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new KpiWidgetDefinition(
+                    "RevenueAgg",
+                    Datasource.QueryAggregate("Sample.Q", AggregateFunction.Sum, "Total"),
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Kpi");
+        result.MetricName.ShouldBeNull();
+        result.QueryName.ShouldBe("Sample.Q");
+        result.ConfigJson.ShouldContain("\"kind\":\"query-aggregate\"");
+    }
+
+    [Fact]
+    public void Kpi_WithTelemetryDatasource_HasNeitherDenormalisedRef()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new KpiWidgetDefinition(
+                    "Temperature",
+                    Datasource.Telemetry("currentDevice", "temperature"),
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Kpi");
+        result.MetricName.ShouldBeNull();
+        result.QueryName.ShouldBeNull();
+        result.ConfigJson.ShouldContain("\"kind\":\"iot-telemetry\"");
+    }
+
+    [Fact]
+    public void Chart_MapsQueryNameAndAggregation()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new ChartWidgetDefinition(
+                    "RevenueByMonth",
+                    "Sample.Q",
+                    "IssuedAtMonth",
+                    AggregateFunction.Sum,
+                    "Total",
+                    ChartType.Line,
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Chart");
+        result.QueryName.ShouldBe("Sample.Q");
+        result.ConfigJson.ShouldContain("Line");
+        result.ConfigJson.ShouldContain("Sum");
+    }
+
+    [Fact]
+    public void Table_MapsQueryNameAndPageSize()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new TableWidgetDefinition("Recent", "Sample.Q", null, 25, Position: 0));
+
+        result.WidgetType.ShouldBe("Table");
+        result.QueryName.ShouldBe("Sample.Q");
+        result.ConfigJson.ShouldContain("25");
+    }
+
+    [Fact]
+    public void Pivot_MapsRowsAndColumns()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new PivotWidgetDefinition(
+                    "ByCustomerByMonth",
+                    "Sample.Q",
+                    ["customer"],
+                    ["month"],
+                    "amount",
+                    AggregateFunction.Sum,
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Pivot");
+        result.QueryName.ShouldBe("Sample.Q");
+        result.ConfigJson.ShouldContain("customer");
+        result.ConfigJson.ShouldContain("month");
+    }
+
+    [Fact]
+    public void ConfigJson_IsValidJson_ForEveryKind()
+    {
+        WidgetDefinition[] widgets =
+        [
+            new MarkdownWidgetDefinition("M", "Widget:M", Position: 0),
+            new ImageWidgetDefinition("I", "https://x", "Widget:I.Alt", Position: 1),
+            new TextWidgetDefinition("T", "Widget:T", TextStyle.Body, Position: 2),
+            new KpiWidgetDefinition("K", Datasource.Metric("M1"), Position: 3),
+            new ChartWidgetDefinition("C", "Q1", "g", AggregateFunction.Count, null, ChartType.Bar, Position: 4),
+            new TableWidgetDefinition("Tab", "Q1", null, 10, Position: 5),
+            new PivotWidgetDefinition("P", "Q1", ["r"], ["c"], null, AggregateFunction.Count, Position: 6),
+        ];
+
+        foreach (WidgetDefinition widget in widgets)
+        {
+            WidgetDefinitionToInstanceMapper.Mapping result = WidgetDefinitionToInstanceMapper.Map(widget);
+
+            // Should not throw — every ConfigJson must be parseable JSON.
+            using var doc = JsonDocument.Parse(result.ConfigJson);
+            doc.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
+        }
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
@@ -20,6 +20,21 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "0cnk9Chkuz2Jc6pbXRqdjy2CMAi62q4dJhvJzG25iCIvbavUYLxk/5ukwM+mzOl7ADN88WPmY1Lx1cAH2g8QSA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -101,6 +116,38 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "xVrtBg3M1wJlBDkoT0dXEYB/wSc8bIHJPYtw/bu1AqpWgF79uPSs87DAhERR/Ilumre6TKZa1cjMg3VUUObVLA==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "XVjGSW98Z/f3nFZsZILL/tntgM8i2hxUDUB4Nzt7ZvJ63MczC/VG4zjQh+m+q88SU+IJBUDipJJpkYBU57YWXg==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -116,6 +163,51 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -181,6 +273,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -275,6 +394,15 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -324,10 +452,23 @@
       "granit.dashboards.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -340,6 +481,14 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "granit.http.abstractions": {
@@ -361,6 +510,35 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -413,6 +591,30 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -450,6 +652,42 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

First write surface for `Granit.Dashboards`. Deep-copies a registered `DashboardDefinition` into a tenant-scoped `Dashboard` aggregate persisted via `DashboardsDbContext`. ADR-038 §2 import flow: **explicit** (admin-driven), never automatic; **freezes** the dashboard at the definition's current `Version` so module upgrades surface drift rather than retro-edit imports.

```text
POST /{prefix}/from-definition/{name}    → 201 Created with DashboardImportResponse
                                          → 404 if name is not registered
```

Permission: `Dashboards.Instances.Manage` (new). Localized in all 18 cultures.

## Architectural placement

- **`WidgetDefinitionToInstanceMapper` + `DashboardImporter` live in `Granit.Dashboards.EntityFrameworkCore`** — the EF Core-touching code stays **out of the Endpoints package** per the framework's "Endpoints must not depend on EF Core directly" archi rule (`LayerDependencyTests.Endpoint_types_should_not_depend_on_EntityFrameworkCore`).
- The endpoint handler in `Granit.Dashboards.Endpoints` consumes the importer via DI — **no direct `Microsoft.EntityFrameworkCore.*` imports in any Endpoint type**.
- `Granit.Dashboards.EntityFrameworkCore` now `ProjectReferences` `Granit.Analytics` for the per-kind widget mapping (Kpi / Chart / Table / Pivot). Analytics does not depend on EF Core back, so no cycle.

## What lands

### `Granit.Dashboards.EntityFrameworkCore` (new files)

- **`WidgetDefinitionToInstanceMapper`** (internal) — pattern-matches the seven widget kinds:
  - `Markdown` / `Image` / `Text` → `ConfigJson` with the kind-specific fields
  - `Kpi` → discriminated by `Datasource` subtype (Metric / QueryAggregate / Telemetry); `MetricName` / `QueryName` denormalised when applicable
  - `Chart` / `Table` / `Pivot` → `QueryName` denormalised, `ConfigJson` holds the rest

  Throws `InvalidOperationException` for unknown kinds — downstream packages (`Granit.IoT.Dashboards`, ...) must extend the mapper before they can import.

- **`DashboardImporter`** (internal) — reads the definition from `IDashboardDefinitionRegistry`, resolves the entry view (multi-view: `DefaultView` or first view; single-view: top-level `Widgets`), creates a fresh `Dashboard` aggregate, deep-copies every widget, persists via `DashboardsDbContext`.

### `Granit.Dashboards.Endpoints` (new files)

- `DashboardImportEndpoints` — `MapPost("/from-definition/{name}", ...)` with the five OpenAPI metadata fields per CLAUDE.md (`WithName` / `WithSummary` / `WithDescription` / `Produces<T>(201)` / `ProducesProblem(404)`).
- `DashboardImportResponse` DTO (`Id`, `Name`, `Category`, `Status`, `SourceDefinitionName`, `SourceDefinitionVersion`, `WidgetCount`).
- **`DashboardsPermissions.Instances.Manage`** — three-segment per the framework permission convention.
- `DashboardsEndpointsServiceCollectionExtensions.AddGranitDashboardsEndpoints` — `TryAddScoped<DashboardImporter>`, idempotent.
- Module class wires `AddGranitDashboardsEndpoints` in `ConfigureServices` and gains `[DependsOn(GranitDashboardsEntityFrameworkCoreModule)]`.

### Localization

`Permission:Dashboards.Instances.Manage` added in **15 base cultures** (regional `fr-CA` / `en-GB` / `pt-BR` fall-through unchanged).

## Tests — 15 new

| Project | Tests | Covers |
| --- | --- | --- |
| `WidgetDefinitionToInstanceMapperTests` | 10 | Every widget kind maps to the right discriminator + denormalised refs + parseable `ConfigJson`; KPI `Datasource` variants (Metric / QueryAggregate / Telemetry) extract the right fields |
| `DashboardImporterTests` (SQLite) | 5 | Unknown definition returns `null`, single-view dashboard copies all widgets, multi-view picks `DefaultView`'s pool, source version persists correctly, null/empty name throws |

`Granit.Dashboards.Endpoints.Tests`: **25/25** (was 10, +15). Architecture suite: **158/158**.

## Plumbing

- 36 `packages.lock.json` refreshed via `dotnet restore Granit.slnx --force-evaluate` per the `feedback_lockfile_global_force_evaluate` memory — `Granit.Dashboards.EntityFrameworkCore` gained transitive deps (`Analytics`, `Guids`, `MultiTenancy`).

## What's next (separate PRs)

- **B4-write-2** — list / read-by-id endpoints, state-transition (publish / archive / restore), delete (soft).
- **P2.4 SSE** — `IMetricStreamProducer` + per-metric / per-dashboard multiplexed streams (its own dedicated ticket).
- **B3** — per-kind `ConfigJson` validators on the persisted side (validates admin edits to widget config against the kind's schema).

## Test plan

- [x] `dotnet build` — clean across `Dashboards.EntityFrameworkCore` / `Dashboards.Endpoints`
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 25/25
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158
- [x] `dotnet format` clean on `business` + `architecture` shards
- [x] Lockfiles refreshed globally
- [ ] CI green