### PR TITLE
feat(dashboards): list + read-by-id endpoints (B4-write-2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12996,12 +12996,48 @@
       "members": []
     },
     {
+      "name": "DashboardDetailResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardDetailResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardDetailResponse.cs",
+      "line": 19,
+      "members": []
+    },
+    {
       "name": "DashboardImportResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardImportResponse",
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardImportResponse.cs",
       "line": 15,
+      "members": []
+    },
+    {
+      "name": "DashboardSummaryResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardSummaryResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardSummaryResponse.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "PagedResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.PagedResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/PagedResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "WidgetInstanceResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.WidgetInstanceResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/WidgetInstanceResponse.cs",
+      "line": 19,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardDetailResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardDetailResponse.cs
@@ -1,0 +1,29 @@
+using Granit.Dashboards.Domain;
+
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Full payload for <c>GET /dashboards/{id}</c> — summary fields plus the widget
+/// tree and layout values needed to render the dashboard.
+/// </summary>
+/// <param name="Id">Persisted dashboard identifier.</param>
+/// <param name="Name">Tenant-renamable display name.</param>
+/// <param name="Category">Coarse grouping.</param>
+/// <param name="Status">Lifecycle state.</param>
+/// <param name="IsSystem">When true, only re-syncable; never deletable by tenant admins.</param>
+/// <param name="SourceDefinitionName">Source DashboardDefinition wire identifier. Null for ad-hoc dashboards.</param>
+/// <param name="SourceDefinitionVersion">Source definition version at import time.</param>
+/// <param name="LayoutColumns">Grid columns at the base viewport.</param>
+/// <param name="LayoutRowHeight">Grid row height in CSS pixels at the base viewport.</param>
+/// <param name="Widgets">Widgets pinned on the dashboard, in declared <c>Position</c> order.</param>
+public sealed record DashboardDetailResponse(
+    Guid Id,
+    string Name,
+    DashboardCategory Category,
+    DashboardStatus Status,
+    bool IsSystem,
+    string? SourceDefinitionName,
+    string? SourceDefinitionVersion,
+    int LayoutColumns,
+    int LayoutRowHeight,
+    IReadOnlyList<WidgetInstanceResponse> Widgets);

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardSummaryResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardSummaryResponse.cs
@@ -1,0 +1,26 @@
+using Granit.Dashboards.Domain;
+
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Lightweight projection of a persisted <see cref="Dashboard"/> for the list
+/// endpoint. Strips the widget tree — the read-by-id endpoint
+/// (<see cref="DashboardDetailResponse"/>) carries the full payload.
+/// </summary>
+/// <param name="Id">Persisted dashboard identifier.</param>
+/// <param name="Name">Tenant-renamable display name.</param>
+/// <param name="Category">Coarse grouping.</param>
+/// <param name="Status">Lifecycle state (Draft / Published / Archived).</param>
+/// <param name="IsSystem">When true, only re-syncable; never deletable by tenant admins.</param>
+/// <param name="SourceDefinitionName">Wire identifier of the source DashboardDefinition. Null for ad-hoc dashboards composed entirely in the UI.</param>
+/// <param name="SourceDefinitionVersion">Version of the source definition at import time. Null for ad-hoc dashboards.</param>
+/// <param name="WidgetCount">Number of widgets currently pinned on the dashboard.</param>
+public sealed record DashboardSummaryResponse(
+    Guid Id,
+    string Name,
+    DashboardCategory Category,
+    DashboardStatus Status,
+    bool IsSystem,
+    string? SourceDefinitionName,
+    string? SourceDefinitionVersion,
+    int WidgetCount);

--- a/src/Granit.Dashboards.Endpoints/Dtos/PagedResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/PagedResponse.cs
@@ -1,0 +1,17 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Generic pagination envelope used by the list endpoints. The frontend renders
+/// pagination controls from <see cref="TotalCount"/> + <see cref="Page"/> +
+/// <see cref="PageSize"/>; <see cref="Items"/> carries the page slice.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+/// <param name="Items">Page slice — at most <see cref="PageSize"/> items.</param>
+/// <param name="TotalCount">Total number of items across all pages.</param>
+/// <param name="Page">Zero-based current page index.</param>
+/// <param name="PageSize">Number of items requested per page.</param>
+public sealed record PagedResponse<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/Granit.Dashboards.Endpoints/Dtos/WidgetInstanceResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/WidgetInstanceResponse.cs
@@ -1,0 +1,29 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Wire-level projection of a persisted <c>WidgetInstance</c>. Carries the
+/// type discriminator + denormalised metric / query references for client-side
+/// validation, plus the kind-specific JSON config blob the frontend interprets
+/// against the <c>WidgetType</c>.
+/// </summary>
+/// <param name="Id">Widget instance identifier.</param>
+/// <param name="WidgetType">Kind discriminator (<c>Markdown</c>, <c>Image</c>, <c>Text</c>, <c>Kpi</c>, <c>Chart</c>, <c>Table</c>, <c>Pivot</c>, ...).</param>
+/// <param name="Position">Dense-ranked grid order — 0-based.</param>
+/// <param name="Width">Grid columns.</param>
+/// <param name="Height">Grid rows.</param>
+/// <param name="TitleLocalizationKey">Localization key for the widget title — typically <c>Widget:{DashboardName}.{Slug}</c>.</param>
+/// <param name="MetricName">Denormalised metric reference for KPI widgets bound to a <c>MetricDatasource</c>; null otherwise.</param>
+/// <param name="QueryName">Denormalised query reference for KPI widgets bound to a <c>QueryAggregateDatasource</c>, or for Chart / Table / Pivot widgets; null otherwise.</param>
+/// <param name="ConfigJson">Kind-specific JSON payload — interpreted by the frontend against <see cref="WidgetType"/>. Includes the full <c>Datasource</c> for KPI widgets.</param>
+/// <param name="RequiredPermission">Optional per-widget permission override.</param>
+public sealed record WidgetInstanceResponse(
+    Guid Id,
+    string WidgetType,
+    int Position,
+    int Width,
+    int Height,
+    string TitleLocalizationKey,
+    string? MetricName,
+    string? QueryName,
+    string ConfigJson,
+    string? RequiredPermission);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardInstanceEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardInstanceEndpoints.cs
@@ -1,0 +1,95 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the read side of the persisted <see cref="Dashboard"/>
+/// aggregate — list (paged) and read-by-id. Multi-tenant filtering is applied
+/// by <c>DashboardsDbContext</c> (via <c>ApplyGranitConventions</c>); these
+/// handlers add status filtering, paging and DTO projection.
+/// </summary>
+internal static class DashboardInstanceEndpoints
+{
+    public static RouteGroupBuilder MapInstanceEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", ListAsync)
+            .WithName("ListGranitDashboards")
+            .WithSummary("Lists the current tenant's persisted dashboards (paged).")
+            .WithDescription(
+                "Returns the tenant's dashboards as a paged summary list, optionally "
+                + "filtered by ?status= (Draft / Published / Archived). Results are "
+                + "ordered by Name ascending. Pagination defaults: page=0, pageSize=50; "
+                + "pageSize is capped at 200. Multi-tenant filter is applied by the "
+                + "DbContext — cross-tenant rows are never reachable.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Read)
+            .Produces<PagedResponse<DashboardSummaryResponse>>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        group.MapGet("/{id:guid}", ReadByIdAsync)
+            .WithName("ReadGranitDashboardById")
+            .WithSummary("Reads a single persisted dashboard with its widget tree.")
+            .WithDescription(
+                "Returns the full dashboard payload including the layout values and "
+                + "the ordered widget pool. Multi-tenant filtered — returns 404 when "
+                + "the id is not found in the current tenant's scope (avoids leaking "
+                + "the existence of cross-tenant dashboards).")
+            .RequireAuthorization(DashboardsPermissions.Instances.Read)
+            .Produces<DashboardDetailResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<PagedResponse<DashboardSummaryResponse>>, ProblemHttpResult>> ListAsync(
+        [FromServices] DashboardReader reader,
+        [FromQuery] DashboardStatus? status,
+        [FromQuery] int page = 0,
+        [FromQuery] int pageSize = 50,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            DashboardListPage result = await reader.ListAsync(status, page, pageSize, cancellationToken).ConfigureAwait(false);
+
+            PagedResponse<DashboardSummaryResponse> response = new(
+                Items: [.. result.Items.Select(DashboardInstanceProjection.ToSummary)],
+                TotalCount: result.TotalCount,
+                Page: result.Page,
+                PageSize: result.PageSize);
+
+            return TypedResults.Ok(response);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    private static async Task<Results<Ok<DashboardDetailResponse>, ProblemHttpResult>> ReadByIdAsync(
+        [FromRoute] Guid id,
+        [FromServices] DashboardReader reader,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await reader.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Dashboard '{id}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(DashboardInstanceProjection.ToDetail(dashboard));
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -34,6 +34,7 @@ public static class DashboardsEndpointRouteBuilderExtensions
 
         group.MapCatalogEndpoints();
         group.MapImportEndpoints();
+        group.MapInstanceEndpoints();
 
         return group;
     }

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class DashboardsEndpointsServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddScoped<DashboardImporter>();
+        services.TryAddScoped<DashboardReader>();
 
         return services;
     }

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardInstanceProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardInstanceProjection.cs
@@ -1,0 +1,50 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Maps the persisted <see cref="Dashboard"/> aggregate (and its
+/// <see cref="WidgetInstance"/> rows) to the wire DTOs returned by the list /
+/// read-by-id endpoints. Extracted so the projection logic stays testable
+/// without any HTTP harness.
+/// </summary>
+internal static class DashboardInstanceProjection
+{
+    public static DashboardSummaryResponse ToSummary(Dashboard dashboard)
+        => new(
+            Id: dashboard.Id,
+            Name: dashboard.Name,
+            Category: dashboard.Category,
+            Status: dashboard.Status,
+            IsSystem: dashboard.IsSystem,
+            SourceDefinitionName: dashboard.SourceDefinitionName,
+            SourceDefinitionVersion: dashboard.SourceDefinitionVersion,
+            WidgetCount: dashboard.Widgets.Count);
+
+    public static DashboardDetailResponse ToDetail(Dashboard dashboard)
+        => new(
+            Id: dashboard.Id,
+            Name: dashboard.Name,
+            Category: dashboard.Category,
+            Status: dashboard.Status,
+            IsSystem: dashboard.IsSystem,
+            SourceDefinitionName: dashboard.SourceDefinitionName,
+            SourceDefinitionVersion: dashboard.SourceDefinitionVersion,
+            LayoutColumns: dashboard.LayoutColumns,
+            LayoutRowHeight: dashboard.LayoutRowHeight,
+            Widgets: [.. dashboard.Widgets.OrderBy(w => w.Position).Select(ToWidgetInstance)]);
+
+    public static WidgetInstanceResponse ToWidgetInstance(WidgetInstance widget)
+        => new(
+            Id: widget.Id,
+            WidgetType: widget.WidgetType,
+            Position: widget.Position,
+            Width: widget.Width,
+            Height: widget.Height,
+            TitleLocalizationKey: widget.TitleLocalizationKey,
+            MetricName: widget.MetricName,
+            QueryName: widget.QueryName,
+            ConfigJson: widget.ConfigJson,
+            RequiredPermission: widget.RequiredPermission);
+}

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Dashboardy",
     "Permission:Dashboards.Catalog.Read": "Procházet katalog dashboardů (zobrazit seznam všech registrovaných DashboardDefinition)",
-    "Permission:Dashboards.Instances.Manage": "Spravovat dashboardy nájemce (importovat z definice, upravit, publikovat, archivovat, obnovit)"
+    "Permission:Dashboards.Instances.Manage": "Spravovat dashboardy nájemce (importovat z definice, upravit, publikovat, archivovat, obnovit)",
+    "Permission:Dashboards.Instances.Read": "Číst dashboardy nájemce (seznam a čtení podle id, včetně detekce odchylek)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Den Dashboard-Katalog durchsuchen (alle registrierten DashboardDefinitions auflisten)",
-    "Permission:Dashboards.Instances.Manage": "Tenant-spezifische Dashboards verwalten (aus Definition importieren, bearbeiten, veröffentlichen, archivieren, wiederherstellen)"
+    "Permission:Dashboards.Instances.Manage": "Tenant-spezifische Dashboards verwalten (aus Definition importieren, bearbeiten, veröffentlichen, archivieren, wiederherstellen)",
+    "Permission:Dashboards.Instances.Read": "Tenant-spezifische Dashboards lesen (Liste und Lesen anhand der ID, einschließlich Drift-Erkennung)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Browse the dashboard catalogue (list every registered DashboardDefinition)",
-    "Permission:Dashboards.Instances.Manage": "Manage tenant-scoped dashboards (import from definition, edit, publish, archive, restore)"
+    "Permission:Dashboards.Instances.Manage": "Manage tenant-scoped dashboards (import from definition, edit, publish, archive, restore)",
+    "Permission:Dashboards.Instances.Read": "Read tenant-scoped dashboards (list and read-by-id, including drift detection)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Paneles",
     "Permission:Dashboards.Catalog.Read": "Explorar el catálogo de paneles (listar todas las DashboardDefinition registradas)",
-    "Permission:Dashboards.Instances.Manage": "Gestionar paneles del inquilino (importar desde definición, editar, publicar, archivar, restaurar)"
+    "Permission:Dashboards.Instances.Manage": "Gestionar paneles del inquilino (importar desde definición, editar, publicar, archivar, restaurar)",
+    "Permission:Dashboards.Instances.Read": "Leer paneles del inquilino (lista y lectura por identificador, incluida la detección de desviaciones)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Tableaux de bord",
     "Permission:Dashboards.Catalog.Read": "Parcourir le catalogue des tableaux de bord (lister chaque DashboardDefinition enregistrée)",
-    "Permission:Dashboards.Instances.Manage": "Gérer les tableaux de bord du locataire (importer depuis une définition, éditer, publier, archiver, restaurer)"
+    "Permission:Dashboards.Instances.Manage": "Gérer les tableaux de bord du locataire (importer depuis une définition, éditer, publier, archiver, restaurer)",
+    "Permission:Dashboards.Instances.Read": "Lire les tableaux de bord du locataire (liste et lecture par identifiant, détection de dérive)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "डैशबोर्ड",
     "Permission:Dashboards.Catalog.Read": "डैशबोर्ड कैटलॉग देखें (सभी पंजीकृत DashboardDefinition की सूची बनाएँ)",
-    "Permission:Dashboards.Instances.Manage": "टेनेंट डैशबोर्ड प्रबंधित करें (परिभाषा से आयात, संपादन, प्रकाशन, संग्रह, पुनर्स्थापन)"
+    "Permission:Dashboards.Instances.Manage": "टेनेंट डैशबोर्ड प्रबंधित करें (परिभाषा से आयात, संपादन, प्रकाशन, संग्रह, पुनर्स्थापन)",
+    "Permission:Dashboards.Instances.Read": "टेनेंट डैशबोर्ड पढ़ें (सूची और आईडी द्वारा पढ़ना, ड्रिफ्ट डिटेक्शन सहित)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Dashboard",
     "Permission:Dashboards.Catalog.Read": "Sfogliare il catalogo dei dashboard (elencare ogni DashboardDefinition registrata)",
-    "Permission:Dashboards.Instances.Manage": "Gestire i dashboard del tenant (importare dalla definizione, modificare, pubblicare, archiviare, ripristinare)"
+    "Permission:Dashboards.Instances.Manage": "Gestire i dashboard del tenant (importare dalla definizione, modificare, pubblicare, archiviare, ripristinare)",
+    "Permission:Dashboards.Instances.Read": "Leggere i dashboard del tenant (elenco e lettura per id, inclusa la rilevazione del drift)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "ダッシュボード",
     "Permission:Dashboards.Catalog.Read": "ダッシュボードカタログを参照する（登録済みの DashboardDefinition をすべて一覧表示）",
-    "Permission:Dashboards.Instances.Manage": "テナントスコープのダッシュボードを管理する（定義からインポート、編集、公開、アーカイブ、復元）"
+    "Permission:Dashboards.Instances.Manage": "テナントスコープのダッシュボードを管理する（定義からインポート、編集、公開、アーカイブ、復元）",
+    "Permission:Dashboards.Instances.Read": "テナントスコープのダッシュボードを読み取る（一覧、ID 単一読み取り、ドリフト検出を含む）"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "대시보드",
     "Permission:Dashboards.Catalog.Read": "대시보드 카탈로그 탐색(등록된 모든 DashboardDefinition 나열)",
-    "Permission:Dashboards.Instances.Manage": "테넌트 범위 대시보드 관리(정의에서 가져오기, 편집, 게시, 보관, 복원)"
+    "Permission:Dashboards.Instances.Manage": "테넌트 범위 대시보드 관리(정의에서 가져오기, 편집, 게시, 보관, 복원)",
+    "Permission:Dashboards.Instances.Read": "테넌트 범위 대시보드 읽기(목록 및 ID 단일 조회, 드리프트 감지 포함)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Door de dashboard-catalogus bladeren (alle geregistreerde DashboardDefinitions weergeven)",
-    "Permission:Dashboards.Instances.Manage": "Beheer huurder-specifieke dashboards (importeren vanuit definitie, bewerken, publiceren, archiveren, herstellen)"
+    "Permission:Dashboards.Instances.Manage": "Beheer huurder-specifieke dashboards (importeren vanuit definitie, bewerken, publiceren, archiveren, herstellen)",
+    "Permission:Dashboards.Instances.Read": "Huurder-specifieke dashboards lezen (lijst en lezen op id, inclusief driftdetectie)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Pulpity",
     "Permission:Dashboards.Catalog.Read": "Przeglądanie katalogu pulpitów (lista wszystkich zarejestrowanych DashboardDefinition)",
-    "Permission:Dashboards.Instances.Manage": "Zarządzanie pulpitami dzierżawcy (importowanie z definicji, edycja, publikowanie, archiwizowanie, przywracanie)"
+    "Permission:Dashboards.Instances.Manage": "Zarządzanie pulpitami dzierżawcy (importowanie z definicji, edycja, publikowanie, archiwizowanie, przywracanie)",
+    "Permission:Dashboards.Instances.Read": "Odczyt pulpitów dzierżawcy (lista i odczyt po identyfikatorze, w tym wykrywanie dryfu)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Painéis",
     "Permission:Dashboards.Catalog.Read": "Navegar pelo catálogo de painéis (listar todas as DashboardDefinition registadas)",
-    "Permission:Dashboards.Instances.Manage": "Gerir painéis do inquilino (importar a partir de definição, editar, publicar, arquivar, restaurar)"
+    "Permission:Dashboards.Instances.Manage": "Gerir painéis do inquilino (importar a partir de definição, editar, publicar, arquivar, restaurar)",
+    "Permission:Dashboards.Instances.Read": "Ler painéis do inquilino (lista e leitura por id, incluindo deteção de desvio)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Instrumentpaneler",
     "Permission:Dashboards.Catalog.Read": "Bläddra i instrumentpanelskatalogen (lista alla registrerade DashboardDefinition)",
-    "Permission:Dashboards.Instances.Manage": "Hantera klientspecifika instrumentpaneler (importera från definition, redigera, publicera, arkivera, återställa)"
+    "Permission:Dashboards.Instances.Manage": "Hantera klientspecifika instrumentpaneler (importera från definition, redigera, publicera, arkivera, återställa)",
+    "Permission:Dashboards.Instances.Read": "Läsa klientspecifika instrumentpaneler (lista och läs efter id, inklusive driftdetektion)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "Panolar",
     "Permission:Dashboards.Catalog.Read": "Pano kataloğunu görüntüleme (kayıtlı her DashboardDefinition'ı listeleme)",
-    "Permission:Dashboards.Instances.Manage": "Kiracıya özel panoları yönet (tanımdan içe aktar, düzenle, yayınla, arşivle, geri yükle)"
+    "Permission:Dashboards.Instances.Manage": "Kiracıya özel panoları yönet (tanımdan içe aktar, düzenle, yayınla, arşivle, geri yükle)",
+    "Permission:Dashboards.Instances.Read": "Kiracıya özel panoları oku (liste ve id ile okuma, sürüm sapması tespiti dâhil)"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
@@ -3,6 +3,7 @@
   "texts": {
     "PermissionGroup:Dashboards": "仪表板",
     "Permission:Dashboards.Catalog.Read": "浏览仪表板目录（列出每个已注册的 DashboardDefinition）",
-    "Permission:Dashboards.Instances.Manage": "管理租户范围的仪表板（从定义导入、编辑、发布、归档、恢复）"
+    "Permission:Dashboards.Instances.Manage": "管理租户范围的仪表板（从定义导入、编辑、发布、归档、恢复）",
+    "Permission:Dashboards.Instances.Read": "读取租户范围的仪表板（列表与按 id 读取，含偏移检测）"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissionDefinitionProvider.cs
@@ -25,6 +25,12 @@ internal sealed class DashboardsPermissionDefinitionProvider : IPermissionDefini
             MultiTenancySides.Both);
 
         group.AddPermission(
+            DashboardsPermissions.Instances.Read,
+            LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
+                "Permission:Dashboards.Instances.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
             DashboardsPermissions.Instances.Manage,
             LocalizableString.Create<DashboardsEndpointsLocalizationResource>(
                 "Permission:Dashboards.Instances.Manage"),

--- a/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
+++ b/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs
@@ -19,6 +19,12 @@ public static class DashboardsPermissions
     public static class Instances
     {
         /// <summary>
+        /// Grants read access to the tenant's persisted Dashboards — list, read-by-id,
+        /// drift-detection. Required by every read-side endpoint on the aggregate.
+        /// </summary>
+        public const string Read = "Dashboards.Instances.Read";
+
+        /// <summary>
         /// Grants write access to the persisted Dashboard aggregate — covers import (deep-copy
         /// from a registered DashboardDefinition), state transitions (publish / archive /
         /// restore), and the upcoming widget-edit endpoints.

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardReader.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardReader.cs
@@ -1,0 +1,69 @@
+using Granit.Dashboards.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Read-side service for the persisted <see cref="Dashboard"/> aggregate. The
+/// <see cref="DashboardsDbContext"/> already applies the multi-tenant query filter
+/// via <c>ApplyGranitConventions</c>, so the reader only handles status / paging
+/// and widget eager-loading.
+/// </summary>
+internal sealed class DashboardReader(DashboardsDbContext db)
+{
+    /// <summary>
+    /// Lists the current tenant's dashboards, optionally filtered by status, with
+    /// stable ordering (Name ascending). Returns the page slice plus the total
+    /// count so the caller can render pagination controls.
+    /// </summary>
+    public async Task<DashboardListPage> ListAsync(
+        DashboardStatus? status,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        if (page < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(page), "Page must be >= 0.");
+        }
+
+        if (pageSize is < 1 or > 200)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be between 1 and 200.");
+        }
+
+        IQueryable<Dashboard> query = db.Dashboards.AsNoTracking();
+        if (status.HasValue)
+        {
+            query = query.Where(d => d.Status == status.Value);
+        }
+
+        int total = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        List<Dashboard> items = await query
+            .OrderBy(d => d.Name)
+            .Skip(page * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new DashboardListPage(items, total, page, pageSize);
+    }
+
+    /// <summary>
+    /// Returns the dashboard with the supplied id (eager-loading widgets) or
+    /// <c>null</c> when none exists. Multi-tenant filtered through the DbContext.
+    /// </summary>
+    public Task<Dashboard?> FindByIdAsync(Guid id, CancellationToken cancellationToken)
+        => db.Dashboards
+            .AsNoTracking()
+            .Include(d => d.Widgets)
+            .SingleOrDefaultAsync(d => d.Id == id, cancellationToken);
+}
+
+/// <summary>Pagination envelope returned by <see cref="DashboardReader.ListAsync"/>.</summary>
+internal sealed record DashboardListPage(
+    IReadOnlyList<Dashboard> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardImporterTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardImporterTests.cs
@@ -1,7 +1,6 @@
 using Granit.Dashboards;
 using Granit.Dashboards.Domain;
 using Granit.Dashboards.EntityFrameworkCore.Internal;
-using Granit.Dashboards.EntityFrameworkCore.Internal;
 using Granit.Dashboards.Widgets;
 using Granit.Guids;
 using Microsoft.Data.Sqlite;

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardInstanceProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardInstanceProjectionTests.cs
@@ -1,0 +1,89 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Locks the projection logic backing <c>GET /</c> + <c>GET /{id}</c> — pure
+/// in-memory tests, no DbContext required.
+/// </summary>
+public sealed class DashboardInstanceProjectionTests
+{
+    [Fact]
+    public void ToSummary_StripsWidgetTreeButReportsCount()
+    {
+        Dashboard dashboard = NewDashboardWithWidgets(2);
+
+        DashboardSummaryResponse summary = DashboardInstanceProjection.ToSummary(dashboard);
+
+        summary.Id.ShouldBe(dashboard.Id);
+        summary.Name.ShouldBe(dashboard.Name);
+        summary.WidgetCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ToDetail_OrdersWidgetsByPosition()
+    {
+        var dashboard = Dashboard.Create(Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        // Inserted out of position-order on purpose.
+        dashboard.AddWidget(Guid.NewGuid(), "Markdown", position: 2, width: 12, height: 1, titleLocalizationKey: "Widget:S.Two", configJson: "{}");
+        dashboard.AddWidget(Guid.NewGuid(), "Markdown", position: 0, width: 12, height: 1, titleLocalizationKey: "Widget:S.Zero", configJson: "{}");
+        dashboard.AddWidget(Guid.NewGuid(), "Markdown", position: 1, width: 12, height: 1, titleLocalizationKey: "Widget:S.One", configJson: "{}");
+
+        DashboardDetailResponse detail = DashboardInstanceProjection.ToDetail(dashboard);
+
+        detail.Widgets.Select(w => w.Position).ShouldBe([0, 1, 2]);
+        detail.Widgets[0].TitleLocalizationKey.ShouldBe("Widget:S.Zero");
+    }
+
+    [Fact]
+    public void ToDetail_CarriesLayoutValues()
+    {
+        var dashboard = Dashboard.Create(
+            Guid.NewGuid(), "Sample", DashboardCategory.Finance,
+            layoutColumns: 16, layoutRowHeight: 64);
+
+        DashboardDetailResponse detail = DashboardInstanceProjection.ToDetail(dashboard);
+
+        detail.LayoutColumns.ShouldBe(16);
+        detail.LayoutRowHeight.ShouldBe(64);
+    }
+
+    [Fact]
+    public void ToWidgetInstance_PreservesAllFields()
+    {
+        var dashboard = Dashboard.Create(Guid.NewGuid(), "S", DashboardCategory.Finance);
+        WidgetInstance widget = dashboard.AddWidget(
+            Guid.NewGuid(), "Kpi",
+            position: 0, width: 3, height: 1,
+            titleLocalizationKey: "Widget:S.UnpaidCount",
+            configJson: "{\"kind\":\"metric\"}",
+            metricName: "Sample.Metric",
+            queryName: null,
+            requiredPermission: "Custom.Composite.Read");
+
+        WidgetInstanceResponse response = DashboardInstanceProjection.ToWidgetInstance(widget);
+
+        response.WidgetType.ShouldBe("Kpi");
+        response.MetricName.ShouldBe("Sample.Metric");
+        response.QueryName.ShouldBeNull();
+        response.ConfigJson.ShouldContain("metric");
+        response.RequiredPermission.ShouldBe("Custom.Composite.Read");
+    }
+
+    private static Dashboard NewDashboardWithWidgets(int count)
+    {
+        var d = Dashboard.Create(Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        for (int i = 0; i < count; i++)
+        {
+            d.AddWidget(Guid.NewGuid(), "Markdown",
+                position: i, width: 12, height: 1,
+                titleLocalizationKey: $"Widget:S.{i}",
+                configJson: "{}");
+        }
+        return d;
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardReaderTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardReaderTests.cs
@@ -1,0 +1,157 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Widgets;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed read-side tests — verifies status filtering, paging, ordering,
+/// and the eager-load behaviour of <see cref="DashboardReader"/>. Pure
+/// SQL-on-aggregate, no HTTP harness.
+/// </summary>
+public sealed class DashboardReaderTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext seed = NewContext();
+        await seed.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        seed.Dashboards.AddRange(
+            DashboardWith("Alpha", DashboardCategory.Finance, DashboardStatus.Draft, widgetCount: 2),
+            DashboardWith("Beta", DashboardCategory.Operations, DashboardStatus.Published, widgetCount: 0),
+            DashboardWith("Gamma", DashboardCategory.Finance, DashboardStatus.Published, widgetCount: 1),
+            DashboardWith("Delta", DashboardCategory.Iot, DashboardStatus.Archived, widgetCount: 3));
+        await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task ListAsync_NoStatusFilter_ReturnsAllOrderedByName()
+    {
+        DashboardReader reader = new(NewContext());
+
+        DashboardListPage page = await reader.ListAsync(status: null, page: 0, pageSize: 50, TestContext.Current.CancellationToken);
+
+        page.TotalCount.ShouldBe(4);
+        page.Items.Select(d => d.Name).ShouldBe(["Alpha", "Beta", "Delta", "Gamma"]);
+    }
+
+    [Fact]
+    public async Task ListAsync_StatusFilter_NarrowsToMatchingRows()
+    {
+        DashboardReader reader = new(NewContext());
+
+        DashboardListPage page = await reader.ListAsync(DashboardStatus.Published, page: 0, pageSize: 50, TestContext.Current.CancellationToken);
+
+        page.TotalCount.ShouldBe(2);
+        page.Items.Select(d => d.Name).ShouldBe(["Beta", "Gamma"]);
+    }
+
+    [Fact]
+    public async Task ListAsync_PagingSlicesByPageSize_AndReportsTotal()
+    {
+        DashboardReader reader = new(NewContext());
+
+        DashboardListPage page0 = await reader.ListAsync(status: null, page: 0, pageSize: 2, TestContext.Current.CancellationToken);
+        DashboardListPage page1 = await reader.ListAsync(status: null, page: 1, pageSize: 2, TestContext.Current.CancellationToken);
+
+        page0.Items.Count.ShouldBe(2);
+        page0.Items.Select(d => d.Name).ShouldBe(["Alpha", "Beta"]);
+        page0.TotalCount.ShouldBe(4);
+
+        page1.Items.Count.ShouldBe(2);
+        page1.Items.Select(d => d.Name).ShouldBe(["Delta", "Gamma"]);
+        page1.TotalCount.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task ListAsync_NegativePage_Throws()
+    {
+        DashboardReader reader = new(NewContext());
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            reader.ListAsync(status: null, page: -1, pageSize: 10, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ListAsync_PageSizeOutOfBounds_Throws()
+    {
+        DashboardReader reader = new(NewContext());
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            reader.ListAsync(status: null, page: 0, pageSize: 0, TestContext.Current.CancellationToken));
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            reader.ListAsync(status: null, page: 0, pageSize: 201, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_KnownId_EagerLoadsWidgets()
+    {
+        Guid alphaId;
+        await using (DashboardsDbContext ctx = NewContext())
+        {
+            alphaId = await ctx.Dashboards.Where(d => d.Name == "Alpha").Select(d => d.Id).SingleAsync(TestContext.Current.CancellationToken);
+        }
+
+        DashboardReader reader = new(NewContext());
+        Dashboard? loaded = await reader.FindByIdAsync(alphaId, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Widgets.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_UnknownId_ReturnsNull()
+    {
+        DashboardReader reader = new(NewContext());
+
+        Dashboard? loaded = await reader.FindByIdAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        loaded.ShouldBeNull();
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+
+    private static Dashboard DashboardWith(string name, DashboardCategory category, DashboardStatus status, int widgetCount)
+    {
+        var d = Dashboard.Create(Guid.NewGuid(), name, category);
+        for (int i = 0; i < widgetCount; i++)
+        {
+            d.AddWidget(
+                Guid.NewGuid(), "Markdown",
+                position: i, width: 12, height: 1,
+                titleLocalizationKey: $"Widget:{name}.{i}",
+                configJson: "{}");
+        }
+
+        if (status == DashboardStatus.Published)
+        {
+            d.Publish();
+        }
+        else if (status == DashboardStatus.Archived)
+        {
+            d.Publish();
+            d.Archive();
+        }
+
+        d.ClearDomainEvents();
+        return d;
+    }
+}


### PR DESCRIPTION
## Summary

- `GET /dashboards` — paginated list with optional `?status=` filter (`page>=0`, `pageSize` 1..200, default page=0/pageSize=50). Returns lightweight `DashboardSummaryResponse` (no widget tree, just `WidgetCount`).
- `GET /dashboards/{id:guid}` — full detail with eager-loaded widgets ordered by `Position`. 404 on miss (multi-tenant isolation inherited from `DashboardsDbContext` via `ApplyGranitConventions` — no cross-tenant leakage).
- Both endpoints gated by new `Dashboards.Instances.Read` permission (15 base cultures translated; regional variants fall through).

## Architecture

- `DashboardReader` lives in `Granit.Dashboards.EntityFrameworkCore.Internal` — keeps the `Granit.Dashboards.Endpoints` package's EF Core ban intact.
- Pure projection (`DashboardInstanceProjection`) maps aggregate → wire shapes; widget DTOs stay agnostic of EF.
- Pagination envelope `PagedResponse<T>(Items, TotalCount, Page, PageSize)` reusable across the module.

## Tests

- 7 SQLite-backed `DashboardReaderTests` — list ordering, status filtering, paging, bounds validation, eager-load on `FindByIdAsync`.
- 4 `DashboardInstanceProjectionTests` — summary strips widgets, detail orders by position, layout values carried, all widget fields preserved.

## Test plan

- [x] `dotnet build tests/Granit.Dashboards.Endpoints.Tests` — 0 warnings, 0 errors
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 36/36 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed