### PR TITLE
feat(dashboards): state transition endpoints — Publish / Archive / Restore (B4-write-3)

### DIFF
--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardStateTransitionEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardStateTransitionEndpoints.cs
@@ -1,0 +1,104 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for state transitions on the persisted <see cref="Dashboard"/>
+/// aggregate — Publish (Draft → Published), Archive (any → Archived) and Restore
+/// (Archived → Draft). Each handler returns the post-transition summary so the
+/// caller can refresh its view without an extra GET.
+/// </summary>
+internal static class DashboardStateTransitionEndpoints
+{
+    public static RouteGroupBuilder MapStateTransitionEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{id:guid}/publish", PublishAsync)
+            .WithName("PublishGranitDashboard")
+            .WithSummary("Transitions the dashboard from Draft to Published.")
+            .WithDescription(
+                "Publishes a Draft dashboard, making it visible to consumers. "
+                + "Idempotent — already-Published dashboards return the current state. "
+                + "An Archived dashboard must be Restored before it can be Published "
+                + "(returns 409 Conflict).")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<DashboardSummaryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        group.MapPost("/{id:guid}/archive", ArchiveAsync)
+            .WithName("ArchiveGranitDashboard")
+            .WithSummary("Archives the dashboard.")
+            .WithDescription(
+                "Archives the dashboard regardless of its current status. Idempotent — "
+                + "already-Archived dashboards return the current state. Use POST "
+                + "/{id}/restore to bring it back to Draft.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<DashboardSummaryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/{id:guid}/restore", RestoreAsync)
+            .WithName("RestoreGranitDashboard")
+            .WithSummary("Restores an archived dashboard to Draft.")
+            .WithDescription(
+                "Transitions an Archived dashboard back to Draft. Returns 409 Conflict "
+                + "when the dashboard is not Archived (the domain rejects spurious "
+                + "transitions to keep the state machine deterministic).")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<DashboardSummaryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        return group;
+    }
+
+    private static Task<Results<Ok<DashboardSummaryResponse>, ProblemHttpResult>> PublishAsync(
+        [FromRoute] Guid id,
+        [FromServices] DashboardStateTransitionService service,
+        CancellationToken cancellationToken)
+        => RunAsync(id, service.PublishAsync, cancellationToken);
+
+    private static Task<Results<Ok<DashboardSummaryResponse>, ProblemHttpResult>> ArchiveAsync(
+        [FromRoute] Guid id,
+        [FromServices] DashboardStateTransitionService service,
+        CancellationToken cancellationToken)
+        => RunAsync(id, service.ArchiveAsync, cancellationToken);
+
+    private static Task<Results<Ok<DashboardSummaryResponse>, ProblemHttpResult>> RestoreAsync(
+        [FromRoute] Guid id,
+        [FromServices] DashboardStateTransitionService service,
+        CancellationToken cancellationToken)
+        => RunAsync(id, service.RestoreAsync, cancellationToken);
+
+    private static async Task<Results<Ok<DashboardSummaryResponse>, ProblemHttpResult>> RunAsync(
+        Guid id,
+        Func<Guid, CancellationToken, Task<DashboardStateTransitionResult>> transition,
+        CancellationToken cancellationToken)
+    {
+        DashboardStateTransitionResult result = await transition(id, cancellationToken).ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            DashboardStateTransitionOutcome.Updated =>
+                TypedResults.Ok(DashboardInstanceProjection.ToSummary(result.Dashboard!)),
+            DashboardStateTransitionOutcome.NotFound =>
+                TypedResults.Problem(
+                    detail: $"Dashboard '{id}' not found.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardStateTransitionOutcome.Conflict =>
+                TypedResults.Problem(
+                    detail: result.ConflictReason,
+                    statusCode: StatusCodes.Status409Conflict),
+            _ => throw new InvalidOperationException($"Unhandled outcome '{result.Outcome}'."),
+        };
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class DashboardsEndpointRouteBuilderExtensions
         group.MapCatalogEndpoints();
         group.MapImportEndpoints();
         group.MapInstanceEndpoints();
+        group.MapStateTransitionEndpoints();
 
         return group;
     }

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class DashboardsEndpointsServiceCollectionExtensions
 
         services.TryAddScoped<DashboardImporter>();
         services.TryAddScoped<DashboardReader>();
+        services.TryAddScoped<DashboardStateTransitionService>();
 
         return services;
     }

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardStateTransitionService.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardStateTransitionService.cs
@@ -1,0 +1,74 @@
+using Granit.Dashboards.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Write-side service that drives the <see cref="Dashboard"/> aggregate's state
+/// machine — Publish (Draft → Published), Archive (any → Archived) and Restore
+/// (Archived → Draft). Each transition loads the aggregate (multi-tenant filtered
+/// by the DbContext), invokes the domain method, and persists the change.
+/// </summary>
+internal sealed class DashboardStateTransitionService(DashboardsDbContext db)
+{
+    public Task<DashboardStateTransitionResult> PublishAsync(Guid id, CancellationToken cancellationToken)
+        => TransitionAsync(id, d => d.Publish(), cancellationToken);
+
+    public Task<DashboardStateTransitionResult> ArchiveAsync(Guid id, CancellationToken cancellationToken)
+        => TransitionAsync(id, d => d.Archive(), cancellationToken);
+
+    public Task<DashboardStateTransitionResult> RestoreAsync(Guid id, CancellationToken cancellationToken)
+        => TransitionAsync(id, d => d.Restore(), cancellationToken);
+
+    private async Task<DashboardStateTransitionResult> TransitionAsync(
+        Guid id,
+        Action<Dashboard> transition,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await db.Dashboards
+            .SingleOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return DashboardStateTransitionResult.NotFound();
+        }
+
+        try
+        {
+            transition(dashboard);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DashboardStateTransitionResult.Conflict(ex.Message);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return DashboardStateTransitionResult.Success(dashboard);
+    }
+}
+
+/// <summary>
+/// Outcome of a state transition request — either the updated aggregate, a 404
+/// (no row in the tenant scope), or a 409 with the domain's invariant message.
+/// </summary>
+internal sealed record DashboardStateTransitionResult(
+    DashboardStateTransitionOutcome Outcome,
+    Dashboard? Dashboard,
+    string? ConflictReason)
+{
+    public static DashboardStateTransitionResult Success(Dashboard dashboard)
+        => new(DashboardStateTransitionOutcome.Updated, dashboard, null);
+
+    public static DashboardStateTransitionResult NotFound()
+        => new(DashboardStateTransitionOutcome.NotFound, null, null);
+
+    public static DashboardStateTransitionResult Conflict(string reason)
+        => new(DashboardStateTransitionOutcome.Conflict, null, reason);
+}
+
+internal enum DashboardStateTransitionOutcome
+{
+    Updated,
+    NotFound,
+    Conflict,
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardStateTransitionServiceTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardStateTransitionServiceTests.cs
@@ -1,0 +1,227 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed write-side tests — locks the load + mutate + persist round-trip
+/// of <see cref="DashboardStateTransitionService"/>: idempotency, the
+/// Draft → Published → Archived → Draft cycle, the invariants enforced by the
+/// domain (cannot publish an archived dashboard, cannot restore a non-archived
+/// one), and the not-found contract.
+/// </summary>
+public sealed class DashboardStateTransitionServiceTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext seed = NewContext();
+        await seed.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task PublishAsync_DraftDashboard_TransitionsToPublished()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Draft);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.PublishAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard.ShouldNotBeNull();
+        result.Dashboard.Status.ShouldBe(DashboardStatus.Published);
+
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Published);
+    }
+
+    [Fact]
+    public async Task PublishAsync_AlreadyPublished_IsIdempotent()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Published);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.PublishAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard!.Status.ShouldBe(DashboardStatus.Published);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ArchivedDashboard_ReturnsConflict()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Archived);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.PublishAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Conflict);
+        result.ConflictReason.ShouldNotBeNullOrWhiteSpace();
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Archived);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_FromDraft_TransitionsToArchived()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Draft);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.ArchiveAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard!.Status.ShouldBe(DashboardStatus.Archived);
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Archived);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_FromPublished_TransitionsToArchived()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Published);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.ArchiveAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard!.Status.ShouldBe(DashboardStatus.Archived);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_AlreadyArchived_IsIdempotent()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Archived);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.ArchiveAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard!.Status.ShouldBe(DashboardStatus.Archived);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_FromArchived_TransitionsToDraft()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Archived);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.RestoreAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Updated);
+        result.Dashboard!.Status.ShouldBe(DashboardStatus.Draft);
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Draft);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_FromDraft_ReturnsConflict()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Draft);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.RestoreAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Conflict);
+        result.ConflictReason.ShouldNotBeNullOrWhiteSpace();
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Draft);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_FromPublished_ReturnsConflict()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Published);
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.RestoreAsync(id, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task PublishAsync_UnknownId_ReturnsNotFound()
+    {
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.PublishAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.NotFound);
+        result.Dashboard.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_UnknownId_ReturnsNotFound()
+    {
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.ArchiveAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_UnknownId_ReturnsNotFound()
+    {
+        DashboardStateTransitionService service = new(NewContext());
+
+        DashboardStateTransitionResult result = await service.RestoreAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardStateTransitionOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task FullLifecycle_DraftPublishArchiveRestore_RoundTripsCorrectly()
+    {
+        Guid id = await SeedAsync(DashboardStatus.Draft);
+        DashboardStateTransitionService service = new(NewContext());
+
+        (await service.PublishAsync(id, TestContext.Current.CancellationToken)).Dashboard!.Status.ShouldBe(DashboardStatus.Published);
+        (await service.ArchiveAsync(id, TestContext.Current.CancellationToken)).Dashboard!.Status.ShouldBe(DashboardStatus.Archived);
+        (await service.RestoreAsync(id, TestContext.Current.CancellationToken)).Dashboard!.Status.ShouldBe(DashboardStatus.Draft);
+
+        (await StatusOnDiskAsync(id)).ShouldBe(DashboardStatus.Draft);
+    }
+
+    private async Task<Guid> SeedAsync(DashboardStatus status)
+    {
+        var dashboard = Dashboard.Create(Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        if (status == DashboardStatus.Published)
+        {
+            dashboard.Publish();
+        }
+        else if (status == DashboardStatus.Archived)
+        {
+            dashboard.Publish();
+            dashboard.Archive();
+        }
+        dashboard.ClearDomainEvents();
+
+        await using DashboardsDbContext ctx = NewContext();
+        ctx.Dashboards.Add(dashboard);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return dashboard.Id;
+    }
+
+    private async Task<DashboardStatus> StatusOnDiskAsync(Guid id)
+    {
+        await using DashboardsDbContext ctx = NewContext();
+        return await ctx.Dashboards
+            .AsNoTracking()
+            .Where(d => d.Id == id)
+            .Select(d => d.Status)
+            .SingleAsync(TestContext.Current.CancellationToken);
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

Three state-transition endpoints on persisted dashboards, completing the B4 write surface alongside #1467 (import) and #1468 (list / read-by-id):

- `POST /dashboards/{id:guid}/publish` — Draft → Published (idempotent on Published; **409 Conflict** when Archived per the domain's one-way rule).
- `POST /dashboards/{id:guid}/archive` — any → Archived (always idempotent).
- `POST /dashboards/{id:guid}/restore` — Archived → Draft (**409 Conflict** when not Archived).

All gated by the existing `Dashboards.Instances.Manage` permission whose docstring already advertises state transitions — no new permission, no new localization key. Each handler returns `DashboardSummaryResponse` (from #1468) so the caller refreshes without a follow-up GET.

## Architecture

- `DashboardStateTransitionService` lives in `Granit.Dashboards.EntityFrameworkCore.Internal` — keeps the Endpoints package's EF Core ban intact.
- A single load + mutate + save round-trip per call. `InvalidOperationException` from the domain (the aggregate's invariant guard) maps to a `Conflict` outcome carrying the invariant message; missing rows surface as `NotFound` (multi-tenant scoped via `DbContext`'s `ApplyGranitConventions`).
- Result envelope `DashboardStateTransitionResult { Outcome, Dashboard?, ConflictReason? }` keeps the endpoint handler a 3-arm switch — no exception-driven control flow at the HTTP layer.

## Tests

13 SQLite-backed tests on `DashboardStateTransitionServiceTests`:

- one happy-path test per transition (verifies in-memory + on-disk state)
- idempotency on already-Published, already-Archived
- invariant-violation conflicts: Publish-when-Archived, Restore-when-Draft, Restore-when-Published
- 404 on unknown id for all three operations
- full Draft → Published → Archived → Draft lifecycle round-trip

## Test plan

- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 49/49 passed (13 new + 36 existing)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift