### PR TITLE
feat(dashboards): metadata edit endpoint — PUT /dashboards/{id} (B4-write-4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13014,6 +13014,15 @@
       "members": []
     },
     {
+      "name": "DashboardMetadataUpdateRequest",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardMetadataUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardMetadataUpdateRequest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "DashboardSummaryResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardSummaryResponse",
       "kind": "record",

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardMetadataUpdateRequest.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardMetadataUpdateRequest.cs
@@ -1,0 +1,12 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Payload for <c>PUT /dashboards/{id}</c> — full replacement of the dashboard's
+/// editable metadata (name + grid layout). Status, source-definition fields,
+/// and the widget pool are immutable through this endpoint and are managed by
+/// dedicated routes (state transitions, widget endpoints).
+/// </summary>
+public sealed record DashboardMetadataUpdateRequest(
+    string Name,
+    int LayoutColumns,
+    int LayoutRowHeight);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardMetadataEditEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardMetadataEditEndpoints.cs
@@ -1,0 +1,71 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handler for <c>PUT /dashboards/{id}</c> — edits the dashboard's
+/// editable metadata (name + grid layout). Status, source-definition pinning,
+/// and the widget pool are intentionally out of scope here; they belong to the
+/// state-transition / import / widget endpoints respectively.
+/// </summary>
+internal static class DashboardMetadataEditEndpoints
+{
+    public static RouteGroupBuilder MapMetadataEditEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPut("/{id:guid}", UpdateMetadataAsync)
+            .WithName("UpdateGranitDashboardMetadata")
+            .WithSummary("Updates the dashboard's name and grid layout.")
+            .WithDescription(
+                "Full replacement of the editable metadata: Name, LayoutColumns and "
+                + "LayoutRowHeight. FluentValidation runs first (Name not empty, layout "
+                + "values > 0); the domain guards are kept as defense-in-depth and "
+                + "surface as 422 if hit. Returns the updated dashboard summary so "
+                + "callers refresh without a follow-up GET.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<DashboardSummaryResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<DashboardSummaryResponse>, ProblemHttpResult>> UpdateMetadataAsync(
+        [FromRoute] Guid id,
+        [FromBody] DashboardMetadataUpdateRequest request,
+        [FromServices] DashboardEditor editor,
+        CancellationToken cancellationToken)
+    {
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id,
+            request.Name,
+            request.LayoutColumns,
+            request.LayoutRowHeight,
+            cancellationToken).ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            DashboardEditOutcome.Updated =>
+                TypedResults.Ok(DashboardInstanceProjection.ToSummary(result.Dashboard!)),
+            DashboardEditOutcome.NotFound =>
+                TypedResults.Problem(
+                    detail: $"Dashboard '{id}' not found.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardEditOutcome.Invalid =>
+                TypedResults.Problem(
+                    detail: result.InvalidReason,
+                    statusCode: StatusCodes.Status422UnprocessableEntity),
+            _ => throw new InvalidOperationException($"Unhandled outcome '{result.Outcome}'."),
+        };
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class DashboardsEndpointRouteBuilderExtensions
         group.MapCatalogEndpoints();
         group.MapImportEndpoints();
         group.MapInstanceEndpoints();
+        group.MapMetadataEditEndpoints();
         group.MapStateTransitionEndpoints();
 
         return group;

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class DashboardsEndpointsServiceCollectionExtensions
 
         services.TryAddScoped<DashboardImporter>();
         services.TryAddScoped<DashboardReader>();
+        services.TryAddScoped<DashboardEditor>();
         services.TryAddScoped<DashboardStateTransitionService>();
 
         return services;

--- a/src/Granit.Dashboards.Endpoints/Validators/DashboardMetadataUpdateRequestValidator.cs
+++ b/src/Granit.Dashboards.Endpoints/Validators/DashboardMetadataUpdateRequestValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Dashboards.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="DashboardMetadataUpdateRequest"/>. Built-in rules
+/// (NotEmpty, MaximumLength, GreaterThan) are auto-mapped to localized error
+/// codes by <c>GranitErrorCodeLanguageManager</c> — no hardcoded messages.
+/// </summary>
+internal sealed class DashboardMetadataUpdateRequestValidator : GranitValidator<DashboardMetadataUpdateRequest>
+{
+    internal const int MaxNameLength = 200;
+
+    public DashboardMetadataUpdateRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(MaxNameLength);
+
+        RuleFor(x => x.LayoutColumns)
+            .GreaterThan(0);
+
+        RuleFor(x => x.LayoutRowHeight)
+            .GreaterThan(0);
+    }
+}

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardEditor.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardEditor.cs
@@ -1,0 +1,69 @@
+using Granit.Dashboards.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Write-side service for editable <see cref="Dashboard"/> metadata — name and
+/// grid layout. Each call is a single load + mutate + save round-trip and
+/// inherits the multi-tenant filter from <see cref="DashboardsDbContext"/>.
+/// </summary>
+internal sealed class DashboardEditor(DashboardsDbContext db)
+{
+    public async Task<DashboardEditResult> UpdateMetadataAsync(
+        Guid id,
+        string name,
+        int layoutColumns,
+        int layoutRowHeight,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await db.Dashboards
+            .Include(d => d.Widgets)
+            .SingleOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return DashboardEditResult.NotFound();
+        }
+
+        try
+        {
+            dashboard.Rename(name);
+            dashboard.UpdateLayout(layoutColumns, layoutRowHeight);
+        }
+        catch (ArgumentException ex)
+        {
+            return DashboardEditResult.Invalid(ex.Message);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return DashboardEditResult.Success(dashboard);
+    }
+}
+
+/// <summary>
+/// Outcome of an edit request — updated aggregate, 404 (no row in scope), or
+/// 422 carrying the domain-guard message (defense-in-depth — FluentValidation
+/// runs first at the HTTP layer).
+/// </summary>
+internal sealed record DashboardEditResult(
+    DashboardEditOutcome Outcome,
+    Dashboard? Dashboard,
+    string? InvalidReason)
+{
+    public static DashboardEditResult Success(Dashboard dashboard)
+        => new(DashboardEditOutcome.Updated, dashboard, null);
+
+    public static DashboardEditResult NotFound()
+        => new(DashboardEditOutcome.NotFound, null, null);
+
+    public static DashboardEditResult Invalid(string reason)
+        => new(DashboardEditOutcome.Invalid, null, reason);
+}
+
+internal enum DashboardEditOutcome
+{
+    Updated,
+    NotFound,
+    Invalid,
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardEditorTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardEditorTests.cs
@@ -1,0 +1,170 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed write-side tests for <see cref="DashboardEditor"/> — round-trips
+/// the rename + layout update, exercises idempotency on no-op edits, and
+/// asserts the domain-guard fallback path (HTTP layer's FluentValidation runs
+/// first; these tests confirm the editor still rejects bad input even when
+/// validation is bypassed, e.g. internal callers).
+/// </summary>
+public sealed class DashboardEditorTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext seed = NewContext();
+        await seed.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task UpdateMetadataAsync_RenamesAndResizesLayout()
+    {
+        Guid id = await SeedAsync(name: "Old", layoutColumns: 12, layoutRowHeight: 80);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "New", layoutColumns: 16, layoutRowHeight: 64, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Updated);
+        result.Dashboard.ShouldNotBeNull();
+        result.Dashboard.Name.ShouldBe("New");
+        result.Dashboard.LayoutColumns.ShouldBe(16);
+        result.Dashboard.LayoutRowHeight.ShouldBe(64);
+
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard onDisk = await readBack.Dashboards.AsNoTracking().SingleAsync(d => d.Id == id, TestContext.Current.CancellationToken);
+        onDisk.Name.ShouldBe("New");
+        onDisk.LayoutColumns.ShouldBe(16);
+        onDisk.LayoutRowHeight.ShouldBe(64);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_NoOpEdit_LeavesAggregateUnchanged()
+    {
+        Guid id = await SeedAsync(name: "Same", layoutColumns: 12, layoutRowHeight: 80);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "Same", layoutColumns: 12, layoutRowHeight: 80, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Updated);
+        result.Dashboard!.Name.ShouldBe("Same");
+        result.Dashboard.LayoutColumns.ShouldBe(12);
+        result.Dashboard.LayoutRowHeight.ShouldBe(80);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_PreservesWidgetTree()
+    {
+        Guid id = await SeedAsync(name: "WithWidgets", layoutColumns: 12, layoutRowHeight: 80, widgetCount: 3);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "Renamed", layoutColumns: 16, layoutRowHeight: 64, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Updated);
+        result.Dashboard!.Widgets.Count.ShouldBe(3);
+
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard onDisk = await readBack.Dashboards.AsNoTracking()
+            .Include(d => d.Widgets)
+            .SingleAsync(d => d.Id == id, TestContext.Current.CancellationToken);
+        onDisk.Widgets.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_BlankName_ReturnsInvalid()
+    {
+        Guid id = await SeedAsync(name: "Original", layoutColumns: 12, layoutRowHeight: 80);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "   ", layoutColumns: 16, layoutRowHeight: 64, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Invalid);
+        result.InvalidReason.ShouldNotBeNullOrWhiteSpace();
+
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard onDisk = await readBack.Dashboards.AsNoTracking().SingleAsync(d => d.Id == id, TestContext.Current.CancellationToken);
+        onDisk.Name.ShouldBe("Original");
+        onDisk.LayoutColumns.ShouldBe(12);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_NonPositiveLayoutColumns_ReturnsInvalid()
+    {
+        Guid id = await SeedAsync(name: "Original", layoutColumns: 12, layoutRowHeight: 80);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "Renamed", layoutColumns: 0, layoutRowHeight: 64, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Invalid);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_NonPositiveLayoutRowHeight_ReturnsInvalid()
+    {
+        Guid id = await SeedAsync(name: "Original", layoutColumns: 12, layoutRowHeight: 80);
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            id, "Renamed", layoutColumns: 16, layoutRowHeight: -1, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.Invalid);
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_UnknownId_ReturnsNotFound()
+    {
+        DashboardEditor editor = new(NewContext());
+
+        DashboardEditResult result = await editor.UpdateMetadataAsync(
+            Guid.NewGuid(), "Whatever", layoutColumns: 16, layoutRowHeight: 64, TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardEditOutcome.NotFound);
+        result.Dashboard.ShouldBeNull();
+    }
+
+    private async Task<Guid> SeedAsync(string name, int layoutColumns, int layoutRowHeight, int widgetCount = 0)
+    {
+        var dashboard = Dashboard.Create(
+            Guid.NewGuid(), name, DashboardCategory.Finance,
+            layoutColumns: layoutColumns, layoutRowHeight: layoutRowHeight);
+        for (int i = 0; i < widgetCount; i++)
+        {
+            dashboard.AddWidget(
+                Guid.NewGuid(), "Markdown",
+                position: i, width: 12, height: 1,
+                titleLocalizationKey: $"Widget:{name}.{i}",
+                configJson: "{}");
+        }
+        dashboard.ClearDomainEvents();
+
+        await using DashboardsDbContext ctx = NewContext();
+        ctx.Dashboards.Add(dashboard);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return dashboard.Id;
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

`PUT /dashboards/{id:guid}` — edits the dashboard's editable metadata (name + grid layout). Status transitions, source-definition pinning and the widget pool stay out of scope; they live on the state-transition / import / (forthcoming) widget endpoints.

- **Validation**: `DashboardMetadataUpdateRequestValidator` (first FluentValidation validator in this package) — `NotEmpty` + `MaximumLength(200)` on `Name`, `GreaterThan(0)` on `LayoutColumns` and `LayoutRowHeight`. Built-in rules auto-localize via `GranitErrorCodeLanguageManager` — no hardcoded messages.
- **Defense-in-depth**: domain guards (`Rename` rejects blank, `UpdateLayout` rejects non-positive) stay in place. If they fire (e.g. internal callers bypassing FluentValidation), the editor returns `Invalid` → 422 with the domain message.
- **Permission**: `Dashboards.Instances.Manage` (existing — covers state transitions and edits per its docstring).
- **Architecture**: `DashboardEditor` lives in `Granit.Dashboards.EntityFrameworkCore.Internal` so the Endpoints package's EF Core ban holds.

## Tests

7 SQLite-backed `DashboardEditorTests`:

- rename + layout resize round-trip with read-back from disk
- no-op edit (same values) leaves aggregate unchanged
- widget tree preserved across an edit
- blank name → `Invalid`, on-disk row untouched
- `LayoutColumns = 0` → `Invalid`
- `LayoutRowHeight = -1` → `Invalid`
- unknown id → `NotFound`

## Test plan

- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 56/56 passed (7 new + 49 existing)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift