### PR TITLE
feat(dashboards): widget add + remove endpoints (B4-write-5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12987,6 +12987,15 @@
       "members": []
     },
     {
+      "name": "AddWidgetRequest",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.AddWidgetRequest",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/AddWidgetRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "DashboardCatalogEntryResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardCatalogEntryResponse",
       "kind": "record",

--- a/src/Granit.Dashboards.Endpoints/Dtos/AddWidgetRequest.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/AddWidgetRequest.cs
@@ -1,0 +1,19 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Payload for <c>POST /dashboards/{id}/widgets</c> — pins a new widget into
+/// the dashboard's widget pool. The server allocates the widget id (callers
+/// don't choose it). Optional fields (MetricName, QueryName, RequiredPermission)
+/// follow the widget kind: KPI widgets carry MetricName, table widgets carry
+/// QueryName, free-form widgets carry neither.
+/// </summary>
+public sealed record AddWidgetRequest(
+    string WidgetType,
+    int Position,
+    int Width,
+    int Height,
+    string TitleLocalizationKey,
+    string ConfigJson,
+    string? MetricName = null,
+    string? QueryName = null,
+    string? RequiredPermission = null);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
@@ -1,0 +1,115 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the dashboard's widget pool — add and remove widget
+/// instances. Update lands later (requires a new aggregate method); for now,
+/// editing config means delete + add.
+/// </summary>
+internal static class DashboardWidgetEndpoints
+{
+    public static RouteGroupBuilder MapWidgetEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{id:guid}/widgets", AddWidgetAsync)
+            .WithName("AddGranitDashboardWidget")
+            .WithSummary("Adds a widget instance to the dashboard.")
+            .WithDescription(
+                "Pins a new widget into the dashboard's widget pool. The widget id is "
+                + "allocated server-side. FluentValidation runs first (non-empty type / "
+                + "title / config; non-negative position; positive width and height); "
+                + "the domain guards stay as defense-in-depth and surface as 422 if hit. "
+                + "Returns 201 with the new widget payload, or 404 when the parent "
+                + "dashboard is not in the current tenant's scope.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<WidgetInstanceResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapDelete("/{id:guid}/widgets/{widgetId:guid}", RemoveWidgetAsync)
+            .WithName("RemoveGranitDashboardWidget")
+            .WithSummary("Removes a widget instance from the dashboard.")
+            .WithDescription(
+                "Removes the named widget from the dashboard's pool. Returns 204 on "
+                + "successful removal, 404 when the dashboard is not in the current "
+                + "tenant's scope, or when the widget id does not belong to that "
+                + "dashboard. Idempotent retries on a removed widget therefore receive "
+                + "a 404 — callers treat this as benign.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Created<WidgetInstanceResponse>, ProblemHttpResult>> AddWidgetAsync(
+        [FromRoute] Guid id,
+        [FromBody] AddWidgetRequest request,
+        [FromServices] DashboardWidgetService service,
+        CancellationToken cancellationToken)
+    {
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId: id,
+            widgetType: request.WidgetType,
+            position: request.Position,
+            width: request.Width,
+            height: request.Height,
+            titleLocalizationKey: request.TitleLocalizationKey,
+            configJson: request.ConfigJson,
+            metricName: request.MetricName,
+            queryName: request.QueryName,
+            requiredPermission: request.RequiredPermission,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            DashboardWidgetAddOutcome.Created =>
+                TypedResults.Created(
+                    $"/dashboards/{id}/widgets/{result.Widget!.Id}",
+                    DashboardInstanceProjection.ToWidgetInstance(result.Widget)),
+            DashboardWidgetAddOutcome.NotFound =>
+                TypedResults.Problem(
+                    detail: $"Dashboard '{id}' not found.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardWidgetAddOutcome.Invalid =>
+                TypedResults.Problem(
+                    detail: result.InvalidReason,
+                    statusCode: StatusCodes.Status422UnprocessableEntity),
+            _ => throw new InvalidOperationException($"Unhandled outcome '{result.Outcome}'."),
+        };
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> RemoveWidgetAsync(
+        [FromRoute] Guid id,
+        [FromRoute] Guid widgetId,
+        [FromServices] DashboardWidgetService service,
+        CancellationToken cancellationToken)
+    {
+        DashboardWidgetRemoveResult result = await service.RemoveWidgetAsync(id, widgetId, cancellationToken).ConfigureAwait(false);
+
+        return result switch
+        {
+            DashboardWidgetRemoveResult.Removed => TypedResults.NoContent(),
+            DashboardWidgetRemoveResult.DashboardNotFound =>
+                TypedResults.Problem(
+                    detail: $"Dashboard '{id}' not found.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardWidgetRemoveResult.WidgetNotFound =>
+                TypedResults.Problem(
+                    detail: $"Widget '{widgetId}' not found on dashboard '{id}'.",
+                    statusCode: StatusCodes.Status404NotFound),
+            _ => throw new InvalidOperationException($"Unhandled outcome '{result}'."),
+        };
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -37,6 +37,7 @@ public static class DashboardsEndpointRouteBuilderExtensions
         group.MapInstanceEndpoints();
         group.MapMetadataEditEndpoints();
         group.MapStateTransitionEndpoints();
+        group.MapWidgetEndpoints();
 
         return group;
     }

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class DashboardsEndpointsServiceCollectionExtensions
         services.TryAddScoped<DashboardReader>();
         services.TryAddScoped<DashboardEditor>();
         services.TryAddScoped<DashboardStateTransitionService>();
+        services.TryAddScoped<DashboardWidgetService>();
 
         return services;
     }

--- a/src/Granit.Dashboards.Endpoints/Validators/AddWidgetRequestValidator.cs
+++ b/src/Granit.Dashboards.Endpoints/Validators/AddWidgetRequestValidator.cs
@@ -1,0 +1,54 @@
+using FluentValidation;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Dashboards.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="AddWidgetRequest"/>. Built-in rules auto-localize via
+/// <c>GranitErrorCodeLanguageManager</c>; the domain guards in
+/// <c>WidgetInstance.Create</c> stay as defense-in-depth.
+/// </summary>
+internal sealed class AddWidgetRequestValidator : GranitValidator<AddWidgetRequest>
+{
+    internal const int MaxWidgetTypeLength = 100;
+    internal const int MaxLocalizationKeyLength = 200;
+    internal const int MaxConfigJsonLength = 16_000;
+    internal const int MaxPermissionLength = 200;
+
+    public AddWidgetRequestValidator()
+    {
+        RuleFor(x => x.WidgetType)
+            .NotEmpty()
+            .MaximumLength(MaxWidgetTypeLength);
+
+        RuleFor(x => x.TitleLocalizationKey)
+            .NotEmpty()
+            .MaximumLength(MaxLocalizationKeyLength);
+
+        RuleFor(x => x.ConfigJson)
+            .NotEmpty()
+            .MaximumLength(MaxConfigJsonLength);
+
+        RuleFor(x => x.Position)
+            .GreaterThanOrEqualTo(0);
+
+        RuleFor(x => x.Width)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Height)
+            .GreaterThan(0);
+
+        RuleFor(x => x.MetricName)
+            .MaximumLength(MaxLocalizationKeyLength)
+            .When(x => x.MetricName is not null);
+
+        RuleFor(x => x.QueryName)
+            .MaximumLength(MaxLocalizationKeyLength)
+            .When(x => x.QueryName is not null);
+
+        RuleFor(x => x.RequiredPermission)
+            .MaximumLength(MaxPermissionLength)
+            .When(x => x.RequiredPermission is not null);
+    }
+}

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardWidgetService.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardWidgetService.cs
@@ -1,0 +1,132 @@
+using Granit.Dashboards.Domain;
+using Granit.Guids;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Dashboards.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Write-side service for the dashboard's widget pool — add and remove widget
+/// instances. Each call is one load + mutate + save round-trip and inherits
+/// the multi-tenant filter from <see cref="DashboardsDbContext"/>. Widget ids
+/// are allocated server-side via <see cref="IGuidGenerator"/> (callers never
+/// choose them).
+/// </summary>
+internal sealed class DashboardWidgetService(DashboardsDbContext db, IGuidGenerator guidGenerator)
+{
+    public async Task<DashboardWidgetAddResult> AddWidgetAsync(
+        Guid dashboardId,
+        string widgetType,
+        int position,
+        int width,
+        int height,
+        string titleLocalizationKey,
+        string configJson,
+        string? metricName,
+        string? queryName,
+        string? requiredPermission,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await LoadAsync(dashboardId, cancellationToken).ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return DashboardWidgetAddResult.NotFound();
+        }
+
+        WidgetInstance widget;
+        try
+        {
+            widget = dashboard.AddWidget(
+                widgetId: guidGenerator.Create(),
+                widgetType: widgetType,
+                position: position,
+                width: width,
+                height: height,
+                titleLocalizationKey: titleLocalizationKey,
+                configJson: configJson,
+                metricName: metricName,
+                queryName: queryName,
+                requiredPermission: requiredPermission);
+        }
+        catch (ArgumentException ex)
+        {
+            return DashboardWidgetAddResult.Invalid(ex.Message);
+        }
+
+        // Explicit attach — the dashboard root navigation is configured via
+        // HasMany().WithOne().HasForeignKey() without a back-navigation, so the
+        // change tracker doesn't always pick up the new child as Added when
+        // appended through the aggregate's collection field. Marking it
+        // explicitly keeps SaveChanges deterministic.
+        db.WidgetInstances.Add(widget);
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return DashboardWidgetAddResult.Success(dashboard, widget);
+    }
+
+    public async Task<DashboardWidgetRemoveResult> RemoveWidgetAsync(
+        Guid dashboardId,
+        Guid widgetId,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await LoadAsync(dashboardId, cancellationToken).ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return DashboardWidgetRemoveResult.DashboardNotFound;
+        }
+
+        bool wasPresent = dashboard.Widgets.Any(w => w.Id == widgetId);
+        dashboard.RemoveWidget(widgetId);
+
+        if (!wasPresent)
+        {
+            return DashboardWidgetRemoveResult.WidgetNotFound;
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return DashboardWidgetRemoveResult.Removed;
+    }
+
+    private Task<Dashboard?> LoadAsync(Guid id, CancellationToken cancellationToken)
+        => db.Dashboards
+            .Include(d => d.Widgets)
+            .SingleOrDefaultAsync(d => d.Id == id, cancellationToken);
+}
+
+/// <summary>
+/// Outcome of an add request — created widget bundled with its parent dashboard
+/// summary, or 404 (no row in scope), or 422 (domain-guard fallback).
+/// </summary>
+internal sealed record DashboardWidgetAddResult(
+    DashboardWidgetAddOutcome Outcome,
+    Dashboard? Dashboard,
+    WidgetInstance? Widget,
+    string? InvalidReason)
+{
+    public static DashboardWidgetAddResult Success(Dashboard dashboard, WidgetInstance widget)
+        => new(DashboardWidgetAddOutcome.Created, dashboard, widget, null);
+
+    public static DashboardWidgetAddResult NotFound()
+        => new(DashboardWidgetAddOutcome.NotFound, null, null, null);
+
+    public static DashboardWidgetAddResult Invalid(string reason)
+        => new(DashboardWidgetAddOutcome.Invalid, null, null, reason);
+}
+
+internal enum DashboardWidgetAddOutcome
+{
+    Created,
+    NotFound,
+    Invalid,
+}
+
+/// <summary>
+/// Outcome of a remove request — distinguishes "dashboard not found" (404 on
+/// the parent path) from "widget not found within an existing dashboard" (404
+/// on the widget id), which the caller surfaces as different error messages.
+/// </summary>
+internal enum DashboardWidgetRemoveResult
+{
+    Removed,
+    DashboardNotFound,
+    WidgetNotFound,
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardWidgetServiceTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardWidgetServiceTests.cs
@@ -1,0 +1,237 @@
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Guids;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed tests for <see cref="DashboardWidgetService"/> — round-trips
+/// the add + remove operations through the real <see cref="DashboardsDbContext"/>,
+/// asserts the domain-guard fallback path, and locks the dashboard-vs-widget
+/// 404 distinction (the 404 reason matters for caller diagnostics).
+/// </summary>
+public sealed class DashboardWidgetServiceTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        await using DashboardsDbContext seed = NewContext();
+        await seed.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task AddWidgetAsync_AppendsToWidgetPool_AndReturnsCreated()
+    {
+        Guid dashboardId = await SeedAsync(widgetCount: 1);
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "Markdown", position: 1, width: 6, height: 1,
+            titleLocalizationKey: "Widget:Sample.Two",
+            configJson: "{}",
+            metricName: null, queryName: null, requiredPermission: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.Created);
+        result.Widget.ShouldNotBeNull();
+        result.Widget.WidgetType.ShouldBe("Markdown");
+        result.Widget.Position.ShouldBe(1);
+
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard onDisk = await readBack.Dashboards.AsNoTracking()
+            .Include(d => d.Widgets)
+            .SingleAsync(d => d.Id == dashboardId, TestContext.Current.CancellationToken);
+        onDisk.Widgets.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_PreservesAllOptionalFields()
+    {
+        Guid dashboardId = await SeedAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "Kpi", position: 0, width: 3, height: 1,
+            titleLocalizationKey: "Widget:Sample.UnpaidCount",
+            configJson: "{\"kind\":\"metric\"}",
+            metricName: "Sample.Metric",
+            queryName: null,
+            requiredPermission: "Custom.Composite.Read",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.Created);
+        result.Widget!.MetricName.ShouldBe("Sample.Metric");
+        result.Widget.QueryName.ShouldBeNull();
+        result.Widget.RequiredPermission.ShouldBe("Custom.Composite.Read");
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_AllocatesWidgetIdServerSide()
+    {
+        Guid dashboardId = await SeedAsync();
+        var expected = Guid.NewGuid();
+        IGuidGenerator gen = Substitute.For<IGuidGenerator>();
+        gen.Create().Returns(expected);
+        DashboardWidgetService service = new(NewContext(), gen);
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "Markdown", 0, 6, 1, "Widget:K", "{}", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        result.Widget!.Id.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_BlankWidgetType_ReturnsInvalid()
+    {
+        Guid dashboardId = await SeedAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "  ", 0, 6, 1, "Widget:K", "{}", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.Invalid);
+        result.InvalidReason.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_NegativePosition_ReturnsInvalid()
+    {
+        Guid dashboardId = await SeedAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "Markdown", -1, 6, 1, "Widget:K", "{}", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.Invalid);
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_NonPositiveWidth_ReturnsInvalid()
+    {
+        Guid dashboardId = await SeedAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            dashboardId, "Markdown", 0, 0, 1, "Widget:K", "{}", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.Invalid);
+    }
+
+    [Fact]
+    public async Task AddWidgetAsync_UnknownDashboard_ReturnsNotFound()
+    {
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetAddResult result = await service.AddWidgetAsync(
+            Guid.NewGuid(), "Markdown", 0, 6, 1, "Widget:K", "{}", null, null, null,
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetAddOutcome.NotFound);
+        result.Widget.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RemoveWidgetAsync_RemovesPinnedWidget_AndPersists()
+    {
+        (Guid dashboardId, Guid widgetId) = await SeedWithKnownWidgetAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetRemoveResult result = await service.RemoveWidgetAsync(dashboardId, widgetId, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(DashboardWidgetRemoveResult.Removed);
+
+        await using DashboardsDbContext readBack = NewContext();
+        Dashboard onDisk = await readBack.Dashboards.AsNoTracking()
+            .Include(d => d.Widgets)
+            .SingleAsync(d => d.Id == dashboardId, TestContext.Current.CancellationToken);
+        onDisk.Widgets.ShouldNotContain(w => w.Id == widgetId);
+    }
+
+    [Fact]
+    public async Task RemoveWidgetAsync_UnknownDashboard_ReturnsDashboardNotFound()
+    {
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetRemoveResult result = await service.RemoveWidgetAsync(
+            Guid.NewGuid(), Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(DashboardWidgetRemoveResult.DashboardNotFound);
+    }
+
+    [Fact]
+    public async Task RemoveWidgetAsync_UnknownWidgetOnExistingDashboard_ReturnsWidgetNotFound()
+    {
+        Guid dashboardId = await SeedAsync(widgetCount: 1);
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetRemoveResult result = await service.RemoveWidgetAsync(
+            dashboardId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(DashboardWidgetRemoveResult.WidgetNotFound);
+    }
+
+    private async Task<Guid> SeedAsync(int widgetCount = 0)
+    {
+        var dashboard = Dashboard.Create(Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        for (int i = 0; i < widgetCount; i++)
+        {
+            dashboard.AddWidget(
+                Guid.NewGuid(), "Markdown",
+                position: i, width: 12, height: 1,
+                titleLocalizationKey: $"Widget:Sample.{i}",
+                configJson: "{}");
+        }
+        dashboard.ClearDomainEvents();
+
+        await using DashboardsDbContext ctx = NewContext();
+        ctx.Dashboards.Add(dashboard);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return dashboard.Id;
+    }
+
+    private async Task<(Guid dashboardId, Guid widgetId)> SeedWithKnownWidgetAsync()
+    {
+        var dashboard = Dashboard.Create(Guid.NewGuid(), "Sample", DashboardCategory.Finance);
+        var widgetId = Guid.NewGuid();
+        dashboard.AddWidget(widgetId, "Markdown",
+            position: 0, width: 12, height: 1,
+            titleLocalizationKey: "Widget:Sample.0",
+            configJson: "{}");
+        dashboard.ClearDomainEvents();
+
+        await using DashboardsDbContext ctx = NewContext();
+        ctx.Dashboards.Add(dashboard);
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (dashboard.Id, widgetId);
+    }
+
+    private DashboardWidgetService NewService()
+    {
+        IGuidGenerator gen = Substitute.For<IGuidGenerator>();
+        gen.Create().Returns(_ => Guid.NewGuid());
+        return new DashboardWidgetService(NewContext(), gen);
+    }
+
+    private DashboardsDbContext NewContext()
+    {
+        DbContextOptions<DashboardsDbContext> options = new DbContextOptionsBuilder<DashboardsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        return new DashboardsDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /dashboards/{id:guid}/widgets` — pins a new widget into the dashboard's widget pool. Server allocates the widget id (callers don't choose it). Returns `201 Created` + `WidgetInstanceResponse`, `404` when the parent dashboard is out of tenant scope, `422` if the domain guards fire (FluentValidation runs first).
- `DELETE /dashboards/{id:guid}/widgets/{widgetId:guid}` — removes a widget from the pool. `204` on success; `404` distinguishes \"dashboard not in tenant scope\" from \"widget not on that dashboard\" so caller diagnostics stay precise.

Both gated by `Dashboards.Instances.Manage`.

## Architecture

- `DashboardWidgetService` lives in `Granit.Dashboards.EntityFrameworkCore.Internal` — keeps the Endpoints package's EF Core ban intact.
- The service explicitly attaches the new `WidgetInstance` to the `WidgetInstances` `DbSet` after `Dashboard.AddWidget` because the aggregate's `HasMany().WithOne().HasForeignKey()` navigation has no back-reference; without the explicit `Add`, EF's change tracker doesn't auto-mark new children appended through the field-backed collection as `Added`, and `SaveChanges` fails with `DbUpdateConcurrencyException`. This is documented inline.
- `AddWidgetRequestValidator` is the second FluentValidation validator in the package (after `DashboardMetadataUpdateRequestValidator`). All rules use built-in operators (`NotEmpty`, `MaximumLength`, `GreaterThan`, `GreaterThanOrEqualTo`) so `GranitErrorCodeLanguageManager` auto-localizes them — no hardcoded messages.

## Tests

10 SQLite-backed `DashboardWidgetServiceTests`:

- add round-trip + pool-size assertion
- optional-field preservation (MetricName, QueryName, RequiredPermission)
- server-side widget-id allocation via `IGuidGenerator`
- domain-guard fallback paths: blank type, negative position, non-positive width
- unknown-dashboard → `NotFound`
- remove round-trip with on-disk verification
- 404 distinction: `DashboardNotFound` vs `WidgetNotFound` (different reasons matter for caller UX)

## Out of scope

`PUT /dashboards/{id}/widgets/{widgetId}` (widget-config update) needs a new aggregate method (`UpdateWidget`) that doesn't exist yet — own follow-up so the domain change is reviewed independently.

## Test plan

- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 66/66 passed (10 new + 56 existing)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift