### PR TITLE
feat(dashboards): widget update endpoint — PUT /dashboards/{id}/widgets/{widgetId} (B4-write-6)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13050,6 +13050,15 @@
       "members": []
     },
     {
+      "name": "UpdateWidgetRequest",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.UpdateWidgetRequest",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/UpdateWidgetRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "WidgetInstanceResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.WidgetInstanceResponse",
       "kind": "record",

--- a/src/Granit.Dashboards.Endpoints/Dtos/UpdateWidgetRequest.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/UpdateWidgetRequest.cs
@@ -1,0 +1,15 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Payload for <c>PUT /dashboards/{id}/widgets/{widgetId}</c> — full
+/// replacement of the widget's editable fields (layout + title + config).
+/// WidgetType, MetricName, QueryName and RequiredPermission are intentionally
+/// out of scope: switching widget kind or rebinding to a different
+/// metric/query is delete + add, not edit.
+/// </summary>
+public sealed record UpdateWidgetRequest(
+    int Position,
+    int Width,
+    int Height,
+    string TitleLocalizationKey,
+    string ConfigJson);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
@@ -13,9 +13,10 @@ using Microsoft.AspNetCore.Routing;
 namespace Granit.Dashboards.Endpoints.Endpoints;
 
 /// <summary>
-/// HTTP handlers for the dashboard's widget pool — add and remove widget
-/// instances. Update lands later (requires a new aggregate method); for now,
-/// editing config means delete + add.
+/// HTTP handlers for the dashboard's widget pool — add, update and remove
+/// widget instances. The update endpoint replaces layout / title / config but
+/// not WidgetType / MetricName / QueryName / RequiredPermission (those are
+/// delete + add).
 /// </summary>
 internal static class DashboardWidgetEndpoints
 {
@@ -33,6 +34,23 @@ internal static class DashboardWidgetEndpoints
                 + "dashboard is not in the current tenant's scope.")
             .RequireAuthorization(DashboardsPermissions.Instances.Manage)
             .Produces<WidgetInstanceResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapPut("/{id:guid}/widgets/{widgetId:guid}", UpdateWidgetAsync)
+            .WithName("UpdateGranitDashboardWidget")
+            .WithSummary("Updates a widget's layout, title and config.")
+            .WithDescription(
+                "Full replacement of the widget's editable fields: Position, Width, "
+                + "Height, TitleLocalizationKey, ConfigJson. WidgetType, MetricName, "
+                + "QueryName and RequiredPermission stay immutable — switching widget "
+                + "kind or rebinding to a different metric/query is delete + add, not "
+                + "edit. Returns 200 with the updated widget, 404 when the dashboard "
+                + "or the widget id is not in scope, or 422 when the domain guards "
+                + "reject the input.")
+            .RequireAuthorization(DashboardsPermissions.Instances.Manage)
+            .Produces<WidgetInstanceResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
@@ -83,6 +101,43 @@ internal static class DashboardWidgetEndpoints
                     detail: $"Dashboard '{id}' not found.",
                     statusCode: StatusCodes.Status404NotFound),
             DashboardWidgetAddOutcome.Invalid =>
+                TypedResults.Problem(
+                    detail: result.InvalidReason,
+                    statusCode: StatusCodes.Status422UnprocessableEntity),
+            _ => throw new InvalidOperationException($"Unhandled outcome '{result.Outcome}'."),
+        };
+    }
+
+    private static async Task<Results<Ok<WidgetInstanceResponse>, ProblemHttpResult>> UpdateWidgetAsync(
+        [FromRoute] Guid id,
+        [FromRoute] Guid widgetId,
+        [FromBody] UpdateWidgetRequest request,
+        [FromServices] DashboardWidgetService service,
+        CancellationToken cancellationToken)
+    {
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            dashboardId: id,
+            widgetId: widgetId,
+            position: request.Position,
+            width: request.Width,
+            height: request.Height,
+            titleLocalizationKey: request.TitleLocalizationKey,
+            configJson: request.ConfigJson,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            DashboardWidgetUpdateOutcome.Updated =>
+                TypedResults.Ok(DashboardInstanceProjection.ToWidgetInstance(result.Widget!)),
+            DashboardWidgetUpdateOutcome.DashboardNotFound =>
+                TypedResults.Problem(
+                    detail: $"Dashboard '{id}' not found.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardWidgetUpdateOutcome.WidgetNotFound =>
+                TypedResults.Problem(
+                    detail: $"Widget '{widgetId}' not found on dashboard '{id}'.",
+                    statusCode: StatusCodes.Status404NotFound),
+            DashboardWidgetUpdateOutcome.Invalid =>
                 TypedResults.Problem(
                     detail: result.InvalidReason,
                     statusCode: StatusCodes.Status422UnprocessableEntity),

--- a/src/Granit.Dashboards.Endpoints/Validators/UpdateWidgetRequestValidator.cs
+++ b/src/Granit.Dashboards.Endpoints/Validators/UpdateWidgetRequestValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Dashboards.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="UpdateWidgetRequest"/>. Mirrors the constraints in
+/// <see cref="AddWidgetRequestValidator"/> — the same domain guards apply on
+/// create and update; HTTP-layer validation kept symmetric so callers see the
+/// same error codes.
+/// </summary>
+internal sealed class UpdateWidgetRequestValidator : GranitValidator<UpdateWidgetRequest>
+{
+    public UpdateWidgetRequestValidator()
+    {
+        RuleFor(x => x.TitleLocalizationKey)
+            .NotEmpty()
+            .MaximumLength(AddWidgetRequestValidator.MaxLocalizationKeyLength);
+
+        RuleFor(x => x.ConfigJson)
+            .NotEmpty()
+            .MaximumLength(AddWidgetRequestValidator.MaxConfigJsonLength);
+
+        RuleFor(x => x.Position)
+            .GreaterThanOrEqualTo(0);
+
+        RuleFor(x => x.Width)
+            .GreaterThan(0);
+
+        RuleFor(x => x.Height)
+            .GreaterThan(0);
+    }
+}

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardWidgetService.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardWidgetService.cs
@@ -63,6 +63,42 @@ internal sealed class DashboardWidgetService(DashboardsDbContext db, IGuidGenera
         return DashboardWidgetAddResult.Success(dashboard, widget);
     }
 
+    public async Task<DashboardWidgetUpdateResult> UpdateWidgetAsync(
+        Guid dashboardId,
+        Guid widgetId,
+        int position,
+        int width,
+        int height,
+        string titleLocalizationKey,
+        string configJson,
+        CancellationToken cancellationToken)
+    {
+        Dashboard? dashboard = await LoadAsync(dashboardId, cancellationToken).ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return DashboardWidgetUpdateResult.DashboardNotFound();
+        }
+
+        bool found;
+        try
+        {
+            found = dashboard.UpdateWidget(widgetId, position, width, height, titleLocalizationKey, configJson);
+        }
+        catch (ArgumentException ex)
+        {
+            return DashboardWidgetUpdateResult.Invalid(ex.Message);
+        }
+
+        if (!found)
+        {
+            return DashboardWidgetUpdateResult.WidgetNotFound();
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        WidgetInstance widget = dashboard.Widgets.Single(w => w.Id == widgetId);
+        return DashboardWidgetUpdateResult.Success(widget);
+    }
+
     public async Task<DashboardWidgetRemoveResult> RemoveWidgetAsync(
         Guid dashboardId,
         Guid widgetId,
@@ -129,4 +165,35 @@ internal enum DashboardWidgetRemoveResult
     Removed,
     DashboardNotFound,
     WidgetNotFound,
+}
+
+/// <summary>
+/// Outcome of an update request — updated widget on success, or one of three
+/// failure reasons (dashboard not found, widget not found on that dashboard,
+/// domain-guard rejection).
+/// </summary>
+internal sealed record DashboardWidgetUpdateResult(
+    DashboardWidgetUpdateOutcome Outcome,
+    WidgetInstance? Widget,
+    string? InvalidReason)
+{
+    public static DashboardWidgetUpdateResult Success(WidgetInstance widget)
+        => new(DashboardWidgetUpdateOutcome.Updated, widget, null);
+
+    public static DashboardWidgetUpdateResult DashboardNotFound()
+        => new(DashboardWidgetUpdateOutcome.DashboardNotFound, null, null);
+
+    public static DashboardWidgetUpdateResult WidgetNotFound()
+        => new(DashboardWidgetUpdateOutcome.WidgetNotFound, null, null);
+
+    public static DashboardWidgetUpdateResult Invalid(string reason)
+        => new(DashboardWidgetUpdateOutcome.Invalid, null, reason);
+}
+
+internal enum DashboardWidgetUpdateOutcome
+{
+    Updated,
+    DashboardNotFound,
+    WidgetNotFound,
+    Invalid,
 }

--- a/src/Granit.Dashboards/Domain/Dashboard.cs
+++ b/src/Granit.Dashboards/Domain/Dashboard.cs
@@ -202,6 +202,36 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
         AddDomainEvent(new DashboardModifiedEvent(Id, TenantId));
     }
 
+    /// <summary>
+    /// Updates the layout (position / size), title localization key, and JSON
+    /// configuration of a pinned widget. WidgetType, MetricName, QueryName and
+    /// RequiredPermission are intentionally immutable here — switching widget
+    /// kind or rebinding to a different metric/query is delete + add, not edit.
+    /// Returns <c>true</c> when the widget existed; <c>false</c> when it was
+    /// not pinned.
+    /// </summary>
+    public bool UpdateWidget(
+        Guid widgetId,
+        int position,
+        int width,
+        int height,
+        string titleLocalizationKey,
+        string configJson)
+    {
+        WidgetInstance? widget = _widgets.FirstOrDefault(w => w.Id == widgetId);
+        if (widget is null)
+        {
+            return false;
+        }
+
+        widget.Reposition(position, width, height);
+        widget.UpdateTitle(titleLocalizationKey);
+        widget.UpdateConfig(configJson);
+
+        AddDomainEvent(new DashboardModifiedEvent(Id, TenantId));
+        return true;
+    }
+
     /// <summary>Transitions <see cref="DashboardStatus.Draft"/> → <see cref="DashboardStatus.Published"/>.</summary>
     public void Publish()
     {

--- a/src/Granit.Dashboards/Domain/WidgetInstance.cs
+++ b/src/Granit.Dashboards/Domain/WidgetInstance.cs
@@ -150,6 +150,13 @@ public sealed class WidgetInstance : Entity
         ConfigJson = configJson;
     }
 
+    /// <summary>Updates the localization key used to render the widget's title.</summary>
+    internal void UpdateTitle(string titleLocalizationKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(titleLocalizationKey);
+        TitleLocalizationKey = titleLocalizationKey;
+    }
+
     /// <summary>
     /// Applies (or clears) the per-instance presentation overrides. Pass <c>null</c>
     /// to revert to the imported defaults.

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardWidgetServiceTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardWidgetServiceTests.cs
@@ -146,6 +146,92 @@ public sealed class DashboardWidgetServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpdateWidgetAsync_UpdatesEditableFields_AndPersists()
+    {
+        (Guid dashboardId, Guid widgetId) = await SeedWithKnownWidgetAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            dashboardId, widgetId,
+            position: 5, width: 6, height: 2,
+            titleLocalizationKey: "Widget:Renamed",
+            configJson: "{\"v\":2}",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetUpdateOutcome.Updated);
+        result.Widget.ShouldNotBeNull();
+        result.Widget.Position.ShouldBe(5);
+        result.Widget.Width.ShouldBe(6);
+        result.Widget.Height.ShouldBe(2);
+        result.Widget.TitleLocalizationKey.ShouldBe("Widget:Renamed");
+        result.Widget.ConfigJson.ShouldBe("{\"v\":2}");
+
+        await using DashboardsDbContext readBack = NewContext();
+        WidgetInstance onDisk = await readBack.WidgetInstances.AsNoTracking()
+            .SingleAsync(w => w.Id == widgetId, TestContext.Current.CancellationToken);
+        onDisk.Position.ShouldBe(5);
+        onDisk.TitleLocalizationKey.ShouldBe("Widget:Renamed");
+        onDisk.ConfigJson.ShouldBe("{\"v\":2}");
+    }
+
+    [Fact]
+    public async Task UpdateWidgetAsync_BlankTitle_ReturnsInvalid_AndDoesNotPersist()
+    {
+        (Guid dashboardId, Guid widgetId) = await SeedWithKnownWidgetAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            dashboardId, widgetId, 0, 12, 1, "  ", "{}",
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetUpdateOutcome.Invalid);
+        result.InvalidReason.ShouldNotBeNullOrWhiteSpace();
+
+        await using DashboardsDbContext readBack = NewContext();
+        WidgetInstance onDisk = await readBack.WidgetInstances.AsNoTracking()
+            .SingleAsync(w => w.Id == widgetId, TestContext.Current.CancellationToken);
+        onDisk.TitleLocalizationKey.ShouldBe("Widget:Sample.0");
+    }
+
+    [Fact]
+    public async Task UpdateWidgetAsync_NegativePosition_ReturnsInvalid()
+    {
+        (Guid dashboardId, Guid widgetId) = await SeedWithKnownWidgetAsync();
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            dashboardId, widgetId, -1, 12, 1, "Widget:K", "{}",
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetUpdateOutcome.Invalid);
+    }
+
+    [Fact]
+    public async Task UpdateWidgetAsync_UnknownDashboard_ReturnsDashboardNotFound()
+    {
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            Guid.NewGuid(), Guid.NewGuid(), 0, 12, 1, "Widget:K", "{}",
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetUpdateOutcome.DashboardNotFound);
+    }
+
+    [Fact]
+    public async Task UpdateWidgetAsync_UnknownWidgetOnExistingDashboard_ReturnsWidgetNotFound()
+    {
+        Guid dashboardId = await SeedAsync(widgetCount: 1);
+        DashboardWidgetService service = NewService();
+
+        DashboardWidgetUpdateResult result = await service.UpdateWidgetAsync(
+            dashboardId, Guid.NewGuid(), 0, 12, 1, "Widget:K", "{}",
+            TestContext.Current.CancellationToken);
+
+        result.Outcome.ShouldBe(DashboardWidgetUpdateOutcome.WidgetNotFound);
+    }
+
+    [Fact]
     public async Task RemoveWidgetAsync_RemovesPinnedWidget_AndPersists()
     {
         (Guid dashboardId, Guid widgetId) = await SeedWithKnownWidgetAsync();

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardStateMachineTests.cs
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardStateMachineTests.cs
@@ -137,6 +137,84 @@ public sealed class DashboardStateMachineTests
     }
 
     [Fact]
+    public void UpdateWidget_UpdatesEditableFields_AndRaisesModifiedEvent()
+    {
+        Dashboard dashboard = NewDraft();
+        WidgetInstance widget = dashboard.AddWidget(
+            Guid.NewGuid(), "Kpi", position: 0, width: 3, height: 1,
+            titleLocalizationKey: "Widget:Sample.Title",
+            configJson: "{\"a\":1}",
+            metricName: "M",
+            requiredPermission: "P.Read");
+        dashboard.ClearDomainEvents();
+
+        bool found = dashboard.UpdateWidget(
+            widget.Id, position: 4, width: 6, height: 2,
+            titleLocalizationKey: "Widget:Sample.Renamed",
+            configJson: "{\"a\":2}");
+
+        found.ShouldBeTrue();
+        widget.Position.ShouldBe(4);
+        widget.Width.ShouldBe(6);
+        widget.Height.ShouldBe(2);
+        widget.TitleLocalizationKey.ShouldBe("Widget:Sample.Renamed");
+        widget.ConfigJson.ShouldBe("{\"a\":2}");
+        // Identity-bound fields stay frozen.
+        widget.WidgetType.ShouldBe("Kpi");
+        widget.MetricName.ShouldBe("M");
+        widget.RequiredPermission.ShouldBe("P.Read");
+        dashboard.DomainEvents.OfType<DashboardModifiedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void UpdateWidget_UnknownId_ReturnsFalseAndRaisesNoEvent()
+    {
+        Dashboard dashboard = NewDraft();
+        dashboard.AddWidget(Guid.NewGuid(), "Markdown", 0, 12, 1, "Widget:S", "{}");
+        dashboard.ClearDomainEvents();
+
+        bool found = dashboard.UpdateWidget(
+            Guid.NewGuid(), 1, 6, 1, "Widget:Other", "{}");
+
+        found.ShouldBeFalse();
+        dashboard.DomainEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void UpdateWidget_RejectsNegativePosition()
+    {
+        Dashboard dashboard = NewDraft();
+        WidgetInstance widget = dashboard.AddWidget(Guid.NewGuid(), "Markdown", 0, 12, 1, "Widget:S", "{}");
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            dashboard.UpdateWidget(widget.Id, -1, 12, 1, "Widget:S", "{}"));
+    }
+
+    [Fact]
+    public void UpdateWidget_RejectsNonPositiveSize()
+    {
+        Dashboard dashboard = NewDraft();
+        WidgetInstance widget = dashboard.AddWidget(Guid.NewGuid(), "Markdown", 0, 12, 1, "Widget:S", "{}");
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            dashboard.UpdateWidget(widget.Id, 0, 0, 1, "Widget:S", "{}"));
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            dashboard.UpdateWidget(widget.Id, 0, 12, 0, "Widget:S", "{}"));
+    }
+
+    [Fact]
+    public void UpdateWidget_RejectsBlankTitleOrConfig()
+    {
+        Dashboard dashboard = NewDraft();
+        WidgetInstance widget = dashboard.AddWidget(Guid.NewGuid(), "Markdown", 0, 12, 1, "Widget:S", "{}");
+
+        Should.Throw<ArgumentException>(() =>
+            dashboard.UpdateWidget(widget.Id, 0, 12, 1, "  ", "{}"));
+        Should.Throw<ArgumentException>(() =>
+            dashboard.UpdateWidget(widget.Id, 0, 12, 1, "Widget:S", "  "));
+    }
+
+    [Fact]
     public void Create_RejectsEmptyName()
     {
         Should.Throw<ArgumentException>(() =>


### PR DESCRIPTION
## Summary

`PUT /dashboards/{id:guid}/widgets/{widgetId:guid}` — full replacement of a widget's editable fields (layout + title + config). Closes the basic widget CRUD surface alongside the add/remove pair from #1472.

- **Editable**: `Position`, `Width`, `Height`, `TitleLocalizationKey`, `ConfigJson`.
- **Frozen**: `WidgetType`, `MetricName`, `QueryName`, `RequiredPermission` — switching widget kind or rebinding to a different metric/query is delete + add, not edit. Enforced at the domain level (locked by tests) and not exposed in the request DTO.
- Permission: `Dashboards.Instances.Manage` (existing).
- Response: `200` + `WidgetInstanceResponse`, `404` distinguishing \"dashboard not in tenant scope\" from \"widget not on that dashboard\", `422` on domain-guard rejection (e.g. blank title).

## Domain change

- `Dashboard.UpdateWidget(...)` is the new public method on the aggregate. Delegates to `WidgetInstance.Reposition`, the new `WidgetInstance.UpdateTitle`, and `WidgetInstance.UpdateConfig`. Raises `DashboardModifiedEvent` on success.
- Returns `bool` so the calling service can distinguish \"widget not on that dashboard\" from \"domain rejected the input\" without exception-driven control flow.

## Tests

- **5 domain tests** in `DashboardStateMachineTests` — happy-path edit + identity-field frozen + `DashboardModifiedEvent`, unknown-id no-op (returns false, raises no event), guard rejection on negative position / non-positive size / blank title or config.
- **5 SQLite-backed service tests** in `DashboardWidgetServiceTests` — round-trip with on-disk verification, blank title preserves prior value (Invalid path), negative position rejection, dashboard-not-found vs widget-not-found 404 distinction.

## Test plan

- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 71/71 passed (5 new + 66 existing)
- [x] `dotnet test tests/Granit.Dashboards.EntityFrameworkCore.Tests` — 26/26 passed (5 new)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift