### PR TITLE
chore(archi): share [INFRA] pairing exemptions across Query↔Export and Query↔Metric (D1 #1396)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,6 +763,18 @@ Pure infrastructure entities (audit log details, internal cache rows like
 `AIWorkspaceEntity`, `TenantFeatureOverride`) are exempt and use the reflection-based
 fallback.
 
+**Exemption list — canonical location**: `tests/Granit.ArchitectureTests/PairingExemptions.cs`
+holds the **shared** `[INFRA]` set consumed by both `QueryExportPairingTests` and
+`QueryMetricPairingTests`. Adding an `[INFRA]` entry exempts the entity from **both**
+pairings (it surfaces in neither admin grids nor business KPIs). Each entry MUST carry
+a one-line inline-comment justification.
+
+`[BACKLOG]` exemptions (admin-visible entities awaiting their first metric) live
+locally in `QueryMetricPairingTests.MetricBacklog` — the backlog is metric-specific and
+is removed entry-by-entry as each module ships its first `MetricDefinition` for that
+entity. The Query↔Export pairing has no backlog mechanism: an admin-visible entity
+without an `ExportDefinition` is always rejected.
+
 ### DTOs & API responses
 
 - **Prefixed names**: `WorkflowTransitionRequest`, not `TransitionRequest` — OpenAPI flattens namespaces

--- a/tests/Granit.ArchitectureTests/PairingExemptions.cs
+++ b/tests/Granit.ArchitectureTests/PairingExemptions.cs
@@ -1,0 +1,70 @@
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Canonical list of entities exempted from the cross-primitive pairing rules
+/// — Query ↔ Export (ADR-020) and Query ↔ Metric (EPIC #1366 / story #1396).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two categories live here:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <c>[INFRA]</c> — pure infrastructure / audit / config / internal cache
+///     entities. They surface in neither admin grids nor business KPIs and
+///     are exempted permanently from <see cref="Infrastructure"/>.
+///     Both <c>QueryMetricPairingTests</c> and <c>QueryExportPairingTests</c>
+///     consume this single list so additions stay in lockstep.
+///   </item>
+///   <item>
+///     <c>[BACKLOG]</c> — admin-visible entities that should ship at least one
+///     <c>MetricDefinition</c> but haven't yet. They live in
+///     <c>QueryMetricPairingTests</c> only — backlog is metric-specific. Once
+///     a module ships its first <c>MetricDefinition</c> for the entity, the
+///     entry is removed and the rule starts enforcing.
+///   </item>
+/// </list>
+/// <para>
+/// Adding a new <c>[INFRA]</c> entry MUST come with a one-line justification
+/// (inline comment) and must apply to <i>both</i> pairings. If an entity needs
+/// only a metric exemption (e.g. it has a real export but no useful KPI), put
+/// it in the local <c>QueryMetricPairingTests</c> backlog list, not here.
+/// </para>
+/// </remarks>
+internal static class PairingExemptions
+{
+    /// <summary>
+    /// Permanent <c>[INFRA]</c> exemptions — entities that surface in neither
+    /// admin grids nor business KPIs (audit logs, RBAC config, internal caches,
+    /// platform settings, transient job records).
+    /// </summary>
+    public static readonly HashSet<string> Infrastructure = new(StringComparer.Ordinal)
+    {
+        "Granit.AI.AIUsageRecord",                                                        // [INFRA] AI cost / audit log
+        "Granit.Auditing.Domain.AuditEntityChange",                                       // [INFRA] audit log
+        "Granit.Auditing.Domain.AuditEntry",                                              // [INFRA] audit log
+        "Granit.Authorization.Domain.PermissionGrant",                                    // [INFRA] RBAC config
+        "Granit.Authorization.Domain.RoleMetadata",                                       // [INFRA] RBAC config
+        "Granit.BackgroundJobs.Domain.BackgroundJobDefinition",                           // [INFRA] job config
+        "Granit.DataExchange.Export.Domain.ExportJob",                                    // [INFRA] transient export job
+        "Granit.DataExchange.Import.Domain.ImportJob",                                    // [INFRA] transient import job
+        "Granit.Identity.Federated.Domain.UserCacheEntry",                                // [INFRA] internal user cache
+        "Granit.Identity.Local.Domain.GranitRole",                                        // [INFRA] RBAC config
+        "Granit.Identity.Local.Domain.GranitUserGroup",                                   // [INFRA] RBAC config
+        "Granit.Localization.Domain.LocalizationOverride",                                // [INFRA] localization config
+        "Granit.Metering.Domain.MeterDefinition",                                         // [INFRA] metering config
+        "Granit.MultiTenancy.Domain.Tenant",                                              // [INFRA] platform-admin entity
+        "Granit.Notifications.Domain.NotificationPreference",                             // [INFRA] user preference config
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication",              // [INFRA] OAuth client config
+        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope",                    // [INFRA] OAuth scope config
+        "Granit.Parties.EntityFrameworkCore.Entities.PartyDuplicateCandidate",            // [INFRA] deduplication queue
+        "Granit.QueryEngine.SavedViews.Domain.SavedView",                                 // [INFRA] grid tooling
+        "Granit.ReferenceData.Domain.DynamicReferenceDataEntity",                         // [INFRA] reference-data config
+        "Granit.Scheduling.Domain.ScheduledAction",                                       // [INFRA] scheduling state
+        "Granit.Settings.Domain.SettingRecord",                                           // [INFRA] settings config
+        "Granit.Tax.Domain.TaxRateOverride",                                              // [INFRA] tax config
+        "Granit.Tax.TaxRateEntry",                                                        // [INFRA] tax config
+        "Granit.Timeline.Domain.TimelineEntry",                                           // [INFRA] audit log
+        "Granit.Workflow.Domain.WorkflowTransitionRecord",                                // [INFRA] workflow audit
+    };
+}

--- a/tests/Granit.ArchitectureTests/QueryExportPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryExportPairingTests.cs
@@ -21,25 +21,13 @@ namespace Granit.ArchitectureTests;
 /// </remarks>
 public sealed class QueryExportPairingTests
 {
-    /// <summary>
-    /// Entities deliberately exempted from the pairing rule. Each entry MUST be justified.
-    /// Pure infrastructure entities (internal cache rows, audit log details, internal
-    /// config state) that are not exposed in an admin grid use the reflection-based
-    /// fallback <c>ReflectionExportDefinition</c> and do not need a paired Query.
-    /// </summary>
-    private static readonly HashSet<string> PairingExemptions = new(StringComparer.Ordinal)
-    {
-        // Add justified exemptions here, e.g.:
-        // "Granit.AI.Domain.AIWorkspaceEntity",  // internal workspace state, never admin-listed
-    };
-
     [Fact]
     public void Every_QueryDefinition_should_have_a_matching_ExportDefinition()
     {
         (HashSet<Type> queryEntities, HashSet<Type> exportEntities) = ScanEntities();
 
         IEnumerable<string> queryWithoutExport = queryEntities
-            .Where(t => !exportEntities.Contains(t) && !PairingExemptions.Contains(t.FullName!))
+            .Where(t => !exportEntities.Contains(t) && !PairingExemptions.Infrastructure.Contains(t.FullName!))
             .Select(t => t.FullName!)
             .OrderBy(s => s, StringComparer.Ordinal);
 
@@ -47,7 +35,7 @@ public sealed class QueryExportPairingTests
             "ADR-020 pairing rule: every entity with a QueryDefinition must also have an ExportDefinition. " +
             "Add the matching `ExportDefinition<T>` in the same module's `Exports/` folder, " +
             "register it via `services.AddExportDefinition<T, TDefinition>()`, " +
-            "or add the entity to PairingExemptions with a justification.");
+            "or add the entity to PairingExemptions.Infrastructure with a justification (`[INFRA]`).");
     }
 
     [Fact]
@@ -56,7 +44,7 @@ public sealed class QueryExportPairingTests
         (HashSet<Type> queryEntities, HashSet<Type> exportEntities) = ScanEntities();
 
         IEnumerable<string> exportWithoutQuery = exportEntities
-            .Where(t => !queryEntities.Contains(t) && !PairingExemptions.Contains(t.FullName!))
+            .Where(t => !queryEntities.Contains(t) && !PairingExemptions.Infrastructure.Contains(t.FullName!))
             .Select(t => t.FullName!)
             .OrderBy(s => s, StringComparer.Ordinal);
 
@@ -64,7 +52,7 @@ public sealed class QueryExportPairingTests
             "ADR-020 pairing rule: every entity with an ExportDefinition must also have a QueryDefinition. " +
             "Add the matching `QueryDefinition<T>` in the same module's `Queries/` folder, " +
             "register it via `services.AddQueryDefinition<T, TDefinition>()`, " +
-            "or add the entity to PairingExemptions with a justification.");
+            "or add the entity to PairingExemptions.Infrastructure with a justification (`[INFRA]`).");
     }
 
     private static (HashSet<Type> queryEntities, HashSet<Type> exportEntities) ScanEntities()

--- a/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
@@ -42,63 +42,21 @@ namespace Granit.ArchitectureTests;
 public sealed class QueryMetricPairingTests
 {
     /// <summary>
-    /// Entities exempted from the Query ↔ Metric pairing rule. Each entry MUST carry a
-    /// one-line justification (inline comment).
+    /// <c>[BACKLOG]</c> entities — admin-visible aggregates that <i>should</i>
+    /// ship at least one <see cref="MetricDefinition{TEntity, TValue}"/> but
+    /// haven't yet. These are exempted as a known-debt baseline at the time D1
+    /// (#1396) landed (post-A4 #1377). Remove an entry when the owning module
+    /// ships its first <c>MetricDefinition</c> for that entity — the rule then
+    /// begins enforcing for that entity going forward.
     /// </summary>
     /// <remarks>
-    /// This list is pre-populated with the current baseline at the time of D1's
-    /// introduction (EPIC #1366). Entries marked <c>[BACKLOG]</c> are admin-visible
-    /// entities that should eventually ship a metric — they are exempted today so the
-    /// rule can be enforced going forward without forcing a framework-wide retrofit.
-    /// Removing an entry from <c>[BACKLOG]</c> requires shipping at least one
-    /// MetricDefinition for that entity.
-    ///
-    /// Entries marked <c>[INFRA]</c> are genuine infrastructure / audit / internal cache
-    /// entities that have no useful KPI on the admin UI — these are permanent
-    /// exemptions.
+    /// <c>[INFRA]</c> exemptions live in the shared <see cref="PairingExemptions"/>
+    /// set so Query↔Export and Query↔Metric stay in lockstep. Each entry below MUST
+    /// carry a one-line justification (inline comment) describing the metric that
+    /// would unblock removal.
     /// </remarks>
-    private static readonly HashSet<string> PairingExemptions = new(StringComparer.Ordinal)
+    private static readonly HashSet<string> MetricBacklog = new(StringComparer.Ordinal)
     {
-        // ── [INFRA] permanent exemptions ────────────────────────────────────
-        // System / audit / configuration entities with no useful business KPI on the
-        // admin UI. These are not "admin-visible" in the grid-with-KPI sense — they
-        // either back tooling (saved views, exports), record auditing trails, or
-        // hold security / config state.
-
-        "Granit.AI.AIUsageRecord",                                                        // [INFRA] AI cost / audit log
-        "Granit.Auditing.Domain.AuditEntityChange",                                       // [INFRA] audit log
-        "Granit.Auditing.Domain.AuditEntry",                                              // [INFRA] audit log
-        "Granit.Authorization.Domain.PermissionGrant",                                    // [INFRA] RBAC config
-        "Granit.Authorization.Domain.RoleMetadata",                                       // [INFRA] RBAC config
-        "Granit.BackgroundJobs.Domain.BackgroundJobDefinition",                           // [INFRA] job config
-        "Granit.DataExchange.Export.Domain.ExportJob",                                    // [INFRA] transient export job
-        "Granit.DataExchange.Import.Domain.ImportJob",                                    // [INFRA] transient import job
-        "Granit.Identity.Federated.Domain.UserCacheEntry",                                // [INFRA] internal user cache
-        "Granit.Identity.Local.Domain.GranitRole",                                        // [INFRA] RBAC config
-        "Granit.Identity.Local.Domain.GranitUserGroup",                                   // [INFRA] RBAC config
-        "Granit.Localization.Domain.LocalizationOverride",                                // [INFRA] localization config
-        "Granit.Metering.Domain.MeterDefinition",                                         // [INFRA] metering config
-        "Granit.MultiTenancy.Domain.Tenant",                                              // [INFRA] platform-admin entity
-        "Granit.Notifications.Domain.NotificationPreference",                             // [INFRA] user preference config
-        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictApplication",              // [INFRA] OAuth client config
-        "Granit.OpenIddict.Entities.OpenIddict.GranitOpenIddictScope",                    // [INFRA] OAuth scope config
-        "Granit.Parties.EntityFrameworkCore.Entities.PartyDuplicateCandidate",            // [INFRA] deduplication queue
-        "Granit.QueryEngine.SavedViews.Domain.SavedView",                                 // [INFRA] grid tooling
-        "Granit.ReferenceData.Domain.DynamicReferenceDataEntity",                         // [INFRA] reference-data config
-        "Granit.Scheduling.Domain.ScheduledAction",                                       // [INFRA] scheduling state
-        "Granit.Settings.Domain.SettingRecord",                                           // [INFRA] settings config
-        "Granit.Tax.Domain.TaxRateOverride",                                              // [INFRA] tax config
-        "Granit.Tax.TaxRateEntry",                                                        // [INFRA] tax config
-        "Granit.Timeline.Domain.TimelineEntry",                                           // [INFRA] audit log
-        "Granit.Workflow.Domain.WorkflowTransitionRecord",                                // [INFRA] workflow audit
-
-        // ── [BACKLOG] admin-visible entities awaiting their first metric ────
-        // These DO surface in admin grids and SHOULD ship at least one MetricDefinition.
-        // They are exempted here as a known-debt baseline at the time D1 (#1396)
-        // landed (post-A4 #1377). Remove an entry from this list when the matching
-        // module ships its first MetricDefinition for that entity — the rule then
-        // begins enforcing for that entity going forward.
-
         "Granit.BlobStorage.Domain.BlobDescriptor",                                       // [BACKLOG] storage-usage KPIs
         "Granit.Catalog.Domain.Product",                                                  // [BACKLOG] catalog count / activation
         "Granit.CustomerBalance.Domain.BalanceAccount",                                   // [BACKLOG] balance totals
@@ -118,13 +76,16 @@ public sealed class QueryMetricPairingTests
         "Granit.Webhooks.Domain.WebhookSubscription",                                     // [BACKLOG] active-subscription count
     };
 
+    private static bool IsExempt(string fullName) =>
+        PairingExemptions.Infrastructure.Contains(fullName) || MetricBacklog.Contains(fullName);
+
     [Fact]
     public void Every_QueryDefinition_should_have_a_matching_MetricDefinition()
     {
         (HashSet<Type> queryEntities, HashSet<Type> metricEntities) = ScanEntities();
 
         IEnumerable<string> queryWithoutMetric = queryEntities
-            .Where(t => !metricEntities.Contains(t) && !PairingExemptions.Contains(t.FullName!))
+            .Where(t => !metricEntities.Contains(t) && !IsExempt(t.FullName!))
             .Select(t => t.FullName!)
             .OrderBy(s => s, StringComparer.Ordinal);
 
@@ -133,9 +94,8 @@ public sealed class QueryMetricPairingTests
             "should also have at least one MetricDefinition. " +
             "Add a `*MetricDefinition` in the same module's `Metrics/` folder, " +
             "register it via `services.AddMetricDefinition<TEntity, TValue, TDefinition>()`, " +
-            "or add the entity to PairingExemptions with a justification " +
-            "(`[BACKLOG]` for admin-visible entities awaiting their first metric, " +
-            "`[INFRA]` for permanent exemptions on infrastructure / audit / internal cache entities).");
+            "or add the entity to MetricBacklog (`[BACKLOG]` admin-visible entity awaiting its first metric) " +
+            "or PairingExemptions.Infrastructure (`[INFRA]` permanent exemption on an audit / config / cache entity).");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes the leftover DoD items on **#1396** (D1 — Query ↔ Metric pairing). The pairing test itself was already shipped earlier; what remained was:

1. **Shared exemption list** — the \`[INFRA]\` set was duplicated between \`QueryExportPairingTests\` and \`QueryMetricPairingTests\`. Both lists shared the same intent for audit / config / cache entities, so duplication invited drift.
2. **CLAUDE.md docs** — the canonical location + the \`[INFRA]\` vs \`[BACKLOG]\` distinction wasn't documented.

## What changes

- **New** \`tests/Granit.ArchitectureTests/PairingExemptions.cs\` — canonical \`Infrastructure\` set with one-line justifications.
- **\`QueryMetricPairingTests\`** — references \`PairingExemptions.Infrastructure\`. The \`[BACKLOG]\` entries (admin-visible entities awaiting their first metric) stay in a local \`MetricBacklog\` list because the backlog is metric-specific: an entity awaiting its first metric isn't awaiting its first export.
- **\`QueryExportPairingTests\`** — references \`PairingExemptions.Infrastructure\`. No backlog for Query↔Export: an admin-visible entity without an \`ExportDefinition\` is always rejected.
- **\`CLAUDE.md\`** — documents the canonical location, the \`[INFRA]\` vs \`[BACKLOG]\` split, and the rule that adding an \`[INFRA]\` entry exempts the entity from **both** pairings.

## Test plan

- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 158/158 passed
- [x] \`dotnet format .github/shard-filters/architecture.slnf --verify-no-changes\` — clean
- [x] \`npx markdownlint-cli2 CLAUDE.md\` — clean