### PR TITLE
feat(dashboards): MapWidgetDefinition — declarative geocoded-rows widget (B7-1 #1404)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4101,7 +4101,7 @@
       "kind": "class",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddAnalyticsWidgets",
@@ -4130,6 +4130,15 @@
       "members": []
     },
     {
+      "name": "Geography",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.Geography",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
+      "line": 30,
+      "members": []
+    },
+    {
       "name": "KpiWidgetDefinition",
       "fqn": "Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition",
       "kind": "record",
@@ -4137,6 +4146,69 @@
       "file": "src/Granit.Analytics/Dashboards/Widgets/KpiWidgetDefinition.cs",
       "line": 26,
       "members": []
+    },
+    {
+      "name": "LatLng",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.LatLng",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "MapCenter",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.MapCenter",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
+      "line": 88,
+      "members": [
+        {
+          "name": "MapCenter",
+          "kind": "method",
+          "signature": "MapCenter(double latitude, double longitude)",
+          "returnType": "double Latitude { get; } public double Longitude { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "MapPointSource",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.MapPointSource",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "LatLng",
+          "kind": "method",
+          "signature": "LatLng(string LatitudeColumn, string LongitudeColumn)",
+          "returnType": "sealed record"
+        },
+        {
+          "name": "Geography",
+          "kind": "method",
+          "signature": "Geography(string GeographyColumn)",
+          "returnType": "sealed record"
+        }
+      ]
+    },
+    {
+      "name": "MapWidgetDefinition",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.MapWidgetDefinition",
+      "kind": "record",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
+      "line": 67,
+      "members": [
+        {
+          "name": "MapCenter",
+          "kind": "method",
+          "signature": "MapCenter(double latitude, double longitude)",
+          "returnType": "double Latitude { get; } public double Longitude { get; } public"
+        }
+      ]
     },
     {
       "name": "PivotWidgetDefinition",

--- a/src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs
+++ b/src/Granit.Analytics/Dashboards/Json/AnalyticsWidgetSerialization.cs
@@ -5,21 +5,22 @@ using Granit.Dashboards.Json;
 namespace Granit.Analytics.Dashboards.Json;
 
 /// <summary>
-/// Convenience helpers wiring the four analytics-flavoured widget kinds
+/// Convenience helpers wiring the analytics-flavoured widget kinds
 /// (<see cref="KpiWidgetDefinition"/>, <see cref="ChartWidgetDefinition"/>,
-/// <see cref="TableWidgetDefinition"/>, <see cref="PivotWidgetDefinition"/>) into
-/// the JSON polymorphism chain shared by the dashboards stack.
+/// <see cref="TableWidgetDefinition"/>, <see cref="PivotWidgetDefinition"/>,
+/// <see cref="MapWidgetDefinition"/>) into the JSON polymorphism chain shared
+/// by the dashboards stack.
 /// </summary>
 /// <remarks>
 /// Hosts that expose dashboard endpoints call
 /// <see cref="AddAnalyticsWidgets(JsonSerializerOptions)"/> once on their shared
 /// <see cref="JsonSerializerOptions"/> at startup. The discriminators (<c>"kpi"</c>,
-/// <c>"chart"</c>, <c>"table"</c>, <c>"pivot"</c>) become the contract surfaced to
-/// frontends and stay stable across module upgrades.
+/// <c>"chart"</c>, <c>"table"</c>, <c>"pivot"</c>, <c>"map"</c>) become the
+/// contract surfaced to frontends and stay stable across module upgrades.
 /// </remarks>
 public static class AnalyticsWidgetSerialization
 {
-    /// <summary>Registers the four analytics widget kinds on the supplied options.</summary>
+    /// <summary>Registers the analytics widget kinds on the supplied options.</summary>
     /// <param name="options">Target serializer options.</param>
     /// <returns>The same <paramref name="options"/> for chaining.</returns>
     public static JsonSerializerOptions AddAnalyticsWidgets(this JsonSerializerOptions options)
@@ -30,6 +31,7 @@ public static class AnalyticsWidgetSerialization
         options.AddDerivedType<ChartWidgetDefinition>("chart");
         options.AddDerivedType<TableWidgetDefinition>("table");
         options.AddDerivedType<PivotWidgetDefinition>("pivot");
+        options.AddDerivedType<MapWidgetDefinition>("map");
 
         return options;
     }

--- a/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+using Granit.Dashboards;
+
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Describes how a <see cref="MapWidgetDefinition"/> reads coordinates from the
+/// rows produced by its backing <c>QueryDefinition</c>.
+/// </summary>
+/// <remarks>
+/// Two flavours are supported per B7 (#1404). The default <see cref="LatLng"/>
+/// path maps to plain decimal columns and works on any database. The opt-in
+/// <see cref="Geography"/> path reads a single <c>geography(Point)</c> column —
+/// PostGIS-only, but unlocks server-side spatial filters
+/// (<c>ST_DWithin</c>, <c>ST_Within</c>, …) in follow-up stories.
+/// JSON polymorphism uses the <c>"kind"</c> discriminator (<c>"lat-lng"</c> /
+/// <c>"geography"</c>) — same convention as <c>Datasource</c>.
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(LatLng), "lat-lng")]
+[JsonDerivedType(typeof(Geography), "geography")]
+public abstract record MapPointSource
+{
+    private MapPointSource() { }
+
+    /// <summary>Column-pair source: rows expose a decimal latitude and longitude.</summary>
+    public sealed record LatLng(string LatitudeColumn, string LongitudeColumn) : MapPointSource;
+
+    /// <summary>PostGIS source: a single <c>geography(Point)</c> column.</summary>
+    public sealed record Geography(string GeographyColumn) : MapPointSource;
+}
+
+/// <summary>
+/// Map widget — renders geocoded query rows as markers on an interactive map.
+/// Useful for any tenant with location data: customer addresses, branch offices,
+/// delivery routes, sales-by-region. Orthogonal to IoT real-time tracking
+/// (a future <c>granit-iot</c> dashboard module owns live device traces).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Bound to a <c>QueryDefinition</c> by name (same pattern as
+/// <see cref="TableWidgetDefinition"/>). The query's row shape determines how
+/// coordinates are read via <see cref="PointSource"/> — column pair on any
+/// database, or a single PostGIS <c>geography(Point)</c> column.
+/// </para>
+/// <para>
+/// Configuration is intentionally narrow at v1: cluster threshold, default
+/// camera (zoom + center), popup template, optional detail-route, optional
+/// tile-URL override. Permission filtering and per-widget overrides come from
+/// the parent <see cref="WidgetDefinition"/>.
+/// </para>
+/// </remarks>
+/// <param name="Slug">See <see cref="WidgetDefinition.Slug"/>.</param>
+/// <param name="QueryName">The <c>QueryDefinition.Name</c> backing this map.</param>
+/// <param name="PointSource">How rows expose coordinates — lat/lng pair or PostGIS geography column.</param>
+/// <param name="PopupColumns">Whitelisted column names rendered in the marker popup, in order. <c>null</c> = no popup body beyond the entity id.</param>
+/// <param name="DefaultZoom">Initial map zoom (Leaflet scale: 0 world → 18 building). Defaults to <c>5</c> (country level).</param>
+/// <param name="DefaultCenter">Initial map center as <c>(latitude, longitude)</c>. Falls back to the bounding box of the rendered points when <c>null</c>.</param>
+/// <param name="ClusterThreshold">Row count above which marker clustering activates automatically. Defaults to <c>200</c>.</param>
+/// <param name="DetailRoute">Optional route template invoked on marker click — <c>{id}</c> is substituted with the row's primary key. Example: <c>/customers/{id}</c>.</param>
+/// <param name="TileUrlTemplate">Optional Leaflet tile-URL template overriding the OpenStreetMap default. Frontend hosts MUST keep a visible attribution that matches the tile provider's licence.</param>
+/// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
+/// <param name="Size">Defaults to <see cref="WidgetSize.MediaTile"/> — maps usually want square real-estate.</param>
+/// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
+/// <param name="TimeWindowOverride">See <see cref="WidgetDefinition.TimeWindowOverride"/>.</param>
+/// <param name="Actions">See <see cref="WidgetDefinition.Actions"/>.</param>
+public sealed record MapWidgetDefinition(
+    string Slug,
+    string QueryName,
+    MapPointSource PointSource,
+    IReadOnlyList<string>? PopupColumns,
+    int Position,
+    int DefaultZoom = 5,
+    MapCenter? DefaultCenter = null,
+    int ClusterThreshold = 200,
+    string? DetailRoute = null,
+    string? TileUrlTemplate = null,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null,
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile, RequiredPermission, TimeWindowOverride, Actions);
+
+/// <summary>
+/// Latitude / longitude pair used to seed a <see cref="MapWidgetDefinition.DefaultCenter"/>.
+/// Coordinates outside <c>[-90, 90]</c> / <c>[-180, 180]</c> are rejected at construction.
+/// </summary>
+public sealed record MapCenter
+{
+    /// <summary>Latitude in decimal degrees, in <c>[-90, 90]</c>.</summary>
+    public double Latitude { get; }
+
+    /// <summary>Longitude in decimal degrees, in <c>[-180, 180]</c>.</summary>
+    public double Longitude { get; }
+
+    /// <summary>Creates a center, rejecting out-of-range coordinates.</summary>
+    public MapCenter(double latitude, double longitude)
+    {
+        if (latitude is < -90 or > 90)
+        {
+            throw new ArgumentOutOfRangeException(nameof(latitude), "Latitude must be within [-90, 90].");
+        }
+
+        if (longitude is < -180 or > 180)
+        {
+            throw new ArgumentOutOfRangeException(nameof(longitude), "Longitude must be within [-180, 180].");
+        }
+
+        Latitude = latitude;
+        Longitude = longitude;
+    }
+}

--- a/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/AnalyticsWidgetDefinitionTests.cs
@@ -81,4 +81,62 @@ public sealed class AnalyticsWidgetDefinitionTests
         widget.ValueField.ShouldBeNull();
         widget.ValueAggregation.ShouldBe(AggregateFunction.Count);
     }
+
+    [Fact]
+    public void Map_DefaultsToMediaTileSize_AndCarriesLatLngSource()
+    {
+        MapWidgetDefinition widget = new(
+            Slug: "Customers",
+            QueryName: "Sample.PartyQuery",
+            PointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
+            PopupColumns: ["Name", "City"],
+            Position: 0);
+
+        widget.Size.ShouldBe(WidgetSize.MediaTile);
+        widget.DefaultZoom.ShouldBe(5);
+        widget.DefaultCenter.ShouldBeNull();
+        widget.ClusterThreshold.ShouldBe(200);
+        widget.DetailRoute.ShouldBeNull();
+        widget.TileUrlTemplate.ShouldBeNull();
+        MapPointSource.LatLng latLng = widget.PointSource.ShouldBeOfType<MapPointSource.LatLng>();
+        latLng.LatitudeColumn.ShouldBe("Latitude");
+        latLng.LongitudeColumn.ShouldBe("Longitude");
+    }
+
+    [Fact]
+    public void Map_PostGisVariant_ExposesGeographyColumn()
+    {
+        MapWidgetDefinition widget = new(
+            Slug: "Offices",
+            QueryName: "Sample.OfficeQuery",
+            PointSource: new MapPointSource.Geography("Location"),
+            PopupColumns: null,
+            Position: 0);
+
+        MapPointSource.Geography geo = widget.PointSource.ShouldBeOfType<MapPointSource.Geography>();
+        geo.GeographyColumn.ShouldBe("Location");
+        widget.PopupColumns.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapCenter_RejectsLatitudeOutsideRange()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new MapCenter(latitude: 91.0, longitude: 0.0));
+        Should.Throw<ArgumentOutOfRangeException>(() => new MapCenter(latitude: -90.5, longitude: 0.0));
+    }
+
+    [Fact]
+    public void MapCenter_RejectsLongitudeOutsideRange()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new MapCenter(latitude: 0.0, longitude: 180.5));
+        Should.Throw<ArgumentOutOfRangeException>(() => new MapCenter(latitude: 0.0, longitude: -181.0));
+    }
+
+    [Fact]
+    public void MapCenter_AcceptsBoundaryCoordinates()
+    {
+        Should.NotThrow(() => new MapCenter(90.0, 180.0));
+        Should.NotThrow(() => new MapCenter(-90.0, -180.0));
+        Should.NotThrow(() => new MapCenter(0.0, 0.0));
+    }
 }

--- a/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/Json/AnalyticsWidgetSerializationTests.cs
@@ -9,10 +9,11 @@ using Xunit;
 namespace Granit.Analytics.Tests.Dashboards.Json;
 
 /// <summary>
-/// Exercises the round-trip for the four analytics widgets registered via
+/// Exercises the round-trip for the analytics widgets registered via
 /// <see cref="AnalyticsWidgetSerialization.AddAnalyticsWidgets"/> — the wire format
 /// must surface the canonical short discriminators (<c>"kpi"</c>, <c>"chart"</c>,
-/// <c>"table"</c>, <c>"pivot"</c>) and survive a serialize / deserialize cycle.
+/// <c>"table"</c>, <c>"pivot"</c>, <c>"map"</c>) and survive a serialize /
+/// deserialize cycle.
 /// </summary>
 public sealed class AnalyticsWidgetSerializationTests
 {
@@ -78,7 +79,40 @@ public sealed class AnalyticsWidgetSerializationTests
     }
 
     [Fact]
-    public void RoundTrip_PreservesAllFourAnalyticsWidgetTypes()
+    public void Map_SerializesWithStableDiscriminator()
+    {
+        WidgetDefinition widget = new MapWidgetDefinition(
+            Slug: "CustomerLocations",
+            QueryName: "Granit.Parties.PartyQuery",
+            PointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
+            PopupColumns: ["DisplayName", "City"],
+            Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"map\"");
+        json.ShouldNotContain("$type");
+    }
+
+    [Fact]
+    public void Map_PostGisVariant_SerializesWithGeographyColumn()
+    {
+        WidgetDefinition widget = new MapWidgetDefinition(
+            Slug: "BranchOffices",
+            QueryName: "Granit.Parties.OfficeQuery",
+            PointSource: new MapPointSource.Geography("Location"),
+            PopupColumns: ["DisplayName"],
+            Position: 0);
+
+        string json = JsonSerializer.Serialize(widget, NewOptions());
+
+        json.ShouldContain("\"type\":\"map\"");
+        json.ShouldContain("\"kind\":\"geography\"");
+        json.ShouldContain("\"GeographyColumn\":\"Location\"");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesAllAnalyticsWidgetTypes()
     {
         JsonSerializerOptions options = NewOptions();
 
@@ -88,6 +122,7 @@ public sealed class AnalyticsWidgetSerializationTests
             new ChartWidgetDefinition("Chart", "Q1", "g", AggregateFunction.Sum, "f", ChartType.Bar, Position: 1),
             new TableWidgetDefinition("Table", "Q1", null, 25, Position: 2),
             new PivotWidgetDefinition("Pivot", "Q1", ["r"], ["c"], null, AggregateFunction.Count, Position: 3),
+            new MapWidgetDefinition("Map", "Q1", new MapPointSource.LatLng("Lat", "Lng"), ["Name"], Position: 4),
         ];
 
         foreach (WidgetDefinition original in originals)
@@ -98,5 +133,39 @@ public sealed class AnalyticsWidgetSerializationTests
             decoded.ShouldNotBeNull();
             decoded.GetType().ShouldBe(original.GetType());
         }
+    }
+
+    [Fact]
+    public void Map_RoundTrip_PreservesAllConfigurationFields()
+    {
+        JsonSerializerOptions options = NewOptions();
+
+        MapWidgetDefinition original = new(
+            Slug: "Customers",
+            QueryName: "Granit.Parties.PartyQuery",
+            PointSource: new MapPointSource.LatLng("Lat", "Lng"),
+            PopupColumns: ["Name", "City"],
+            Position: 0,
+            DefaultZoom: 8,
+            DefaultCenter: new MapCenter(50.85, 4.35),
+            ClusterThreshold: 500,
+            DetailRoute: "/customers/{id}",
+            TileUrlTemplate: "https://tiles.example.com/{z}/{x}/{y}.png");
+
+        string json = JsonSerializer.Serialize<WidgetDefinition>(original, options);
+        WidgetDefinition? decoded = JsonSerializer.Deserialize<WidgetDefinition>(json, options);
+
+        MapWidgetDefinition map = decoded.ShouldBeOfType<MapWidgetDefinition>();
+        map.Slug.ShouldBe("Customers");
+        map.QueryName.ShouldBe("Granit.Parties.PartyQuery");
+        map.PointSource.ShouldBeOfType<MapPointSource.LatLng>();
+        map.PopupColumns.ShouldBe(["Name", "City"]);
+        map.DefaultZoom.ShouldBe(8);
+        map.DefaultCenter.ShouldNotBeNull();
+        map.DefaultCenter.Latitude.ShouldBe(50.85);
+        map.DefaultCenter.Longitude.ShouldBe(4.35);
+        map.ClusterThreshold.ShouldBe(500);
+        map.DetailRoute.ShouldBe("/customers/{id}");
+        map.TileUrlTemplate.ShouldBe("https://tiles.example.com/{z}/{x}/{y}.png");
     }
 }


### PR DESCRIPTION
## Summary

First slice of B7 (#1404) — ships the **declarative half** of the MapWidget. Renderer and React component land in follow-ups.

A `MapWidget` lets module authors expose a query whose rows carry coordinates as a marker map alongside their KPI / chart / table widgets — useful for any tenant with location data (customers by city, branch offices, deliveries, sales-by-region).

## What ships

- **`MapWidgetDefinition`** in `Granit.Analytics/Dashboards/Widgets/` — bound to a `QueryName` (same pattern as `TableWidgetDefinition`). Defaults: `Size = MediaTile`, `DefaultZoom = 5`, `ClusterThreshold = 200`, no detail route, OSM tiles.
- **`MapPointSource`** discriminated union:
  - `LatLng(LatitudeColumn, LongitudeColumn)` — any database
  - `Geography(GeographyColumn)` — PostGIS opt-in
- **`MapCenter`** with construction-time range checks (latitude in `[-90, 90]`, longitude in `[-180, 180]`).
- **JSON polymorphism**: `"map"` discriminator on `WidgetDefinition`, `"kind"` discriminator (`lat-lng` / `geography`) on `MapPointSource`. Same convention as `Datasource`.

## Tests

- **5 new** `AnalyticsWidgetDefinitionTests`: default sizing + LatLng exposure, PostGIS variant exposes the geography column, `MapCenter` rejects out-of-range latitude / longitude, accepts the boundaries.
- **3 new** `AnalyticsWidgetSerializationTests`: `"map"` discriminator stability, PostGIS variant carries `"kind":"geography"` + `GeographyColumn`, full-config round-trip (zoom + center + cluster + detail route + tile URL override).

## Out of scope (follow-ups)

- Server-side renderer producing `MapWidgetPayload` — depends on the broader B3 widget-renderer architecture.
- React `<MapWidget>` (B5 / `granit-front`).
- PostGIS integration test using the `postgis/postgis` Testcontainers image.
- `THIRD-PARTY-NOTICES.md` update for Leaflet / OSM tiles — lands with the React component PR.

## Test plan

- [x] `dotnet test tests/Granit.Analytics.Tests` — 35/35 passed (8 new + 27 existing)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 158/158 passed
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift