### PR TITLE
feat(dashboards): split OpenAPI tags into Catalogue / Instances / Widgets sub-groups

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13206,6 +13206,18 @@
           "kind": "property",
           "signature": "string CatalogTagName",
           "returnType": "string"
+        },
+        {
+          "name": "InstancesTagName",
+          "kind": "property",
+          "signature": "string InstancesTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "WidgetsTagName",
+          "kind": "property",
+          "signature": "string WidgetsTagName",
+          "returnType": "string"
         }
       ]
     },

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -13,14 +13,16 @@ namespace Granit.Dashboards.Endpoints.Extensions;
 public static class DashboardsEndpointRouteBuilderExtensions
 {
     /// <summary>
-    /// Maps the Granit.Dashboards endpoints onto <paramref name="endpoints"/>. Today
-    /// ships the read-only catalogue endpoint and the import endpoint
-    /// (<c>POST /from-definition/{name}</c>); the list / read / state-transition
-    /// endpoints land on the same route group in subsequent stories.
+    /// Maps the Granit.Dashboards endpoints onto <paramref name="endpoints"/>. The
+    /// surface is split across three OpenAPI sub-tags per CLAUDE.md tagging
+    /// convention: <c>Dashboards - Catalogue</c> for the read-only catalogue,
+    /// <c>Dashboards - Instances</c> for the persisted aggregate (import, list,
+    /// read, edit, state transitions), and <c>Dashboards - Widgets</c> for the
+    /// widget-pool CRUD.
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="DashboardsEndpointsOptions"/>.</param>
-    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    /// <returns>The outer <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitDashboards(
         this IEndpointRouteBuilder endpoints,
         Action<DashboardsEndpointsOptions>? configure = null)
@@ -28,16 +30,25 @@ public static class DashboardsEndpointRouteBuilderExtensions
         DashboardsEndpointsOptions options = new();
         configure?.Invoke(options);
 
-        RouteGroupBuilder group = endpoints
-            .MapGranitGroup(options.RoutePrefix)
-            .WithTags(options.CatalogTagName);
+        RouteGroupBuilder group = endpoints.MapGranitGroup(options.RoutePrefix);
 
-        group.MapCatalogEndpoints();
-        group.MapImportEndpoints();
-        group.MapInstanceEndpoints();
-        group.MapMetadataEditEndpoints();
-        group.MapStateTransitionEndpoints();
-        group.MapWidgetEndpoints();
+        // Catalogue — read-only view of registered DashboardDefinitions.
+        RouteGroupBuilder catalogGroup = group.MapGranitGroup("")
+            .WithTags(options.CatalogTagName);
+        catalogGroup.MapCatalogEndpoints();
+
+        // Instances — the persisted Dashboard aggregate (import + CRUD on metadata + state machine).
+        RouteGroupBuilder instancesGroup = group.MapGranitGroup("")
+            .WithTags(options.InstancesTagName);
+        instancesGroup.MapImportEndpoints();
+        instancesGroup.MapInstanceEndpoints();
+        instancesGroup.MapMetadataEditEndpoints();
+        instancesGroup.MapStateTransitionEndpoints();
+
+        // Widgets — pool CRUD scoped under /{id}/widgets.
+        RouteGroupBuilder widgetsGroup = group.MapGranitGroup("")
+            .WithTags(options.WidgetsTagName);
+        widgetsGroup.MapWidgetEndpoints();
 
         return group;
     }

--- a/src/Granit.Dashboards.Endpoints/Options/DashboardsEndpointsOptions.cs
+++ b/src/Granit.Dashboards.Endpoints/Options/DashboardsEndpointsOptions.cs
@@ -15,9 +15,23 @@ public sealed class DashboardsEndpointsOptions
     public string RoutePrefix { get; set; } = "dashboards";
 
     /// <summary>
-    /// OpenAPI tag for the dashboards endpoints. Per CLAUDE.md sub-tag convention
+    /// OpenAPI tag for the dashboard catalogue endpoints (read-only view of every
+    /// registered <c>DashboardDefinition</c>). Per CLAUDE.md sub-tag convention
     /// (<c>&lt;Module&gt; - &lt;SubGroup&gt;</c>) the catalogue gets its own subgroup
-    /// to keep room for the upcoming import / CRUD endpoints.
+    /// so Scalar groups it alphabetically next to its siblings.
     /// </summary>
     public string CatalogTagName { get; set; } = "Dashboards - Catalogue";
+
+    /// <summary>
+    /// OpenAPI tag for the persisted Dashboard aggregate endpoints — list,
+    /// read-by-id, import, edit metadata, state transitions (publish / archive
+    /// / restore). Per CLAUDE.md sub-tag convention.
+    /// </summary>
+    public string InstancesTagName { get; set; } = "Dashboards - Instances";
+
+    /// <summary>
+    /// OpenAPI tag for the widget pool endpoints — add / update / remove widget
+    /// instances on a persisted dashboard. Per CLAUDE.md sub-tag convention.
+    /// </summary>
+    public string WidgetsTagName { get; set; } = "Dashboards - Widgets";
 }

--- a/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Granit.Dashboards.Endpoints.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Dashboards.Endpoints.Tests/MapGranitDashboardsTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/MapGranitDashboardsTests.cs
@@ -1,0 +1,125 @@
+using Granit.Dashboards.Endpoints.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests;
+
+/// <summary>
+/// Locks the OpenAPI sub-tag wiring for <c>MapGranitDashboards</c> — every endpoint
+/// must carry exactly one of the three documented tags
+/// (<c>Dashboards - Catalogue</c>, <c>Dashboards - Instances</c>,
+/// <c>Dashboards - Widgets</c>) per the route group it belongs to. CLAUDE.md
+/// tagging convention: <c>&lt;Module&gt; - &lt;SubGroup&gt;</c>.
+/// </summary>
+public sealed class MapGranitDashboardsTests
+{
+    [Fact]
+    public void MapGranitDashboards_WithDefaultOptions_ReturnsRouteGroup()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        WebApplication app = builder.Build();
+
+        RouteGroupBuilder result = app.MapGranitDashboards();
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void MapGranitDashboards_GroupsCatalogueImportInstancesAndWidgetsUnderDistinctTags()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        WebApplication app = builder.Build();
+
+        app.MapGranitDashboards();
+
+        Dictionary<string, IReadOnlyList<string>> tagsByPath = CollectTagsByPath(app);
+
+        AssertTag(tagsByPath, "/dashboards/catalog", "Dashboards - Catalogue");
+
+        // Instances sub-tag covers import + list + read + edit + state transitions.
+        AssertTag(tagsByPath, "/dashboards/from-definition/{name}", "Dashboards - Instances");
+        AssertTag(tagsByPath, "/dashboards/", "Dashboards - Instances");
+        AssertTag(tagsByPath, "/dashboards/{id:guid}", "Dashboards - Instances");
+        AssertTag(tagsByPath, "/dashboards/{id:guid}/publish", "Dashboards - Instances");
+        AssertTag(tagsByPath, "/dashboards/{id:guid}/archive", "Dashboards - Instances");
+        AssertTag(tagsByPath, "/dashboards/{id:guid}/restore", "Dashboards - Instances");
+
+        // Widgets sub-tag scopes the widget pool.
+        AssertTag(tagsByPath, "/dashboards/{id:guid}/widgets", "Dashboards - Widgets");
+        AssertTag(tagsByPath, "/dashboards/{id:guid}/widgets/{widgetId:guid}", "Dashboards - Widgets");
+    }
+
+    [Fact]
+    public void MapGranitDashboards_HonoursCustomTagOverrides()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        WebApplication app = builder.Build();
+
+        app.MapGranitDashboards(opts =>
+        {
+            opts.CatalogTagName = "BI - Catalog";
+            opts.InstancesTagName = "BI - Instances";
+            opts.WidgetsTagName = "BI - Widgets";
+        });
+
+        HashSet<string> distinctTags = [.. CollectTagsByPath(app).Values.SelectMany(t => t)];
+
+        distinctTags.ShouldBe(["BI - Catalog", "BI - Instances", "BI - Widgets"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void MapGranitDashboards_HonoursCustomRoutePrefix()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        WebApplication app = builder.Build();
+
+        app.MapGranitDashboards(opts => opts.RoutePrefix = "bi");
+
+        Dictionary<string, IReadOnlyList<string>> tagsByPath = CollectTagsByPath(app);
+        AssertTag(tagsByPath, "/bi/catalog", "Dashboards - Catalogue");
+    }
+
+    private static void AssertTag(Dictionary<string, IReadOnlyList<string>> tagsByPath, string path, string expectedTag)
+    {
+        tagsByPath.ShouldContainKey(path,
+            customMessage: $"Expected an endpoint at '{path}'. Available paths: {string.Join(", ", tagsByPath.Keys.OrderBy(k => k))}.");
+        tagsByPath[path].ShouldBe([expectedTag]);
+    }
+
+    private static Dictionary<string, IReadOnlyList<string>> CollectTagsByPath(WebApplication app)
+    {
+        Dictionary<string, IReadOnlyList<string>> result = [];
+
+        IEnumerable<Endpoint> endpoints = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(s => s.Endpoints);
+
+        foreach (Endpoint endpoint in endpoints)
+        {
+            if (endpoint is not RouteEndpoint route)
+            {
+                continue;
+            }
+
+            ITagsMetadata? tags = endpoint.Metadata.GetMetadata<ITagsMetadata>();
+            if (tags is null)
+            {
+                continue;
+            }
+
+            string path = "/" + route.RoutePattern.RawText?.TrimStart('/');
+            result[path] = [.. tags.Tags];
+        }
+
+        return result;
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "7.1.0",
         "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -106,6 +117,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -165,6 +181,58 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -177,6 +245,16 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -200,6 +278,50 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -208,6 +330,67 @@
           "Microsoft.Extensions.DependencyInjection": "10.0.7",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -308,8 +491,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
       "System.Management": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Splits the dashboards endpoint surface across **three OpenAPI tags** per the CLAUDE.md tagging convention (\`<Module> - <SubGroup>\`). Today every endpoint lands under one \`Dashboards - Catalogue\` tag — that label predates the import / CRUD endpoints and lumps everything together in Scalar.

After this PR:

| Sub-tag | Endpoints |
| ------- | --------- |
| \`Dashboards - Catalogue\` | \`GET /dashboards/catalog\` |
| \`Dashboards - Instances\` | \`POST /dashboards/from-definition/{name}\`, \`GET /dashboards\`, \`GET /dashboards/{id}\`, \`PUT /dashboards/{id}\`, \`POST /{id}/{publish,archive,restore}\` |
| \`Dashboards - Widgets\` | \`POST /dashboards/{id}/widgets\`, \`PUT /dashboards/{id}/widgets/{widgetId}\`, \`DELETE /dashboards/{id}/widgets/{widgetId}\` |

## What changes

- **\`DashboardsEndpointsOptions\`**: ships \`InstancesTagName\` + \`WidgetsTagName\` alongside the existing \`CatalogTagName\`. Sensible defaults, fully overridable.
- **\`MapGranitDashboards\`** now builds three nested \`MapGranitGroup(\"\")\` route groups under the route prefix, each with its own \`.WithTags(...)\`. Same shape as \`Granit.AI.Endpoints\`' four-tag split — keeps the framework's surface consistent.
- **4 new \`MapGranitDashboardsTests\`**: returns-non-null smoke, default-tags per-route mapping, custom-tag override, custom-route-prefix. Reads tags directly from the route data source's endpoint metadata via \`ITagsMetadata\`.

## Test plan

- [x] \`dotnet test tests/Granit.Dashboards.Endpoints.Tests\` — 75/75 passed (4 new + 71 existing)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 158/158 passed
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` — clean
- [x] \`dotnet restore Granit.slnx --force-evaluate\` — only the new \`Microsoft.AspNetCore.Mvc.Testing\` reference reflected in the lockfile