### PR TITLE
test(archi): permission localization completeness across the 18 cultures

### DIFF
--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Zobrazit právní dokumenty a stav souhlasu",
     "Permission:Privacy.Deletion.Execute": "Požádat o smazání osobních údajů",
     "Permission:Privacy.Export.Execute": "Požádat o export osobních údajů",
+    "Permission:Privacy.LegalDocuments.Create": "Vytvořit nové návrhy právních dokumentů",
+    "Permission:Privacy.LegalDocuments.Manage": "Upravit, publikovat a archivovat právní dokumenty",
+    "Permission:Privacy.LegalDocuments.Read": "Zobrazit verze a historii právních dokumentů",
     "Permission:Privacy.Purposes.Read": "Zobrazit registrované účely zpracování",
     "PermissionGroup:Privacy": "Soukromí (GDPR)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Rechtliche Dokumente und Einwilligungsstatus anzeigen",
     "Permission:Privacy.Deletion.Execute": "Löschung personenbezogener Daten anfordern",
     "Permission:Privacy.Export.Execute": "Export personenbezogener Daten anfordern",
+    "Permission:Privacy.LegalDocuments.Create": "Neue Entwürfe rechtlicher Dokumente erstellen",
+    "Permission:Privacy.LegalDocuments.Manage": "Rechtliche Dokumente bearbeiten, veröffentlichen und archivieren",
+    "Permission:Privacy.LegalDocuments.Read": "Versionen und Historie rechtlicher Dokumente anzeigen",
     "Permission:Privacy.Purposes.Read": "Registrierte Verarbeitungszwecke anzeigen",
     "PermissionGroup:Privacy": "Datenschutz (DSGVO)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "View legal documents and consent status",
     "Permission:Privacy.Deletion.Execute": "Request personal data deletion",
     "Permission:Privacy.Export.Execute": "Request personal data export",
+    "Permission:Privacy.LegalDocuments.Create": "Create new legal document drafts",
+    "Permission:Privacy.LegalDocuments.Manage": "Edit, publish, and archive legal documents",
+    "Permission:Privacy.LegalDocuments.Read": "View legal document versions and history",
     "Permission:Privacy.Purposes.Read": "Read registered processing purposes",
     "PermissionGroup:Privacy": "Privacy"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Ver documentos legales y estado de consentimiento",
     "Permission:Privacy.Deletion.Execute": "Solicitar eliminación de datos personales",
     "Permission:Privacy.Export.Execute": "Solicitar exportación de datos personales",
+    "Permission:Privacy.LegalDocuments.Create": "Crear nuevos borradores de documentos legales",
+    "Permission:Privacy.LegalDocuments.Manage": "Editar, publicar y archivar documentos legales",
+    "Permission:Privacy.LegalDocuments.Read": "Ver versiones e historial de documentos legales",
     "Permission:Privacy.Purposes.Read": "Consultar los fines del tratamiento",
     "PermissionGroup:Privacy": "Privacidad (RGPD)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Consulter les documents légaux et le statut de consentement",
     "Permission:Privacy.Deletion.Execute": "Demander la suppression des données personnelles",
     "Permission:Privacy.Export.Execute": "Demander l'export des données personnelles",
+    "Permission:Privacy.LegalDocuments.Create": "Créer de nouveaux brouillons de documents légaux",
+    "Permission:Privacy.LegalDocuments.Manage": "Modifier, publier et archiver les documents légaux",
+    "Permission:Privacy.LegalDocuments.Read": "Consulter les versions et l'historique des documents légaux",
     "Permission:Privacy.Purposes.Read": "Consulter les finalités de traitement",
     "PermissionGroup:Privacy": "Confidentialité (RGPD)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/hi.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "कानूनी दस्तावेज़ और सहमति स्थिति देखें",
     "Permission:Privacy.Deletion.Execute": "व्यक्तिगत डेटा हटाने का अनुरोध करें",
     "Permission:Privacy.Export.Execute": "व्यक्तिगत डेटा निर्यात का अनुरोध करें",
+    "Permission:Privacy.LegalDocuments.Create": "नए कानूनी दस्तावेज़ ड्राफ़्ट बनाएं",
+    "Permission:Privacy.LegalDocuments.Manage": "कानूनी दस्तावेज़ों को संपादित करें, प्रकाशित करें और संग्रहीत करें",
+    "Permission:Privacy.LegalDocuments.Read": "कानूनी दस्तावेज़ संस्करण और इतिहास देखें",
     "Permission:Privacy.Purposes.Read": "पंजीकृत प्रसंस्करण उद्देश्य पढ़ें",
     "PermissionGroup:Privacy": "गोपनीयता"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Visualizzare documenti legali e stato del consenso",
     "Permission:Privacy.Deletion.Execute": "Richiedere la cancellazione dei dati personali",
     "Permission:Privacy.Export.Execute": "Richiedere l'esportazione dei dati personali",
+    "Permission:Privacy.LegalDocuments.Create": "Creare nuove bozze di documenti legali",
+    "Permission:Privacy.LegalDocuments.Manage": "Modificare, pubblicare e archiviare documenti legali",
+    "Permission:Privacy.LegalDocuments.Read": "Visualizzare versioni e cronologia dei documenti legali",
     "Permission:Privacy.Purposes.Read": "Consultare le finalità del trattamento",
     "PermissionGroup:Privacy": "Privacy (GDPR)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "法的文書と同意ステータスを表示",
     "Permission:Privacy.Deletion.Execute": "個人データの削除を要求",
     "Permission:Privacy.Export.Execute": "個人データのエクスポートを要求",
+    "Permission:Privacy.LegalDocuments.Create": "法的文書の新しいドラフトを作成",
+    "Permission:Privacy.LegalDocuments.Manage": "法的文書を編集、公開、アーカイブ",
+    "Permission:Privacy.LegalDocuments.Read": "法的文書のバージョンと履歴を表示",
     "Permission:Privacy.Purposes.Read": "登録済みの処理目的を表示",
     "PermissionGroup:Privacy": "プライバシー (GDPR)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "법적 문서 및 동의 상태 조회",
     "Permission:Privacy.Deletion.Execute": "개인 데이터 삭제 요청",
     "Permission:Privacy.Export.Execute": "개인 데이터 내보내기 요청",
+    "Permission:Privacy.LegalDocuments.Create": "새 법적 문서 초안 작성",
+    "Permission:Privacy.LegalDocuments.Manage": "법적 문서 편집, 게시 및 보관",
+    "Permission:Privacy.LegalDocuments.Read": "법적 문서 버전 및 이력 조회",
     "Permission:Privacy.Purposes.Read": "등록된 처리 목적 조회",
     "PermissionGroup:Privacy": "개인정보 (GDPR)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Juridische documenten en toestemmingsstatus bekijken",
     "Permission:Privacy.Deletion.Execute": "Verwijdering van persoonsgegevens aanvragen",
     "Permission:Privacy.Export.Execute": "Export van persoonsgegevens aanvragen",
+    "Permission:Privacy.LegalDocuments.Create": "Nieuwe concepten van juridische documenten maken",
+    "Permission:Privacy.LegalDocuments.Manage": "Juridische documenten bewerken, publiceren en archiveren",
+    "Permission:Privacy.LegalDocuments.Read": "Versies en geschiedenis van juridische documenten bekijken",
     "Permission:Privacy.Purposes.Read": "Geregistreerde verwerkingsdoeleinden bekijken",
     "PermissionGroup:Privacy": "Privacy (AVG)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Wyświetlanie dokumentów prawnych i statusu zgody",
     "Permission:Privacy.Deletion.Execute": "Żądanie usunięcia danych osobowych",
     "Permission:Privacy.Export.Execute": "Żądanie eksportu danych osobowych",
+    "Permission:Privacy.LegalDocuments.Create": "Tworzenie nowych szkiców dokumentów prawnych",
+    "Permission:Privacy.LegalDocuments.Manage": "Edytowanie, publikowanie i archiwizowanie dokumentów prawnych",
+    "Permission:Privacy.LegalDocuments.Read": "Wyświetlanie wersji i historii dokumentów prawnych",
     "Permission:Privacy.Purposes.Read": "Przeglądaj zarejestrowane cele przetwarzania",
     "PermissionGroup:Privacy": "Prywatność (RODO)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Ver documentos legais e estado de consentimento",
     "Permission:Privacy.Deletion.Execute": "Solicitar eliminação de dados pessoais",
     "Permission:Privacy.Export.Execute": "Solicitar exportação de dados pessoais",
+    "Permission:Privacy.LegalDocuments.Create": "Criar novos rascunhos de documentos legais",
+    "Permission:Privacy.LegalDocuments.Manage": "Editar, publicar e arquivar documentos legais",
+    "Permission:Privacy.LegalDocuments.Read": "Ver versões e histórico de documentos legais",
     "Permission:Privacy.Purposes.Read": "Consultar as finalidades do tratamento",
     "PermissionGroup:Privacy": "Privacidade (RGPD)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Visa juridiska dokument och samtycksstatus",
     "Permission:Privacy.Deletion.Execute": "Begär radering av personuppgifter",
     "Permission:Privacy.Export.Execute": "Begär export av personuppgifter",
+    "Permission:Privacy.LegalDocuments.Create": "Skapa nya utkast till juridiska dokument",
+    "Permission:Privacy.LegalDocuments.Manage": "Redigera, publicera och arkivera juridiska dokument",
+    "Permission:Privacy.LegalDocuments.Read": "Visa versioner och historik för juridiska dokument",
     "Permission:Privacy.Purposes.Read": "Visa registrerade behandlingsändamål",
     "PermissionGroup:Privacy": "Integritet (GDPR)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "Yasal belgeleri ve onay durumunu görüntüle",
     "Permission:Privacy.Deletion.Execute": "Kişisel veri silme talep et",
     "Permission:Privacy.Export.Execute": "Kişisel veri dışa aktarımı talep et",
+    "Permission:Privacy.LegalDocuments.Create": "Yeni yasal belge taslakları oluştur",
+    "Permission:Privacy.LegalDocuments.Manage": "Yasal belgeleri düzenle, yayınla ve arşivle",
+    "Permission:Privacy.LegalDocuments.Read": "Yasal belgelerin sürümlerini ve geçmişini görüntüle",
     "Permission:Privacy.Purposes.Read": "Kayıtlı işleme amaçlarını görüntüle",
     "PermissionGroup:Privacy": "Gizlilik (KVKK)"
   }

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
@@ -5,6 +5,9 @@
     "Permission:Privacy.Agreements.Read": "查看法律文件和同意状态",
     "Permission:Privacy.Deletion.Execute": "请求删除个人数据",
     "Permission:Privacy.Export.Execute": "请求导出个人数据",
+    "Permission:Privacy.LegalDocuments.Create": "创建新的法律文档草稿",
+    "Permission:Privacy.LegalDocuments.Manage": "编辑、发布和归档法律文档",
+    "Permission:Privacy.LegalDocuments.Read": "查看法律文档的版本和历史记录",
     "Permission:Privacy.Purposes.Read": "查看已注册的处理目的",
     "PermissionGroup:Privacy": "隐私 (GDPR)"
   }

--- a/tests/Granit.ArchitectureTests/PermissionLocalizationCompletenessTests.cs
+++ b/tests/Granit.ArchitectureTests/PermissionLocalizationCompletenessTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Companion to <see cref="MetricLocalizationCompletenessTests"/> and
+/// <see cref="DashboardLocalizationCompletenessTests"/> — extends the same
+/// 15-base-cultures completeness rule to permission constants. Every
+/// <c>public const string Name = "Group.Resource.Action";</c> in a module's
+/// <c>*Permissions.cs</c> file MUST have a <c>Permission:{value}</c> resource
+/// key in all 15 base cultures of that module's <c>Localization/</c> directory.
+/// Regional variants (<c>fr-CA</c>, <c>en-GB</c>, <c>pt-BR</c>) are exempt:
+/// they ship only differing keys and fall through to their parent culture.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure aggregates every (permission, culture) pair missing a key, so a
+/// developer adding a new permission without a complete translation pack sees
+/// the entire list at once instead of one-failure-per-culture spam.
+/// </para>
+/// <para>
+/// <see cref="PairingExemptions"/> is not used here — permissions are always
+/// user-facing and there is no equivalent of an <c>[INFRA]</c> exemption (an
+/// internal permission that nobody will ever see translated). If a permission
+/// surfaces in the admin UI, it surfaces in every supported culture.
+/// </para>
+/// </remarks>
+public sealed partial class PermissionLocalizationCompletenessTests
+{
+    private static readonly string[] BaseCultures =
+    [
+        "en", "fr", "nl", "de", "es", "it", "pt", "zh", "ja",
+        "pl", "tr", "ko", "sv", "cs", "hi",
+    ];
+
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Every_permission_constant_should_have_localization_keys_in_all_base_cultures()
+    {
+        IReadOnlyList<PermissionDescriptor> permissions = ScanPermissions();
+        permissions.ShouldNotBeEmpty(
+            "No permissions discovered — the test cannot run. " +
+            "Ensure at least one *.Endpoints module ships a *Permissions.cs file with a permission constant.");
+
+        List<string> missing = [];
+
+        foreach (PermissionDescriptor permission in permissions)
+        {
+            string moduleSrcDir = Path.Join(RepoRoot, "src", permission.OwningModuleDir);
+            string localizationDir = Path.Join(moduleSrcDir, "Localization");
+
+            if (!Directory.Exists(localizationDir))
+            {
+                missing.Add(
+                    $"{permission.Value} (declared in {permission.OwningModuleDir}): " +
+                    $"Localization/ directory not found at {Path.GetRelativePath(RepoRoot, localizationDir)}");
+                continue;
+            }
+
+            string resourceKey = $"Permission:{permission.Value}";
+
+            foreach (string culture in BaseCultures)
+            {
+                bool found = LocateKeyInCultureFiles(localizationDir, culture, resourceKey);
+                if (!found)
+                {
+                    missing.Add(
+                        $"{permission.Value} -> {culture} " +
+                        $"(expected key '{resourceKey}' in src/{permission.OwningModuleDir}/Localization/**/{culture}.json)");
+                }
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            $"Every permission constant must have a 'Permission:{{Value}}' key in all 15 base cultures " +
+            $"of its owning module. {missing.Count} key(s) missing:" + Environment.NewLine +
+            string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
+    }
+
+    private static bool LocateKeyInCultureFiles(string localizationDir, string culture, string resourceKey)
+    {
+        string[] candidateFiles = Directory.GetFiles(localizationDir, $"{culture}.json", SearchOption.AllDirectories);
+        return candidateFiles.Any(file => FileContainsKey(file, resourceKey));
+    }
+
+    private static bool FileContainsKey(string filePath, string key)
+    {
+        using FileStream stream = File.OpenRead(filePath);
+        using var document = JsonDocument.Parse(stream);
+
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        // Granit localization files use either a flat root object ({ "Key": "Value" })
+        // or a nested layout with the culture envelope ({ "culture": "...", "texts": { "Key": "Value" } }).
+        if (root.TryGetProperty("texts", out JsonElement texts)
+            && texts.ValueKind == JsonValueKind.Object
+            && texts.TryGetProperty(key, out _))
+        {
+            return true;
+        }
+
+        return root.TryGetProperty(key, out _);
+    }
+
+    private static List<PermissionDescriptor> ScanPermissions()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<PermissionDescriptor> permissions = [];
+
+        foreach (string permissionFile in EnumeratePermissionFiles(srcDir))
+        {
+            string relativePath = Path.GetRelativePath(srcDir, permissionFile);
+            string moduleDir = relativePath.Split(Path.DirectorySeparatorChar)[0];
+
+            foreach ((string name, string value) in EnumeratePermissionConstants(permissionFile))
+            {
+                if (name == "GroupName")
+                {
+                    continue;
+                }
+
+                permissions.Add(new PermissionDescriptor(value, moduleDir));
+            }
+        }
+
+        return permissions;
+    }
+
+    private static IEnumerable<string> EnumeratePermissionFiles(string srcDir)
+    {
+        foreach (string csFile in Directory.GetFiles(srcDir, "*Permissions.cs", SearchOption.AllDirectories))
+        {
+            if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            string relativePath = Path.GetRelativePath(srcDir, csFile);
+            string moduleName = relativePath.Split(Path.DirectorySeparatorChar)[0];
+            if (!moduleName.EndsWith(".Endpoints", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            yield return csFile;
+        }
+    }
+
+    private static IEnumerable<(string Name, string Value)> EnumeratePermissionConstants(string file)
+    {
+        foreach (string line in File.ReadLines(file))
+        {
+            Match match = PermissionConstant().Match(line);
+            if (match.Success)
+            {
+                yield return (match.Groups[1].Value, match.Groups[2].Value);
+            }
+        }
+    }
+
+    [GeneratedRegex(@"public\s+const\s+string\s+(\w+)\s*=\s*""([^""]+)""", RegexOptions.Multiline)]
+    private static partial Regex PermissionConstant();
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(PermissionLocalizationCompletenessTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    private sealed record PermissionDescriptor(string Value, string OwningModuleDir);
+}


### PR DESCRIPTION
## Summary

Adds the missing companion to \`MetricLocalizationCompleteness\` / \`DashboardLocalizationCompleteness\` — extends the same 15-base-cultures completeness rule to permission constants. Every \`public const string\` in a module's \`*Permissions.cs\` file must have a matching \`Permission:{value}\` resource key in all 15 base cultures of that module's \`Localization/\` directory.

## Test design

- Scans \`src/*.Endpoints/**/*Permissions.cs\` (same shape as \`PermissionConventionTests\`).
- Parses \`public const string ... = \"...\";\` constants, skips \`GroupName\`.
- For each \`{value}\` like \`Privacy.LegalDocuments.Read\`, looks for \`Permission:{value}\` in every base-culture JSON file under the module's \`Localization/\` tree.
- Failure aggregates every \`(permission, culture)\` pair so a developer adding a new permission without a complete translation pack sees the whole list at once.

No exemption list: permissions are always user-facing — an internal permission nobody sees translated is itself a bug worth catching.

## Baseline gap fixed

\`Granit.Privacy.Endpoints\` had three permissions with **no** localization at all:

- \`Privacy.LegalDocuments.Read\` — view legal document versions and history
- \`Privacy.LegalDocuments.Create\` — create new legal document drafts
- \`Privacy.LegalDocuments.Manage\` — edit, publish, and archive legal documents

Translations added in the 15 base cultures (en/fr/nl/de/es/it/pt/zh/ja/pl/tr/ko/sv/cs/hi), following the existing \`PrivacyEndpoints\` translation conventions — including the locale-native GDPR acronyms already in use (RGPD / DSGVO / RODO / GDPR / KVKK / AVG / …).

## Test plan

- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 159/159 passed (1 new + 158 existing)
- [x] \`dotnet format .github/shard-filters/architecture.slnf --verify-no-changes\` — clean