### PR TITLE
docs(dashboards): cross-link analytics inline metrics with dashboards endpoints

### DIFF
--- a/docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx
@@ -271,4 +271,6 @@ Migration story for module upgrades that remove a `DashboardDefinition`:
 ## Read next
 
 - [Overview](/dotnet/business/analytics/) — Three-layer BI stack, package structure.
+- [Inline metrics](/dotnet/business/analytics/inline-metrics/) — Walk-through of declaring, registering, and rendering a `MetricDefinition` end-to-end.
 - [Dashboards conventions](/dotnet/business/dashboards/conventions/) — `DashboardDefinition` shape, the seven widget kinds, `Datasource` abstraction, JSON wire format.
+- [Dashboards endpoints](/dotnet/business/dashboards/endpoints/) — REST surface (catalogue / import / list / read / state transitions / widget CRUD) that hosts the rendered metrics.

--- a/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
@@ -124,3 +124,10 @@ breaking pull consumers.
 
 - [Conventions](/dotnet/business/analytics/conventions/) — Naming rules, mandatory
   metric structure, localization keys, project layout. Read this first.
+- [Inline metrics](/dotnet/business/analytics/inline-metrics/) — Layer 1 walk-through:
+  declare, register, render a `MetricDefinition` end-to-end.
+- [Dashboards — Overview](/dotnet/business/dashboards/) — Layer 2: composable
+  widget grids that consume the same metrics via `KpiWidgetDefinition`.
+- [Dashboards — Endpoints](/dotnet/business/dashboards/endpoints/) — REST
+  surface that exposes the persisted `Dashboard` aggregate (catalogue / import
+  / list / read / state transitions / widget CRUD).

--- a/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
@@ -243,3 +243,7 @@ Use these as a starting template when shipping metrics for your own module.
 - [Overview](/dotnet/business/analytics/) — Three-layer BI stack
 - [Conventions](/dotnet/business/analytics/conventions/) — Naming formula, period
   tokens, anti-patterns
+- [Dashboards — Conventions](/dotnet/business/dashboards/conventions/) — How
+  inline metrics compose into widget-grid dashboards via `KpiWidgetDefinition`
+- [Dashboards — Endpoints](/dotnet/business/dashboards/endpoints/) — REST
+  surface that hosts the rendered metrics inside dashboards

--- a/docs-site/src/content/docs/dotnet/business/dashboards/conventions.mdx
+++ b/docs-site/src/content/docs/dotnet/business/dashboards/conventions.mdx
@@ -360,3 +360,4 @@ helper for its widget catalogue.
 - [Endpoints](/dotnet/business/dashboards/endpoints/) — REST surface: catalogue, import, CRUD, state transitions, widget CRUD
 - [ADR-038](/dotnet/architecture/adr/038-analytics-dashboard-definition-vs-aggregate/) — DashboardDefinition vs Dashboard boundary
 - [Analytics conventions](/dotnet/business/analytics/conventions/) — `MetricDefinition` naming, period tokens
+- [Inline metrics](/dotnet/business/analytics/inline-metrics/) — How a metric used by a `KpiWidget` is declared, registered, and rendered (Layer 1 walk-through)

--- a/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
@@ -209,5 +209,7 @@ which UIs treat as benign.
 ## Read next
 
 - [Conventions](/dotnet/business/dashboards/conventions/) — `DashboardDefinition` declarative shape, widget catalogue, JSON wire format.
+- [Analytics inline metrics](/dotnet/business/analytics/inline-metrics/) — How the metrics surfaced by `KpiWidget` are declared and rendered.
+- [Analytics conventions](/dotnet/business/analytics/conventions/) — Naming formula, period tokens, and the empty-set semantics shared with widget renderers.
 - [ADR-038](/dotnet/architecture/adr/038-analytics-dashboard-definition-vs-aggregate/) — boundary between the catalogue entry and the persisted aggregate.
 - [Permissions](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs) — full source of the permission constants.


### PR DESCRIPTION
## Summary

Closes the missing edges in the analytics ↔ dashboards docs graph so a reader landing on either side can follow the chain end-to-end (declare a metric → consume it via \`KpiWidget\` → ship dashboards via the REST surface).

| File | New Read-next entries |
| ---- | --------------------- |
| \`analytics/index.mdx\` | \`inline-metrics\`, \`dashboards/\`, \`dashboards/endpoints/\` |
| \`analytics/conventions.mdx\` | \`inline-metrics\`, \`dashboards/endpoints/\` |
| \`analytics/inline-metrics.mdx\` | \`dashboards/conventions/\`, \`dashboards/endpoints/\` |
| \`dashboards/conventions.mdx\` | \`analytics/inline-metrics/\` |
| \`dashboards/endpoints.mdx\` | \`analytics/inline-metrics/\`, \`analytics/conventions/\` |

## Test plan

- [x] \`npx astro build\` — 443 pages, all internal links valid
- [x] \`npx markdownlint-cli2\` on the 5 changed files — no new errors (the pre-existing MD060 entries on \`endpoints.mdx\` are unchanged)