### PR TITLE
docs(d4): refresh PACKAGE_COUNT and ADR_COUNT (#1399 audit)

### DIFF
--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,8 +1,8 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 303;
+export const PACKAGE_COUNT = 306;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 58;
-export const ADR_COUNT = 37;
+export const ADR_COUNT = 38;


### PR DESCRIPTION
## Summary

Audit pass on D4 (#1399 — analytics conventions docs) — the page itself was already at the canonical path (\`docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx\`) with sidebar frontmatter and cross-links wired (the latter landed via #1480 today). The two leftovers in the DoD checklist were the framework-wide counters in \`docs-site/src/data/constants.ts\`:

| Constant | Was | Now | Reason |
| -------- | --- | --- | ------ |
| \`PACKAGE_COUNT\` | 303 | 306 | Dashboards epic added \`Granit.Dashboards.Abstractions\` + \`Granit.Dashboards\` + \`Granit.Dashboards.EntityFrameworkCore\` + \`Granit.Dashboards.Endpoints\`. Counter wasn't bumped at the time. |
| \`ADR_COUNT\` | 37 | 38 | ADR-038 (analytics-dashboard-definition-vs-aggregate) shipped earlier in #1366 without bumping the constant. |

Verified via \`ls -d src/Granit.* | wc -l\` (306) and \`ls docs-site/.../adr/*.md | wc -l\` (38).

## Out of scope

- C5 \"odata-power-bi\" cross-link — its target page (#1394) doesn't exist yet because Feature C is gated by C0 (#1389, OData spike). Will land alongside C5 itself.

## Test plan

- [x] \`npx astro build\` — 443 pages, all internal links valid
- [x] Constants verified against the filesystem (\`ls -d src/Granit.*\`, \`ls .../adr/*.md\`)