### PR TITLE
feat(analytics): KPI widget renderer + datasource dispatch (B3-2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -102,6 +102,7 @@
         "Granit.Analytics.EntityFrameworkCore",
         "Granit.Authorization",
         "Granit.Caching",
+        "Granit.Dashboards",
         "Granit.Http.Abstractions",
         "Granit.MultiTenancy",
         "Granit.Timing",
@@ -4307,6 +4308,22 @@
       ]
     },
     {
+      "name": "AnalyticsRenderingServiceCollectionExtensions",
+      "fqn": "Granit.Analytics.Endpoints.Extensions.AnalyticsRenderingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitAnalyticsWidgetRenderers",
+          "kind": "method",
+          "signature": "AddGranitAnalyticsWidgetRenderers(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitAnalyticsEndpointsModule",
       "fqn": "Granit.Analytics.Endpoints.GranitAnalyticsEndpointsModule",
       "kind": "class",
@@ -4373,6 +4390,38 @@
       "file": "src/Granit.Analytics.Endpoints/Permissions/AnalyticsPermissions.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "IDatasourceEvaluator",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.IDatasourceEvaluator",
+      "kind": "interface",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/IDatasourceEvaluator.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "EvaluateAsync",
+          "kind": "method",
+          "signature": "EvaluateAsync(TDatasource datasource, WidgetInstance widget, WidgetRenderContext context, CancellationToken cancellationToken)",
+          "returnType": "Task<KpiEvaluation>"
+        }
+      ]
+    },
+    {
+      "name": "KpiEvaluation",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.KpiEvaluation",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/KpiEvaluation.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Snapshot",
+          "kind": "method",
+          "signature": "Snapshot(MetricSnapshotPayload payload, RefreshHint refreshHint)",
+          "returnType": "KpiEvaluation"
+        }
+      ]
     },
     {
       "name": "AnalyticsEntityFrameworkCoreServiceCollectionExtensions",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -1,0 +1,45 @@
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Dashboards;
+using Granit.Dashboards.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Analytics.Endpoints.Extensions;
+
+/// <summary>
+/// DI registration helpers for the analytics-side widget rendering pipeline
+/// — the KPI <see cref="IWidgetInstanceRenderer"/> plus the per-datasource
+/// evaluators it dispatches to. Public so applications wiring dashboards have
+/// a single, well-named hook (the rest of the rendering machinery stays
+/// internal).
+/// </summary>
+public static class AnalyticsRenderingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <c>"Kpi"</c> widget renderer plus the bundled
+    /// <see cref="IDatasourceEvaluator{TDatasource}"/> implementations for
+    /// <see cref="MetricDatasource"/> (full), <see cref="QueryAggregateDatasource"/>
+    /// (stub — returns Unavailable until the query-aggregate path lands), and
+    /// <see cref="TelemetryDatasource"/> (stub — replaced by
+    /// <c>Granit.IoT.Dashboards</c> when shipped).
+    /// </summary>
+    /// <remarks>
+    /// Call AFTER <c>AddGranitAnalyticsEndpoints()</c> — the
+    /// <see cref="MetricDatasourceEvaluator"/> resolves the runner registry
+    /// surfaced by that registration.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitAnalyticsWidgetRenderers(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<IDatasourceEvaluator<MetricDatasource>, MetricDatasourceEvaluator>();
+        services.TryAddSingleton<IDatasourceEvaluator<QueryAggregateDatasource>, QueryAggregateDatasourceEvaluator>();
+        services.TryAddSingleton<IDatasourceEvaluator<TelemetryDatasource>, TelemetryDatasourceEvaluator>();
+
+        services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
+
+        return services;
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
+++ b/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards\Granit.Dashboards.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />

--- a/src/Granit.Analytics.Endpoints/Rendering/IDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/IDatasourceEvaluator.cs
@@ -1,0 +1,39 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Per-<see cref="Datasource"/> evaluator producing a KPI tile snapshot from
+/// the persisted <see cref="WidgetInstance"/> + the per-render
+/// <see cref="WidgetRenderContext"/>. ADR-039 §7.bis — the
+/// <see cref="KpiWidgetInstanceRenderer"/> dispatches on
+/// <c>Datasource.Kind</c> to the matching closed evaluator (one per
+/// <c>MetricDatasource</c> / <c>QueryAggregateDatasource</c> /
+/// <c>TelemetryDatasource</c>), so adding a new datasource kind is purely
+/// additive (new evaluator + DI registration, no central switch).
+/// </summary>
+/// <typeparam name="TDatasource">
+/// The concrete datasource record this evaluator handles. Pinned by the closed
+/// type so the dispatch stays reflection-free at runtime.
+/// </typeparam>
+public interface IDatasourceEvaluator<TDatasource> where TDatasource : Datasource
+{
+    /// <summary>
+    /// Produces a <see cref="KpiEvaluation"/> for the supplied datasource. The
+    /// evaluator <b>must not</b> apply per-widget permission filtering — the
+    /// <c>IDashboardRenderer</c> applies it uniformly upstream (ADR-039 §3.a).
+    /// Implementations should honour <paramref name="cancellationToken"/> on
+    /// every async hop they own.
+    /// </summary>
+    /// <param name="datasource">The persisted datasource — already deserialised by the renderer from <c>WidgetInstance.ConfigJson</c>.</param>
+    /// <param name="widget">The persisted widget — surfaces <c>WidgetType</c>, <c>ConfigJson</c>, <c>MetricName</c> / <c>QueryName</c> as relevant to the kind.</param>
+    /// <param name="context">Per-render context — see <see cref="WidgetRenderContext"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<KpiEvaluation> EvaluateAsync(
+        TDatasource datasource,
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/KpiEvaluation.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/KpiEvaluation.cs
@@ -1,0 +1,45 @@
+using Granit.Analytics.Endpoints.Dtos;
+using Granit.Analytics.Metrics;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Result of an <see cref="IDatasourceEvaluator{TDatasource}"/> evaluation for a
+/// KPI widget — either a successful <see cref="MetricSnapshotPayload"/> or an
+/// "unavailable" sentinel carrying a localization key. The
+/// <see cref="KpiWidgetInstanceRenderer"/> reuses this shape regardless of which
+/// concrete <c>Datasource</c> kind produced it, so the dispatch site stays a
+/// pure switch with no per-kind envelope plumbing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Returning an envelope-shaped result (rather than raising an exception) lets
+/// stubbed datasources (<see cref="QueryAggregateDatasourceEvaluator"/>,
+/// <see cref="TelemetryDatasourceEvaluator"/>) participate in the dispatch
+/// without leaking the cross-cutting "unavailable" concept into the renderer.
+/// The renderer maps it 1-to-1 onto <c>WidgetSnapshotEnvelope.ForSnapshot</c> /
+/// <c>Unavailable</c> per ADR-039 §7.bis.
+/// </para>
+/// </remarks>
+/// <param name="Payload">The KPI snapshot payload — non-null when the evaluation succeeded; <see langword="null"/> when the datasource yielded no usable result.</param>
+/// <param name="RefreshHint">The refresh hint surfaced on the wire envelope. For metric paths it mirrors the underlying <c>MetricDefinition.RefreshHint</c>; for stub paths it is <see cref="RefreshHint.Static"/>.</param>
+/// <param name="UnavailableReasonLocalizationKey">Localization key surfaced on the unavailable envelope. Ignored when <paramref name="Payload"/> is non-null. Defaults to <c>Widget:Unavailable</c> when null on an unavailable result.</param>
+public sealed record KpiEvaluation(
+    MetricSnapshotPayload? Payload,
+    RefreshHint RefreshHint,
+    string? UnavailableReasonLocalizationKey = null)
+{
+    /// <summary>Builds a successful evaluation carrying the supplied payload.</summary>
+    public static KpiEvaluation Snapshot(MetricSnapshotPayload payload, RefreshHint refreshHint)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return new KpiEvaluation(payload, refreshHint);
+    }
+
+    /// <summary>Builds an "unavailable" evaluation carrying a localization key.</summary>
+    public static KpiEvaluation Unavailable(RefreshHint refreshHint, string reasonLocalizationKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reasonLocalizationKey);
+        return new KpiEvaluation(Payload: null, refreshHint, reasonLocalizationKey);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/KpiWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/KpiWidgetInstanceRenderer.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Kpi"</c> widget kind.
+/// Deserialises the persisted <see cref="WidgetInstance.ConfigJson"/> into a
+/// polymorphic <see cref="Datasource"/> and dispatches to the matching
+/// <see cref="IDatasourceEvaluator{TDatasource}"/> — ADR-039 §7.bis. Adding a
+/// new datasource kind is purely additive (new evaluator + DI registration);
+/// the renderer's switch never grows.
+/// </summary>
+internal sealed class KpiWidgetInstanceRenderer(
+    IDatasourceEvaluator<MetricDatasource> metricEvaluator,
+    IDatasourceEvaluator<QueryAggregateDatasource> queryEvaluator,
+    IDatasourceEvaluator<TelemetryDatasource> telemetryEvaluator,
+    IClock clock) : IWidgetInstanceRenderer
+{
+    // The persisted ConfigJson was written by WidgetDefinitionToInstanceMapper with
+    // PropertyNamingPolicy = CamelCase — must round-trip with the same policy.
+    // The polymorphism discriminator ("kind") is fixed by [JsonPolymorphic] and
+    // is unaffected by the naming policy. JsonStringEnumConverter accepts both
+    // string and integer enum values, so the renderer reads either form (forward-
+    // compatible if the mapper switches to string enums later).
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // Snapshot serialisation: camelCase properties + PascalCase enum members
+    // (matches host JsonStringEnumConverter() default, locked by ADR-039 §6.1).
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly IDatasourceEvaluator<MetricDatasource> _metricEvaluator = metricEvaluator;
+    private readonly IDatasourceEvaluator<QueryAggregateDatasource> _queryEvaluator = queryEvaluator;
+    private readonly IDatasourceEvaluator<TelemetryDatasource> _telemetryEvaluator = telemetryEvaluator;
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Kpi";
+
+    public async Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+        ArgumentNullException.ThrowIfNull(context);
+
+        Datasource datasource = JsonSerializer.Deserialize<Datasource>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Kpi') has an empty or null ConfigJson — datasource cannot be resolved.");
+
+        KpiEvaluation evaluation = datasource switch
+        {
+            MetricDatasource m => await _metricEvaluator.EvaluateAsync(m, widget, context, cancellationToken).ConfigureAwait(false),
+            QueryAggregateDatasource q => await _queryEvaluator.EvaluateAsync(q, widget, context, cancellationToken).ConfigureAwait(false),
+            TelemetryDatasource t => await _telemetryEvaluator.EvaluateAsync(t, widget, context, cancellationToken).ConfigureAwait(false),
+            _ => throw new InvalidOperationException(
+                $"Unknown KPI datasource kind '{datasource.GetType().Name}' on widget {widget.Id}."),
+        };
+
+        DateTimeOffset emittedAt = _clock.Now;
+
+        return evaluation.Payload is { } payload
+            ? WidgetSnapshotEnvelope.ForSnapshot(
+                widgetType: WidgetType,
+                snapshot: JsonSerializer.SerializeToElement(payload, SnapshotJsonOptions),
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: evaluation.RefreshHint)
+            : WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: evaluation.RefreshHint,
+                reasonLocalizationKey: evaluation.UnavailableReasonLocalizationKey ?? "Widget:Unavailable");
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/MetricDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MetricDatasourceEvaluator.cs
@@ -1,0 +1,68 @@
+using Granit.Analytics.Endpoints.Dtos;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IDatasourceEvaluator{TDatasource}"/> for <see cref="MetricDatasource"/> —
+/// resolves the matching <see cref="IMetricRunner"/> by name, runs it against
+/// the resolved render-context period, and shapes the result into a
+/// <see cref="MetricSnapshotPayload"/>. Reuses the same runner registry as the
+/// inline <c>POST /metrics/{name}</c> path so dashboard-rendered KPIs and ad-hoc
+/// metric requests cannot diverge in semantics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache layer used by <see cref="MetricEndpointService"/> is intentionally
+/// bypassed here: the dashboard render endpoint owns its own cache key recipe
+/// (ADR-039 §5 — the same key seeds the future WS subscription topic). Wiring
+/// FusionCache once at the renderer level avoids two caches stamping each
+/// other's TTL. The metric-runner pipeline (BaseFilter, period selector,
+/// multi-tenant filter) still applies through <see cref="IMetricRunner.ExecuteAsync"/>.
+/// </para>
+/// <para>
+/// Comparison-window deltas (<c>compareTo</c>) are not surfaced by the
+/// dashboard render endpoint in B3-2 — KPI tiles render the bare value plus
+/// any client-side delta widget. When a future story adds dashboard-level
+/// comparison the evaluator will populate <see cref="MetricSnapshotPayload.Previous"/>.
+/// </para>
+/// </remarks>
+internal sealed class MetricDatasourceEvaluator(MetricEndpointService metricService)
+    : IDatasourceEvaluator<MetricDatasource>
+{
+    private readonly MetricEndpointService _metricService = metricService;
+
+    public async Task<KpiEvaluation> EvaluateAsync(
+        MetricDatasource datasource,
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(datasource);
+        ArgumentNullException.ThrowIfNull(widget);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!_metricService.TryGetRunner(datasource.MetricName, out IMetricRunner runner))
+        {
+            return KpiEvaluation.Unavailable(RefreshHint.Static, "Widget:Unavailable.MetricNotFound");
+        }
+
+        ResolvedPeriod? period = runner.SupportsPeriod ? context.Period : null;
+
+        decimal? value = await runner.ExecuteAsync(period, cancellationToken).ConfigureAwait(false);
+
+        MetricSnapshotPayload payload = new(
+            value,
+            runner.ValueKind,
+            runner.CurrencyCode,
+            runner.IsHigherBetter,
+            NoData: !value.HasValue,
+            Previous: null);
+
+        return KpiEvaluation.Snapshot(payload, runner.RefreshHint);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
@@ -1,0 +1,36 @@
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Stub <see cref="IDatasourceEvaluator{TDatasource}"/> for
+/// <see cref="QueryAggregateDatasource"/> — returns an "unavailable" evaluation
+/// until the real implementation lands. Wired in B3-2 so the polymorphic
+/// <see cref="Datasource"/> dispatch in <see cref="KpiWidgetInstanceRenderer"/>
+/// covers every shipped <c>Datasource</c> kind, even when the underlying
+/// pipeline is not yet built — the renderer never throws on an unknown kind,
+/// it surfaces a localized <c>Widget:Unavailable.*</c> reason instead.
+/// </summary>
+/// <remarks>
+/// The full implementation builds an <c>IQueryable&lt;TEntity&gt;</c> from the
+/// named <c>QueryDefinition</c>, applies the dashboard filter spec + period
+/// selector, then runs the declared <see cref="QueryEngine.Filtering.AggregateFunction"/>.
+/// Empty-set semantics mirror the metric path (<c>Sum</c>/<c>Count</c> → 0,
+/// <c>Avg</c>/<c>Min</c>/<c>Max</c> → null) — see ADR-039 §7.bis. Tracked as
+/// a follow-up slice; until then a dashboard widget bound to a query-aggregate
+/// datasource renders as <c>Unavailable</c> rather than falling over.
+/// </remarks>
+internal sealed class QueryAggregateDatasourceEvaluator : IDatasourceEvaluator<QueryAggregateDatasource>
+{
+    public Task<KpiEvaluation> EvaluateAsync(
+        QueryAggregateDatasource datasource,
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(KpiEvaluation.Unavailable(
+            RefreshHint.Static,
+            "Widget:Unavailable.QueryAggregateNotImplemented"));
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/TelemetryDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TelemetryDatasourceEvaluator.cs
@@ -1,0 +1,28 @@
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Stub <see cref="IDatasourceEvaluator{TDatasource}"/> for
+/// <see cref="TelemetryDatasource"/> — returns an "unavailable" evaluation. The
+/// real implementation lives in <c>Granit.IoT.Dashboards</c> (deferred, outside
+/// <c>granit-dotnet</c>): it resolves <see cref="TelemetryDatasource.EntityAlias"/>
+/// against <see cref="WidgetRenderContext.ResolvedEntityAliases"/> and queries
+/// the IoT telemetry store. Until that package ships, telemetry-bound KPIs
+/// render as <c>Unavailable</c> with a dedicated reason key — same dispatch
+/// path, no central <c>switch</c> to amend.
+/// </summary>
+internal sealed class TelemetryDatasourceEvaluator : IDatasourceEvaluator<TelemetryDatasource>
+{
+    public Task<KpiEvaluation> EvaluateAsync(
+        TelemetryDatasource datasource,
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(KpiEvaluation.Unavailable(
+            RefreshHint.Static,
+            "Widget:Unavailable.TelemetryNotImplemented"));
+}

--- a/src/Granit.Analytics.Endpoints/packages.lock.json
+++ b/src/Granit.Analytics.Endpoints/packages.lock.json
@@ -74,6 +74,14 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dashboards.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Dashboards/Granit.Dashboards.csproj
+++ b/src/Granit.Dashboards/Granit.Dashboards.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/KpiWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/KpiWidgetInstanceRendererTests.cs
@@ -1,0 +1,230 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Dtos;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// Locks the dispatch contract for <see cref="KpiWidgetInstanceRenderer"/> per
+/// ADR-039 §7.bis — the renderer parses <c>WidgetInstance.ConfigJson</c> as a
+/// polymorphic <c>Datasource</c>, routes to the matching
+/// <see cref="IDatasourceEvaluator{TDatasource}"/>, and shapes the result into
+/// the locked-v1 <see cref="WidgetSnapshotEnvelope"/> wire shape.
+/// </summary>
+public sealed class KpiWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 28, 14, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly RecordingEvaluator<MetricDatasource> _metricEvaluator = new();
+    private readonly RecordingEvaluator<QueryAggregateDatasource> _queryEvaluator = new();
+    private readonly RecordingEvaluator<TelemetryDatasource> _telemetryEvaluator = new();
+
+    public KpiWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsKpi()
+    {
+        BuildRenderer().WidgetType.ShouldBe("Kpi");
+    }
+
+    [Fact]
+    public async Task RenderAsync_DispatchesMetricDatasource_ToMetricEvaluator()
+    {
+        _metricEvaluator.Result = KpiEvaluation.Snapshot(
+            new MetricSnapshotPayload(
+                Value: 42m,
+                ValueKind: MetricValueKind.Count,
+                Currency: null,
+                IsHigherBetter: true,
+                NoData: false,
+                Previous: null),
+            RefreshHint.Dynamic);
+
+        WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"metric\",\"metricName\":\"Granit.Test.Count\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        _metricEvaluator.LastDatasource.ShouldNotBeNull();
+        _metricEvaluator.LastDatasource!.MetricName.ShouldBe("Granit.Test.Count");
+        _queryEvaluator.LastDatasource.ShouldBeNull();
+        _telemetryEvaluator.LastDatasource.ShouldBeNull();
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Kpi");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        envelope.EmittedAt.ShouldBe(Now);
+        envelope.Sequence.ShouldBe(1);
+        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+
+        envelope.Snapshot.ShouldNotBeNull();
+        envelope.Snapshot!.Value.GetProperty("value").GetDecimal().ShouldBe(42m);
+        envelope.Snapshot.Value.GetProperty("noData").GetBoolean().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RenderAsync_DispatchesQueryAggregateDatasource_ToQueryEvaluator()
+    {
+        _queryEvaluator.Result = KpiEvaluation.Unavailable(
+            RefreshHint.Static,
+            "Widget:Unavailable.QueryAggregateNotImplemented");
+
+        WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"query-aggregate\",\"queryName\":\"Granit.Invoicing.InvoiceQuery\",\"aggregation\":\"Count\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        _queryEvaluator.LastDatasource.ShouldNotBeNull();
+        _queryEvaluator.LastDatasource!.QueryName.ShouldBe("Granit.Invoicing.InvoiceQuery");
+        _queryEvaluator.LastDatasource.Aggregation.ShouldBe(AggregateFunction.Count);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.WidgetType.ShouldBe("Kpi");
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotImplemented");
+        envelope.Snapshot.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RenderAsync_DispatchesTelemetryDatasource_ToTelemetryEvaluator()
+    {
+        _telemetryEvaluator.Result = KpiEvaluation.Unavailable(
+            RefreshHint.Static,
+            "Widget:Unavailable.TelemetryNotImplemented");
+
+        WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"iot-telemetry\",\"entityAlias\":\"currentDevice\",\"telemetryKey\":\"temperature\",\"aggregation\":\"Last\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        _telemetryEvaluator.LastDatasource.ShouldNotBeNull();
+        _telemetryEvaluator.LastDatasource!.EntityAlias.ShouldBe("currentDevice");
+        _telemetryEvaluator.LastDatasource.TelemetryKey.ShouldBe("temperature");
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnavailableEvaluation_DefaultsReasonKey_WhenEvaluatorOmitsIt()
+    {
+        // Defensive — KpiEvaluation.Unavailable enforces a non-null key, but the
+        // renderer must still default if a future evaluator forgets one (the
+        // public surface of the contract).
+        _metricEvaluator.Result = new KpiEvaluation(
+            Payload: null,
+            RefreshHint: RefreshHint.Static,
+            UnavailableReasonLocalizationKey: null);
+
+        WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"metric\",\"metricName\":\"Granit.Test.Count\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable");
+    }
+
+    [Fact]
+    public async Task RenderAsync_PassesRenderContext_Through_ToEvaluator()
+    {
+        _metricEvaluator.Result = KpiEvaluation.Snapshot(
+            new MetricSnapshotPayload(0m, MetricValueKind.Count, null, true, false, null),
+            RefreshHint.Dynamic);
+
+        WidgetRenderContext context = BuildContext(
+            period: new ResolvedPeriod(Now.AddDays(-7), Now));
+
+        await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"metric\",\"metricName\":\"Granit.Test.Count\"}"),
+            context,
+            TestContext.Current.CancellationToken);
+
+        _metricEvaluator.LastContext.ShouldBeSameAs(context);
+    }
+
+    [Fact]
+    public async Task RenderAsync_SnapshotPayload_SerialisesAsCamelCase()
+    {
+        // Locks ADR-039 §6.1 wire convention for the inner snapshot — camelCase
+        // properties + PascalCase enum members. The frontend's discriminated-union
+        // types depend on this exact shape.
+        _metricEvaluator.Result = KpiEvaluation.Snapshot(
+            new MetricSnapshotPayload(
+                Value: 1234.56m,
+                ValueKind: MetricValueKind.Currency,
+                Currency: "EUR",
+                IsHigherBetter: true,
+                NoData: false,
+                Previous: null),
+            RefreshHint.Dynamic);
+
+        WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
+            BuildWidget("{\"kind\":\"metric\",\"metricName\":\"Granit.Test.Revenue\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"value\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"valueKind\":\"Currency\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"currency\":\"EUR\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"isHigherBetter\":true", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"noData\":false", StringComparison.Ordinal).ShouldBeTrue(raw);
+    }
+
+    private KpiWidgetInstanceRenderer BuildRenderer() =>
+        new(_metricEvaluator, _queryEvaluator, _telemetryEvaluator, _clock);
+
+    private static WidgetInstance BuildWidget(string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson);
+
+    private static WidgetRenderContext BuildContext(ResolvedPeriod? period = null) =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: period,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class RecordingEvaluator<TDatasource> : IDatasourceEvaluator<TDatasource>
+        where TDatasource : Datasource
+    {
+        public TDatasource? LastDatasource { get; private set; }
+
+        public WidgetRenderContext? LastContext { get; private set; }
+
+        public KpiEvaluation Result { get; set; } = KpiEvaluation.Unavailable(
+            RefreshHint.Static, "Widget:Unavailable.TestDefault");
+
+        public Task<KpiEvaluation> EvaluateAsync(
+            TDatasource datasource,
+            WidgetInstance widget,
+            WidgetRenderContext context,
+            CancellationToken cancellationToken)
+        {
+            LastDatasource = datasource;
+            LastContext = context;
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
@@ -1,0 +1,218 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Endpoints.Options;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+public sealed class MetricDatasourceEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 28, 14, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+
+    public MetricDatasourceEvaluatorTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public async Task EvaluateAsync_KnownMetric_BuildsSnapshotFromRunner()
+    {
+        StubRunner runner = new(
+            name: "Granit.Test.UnpaidCount",
+            value: 12m,
+            supportsPeriod: false,
+            valueKind: MetricValueKind.Count,
+            isHigherBetter: false,
+            refreshHint: RefreshHint.Dynamic);
+
+        MetricDatasourceEvaluator evaluator = BuildEvaluator(runner);
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new MetricDatasource("Granit.Test.UnpaidCount"),
+            BuildWidget(),
+            BuildContext(period: null),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBe(12m);
+        result.Payload.ValueKind.ShouldBe(MetricValueKind.Count);
+        result.Payload.IsHigherBetter.ShouldBeFalse();
+        result.Payload.NoData.ShouldBeFalse();
+        result.Payload.Previous.ShouldBeNull();
+        result.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        result.UnavailableReasonLocalizationKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RunnerReturnsNull_FlagsNoData()
+    {
+        StubRunner runner = new(
+            name: "Granit.Test.AvgRevenue",
+            value: null,
+            supportsPeriod: true,
+            valueKind: MetricValueKind.Currency,
+            currencyCode: "EUR",
+            isHigherBetter: true,
+            refreshHint: RefreshHint.Static);
+
+        MetricDatasourceEvaluator evaluator = BuildEvaluator(runner);
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new MetricDatasource("Granit.Test.AvgRevenue"),
+            BuildWidget(),
+            BuildContext(period: new ResolvedPeriod(Now.AddDays(-7), Now)),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBeNull();
+        result.Payload.NoData.ShouldBeTrue();
+        result.Payload.Currency.ShouldBe("EUR");
+        result.RefreshHint.ShouldBe(RefreshHint.Static);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_UnknownMetric_ReturnsUnavailableWithDedicatedKey()
+    {
+        StubRunner runner = new("Granit.Test.OtherMetric", value: 1m, supportsPeriod: false);
+        MetricDatasourceEvaluator evaluator = BuildEvaluator(runner);
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new MetricDatasource("Granit.Test.MissingMetric"),
+            BuildWidget(),
+            BuildContext(period: null),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldBeNull();
+        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
+        result.RefreshHint.ShouldBe(RefreshHint.Static);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PeriodAwareRunner_ReceivesContextPeriod()
+    {
+        ResolvedPeriod expected = new(
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+
+        StubRunner runner = new("Granit.Test.Sum", value: 7m, supportsPeriod: true);
+        MetricDatasourceEvaluator evaluator = BuildEvaluator(runner);
+
+        await evaluator.EvaluateAsync(
+            new MetricDatasource("Granit.Test.Sum"),
+            BuildWidget(),
+            BuildContext(period: expected),
+            TestContext.Current.CancellationToken);
+
+        runner.LastPeriod.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RunnerWithoutPeriodSupport_IgnoresContextPeriod()
+    {
+        // A non-period-aware metric (e.g. a "current open invoices" tile) must not
+        // receive the context's period — the runner's own filter pipeline applies
+        // unchanged.
+        ResolvedPeriod context = new(
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+
+        StubRunner runner = new("Granit.Test.Count", value: 4m, supportsPeriod: false);
+        MetricDatasourceEvaluator evaluator = BuildEvaluator(runner);
+
+        await evaluator.EvaluateAsync(
+            new MetricDatasource("Granit.Test.Count"),
+            BuildWidget(),
+            BuildContext(period: context),
+            TestContext.Current.CancellationToken);
+
+        runner.LastPeriod.ShouldBeNull();
+    }
+
+    private MetricDatasourceEvaluator BuildEvaluator(IMetricRunner runner)
+    {
+        IFusionCache cache = new FusionCache(
+            new FusionCacheOptions { CacheName = "test" },
+            new MemoryCache(new MemoryCacheOptions()));
+
+        MetricEndpointService service = new(
+            [runner],
+            new PeriodResolver(_clock),
+            cache,
+            _clock,
+            Microsoft.Extensions.Options.Options.Create(new AnalyticsEndpointsOptions()),
+            _currentTenant);
+
+        return new MetricDatasourceEvaluator(service);
+    }
+
+    private static WidgetInstance BuildWidget()
+    {
+        return WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: "{\"kind\":\"metric\",\"metricName\":\"Granit.Test.UnpaidCount\"}");
+    }
+
+    private static WidgetRenderContext BuildContext(ResolvedPeriod? period) =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: period,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class StubRunner : IMetricRunner
+    {
+        private readonly decimal? _value;
+
+        public StubRunner(
+            string name,
+            decimal? value,
+            bool supportsPeriod,
+            MetricValueKind valueKind = MetricValueKind.Count,
+            string? currencyCode = null,
+            bool isHigherBetter = true,
+            RefreshHint refreshHint = RefreshHint.Dynamic)
+        {
+            Name = name;
+            _value = value;
+            SupportsPeriod = supportsPeriod;
+            ValueKind = valueKind;
+            CurrencyCode = currencyCode;
+            IsHigherBetter = isHigherBetter;
+            RefreshHint = refreshHint;
+        }
+
+        public string Name { get; }
+        public RefreshHint RefreshHint { get; }
+        public bool SupportsPeriod { get; }
+        public MetricValueKind ValueKind { get; }
+        public string? CurrencyCode { get; }
+        public bool IsHigherBetter { get; }
+        public ResolvedPeriod? LastPeriod { get; private set; }
+
+        public Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken)
+        {
+            LastPeriod = period;
+            return Task.FromResult(_value);
+        }
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -1,0 +1,79 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// The framework ships <see cref="QueryAggregateDatasourceEvaluator"/> and
+/// <see cref="TelemetryDatasourceEvaluator"/> as stubs (the full implementations
+/// land in follow-up slices / <c>Granit.IoT.Dashboards</c>). The contract for
+/// today: never throw, always surface a localizable
+/// <c>Widget:Unavailable.*</c> reason key — so a dashboard bound to either kind
+/// renders a typed "unavailable" widget instead of a 500.
+/// </summary>
+public sealed class StubDatasourceEvaluatorsTests
+{
+    private static WidgetInstance BuildWidget(string widgetType) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: widgetType,
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: "{}");
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    [Fact]
+    public async Task QueryAggregateEvaluator_ReturnsUnavailableWithDedicatedKey()
+    {
+        QueryAggregateDatasourceEvaluator evaluator = new();
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Invoicing.InvoiceQuery",
+                Aggregation: AggregateFunction.Count),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldBeNull();
+        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotImplemented");
+        result.RefreshHint.ShouldBe(RefreshHint.Static);
+    }
+
+    [Fact]
+    public async Task TelemetryEvaluator_ReturnsUnavailableWithDedicatedKey()
+    {
+        TelemetryDatasourceEvaluator evaluator = new();
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new TelemetryDatasource(
+                EntityAlias: "currentDevice",
+                TelemetryKey: "temperature"),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldBeNull();
+        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
+        result.RefreshHint.ShouldBe(RefreshHint.Static);
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -347,6 +347,7 @@
           "Granit.Analytics.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -385,6 +386,14 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.abstractions": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1505,6 +1505,7 @@
           "Granit.Analytics.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Wires the KPI side of the dashboard render pipeline per [ADR-039 §7.bis](docs-site/src/content/docs/dotnet/architecture/adr/039-widget-renderer-architecture.md#7bis-kpi-renderer--dispatch-on-datasourcekind):

- **`KpiWidgetInstanceRenderer`** (`"Kpi"`) deserialises `WidgetInstance.ConfigJson` into the polymorphic `Datasource` and routes to the matching `IDatasourceEvaluator<T>`. Single switch — adding a new datasource kind is a new evaluator + DI registration, no central change.
- **`MetricDatasourceEvaluator`** (full): reuses the existing `IMetricRunner` registry, so dashboard-rendered KPIs and the ad-hoc `POST /metrics/{name}` endpoint cannot diverge in semantics (BaseFilter, period selector, multi-tenant filter all flow through the same runner).
- **`QueryAggregateDatasourceEvaluator`** + **`TelemetryDatasourceEvaluator`** ship as stubs returning `Unavailable` with dedicated localization keys (`Widget:Unavailable.QueryAggregateNotImplemented`, `Widget:Unavailable.TelemetryNotImplemented`). Full implementations land in a follow-up slice / `Granit.IoT.Dashboards` respectively.
- `KpiEvaluation` is the shared result envelope so stub evaluators participate in dispatch without leaking the `Unavailable` plumbing into the renderer.

JSON serialisation locks ADR-039 §6.1 (camelCase property names + PascalCase enum members). Deserialisation accepts both string and integer enum values via `JsonStringEnumConverter` — forward-compatible with the persisted `ConfigJson` contract.

`Granit.Analytics.Endpoints` now references `Granit.Dashboards` — required cross-package edge for analytics-side renderers (`WidgetInstance` + `IWidgetInstanceRenderer` live in `Granit.Dashboards`).

## Test plan

- [x] Unit tests cover dispatch on each `Datasource.Kind` (Metric / QueryAggregate / Telemetry)
- [x] Unit tests cover `MetricDatasourceEvaluator` happy-path + no-data + missing-runner + period-aware/period-blind dispatch
- [x] Unit tests pin the wire shape — camelCase fields, PascalCase enums, snapshot serialised by concrete type (not `object`)
- [x] Stub evaluators surface their dedicated `Widget:Unavailable.*` reason key
- [x] `dotnet build .github/shard-filters/business.slnf` clean
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests` — 45 passing (14 new in `Rendering/`)
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` clean

## Follow-ups

- B3-2bis: full `QueryAggregateDatasourceEvaluator` (build `IQueryable<TEntity>` from named `QueryDefinition`, apply dashboard filters + period, run declared `AggregateFunction`)
- B3-3 / B3-4 / B3-5 / B3-6 / B7-2: per-kind renderers for Markdown / Text / Image / Table / Chart / Pivot / Map
- B4-render: `POST /dashboards/{id}/render` + `IDashboardRenderer` (registry dispatch, permission gate, error isolation per ADR-039 §3)
