### PR TITLE
feat(dashboards): static-content widget renderers (B3-3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -635,6 +635,7 @@
         "Granit.Dashboards.EntityFrameworkCore",
         "Granit.Authorization",
         "Granit.Http.Abstractions",
+        "Granit.Timing",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -13231,6 +13232,22 @@
       ]
     },
     {
+      "name": "DashboardsRenderingServiceCollectionExtensions",
+      "fqn": "Granit.Dashboards.Endpoints.Extensions.DashboardsRenderingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Extensions/DashboardsRenderingServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitDashboardsContentWidgetRenderers",
+          "kind": "method",
+          "signature": "AddGranitDashboardsContentWidgetRenderers(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitDashboardsEndpointsModule",
       "fqn": "Granit.Dashboards.Endpoints.GranitDashboardsEndpointsModule",
       "kind": "class",
@@ -13305,6 +13322,33 @@
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Permissions/DashboardsPermissions.cs",
       "line": 19,
+      "members": []
+    },
+    {
+      "name": "ImageWidgetSnapshot",
+      "fqn": "Granit.Dashboards.Endpoints.Rendering.ImageWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Rendering/ImageWidgetSnapshot.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "MarkdownWidgetSnapshot",
+      "fqn": "Granit.Dashboards.Endpoints.Rendering.MarkdownWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Rendering/MarkdownWidgetSnapshot.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TextWidgetSnapshot",
+      "fqn": "Granit.Dashboards.Endpoints.Rendering.TextWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Rendering/TextWidgetSnapshot.cs",
+      "line": 13,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsRenderingServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using Granit.Dashboards.Endpoints.Rendering;
+using Granit.Dashboards.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Dashboards.Endpoints.Extensions;
+
+/// <summary>
+/// DI registration for the framework-side <see cref="IWidgetInstanceRenderer"/>
+/// implementations bundled with <c>Granit.Dashboards.Endpoints</c> — currently
+/// the static-content kinds (<c>Markdown</c>, <c>Text</c>, <c>Image</c>) that
+/// do not need analytics or persistence to render. KPI / Chart / Table / Pivot
+/// renderers ship from <c>Granit.Analytics.Endpoints</c> on the same
+/// registration surface, so a host wiring both packages ends up with the full
+/// catalogue of renderers under one <see cref="IEnumerable{T}"/> at the
+/// dashboard render endpoint.
+/// </summary>
+public static class DashboardsRenderingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the bundled static-content renderers (<c>Markdown</c>,
+    /// <c>Text</c>, <c>Image</c>). Each renderer registers itself as an
+    /// <see cref="IWidgetInstanceRenderer"/> — the dashboard renderer keys on
+    /// <see cref="IWidgetInstanceRenderer.WidgetType"/> at startup, so adding a
+    /// new kind is purely additive (no central switch).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitDashboardsContentWidgetRenderers(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<IWidgetInstanceRenderer, MarkdownWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, TextWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, ImageWidgetInstanceRenderer>();
+
+        return services;
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
+++ b/src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Dashboards.Endpoints/Rendering/ImageWidgetInstanceRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/ImageWidgetInstanceRenderer.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Dashboards.Widgets;
+using Granit.Timing;
+
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Image"</c> widget kind —
+/// static image tile (logo, illustration, banner). The renderer surfaces the
+/// declarative source / alt key / fit mode unchanged; the frontend resolves
+/// blob references and the alt-text localization key against the active
+/// session and culture.
+/// </summary>
+internal sealed class ImageWidgetInstanceRenderer(IClock clock) : IWidgetInstanceRenderer
+{
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Image";
+
+    public Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        ImageConfig config = JsonSerializer.Deserialize<ImageConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Image') has empty ConfigJson — image source cannot be resolved.");
+
+        ImageWidgetSnapshot snapshot = new(config.Source, config.AltLocalizationKey, config.Fit);
+
+        return Task.FromResult(WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: _clock.Now,
+            refreshHint: RefreshHint.Static));
+    }
+
+    private sealed record ImageConfig(string Source, string AltLocalizationKey, ImageFit Fit);
+}

--- a/src/Granit.Dashboards.Endpoints/Rendering/ImageWidgetSnapshot.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/ImageWidgetSnapshot.cs
@@ -1,0 +1,18 @@
+using Granit.Dashboards.Widgets;
+
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Image"</c> widget kind — a static image
+/// tile (logo, illustration, banner). Mirrors the declarative
+/// <see cref="ImageWidgetDefinition"/>; the frontend resolves blob references
+/// (<c>"blob:..."</c>) and the alt-text localization key against the active
+/// session and culture.
+/// </summary>
+/// <param name="Source">URL or blob reference (<c>"blob:logo-banner"</c>, <c>"https://cdn..."</c>).</param>
+/// <param name="AltLocalizationKey">Localization key for the alt text (accessibility).</param>
+/// <param name="Fit">How the image fills its grid cell — see <see cref="ImageFit"/>.</param>
+public sealed record ImageWidgetSnapshot(
+    string Source,
+    string AltLocalizationKey,
+    ImageFit Fit);

--- a/src/Granit.Dashboards.Endpoints/Rendering/MarkdownWidgetInstanceRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/MarkdownWidgetInstanceRenderer.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Markdown"</c> widget kind.
+/// Static content tile — does not query the data layer. The renderer parses
+/// <see cref="WidgetInstance.ConfigJson"/> into a <see cref="MarkdownWidgetSnapshot"/>
+/// and surfaces <see cref="RefreshHint.Static"/> so the frontend can drop the
+/// widget out of its refresh loop.
+/// </summary>
+internal sealed class MarkdownWidgetInstanceRenderer(IClock clock) : IWidgetInstanceRenderer
+{
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Markdown";
+
+    public Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        MarkdownConfig config = JsonSerializer.Deserialize<MarkdownConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Markdown') has empty ConfigJson — content key cannot be resolved.");
+
+        MarkdownWidgetSnapshot snapshot = new(config.ContentLocalizationKey);
+
+        return Task.FromResult(WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: _clock.Now,
+            refreshHint: RefreshHint.Static));
+    }
+
+    private sealed record MarkdownConfig(string ContentLocalizationKey);
+}

--- a/src/Granit.Dashboards.Endpoints/Rendering/MarkdownWidgetSnapshot.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/MarkdownWidgetSnapshot.cs
@@ -1,0 +1,11 @@
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Markdown"</c> widget kind. Carries the
+/// localization key the frontend resolves to a markdown body — the renderer
+/// itself never resolves the key (the active locale lives on the client and
+/// the localization bundle ships separately), so the snapshot stays static
+/// regardless of the requesting user's culture.
+/// </summary>
+/// <param name="ContentLocalizationKey">Localization key whose value is the markdown body (e.g. <c>"Widget:Granit.Invoicing.FinanceOverview.Banner"</c>).</param>
+public sealed record MarkdownWidgetSnapshot(string ContentLocalizationKey);

--- a/src/Granit.Dashboards.Endpoints/Rendering/TextWidgetInstanceRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/TextWidgetInstanceRenderer.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Dashboards.Widgets;
+using Granit.Timing;
+
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Text"</c> widget kind —
+/// plain-text tile (heading, subheading, caption) without markdown rendering.
+/// Static; does not touch the data layer.
+/// </summary>
+internal sealed class TextWidgetInstanceRenderer(IClock clock) : IWidgetInstanceRenderer
+{
+    // ConfigJson was written by WidgetDefinitionToInstanceMapper with
+    // PropertyNamingPolicy = CamelCase + Style as a PascalCase string —
+    // JsonStringEnumConverter accepts both string and integer enum values.
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Text";
+
+    public Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        TextConfig config = JsonSerializer.Deserialize<TextConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Text') has empty ConfigJson — content key cannot be resolved.");
+
+        TextWidgetSnapshot snapshot = new(config.ContentLocalizationKey, config.Style);
+
+        return Task.FromResult(WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: _clock.Now,
+            refreshHint: RefreshHint.Static));
+    }
+
+    private sealed record TextConfig(string ContentLocalizationKey, TextStyle Style);
+}

--- a/src/Granit.Dashboards.Endpoints/Rendering/TextWidgetSnapshot.cs
+++ b/src/Granit.Dashboards.Endpoints/Rendering/TextWidgetSnapshot.cs
@@ -1,0 +1,15 @@
+using Granit.Dashboards.Widgets;
+
+namespace Granit.Dashboards.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Text"</c> widget kind — a plain-text tile
+/// (page heading, section subheading, caption) with no data binding. Mirrors
+/// the declarative <see cref="TextWidgetDefinition"/> 1-to-1; the frontend
+/// resolves the localization key against the active culture.
+/// </summary>
+/// <param name="ContentLocalizationKey">Localization key for the text body.</param>
+/// <param name="Style">Visual style hint inherited from <see cref="TextWidgetDefinition.Style"/>.</param>
+public sealed record TextWidgetSnapshot(
+    string ContentLocalizationKey,
+    TextStyle Style);

--- a/src/Granit.Dashboards/Granit.Dashboards.csproj
+++ b/src/Granit.Dashboards/Granit.Dashboards.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
     <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
+    <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1982,6 +1982,7 @@
           "Granit.Dashboards": "[0.1.0-dev, )",
           "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Dashboards.Endpoints.Tests/Rendering/ImageWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Rendering/ImageWidgetInstanceRendererTests.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Rendering;
+using Granit.Dashboards.Rendering;
+using Granit.Dashboards.Widgets;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Rendering;
+
+public sealed class ImageWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public ImageWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsImage()
+    {
+        new ImageWidgetInstanceRenderer(_clock).WidgetType.ShouldBe("Image");
+    }
+
+    [Theory]
+    [InlineData("Contain", ImageFit.Contain)]
+    [InlineData("Cover", ImageFit.Cover)]
+    [InlineData("Fill", ImageFit.Fill)]
+    public async Task RenderAsync_RoundsTripFitAcrossEveryEnumMember(string persistedFit, ImageFit expected)
+    {
+        WidgetInstance widget = BuildWidget(
+            $"{{\"source\":\"blob:logo\",\"altLocalizationKey\":\"Widget:Logo.Alt\",\"fit\":\"{persistedFit}\"}}");
+
+        WidgetSnapshotEnvelope envelope = await new ImageWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Image");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Static);
+        envelope.EmittedAt.ShouldBe(Now);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        envelope.Snapshot!.Value.GetProperty("source").GetString().ShouldBe("blob:logo");
+        envelope.Snapshot.Value.GetProperty("altLocalizationKey").GetString().ShouldBe("Widget:Logo.Alt");
+        envelope.Snapshot.Value.GetProperty("fit").GetString().ShouldBe(expected.ToString());
+    }
+
+    [Fact]
+    public async Task RenderAsync_SerialisesFitAsPascalCaseString()
+    {
+        WidgetInstance widget = BuildWidget(
+            "{\"source\":\"https://cdn/logo.png\",\"altLocalizationKey\":\"Widget:Logo.Alt\",\"fit\":\"Cover\"}");
+
+        WidgetSnapshotEnvelope envelope = await new ImageWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"fit\":\"Cover\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"fit\":1", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    private static WidgetInstance BuildWidget(string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Image",
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Rendering/MarkdownWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Rendering/MarkdownWidgetInstanceRendererTests.cs
@@ -1,0 +1,86 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Rendering;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Rendering;
+
+public sealed class MarkdownWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public MarkdownWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsMarkdown()
+    {
+        new MarkdownWidgetInstanceRenderer(_clock).WidgetType.ShouldBe("Markdown");
+    }
+
+    [Fact]
+    public async Task RenderAsync_BuildsSnapshotEnvelopeFromConfigJson()
+    {
+        WidgetInstance widget = BuildWidget(
+            "Markdown",
+            "{\"contentLocalizationKey\":\"Widget:Granit.Invoicing.Banner\"}");
+
+        WidgetSnapshotEnvelope envelope = await new MarkdownWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Markdown");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Static);
+        envelope.EmittedAt.ShouldBe(Now);
+        envelope.Sequence.ShouldBe(1);
+        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+
+        envelope.Snapshot.ShouldNotBeNull();
+        envelope.Snapshot!.Value
+            .GetProperty("contentLocalizationKey").GetString()
+            .ShouldBe("Widget:Granit.Invoicing.Banner");
+    }
+
+    [Fact]
+    public async Task RenderAsync_SnapshotPropertiesAreCamelCase()
+    {
+        // Locks ADR-039 §6.1 — wire convention is camelCase for properties.
+        WidgetInstance widget = BuildWidget(
+            "Markdown",
+            "{\"contentLocalizationKey\":\"Widget:Test\"}");
+
+        WidgetSnapshotEnvelope envelope = await new MarkdownWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"contentLocalizationKey\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"ContentLocalizationKey\"", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    private static WidgetInstance BuildWidget(string widgetType, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: widgetType,
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Rendering/TextWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Rendering/TextWidgetInstanceRendererTests.cs
@@ -1,0 +1,89 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Rendering;
+using Granit.Dashboards.Rendering;
+using Granit.Dashboards.Widgets;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Rendering;
+
+public sealed class TextWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public TextWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsText()
+    {
+        new TextWidgetInstanceRenderer(_clock).WidgetType.ShouldBe("Text");
+    }
+
+    [Theory]
+    [InlineData("Body", TextStyle.Body)]
+    [InlineData("Heading", TextStyle.Heading)]
+    [InlineData("Subheading", TextStyle.Subheading)]
+    [InlineData("Caption", TextStyle.Caption)]
+    public async Task RenderAsync_RoundsTripStyleAcrossEveryEnumMember(string persistedStyle, TextStyle expected)
+    {
+        // The mapper writes Style as a PascalCase string ("Heading"), so the
+        // renderer must accept that exact form for every enum member shipped.
+        WidgetInstance widget = BuildWidget(
+            "Text",
+            $"{{\"contentLocalizationKey\":\"Widget:Title\",\"style\":\"{persistedStyle}\"}}");
+
+        WidgetSnapshotEnvelope envelope = await new TextWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.Snapshot.ShouldNotBeNull();
+        envelope.Snapshot!.Value.GetProperty("contentLocalizationKey").GetString()
+            .ShouldBe("Widget:Title");
+        envelope.Snapshot.Value.GetProperty("style").GetString()
+            .ShouldBe(expected.ToString());
+    }
+
+    [Fact]
+    public async Task RenderAsync_SerialisesStyleAsPascalCaseString()
+    {
+        // ADR-039 §6.1 — enum members travel as PascalCase strings on the wire.
+        WidgetInstance widget = BuildWidget(
+            "Text",
+            "{\"contentLocalizationKey\":\"Widget:Title\",\"style\":\"Heading\"}");
+
+        WidgetSnapshotEnvelope envelope = await new TextWidgetInstanceRenderer(_clock)
+            .RenderAsync(widget, BuildContext(), TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"style\":\"Heading\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        // Guard against an accidental int-encoded payload (would break the frontend's union).
+        raw.Contains("\"style\":1", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    private static WidgetInstance BuildWidget(string widgetType, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: widgetType,
+            position: 0,
+            width: 1,
+            height: 1,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Dashboards.Endpoints.Tests/packages.lock.json
@@ -640,6 +640,7 @@
           "Granit.Dashboards": "[0.1.0-dev, )",
           "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },


### PR DESCRIPTION
## Summary

Ships the static-content side of the dashboard render pipeline per [ADR-039](docs-site/src/content/docs/dotnet/architecture/adr/039-widget-renderer-architecture.md):

- `MarkdownWidgetInstanceRenderer` (`"Markdown"`) — banner / runbook content
- `TextWidgetInstanceRenderer` (`"Text"`) — heading / subheading / caption (with \`TextStyle\`)
- `ImageWidgetInstanceRenderer` (`"Image"`) — logo / banner photo (with \`ImageFit\`)

All three are static (no data layer, \`RefreshHint.Static\`). Each parses \`WidgetInstance.ConfigJson\` into a per-kind config record then projects to a public \`*WidgetSnapshot\` record consumed by the frontend.

\`AddGranitDashboardsContentWidgetRenderers()\` registers the three behind the same \`IWidgetInstanceRenderer\` surface as the KPI renderer (B3-2 #1484) — a host wiring both packages gets the full catalogue under one \`IEnumerable<T>\` at the dashboard render endpoint.

## Wire shape

ADR-039 §6.1 — camelCase property names + PascalCase enum members. Theory tests round-trip every \`TextStyle\` / \`ImageFit\` member to guard against an accidental int-encoded payload that would break the frontend's discriminated union.

## Test plan

- [x] Unit tests cover renderer happy-path + every enum member
- [x] Wire-shape tests pin camelCase properties + PascalCase enums
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Dashboards.Endpoints.Tests\` — 89 passing (14 new in \`Rendering/\`)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-4 / B3-5 / B3-6 / B7-2: Table / Chart / Pivot / Map renderers
- B4-render: \`POST /dashboards/{id}/render\` + \`IDashboardRenderer\` (registry dispatch, permission gate, error isolation per ADR-039 §3)