### PR TITLE
feat(dashboards): dashboard render endpoint + IDashboardRenderer (B4-render)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13164,6 +13164,42 @@
       "members": []
     },
     {
+      "name": "DashboardRenderPeriodResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardRenderPeriodResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "DashboardRenderRequest",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardRenderRequest",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "DashboardRenderResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardRenderResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "DashboardRenderedWidgetResponse",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardRenderedWidgetResponse",
+      "kind": "record",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
+      "line": 47,
+      "members": []
+    },
+    {
       "name": "DashboardSummaryResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardSummaryResponse",
       "kind": "record",
@@ -13221,7 +13257,7 @@
       "kind": "class",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDashboardsEndpoints",
@@ -13519,6 +13555,15 @@
       "members": []
     },
     {
+      "name": "DashboardRenderResult",
+      "fqn": "Granit.Dashboards.Rendering.DashboardRenderResult",
+      "kind": "record",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Rendering/IDashboardRenderer.cs",
+      "line": 43,
+      "members": []
+    },
+    {
       "name": "EntityAliasBinding",
       "fqn": "Granit.Dashboards.Rendering.EntityAliasBinding",
       "kind": "record",
@@ -13526,6 +13571,22 @@
       "file": "src/Granit.Dashboards/Rendering/EntityAliasBinding.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "IDashboardRenderer",
+      "fqn": "Granit.Dashboards.Rendering.IDashboardRenderer",
+      "kind": "interface",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Rendering/IDashboardRenderer.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "RenderAsync",
+          "kind": "method",
+          "signature": "RenderAsync(Dashboard dashboard, WidgetRenderContext context, CancellationToken cancellationToken)",
+          "returnType": "Task<DashboardRenderResult>"
+        }
+      ]
     },
     {
       "name": "IWidgetInstanceRenderer",
@@ -13542,6 +13603,15 @@
           "returnType": "string WidgetType { get; } Task<WidgetSnapshotEnvelope>"
         }
       ]
+    },
+    {
+      "name": "RenderedWidget",
+      "fqn": "Granit.Dashboards.Rendering.RenderedWidget",
+      "kind": "record",
+      "project": "Granit.Dashboards",
+      "file": "src/Granit.Dashboards/Rendering/IDashboardRenderer.cs",
+      "line": 56,
+      "members": []
     },
     {
       "name": "WidgetRenderContext",

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs
@@ -1,0 +1,34 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Request body for <c>POST /dashboards/{id}/render</c> — drives the per-render
+/// <see cref="Rendering.WidgetRenderContext"/> the dashboard renderer hands to
+/// each <see cref="Rendering.IWidgetInstanceRenderer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The period window is supplied as absolute <see cref="PeriodFrom"/> /
+/// <see cref="PeriodTo"/> bounds; named-token resolution (<c>"mtd"</c>,
+/// <c>"qtd"</c>, …) is the caller's responsibility (mirrors the analytics
+/// inline-metric endpoint, which resolves tokens client-side or via a separate
+/// helper). Both bounds are required together — supplying only one is a 400.
+/// </para>
+/// <para>
+/// <see cref="Filters"/> mirrors the dashboard-level filter spec:
+/// <c>{ "Status": "Open" }</c> drives an unpaid-invoices KPI and an
+/// unpaid-invoices table on the same dashboard. The renderer pipeline doesn't
+/// interpret the values — each typed widget renderer applies them in its own
+/// way.
+/// </para>
+/// </remarks>
+/// <param name="PeriodFrom">Inclusive lower bound (UTC). Required when <see cref="PeriodTo"/> is supplied.</param>
+/// <param name="PeriodTo">Exclusive upper bound (UTC). Required when <see cref="PeriodFrom"/> is supplied.</param>
+/// <param name="PeriodToken">Optional named token (e.g. <c>"mtd"</c>) — echoed in the response for client convenience; the renderer never re-resolves it server-side.</param>
+/// <param name="Locale">Active BCP-47 locale tag (e.g. <c>"en"</c>, <c>"fr-CA"</c>). Defaults to <c>"en"</c> when omitted.</param>
+/// <param name="Filters">Dashboard-level filter bindings. <see langword="null"/> = no filters; the typed renderers apply their own defaults.</param>
+public sealed record DashboardRenderRequest(
+    DateTimeOffset? PeriodFrom = null,
+    DateTimeOffset? PeriodTo = null,
+    string? PeriodToken = null,
+    string? Locale = null,
+    IReadOnlyDictionary<string, string>? Filters = null);

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Wire-shape for <c>POST /dashboards/{id}/render</c>. Bundles every widget's
+/// envelope into one HTTP round-trip. Per ADR-039 §6 — the bundle is a
+/// transport optimisation, not the cache identity (the frontend's
+/// <c>useDashboard</c> hook splits it into per-widget TanStack entries before
+/// storing it).
+/// </summary>
+/// <param name="DashboardId">Dashboard identifier — matches <c>Dashboard.Id</c>.</param>
+/// <param name="RenderedAt">Server-side timestamp at which the bundle was composed.</param>
+/// <param name="Period">Period the renderer ran against. <see langword="null"/> when the request omitted period bounds.</param>
+/// <param name="Widgets">One flat record per widget, in <c>WidgetInstance.Position</c> order.</param>
+public sealed record DashboardRenderResponse(
+    Guid DashboardId,
+    DateTimeOffset RenderedAt,
+    DashboardRenderPeriodResponse? Period,
+    IReadOnlyList<DashboardRenderedWidgetResponse> Widgets);
+
+/// <summary>
+/// Period echoed back to the client. <see cref="Token"/> mirrors the request's
+/// named-token field unchanged — useful for clients that compose UIs around
+/// rotating presets (<c>"mtd"</c>, <c>"qtd"</c>, …).
+/// </summary>
+/// <param name="From">Inclusive lower bound (UTC).</param>
+/// <param name="To">Exclusive upper bound (UTC).</param>
+/// <param name="Token">Optional named token echoed from the request.</param>
+public sealed record DashboardRenderPeriodResponse(DateTimeOffset From, DateTimeOffset To, string? Token = null);
+
+/// <summary>
+/// One widget's slot in the bundle. Flattens the widget id alongside the
+/// envelope fields surfaced by <see cref="WidgetSnapshotEnvelope"/> — the wire
+/// shape ADR-039 §6 locks for every framework dashboard endpoint.
+/// </summary>
+/// <param name="Id">Persisted <c>WidgetInstance.Id</c>.</param>
+/// <param name="WidgetType">Declarative kind discriminator — mirrors <c>WidgetDefinition</c>'s <c>[JsonDerivedType]</c> tag (<c>"Kpi"</c>, <c>"Markdown"</c>, …).</param>
+/// <param name="Status">Runtime outcome (<see cref="WidgetSnapshotStatus.Snapshot"/> / <see cref="WidgetSnapshotStatus.Unavailable"/> / <see cref="WidgetSnapshotStatus.Error"/>).</param>
+/// <param name="Sequence">Always <c>1</c> in pull mode; future push transport increments per (widget, tenant). EPIC #1366 invariant #2.</param>
+/// <param name="EmittedAt">Server-side timestamp of the widget's computation.</param>
+/// <param name="RefreshHint">Pull / push transport hint — drives the frontend's per-widget cache TTL.</param>
+/// <param name="Snapshot">Pre-serialised typed payload. <see langword="null"/> when <see cref="Status"/> is not <see cref="WidgetSnapshotStatus.Snapshot"/>.</param>
+/// <param name="UnavailableReasonLocalizationKey">Localization key for the user-facing reason when <see cref="Status"/> is <see cref="WidgetSnapshotStatus.Unavailable"/>; <see langword="null"/> otherwise.</param>
+public sealed record DashboardRenderedWidgetResponse(
+    Guid Id,
+    string WidgetType,
+    WidgetSnapshotStatus Status,
+    long Sequence,
+    DateTimeOffset EmittedAt,
+    RefreshHint RefreshHint,
+    JsonElement? Snapshot,
+    string? UnavailableReasonLocalizationKey = null);

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
@@ -1,0 +1,86 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Permissions;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Rendering;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Dashboards.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handler for <c>POST /dashboards/{id}/render</c> — composes the dashboard
+/// bundle by dispatching every widget through its registered
+/// <see cref="IWidgetInstanceRenderer"/>. Per ADR-039 §3 the underlying
+/// <see cref="IDashboardRenderer"/> applies a uniform permission gate and
+/// per-widget error isolation, so the endpoint surface stays trivial — load,
+/// build context, dispatch, project.
+/// </summary>
+internal static class DashboardRenderEndpoints
+{
+    public static RouteGroupBuilder MapRenderEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{id:guid}/render", RenderAsync)
+            .WithName("RenderGranitDashboard")
+            .WithSummary("Renders a dashboard's widget pool into one bundle response.")
+            .WithDescription(
+                "Loads the persisted dashboard, builds the per-render context "
+                + "(tenant, principal, period, locale, dashboard filters, resolved "
+                + "entity aliases) and dispatches every widget through its registered "
+                + "IWidgetInstanceRenderer. Each widget surfaces independently as "
+                + "Snapshot / Unavailable / Error — one bad widget cannot 500 the "
+                + "whole render. Multi-tenant filtered through the DbContext (404 "
+                + "for cross-tenant ids — never leaks existence).")
+            .RequireAuthorization(DashboardsPermissions.Instances.Read)
+            .Produces<DashboardRenderResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<DashboardRenderResponse>, ProblemHttpResult>> RenderAsync(
+        [FromRoute] Guid id,
+        [FromBody] DashboardRenderRequest? request,
+        [FromServices] DashboardReader reader,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        DashboardRenderRequest body = request ?? new DashboardRenderRequest();
+
+        // Period bound consistency is enforced by DashboardRenderRequestValidator
+        // (FluentValidationAutoEndpointFilter runs before this handler — see
+        // MapGranitGroup wiring).
+
+        Dashboard? dashboard = await reader.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (dashboard is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Dashboard '{id}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        ResolvedPeriod? period = DashboardRenderProjection.TryBuildResolvedPeriod(body);
+
+        WidgetRenderContext context = new(
+            TenantId: null,                                          // populated upstream via ICurrentTenant when wired into the host
+            User: user,
+            Period: period,
+            Locale: body.Locale ?? "en",
+            DashboardFilters: body.Filters ?? new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+        DashboardRenderResult result = await renderer
+            .RenderAsync(dashboard, context, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(DashboardRenderProjection.ToResponse(result, body.PeriodToken));
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointRouteBuilderExtensions.cs
@@ -37,13 +37,14 @@ public static class DashboardsEndpointRouteBuilderExtensions
             .WithTags(options.CatalogTagName);
         catalogGroup.MapCatalogEndpoints();
 
-        // Instances — the persisted Dashboard aggregate (import + CRUD on metadata + state machine).
+        // Instances — the persisted Dashboard aggregate (import + CRUD on metadata + state machine + render).
         RouteGroupBuilder instancesGroup = group.MapGranitGroup("")
             .WithTags(options.InstancesTagName);
         instancesGroup.MapImportEndpoints();
         instancesGroup.MapInstanceEndpoints();
         instancesGroup.MapMetadataEditEndpoints();
         instancesGroup.MapStateTransitionEndpoints();
+        instancesGroup.MapRenderEndpoints();
 
         // Widgets — pool CRUD scoped under /{id}/widgets.
         RouteGroupBuilder widgetsGroup = group.MapGranitGroup("")

--- a/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
+++ b/src/Granit.Dashboards.Endpoints/Extensions/DashboardsEndpointsServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using Granit.Dashboards.Endpoints.Internal;
 using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -24,6 +26,7 @@ public static class DashboardsEndpointsServiceCollectionExtensions
         services.TryAddScoped<DashboardEditor>();
         services.TryAddScoped<DashboardStateTransitionService>();
         services.TryAddScoped<DashboardWidgetService>();
+        services.TryAddScoped<IDashboardRenderer, DashboardRenderer>();
 
         return services;
     }

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -1,0 +1,52 @@
+using Granit.Analytics;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Translates the rendering-pipeline <see cref="DashboardRenderResult"/> into
+/// the HTTP-shape <see cref="DashboardRenderResponse"/>. Lives next to the
+/// other projection helpers so the endpoint handler stays reflection-free and
+/// the wire shape can be unit-tested without an HTTP harness.
+/// </summary>
+internal static class DashboardRenderProjection
+{
+    public static DashboardRenderResponse ToResponse(DashboardRenderResult result, string? periodToken)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        DashboardRenderPeriodResponse? period = result.Period is { } p
+            ? new DashboardRenderPeriodResponse(p.From, p.To, periodToken)
+            : null;
+
+        DashboardRenderedWidgetResponse[] widgets = [.. result.Widgets.Select(rw =>
+            new DashboardRenderedWidgetResponse(
+                Id: rw.WidgetId,
+                WidgetType: rw.Envelope.WidgetType,
+                Status: rw.Envelope.Status,
+                Sequence: rw.Envelope.Sequence,
+                EmittedAt: rw.Envelope.EmittedAt,
+                RefreshHint: rw.Envelope.RefreshHint,
+                Snapshot: rw.Envelope.Snapshot,
+                UnavailableReasonLocalizationKey: rw.Envelope.UnavailableReasonLocalizationKey))];
+
+        return new DashboardRenderResponse(
+            DashboardId: result.DashboardId,
+            RenderedAt: result.RenderedAt,
+            Period: period,
+            Widgets: widgets);
+    }
+
+    public static ResolvedPeriod? TryBuildResolvedPeriod(DashboardRenderRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.PeriodFrom is { } from && request.PeriodTo is { } to)
+        {
+            return new ResolvedPeriod(from, to);
+        }
+
+        return null;
+    }
+}

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
@@ -1,0 +1,119 @@
+using Granit.Analytics.Metrics;
+using Granit.Authorization;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Default <see cref="IDashboardRenderer"/> — keys registered
+/// <see cref="IWidgetInstanceRenderer"/> implementations by
+/// <see cref="IWidgetInstanceRenderer.WidgetType"/> at startup, then dispatches
+/// each persisted widget through the matching renderer with a uniform
+/// permission gate (3.a) and per-widget error isolation (3.c) per ADR-039 §3.
+/// </summary>
+internal sealed partial class DashboardRenderer(
+    IEnumerable<IWidgetInstanceRenderer> renderers,
+    IPermissionChecker permissionChecker,
+    IClock clock,
+    ILogger<DashboardRenderer> logger) : IDashboardRenderer
+{
+    private readonly Dictionary<string, IWidgetInstanceRenderer> _byType =
+        renderers.ToDictionary(r => r.WidgetType, StringComparer.Ordinal);
+
+    private readonly IPermissionChecker _permissionChecker = permissionChecker;
+    private readonly IClock _clock = clock;
+    private readonly ILogger<DashboardRenderer> _logger = logger;
+
+    public async Task<DashboardRenderResult> RenderAsync(
+        Dashboard dashboard,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dashboard);
+        ArgumentNullException.ThrowIfNull(context);
+
+        List<RenderedWidget> results = new(dashboard.Widgets.Count);
+
+        // Project to a stable List in Position order BEFORE iterating — keeps the
+        // outbound order deterministic regardless of which renderer is faster.
+        WidgetInstance[] ordered = [.. dashboard.Widgets.OrderBy(w => w.Position)];
+
+        foreach (WidgetInstance widget in ordered)
+        {
+            DateTimeOffset emittedAt = _clock.Now;
+
+            // 3.a — permission gate. Drops to Unavailable BEFORE the typed renderer
+            //       runs, so a widget the user cannot read never hits the metric / query.
+            if (widget.RequiredPermission is { } perm
+                && !await _permissionChecker.IsGrantedAsync(perm, cancellationToken).ConfigureAwait(false))
+            {
+                results.Add(new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.Unavailable(
+                    widgetType: widget.WidgetType,
+                    sequence: 1,
+                    emittedAt: emittedAt,
+                    refreshHint: RefreshHint.Static)));
+                continue;
+            }
+
+            // 3.b — registered renderer? An unknown WidgetType (module unloaded,
+            //       version mismatch) becomes Error, not a 500 — one widget cannot
+            //       break a whole grid.
+            if (!_byType.TryGetValue(widget.WidgetType, out IWidgetInstanceRenderer? renderer))
+            {
+                LogUnknownWidgetType(widget.Id, widget.WidgetType);
+                results.Add(new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.Error(
+                    widgetType: widget.WidgetType,
+                    sequence: 1,
+                    emittedAt: emittedAt,
+                    refreshHint: RefreshHint.Static)));
+                continue;
+            }
+
+            // 3.c — typed dispatch. Caller cancellation propagates; any other
+            //       exception is captured server-side and returned as Error.
+            try
+            {
+                WidgetSnapshotEnvelope envelope = await renderer
+                    .RenderAsync(widget, context, cancellationToken)
+                    .ConfigureAwait(false);
+                results.Add(new RenderedWidget(widget.Id, envelope));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Per-widget error isolation REQUIRES a generic catch — see ADR-039 §3.c.
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                LogRendererThrew(ex, widget.Id, widget.WidgetType);
+                results.Add(new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.Error(
+                    widgetType: widget.WidgetType,
+                    sequence: 1,
+                    emittedAt: emittedAt,
+                    refreshHint: RefreshHint.Static)));
+            }
+        }
+
+        return new DashboardRenderResult(
+            DashboardId: dashboard.Id,
+            RenderedAt: _clock.Now,
+            Period: context.Period,
+            Widgets: results);
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "Widget {WidgetId} references unknown WidgetType '{WidgetType}' — surfacing Error envelope. Module unloaded or version mismatch?")]
+    private partial void LogUnknownWidgetType(Guid widgetId, string widgetType);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Error,
+        Message = "Renderer for widget {WidgetId} ('{WidgetType}') threw — surfacing Error envelope. Per-widget isolation: other widgets continue.")]
+    private partial void LogRendererThrew(Exception exception, Guid widgetId, string widgetType);
+}

--- a/src/Granit.Dashboards.Endpoints/Validators/DashboardRenderRequestValidator.cs
+++ b/src/Granit.Dashboards.Endpoints/Validators/DashboardRenderRequestValidator.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Dashboards.Endpoints.Validators;
+
+/// <summary>
+/// Validates the body of <c>POST {prefix}/dashboards/{id}/render</c>. The
+/// optional period is supplied as absolute <see cref="DashboardRenderRequest.PeriodFrom"/>
+/// / <see cref="DashboardRenderRequest.PeriodTo"/> bounds — both required
+/// together, with <c>From</c> strictly before <c>To</c>. When neither is
+/// supplied, the renderer runs without a period filter (typical for
+/// dashboards composed exclusively of static-content widgets).
+/// </summary>
+internal sealed class DashboardRenderRequestValidator : GranitValidator<DashboardRenderRequest>
+{
+    public DashboardRenderRequestValidator()
+    {
+        RuleFor(x => x)
+            .Must(BothPeriodBoundsOrNeither)
+            .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecBoundsCode");
+
+        RuleFor(x => x)
+            .Must(FromBeforeTo)
+            .When(x => x.PeriodFrom.HasValue && x.PeriodTo.HasValue)
+            .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecOrderingCode");
+    }
+
+    private static bool BothPeriodBoundsOrNeither(DashboardRenderRequest request) =>
+        request.PeriodFrom.HasValue == request.PeriodTo.HasValue;
+
+    private static bool FromBeforeTo(DashboardRenderRequest request) =>
+        request.PeriodFrom!.Value < request.PeriodTo!.Value;
+}

--- a/src/Granit.Dashboards/Rendering/IDashboardRenderer.cs
+++ b/src/Granit.Dashboards/Rendering/IDashboardRenderer.cs
@@ -1,0 +1,56 @@
+using Granit.Dashboards.Domain;
+
+namespace Granit.Dashboards.Rendering;
+
+/// <summary>
+/// Renders a persisted <see cref="Dashboard"/> aggregate into a wire-shaped
+/// bundle, dispatching each widget through its registered
+/// <see cref="IWidgetInstanceRenderer"/>. Per ADR-039 §3 — three guarantees
+/// concentrated here:
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item><b>Permission gate.</b> Widgets carrying a <c>RequiredPermission</c> the user lacks short-circuit to <c>Unavailable</c> BEFORE the typed renderer runs — story B4 acceptance criterion 4 (a widget pointing at an unreadable metric returns <c>WidgetUnavailable</c>; the dashboard renders without it; no 403 for the whole request).</item>
+///   <item><b>Error isolation.</b> A bad config row, an unloaded module, or an unhandled exception in one renderer never kills the whole render. The dashboard always returns 200 with one or more widgets in <c>Error</c> / <c>Unavailable</c> state.</item>
+///   <item><b>Deterministic ordering.</b> Widgets stream out in <see cref="WidgetInstance.Position"/> order, regardless of which renderer is faster — the frontend reconciles future incremental push messages by widget id, not position.</item>
+/// </list>
+/// </remarks>
+public interface IDashboardRenderer
+{
+    /// <summary>
+    /// Renders the supplied dashboard against <paramref name="context"/>, returning
+    /// one envelope per widget plus the surrounding bundle metadata.
+    /// </summary>
+    /// <param name="dashboard">The dashboard aggregate (already loaded from persistence).</param>
+    /// <param name="context">Per-render context — see <see cref="WidgetRenderContext"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DashboardRenderResult> RenderAsync(
+        Dashboard dashboard,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Result of a dashboard render — the per-widget envelopes plus the timestamp
+/// of the bundle. Endpoint-level wire DTOs (e.g. <c>DashboardRenderResponse</c>)
+/// project this onto whatever shape the HTTP response demands; the rendering
+/// pipeline itself never mints HTTP DTOs.
+/// </summary>
+/// <param name="DashboardId">Dashboard identifier — matches <see cref="Dashboard.Id"/>.</param>
+/// <param name="RenderedAt">Server-side timestamp at which the bundle was composed.</param>
+/// <param name="Period">The resolved period that flowed into <see cref="WidgetRenderContext.Period"/>; surfaced here so the wire response can echo it back to the client without re-resolving.</param>
+/// <param name="Widgets">One envelope per widget, ordered by <see cref="WidgetInstance.Position"/>. Each tuple carries the widget id alongside its envelope so the wire layer can flatten without holding both collections.</param>
+public sealed record DashboardRenderResult(
+    Guid DashboardId,
+    DateTimeOffset RenderedAt,
+    Granit.Analytics.ResolvedPeriod? Period,
+    IReadOnlyList<RenderedWidget> Widgets);
+
+/// <summary>
+/// One widget's contribution to the dashboard render — the persisted id paired
+/// with the typed renderer's envelope. Wire layer flattens both into the
+/// outbound DTO.
+/// </summary>
+/// <param name="WidgetId">Persisted <see cref="WidgetInstance.Id"/>.</param>
+/// <param name="Envelope">Renderer output (Snapshot / Unavailable / Error).</param>
+public sealed record RenderedWidget(Guid WidgetId, WidgetSnapshotEnvelope Envelope);

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Granit.Analytics;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Rendering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Pins the wire shape locked by ADR-039 §6 — the JSON the endpoint emits
+/// must travel through this projection unchanged from the typed envelopes the
+/// renderer pipeline produces. Frontend types in
+/// <c>granit-front/@granit/analytics</c> consume these fields directly; a
+/// silent rename here ripples to TypeScript.
+/// </summary>
+public sealed class DashboardRenderProjectionTests
+{
+    private static readonly DateTimeOffset RenderedAt = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ToResponse_MapsEnvelopeFieldsOntoFlattenedWidgetRecords()
+    {
+        var widgetId = Guid.NewGuid();
+        JsonElement payload = JsonSerializer.SerializeToElement(new { value = 42 });
+
+        DashboardRenderResult result = new(
+            DashboardId: Guid.NewGuid(),
+            RenderedAt: RenderedAt,
+            Period: new ResolvedPeriod(RenderedAt.AddDays(-7), RenderedAt),
+            Widgets:
+            [
+                new RenderedWidget(widgetId, WidgetSnapshotEnvelope.ForSnapshot(
+                    widgetType: "Kpi",
+                    snapshot: payload,
+                    sequence: 1,
+                    emittedAt: RenderedAt,
+                    refreshHint: RefreshHint.Dynamic)),
+            ]);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: "mtd");
+
+        response.DashboardId.ShouldBe(result.DashboardId);
+        response.RenderedAt.ShouldBe(RenderedAt);
+        response.Period.ShouldNotBeNull();
+        response.Period!.From.ShouldBe(RenderedAt.AddDays(-7));
+        response.Period.To.ShouldBe(RenderedAt);
+        response.Period.Token.ShouldBe("mtd");
+
+        response.Widgets.Count.ShouldBe(1);
+        DashboardRenderedWidgetResponse w = response.Widgets[0];
+        w.Id.ShouldBe(widgetId);
+        w.WidgetType.ShouldBe("Kpi");
+        w.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        w.Sequence.ShouldBe(1);
+        w.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        w.Snapshot.ShouldNotBeNull();
+        w.Snapshot!.Value.GetProperty("value").GetInt32().ShouldBe(42);
+        w.UnavailableReasonLocalizationKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_NullPeriod_OmitsPeriodEnvelopeField()
+    {
+        DashboardRenderResult result = new(
+            DashboardId: Guid.NewGuid(),
+            RenderedAt: RenderedAt,
+            Period: null,
+            Widgets: []);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: null);
+
+        response.Period.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_UnavailableEnvelope_PreservesReasonKey()
+    {
+        DashboardRenderResult result = new(
+            DashboardId: Guid.NewGuid(),
+            RenderedAt: RenderedAt,
+            Period: null,
+            Widgets:
+            [
+                new RenderedWidget(Guid.NewGuid(), WidgetSnapshotEnvelope.Unavailable(
+                    widgetType: "Kpi",
+                    sequence: 1,
+                    emittedAt: RenderedAt,
+                    refreshHint: RefreshHint.Static,
+                    reasonLocalizationKey: "Widget:Unavailable.MetricNotFound")),
+            ]);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: null);
+
+        DashboardRenderedWidgetResponse w = response.Widgets[0];
+        w.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        w.Snapshot.ShouldBeNull();
+        w.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("2026-04-01T00:00:00Z", null, null)]                 // single bound = no period
+    [InlineData(null, "2026-05-01T00:00:00Z", null)]                 // single bound = no period
+    [InlineData("2026-04-01T00:00:00Z", "2026-05-01T00:00:00Z", "mtd")]
+    public void TryBuildResolvedPeriod_RequiresBothBounds(string? from, string? to, string? expectedToken)
+    {
+        DashboardRenderRequest request = new(
+            PeriodFrom: from is null ? null : DateTimeOffset.Parse(from, System.Globalization.CultureInfo.InvariantCulture),
+            PeriodTo: to is null ? null : DateTimeOffset.Parse(to, System.Globalization.CultureInfo.InvariantCulture));
+
+        ResolvedPeriod? period = DashboardRenderProjection.TryBuildResolvedPeriod(request);
+
+        if (from is null || to is null)
+        {
+            period.ShouldBeNull();
+        }
+        else
+        {
+            period.ShouldNotBeNull();
+            // Asserting expectedToken non-null for completeness — the token isn't
+            // part of ResolvedPeriod itself, so we just assert resolution succeeded.
+            expectedToken.ShouldNotBeNull();
+        }
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRendererTests.cs
@@ -1,0 +1,258 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.Analytics;
+using Granit.Analytics.Metrics;
+using Granit.Authorization;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Locks the three guarantees ADR-039 §3 concentrates in
+/// <see cref="DashboardRenderer"/>: per-widget permission gate (3.a),
+/// registry-driven dispatch with Error fallback (3.b), and per-widget
+/// exception isolation (3.c). Each test pins one guarantee — failures are
+/// regressions that cannot reach production without bumping these tests.
+/// </summary>
+public sealed class DashboardRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly IPermissionChecker _permissionChecker = Substitute.For<IPermissionChecker>();
+
+    public DashboardRendererTests()
+    {
+        _clock.Now.Returns(Now);
+        _permissionChecker.IsGrantedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true); // default: every permission granted
+    }
+
+    [Fact]
+    public async Task RenderAsync_OrdersWidgetsByPosition_RegardlessOfRendererSpeed()
+    {
+        Dashboard dashboard = BuildDashboard(
+            ("Markdown", Position: 2),
+            ("Markdown", Position: 0),
+            ("Markdown", Position: 1));
+
+        DashboardRenderer renderer = BuildRenderer(new ImmediateRenderer("Markdown"));
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        Guid[] orderedIds = [..
+            dashboard.Widgets.OrderBy(w => w.Position).Select(w => w.Id)];
+
+        result.Widgets.Select(rw => rw.WidgetId).ShouldBe(orderedIds);
+    }
+
+    [Fact]
+    public async Task RenderAsync_PermissionDenied_ReturnsUnavailable_BeforeRendererRuns()
+    {
+        Dashboard dashboard = BuildDashboard(
+            ("Markdown", Position: 0, RequiredPermission: "Module.Resource.Read"));
+
+        _permissionChecker.IsGrantedAsync("Module.Resource.Read", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        ImmediateRenderer markdown = new("Markdown");
+        DashboardRenderer renderer = BuildRenderer(markdown);
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        markdown.CallCount.ShouldBe(0); // gate must fire BEFORE the renderer
+        result.Widgets[0].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        result.Widgets[0].Envelope.WidgetType.ShouldBe("Markdown");
+    }
+
+    [Fact]
+    public async Task RenderAsync_NoRequiredPermission_DoesNotCallChecker()
+    {
+        // Widgets with RequiredPermission == null inherit dashboard-level access —
+        // the renderer must not call IPermissionChecker for them (avoids spurious
+        // checks on framework-shipped read-everywhere widgets like Markdown).
+        Dashboard dashboard = BuildDashboard(("Markdown", Position: 0));
+
+        DashboardRenderer renderer = BuildRenderer(new ImmediateRenderer("Markdown"));
+
+        await renderer.RenderAsync(dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        await _permissionChecker.DidNotReceive()
+            .IsGrantedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownWidgetType_ReturnsErrorEnvelope()
+    {
+        Dashboard dashboard = BuildDashboard(("PhantomKind", Position: 0));
+
+        // No renderer registered for "PhantomKind" — must surface Error, not 500.
+        DashboardRenderer renderer = BuildRenderer();
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        result.Widgets[0].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Error);
+        result.Widgets[0].Envelope.WidgetType.ShouldBe("PhantomKind");
+    }
+
+    [Fact]
+    public async Task RenderAsync_RendererThrows_ReturnsErrorEnvelope_OtherWidgetsContinue()
+    {
+        Dashboard dashboard = BuildDashboard(
+            ("Markdown", Position: 0),
+            ("Boom", Position: 1),
+            ("Markdown", Position: 2));
+
+        DashboardRenderer renderer = BuildRenderer(
+            new ImmediateRenderer("Markdown"),
+            new ThrowingRenderer("Boom"));
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        result.Widgets.Count.ShouldBe(3);
+        result.Widgets[0].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        result.Widgets[1].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Error);
+        result.Widgets[1].Envelope.WidgetType.ShouldBe("Boom");
+        result.Widgets[2].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+    }
+
+    [Fact]
+    public async Task RenderAsync_OperationCanceled_PropagatesAsCancellation()
+    {
+        // Cancellation must propagate (per ADR-039 §3.c) — wrapping it in Error
+        // would mask the caller's intent.
+        Dashboard dashboard = BuildDashboard(("Markdown", Position: 0));
+
+        DashboardRenderer renderer = BuildRenderer(new CancelingRenderer("Markdown"));
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await renderer.RenderAsync(dashboard, BuildContext(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RenderAsync_EmitsBundleMetadata_FromContextAndClock()
+    {
+        Dashboard dashboard = BuildDashboard(("Markdown", Position: 0));
+        DashboardRenderer renderer = BuildRenderer(new ImmediateRenderer("Markdown"));
+
+        ResolvedPeriod period = new(Now.AddDays(-7), Now);
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(period), TestContext.Current.CancellationToken);
+
+        result.DashboardId.ShouldBe(dashboard.Id);
+        result.Period.ShouldBe(period);
+        result.RenderedAt.ShouldBe(Now);
+    }
+
+    [Fact]
+    public async Task RenderAsync_EmptyDashboard_ReturnsEmptyWidgetList()
+    {
+        var dashboard = Dashboard.Create(
+            id: Guid.NewGuid(),
+            name: "Empty",
+            category: DashboardCategory.Finance,
+            sourceDefinitionName: null,
+            sourceDefinitionVersion: null,
+            isSystem: false,
+            layoutColumns: 12,
+            layoutRowHeight: 60);
+
+        DashboardRenderer renderer = BuildRenderer();
+
+        DashboardRenderResult result = await renderer.RenderAsync(
+            dashboard, BuildContext(), TestContext.Current.CancellationToken);
+
+        result.Widgets.ShouldBeEmpty();
+    }
+
+    private DashboardRenderer BuildRenderer(params IWidgetInstanceRenderer[] renderers) =>
+        new(renderers, _permissionChecker, _clock, NullLogger<DashboardRenderer>.Instance);
+
+    private static WidgetRenderContext BuildContext(ResolvedPeriod? period = null) =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: period,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private static Dashboard BuildDashboard(params (string WidgetType, int Position, string? RequiredPermission)[] widgets)
+    {
+        var dashboard = Dashboard.Create(
+            id: Guid.NewGuid(),
+            name: "TestDashboard",
+            category: DashboardCategory.Finance,
+            sourceDefinitionName: null,
+            sourceDefinitionVersion: null,
+            isSystem: false,
+            layoutColumns: 12,
+            layoutRowHeight: 60);
+
+        foreach ((string widgetType, int position, string? requiredPermission) in widgets)
+        {
+            dashboard.AddWidget(
+                widgetId: Guid.NewGuid(),
+                widgetType: widgetType,
+                position: position,
+                width: 1,
+                height: 1,
+                titleLocalizationKey: "Widget:Test",
+                configJson: "{}",
+                requiredPermission: requiredPermission);
+        }
+
+        return dashboard;
+    }
+
+    private static Dashboard BuildDashboard(params (string WidgetType, int Position)[] widgets) =>
+        BuildDashboard([.. widgets.Select(w => (w.WidgetType, w.Position, (string?)null))]);
+
+    private sealed class ImmediateRenderer(string widgetType) : IWidgetInstanceRenderer
+    {
+        public int CallCount { get; private set; }
+        public string WidgetType { get; } = widgetType;
+
+        public Task<WidgetSnapshotEnvelope> RenderAsync(
+            WidgetInstance widget, WidgetRenderContext context, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(WidgetSnapshotEnvelope.ForSnapshot(
+                widgetType: WidgetType,
+                snapshot: JsonSerializer.SerializeToElement(new { ok = true }),
+                sequence: 1,
+                emittedAt: DateTimeOffset.UtcNow,
+                refreshHint: RefreshHint.Static));
+        }
+    }
+
+    private sealed class ThrowingRenderer(string widgetType) : IWidgetInstanceRenderer
+    {
+        public string WidgetType { get; } = widgetType;
+
+        public Task<WidgetSnapshotEnvelope> RenderAsync(
+            WidgetInstance widget, WidgetRenderContext context, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("simulated renderer failure");
+    }
+
+    private sealed class CancelingRenderer(string widgetType) : IWidgetInstanceRenderer
+    {
+        public string WidgetType { get; } = widgetType;
+
+        public Task<WidgetSnapshotEnvelope> RenderAsync(
+            WidgetInstance widget, WidgetRenderContext context, CancellationToken cancellationToken) =>
+            throw new OperationCanceledException();
+    }
+}


### PR DESCRIPTION
## Summary

Composes the per-widget envelopes shipped by B3-1 / B3-2 / B3-3 into one bundle response — \`POST /dashboards/{id}/render\`. Per [ADR-039 §3](docs-site/src/content/docs/dotnet/architecture/adr/039-widget-renderer-architecture.md#3-registry--dashboard-renderer--idashboardrenderer) \`IDashboardRenderer\` concentrates three guarantees in one place:

- **Permission gate (3.a)** — widgets with a \`RequiredPermission\` the user lacks short-circuit to \`Unavailable\` BEFORE the typed renderer runs. No 403 on the whole request; no underlying metric / query touched.
- **Registry-driven dispatch (3.b)** — unknown \`WidgetType\` becomes \`Error\`, not 500. A module unloaded at runtime cannot break a whole grid.
- **Per-widget exception isolation (3.c)** — a renderer that throws is surfaced as \`Error\`, other widgets continue rendering. \`OperationCanceledException\` propagates unchanged.

\`DashboardRenderResponse\` flattens each \`RenderedWidget\` into \`id\` + \`WidgetSnapshotEnvelope\` fields per ADR-039 §6. \`JsonElement?\` \`Snapshot\` travels by-value through STJ; \`status\` / \`refreshHint\` as PascalCase strings (§6.1). The frontend \`useDashboard\` hook then splits the bundle into per-widget TanStack entries (§6.2) — cache identity is per-widget, not per-bundle.

\`DashboardRenderRequest\` covers period bounds, locale, dashboard filters. Period token is echoed back to the client; named-token resolution stays client-side (or in a follow-up shared helper) to avoid pulling \`Granit.Analytics.Endpoints\` into \`Granit.Dashboards.Endpoints\`. FluentValidation auto-runs \`DashboardRenderRequestValidator\` before the handler — period bounds must come together, \`From\` strictly before \`To\`.

## Test plan

- [x] \`DashboardRendererTests\`: 8 tests pin ordering, permission gate, unknown-kind Error, exception isolation, cancellation propagation, bundle metadata
- [x] \`DashboardRenderProjectionTests\`: 6 tests pin the wire shape (envelope flatten, period echo, unavailable reason key)
- [x] Architecture tests pass (189 / 189) — including the validator pairing rule
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Dashboards.Endpoints.Tests\` — 104 passing (15 new in \`Internal/Dashboard*Tests\`)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-2bis: full \`QueryAggregateDatasourceEvaluator\` (the stub still returns \`Widget:Unavailable.QueryAggregateNotImplemented\`)
- B3-4 / B3-5 / B3-6 / B7-2: Table / Chart / Pivot / Map renderers
- Period-token resolution shared helper (promote \`PeriodResolver\` to a cross-package abstraction, or accept the client-side resolution status quo)