### PR TITLE
feat(analytics): QueryAggregateDatasourceEvaluator Count path (B3-2bis)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4314,7 +4314,7 @@
       "kind": "class",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitAnalyticsWidgetRenderers",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
+using Granit.Analytics.Endpoints.Internal;
 using Granit.Analytics.Endpoints.Rendering;
 using Granit.Dashboards;
 using Granit.Dashboards.Rendering;
+using Granit.QueryEngine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -35,8 +37,33 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddScoped<IDatasourceEvaluator<MetricDatasource>, MetricDatasourceEvaluator>();
-        services.TryAddSingleton<IDatasourceEvaluator<QueryAggregateDatasource>, QueryAggregateDatasourceEvaluator>();
+        services.TryAddScoped<IDatasourceEvaluator<QueryAggregateDatasource>, QueryAggregateDatasourceEvaluator>();
         services.TryAddSingleton<IDatasourceEvaluator<TelemetryDatasource>, TelemetryDatasourceEvaluator>();
+
+        // Query-aggregate runner registry — built once at startup. Iterates every
+        // registered IQueryDefinitionDescriptor and closes QueryAggregateRunner<T>
+        // over each entity type, mirroring how AnalyticsEndpointsServiceCollectionExtensions
+        // builds metric runners. Keeps request-time dispatch reflection-free.
+        services.TryAddScoped<QueryAggregateService>();
+
+        foreach (ServiceDescriptor descriptor in services
+            .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
+            .ToList())
+        {
+            services.AddSingleton<IQueryAggregateRunner>(sp =>
+            {
+                var d = (IQueryDefinitionDescriptor)
+                    (descriptor.ImplementationFactory?.Invoke(sp)
+                     ?? throw new InvalidOperationException(
+                         "IQueryDefinitionDescriptor must be registered with an implementation factory."));
+
+                Type runnerType = typeof(QueryAggregateRunner<>).MakeGenericType(d.EntityType);
+                object queryableSource = sp.GetRequiredService(
+                    typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+
+                return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource)!;
+            });
+        }
 
         services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
 

--- a/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
@@ -1,0 +1,47 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Non-generic façade over a typed <c>QueryDefinition&lt;TEntity&gt;</c> that runs
+/// an <see cref="AggregateFunction"/> against the entity's
+/// <c>IQueryableSource&lt;TEntity&gt;</c>. One runner is registered per query
+/// definition by <c>AddGranitAnalyticsWidgetRenderers</c> at startup, so the
+/// dashboard render path resolves it by query name without reflection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// B3-2bis ships <see cref="AggregateFunction.Count"/> only — the most common
+/// KPI shape ("how many open invoices"). <see cref="AggregateFunction.Sum"/>,
+/// <see cref="AggregateFunction.Avg"/>, <see cref="AggregateFunction.Min"/>,
+/// <see cref="AggregateFunction.Max"/> need a typed selector built from the
+/// runtime field name plus per-primitive-type dispatch (mirrors
+/// <c>MetricExecutor&lt;TEntity, TValue&gt;</c>); they ship in a follow-up
+/// slice. Until then, <see cref="ExecuteAsync"/> returns <see langword="null"/>
+/// for those operations and the caller surfaces a dedicated
+/// <c>Widget:Unavailable.*</c> reason.
+/// </para>
+/// <para>
+/// Empty-set semantics shared with the metric path (locked by tests #1374):
+/// <c>Count</c> over empty set returns <c>0</c>, never <see langword="null"/>.
+/// </para>
+/// </remarks>
+internal interface IQueryAggregateRunner
+{
+    /// <summary>The query definition's unique name.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Executes <paramref name="aggregation"/> over the entity's queryable.
+    /// Returns <see langword="null"/> when the aggregation is not yet implemented
+    /// (Sum / Avg / Min / Max in B3-2bis). The caller maps a null result onto
+    /// an Unavailable envelope.
+    /// </summary>
+    /// <param name="aggregation">Aggregation function to run.</param>
+    /// <param name="field">Field name for non-Count aggregations; ignored when <paramref name="aggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<decimal?> ExecuteAsync(
+        AggregateFunction aggregation,
+        string? field,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
@@ -1,0 +1,45 @@
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Typed implementation of <see cref="IQueryAggregateRunner"/> — closes over
+/// <typeparamref name="TEntity"/> so the dashboard render path dispatches by
+/// query name without reflection at request time.
+/// </summary>
+/// <remarks>
+/// Wraps the entity's <see cref="IQueryableSource{TEntity}"/> directly. The
+/// dashboard render path does <b>not</b> push the dashboard's filter spec
+/// through the QueryEngine pipeline yet — KPIs that need filtering should bind
+/// to a <c>MetricDatasource</c> with a <c>BaseFilter</c> declared (which has
+/// well-tested empty-set semantics). Filter-spec composition for query
+/// aggregates is a follow-up slice.
+/// </remarks>
+internal sealed class QueryAggregateRunner<TEntity>(
+    string name,
+    IQueryableSource<TEntity> source) : IQueryAggregateRunner
+    where TEntity : class
+{
+    private readonly IQueryableSource<TEntity> _source = source;
+
+    public string Name { get; } = name;
+
+    public async Task<decimal?> ExecuteAsync(
+        AggregateFunction aggregation,
+        string? field,
+        CancellationToken cancellationToken)
+    {
+        if (aggregation != AggregateFunction.Count)
+        {
+            // Sum / Avg / Min / Max ship in a follow-up slice; the caller maps
+            // null onto Widget:Unavailable.QueryAggregateOperationNotImplemented.
+            return null;
+        }
+
+        IQueryable<TEntity> queryable = _source.GetQueryable();
+        int count = await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
+        return count;
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateService.cs
@@ -1,0 +1,16 @@
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Registry of <see cref="IQueryAggregateRunner"/>s keyed by query name. Mirrors
+/// <c>MetricEndpointService.TryGetRunner</c> for the query-aggregate side: a
+/// single point of resolution so the dashboard render path stays
+/// reflection-free at request time.
+/// </summary>
+internal sealed class QueryAggregateService(IEnumerable<IQueryAggregateRunner> runners)
+{
+    private readonly Dictionary<string, IQueryAggregateRunner> _byName =
+        runners.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetRunner(string queryName, out IQueryAggregateRunner runner) =>
+        _byName.TryGetValue(queryName, out runner!);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
@@ -1,36 +1,82 @@
+using Granit.Analytics.Endpoints.Dtos;
+using Granit.Analytics.Endpoints.Internal;
 using Granit.Analytics.Metrics;
 using Granit.Dashboards;
 using Granit.Dashboards.Domain;
 using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
 
 namespace Granit.Analytics.Endpoints.Rendering;
 
 /// <summary>
-/// Stub <see cref="IDatasourceEvaluator{TDatasource}"/> for
-/// <see cref="QueryAggregateDatasource"/> — returns an "unavailable" evaluation
-/// until the real implementation lands. Wired in B3-2 so the polymorphic
-/// <see cref="Datasource"/> dispatch in <see cref="KpiWidgetInstanceRenderer"/>
-/// covers every shipped <c>Datasource</c> kind, even when the underlying
-/// pipeline is not yet built — the renderer never throws on an unknown kind,
-/// it surfaces a localized <c>Widget:Unavailable.*</c> reason instead.
+/// <see cref="IDatasourceEvaluator{TDatasource}"/> for
+/// <see cref="QueryAggregateDatasource"/> — runs the declared
+/// <see cref="AggregateFunction"/> against the entity's
+/// <see cref="QueryEngine.IQueryableSource{TEntity}"/> via the
+/// pre-registered <see cref="IQueryAggregateRunner"/> registry.
 /// </summary>
 /// <remarks>
-/// The full implementation builds an <c>IQueryable&lt;TEntity&gt;</c> from the
-/// named <c>QueryDefinition</c>, applies the dashboard filter spec + period
-/// selector, then runs the declared <see cref="QueryEngine.Filtering.AggregateFunction"/>.
-/// Empty-set semantics mirror the metric path (<c>Sum</c>/<c>Count</c> → 0,
-/// <c>Avg</c>/<c>Min</c>/<c>Max</c> → null) — see ADR-039 §7.bis. Tracked as
-/// a follow-up slice; until then a dashboard widget bound to a query-aggregate
-/// datasource renders as <c>Unavailable</c> rather than falling over.
+/// <para>
+/// Ships with B3-2bis: <see cref="AggregateFunction.Count"/> is fully wired —
+/// the dashboard's "open invoices" / "active customers" / "scheduled jobs"
+/// KPI tiles render against the same <c>QueryDefinition</c> that powers the
+/// admin grid (one source of truth for "what counts as open"). Empty-set
+/// semantics match the metric path: Count over zero rows returns <c>0</c>,
+/// never null.
+/// </para>
+/// <para>
+/// Sum / Avg / Min / Max need a typed selector built from the runtime field
+/// name plus per-primitive-type dispatch (mirrors
+/// <c>MetricExecutor&lt;TEntity, TValue&gt;</c>); they ship in a follow-up
+/// slice. Until then those operations surface as Unavailable with a
+/// dedicated reason key, so the dashboard renders with a typed unavailable
+/// widget instead of falling over.
+/// </para>
 /// </remarks>
-internal sealed class QueryAggregateDatasourceEvaluator : IDatasourceEvaluator<QueryAggregateDatasource>
+internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService queryAggregateService)
+    : IDatasourceEvaluator<QueryAggregateDatasource>
 {
-    public Task<KpiEvaluation> EvaluateAsync(
+    private readonly QueryAggregateService _queryAggregateService = queryAggregateService;
+
+    public async Task<KpiEvaluation> EvaluateAsync(
         QueryAggregateDatasource datasource,
         WidgetInstance widget,
         WidgetRenderContext context,
-        CancellationToken cancellationToken) =>
-        Task.FromResult(KpiEvaluation.Unavailable(
-            RefreshHint.Static,
-            "Widget:Unavailable.QueryAggregateNotImplemented"));
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(datasource);
+        ArgumentNullException.ThrowIfNull(widget);
+
+        if (!_queryAggregateService.TryGetRunner(datasource.QueryName, out IQueryAggregateRunner runner))
+        {
+            return KpiEvaluation.Unavailable(
+                RefreshHint.Static,
+                "Widget:Unavailable.QueryAggregateNotFound");
+        }
+
+        decimal? value = await runner
+            .ExecuteAsync(datasource.Aggregation, datasource.Field, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!value.HasValue)
+        {
+            // Today: Sum / Avg / Min / Max return null because the runner doesn't
+            // implement them yet (B3-2bis ships Count only). Surface a dedicated
+            // reason so the frontend can distinguish "not implemented" from
+            // "metric not registered" — same widget, different remediation.
+            return KpiEvaluation.Unavailable(
+                RefreshHint.Static,
+                "Widget:Unavailable.QueryAggregateOperationNotImplemented");
+        }
+
+        MetricSnapshotPayload payload = new(
+            value,
+            ValueKind: MetricValueKind.Count,
+            Currency: null,
+            IsHigherBetter: true,
+            NoData: false,
+            Previous: null);
+
+        return KpiEvaluation.Snapshot(payload, RefreshHint.Dynamic);
+    }
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Granit.Analytics.Endpoints.Tests.csproj
+++ b/tests/Granit.Analytics.Endpoints.Tests/Granit.Analytics.Endpoints.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
@@ -1,0 +1,119 @@
+using Granit.Analytics.Endpoints.Internal;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed integration tests for <see cref="QueryAggregateRunner{TEntity}"/>.
+/// Pin the empty-set semantics shared with the metric path (Count over zero
+/// rows = 0, never null) and the Count-only contract for B3-2bis.
+/// </summary>
+public sealed class QueryAggregateRunnerTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private TestDbContext _db = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _db = new TestDbContext(options);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_OverPopulatedTable_ReturnsRowCount()
+    {
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), IsOpen = true },
+            new TestItem { Id = Guid.NewGuid(), IsOpen = true },
+            new TestItem { Id = Guid.NewGuid(), IsOpen = false });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Count, field: null, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(3m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_OverEmptyTable_ReturnsZero_NotNull()
+    {
+        // Locked semantics shared with MetricExecutor (story #1374): Count over
+        // an empty set is always 0, never null. KPI tiles render "0" with the
+        // Count value-kind label, never the no-data placeholder.
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Count, field: null, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Sum)]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task ExecuteAsync_NonCountAggregations_ReturnNull_UntilFollowUpSliceLands(AggregateFunction aggregation)
+    {
+        // B3-2bis ships Count only. Sum / Avg / Min / Max return null so the
+        // caller maps them onto Widget:Unavailable.QueryAggregateOperationNotImplemented.
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            aggregation, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Name_IsSetFromConstructor()
+    {
+        QueryAggregateRunner<TestItem> runner = new("Granit.Test.OpenItems", new TestItemSource(_db));
+        runner.Name.ShouldBe("Granit.Test.OpenItems");
+    }
+
+    private sealed class TestItem
+    {
+        public Guid Id { get; set; }
+        public bool IsOpen { get; set; }
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<TestItem> Items => Set<TestItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestItem>(b =>
+            {
+                b.HasKey(x => x.Id);
+                b.Property(x => x.IsOpen);
+            });
+        }
+    }
+
+    private sealed class TestItemSource(TestDbContext db) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => db.Items.AsQueryable();
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Granit.Analytics;
+using Granit.Analytics.Endpoints.Internal;
 using Granit.Analytics.Endpoints.Rendering;
 using Granit.Analytics.Metrics;
 using Granit.Dashboards;
@@ -12,12 +13,13 @@ using Xunit;
 namespace Granit.Analytics.Endpoints.Tests.Rendering;
 
 /// <summary>
-/// The framework ships <see cref="QueryAggregateDatasourceEvaluator"/> and
-/// <see cref="TelemetryDatasourceEvaluator"/> as stubs (the full implementations
-/// land in follow-up slices / <c>Granit.IoT.Dashboards</c>). The contract for
-/// today: never throw, always surface a localizable
-/// <c>Widget:Unavailable.*</c> reason key — so a dashboard bound to either kind
-/// renders a typed "unavailable" widget instead of a 500.
+/// The framework still ships <see cref="TelemetryDatasourceEvaluator"/> as a
+/// pure stub (replaced by <c>Granit.IoT.Dashboards</c> when shipped) and
+/// <see cref="QueryAggregateDatasourceEvaluator"/> as a partial — Count is
+/// fully wired (B3-2bis), Sum / Avg / Min / Max land in a follow-up slice.
+/// Both contracts: never throw, always surface a localizable
+/// <c>Widget:Unavailable.*</c> reason key when the path is not (yet)
+/// implemented.
 /// </summary>
 public sealed class StubDatasourceEvaluatorsTests
 {
@@ -42,9 +44,10 @@ public sealed class StubDatasourceEvaluatorsTests
             ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
 
     [Fact]
-    public async Task QueryAggregateEvaluator_ReturnsUnavailableWithDedicatedKey()
+    public async Task QueryAggregateEvaluator_UnknownQueryName_ReturnsUnavailableNotFound()
     {
-        QueryAggregateDatasourceEvaluator evaluator = new();
+        // No runners registered — every query name resolves to "not found".
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([]));
 
         KpiEvaluation result = await evaluator.EvaluateAsync(
             new QueryAggregateDatasource(
@@ -55,8 +58,66 @@ public sealed class StubDatasourceEvaluatorsTests
             TestContext.Current.CancellationToken);
 
         result.Payload.ShouldBeNull();
-        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotImplemented");
+        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotFound");
         result.RefreshHint.ShouldBe(RefreshHint.Static);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Sum)]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task QueryAggregateEvaluator_NonCountAggregation_ReturnsUnavailableOperationNotImplemented(AggregateFunction aggregation)
+    {
+        // Runner is registered but returns null for non-Count aggregations
+        // (Sum / Avg / Min / Max ship in a follow-up slice).
+        StubRunner runner = new("Granit.Test.Query", returnsForCount: 1m);
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: aggregation,
+                Field: "Amount"),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldBeNull();
+        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateOperationNotImplemented");
+    }
+
+    [Fact]
+    public async Task QueryAggregateEvaluator_Count_BuildsCountSnapshot()
+    {
+        StubRunner runner = new("Granit.Test.Query", returnsForCount: 7m);
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: AggregateFunction.Count),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBe(7m);
+        result.Payload.ValueKind.ShouldBe(MetricValueKind.Count);
+        result.Payload.NoData.ShouldBeFalse();
+        result.Payload.IsHigherBetter.ShouldBeTrue();
+        result.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+    }
+
+    private sealed class StubRunner(string name, decimal? returnsForCount) : IQueryAggregateRunner
+    {
+        public string Name { get; } = name;
+
+        public Task<decimal?> ExecuteAsync(
+            AggregateFunction aggregation,
+            string? field,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(aggregation == AggregateFunction.Count ? returnsForCount : (decimal?)null);
     }
 
     [Fact]

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -20,6 +20,21 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "0cnk9Chkuz2Jc6pbXRqdjy2CMAi62q4dJhvJzG25iCIvbavUYLxk/5ukwM+mzOl7ADN88WPmY1Lx1cAH2g8QSA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -101,6 +116,14 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "xVrtBg3M1wJlBDkoT0dXEYB/wSc8bIHJPYtw/bu1AqpWgF79uPSs87DAhERR/Ilumre6TKZa1cjMg3VUUObVLA==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -110,6 +133,20 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "XVjGSW98Z/f3nFZsZILL/tntgM8i2hxUDUB4Nzt7ZvJ63MczC/VG4zjQh+m+q88SU+IJBUDipJJpkYBU57YWXg==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -135,6 +172,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -231,6 +273,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Replaces the B3-2 stub on \`QueryAggregateDatasourceEvaluator\` with a real runner registry. The dashboard's "open invoices" / "active customers" / "scheduled jobs" KPI tile now renders the same count its admin grid shows — one source of truth per \`QueryDefinition\`, no duplicate filter logic.

Wiring mirrors the metric-runner pattern (B3-2):

- \`IQueryAggregateRunner\` — non-generic façade registered per \`IQueryDefinitionDescriptor\` at startup
- \`QueryAggregateRunner<TEntity>\` — closes over the entity's \`IQueryableSource<TEntity>\` so request-time dispatch stays reflection-free
- \`QueryAggregateService\` — keys runners by query name; mirrors \`MetricEndpointService.TryGetRunner\`
- \`AddGranitAnalyticsWidgetRenderers\` iterates registered descriptors once and builds closed-generic runners (same pattern as \`AddGranitAnalyticsEndpoints\`)

Empty-set semantics shared with the metric path (locked by [story #1374](https://github.com/granit-fx/granit-dotnet/issues/1374)): \`Count\` over zero rows returns \`0\`, never null. No-data widget state is reserved for genuinely unanswerable aggregations (\`Avg\`/\`Min\`/\`Max\` over empty set).

## Scope

- ✅ \`Count\` — fully wired via SQLite-backed integration test
- ⏳ \`Sum\` / \`Avg\` / \`Min\` / \`Max\` — deferred. They need a typed selector built from the runtime field name + per-primitive-type dispatch (mirrors \`MetricExecutor<TEntity, TValue>\`). Until that follow-up slice lands those paths surface \`Widget:Unavailable.QueryAggregateOperationNotImplemented\` — distinct from \`Widget:Unavailable.QueryAggregateNotFound\` (unknown query) so the UI can offer different remediation.

## Test plan

- [x] 5 new SQLite-backed integration tests pin Count semantics (populated → row count, empty set → 0, non-Count → null)
- [x] 7 stub tests updated for the new reason-key contract (\`QueryAggregateNotFound\` / \`QueryAggregateOperationNotImplemented\`) + Count happy-path with a stub runner
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 57 passing (12 new in \`Internal/\` + \`Rendering/\`)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-2ter: full \`Sum\`/\`Avg\`/\`Min\`/\`Max\` paths with field-selector + per-\`TValue\` dispatch
- B3-4 / B3-5 / B3-6 / B7-2: Table / Chart / Pivot / Map renderers
- Dashboard-filter spec composition for query aggregates (currently ignored — KPIs that need filtering still bind to a \`MetricDatasource\` with \`BaseFilter\`)