### PR TITLE
feat(analytics): Sum/Avg/Min/Max in QueryAggregateRunner (B3-2ter)

### DIFF
--- a/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
@@ -11,19 +11,27 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// B3-2bis ships <see cref="AggregateFunction.Count"/> only — the most common
-/// KPI shape ("how many open invoices"). <see cref="AggregateFunction.Sum"/>,
-/// <see cref="AggregateFunction.Avg"/>, <see cref="AggregateFunction.Min"/>,
-/// <see cref="AggregateFunction.Max"/> need a typed selector built from the
-/// runtime field name plus per-primitive-type dispatch (mirrors
-/// <c>MetricExecutor&lt;TEntity, TValue&gt;</c>); they ship in a follow-up
-/// slice. Until then, <see cref="ExecuteAsync"/> returns <see langword="null"/>
-/// for those operations and the caller surfaces a dedicated
-/// <c>Widget:Unavailable.*</c> reason.
+/// All five <see cref="AggregateFunction"/> members are wired (B3-2bis +
+/// B3-2ter): <see cref="AggregateFunction.Count"/> takes no field;
+/// <see cref="AggregateFunction.Sum"/>, <see cref="AggregateFunction.Avg"/>,
+/// <see cref="AggregateFunction.Min"/>, <see cref="AggregateFunction.Max"/>
+/// resolve the field name reflectively against the closed entity type
+/// and dispatch to EF Core's typed aggregator per primitive type
+/// (<c>int</c> / <c>long</c> / <c>decimal</c> / <c>double</c>).
 /// </para>
 /// <para>
 /// Empty-set semantics shared with the metric path (locked by tests #1374):
-/// <c>Count</c> over empty set returns <c>0</c>, never <see langword="null"/>.
+/// </para>
+/// <list type="bullet">
+///   <item><c>Count</c> empty → <c>0</c>.</item>
+///   <item><c>Sum</c> empty → <c>0</c> (sum-of-empty identity).</item>
+///   <item><c>Avg</c> / <c>Min</c> / <c>Max</c> empty → <see langword="null"/> (semantic "no data"; division by zero / empty-set extremum is undefined).</item>
+/// </list>
+/// <para>
+/// Configuration errors (unknown field, unsupported field type) throw —
+/// <c>IDashboardRenderer</c>'s per-widget error isolation surfaces those as
+/// <c>Error</c> envelopes per ADR-039 §3.c. The dashboard render keeps
+/// returning 200; the misconfigured widget is the only one affected.
 /// </para>
 /// </remarks>
 internal interface IQueryAggregateRunner
@@ -33,13 +41,15 @@ internal interface IQueryAggregateRunner
 
     /// <summary>
     /// Executes <paramref name="aggregation"/> over the entity's queryable.
-    /// Returns <see langword="null"/> when the aggregation is not yet implemented
-    /// (Sum / Avg / Min / Max in B3-2bis). The caller maps a null result onto
-    /// an Unavailable envelope.
+    /// Returns the projected <see cref="decimal"/> value, or <see langword="null"/>
+    /// for empty-set Avg / Min / Max. <c>Count</c> and <c>Sum</c> never return
+    /// null (they coerce to <c>0</c>).
     /// </summary>
     /// <param name="aggregation">Aggregation function to run.</param>
-    /// <param name="field">Field name for non-Count aggregations; ignored when <paramref name="aggregation"/> is <see cref="AggregateFunction.Count"/>.</param>
+    /// <param name="field">Field name for non-Count aggregations; required (not validated when <paramref name="aggregation"/> is <see cref="AggregateFunction.Count"/>). Resolved against the closed entity type reflectively (case-insensitive); unknown field throws.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="ArgumentException">Field is null/empty for a non-Count aggregation, or field is not a property of the entity.</exception>
+    /// <exception cref="NotSupportedException">Field's primitive type is not one of int / long / decimal / double.</exception>
     Task<decimal?> ExecuteAsync(
         AggregateFunction aggregation,
         string? field,

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Reflection;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Filtering;
 using Microsoft.EntityFrameworkCore;
@@ -7,14 +10,17 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// <summary>
 /// Typed implementation of <see cref="IQueryAggregateRunner"/> — closes over
 /// <typeparamref name="TEntity"/> so the dashboard render path dispatches by
-/// query name without reflection at request time.
+/// query name without reflection at request time. Field-name → property
+/// dispatch for Sum / Avg / Min / Max happens once per call (cost is the
+/// reflective property lookup; the LINQ tree itself is materialised by EF Core
+/// without further runtime branching).
 /// </summary>
 /// <remarks>
 /// Wraps the entity's <see cref="IQueryableSource{TEntity}"/> directly. The
 /// dashboard render path does <b>not</b> push the dashboard's filter spec
-/// through the QueryEngine pipeline yet — KPIs that need filtering should bind
-/// to a <c>MetricDatasource</c> with a <c>BaseFilter</c> declared (which has
-/// well-tested empty-set semantics). Filter-spec composition for query
+/// through the QueryEngine pipeline yet — KPIs that need filtering should
+/// bind to a <c>MetricDatasource</c> with a <c>BaseFilter</c> declared
+/// (well-tested empty-set semantics). Filter-spec composition for query
 /// aggregates is a follow-up slice.
 /// </remarks>
 internal sealed class QueryAggregateRunner<TEntity>(
@@ -31,15 +37,160 @@ internal sealed class QueryAggregateRunner<TEntity>(
         string? field,
         CancellationToken cancellationToken)
     {
-        if (aggregation != AggregateFunction.Count)
+        IQueryable<TEntity> queryable = _source.GetQueryable();
+
+        if (aggregation == AggregateFunction.Count)
         {
-            // Sum / Avg / Min / Max ship in a follow-up slice; the caller maps
-            // null onto Widget:Unavailable.QueryAggregateOperationNotImplemented.
-            return null;
+            int count = await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
+            return count;
         }
 
-        IQueryable<TEntity> queryable = _source.GetQueryable();
-        int count = await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
-        return count;
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            throw new ArgumentException(
+                $"Aggregation '{aggregation}' on query '{Name}' requires a Field — Field was null or empty.",
+                nameof(field));
+        }
+
+        PropertyInfo prop = typeof(TEntity).GetProperty(
+            field,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
+            ?? throw new ArgumentException(
+                $"Field '{field}' not found on entity '{typeof(TEntity).Name}' for query '{Name}'.",
+                nameof(field));
+
+        Type underlying = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+
+        return aggregation switch
+        {
+            AggregateFunction.Sum => await ExecuteSumAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Avg => await ExecuteAvgAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Min => await ExecuteMinMaxAsync(queryable, prop, underlying, isMax: false, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Max => await ExecuteMinMaxAsync(queryable, prop, underlying, isMax: true, cancellationToken).ConfigureAwait(false),
+            _ => throw new NotSupportedException(
+                FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
+        };
     }
+
+    private static async Task<decimal?> ExecuteSumAsync(
+        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, CancellationToken ct)
+    {
+        // Sum semantics: empty set = 0 (sum-of-empty identity). Locked by tests #1374
+        // for the metric path and inherited here so dashboard KPIs and inline metrics
+        // never disagree on what "no rows" means for a Sum.
+        if (underlying == typeof(int))
+        {
+            int? r = await q.SumAsync(BuildSelector<int>(prop), ct).ConfigureAwait(false);
+            return r ?? 0;
+        }
+        if (underlying == typeof(long))
+        {
+            long? r = await q.SumAsync(BuildSelector<long>(prop), ct).ConfigureAwait(false);
+            return r ?? 0L;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await q.SumAsync(BuildSelector<decimal>(prop), ct).ConfigureAwait(false);
+            return r ?? 0m;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await q.SumAsync(BuildSelector<double>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : 0m;
+        }
+
+        throw NotSupported(prop, underlying, AggregateFunction.Sum);
+    }
+
+    private static async Task<decimal?> ExecuteAvgAsync(
+        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, CancellationToken ct)
+    {
+        // Avg semantics: empty set = null ("no data"). NEVER zero — division by zero
+        // is undefined and the frontend renders "—".
+        if (underlying == typeof(int))
+        {
+            double? r = await q.AverageAsync(BuildSelector<int>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+        if (underlying == typeof(long))
+        {
+            double? r = await q.AverageAsync(BuildSelector<long>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await q.AverageAsync(BuildSelector<decimal>(prop), ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await q.AverageAsync(BuildSelector<double>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+
+        throw NotSupported(prop, underlying, AggregateFunction.Avg);
+    }
+
+    private static async Task<decimal?> ExecuteMinMaxAsync(
+        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, bool isMax, CancellationToken ct)
+    {
+        // Min/Max semantics: empty set = null. We project to the value type then
+        // call the generic IQueryable<T?>.MinAsync / MaxAsync — no per-type dispatch
+        // needed for the EF Core call, only for the result coercion to decimal.
+        if (underlying == typeof(int))
+        {
+            int? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<int>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(long))
+        {
+            long? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<long>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<decimal>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<double>(prop), isMax, ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+
+        throw NotSupported(prop, underlying, isMax ? AggregateFunction.Max : AggregateFunction.Min);
+    }
+
+    private static Task<TValue?> ExecuteMinMaxTypedAsync<TValue>(
+        IQueryable<TEntity> q,
+        Expression<Func<TEntity, TValue?>> selector,
+        bool isMax,
+        CancellationToken ct)
+        where TValue : struct =>
+        isMax
+            ? q.Select(selector).MaxAsync(ct)
+            : q.Select(selector).MinAsync(ct);
+
+    /// <summary>
+    /// Builds <c>x =&gt; (TValue?)x.{Field}</c>. Lifts non-nullable value types to
+    /// <see cref="Nullable{T}"/> so EF Core's typed Sum / Avg / Min / Max overloads
+    /// can return nullable results — the only way to express "no rows" for
+    /// Avg / Min / Max in SQL.
+    /// </summary>
+    private static Expression<Func<TEntity, TValue?>> BuildSelector<TValue>(PropertyInfo prop) where TValue : struct
+    {
+        ParameterExpression param = Expression.Parameter(typeof(TEntity), "x");
+        Expression access = Expression.Property(param, prop);
+
+        if (prop.PropertyType != typeof(TValue?))
+        {
+            access = Expression.Convert(access, typeof(TValue?));
+        }
+
+        return Expression.Lambda<Func<TEntity, TValue?>>(access, param);
+    }
+
+    private static NotSupportedException NotSupported(PropertyInfo prop, Type underlying, AggregateFunction aggregation) =>
+        new(FormattableString.Invariant(
+            $"Aggregation '{aggregation}' on field '{prop.Name}' (type '{underlying.Name}') is not supported. Supported types: int, long, decimal, double."));
 }

--- a/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
@@ -12,27 +12,12 @@ namespace Granit.Analytics.Endpoints.Rendering;
 /// <see cref="IDatasourceEvaluator{TDatasource}"/> for
 /// <see cref="QueryAggregateDatasource"/> — runs the declared
 /// <see cref="AggregateFunction"/> against the entity's
-/// <see cref="QueryEngine.IQueryableSource{TEntity}"/> via the
-/// pre-registered <see cref="IQueryAggregateRunner"/> registry.
+/// <see cref="QueryEngine.IQueryableSource{TEntity}"/> via the pre-registered
+/// <see cref="IQueryAggregateRunner"/> registry. All five aggregations
+/// (Count / Sum / Avg / Min / Max) are wired (B3-2bis + B3-2ter); the dashboard
+/// "open invoices" tile, "average ticket size" tile and "max latency" tile
+/// share the same <c>QueryDefinition</c> their admin grids do.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Ships with B3-2bis: <see cref="AggregateFunction.Count"/> is fully wired —
-/// the dashboard's "open invoices" / "active customers" / "scheduled jobs"
-/// KPI tiles render against the same <c>QueryDefinition</c> that powers the
-/// admin grid (one source of truth for "what counts as open"). Empty-set
-/// semantics match the metric path: Count over zero rows returns <c>0</c>,
-/// never null.
-/// </para>
-/// <para>
-/// Sum / Avg / Min / Max need a typed selector built from the runtime field
-/// name plus per-primitive-type dispatch (mirrors
-/// <c>MetricExecutor&lt;TEntity, TValue&gt;</c>); they ship in a follow-up
-/// slice. Until then those operations surface as Unavailable with a
-/// dedicated reason key, so the dashboard renders with a typed unavailable
-/// widget instead of falling over.
-/// </para>
-/// </remarks>
 internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService queryAggregateService)
     : IDatasourceEvaluator<QueryAggregateDatasource>
 {
@@ -54,27 +39,30 @@ internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService qu
                 "Widget:Unavailable.QueryAggregateNotFound");
         }
 
+        // Configuration errors (unknown field, unsupported type) propagate and
+        // are caught by IDashboardRenderer's per-widget error isolation
+        // (ADR-039 §3.c). The dashboard render still returns 200; the
+        // misconfigured widget alone is surfaced as Error.
         decimal? value = await runner
             .ExecuteAsync(datasource.Aggregation, datasource.Field, cancellationToken)
             .ConfigureAwait(false);
 
-        if (!value.HasValue)
-        {
-            // Today: Sum / Avg / Min / Max return null because the runner doesn't
-            // implement them yet (B3-2bis ships Count only). Surface a dedicated
-            // reason so the frontend can distinguish "not implemented" from
-            // "metric not registered" — same widget, different remediation.
-            return KpiEvaluation.Unavailable(
-                RefreshHint.Static,
-                "Widget:Unavailable.QueryAggregateOperationNotImplemented");
-        }
+        // Empty-set semantics (locked by tests #1374):
+        // - Count / Sum: 0 (never null) — NoData stays false.
+        // - Avg / Min / Max: null when no rows — NoData true so the frontend
+        //   renders the "—" placeholder instead of "0" (which would imply a
+        //   real measurement).
+        bool noData = !value.HasValue;
+        MetricValueKind valueKind = datasource.Aggregation == AggregateFunction.Count
+            ? MetricValueKind.Count
+            : MetricValueKind.Number;
 
         MetricSnapshotPayload payload = new(
             value,
-            ValueKind: MetricValueKind.Count,
+            ValueKind: valueKind,
             Currency: null,
             IsHigherBetter: true,
-            NoData: false,
+            NoData: noData,
             Previous: null);
 
         return KpiEvaluation.Snapshot(payload, RefreshHint.Dynamic);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
@@ -10,8 +10,9 @@ namespace Granit.Analytics.Endpoints.Tests.Internal;
 
 /// <summary>
 /// SQLite-backed integration tests for <see cref="QueryAggregateRunner{TEntity}"/>.
-/// Pin the empty-set semantics shared with the metric path (Count over zero
-/// rows = 0, never null) and the Count-only contract for B3-2bis.
+/// Pin the empty-set semantics shared with the metric path (Count/Sum → 0,
+/// Avg/Min/Max → null), the Sum/Avg/Min/Max field-selector reflection, and
+/// the misconfiguration path (unknown field, unsupported field type).
 /// </summary>
 public sealed class QueryAggregateRunnerTests : IAsyncLifetime
 {
@@ -40,10 +41,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_Count_OverPopulatedTable_ReturnsRowCount()
     {
-        _db.Items.AddRange(
-            new TestItem { Id = Guid.NewGuid(), IsOpen = true },
-            new TestItem { Id = Guid.NewGuid(), IsOpen = true },
-            new TestItem { Id = Guid.NewGuid(), IsOpen = false });
+        SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
@@ -58,8 +56,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     public async Task ExecuteAsync_Count_OverEmptyTable_ReturnsZero_NotNull()
     {
         // Locked semantics shared with MetricExecutor (story #1374): Count over
-        // an empty set is always 0, never null. KPI tiles render "0" with the
-        // Count value-kind label, never the no-data placeholder.
+        // an empty set is always 0, never null.
         QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
 
         decimal? result = await runner.ExecuteAsync(
@@ -68,15 +65,79 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         result.ShouldBe(0m);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_Sum_OverDecimalField_ReturnsTotal()
+    {
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(60m); // 10 + 20 + 30
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_OverEmptySet_ReturnsZero_NotNull()
+    {
+        // Sum-of-empty is 0 (mathematical identity). Never null.
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Avg_OverDecimalField_ReturnsMean()
+    {
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Avg, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(20m); // (10 + 20 + 30) / 3
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Avg_OverEmptySet_ReturnsNull()
+    {
+        // Avg-of-empty is undefined (division by zero). Never zero.
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Avg, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
     [Theory]
-    [InlineData(AggregateFunction.Sum)]
-    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min, 10)]
+    [InlineData(AggregateFunction.Max, 30)]
+    public async Task ExecuteAsync_MinMax_OverDecimalField_ReturnsExtremum(AggregateFunction aggregation, int expected)
+    {
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            aggregation, field: "Amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
     [InlineData(AggregateFunction.Min)]
     [InlineData(AggregateFunction.Max)]
-    public async Task ExecuteAsync_NonCountAggregations_ReturnNull_UntilFollowUpSliceLands(AggregateFunction aggregation)
+    public async Task ExecuteAsync_MinMax_OverEmptySet_ReturnsNull(AggregateFunction aggregation)
     {
-        // B3-2bis ships Count only. Sum / Avg / Min / Max return null so the
-        // caller maps them onto Widget:Unavailable.QueryAggregateOperationNotImplemented.
         QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
 
         decimal? result = await runner.ExecuteAsync(
@@ -86,16 +147,117 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     }
 
     [Fact]
-    public void Name_IsSetFromConstructor()
+    public async Task ExecuteAsync_Sum_OverIntField_RoundsTripsViaInt()
     {
-        QueryAggregateRunner<TestItem> runner = new("Granit.Test.OpenItems", new TestItemSource(_db));
-        runner.Name.ShouldBe("Granit.Test.OpenItems");
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Quantity", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(6m); // 1 + 2 + 3
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_OverDoubleField_RoundsTripsViaDouble()
+    {
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Score", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(6m); // 1.0 + 2.0 + 3.0
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_OverNullableDecimalField_TreatsAllNullAsEmptySet()
+    {
+        // EF Core's SumAsync on a nullable column with all rows NULL returns
+        // null — the runner must coalesce to 0, matching Sum-of-empty semantics.
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Amount = 0m, Quantity = 0, Score = 0d, Bonus = null },
+            new TestItem { Id = Guid.NewGuid(), Amount = 0m, Quantity = 0, Score = 0d, Bonus = null });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Bonus", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownField_Throws()
+    {
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                AggregateFunction.Sum, field: "NotAColumn", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAColumn");
+        ex.Message.ShouldContain(nameof(TestItem));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsupportedFieldType_Throws()
+    {
+        // Aggregating Sum over a string column makes no sense — surface a clear
+        // error so the dashboard renderer's per-widget isolation surfaces it
+        // as Error (config bug, not data bug).
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await runner.ExecuteAsync(
+                AggregateFunction.Sum, field: "Label", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
+    {
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                AggregateFunction.Sum, field: null, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FieldName_IsCaseInsensitive()
+    {
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+
+        decimal? result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "amount", TestContext.Current.CancellationToken);
+
+        result.ShouldBe(60m);
+    }
+
+    private void SeedThree()
+    {
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Amount = 10m, Quantity = 1, Score = 1.0d, Label = "a", Bonus = 5m },
+            new TestItem { Id = Guid.NewGuid(), Amount = 20m, Quantity = 2, Score = 2.0d, Label = "b", Bonus = 10m },
+            new TestItem { Id = Guid.NewGuid(), Amount = 30m, Quantity = 3, Score = 3.0d, Label = "c", Bonus = 15m });
     }
 
     private sealed class TestItem
     {
         public Guid Id { get; set; }
-        public bool IsOpen { get; set; }
+        public decimal Amount { get; set; }
+        public int Quantity { get; set; }
+        public double Score { get; set; }
+        public string Label { get; set; } = string.Empty;
+        public decimal? Bonus { get; set; }
     }
 
     private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
@@ -107,7 +269,11 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
             modelBuilder.Entity<TestItem>(b =>
             {
                 b.HasKey(x => x.Id);
-                b.Property(x => x.IsOpen);
+                b.Property(x => x.Amount);
+                b.Property(x => x.Quantity);
+                b.Property(x => x.Score);
+                b.Property(x => x.Label);
+                b.Property(x => x.Bonus);
             });
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -14,12 +14,13 @@ namespace Granit.Analytics.Endpoints.Tests.Rendering;
 
 /// <summary>
 /// The framework still ships <see cref="TelemetryDatasourceEvaluator"/> as a
-/// pure stub (replaced by <c>Granit.IoT.Dashboards</c> when shipped) and
-/// <see cref="QueryAggregateDatasourceEvaluator"/> as a partial — Count is
-/// fully wired (B3-2bis), Sum / Avg / Min / Max land in a follow-up slice.
-/// Both contracts: never throw, always surface a localizable
-/// <c>Widget:Unavailable.*</c> reason key when the path is not (yet)
-/// implemented.
+/// pure stub (replaced by <c>Granit.IoT.Dashboards</c> when shipped). The
+/// <see cref="QueryAggregateDatasourceEvaluator"/> is fully wired
+/// (B3-2bis Count + B3-2ter Sum/Avg/Min/Max via field-selector reflection);
+/// these tests pin the no-runner-registered branch and the empty-set semantics
+/// at the evaluator layer, complementing
+/// <see cref="Internal.QueryAggregateRunnerTests"/> which exercises the EF
+/// Core path end-to-end.
 /// </summary>
 public sealed class StubDatasourceEvaluatorsTests
 {
@@ -62,35 +63,10 @@ public sealed class StubDatasourceEvaluatorsTests
         result.RefreshHint.ShouldBe(RefreshHint.Static);
     }
 
-    [Theory]
-    [InlineData(AggregateFunction.Sum)]
-    [InlineData(AggregateFunction.Avg)]
-    [InlineData(AggregateFunction.Min)]
-    [InlineData(AggregateFunction.Max)]
-    public async Task QueryAggregateEvaluator_NonCountAggregation_ReturnsUnavailableOperationNotImplemented(AggregateFunction aggregation)
-    {
-        // Runner is registered but returns null for non-Count aggregations
-        // (Sum / Avg / Min / Max ship in a follow-up slice).
-        StubRunner runner = new("Granit.Test.Query", returnsForCount: 1m);
-        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
-
-        KpiEvaluation result = await evaluator.EvaluateAsync(
-            new QueryAggregateDatasource(
-                QueryName: "Granit.Test.Query",
-                Aggregation: aggregation,
-                Field: "Amount"),
-            BuildWidget("Kpi"),
-            BuildContext(),
-            TestContext.Current.CancellationToken);
-
-        result.Payload.ShouldBeNull();
-        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateOperationNotImplemented");
-    }
-
     [Fact]
     public async Task QueryAggregateEvaluator_Count_BuildsCountSnapshot()
     {
-        StubRunner runner = new("Granit.Test.Query", returnsForCount: 7m);
+        StubRunner runner = new("Granit.Test.Query", value: 7m);
         QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
 
         KpiEvaluation result = await evaluator.EvaluateAsync(
@@ -109,7 +85,60 @@ public sealed class StubDatasourceEvaluatorsTests
         result.RefreshHint.ShouldBe(RefreshHint.Dynamic);
     }
 
-    private sealed class StubRunner(string name, decimal? returnsForCount) : IQueryAggregateRunner
+    [Theory]
+    [InlineData(AggregateFunction.Sum)]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task QueryAggregateEvaluator_NumericAggregation_BuildsNumberSnapshot(AggregateFunction aggregation)
+    {
+        StubRunner runner = new("Granit.Test.Query", value: 42m);
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: aggregation,
+                Field: "Amount"),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBe(42m);
+        result.Payload.ValueKind.ShouldBe(MetricValueKind.Number);
+        result.Payload.NoData.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task QueryAggregateEvaluator_AvgMinMaxOnEmptySet_SurfacesNoData(AggregateFunction aggregation)
+    {
+        // Avg / Min / Max over an empty set return null from the runner — the
+        // evaluator must surface that as NoData=true on a Snapshot envelope
+        // (NOT Unavailable). The frontend renders "—"; the widget is still a
+        // first-class result, just with no measurement to display.
+        StubRunner runner = new("Granit.Test.Query", value: null);
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: aggregation,
+                Field: "Amount"),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBeNull();
+        result.Payload.NoData.ShouldBeTrue();
+        result.Payload.ValueKind.ShouldBe(MetricValueKind.Number);
+    }
+
+    private sealed class StubRunner(string name, decimal? value) : IQueryAggregateRunner
     {
         public string Name { get; } = name;
 
@@ -117,7 +146,7 @@ public sealed class StubDatasourceEvaluatorsTests
             AggregateFunction aggregation,
             string? field,
             CancellationToken cancellationToken) =>
-            Task.FromResult(aggregation == AggregateFunction.Count ? returnsForCount : (decimal?)null);
+            Task.FromResult(value);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes the QueryAggregate gap left by B3-2bis (#1489). The dashboard's "average ticket size" / "max latency" / "min margin" KPI tile now renders the same field aggregation the admin grid would compute via QueryEngine — one source of truth, no duplicate field selection logic.

Implementation mirrors \`MetricExecutor<TEntity, TValue>\` but resolves \`TValue\` at request time (the field name is supplied by the \`QueryAggregateDatasource\`, not declared statically):

- \`BuildSelector<TValue>(prop)\` lifts non-nullable value types to \`Nullable<T>\` via \`Expression.Convert\`, so EF Core's typed \`Sum\` / \`Avg\` overloads can return null on empty sets
- Per-primitive dispatch covers \`int\` / \`long\` / \`decimal\` / \`double\` — same set \`MetricExecutor\` accepts
- \`Min\` / \`Max\` use the generic \`IQueryable<T?>.MinAsync\` / \`MaxAsync\` — no per-primitive call dispatch needed thanks to projection through \`Select\`

Configuration errors (unknown field, unsupported field type) throw — \`IDashboardRenderer\`'s per-widget error isolation surfaces them as \`Error\` envelopes per ADR-039 §3.c. The dashboard render still returns 200; the misconfigured widget alone is surfaced.

## Empty-set semantics (locked by tests #1374)

- \`Count\` / \`Sum\` → \`0\` (Sum-of-empty identity, Count over zero rows). \`NoData\` stays false.
- \`Avg\` / \`Min\` / \`Max\` → \`null\`. The evaluator surfaces this as \`NoData=true\` on a \`Snapshot\` envelope (NOT \`Unavailable\`) — the widget is still a first-class result, just with \"—\" instead of a measurement.

The evaluator also flips the value-kind for non-Count aggregations from \`MetricValueKind.Count\` to \`MetricValueKind.Number\`, so the frontend formatting picks decimals + locale separators rather than the integer-count formatter. Currency-aware QueryAggregate is a future story (needs metadata on the \`QueryDefinition\`'s column descriptor).

## Test plan

- [x] 14 new SQLite-backed integration tests pin Sum/Avg/Min/Max over populated and empty sets, all four primitive types, nullable-decimal all-null behaviour, case-insensitive field resolution, and the two configuration-error paths (unknown field, unsupported type)
- [x] Stub tests rewritten — \`OperationNotImplemented\` reason key removed; empty-set Avg/Min/Max now surface \`NoData=true\` on the snapshot
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 70 passing (13 new in \`Internal/\` + \`Rendering/\`)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-4 / B3-5 / B3-6 / B7-2: Table / Chart / Pivot / Map renderers
- Currency-aware QueryAggregate (metadata on \`ColumnDescriptor\` exposes ISO 4217 code so the snapshot can carry it)
- Filter-spec composition for query aggregates (currently the \`DashboardFilters\` dict is ignored)