### PR TITLE
feat(analytics): Table widget renderer (B3-4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4425,6 +4425,24 @@
       ]
     },
     {
+      "name": "TableWidgetColumn",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.TableWidgetColumn",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "TableWidgetSnapshot",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.TableWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "AnalyticsEntityFrameworkCoreServiceCollectionExtensions",
       "fqn": "Granit.Analytics.EntityFrameworkCore.Extensions.AnalyticsEntityFrameworkCoreServiceCollectionExtensions",
       "kind": "class",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -18,12 +18,16 @@ namespace Granit.Analytics.Endpoints.Extensions;
 public static class AnalyticsRenderingServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the <c>"Kpi"</c> widget renderer plus the bundled
-    /// <see cref="IDatasourceEvaluator{TDatasource}"/> implementations for
-    /// <see cref="MetricDatasource"/> (full), <see cref="QueryAggregateDatasource"/>
-    /// (stub — returns Unavailable until the query-aggregate path lands), and
-    /// <see cref="TelemetryDatasource"/> (stub — replaced by
-    /// <c>Granit.IoT.Dashboards</c> when shipped).
+    /// Registers the data-bound widget renderers shipped by
+    /// <c>Granit.Analytics.Endpoints</c>:
+    /// <list type="bullet">
+    ///   <item><c>"Kpi"</c> — dispatches on <c>Datasource.Kind</c> via the
+    ///         per-source <see cref="IDatasourceEvaluator{TDatasource}"/>
+    ///         registry (Metric / QueryAggregate / Telemetry).</item>
+    ///   <item><c>"Table"</c> — runs the named <c>QueryDefinition</c>
+    ///         through the QueryEngine pipeline, projects the first
+    ///         <c>pageSize</c> rows.</item>
+    /// </list>
     /// </summary>
     /// <remarks>
     /// Call AFTER <c>AddGranitAnalyticsEndpoints()</c> — the
@@ -40,11 +44,13 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         services.TryAddScoped<IDatasourceEvaluator<QueryAggregateDatasource>, QueryAggregateDatasourceEvaluator>();
         services.TryAddSingleton<IDatasourceEvaluator<TelemetryDatasource>, TelemetryDatasourceEvaluator>();
 
-        // Query-aggregate runner registry — built once at startup. Iterates every
-        // registered IQueryDefinitionDescriptor and closes QueryAggregateRunner<T>
-        // over each entity type, mirroring how AnalyticsEndpointsServiceCollectionExtensions
-        // builds metric runners. Keeps request-time dispatch reflection-free.
+        // Per-QueryDefinition runner registries — built once at startup. Iterates
+        // every registered IQueryDefinitionDescriptor and closes the runner
+        // generics over each entity type, mirroring how
+        // AnalyticsEndpointsServiceCollectionExtensions builds metric runners.
+        // Keeps request-time dispatch reflection-free.
         services.TryAddScoped<QueryAggregateService>();
+        services.TryAddScoped<TableService>();
 
         foreach (ServiceDescriptor descriptor in services
             .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
@@ -52,21 +58,38 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         {
             services.AddSingleton<IQueryAggregateRunner>(sp =>
             {
-                var d = (IQueryDefinitionDescriptor)
-                    (descriptor.ImplementationFactory?.Invoke(sp)
-                     ?? throw new InvalidOperationException(
-                         "IQueryDefinitionDescriptor must be registered with an implementation factory."));
-
+                IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
                 Type runnerType = typeof(QueryAggregateRunner<>).MakeGenericType(d.EntityType);
                 object queryableSource = sp.GetRequiredService(
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
 
                 return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource)!;
             });
+
+            services.AddScoped<ITableRunner>(sp =>
+            {
+                IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
+                Type runnerType = typeof(TableRunner<>).MakeGenericType(d.EntityType);
+                object queryableSource = sp.GetRequiredService(
+                    typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+                object engine = sp.GetRequiredService(
+                    typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+                object definition = sp.GetRequiredService(
+                    typeof(QueryDefinition<>).MakeGenericType(d.EntityType));
+
+                return (ITableRunner)Activator.CreateInstance(
+                    runnerType, d.Name, queryableSource, engine, definition)!;
+            });
         }
 
         services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, TableWidgetInstanceRenderer>();
 
         return services;
     }
+
+    private static IQueryDefinitionDescriptor ResolveDescriptor(IServiceProvider sp, ServiceDescriptor descriptor) =>
+        (IQueryDefinitionDescriptor)(descriptor.ImplementationFactory?.Invoke(sp)
+            ?? throw new InvalidOperationException(
+                "IQueryDefinitionDescriptor must be registered with an implementation factory."));
 }

--- a/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Non-generic façade over a typed <c>QueryDefinition&lt;TEntity&gt;</c> that
+/// materialises the first <c>pageSize</c> rows for a Table widget. One runner
+/// is registered per query definition by
+/// <c>AddGranitAnalyticsWidgetRenderers</c> at startup, so the dashboard
+/// render path resolves it by query name without reflection.
+/// </summary>
+internal interface ITableRunner
+{
+    /// <summary>The query definition's unique name.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Loads the first <paramref name="pageSize"/> rows through the QueryEngine
+    /// pipeline (filters, default sort, multi-tenancy already applied via
+    /// <c>BuildFilteredQuery</c> upstream) and projects each row to a flat
+    /// JSON object containing only <paramref name="visibleColumns"/>.
+    /// </summary>
+    /// <param name="visibleColumns">Subset of column property names to surface; <see langword="null"/> = every visible column declared on the <c>QueryDefinition</c>.</param>
+    /// <param name="pageSize">Maximum rows to return. Clamped against the QueryDefinition's <c>MaxPageSize</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="ArgumentException">A column name in <paramref name="visibleColumns"/> is not declared by the <c>QueryDefinition</c>.</exception>
+    Task<TableRunnerResult> ExecuteAsync(
+        IReadOnlyList<string>? visibleColumns,
+        int pageSize,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of an <see cref="ITableRunner.ExecuteAsync"/> call. Carries the
+/// per-column metadata the wire envelope needs (<see cref="Columns"/>) plus
+/// the projected row payload (<see cref="Rows"/>) and the count of matching
+/// rows in the underlying source (<see cref="TotalRowCount"/>) so the
+/// frontend can render "showing 5 of 142" affordances without re-querying.
+/// </summary>
+/// <param name="Columns">Column metadata: property name + localization key for the header. Order matches the order rows expose.</param>
+/// <param name="Rows">Per-row JSON object — keys are camelCase property names, values are typed JSON primitives.</param>
+/// <param name="TotalRowCount">Total matching rows in the underlying source — surfaces a "of N" affordance when more rows exist beyond <paramref name="Rows"/>'s page.</param>
+internal sealed record TableRunnerResult(
+    IReadOnlyList<TableRunnerColumn> Columns,
+    IReadOnlyList<JsonElement> Rows,
+    int TotalRowCount);
+
+/// <summary>Column metadata surfaced on the wire envelope.</summary>
+/// <param name="Name">Column property name (camelCase to match the row payload keys).</param>
+/// <param name="LabelLocalizationKey">Localization key for the header, or <see langword="null"/> when the source <c>QueryDefinition</c> declared no localized label.</param>
+internal sealed record TableRunnerColumn(string Name, string? LabelLocalizationKey);

--- a/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using System.Text.Json;
+using Granit.QueryEngine;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Typed implementation of <see cref="ITableRunner"/> — closes over
+/// <typeparamref name="TEntity"/> so the dashboard render path materialises
+/// rows without reflection at request time, then projects each entity to a
+/// camelCase JSON object containing only the requested columns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reuses the <see cref="IQueryEngine{TEntity}"/> pipeline so the table tile
+/// honours the same filter / sort / multi-tenancy contract as the admin grid
+/// — a "5 most recent invoices" tile shows the same five invoices the grid
+/// would show with the same default sort.
+/// </para>
+/// <para>
+/// The QueryEngine clamps <c>pageSize</c> against the QueryDefinition's
+/// <c>MaxPageSize</c>, so a misconfigured tile asking for 10 000 rows is
+/// quietly capped — no DOS vector.
+/// </para>
+/// </remarks>
+internal sealed class TableRunner<TEntity>(
+    string name,
+    IQueryableSource<TEntity> source,
+    IQueryEngine<TEntity> engine,
+    QueryDefinition<TEntity> definition) : ITableRunner
+    where TEntity : class
+{
+    // Shared serialisation options: camelCase property names match the wire
+    // convention used by the rest of the dashboard render envelope (ADR-039
+    // §6.1). Every row passes through this so column keys stay consistent.
+    private static readonly JsonSerializerOptions RowJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly IQueryableSource<TEntity> _source = source;
+    private readonly IQueryEngine<TEntity> _engine = engine;
+    private readonly QueryDefinition<TEntity> _definition = definition;
+
+    public string Name { get; } = name;
+
+    public async Task<TableRunnerResult> ExecuteAsync(
+        IReadOnlyList<string>? visibleColumns,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ColumnDescriptor> selectedColumns = ResolveColumns(visibleColumns);
+
+        QueryRequest request = new()
+        {
+            Page = 1,
+            PageSize = pageSize,
+        };
+
+        PagedResult<TEntity> page = await _engine
+            .ExecuteAsync(_source.GetQueryable(), request, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<JsonElement> rows = ProjectRows(page.Items, selectedColumns);
+        IReadOnlyList<TableRunnerColumn> columns = [..
+            selectedColumns.Select(c => new TableRunnerColumn(
+                Name: ToCamelCase(c.PropertyName),
+                LabelLocalizationKey: c.LabelKey))];
+
+        return new TableRunnerResult(columns, rows, page.TotalCount ?? page.Items.Count);
+    }
+
+    private List<ColumnDescriptor> ResolveColumns(IReadOnlyList<string>? visibleColumns)
+    {
+        IReadOnlyList<ColumnDescriptor> declared = _definition.GetColumns();
+
+        if (visibleColumns is null || visibleColumns.Count == 0)
+        {
+            // Default — every visible column the QueryDefinition declared,
+            // ordered by the declared display order.
+            return [.. declared.Where(c => c.IsVisible).OrderBy(c => c.Order)];
+        }
+
+        var byName = declared.ToDictionary(c => c.PropertyName, StringComparer.OrdinalIgnoreCase);
+
+        var resolved = new List<ColumnDescriptor>(visibleColumns.Count);
+        foreach (string requested in visibleColumns)
+        {
+            if (!byName.TryGetValue(requested, out ColumnDescriptor? col))
+            {
+                throw new ArgumentException(
+                    $"Visible column '{requested}' is not declared by query definition '{Name}'.",
+                    nameof(visibleColumns));
+            }
+
+            resolved.Add(col);
+        }
+
+        return resolved;
+    }
+
+    private static List<JsonElement> ProjectRows(
+        IReadOnlyList<TEntity> entities,
+        IReadOnlyList<ColumnDescriptor> columns)
+    {
+        // Cache the PropertyInfo lookup once per call — the entity type is
+        // closed at construction so the lookup cost is per-render, not per-row.
+        // Shadow properties are skipped: they require EF.Property<T>(entity, name)
+        // which the runner does not reach for in v1.
+        var propByColumn = new Dictionary<string, PropertyInfo?>(StringComparer.Ordinal);
+        foreach (ColumnDescriptor col in columns)
+        {
+            propByColumn[col.PropertyName] = col.IsShadowProperty
+                ? null
+                : typeof(TEntity).GetProperty(col.PropertyName, BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        var rows = new List<JsonElement>(entities.Count);
+        foreach (TEntity entity in entities)
+        {
+            var row = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (ColumnDescriptor col in columns)
+            {
+                PropertyInfo? prop = propByColumn[col.PropertyName];
+                row[col.PropertyName] = prop?.GetValue(entity);
+            }
+
+            rows.Add(JsonSerializer.SerializeToElement(row, RowJsonOptions));
+        }
+
+        return rows;
+    }
+
+    private static string ToCamelCase(string value) =>
+        string.IsNullOrEmpty(value)
+            ? value
+            : JsonNamingPolicy.CamelCase.ConvertName(value);
+}

--- a/src/Granit.Analytics.Endpoints/Internal/TableService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/TableService.cs
@@ -1,0 +1,16 @@
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Registry of <see cref="ITableRunner"/>s keyed by query name. Mirrors
+/// <see cref="QueryAggregateService.TryGetRunner"/> for the table side: a
+/// single point of resolution so the dashboard render path stays
+/// reflection-free at request time.
+/// </summary>
+internal sealed class TableService(IEnumerable<ITableRunner> runners)
+{
+    private readonly Dictionary<string, ITableRunner> _byName =
+        runners.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetRunner(string queryName, out ITableRunner runner) =>
+        _byName.TryGetValue(queryName, out runner!);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Table"</c> widget kind.
+/// Resolves the registered <see cref="ITableRunner"/> by query name, runs it
+/// against the entity's queryable through the QueryEngine pipeline, and
+/// shapes the result into a <see cref="TableWidgetSnapshot"/>. Per-widget
+/// permission gate + error isolation already apply upstream
+/// (<see cref="IDashboardRenderer"/> / ADR-039 §3); this renderer is
+/// responsible for the body shape only.
+/// </summary>
+internal sealed class TableWidgetInstanceRenderer(
+    TableService tableService,
+    IClock clock) : IWidgetInstanceRenderer
+{
+    // ConfigJson was written by WidgetDefinitionToInstanceMapper with
+    // PropertyNamingPolicy = CamelCase + (no enum converter). Match.
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly TableService _tableService = tableService;
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Table";
+
+    public async Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        TableConfig config = JsonSerializer.Deserialize<TableConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Table') has empty ConfigJson — table config cannot be resolved.");
+
+        if (string.IsNullOrWhiteSpace(widget.QueryName))
+        {
+            throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Table') has no QueryName — Table widgets must reference a registered QueryDefinition.");
+        }
+
+        DateTimeOffset emittedAt = _clock.Now;
+
+        if (!_tableService.TryGetRunner(widget.QueryName, out ITableRunner runner))
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
+        }
+
+        int pageSize = config.PageSize > 0
+            ? config.PageSize
+            : DefaultPageSize;
+
+        TableRunnerResult result = await runner
+            .ExecuteAsync(config.VisibleColumns, pageSize, cancellationToken)
+            .ConfigureAwait(false);
+
+        TableWidgetSnapshot snapshot = new(
+            Columns: [.. result.Columns.Select(c => new TableWidgetColumn(c.Name, c.LabelLocalizationKey))],
+            Rows: result.Rows,
+            TotalRowCount: result.TotalRowCount);
+
+        return WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: emittedAt,
+            refreshHint: RefreshHint.Dynamic);
+    }
+
+    /// <summary>
+    /// Default rows-per-tile when the widget config omits <c>pageSize</c> —
+    /// 10 rows fits a typical KPI-row layout without scrolling.
+    /// </summary>
+    private const int DefaultPageSize = 10;
+
+    private sealed record TableConfig(IReadOnlyList<string>? VisibleColumns, int PageSize);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Table"</c> widget kind. The dashboard
+/// render endpoint inlines this as the <c>snapshot</c> field of the
+/// per-widget envelope. The frontend's table renderer consumes it directly:
+/// <see cref="Columns"/> drives the header order, <see cref="Rows"/> carries
+/// the body, <see cref="TotalRowCount"/> drives the "showing N of M"
+/// affordance.
+/// </summary>
+/// <param name="Columns">Column metadata in display order. Each entry's <see cref="TableWidgetColumn.Name"/> matches a key in every row payload.</param>
+/// <param name="Rows">Per-row JSON object (camelCase keys, typed JSON primitives). Length is at most the widget's configured page size.</param>
+/// <param name="TotalRowCount">Total rows in the underlying source after filters apply. May exceed <c>Rows.Count</c> when the page is full.</param>
+public sealed record TableWidgetSnapshot(
+    IReadOnlyList<TableWidgetColumn> Columns,
+    IReadOnlyList<JsonElement> Rows,
+    int TotalRowCount);
+
+/// <summary>One column header on the wire envelope.</summary>
+/// <param name="Name">Column property name (camelCase — matches the key in every row payload).</param>
+/// <param name="LabelLocalizationKey">Localization key for the header. <see langword="null"/> when the source <c>QueryDefinition</c> declared no localized label — the frontend falls back to the property name.</param>
+public sealed record TableWidgetColumn(string Name, string? LabelLocalizationKey);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.QueryEngine;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="TableRunner{TEntity}"/> — substitute the
+/// <see cref="IQueryEngine{TEntity}"/> with NSubstitute so the projection
+/// logic is exercised against a known result set, independent of EF Core
+/// translation. The runner's job is to reshape entities into the wire's
+/// camelCase JSON rows; the QueryEngine pipeline already has its own SQLite
+/// integration tests.
+/// </summary>
+public sealed class TableRunnerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_NullVisibleColumns_ReturnsEveryDeclaredColumn_InOrder()
+    {
+        TableRunner<TestItem> runner = BuildRunner(
+            [new TestItem(Guid.NewGuid(), "Alice", 100m), new TestItem(Guid.NewGuid(), "Bob", 200m)],
+            totalCount: 2);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 10,
+            TestContext.Current.CancellationToken);
+
+        result.Columns.Select(c => c.Name).ShouldBe(["name", "amount"]);
+        result.Columns[0].LabelLocalizationKey.ShouldBe("Column:Name");
+        result.Columns[1].LabelLocalizationKey.ShouldBe("Column:Amount");
+        result.Rows.Count.ShouldBe(2);
+        result.TotalRowCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SubsetVisibleColumns_OnlyReturnsThose_InRequestOrder()
+    {
+        TableRunner<TestItem> runner = BuildRunner(
+            [new TestItem(Guid.NewGuid(), "Alice", 100m)],
+            totalCount: 1);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: ["Amount", "Name"],
+            pageSize: 10,
+            TestContext.Current.CancellationToken);
+
+        result.Columns.Select(c => c.Name).ShouldBe(["amount", "name"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownVisibleColumn_Throws()
+    {
+        TableRunner<TestItem> runner = BuildRunner([], totalCount: 0);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                visibleColumns: ["NotAColumn"],
+                pageSize: 10,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAColumn");
+        ex.Message.ShouldContain("Test.Items");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyResultSet_ReturnsEmptyRowsAndZeroTotal()
+    {
+        TableRunner<TestItem> runner = BuildRunner([], totalCount: 0);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 10,
+            TestContext.Current.CancellationToken);
+
+        result.Rows.ShouldBeEmpty();
+        result.TotalRowCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PaginatedResult_PreservesTotalRowCount()
+    {
+        // The runner shows 5 rows but the query has 142 — the wire envelope
+        // surfaces TotalRowCount=142 so the frontend can render "showing 5 of 142".
+        var id = Guid.NewGuid();
+        TableRunner<TestItem> runner = BuildRunner(
+            [new TestItem(id, "Alice", 100m)],
+            totalCount: 142);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 5,
+            TestContext.Current.CancellationToken);
+
+        result.Rows.Count.ShouldBe(1);
+        result.TotalRowCount.ShouldBe(142);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RowKeysAreCamelCase()
+    {
+        // ADR-039 §6.1 — wire convention is camelCase keys + PascalCase enums.
+        // The Name property on the entity must serialise as "name", not "Name".
+        TableRunner<TestItem> runner = BuildRunner(
+            [new TestItem(Guid.NewGuid(), "Alice", 100m)],
+            totalCount: 1);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 10,
+            TestContext.Current.CancellationToken);
+
+        string raw = result.Rows[0].GetRawText();
+        raw.Contains("\"name\":\"Alice\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"amount\":100", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"Name\"", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullValues_SerialiseAsJsonNull()
+    {
+        TableRunner<TestItem> runner = BuildRunner(
+            [new TestItem(Guid.NewGuid(), Name: null, Amount: 0m)],
+            totalCount: 1);
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: ["Name"],
+            pageSize: 10,
+            TestContext.Current.CancellationToken);
+
+        JsonElement nameValue = result.Rows[0].GetProperty("name");
+        nameValue.ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesPageSizeOnTheRequest()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteAsync(Arg.Any<IQueryable<TestItem>>(), Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<TestItem>([], TotalCount: 0, HasMore: false));
+
+        TableRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
+
+        await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 7,
+            TestContext.Current.CancellationToken);
+
+        await engine.Received(1).ExecuteAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Is<QueryRequest>(r => r.PageSize == 7 && r.Page == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static TableRunner<TestItem> BuildRunner(IReadOnlyList<TestItem> entities, int totalCount)
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteAsync(Arg.Any<IQueryable<TestItem>>(), Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<TestItem>(entities, TotalCount: totalCount, HasMore: false));
+
+        return new TableRunner<TestItem>(
+            name: "Test.Items",
+            source: new TestItemSource(entities),
+            engine: engine,
+            definition: new TestQueryDefinition());
+    }
+
+    public sealed record TestItem(Guid Id, string? Name, decimal Amount);
+
+    public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+
+    public sealed class TestQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Name, c => c.Label("Name").LabelKey("Column:Name"))
+                .Column(x => x.Amount, c => c.Label("Amount").LabelKey("Column:Amount"));
+        }
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
@@ -1,0 +1,193 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// Unit tests for <see cref="TableWidgetInstanceRenderer"/> — substitute the
+/// <see cref="TableService"/>'s underlying <see cref="ITableRunner"/> so the
+/// renderer's envelope shaping is exercised against a known result, with the
+/// runner's projection logic separately covered by
+/// <see cref="Internal.TableRunnerTests"/>.
+/// </summary>
+public sealed class TableWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public TableWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsTable()
+    {
+        new TableWidgetInstanceRenderer(new TableService([]), _clock).WidgetType.ShouldBe("Table");
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownQueryName_ReturnsUnavailable()
+    {
+        // No runner registered — surface Unavailable with the dedicated reason
+        // key so the frontend can render "Query not found" rather than a
+        // generic Error.
+        TableWidgetInstanceRenderer renderer = new(new TableService([]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget("Granit.Test.MissingQuery", "{\"visibleColumns\":null,\"pageSize\":10}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.WidgetType.ShouldBe("Table");
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+    }
+
+    [Fact]
+    public async Task RenderAsync_HappyPath_BuildsTableWidgetSnapshot()
+    {
+        ITableRunner runner = StubRunner.WithRows(
+            "Granit.Test.Items",
+            columns: [new TableRunnerColumn("name", "Column:Name"), new TableRunnerColumn("amount", "Column:Amount")],
+            rows: [JsonSerializer.SerializeToElement(new { name = "Alice", amount = 100 })],
+            totalRowCount: 42);
+
+        TableWidgetInstanceRenderer renderer = new(new TableService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget("Granit.Test.Items", "{\"visibleColumns\":null,\"pageSize\":5}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Table");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        envelope.EmittedAt.ShouldBe(Now);
+        envelope.Sequence.ShouldBe(1);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        JsonElement snap = envelope.Snapshot!.Value;
+        snap.GetProperty("totalRowCount").GetInt32().ShouldBe(42);
+        snap.GetProperty("columns").GetArrayLength().ShouldBe(2);
+        snap.GetProperty("rows").GetArrayLength().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_HappyPath_PassesConfigPageSizeAndVisibleColumns()
+    {
+        var runner = StubRunner.Recording("Granit.Test.Items");
+        TableWidgetInstanceRenderer renderer = new(new TableService([runner]), _clock);
+
+        await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"visibleColumns\":[\"Name\",\"Amount\"],\"pageSize\":7}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        runner.LastVisibleColumns.ShouldBe(["Name", "Amount"]);
+        runner.LastPageSize.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task RenderAsync_OmittedPageSize_DefaultsToTen()
+    {
+        // Config can omit pageSize when the widget definition didn't carry one
+        // (definition's PageSize is int? and serialises as 0 when null).
+        var runner = StubRunner.Recording("Granit.Test.Items");
+        TableWidgetInstanceRenderer renderer = new(new TableService([runner]), _clock);
+
+        await renderer.RenderAsync(
+            BuildWidget("Granit.Test.Items", "{\"visibleColumns\":null,\"pageSize\":0}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        runner.LastPageSize.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task RenderAsync_SnapshotShape_IsCamelCase()
+    {
+        ITableRunner runner = StubRunner.WithRows(
+            "Granit.Test.Items",
+            columns: [new TableRunnerColumn("name", "Column:Name")],
+            rows: [],
+            totalRowCount: 0);
+
+        TableWidgetInstanceRenderer renderer = new(new TableService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget("Granit.Test.Items", "{\"visibleColumns\":null,\"pageSize\":10}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"columns\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"rows\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"totalRowCount\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"labelLocalizationKey\":\"Column:Name\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"Columns\"", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    private static WidgetInstance BuildWidget(string queryName, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Table",
+            position: 0,
+            width: 6,
+            height: 3,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson,
+            queryName: queryName);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class StubRunner(
+        string name,
+        IReadOnlyList<TableRunnerColumn> columns,
+        IReadOnlyList<JsonElement> rows,
+        int totalRowCount) : ITableRunner
+    {
+        public string Name { get; } = name;
+
+        public IReadOnlyList<string>? LastVisibleColumns { get; private set; }
+        public int LastPageSize { get; private set; }
+
+        public Task<TableRunnerResult> ExecuteAsync(
+            IReadOnlyList<string>? visibleColumns,
+            int pageSize,
+            CancellationToken cancellationToken)
+        {
+            LastVisibleColumns = visibleColumns;
+            LastPageSize = pageSize;
+            return Task.FromResult(new TableRunnerResult(columns, rows, totalRowCount));
+        }
+
+        public static StubRunner WithRows(
+            string name,
+            IReadOnlyList<TableRunnerColumn> columns,
+            IReadOnlyList<JsonElement> rows,
+            int totalRowCount) =>
+            new(name, columns, rows, totalRowCount);
+
+        public static StubRunner Recording(string name) =>
+            new(name, [], [], 0);
+    }
+}


### PR DESCRIPTION
## Summary

Ships the \"Table\" widget kind end-to-end. The dashboard's \"5 most recent invoices\" / \"top 10 customers\" tile now renders the same rows the admin grid would show — same \`QueryDefinition\`, same default sort, same multi-tenancy filter, same \`MaxPageSize\` cap. No duplicate filter logic.

## Implementation

Mirrors the QueryAggregate scaffolding shipped in B3-2bis / B3-2ter:

- \`ITableRunner\` — non-generic façade registered per \`IQueryDefinitionDescriptor\` at startup
- \`TableRunner<TEntity>\` — closes over \`IQueryableSource<TEntity>\` + \`IQueryEngine<TEntity>\` + \`QueryDefinition<TEntity>\`. Calls \`engine.ExecuteAsync(...)\` so the table tile inherits the full filter / sort / pagination pipeline. \`AsNoTracking\` + \`MaxPageSize\` clamping enforced upstream by the QueryEngine
- \`TableService\` — keys runners by query name; mirrors \`MetricEndpointService.TryGetRunner\` / \`QueryAggregateService.TryGetRunner\`
- \`AddGranitAnalyticsWidgetRenderers\` iterates registered descriptors once and builds closed-generic runners for **every** data-bound widget kind in a single pass

## Wire shape (ADR-039 §6 + §6.1)

\`\`\`jsonc
{
  \"columns\": [
    { \"name\": \"customerName\", \"labelLocalizationKey\": \"Column:CustomerName\" },
    { \"name\": \"amount\",       \"labelLocalizationKey\": \"Column:Amount\" }
  ],
  \"rows\": [
    { \"customerName\": \"Alice\", \"amount\": 100 },
    { \"customerName\": \"Bob\",   \"amount\": 200 }
  ],
  \"totalRowCount\": 142
}
\`\`\`

- Column names are camelCased on the wire so they match the row payload keys
- Row values are typed JSON primitives — frontend formats them based on \`ValueKind\` resolved from the column descriptor's CLR type
- \`totalRowCount\` echoes the QueryEngine's \`TotalCount\` so the frontend can render \"showing N of M\" without a second round-trip
- Reflection over the closed entity type is cached once per call (per-render cost, not per-row)

## Configuration paths

- Unknown query name → \`Unavailable(\"Widget:Unavailable.QueryNotFound\")\` (not Error — the dashboard shows a clear \"this widget isn't wired up\" message)
- Unknown visible column → \`ArgumentException\`, caught by \`IDashboardRenderer\`'s per-widget isolation as Error envelope (config bug)
- \`pageSize\` omitted / 0 → defaults to 10 rows (typical KPI-row layout)

## Test plan

- [x] 8 unit tests for \`TableRunner\` — default visible columns, subset selection, unknown column throws, empty result, paginated result preserves \`TotalRowCount\`, camelCase keys, null values, request page size pass-through
- [x] 6 unit tests for \`TableWidgetInstanceRenderer\` — \`WidgetType=\"Table\"\`, unknown query → Unavailable, happy-path snapshot shape, config-driven page size + visible columns, default page size, camelCase wire shape
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 84 passing (14 new in \`Internal/\` + \`Rendering/\`)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-5 Chart renderer (group-by extension on \`QueryDefinition\`, single-axis chart series)
- B3-6 Pivot renderer (Postgres integration test for multi-level pivots)
- B7-2 Map renderer (PostGIS opt-in for \`MapPointSource.Geography\`)
- Filter-spec composition (currently \`DashboardFilters\` is ignored on the runner — same status as QueryAggregate)