### PR TITLE
feat(analytics): Chart widget renderer — Count grouping (B3-5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4393,6 +4393,24 @@
       "members": []
     },
     {
+      "name": "ChartBucket",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.ChartBucket",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "ChartWidgetSnapshot",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.ChartWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "IDatasourceEvaluator",
       "fqn": "Granit.Analytics.Endpoints.Rendering.IDatasourceEvaluator",
       "kind": "interface",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -27,6 +27,9 @@ public static class AnalyticsRenderingServiceCollectionExtensions
     ///   <item><c>"Table"</c> — runs the named <c>QueryDefinition</c>
     ///         through the QueryEngine pipeline, projects the first
     ///         <c>pageSize</c> rows.</item>
+    ///   <item><c>"Chart"</c> — runs the named <c>QueryDefinition</c>'s
+    ///         <c>ExecuteGroupedAsync</c> pipeline, returns one bucket per
+    ///         group (Count only in B3-5; Sum/Avg/Min/Max in a follow-up).</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -51,6 +54,7 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         // Keeps request-time dispatch reflection-free.
         services.TryAddScoped<QueryAggregateService>();
         services.TryAddScoped<TableService>();
+        services.TryAddScoped<ChartService>();
 
         foreach (ServiceDescriptor descriptor in services
             .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
@@ -80,10 +84,24 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                 return (ITableRunner)Activator.CreateInstance(
                     runnerType, d.Name, queryableSource, engine, definition)!;
             });
+
+            services.AddScoped<IChartRunner>(sp =>
+            {
+                IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
+                Type runnerType = typeof(ChartRunner<>).MakeGenericType(d.EntityType);
+                object queryableSource = sp.GetRequiredService(
+                    typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+                object engine = sp.GetRequiredService(
+                    typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+
+                return (IChartRunner)Activator.CreateInstance(
+                    runnerType, d.Name, queryableSource, engine)!;
+            });
         }
 
         services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, TableWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, ChartWidgetInstanceRenderer>();
 
         return services;
     }

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -1,0 +1,54 @@
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Typed implementation of <see cref="IChartRunner"/> — closes over
+/// <typeparamref name="TEntity"/> so the dashboard render path dispatches by
+/// query name without reflection at request time. Delegates the actual
+/// grouping to <see cref="IQueryEngine{TEntity}.ExecuteGroupedAsync"/>, which
+/// already knows how to apply common filters, materialise per-group counts
+/// and clamp the result set against <c>MaxGroupCount</c>.
+/// </summary>
+internal sealed class ChartRunner<TEntity>(
+    string name,
+    IQueryableSource<TEntity> source,
+    IQueryEngine<TEntity> engine) : IChartRunner
+    where TEntity : class
+{
+    private readonly IQueryableSource<TEntity> _source = source;
+    private readonly IQueryEngine<TEntity> _engine = engine;
+
+    public string Name { get; } = name;
+
+    public async Task<ChartRunnerResult?> ExecuteAsync(
+        string groupBy,
+        AggregateFunction aggregation,
+        string? field,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(groupBy);
+
+        if (aggregation != AggregateFunction.Count)
+        {
+            // Sum / Avg / Min / Max with field aggregation ship in a follow-up
+            // slice — they need a typed group+aggregate expression tree
+            // (mirrors QueryAggregateRunner B3-2ter, with an extra GroupBy
+            // axis). Returning null lets the caller surface a dedicated
+            // Widget:Unavailable.* reason instead of throwing.
+            return null;
+        }
+
+        QueryRequest request = new() { GroupBy = groupBy };
+
+        GroupedResult<TEntity> result = await _engine
+            .ExecuteGroupedAsync(_source.GetQueryable(), request, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<ChartRunnerBucket> buckets = [..
+            result.Groups.Select(g => new ChartRunnerBucket(g.Label, g.Count))];
+
+        return new ChartRunnerResult(buckets);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Internal/ChartService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartService.cs
@@ -1,0 +1,16 @@
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Registry of <see cref="IChartRunner"/>s keyed by query name. Mirrors
+/// <see cref="QueryAggregateService"/> / <see cref="TableService"/> for the
+/// chart side: a single point of resolution so the dashboard render path
+/// stays reflection-free at request time.
+/// </summary>
+internal sealed class ChartService(IEnumerable<IChartRunner> runners)
+{
+    private readonly Dictionary<string, IChartRunner> _byName =
+        runners.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetRunner(string queryName, out IChartRunner runner) =>
+        _byName.TryGetValue(queryName, out runner!);
+}

--- a/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
@@ -1,0 +1,64 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Non-generic façade over a typed <c>QueryDefinition&lt;TEntity&gt;</c> that
+/// runs a group-by aggregation against the entity's queryable. One runner is
+/// registered per query definition by
+/// <c>AddGranitAnalyticsWidgetRenderers</c> at startup; the dashboard render
+/// path resolves it by query name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// B3-5 ships <see cref="AggregateFunction.Count"/> only — the most common
+/// chart shape ("invoices per status", "tickets per priority"). Reuses
+/// <c>IQueryEngine&lt;TEntity&gt;.ExecuteGroupedAsync</c> for the heavy
+/// lifting so chart tiles inherit the same group-by semantics, multi-tenancy
+/// filter and MaxGroupCount cap as the grid endpoint's grouping pivot.
+/// </para>
+/// <para>
+/// <see cref="AggregateFunction.Sum"/> / <see cref="AggregateFunction.Avg"/> /
+/// <see cref="AggregateFunction.Min"/> / <see cref="AggregateFunction.Max"/>
+/// need a typed group-by expression plus per-primitive-type dispatch
+/// (mirrors <c>QueryAggregateRunner</c> B3-2ter, with an extra GroupBy axis);
+/// they ship in a follow-up slice. Until then the runner returns
+/// <see langword="null"/> for those operations and the caller surfaces a
+/// dedicated <c>Widget:Unavailable.*</c> reason.
+/// </para>
+/// </remarks>
+internal interface IChartRunner
+{
+    /// <summary>The query definition's unique name.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Runs <paramref name="aggregation"/> over the entity's queryable, grouped
+    /// by <paramref name="groupBy"/>. Returns one bucket per group, ordered as
+    /// the underlying <c>ExecuteGroupedAsync</c> orders them. Returns
+    /// <see langword="null"/> when the aggregation is not yet implemented
+    /// (Sum / Avg / Min / Max in B3-5).
+    /// </summary>
+    /// <param name="groupBy">Group-by field name (case-insensitive). Resolved against the QueryDefinition's column descriptors; unknown field is rejected upstream by the QueryEngine.</param>
+    /// <param name="aggregation">Aggregation function applied per group.</param>
+    /// <param name="field">Field aggregated; required for non-Count aggregations, ignored for <see cref="AggregateFunction.Count"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ChartRunnerResult?> ExecuteAsync(
+        string groupBy,
+        AggregateFunction aggregation,
+        string? field,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of an <see cref="IChartRunner.ExecuteAsync"/> call. One bucket per
+/// group; <see cref="ChartRunnerBucket.Label"/> renders directly, <see cref="ChartRunnerBucket.Value"/>
+/// is the projected aggregate value coerced to <see cref="decimal"/>.
+/// </summary>
+/// <param name="Buckets">Group-aggregate results in the order surfaced by <c>IQueryEngine.ExecuteGroupedAsync</c>.</param>
+internal sealed record ChartRunnerResult(IReadOnlyList<ChartRunnerBucket> Buckets);
+
+/// <summary>One group's contribution to the chart series.</summary>
+/// <param name="Label">String-friendly group key (e.g. <c>"Open"</c>, <c>"Paid"</c>, <c>"2026-04"</c>). The QueryEngine builds it from the raw key; null group keys surface as <c>"(null)"</c>.</param>
+/// <param name="Value">Aggregate value for the group. Always a count (B3-5 Count-only); future Sum/Avg/Min/Max land here once the typed dispatch slice ships.</param>
+internal sealed record ChartRunnerBucket(string Label, decimal Value);

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Granit.Timing;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Chart"</c> widget kind.
+/// Resolves the registered <see cref="IChartRunner"/> by query name, runs it
+/// with the configured <c>groupBy</c> + <c>aggregation</c> + <c>field</c>,
+/// and shapes the result into a <see cref="ChartWidgetSnapshot"/>.
+/// Per-widget permission gate + error isolation already apply upstream
+/// (<see cref="IDashboardRenderer"/> / ADR-039 §3); this renderer is
+/// responsible for the body shape only.
+/// </summary>
+internal sealed class ChartWidgetInstanceRenderer(
+    ChartService chartService,
+    IClock clock) : IWidgetInstanceRenderer
+{
+    // ConfigJson was written by WidgetDefinitionToInstanceMapper with
+    // PropertyNamingPolicy = CamelCase + ChartType / Aggregation as
+    // PascalCase strings — JsonStringEnumConverter accepts both string and
+    // integer forms.
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly ChartService _chartService = chartService;
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Chart";
+
+    public async Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        ChartConfig config = JsonSerializer.Deserialize<ChartConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Chart') has empty ConfigJson — chart config cannot be resolved.");
+
+        if (string.IsNullOrWhiteSpace(widget.QueryName))
+        {
+            throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Chart') has no QueryName — Chart widgets must reference a registered QueryDefinition.");
+        }
+
+        DateTimeOffset emittedAt = _clock.Now;
+
+        if (!_chartService.TryGetRunner(widget.QueryName, out IChartRunner runner))
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
+        }
+
+        ChartRunnerResult? result = await runner
+            .ExecuteAsync(config.GroupBy, config.Aggregation, config.Field, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result is null)
+        {
+            // Sum / Avg / Min / Max with field aggregation aren't wired yet —
+            // the runner returned null. Surface a dedicated reason so the UI
+            // can distinguish "operation not implemented" from "query not
+            // found".
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.ChartOperationNotImplemented");
+        }
+
+        ChartWidgetSnapshot snapshot = new(
+            ChartType: config.ChartType,
+            GroupBy: config.GroupBy,
+            Aggregation: config.Aggregation,
+            Field: config.Field,
+            Buckets: [.. result.Buckets.Select(b => new ChartBucket(b.Label, b.Value))]);
+
+        return WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: emittedAt,
+            refreshHint: RefreshHint.Dynamic);
+    }
+
+    private sealed record ChartConfig(
+        string GroupBy,
+        AggregateFunction Aggregation,
+        string? Field,
+        ChartType ChartType);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
@@ -1,0 +1,28 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Chart"</c> widget kind. Echoes the
+/// declarative configuration (<see cref="ChartType"/>, <see cref="GroupBy"/>,
+/// <see cref="Aggregation"/>) so the frontend renders without re-reading the
+/// widget config, and ships one <see cref="ChartBucket"/> per group as the
+/// data series.
+/// </summary>
+/// <param name="ChartType">Visual hint inherited from <see cref="ChartWidgetDefinition.ChartType"/>.</param>
+/// <param name="GroupBy">Group-by field name echoed for the frontend's axis label.</param>
+/// <param name="Aggregation">Aggregation applied per bucket — drives the value-axis label.</param>
+/// <param name="Field">Aggregated field; <see langword="null"/> for <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="Buckets">Group-aggregate series. Order is preserved as the underlying group-by produces it.</param>
+public sealed record ChartWidgetSnapshot(
+    ChartType ChartType,
+    string GroupBy,
+    AggregateFunction Aggregation,
+    string? Field,
+    IReadOnlyList<ChartBucket> Buckets);
+
+/// <summary>One data point on the chart's category axis.</summary>
+/// <param name="Label">String-friendly group key (e.g. <c>"Open"</c>, <c>"Paid"</c>, <c>"2026-04"</c>). Null group keys surface as <c>"(null)"</c>.</param>
+/// <param name="Value">Aggregate value for the bucket — always a count in B3-5; Sum/Avg/Min/Max ship in a follow-up.</param>
+public sealed record ChartBucket(string Label, decimal Value);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -1,0 +1,161 @@
+using Granit.Analytics.Endpoints.Internal;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="ChartRunner{TEntity}"/> — substitute the
+/// <see cref="IQueryEngine{TEntity}"/> with NSubstitute so the runner's
+/// dispatch + bucket projection are exercised against a known
+/// <see cref="GroupedResult{T}"/>, independent of EF Core translation.
+/// The QueryEngine's grouping pipeline already has its own SQLite
+/// integration suite.
+/// </summary>
+public sealed class ChartRunnerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_Count_ProjectsGroupedResultIntoBuckets()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteGroupedAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GroupedResult<TestItem>(
+                [
+                    new GroupEntry<TestItem> { Field = "Status", Value = "Open", Label = "Open", Count = 12 },
+                    new GroupEntry<TestItem> { Field = "Status", Value = "Paid", Label = "Paid", Count = 30 },
+                ],
+                TotalCount: 42));
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ChartRunnerResult? result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Count,
+            field: null,
+            TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Buckets.Count.ShouldBe(2);
+        result.Buckets[0].Label.ShouldBe("Open");
+        result.Buckets[0].Value.ShouldBe(12m);
+        result.Buckets[1].Label.ShouldBe("Paid");
+        result.Buckets[1].Value.ShouldBe(30m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesGroupByFieldOnTheRequest()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteGroupedAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GroupedResult<TestItem>([], 0));
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Count,
+            field: null,
+            TestContext.Current.CancellationToken);
+
+        await engine.Received(1).ExecuteGroupedAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Is<QueryRequest>(r => r.GroupBy == "Status"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyResult_ReturnsEmptyBucketList()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteGroupedAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GroupedResult<TestItem>([], 0));
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ChartRunnerResult? result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Count,
+            field: null,
+            TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result!.Buckets.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Sum)]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task ExecuteAsync_NonCountAggregations_ReturnNull_UntilFollowUpSliceLands(AggregateFunction aggregation)
+    {
+        // B3-5 ships Count only — the runner returns null for Sum / Avg / Min /
+        // Max so the caller (ChartWidgetInstanceRenderer) maps onto a dedicated
+        // Widget:Unavailable.* reason.
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ChartRunnerResult? result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: aggregation,
+            field: "Amount",
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+
+        // The QueryEngine must NOT have been called for an unsupported
+        // aggregation — short-circuit before issuing the SQL group-by.
+        await engine.DidNotReceive().ExecuteGroupedAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_EmptyGroupBy_Throws(string groupBy)
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                groupBy: groupBy,
+                aggregation: AggregateFunction.Count,
+                field: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Name_IsSetFromConstructor()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine);
+
+        runner.Name.ShouldBe("Granit.Test.Items");
+    }
+
+    public sealed class TestItem
+    {
+        public Guid Id { get; set; }
+        public string Status { get; set; } = string.Empty;
+    }
+
+    public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
@@ -1,0 +1,196 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// Unit tests for <see cref="ChartWidgetInstanceRenderer"/> — substitute the
+/// <see cref="ChartService"/>'s underlying <see cref="IChartRunner"/> so the
+/// renderer's envelope shaping is exercised against a known result. Runner
+/// projection logic is covered separately by
+/// <see cref="Internal.ChartRunnerTests"/>.
+/// </summary>
+public sealed class ChartWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public ChartWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsChart()
+    {
+        new ChartWidgetInstanceRenderer(new ChartService([]), _clock).WidgetType.ShouldBe("Chart");
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownQueryName_ReturnsUnavailable()
+    {
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.MissingQuery",
+                "{\"groupBy\":\"Status\",\"aggregation\":\"Count\",\"field\":null,\"chartType\":\"Bar\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.WidgetType.ShouldBe("Chart");
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+    }
+
+    [Fact]
+    public async Task RenderAsync_HappyPath_BuildsChartWidgetSnapshot()
+    {
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            buckets: [new ChartRunnerBucket("Open", 12m), new ChartRunnerBucket("Paid", 30m)]);
+
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"groupBy\":\"Status\",\"aggregation\":\"Count\",\"field\":null,\"chartType\":\"Bar\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Chart");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        envelope.EmittedAt.ShouldBe(Now);
+        envelope.Sequence.ShouldBe(1);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        System.Text.Json.JsonElement snap = envelope.Snapshot!.Value;
+        snap.GetProperty("chartType").GetString().ShouldBe("Bar");
+        snap.GetProperty("groupBy").GetString().ShouldBe("Status");
+        snap.GetProperty("aggregation").GetString().ShouldBe("Count");
+        snap.GetProperty("buckets").GetArrayLength().ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Sum)]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task RenderAsync_NonCountAggregation_ReturnsUnavailable(AggregateFunction aggregation)
+    {
+        // The runner returns null for non-Count aggregations (B3-5 staging) —
+        // the renderer surfaces a dedicated reason key. The frontend can
+        // distinguish "operation not yet implemented" from "query not found".
+        StubRunner runner = new("Granit.Test.Items", buckets: []) { ReturnsNull = true };
+
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                $"{{\"groupBy\":\"Status\",\"aggregation\":\"{aggregation}\",\"field\":\"Amount\",\"chartType\":\"Bar\"}}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.ChartOperationNotImplemented");
+    }
+
+    [Theory]
+    [InlineData("Bar")]
+    [InlineData("HorizontalBar")]
+    [InlineData("Line")]
+    [InlineData("Area")]
+    [InlineData("Pie")]
+    [InlineData("Donut")]
+    public async Task RenderAsync_EveryChartType_RoundTripsAsPascalCase(string chartType)
+    {
+        // ADR-039 §6.1 — enum members on the wire stay PascalCase.
+        StubRunner runner = new("Granit.Test.Items", buckets: []);
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                $"{{\"groupBy\":\"Status\",\"aggregation\":\"Count\",\"field\":null,\"chartType\":\"{chartType}\"}}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains($"\"chartType\":\"{chartType}\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+    }
+
+    [Fact]
+    public async Task RenderAsync_PassesConfigOnToRunner()
+    {
+        StubRunner runner = new("Granit.Test.Items", buckets: []);
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
+
+        await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"groupBy\":\"Status\",\"aggregation\":\"Count\",\"field\":null,\"chartType\":\"Pie\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        runner.LastGroupBy.ShouldBe("Status");
+        runner.LastAggregation.ShouldBe(AggregateFunction.Count);
+        runner.LastField.ShouldBeNull();
+    }
+
+    private static WidgetInstance BuildWidget(string queryName, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Chart",
+            position: 0,
+            width: 6,
+            height: 3,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson,
+            queryName: queryName);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class StubRunner(string name, IReadOnlyList<ChartRunnerBucket> buckets) : IChartRunner
+    {
+        public string Name { get; } = name;
+
+        public bool ReturnsNull { get; init; }
+
+        public string? LastGroupBy { get; private set; }
+        public AggregateFunction LastAggregation { get; private set; }
+        public string? LastField { get; private set; }
+
+        public Task<ChartRunnerResult?> ExecuteAsync(
+            string groupBy,
+            AggregateFunction aggregation,
+            string? field,
+            CancellationToken cancellationToken)
+        {
+            LastGroupBy = groupBy;
+            LastAggregation = aggregation;
+            LastField = field;
+            return Task.FromResult<ChartRunnerResult?>(
+                ReturnsNull ? null : new ChartRunnerResult(buckets));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships the \"Chart\" widget kind end-to-end with **Count-grouped** semantics — the most common chart shape (\"invoices per status\", \"tickets per priority\"). Reuses \`IQueryEngine<TEntity>.ExecuteGroupedAsync\` so chart tiles inherit the same group-by translation, multi-tenancy filter and \`MaxGroupCount\` cap as the grid endpoint's grouping pivot. No duplicate group-by logic.

## Implementation

Mirrors the Table runner scaffolding (B3-4):

- \`IChartRunner\` — non-generic façade registered per \`IQueryDefinitionDescriptor\` at startup
- \`ChartRunner<TEntity>\` — closes over \`IQueryableSource<TEntity>\` + \`IQueryEngine<TEntity>\`. Builds a \`QueryRequest\` with \`GroupBy\` set, calls \`ExecuteGroupedAsync\`, projects per-group Count to \`ChartRunnerBucket\`
- \`ChartService\` — keys runners by query name; mirrors the other registries
- \`AddGranitAnalyticsWidgetRenderers\` iterates registered descriptors once and builds closed-generic \`ChartRunner<T>\`'s alongside the existing \`QueryAggregateRunner<T>\` / \`TableRunner<T>\` in a single registration pass

## Wire shape (ADR-039 §6 + §6.1)

\`\`\`jsonc
{
  \"chartType\": \"Bar\",
  \"groupBy\": \"Status\",
  \"aggregation\": \"Count\",
  \"field\": null,
  \"buckets\": [
    { \"label\": \"Open\", \"value\": 12 },
    { \"label\": \"Paid\", \"value\": 30 }
  ]
}
\`\`\`

- \`ChartType\` / \`Aggregation\` surface as PascalCase strings (\`Bar\`, \`Line\`, \`Pie\`, \`Count\`, \`Sum\`, …) via \`JsonStringEnumConverter\`
- \`buckets[]\` = \`{ label, value }\` pairs in the order \`ExecuteGroupedAsync\` produces them. Null group keys surface as \`\"(null)\"\` labels per the QueryEngine convention

## Scope (Count-only — staged like B3-2bis)

- ✅ \`Count\` — fully wired via \`ExecuteGroupedAsync\`
- ⏳ \`Sum\` / \`Avg\` / \`Min\` / \`Max\` — runner returns null; renderer surfaces \`Widget:Unavailable.ChartOperationNotImplemented\`. Same staging as B3-2bis Count → B3-2ter numeric. The follow-up slice needs a typed Group+Aggregate expression tree (mirrors \`QueryAggregateRunner\`'s primitive dispatch, with an extra GroupBy axis)

\`Widget:Unavailable.QueryNotFound\` (unknown query) is distinct from \`Widget:Unavailable.ChartOperationNotImplemented\` (operation not yet wired) so the UI can offer different remediation.

## Test plan

- [x] 6 unit tests for \`ChartRunner\` — happy-path Count, GroupBy pass-through to \`QueryRequest\`, empty result list, theory on Sum/Avg/Min/Max returning null without calling QueryEngine, empty-\`groupBy\` validation, name property
- [x] 9 unit tests for \`ChartWidgetInstanceRenderer\` — \`WidgetType=\"Chart\"\`, unknown-query Unavailable, happy-path snapshot shape, theory on Sum/Avg/Min/Max → \`ChartOperationNotImplemented\`, theory on every \`ChartType\` round-tripping as PascalCase string, config pass-through to runner
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 108 passing (24 new in \`Internal/\` + \`Rendering/\`)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-5bis: Sum/Avg/Min/Max grouping (typed Group+Aggregate expression tree)
- B3-6 Pivot renderer (Postgres integration test for multi-level pivots)
- B7-2 Map renderer (PostGIS opt-in for \`MapPointSource.Geography\`)