### PR TITLE
feat(analytics): Chart Sum/Avg/Min/Max grouping (B3-5bis)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4398,7 +4398,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs",
-      "line": 28,
+      "line": 33,
       "members": []
     },
     {

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Reflection;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Filtering;
 
@@ -6,11 +8,28 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// <summary>
 /// Typed implementation of <see cref="IChartRunner"/> — closes over
 /// <typeparamref name="TEntity"/> so the dashboard render path dispatches by
-/// query name without reflection at request time. Delegates the actual
-/// grouping to <see cref="IQueryEngine{TEntity}.ExecuteGroupedAsync"/>, which
-/// already knows how to apply common filters, materialise per-group counts
-/// and clamp the result set against <c>MaxGroupCount</c>.
+/// query name without reflection at request time.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Two paths, picked by <see cref="AggregateFunction"/>:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Count</b> — delegates to <c>IQueryEngine&lt;TEntity&gt;.ExecuteGroupedAsync</c>;
+///         grouping happens in SQL.</item>
+///   <item><b>Sum / Avg / Min / Max</b> — streams the filtered entity set
+///         through <c>ExecuteStreamAsync</c> (capped by <c>MaxStreamSize</c>)
+///         and computes the per-group aggregate in memory. Acceptable for
+///         dashboard tiles which are bounded data products; future
+///         optimisation could push the aggregation to SQL via dynamic
+///         expression trees.</item>
+/// </list>
+/// <para>
+/// Sharing <c>ExecuteStreamAsync</c> means the chart tile honours the same
+/// filter pipeline / multi-tenancy / soft-delete contract as the admin grid
+/// — the same rows the table sees are the same rows the chart aggregates.
+/// </para>
+/// </remarks>
 internal sealed class ChartRunner<TEntity>(
     string name,
     IQueryableSource<TEntity> source,
@@ -22,7 +41,7 @@ internal sealed class ChartRunner<TEntity>(
 
     public string Name { get; } = name;
 
-    public async Task<ChartRunnerResult?> ExecuteAsync(
+    public async Task<ChartRunnerResult> ExecuteAsync(
         string groupBy,
         AggregateFunction aggregation,
         string? field,
@@ -30,25 +49,142 @@ internal sealed class ChartRunner<TEntity>(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupBy);
 
-        if (aggregation != AggregateFunction.Count)
+        if (aggregation == AggregateFunction.Count)
         {
-            // Sum / Avg / Min / Max with field aggregation ship in a follow-up
-            // slice — they need a typed group+aggregate expression tree
-            // (mirrors QueryAggregateRunner B3-2ter, with an extra GroupBy
-            // axis). Returning null lets the caller surface a dedicated
-            // Widget:Unavailable.* reason instead of throwing.
-            return null;
+            return await ExecuteCountAsync(groupBy, cancellationToken).ConfigureAwait(false);
         }
 
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            throw new ArgumentException(
+                $"Aggregation '{aggregation}' on chart for query '{Name}' requires a Field — Field was null or empty.",
+                nameof(field));
+        }
+
+        return await ExecuteNumericAsync(groupBy, aggregation, field, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<ChartRunnerResult> ExecuteCountAsync(string groupBy, CancellationToken ct)
+    {
         QueryRequest request = new() { GroupBy = groupBy };
 
         GroupedResult<TEntity> result = await _engine
-            .ExecuteGroupedAsync(_source.GetQueryable(), request, cancellationToken)
+            .ExecuteGroupedAsync(_source.GetQueryable(), request, ct)
             .ConfigureAwait(false);
 
         IReadOnlyList<ChartRunnerBucket> buckets = [..
             result.Groups.Select(g => new ChartRunnerBucket(g.Label, g.Count))];
 
         return new ChartRunnerResult(buckets);
+    }
+
+    private async Task<ChartRunnerResult> ExecuteNumericAsync(
+        string groupBy, AggregateFunction aggregation, string field, CancellationToken ct)
+    {
+        PropertyInfo groupProp = ResolveProperty(groupBy, nameof(groupBy));
+        PropertyInfo valueProp = ResolveProperty(field, nameof(field));
+
+        Type valueUnderlying = Nullable.GetUnderlyingType(valueProp.PropertyType) ?? valueProp.PropertyType;
+        EnsureSupportedNumericType(valueProp, valueUnderlying, aggregation);
+
+        // Stream the filtered set through the QueryEngine pipeline (multi-tenancy,
+        // soft-delete, MaxStreamSize cap apply) and aggregate in memory. Acceptable
+        // for dashboard tiles; pushing the aggregate to SQL would need a typed
+        // GroupBy + Select expression tree per (TKey, TValue) primitive pair.
+        QueryRequest request = new();
+        Dictionary<object, AggregateAccumulator> groups = new(GroupKeyComparer.Instance);
+
+        await foreach (TEntity entity in _engine
+            .ExecuteStreamAsync(_source.GetQueryable(), request, ct)
+            .ConfigureAwait(false))
+        {
+            object? rawKey = groupProp.GetValue(entity);
+            object? rawValue = valueProp.GetValue(entity);
+
+            object key = rawKey ?? GroupKeyComparer.NullSentinel;
+            if (!groups.TryGetValue(key, out AggregateAccumulator? acc))
+            {
+                acc = new AggregateAccumulator(rawKey);
+                groups[key] = acc;
+            }
+
+            if (rawValue is not null)
+            {
+                acc.Add(Convert.ToDecimal(rawValue, CultureInfo.InvariantCulture));
+            }
+        }
+
+        IReadOnlyList<ChartRunnerBucket> buckets = [..
+            groups.Values.Select(acc => new ChartRunnerBucket(
+                Label: LabelOf(acc.RawKey),
+                Value: acc.Compute(aggregation)))];
+
+        return new ChartRunnerResult(buckets);
+    }
+
+    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
+    {
+        PropertyInfo? prop = typeof(TEntity).GetProperty(
+            fieldName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        return prop ?? throw new ArgumentException(
+            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
+            paramName);
+    }
+
+    private static void EnsureSupportedNumericType(PropertyInfo prop, Type underlying, AggregateFunction aggregation)
+    {
+        if (underlying == typeof(int) || underlying == typeof(long)
+            || underlying == typeof(decimal) || underlying == typeof(double))
+        {
+            return;
+        }
+
+        throw new NotSupportedException(FormattableString.Invariant(
+            $"Aggregation '{aggregation}' on field '{prop.Name}' (type '{underlying.Name}') is not supported. Supported types: int, long, decimal, double."));
+    }
+
+    private static string LabelOf(object? key) =>
+        key switch
+        {
+            null => "(null)",
+            string s => s,
+            _ => Convert.ToString(key, CultureInfo.InvariantCulture) ?? "(null)",
+        };
+
+    private sealed class AggregateAccumulator(object? rawKey)
+    {
+        private readonly List<decimal> _values = [];
+
+        public object? RawKey { get; } = rawKey;
+
+        public void Add(decimal value) => _values.Add(value);
+
+        public decimal? Compute(AggregateFunction aggregation) =>
+            aggregation switch
+            {
+                // Sum-of-empty is 0 (mathematical identity, matches MetricExecutor).
+                AggregateFunction.Sum => _values.Count == 0 ? 0m : _values.Sum(),
+
+                // Avg / Min / Max over a group with no usable values surface as
+                // null — locked semantics shared with MetricExecutor #1374.
+                AggregateFunction.Avg => _values.Count == 0 ? null : _values.Average(),
+                AggregateFunction.Min => _values.Count == 0 ? null : _values.Min(),
+                AggregateFunction.Max => _values.Count == 0 ? null : _values.Max(),
+
+                _ => throw new NotSupportedException(
+                    FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
+            };
+    }
+
+    private sealed class GroupKeyComparer : IEqualityComparer<object>
+    {
+        public static readonly GroupKeyComparer Instance = new();
+        public static readonly object NullSentinel = new();
+
+        public new bool Equals(object? x, object? y) => object.Equals(x, y);
+
+        public int GetHashCode(object obj) => obj.GetHashCode();
     }
 }

--- a/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
@@ -11,20 +11,31 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// B3-5 ships <see cref="AggregateFunction.Count"/> only — the most common
-/// chart shape ("invoices per status", "tickets per priority"). Reuses
-/// <c>IQueryEngine&lt;TEntity&gt;.ExecuteGroupedAsync</c> for the heavy
-/// lifting so chart tiles inherit the same group-by semantics, multi-tenancy
-/// filter and MaxGroupCount cap as the grid endpoint's grouping pivot.
+/// Wires every <see cref="AggregateFunction"/> member (B3-5 + B3-5bis):
+/// <see cref="AggregateFunction.Count"/> uses
+/// <c>IQueryEngine&lt;TEntity&gt;.ExecuteGroupedAsync</c> for SQL-level
+/// grouping; the numeric aggregations
+/// (<see cref="AggregateFunction.Sum"/> / <see cref="AggregateFunction.Avg"/>
+/// / <see cref="AggregateFunction.Min"/> / <see cref="AggregateFunction.Max"/>)
+/// stream the filtered entity set through <c>ExecuteStreamAsync</c> and
+/// compute the per-group aggregate in memory. The stream is capped by the
+/// QueryDefinition's <c>MaxStreamSize</c> — chart tiles are bounded data
+/// products and the in-memory pass keeps the implementation
+/// reflection-only at the property-access level (no expression-tree
+/// surgery to push the aggregation to SQL).
 /// </para>
 /// <para>
-/// <see cref="AggregateFunction.Sum"/> / <see cref="AggregateFunction.Avg"/> /
-/// <see cref="AggregateFunction.Min"/> / <see cref="AggregateFunction.Max"/>
-/// need a typed group-by expression plus per-primitive-type dispatch
-/// (mirrors <c>QueryAggregateRunner</c> B3-2ter, with an extra GroupBy axis);
-/// they ship in a follow-up slice. Until then the runner returns
-/// <see langword="null"/> for those operations and the caller surfaces a
-/// dedicated <c>Widget:Unavailable.*</c> reason.
+/// Empty-set semantics shared with the metric path (locked by tests #1374):
+/// </para>
+/// <list type="bullet">
+///   <item><c>Count</c> empty → <c>0</c>. <c>Sum</c> empty → <c>0</c> (sum-of-empty identity).</item>
+///   <item><c>Avg</c> / <c>Min</c> / <c>Max</c> empty group → <see langword="null"/> on the bucket value (the bucket is still reported; the frontend renders "—" for that data point).</item>
+/// </list>
+/// <para>
+/// Configuration errors throw — <c>IDashboardRenderer</c>'s per-widget error
+/// isolation surfaces those as <c>Error</c> envelopes per ADR-039 §3.c.
+/// Unknown field, unsupported field type and empty group-by all fall in
+/// this category.
 /// </para>
 /// </remarks>
 internal interface IChartRunner
@@ -34,16 +45,17 @@ internal interface IChartRunner
 
     /// <summary>
     /// Runs <paramref name="aggregation"/> over the entity's queryable, grouped
-    /// by <paramref name="groupBy"/>. Returns one bucket per group, ordered as
-    /// the underlying <c>ExecuteGroupedAsync</c> orders them. Returns
-    /// <see langword="null"/> when the aggregation is not yet implemented
-    /// (Sum / Avg / Min / Max in B3-5).
+    /// by <paramref name="groupBy"/>. Returns one bucket per group, ordered by
+    /// the underlying query result. Buckets carry <see langword="null"/>
+    /// values for empty-group <c>Avg</c> / <c>Min</c> / <c>Max</c>.
     /// </summary>
-    /// <param name="groupBy">Group-by field name (case-insensitive). Resolved against the QueryDefinition's column descriptors; unknown field is rejected upstream by the QueryEngine.</param>
+    /// <param name="groupBy">Group-by field name (case-insensitive).</param>
     /// <param name="aggregation">Aggregation function applied per group.</param>
     /// <param name="field">Field aggregated; required for non-Count aggregations, ignored for <see cref="AggregateFunction.Count"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task<ChartRunnerResult?> ExecuteAsync(
+    /// <exception cref="ArgumentException">Group-by is null/empty, or non-Count aggregation is missing a field, or the field is not a property of the entity.</exception>
+    /// <exception cref="NotSupportedException">Field's primitive type is not one of int / long / decimal / double.</exception>
+    Task<ChartRunnerResult> ExecuteAsync(
         string groupBy,
         AggregateFunction aggregation,
         string? field,
@@ -52,13 +64,13 @@ internal interface IChartRunner
 
 /// <summary>
 /// Outcome of an <see cref="IChartRunner.ExecuteAsync"/> call. One bucket per
-/// group; <see cref="ChartRunnerBucket.Label"/> renders directly, <see cref="ChartRunnerBucket.Value"/>
-/// is the projected aggregate value coerced to <see cref="decimal"/>.
+/// group; <see cref="ChartRunnerBucket.Label"/> renders directly,
+/// <see cref="ChartRunnerBucket.Value"/> is the projected aggregate value.
 /// </summary>
-/// <param name="Buckets">Group-aggregate results in the order surfaced by <c>IQueryEngine.ExecuteGroupedAsync</c>.</param>
+/// <param name="Buckets">Group-aggregate results in the order surfaced by the underlying query.</param>
 internal sealed record ChartRunnerResult(IReadOnlyList<ChartRunnerBucket> Buckets);
 
 /// <summary>One group's contribution to the chart series.</summary>
-/// <param name="Label">String-friendly group key (e.g. <c>"Open"</c>, <c>"Paid"</c>, <c>"2026-04"</c>). The QueryEngine builds it from the raw key; null group keys surface as <c>"(null)"</c>.</param>
-/// <param name="Value">Aggregate value for the group. Always a count (B3-5 Count-only); future Sum/Avg/Min/Max land here once the typed dispatch slice ships.</param>
-internal sealed record ChartRunnerBucket(string Label, decimal Value);
+/// <param name="Label">String-friendly group key. Null group keys surface as <c>"(null)"</c>.</param>
+/// <param name="Value">Aggregate value. <see langword="null"/> when the aggregation is <c>Avg</c>/<c>Min</c>/<c>Max</c> over a group with no usable values (frontend renders "—").</param>
+internal sealed record ChartRunnerBucket(string Label, decimal? Value);

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
@@ -73,23 +73,9 @@ internal sealed class ChartWidgetInstanceRenderer(
                 reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
         }
 
-        ChartRunnerResult? result = await runner
+        ChartRunnerResult result = await runner
             .ExecuteAsync(config.GroupBy, config.Aggregation, config.Field, cancellationToken)
             .ConfigureAwait(false);
-
-        if (result is null)
-        {
-            // Sum / Avg / Min / Max with field aggregation aren't wired yet —
-            // the runner returned null. Surface a dedicated reason so the UI
-            // can distinguish "operation not implemented" from "query not
-            // found".
-            return WidgetSnapshotEnvelope.Unavailable(
-                widgetType: WidgetType,
-                sequence: 1,
-                emittedAt: emittedAt,
-                refreshHint: RefreshHint.Static,
-                reasonLocalizationKey: "Widget:Unavailable.ChartOperationNotImplemented");
-        }
 
         ChartWidgetSnapshot snapshot = new(
             ChartType: config.ChartType,

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
@@ -24,5 +24,10 @@ public sealed record ChartWidgetSnapshot(
 
 /// <summary>One data point on the chart's category axis.</summary>
 /// <param name="Label">String-friendly group key (e.g. <c>"Open"</c>, <c>"Paid"</c>, <c>"2026-04"</c>). Null group keys surface as <c>"(null)"</c>.</param>
-/// <param name="Value">Aggregate value for the bucket — always a count in B3-5; Sum/Avg/Min/Max ship in a follow-up.</param>
-public sealed record ChartBucket(string Label, decimal Value);
+/// <param name="Value">
+/// Aggregate value for the bucket. <see langword="null"/> when the aggregation
+/// is <c>Avg</c> / <c>Min</c> / <c>Max</c> over a group with no usable values
+/// — the frontend renders "—" for that data point. <c>Count</c> and <c>Sum</c>
+/// always carry a non-null value (zero for empty groups).
+/// </param>
+public sealed record ChartBucket(string Label, decimal? Value);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Granit.Analytics.Endpoints.Internal;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Filtering;
@@ -9,16 +10,15 @@ namespace Granit.Analytics.Endpoints.Tests.Internal;
 
 /// <summary>
 /// Unit tests for <see cref="ChartRunner{TEntity}"/> — substitute the
-/// <see cref="IQueryEngine{TEntity}"/> with NSubstitute so the runner's
-/// dispatch + bucket projection are exercised against a known
-/// <see cref="GroupedResult{T}"/>, independent of EF Core translation.
-/// The QueryEngine's grouping pipeline already has its own SQLite
-/// integration suite.
+/// <see cref="IQueryEngine{TEntity}"/> with NSubstitute. Two paths exist:
+/// Count delegates to <c>ExecuteGroupedAsync</c> (SQL-level grouping), and
+/// Sum/Avg/Min/Max stream the entity set through <c>ExecuteStreamAsync</c>
+/// then aggregate in memory. Tests pin both paths.
 /// </summary>
 public sealed class ChartRunnerTests
 {
     [Fact]
-    public async Task ExecuteAsync_Count_ProjectsGroupedResultIntoBuckets()
+    public async Task ExecuteAsync_Count_DelegatesToExecuteGrouped()
     {
         IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
         engine.ExecuteGroupedAsync(
@@ -34,14 +34,13 @@ public sealed class ChartRunnerTests
 
         ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
 
-        ChartRunnerResult? result = await runner.ExecuteAsync(
+        ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
             aggregation: AggregateFunction.Count,
             field: null,
             TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
-        result!.Buckets.Count.ShouldBe(2);
+        result.Buckets.Count.ShouldBe(2);
         result.Buckets[0].Label.ShouldBe("Open");
         result.Buckets[0].Value.ShouldBe(12m);
         result.Buckets[1].Label.ShouldBe("Paid");
@@ -49,78 +48,248 @@ public sealed class ChartRunnerTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_PassesGroupByFieldOnTheRequest()
+    public async Task ExecuteAsync_Sum_StreamsAndAggregatesInMemory()
     {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Amount = 10m },
+            new() { Status = "Open", Amount = 20m },
+            new() { Status = "Paid", Amount = 50m },
+        ];
+
         IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        engine.ExecuteGroupedAsync(
-                Arg.Any<IQueryable<TestItem>>(),
-                Arg.Any<QueryRequest>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new GroupedResult<TestItem>([], 0));
+        ConfigureStream(engine, items);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
 
-        await runner.ExecuteAsync(
+        ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
-            aggregation: AggregateFunction.Count,
-            field: null,
+            aggregation: AggregateFunction.Sum,
+            field: "Amount",
             TestContext.Current.CancellationToken);
 
-        await engine.Received(1).ExecuteGroupedAsync(
-            Arg.Any<IQueryable<TestItem>>(),
-            Arg.Is<QueryRequest>(r => r.GroupBy == "Status"),
-            Arg.Any<CancellationToken>());
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(30m);
+        byLabel["Paid"].ShouldBe(50m);
     }
 
     [Fact]
-    public async Task ExecuteAsync_EmptyResult_ReturnsEmptyBucketList()
+    public async Task ExecuteAsync_Sum_EmptyGroup_ReturnsZero_NotNull()
     {
+        // Sum-of-empty is 0 (mathematical identity), matches MetricExecutor.
+        // This test guards the case where a group has rows but all values
+        // are null — the bucket still surfaces with Value=0.
+        TestItem[] items =
+        [
+            new() { Status = "Open", BonusNullable = null },
+            new() { Status = "Open", BonusNullable = null },
+        ];
+
         IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        engine.ExecuteGroupedAsync(
-                Arg.Any<IQueryable<TestItem>>(),
-                Arg.Any<QueryRequest>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new GroupedResult<TestItem>([], 0));
+        ConfigureStream(engine, items);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
 
-        ChartRunnerResult? result = await runner.ExecuteAsync(
+        ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
-            aggregation: AggregateFunction.Count,
-            field: null,
+            aggregation: AggregateFunction.Sum,
+            field: "BonusNullable",
             TestContext.Current.CancellationToken);
 
-        result.ShouldNotBeNull();
-        result!.Buckets.ShouldBeEmpty();
+        result.Buckets[0].Value.ShouldBe(0m);
     }
 
     [Theory]
-    [InlineData(AggregateFunction.Sum)]
     [InlineData(AggregateFunction.Avg)]
     [InlineData(AggregateFunction.Min)]
     [InlineData(AggregateFunction.Max)]
-    public async Task ExecuteAsync_NonCountAggregations_ReturnNull_UntilFollowUpSliceLands(AggregateFunction aggregation)
+    public async Task ExecuteAsync_AvgMinMax_EmptyGroup_ReturnsNull(AggregateFunction aggregation)
     {
-        // B3-5 ships Count only — the runner returns null for Sum / Avg / Min /
-        // Max so the caller (ChartWidgetInstanceRenderer) maps onto a dedicated
-        // Widget:Unavailable.* reason.
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        // Avg / Min / Max over a group with no usable values surface as null
+        // — locked semantics shared with MetricExecutor #1374. The frontend
+        // renders "—" for that data point.
+        TestItem[] items =
+        [
+            new() { Status = "Open", BonusNullable = null },
+            new() { Status = "Open", BonusNullable = null },
+        ];
 
-        ChartRunnerResult? result = await runner.ExecuteAsync(
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, items);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: aggregation,
+            field: "BonusNullable",
+            TestContext.Current.CancellationToken);
+
+        result.Buckets[0].Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Avg_PopulatedGroup_ReturnsMean()
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Amount = 10m },
+            new() { Status = "Open", Amount = 30m },
+        ];
+
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, items);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Avg,
+            field: "Amount",
+            TestContext.Current.CancellationToken);
+
+        result.Buckets[0].Value.ShouldBe(20m);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Min, 10)]
+    [InlineData(AggregateFunction.Max, 30)]
+    public async Task ExecuteAsync_MinMax_PopulatedGroup_ReturnsExtremum(AggregateFunction aggregation, int expected)
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Amount = 10m },
+            new() { Status = "Open", Amount = 20m },
+            new() { Status = "Open", Amount = 30m },
+        ];
+
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, items);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
             aggregation: aggregation,
             field: "Amount",
             TestContext.Current.CancellationToken);
 
-        result.ShouldBeNull();
+        result.Buckets[0].Value.ShouldBe(expected);
+    }
 
-        // The QueryEngine must NOT have been called for an unsupported
-        // aggregation — short-circuit before issuing the SQL group-by.
-        await engine.DidNotReceive().ExecuteGroupedAsync(
-            Arg.Any<IQueryable<TestItem>>(),
-            Arg.Any<QueryRequest>(),
-            Arg.Any<CancellationToken>());
+    [Theory]
+    [InlineData("Quantity", typeof(int))]
+    [InlineData("BigQuantity", typeof(long))]
+    [InlineData("Amount", typeof(decimal))]
+    [InlineData("Score", typeof(double))]
+    public async Task ExecuteAsync_Sum_AcceptsAllSupportedPrimitiveTypes(string field, Type _)
+    {
+        TestItem[] items = [new() { Status = "X", Amount = 1m, Quantity = 1, BigQuantity = 1L, Score = 1.0 }];
+
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, items);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Sum,
+            field: field,
+            TestContext.Current.CancellationToken);
+
+        result.Buckets[0].Value.ShouldBe(1m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullGroupKey_SurfacesAsNullSentinel()
+    {
+        TestItem[] items =
+        [
+            new() { Status = null!, Amount = 10m },
+            new() { Status = "Open", Amount = 20m },
+        ];
+
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, items);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Sum,
+            field: "Amount",
+            TestContext.Current.CancellationToken);
+
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel.ShouldContainKey("(null)");
+        byLabel["(null)"].ShouldBe(10m);
+        byLabel["Open"].ShouldBe(20m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownGroupByField_Throws()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, []);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                groupBy: "NotAField",
+                aggregation: AggregateFunction.Sum,
+                field: "Amount",
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAField");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownAggregateField_Throws()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, []);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                groupBy: "Status",
+                aggregation: AggregateFunction.Sum,
+                field: "NotAColumn",
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAColumn");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsupportedFieldType_Throws()
+    {
+        // Aggregating Sum over a string column makes no sense — surface a
+        // clear NotSupportedException so the dashboard renderer's per-widget
+        // isolation surfaces it as Error (config bug, not data bug).
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ConfigureStream(engine, []);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await runner.ExecuteAsync(
+                groupBy: "Status",
+                aggregation: AggregateFunction.Sum,
+                field: "Status",
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                groupBy: "Status",
+                aggregation: AggregateFunction.Sum,
+                field: null,
+                TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -148,10 +317,34 @@ public sealed class ChartRunnerTests
         runner.Name.ShouldBe("Granit.Test.Items");
     }
 
+    private static void ConfigureStream(IQueryEngine<TestItem> engine, IReadOnlyList<TestItem> items) =>
+        engine.ExecuteStreamAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => YieldAsync(items, default));
+
+    private static async IAsyncEnumerable<TestItem> YieldAsync(
+        IReadOnlyList<TestItem> items, [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (TestItem item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
     public sealed class TestItem
     {
         public Guid Id { get; set; }
         public string Status { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+        public int Quantity { get; set; }
+        public long BigQuantity { get; set; }
+        public double Score { get; set; }
+        public decimal? BonusNullable { get; set; }
     }
 
     public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
@@ -83,16 +83,18 @@ public sealed class ChartWidgetInstanceRendererTests
     }
 
     [Theory]
-    [InlineData(AggregateFunction.Sum)]
-    [InlineData(AggregateFunction.Avg)]
-    [InlineData(AggregateFunction.Min)]
-    [InlineData(AggregateFunction.Max)]
-    public async Task RenderAsync_NonCountAggregation_ReturnsUnavailable(AggregateFunction aggregation)
+    [InlineData(AggregateFunction.Sum, "12")]
+    [InlineData(AggregateFunction.Avg, "12")]
+    [InlineData(AggregateFunction.Min, "12")]
+    [InlineData(AggregateFunction.Max, "12")]
+    public async Task RenderAsync_NumericAggregation_BuildsSnapshotWithDecimalValue(
+        AggregateFunction aggregation, string expectedValue)
     {
-        // The runner returns null for non-Count aggregations (B3-5 staging) —
-        // the renderer surfaces a dedicated reason key. The frontend can
-        // distinguish "operation not yet implemented" from "query not found".
-        StubRunner runner = new("Granit.Test.Items", buckets: []) { ReturnsNull = true };
+        // Sum/Avg/Min/Max all flow through the runner to the snapshot now —
+        // no special "OperationNotImplemented" branch (B3-5bis closes that gap).
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            buckets: [new ChartRunnerBucket("Open", decimal.Parse(expectedValue, System.Globalization.CultureInfo.InvariantCulture))]);
 
         ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
 
@@ -103,8 +105,32 @@ public sealed class ChartWidgetInstanceRendererTests
             BuildContext(),
             TestContext.Current.CancellationToken);
 
-        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.ChartOperationNotImplemented");
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        System.Text.Json.JsonElement bucket = envelope.Snapshot!.Value.GetProperty("buckets")[0];
+        bucket.GetProperty("label").GetString().ShouldBe("Open");
+        bucket.GetProperty("value").GetDecimal().ShouldBe(12m);
+    }
+
+    [Fact]
+    public async Task RenderAsync_NullBucketValue_SerialisesAsJsonNull()
+    {
+        // Avg/Min/Max over an empty group surfaces null on the bucket — wire
+        // representation is JSON null, not an omitted field.
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            buckets: [new ChartRunnerBucket("Open", null)]);
+
+        ChartWidgetInstanceRenderer renderer = new(new ChartService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"groupBy\":\"Status\",\"aggregation\":\"Avg\",\"field\":\"Amount\",\"chartType\":\"Bar\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        System.Text.Json.JsonElement bucket = envelope.Snapshot!.Value.GetProperty("buckets")[0];
+        bucket.GetProperty("value").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Null);
     }
 
     [Theory]
@@ -174,13 +200,11 @@ public sealed class ChartWidgetInstanceRendererTests
     {
         public string Name { get; } = name;
 
-        public bool ReturnsNull { get; init; }
-
         public string? LastGroupBy { get; private set; }
         public AggregateFunction LastAggregation { get; private set; }
         public string? LastField { get; private set; }
 
-        public Task<ChartRunnerResult?> ExecuteAsync(
+        public Task<ChartRunnerResult> ExecuteAsync(
             string groupBy,
             AggregateFunction aggregation,
             string? field,
@@ -189,8 +213,7 @@ public sealed class ChartWidgetInstanceRendererTests
             LastGroupBy = groupBy;
             LastAggregation = aggregation;
             LastField = field;
-            return Task.FromResult<ChartRunnerResult?>(
-                ReturnsNull ? null : new ChartRunnerResult(buckets));
+            return Task.FromResult(new ChartRunnerResult(buckets));
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the Chart aggregation gap left by B3-5 (#1492). The dashboard's \"revenue per month\" / \"average ticket size by status\" / \"max latency by region\" tile now renders with the same field-aggregation contract QueryAggregateRunner already established (B3-2ter).

## Implementation

Two paths inside \`ChartRunner<TEntity>\`:

- **Count** — keeps the SQL-level path via \`IQueryEngine.ExecuteGroupedAsync\` (unchanged from B3-5)
- **Sum / Avg / Min / Max** — streams the filtered entity set through \`IQueryEngine.ExecuteStreamAsync\` (capped by \`MaxStreamSize\`) and aggregates in memory. Acceptable for dashboard tiles which are bounded data products, and avoids the typed GroupBy+Aggregate expression-tree surgery that pushing the aggregate to SQL would require. Future optimisation can swap the in-memory path for a per-\`(TKey,TValue)\` typed expression tree without breaking the \`IChartRunner\` contract

Streaming through \`ExecuteStreamAsync\` inherits the same filter pipeline / multi-tenancy / soft-delete contract as the admin grid — chart aggregations and table list endpoints see the same rows.

## Empty-set semantics (locked by tests #1374)

- \`Count\` / \`Sum\` → \`0\` (Count over zero rows, Sum-of-empty identity)
- \`Avg\` / \`Min\` / \`Max\` → \`null\` on the bucket value when no usable values in the group. The bucket is still surfaced (the group exists); the frontend renders \"—\" for that data point

## Contract changes

- \`IChartRunner.ExecuteAsync\` now returns \`Task<ChartRunnerResult>\` (non-nullable). The \"operation not implemented\" sentinel is gone
- \`ChartRunnerBucket.Value\` and the public \`ChartBucket.Value\` are now \`decimal?\` (was \`decimal\`) to carry the empty-set null for Avg/Min/Max
- \`ChartWidgetInstanceRenderer\` drops the \`Widget:Unavailable.ChartOperationNotImplemented\` branch — the reason key no longer exists

## Configuration paths

Unknown group-by field, unknown aggregate field, unsupported field type, missing field for non-Count aggregation, empty group-by — all throw. \`IDashboardRenderer\`'s per-widget isolation surfaces them as \`Error\` envelopes per ADR-039 §3.c.

## Test plan

- [x] 17 new \`ChartRunner\` unit tests — Count delegation to \`ExecuteGroupedAsync\`, Sum/Avg/Min/Max streaming + projection, empty-group semantics for each aggregation, all four primitive types (int/long/decimal/double), null group key handling, every config-error path
- [x] Renderer tests updated to drop \`OperationNotImplemented\` and add coverage for nullable bucket values on the wire
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 120 passing (17 new in \`Internal/\` + \`Rendering/\`)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-6 Pivot renderer (Postgres integration test for multi-level pivots)
- B7-2 Map renderer (PostGIS opt-in for \`MapPointSource.Geography\`)
- SQL-level Sum/Avg/Min/Max for charts (typed Group+Aggregate expression tree per (TKey, TValue) primitive — drop-in replacement for the in-memory aggregator without changing the contract)
- Currency-aware chart aggregations (metadata on \`ColumnDescriptor\` exposes ISO 4217)