### PR TITLE
perf(analytics): SQL-level Chart Sum/Avg/Min/Max via expression trees (B3-5ter)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4341,6 +4341,15 @@
       ]
     },
     {
+      "name": "GroupBucket",
+      "fqn": "Granit.Analytics.Endpoints.Internal.GroupBucket",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Internal/GroupAggregateExecutor.cs",
+      "line": 41,
+      "members": []
+    },
+    {
       "name": "AnalyticsEndpointsOptions",
       "fqn": "Granit.Analytics.Endpoints.Options.AnalyticsEndpointsOptions",
       "kind": "class",

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -16,19 +16,14 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// </para>
 /// <list type="bullet">
 ///   <item><b>Count</b> — delegates to <c>IQueryEngine&lt;TEntity&gt;.ExecuteGroupedAsync</c>;
-///         grouping happens in SQL.</item>
-///   <item><b>Sum / Avg / Min / Max</b> — streams the filtered entity set
-///         through <c>ExecuteStreamAsync</c> (capped by <c>MaxStreamSize</c>)
-///         and computes the per-group aggregate in memory. Acceptable for
-///         dashboard tiles which are bounded data products; future
-///         optimisation could push the aggregation to SQL via dynamic
-///         expression trees.</item>
+///         grouping happens in SQL via the existing QueryEngine pipeline.</item>
+///   <item><b>Sum / Avg / Min / Max</b> — builds a typed
+///         <c>GroupBy(...).Select(...)</c> expression tree via
+///         <see cref="GroupAggregateExecutor"/> and lets EF Core push the
+///         aggregation to SQL. Same filter pipeline / multi-tenancy as the
+///         admin grid (via <c>IQueryEngine.BuildFilteredQuery</c>); same
+///         empty-set semantics as <c>MetricExecutor</c>.</item>
 /// </list>
-/// <para>
-/// Sharing <c>ExecuteStreamAsync</c> means the chart tile honours the same
-/// filter pipeline / multi-tenancy / soft-delete contract as the admin grid
-/// — the same rows the table sees are the same rows the chart aggregates.
-/// </para>
 /// </remarks>
 internal sealed class ChartRunner<TEntity>(
     string name,
@@ -85,39 +80,24 @@ internal sealed class ChartRunner<TEntity>(
         PropertyInfo valueProp = ResolveProperty(field, nameof(field));
 
         Type valueUnderlying = Nullable.GetUnderlyingType(valueProp.PropertyType) ?? valueProp.PropertyType;
-        EnsureSupportedNumericType(valueProp, valueUnderlying, aggregation);
 
-        // Stream the filtered set through the QueryEngine pipeline (multi-tenancy,
-        // soft-delete, MaxStreamSize cap apply) and aggregate in memory. Acceptable
-        // for dashboard tiles; pushing the aggregate to SQL would need a typed
-        // GroupBy + Select expression tree per (TKey, TValue) primitive pair.
-        QueryRequest request = new();
-        Dictionary<object, AggregateAccumulator> groups = new(GroupKeyComparer.Instance);
-
-        await foreach (TEntity entity in _engine
-            .ExecuteStreamAsync(_source.GetQueryable(), request, ct)
-            .ConfigureAwait(false))
+        if (!GroupAggregateExecutor.IsSupportedValueType(valueUnderlying))
         {
-            object? rawKey = groupProp.GetValue(entity);
-            object? rawValue = valueProp.GetValue(entity);
-
-            object key = rawKey ?? GroupKeyComparer.NullSentinel;
-            if (!groups.TryGetValue(key, out AggregateAccumulator? acc))
-            {
-                acc = new AggregateAccumulator(rawKey);
-                groups[key] = acc;
-            }
-
-            if (rawValue is not null)
-            {
-                acc.Add(Convert.ToDecimal(rawValue, CultureInfo.InvariantCulture));
-            }
+            throw new NotSupportedException(FormattableString.Invariant(
+                $"Aggregation '{aggregation}' on field '{valueProp.Name}' (type '{valueUnderlying.Name}') is not supported. Supported types: int, long, decimal, double."));
         }
 
+        // Apply filter pipeline (multi-tenancy, soft-delete, dashboard filters once
+        // they wire through). Same set of rows the admin grid would see.
+        QueryRequest request = new();
+        IQueryable<TEntity> filtered = _engine.BuildFilteredQuery(_source.GetQueryable(), request);
+
+        List<GroupAggregateExecutor.GroupBucket> raw = await GroupAggregateExecutor
+            .ExecuteAsync(filtered, groupProp, valueProp, valueUnderlying, aggregation, ct)
+            .ConfigureAwait(false);
+
         IReadOnlyList<ChartRunnerBucket> buckets = [..
-            groups.Values.Select(acc => new ChartRunnerBucket(
-                Label: LabelOf(acc.RawKey),
-                Value: acc.Compute(aggregation)))];
+            raw.Select(b => new ChartRunnerBucket(LabelOf(b.Key), b.Value))];
 
         return new ChartRunnerResult(buckets);
     }
@@ -133,18 +113,6 @@ internal sealed class ChartRunner<TEntity>(
             paramName);
     }
 
-    private static void EnsureSupportedNumericType(PropertyInfo prop, Type underlying, AggregateFunction aggregation)
-    {
-        if (underlying == typeof(int) || underlying == typeof(long)
-            || underlying == typeof(decimal) || underlying == typeof(double))
-        {
-            return;
-        }
-
-        throw new NotSupportedException(FormattableString.Invariant(
-            $"Aggregation '{aggregation}' on field '{prop.Name}' (type '{underlying.Name}') is not supported. Supported types: int, long, decimal, double."));
-    }
-
     private static string LabelOf(object? key) =>
         key switch
         {
@@ -152,39 +120,4 @@ internal sealed class ChartRunner<TEntity>(
             string s => s,
             _ => Convert.ToString(key, CultureInfo.InvariantCulture) ?? "(null)",
         };
-
-    private sealed class AggregateAccumulator(object? rawKey)
-    {
-        private readonly List<decimal> _values = [];
-
-        public object? RawKey { get; } = rawKey;
-
-        public void Add(decimal value) => _values.Add(value);
-
-        public decimal? Compute(AggregateFunction aggregation) =>
-            aggregation switch
-            {
-                // Sum-of-empty is 0 (mathematical identity, matches MetricExecutor).
-                AggregateFunction.Sum => _values.Count == 0 ? 0m : _values.Sum(),
-
-                // Avg / Min / Max over a group with no usable values surface as
-                // null — locked semantics shared with MetricExecutor #1374.
-                AggregateFunction.Avg => _values.Count == 0 ? null : _values.Average(),
-                AggregateFunction.Min => _values.Count == 0 ? null : _values.Min(),
-                AggregateFunction.Max => _values.Count == 0 ? null : _values.Max(),
-
-                _ => throw new NotSupportedException(
-                    FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
-            };
-    }
-
-    private sealed class GroupKeyComparer : IEqualityComparer<object>
-    {
-        public static readonly GroupKeyComparer Instance = new();
-        public static readonly object NullSentinel = new();
-
-        public new bool Equals(object? x, object? y) => object.Equals(x, y);
-
-        public int GetHashCode(object obj) => obj.GetHashCode();
-    }
 }

--- a/src/Granit.Analytics.Endpoints/Internal/GroupAggregateExecutor.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/GroupAggregateExecutor.cs
@@ -1,0 +1,201 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Granit.QueryEngine.Filtering;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Builds and executes a typed <c>GroupBy(...).Select(...)</c> expression
+/// tree against an <see cref="IQueryable{T}"/>, dispatching at runtime on
+/// the group-by key type and the aggregate field's underlying primitive
+/// type. Pushes the entire aggregation to SQL — no in-memory streaming —
+/// so dashboard charts scale linearly with the number of groups, not the
+/// number of rows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The expression tree built per call is:
+/// </para>
+/// <code>
+/// source
+///     .GroupBy(x =&gt; x.&lt;GroupBy&gt;)                                  // typed via TKey reflection
+///     .Select(g =&gt; new GroupBucket(
+///         (object)g.Key,
+///         (decimal?)((Sum|Avg|Min|Max)(x =&gt; (TValue?)x.&lt;Field&gt;) ?? 0)))  // Sum coalesces; Avg/Min/Max do not
+///     .ToListAsync(ct);
+/// </code>
+/// <para>
+/// EF Core translates this to <c>SELECT &lt;groupBy&gt;, &lt;agg&gt;(&lt;field&gt;)
+/// FROM ... GROUP BY &lt;groupBy&gt;</c>. Empty-set semantics match
+/// <c>MetricExecutor</c> (locked by tests #1374): Sum-of-empty is 0;
+/// Avg/Min/Max over a group with all-null values surface as null on the
+/// bucket value (frontend renders "—").
+/// </para>
+/// </remarks>
+internal static class GroupAggregateExecutor
+{
+    /// <summary>Result row materialised by the EF projection.</summary>
+    /// <param name="Key">Boxed group key — matches the runtime CLR type of the GroupBy property.</param>
+    /// <param name="Value">Aggregate value coerced to <see cref="decimal"/>; <see langword="null"/> for empty Avg/Min/Max groups.</param>
+    public sealed record GroupBucket(object? Key, decimal? Value);
+
+    /// <summary>Supported aggregate field types.</summary>
+    private static readonly HashSet<Type> SupportedNumericTypes =
+        [typeof(int), typeof(long), typeof(decimal), typeof(double)];
+
+    /// <summary>
+    /// Verifies that <paramref name="valueUnderlying"/> is one of the
+    /// supported primitives (int/long/decimal/double).
+    /// </summary>
+    public static bool IsSupportedValueType(Type valueUnderlying) =>
+        SupportedNumericTypes.Contains(valueUnderlying);
+
+    public static async Task<List<GroupBucket>> ExecuteAsync<TEntity>(
+        IQueryable<TEntity> source,
+        PropertyInfo groupProp,
+        PropertyInfo valueProp,
+        Type valueUnderlying,
+        AggregateFunction aggregation,
+        CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        // Dispatch on TKey via reflection — TKey is the runtime CLR type of
+        // the GroupBy property; closed once per call so the EF translator
+        // sees a fully typed expression tree at execution time.
+        Type keyType = groupProp.PropertyType;
+
+        MethodInfo helper = typeof(GroupAggregateExecutor)
+            .GetMethod(nameof(ExecuteTypedAsync), BindingFlags.Static | BindingFlags.NonPublic)!
+            .MakeGenericMethod(typeof(TEntity), keyType);
+
+        var task = (Task<List<GroupBucket>>)helper.Invoke(
+            null,
+            [source, groupProp, valueProp, valueUnderlying, aggregation, cancellationToken])!;
+
+        return await task.ConfigureAwait(false);
+    }
+
+    private static async Task<List<GroupBucket>> ExecuteTypedAsync<TEntity, TKey>(
+        IQueryable<TEntity> source,
+        PropertyInfo groupProp,
+        PropertyInfo valueProp,
+        Type valueUnderlying,
+        AggregateFunction aggregation,
+        CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        Expression<Func<TEntity, TKey>> keySelector = BuildKeySelector<TEntity, TKey>(groupProp);
+        Expression<Func<IGrouping<TKey, TEntity>, GroupBucket>> projection =
+            BuildProjection<TEntity, TKey>(valueProp, valueUnderlying, aggregation);
+
+        return await source.GroupBy(keySelector).Select(projection).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Expression<Func<TEntity, TKey>> BuildKeySelector<TEntity, TKey>(PropertyInfo groupProp)
+    {
+        ParameterExpression x = Expression.Parameter(typeof(TEntity), "x");
+        Expression access = Expression.Property(x, groupProp);
+        return Expression.Lambda<Func<TEntity, TKey>>(access, x);
+    }
+
+    private static Expression<Func<IGrouping<TKey, TEntity>, GroupBucket>> BuildProjection<TEntity, TKey>(
+        PropertyInfo valueProp,
+        Type valueUnderlying,
+        AggregateFunction aggregation)
+    {
+        ParameterExpression g = Expression.Parameter(typeof(IGrouping<TKey, TEntity>), "g");
+        MemberExpression keyAccess = Expression.Property(g, "Key");
+        Expression keyAsObject = Expression.Convert(keyAccess, typeof(object));
+
+        LambdaExpression valueLambda = BuildValueLambda<TEntity>(valueProp, valueUnderlying);
+        Expression aggregateValue = BuildAggregateValue<TEntity>(g, valueLambda, valueUnderlying, aggregation);
+
+        ConstructorInfo ctor = typeof(GroupBucket).GetConstructor([typeof(object), typeof(decimal?)])!;
+        NewExpression bucketNew = Expression.New(ctor, keyAsObject, aggregateValue);
+
+        return Expression.Lambda<Func<IGrouping<TKey, TEntity>, GroupBucket>>(bucketNew, g);
+    }
+
+    private static LambdaExpression BuildValueLambda<TEntity>(PropertyInfo valueProp, Type valueUnderlying)
+    {
+        ParameterExpression x = Expression.Parameter(typeof(TEntity), "x");
+        Expression access = Expression.Property(x, valueProp);
+
+        Type nullableValueType = typeof(Nullable<>).MakeGenericType(valueUnderlying);
+        if (valueProp.PropertyType != nullableValueType)
+        {
+            access = Expression.Convert(access, nullableValueType);
+        }
+
+        Type lambdaType = typeof(Func<,>).MakeGenericType(typeof(TEntity), nullableValueType);
+        return Expression.Lambda(lambdaType, access, x);
+    }
+
+    private static Expression BuildAggregateValue<TEntity>(
+        ParameterExpression gParam,
+        LambdaExpression valueLambda,
+        Type valueUnderlying,
+        AggregateFunction aggregation)
+    {
+        MethodInfo method = ResolveEnumerableMethod(aggregation, valueUnderlying)
+            .MakeGenericMethod(typeof(TEntity));
+
+        MethodCallExpression call = Expression.Call(method, gParam, valueLambda);
+
+        // Sum-of-empty = 0 (mathematical identity, locked by #1374). Avg / Min /
+        // Max keep null on empty groups so the frontend renders "—".
+        Expression result = aggregation == AggregateFunction.Sum
+            ? CoalesceToZero(call)
+            : call;
+
+        // Coerce every primitive (int? / long? / decimal? / double?) to decimal?
+        // for the wire envelope. EF Core translates the cast to a SQL CAST.
+        if (result.Type != typeof(decimal?))
+        {
+            result = Expression.Convert(result, typeof(decimal?));
+        }
+
+        return result;
+    }
+
+    private static MethodInfo ResolveEnumerableMethod(AggregateFunction aggregation, Type valueUnderlying)
+    {
+        string name = aggregation switch
+        {
+            AggregateFunction.Sum => nameof(Enumerable.Sum),
+            AggregateFunction.Avg => nameof(Enumerable.Average),
+            AggregateFunction.Min => nameof(Enumerable.Min),
+            AggregateFunction.Max => nameof(Enumerable.Max),
+            _ => throw new NotSupportedException(
+                $"Aggregation '{aggregation}' is not supported by GroupAggregateExecutor."),
+        };
+
+        Type nullableValueType = typeof(Nullable<>).MakeGenericType(valueUnderlying);
+
+        // Match Enumerable.<Sum/Average/Min/Max><TSource>(IEnumerable<TSource>, Func<TSource, TValue?>).
+        // The per-primitive nullable overload is the right one for SQL translation —
+        // it carries the null semantics needed for empty-group Avg/Min/Max.
+        return typeof(Enumerable).GetMethods()
+            .First(m => m.Name == name
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 1
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[1].ParameterType.IsGenericType
+                && m.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>)
+                && m.GetParameters()[1].ParameterType.GetGenericArguments()[1] == nullableValueType);
+    }
+
+    private static BinaryExpression CoalesceToZero(MethodCallExpression call)
+    {
+        Type returnType = call.Type;                                    // TValue?
+        Type underlying = Nullable.GetUnderlyingType(returnType)
+            ?? throw new InvalidOperationException("Aggregate return type was not nullable — cannot coalesce.");
+        object zero = Activator.CreateInstance(underlying)
+            ?? throw new InvalidOperationException("Failed to instantiate zero value.");
+        ConstantExpression nullableZero = Expression.Constant(zero, returnType);
+        return Expression.Coalesce(call, nullableZero);
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -1,38 +1,61 @@
-using System.Runtime.CompilerServices;
 using Granit.Analytics.Endpoints.Internal;
 using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
 using Granit.QueryEngine.Filtering;
-using NSubstitute;
+using Granit.QueryEngine.Options;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
 namespace Granit.Analytics.Endpoints.Tests.Internal;
 
 /// <summary>
-/// Unit tests for <see cref="ChartRunner{TEntity}"/> — substitute the
-/// <see cref="IQueryEngine{TEntity}"/> with NSubstitute. Two paths exist:
-/// Count delegates to <c>ExecuteGroupedAsync</c> (SQL-level grouping), and
-/// Sum/Avg/Min/Max stream the entity set through <c>ExecuteStreamAsync</c>
-/// then aggregate in memory. Tests pin both paths.
+/// SQLite-backed integration tests for <see cref="ChartRunner{TEntity}"/>
+/// — exercises the SQL-level <c>GroupBy(...).Select(...)</c> expression
+/// tree built by <see cref="GroupAggregateExecutor"/> for Sum/Avg/Min/Max,
+/// plus the <see cref="IQueryEngine{TEntity}.ExecuteGroupedAsync"/>
+/// delegation for Count.
 /// </summary>
-public sealed class ChartRunnerTests
+public sealed class ChartRunnerTests : IAsyncLifetime
 {
-    [Fact]
-    public async Task ExecuteAsync_Count_DelegatesToExecuteGrouped()
-    {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        engine.ExecuteGroupedAsync(
-                Arg.Any<IQueryable<TestItem>>(),
-                Arg.Any<QueryRequest>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new GroupedResult<TestItem>(
-                [
-                    new GroupEntry<TestItem> { Field = "Status", Value = "Open", Label = "Open", Count = 12 },
-                    new GroupEntry<TestItem> { Field = "Status", Value = "Paid", Label = "Paid", Count = 30 },
-                ],
-                TotalCount: 42));
+    private SqliteConnection _connection = null!;
+    private TestDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private IQueryEngine<TestItem> _engine = null!;
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _db = new TestDbContext(options);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        (_provider, _engine) = TestEngineFactory.Build<TestItem, TestQueryDefinition>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _connection.DisposeAsync();
+        await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_GroupsRowsViaExecuteGroupedAsync()
+    {
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -40,27 +63,19 @@ public sealed class ChartRunnerTests
             field: null,
             TestContext.Current.CancellationToken);
 
-        result.Buckets.Count.ShouldBe(2);
-        result.Buckets[0].Label.ShouldBe("Open");
-        result.Buckets[0].Value.ShouldBe(12m);
-        result.Buckets[1].Label.ShouldBe("Paid");
-        result.Buckets[1].Value.ShouldBe(30m);
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(3m);
+        byLabel["Paid"].ShouldBe(2m);
     }
 
     [Fact]
-    public async Task ExecuteAsync_Sum_StreamsAndAggregatesInMemory()
+    public async Task ExecuteAsync_Sum_OverDecimalField_AggregatesPerGroupViaSql()
     {
-        TestItem[] items =
-        [
-            new() { Status = "Open", Amount = 10m },
-            new() { Status = "Open", Amount = 20m },
-            new() { Status = "Paid", Amount = 50m },
-        ];
+        // Five rows: three Open (10, 20, 30 = 60), two Paid (50, 100 = 150).
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -69,78 +84,17 @@ public sealed class ChartRunnerTests
             TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
-        byLabel["Open"].ShouldBe(30m);
-        byLabel["Paid"].ShouldBe(50m);
+        byLabel["Open"].ShouldBe(60m);
+        byLabel["Paid"].ShouldBe(150m);
     }
 
     [Fact]
-    public async Task ExecuteAsync_Sum_EmptyGroup_ReturnsZero_NotNull()
+    public async Task ExecuteAsync_Avg_OverDecimalField_ComputesMeanPerGroup()
     {
-        // Sum-of-empty is 0 (mathematical identity), matches MetricExecutor.
-        // This test guards the case where a group has rows but all values
-        // are null — the bucket still surfaces with Value=0.
-        TestItem[] items =
-        [
-            new() { Status = "Open", BonusNullable = null },
-            new() { Status = "Open", BonusNullable = null },
-        ];
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
-
-        ChartRunnerResult result = await runner.ExecuteAsync(
-            groupBy: "Status",
-            aggregation: AggregateFunction.Sum,
-            field: "BonusNullable",
-            TestContext.Current.CancellationToken);
-
-        result.Buckets[0].Value.ShouldBe(0m);
-    }
-
-    [Theory]
-    [InlineData(AggregateFunction.Avg)]
-    [InlineData(AggregateFunction.Min)]
-    [InlineData(AggregateFunction.Max)]
-    public async Task ExecuteAsync_AvgMinMax_EmptyGroup_ReturnsNull(AggregateFunction aggregation)
-    {
-        // Avg / Min / Max over a group with no usable values surface as null
-        // — locked semantics shared with MetricExecutor #1374. The frontend
-        // renders "—" for that data point.
-        TestItem[] items =
-        [
-            new() { Status = "Open", BonusNullable = null },
-            new() { Status = "Open", BonusNullable = null },
-        ];
-
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
-
-        ChartRunnerResult result = await runner.ExecuteAsync(
-            groupBy: "Status",
-            aggregation: aggregation,
-            field: "BonusNullable",
-            TestContext.Current.CancellationToken);
-
-        result.Buckets[0].Value.ShouldBeNull();
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_Avg_PopulatedGroup_ReturnsMean()
-    {
-        TestItem[] items =
-        [
-            new() { Status = "Open", Amount = 10m },
-            new() { Status = "Open", Amount = 30m },
-        ];
-
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -148,25 +102,21 @@ public sealed class ChartRunnerTests
             field: "Amount",
             TestContext.Current.CancellationToken);
 
-        result.Buckets[0].Value.ShouldBe(20m);
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(20m);  // (10 + 20 + 30) / 3
+        byLabel["Paid"].ShouldBe(75m);  // (50 + 100) / 2
     }
 
     [Theory]
-    [InlineData(AggregateFunction.Min, 10)]
-    [InlineData(AggregateFunction.Max, 30)]
-    public async Task ExecuteAsync_MinMax_PopulatedGroup_ReturnsExtremum(AggregateFunction aggregation, int expected)
+    [InlineData(AggregateFunction.Min, 10, 50)]
+    [InlineData(AggregateFunction.Max, 30, 100)]
+    public async Task ExecuteAsync_MinMax_OverDecimalField_ReturnsExtremumPerGroup(
+        AggregateFunction aggregation, int openExpected, int paidExpected)
     {
-        TestItem[] items =
-        [
-            new() { Status = "Open", Amount = 10m },
-            new() { Status = "Open", Amount = 20m },
-            new() { Status = "Open", Amount = 30m },
-        ];
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -174,22 +124,68 @@ public sealed class ChartRunnerTests
             field: "Amount",
             TestContext.Current.CancellationToken);
 
-        result.Buckets[0].Value.ShouldBe(expected);
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(openExpected);
+        byLabel["Paid"].ShouldBe(paidExpected);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_AllRowsHaveNullValue_ReturnsZero_NotNull()
+    {
+        // All rows in the "Open" group have Bonus=null. Sum-of-empty = 0 in SQL
+        // (SUM(NULL) is NULL there, but the runner coalesces to 0 to match the
+        // metric path's locked semantics #1374).
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null },
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Sum,
+            field: "Bonus",
+            TestContext.Current.CancellationToken);
+
+        result.Buckets.Single().Value.ShouldBe(0m);
     }
 
     [Theory]
-    [InlineData("Quantity", typeof(int))]
-    [InlineData("BigQuantity", typeof(long))]
-    [InlineData("Amount", typeof(decimal))]
-    [InlineData("Score", typeof(double))]
-    public async Task ExecuteAsync_Sum_AcceptsAllSupportedPrimitiveTypes(string field, Type _)
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task ExecuteAsync_AvgMinMax_AllNullsInGroup_ReturnsNull(AggregateFunction aggregation)
     {
-        TestItem[] items = [new() { Status = "X", Amount = 1m, Quantity = 1, BigQuantity = 1L, Score = 1.0 }];
+        // Avg/Min/Max over an all-null column surface as null on the bucket
+        // value — locked semantics shared with MetricExecutor #1374.
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null },
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: aggregation,
+            field: "Bonus",
+            TestContext.Current.CancellationToken);
+
+        result.Buckets.Single().Value.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("Quantity", typeof(int), 6)]    // 1 + 2 + 3 (Open group) by SeedFive
+    [InlineData("BigQuantity", typeof(long), 6)]
+    [InlineData("Amount", typeof(decimal), 60)]
+    [InlineData("Score", typeof(double), 6)]
+    public async Task ExecuteAsync_Sum_AcceptsAllSupportedPrimitiveTypes(string field, Type _, int expectedOpenSum)
+    {
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -197,22 +193,19 @@ public sealed class ChartRunnerTests
             field: field,
             TestContext.Current.CancellationToken);
 
-        result.Buckets[0].Value.ShouldBe(1m);
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(expectedOpenSum);
     }
 
     [Fact]
-    public async Task ExecuteAsync_NullGroupKey_SurfacesAsNullSentinel()
+    public async Task ExecuteAsync_NullGroupKey_SurfacesAsNullSentinelLabel()
     {
-        TestItem[] items =
-        [
-            new() { Status = null!, Amount = 10m },
-            new() { Status = "Open", Amount = 20m },
-        ];
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Status = null, Amount = 10m },
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 20m });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, items);
-
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -229,9 +222,7 @@ public sealed class ChartRunnerTests
     [Fact]
     public async Task ExecuteAsync_UnknownGroupByField_Throws()
     {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, []);
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -246,9 +237,7 @@ public sealed class ChartRunnerTests
     [Fact]
     public async Task ExecuteAsync_UnknownAggregateField_Throws()
     {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, []);
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -266,13 +255,11 @@ public sealed class ChartRunnerTests
         // Aggregating Sum over a string column makes no sense — surface a
         // clear NotSupportedException so the dashboard renderer's per-widget
         // isolation surfaces it as Error (config bug, not data bug).
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ConfigureStream(engine, []);
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
-                groupBy: "Status",
+                groupBy: "Amount",
                 aggregation: AggregateFunction.Sum,
                 field: "Status",
                 TestContext.Current.CancellationToken));
@@ -281,8 +268,7 @@ public sealed class ChartRunnerTests
     [Fact]
     public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
     {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -297,8 +283,7 @@ public sealed class ChartRunnerTests
     [InlineData("   ")]
     public async Task ExecuteAsync_EmptyGroupBy_Throws(string groupBy)
     {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -311,44 +296,98 @@ public sealed class ChartRunnerTests
     [Fact]
     public void Name_IsSetFromConstructor()
     {
-        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
-        ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine);
-
+        ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource(_db), _engine);
         runner.Name.ShouldBe("Granit.Test.Items");
     }
 
-    private static void ConfigureStream(IQueryEngine<TestItem> engine, IReadOnlyList<TestItem> items) =>
-        engine.ExecuteStreamAsync(
-                Arg.Any<IQueryable<TestItem>>(),
-                Arg.Any<QueryRequest>(),
-                Arg.Any<CancellationToken>())
-            .Returns(_ => YieldAsync(items, default));
-
-    private static async IAsyncEnumerable<TestItem> YieldAsync(
-        IReadOnlyList<TestItem> items, [EnumeratorCancellation] CancellationToken ct)
+    private void SeedFive()
     {
-        foreach (TestItem item in items)
-        {
-            ct.ThrowIfCancellationRequested();
-            yield return item;
-        }
-
-        await Task.CompletedTask;
+        _db.Items.AddRange(
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 10m, Quantity = 1, BigQuantity = 1L, Score = 1.0d, Bonus = 5m },
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 20m, Quantity = 2, BigQuantity = 2L, Score = 2.0d, Bonus = 10m },
+            new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 30m, Quantity = 3, BigQuantity = 3L, Score = 3.0d, Bonus = 15m },
+            new TestItem { Id = Guid.NewGuid(), Status = "Paid", Amount = 50m, Quantity = 5, BigQuantity = 5L, Score = 5.0d, Bonus = 20m },
+            new TestItem { Id = Guid.NewGuid(), Status = "Paid", Amount = 100m, Quantity = 10, BigQuantity = 10L, Score = 10.0d, Bonus = 30m });
     }
 
     public sealed class TestItem
     {
         public Guid Id { get; set; }
-        public string Status { get; set; } = string.Empty;
+        public string? Status { get; set; }
         public decimal Amount { get; set; }
         public int Quantity { get; set; }
         public long BigQuantity { get; set; }
         public double Score { get; set; }
-        public decimal? BonusNullable { get; set; }
+        public decimal? Bonus { get; set; }
     }
 
-    public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
+    public sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
     {
-        public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+        public DbSet<TestItem> Items => Set<TestItem>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestItem>(b =>
+            {
+                b.HasKey(x => x.Id);
+                b.Property(x => x.Status);
+                b.Property(x => x.Amount);
+                b.Property(x => x.Quantity);
+                b.Property(x => x.BigQuantity);
+                b.Property(x => x.Score);
+                b.Property(x => x.Bonus);
+            });
+        }
+    }
+
+    public sealed class TestItemSource(TestDbContext db) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => db.Items.AsQueryable();
+    }
+
+    public sealed class TestQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Status, c => c.Label("Status"))
+                .Column(x => x.Amount, c => c.Label("Amount"))
+                .AllowGroupBy(x => x.Status);
+        }
+    }
+
+    /// <summary>
+    /// Builds an <see cref="IQueryEngine{TEntity}"/> via DI without taking a
+    /// runtime dependency on the internal <c>QueryEngine&lt;T&gt;</c>
+    /// implementation. Mirrors the pattern in
+    /// <c>Granit.Analytics.EntityFrameworkCore.Tests.TestEngineFactory</c>.
+    /// </summary>
+    private static class TestEngineFactory
+    {
+        public static (ServiceProvider Provider, IQueryEngine<TEntity> Engine) Build<TEntity, TDefinition>()
+            where TEntity : class
+            where TDefinition : QueryDefinition<TEntity>, new()
+        {
+            ServiceCollection services = new();
+            services.AddMetrics();
+            services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+            services.AddOptions<QueryEngineOptions>();
+            services.AddSingleton(sp => sp.GetRequiredService<IOptions<QueryEngineOptions>>().Value);
+            services.AddGranitQueryEngine();
+            services.AddScoped(typeof(IQueryEngine<>), GetQueryEngineImplementationType());
+            services.AddQueryDefinition<TEntity, TDefinition>();
+
+            ServiceProvider provider = services.BuildServiceProvider();
+            IQueryEngine<TEntity> engine = provider.GetRequiredService<IQueryEngine<TEntity>>();
+            return (provider, engine);
+        }
+
+        private static Type GetQueryEngineImplementationType() =>
+            typeof(QueryEngine.EntityFrameworkCore.GranitQueryEngineEntityFrameworkCoreModule)
+                .Assembly
+                .GetType("Granit.QueryEngine.EntityFrameworkCore.Internal.QueryEngine`1", throwOnError: true)!;
     }
 }


### PR DESCRIPTION
## Summary

Closes the in-memory aggregation tradeoff documented in B3-5bis (#1493). The dashboard's \"revenue per month\" / \"average ticket size by status\" chart tile now scales linearly with the number of **groups**, not the number of rows — a chart over 1M invoices grouped by status returns ~5 rows of network bytes instead of 1M.

## Implementation

New \`GroupAggregateExecutor\` static helper builds a typed \`GroupBy(...).Select(...)\` expression tree at request time and hands it to EF Core for SQL translation. Dispatches at runtime on:

- **TKey** (group-by property type) via \`MakeGenericMethod\` on a typed helper — closed once per call so EF sees a fully typed expression tree at execution
- **TValue** underlying primitive (int / long / decimal / double) via the per-primitive \`Enumerable.Sum\`/\`Average\`/\`Min\`/\`Max\` nullable overload resolved by reflection. Results coerced to \`decimal?\` for the wire envelope

The expression tree shape:

\`\`\`csharp
source
    .GroupBy(x => x.<GroupBy>)
    .Select(g => new GroupBucket(
        (object)g.Key,
        (decimal?)((Sum|Avg|Min|Max)(x => (TValue?)x.<Field>) ?? 0)))
    .ToListAsync(ct);
\`\`\`

EF Core translates this to \`SELECT <groupBy>, <agg>(<field>) FROM ... GROUP BY <groupBy>\`. Same filter pipeline / multi-tenancy / soft-delete contract as the admin grid (via \`IQueryEngine.BuildFilteredQuery\` upstream).

Empty-set semantics unchanged from B3-5bis (locked by #1374):

- Count/Sum coalesce to \`0\` (Sum-of-empty identity)
- Avg/Min/Max over a group with all-null values surface as \`null\` on the bucket (frontend renders \"—\")

## Contract — unchanged

\`IChartRunner\` is unchanged — the swap from in-memory to SQL is internal. Renderer tests still pass (they mock \`IChartRunner\` directly).

## Test plan

- [x] \`ChartRunnerTests\` rewritten as SQLite-backed integration tests (\`IAsyncLifetime\` + real EF Core)
- [x] 21 tests pin: Count delegation, Sum/Avg/Min/Max SQL aggregation, all four primitive types (int/long/decimal/double), all-null group semantics for Sum (→ 0) and Avg/Min/Max (→ null), null group-key handling, every config-error path
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 120 passing
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- Filter-spec composition for QueryAggregate / Chart / Table runners (currently \`DashboardFilters\` ignored)
- Currency-aware chart aggregations (metadata on \`ColumnDescriptor\` exposes ISO 4217)
- B3-6 Pivot renderer (Postgres integration test for multi-level pivots)
- B7-2 Map renderer (PostGIS opt-in)