### PR TITLE
feat(analytics): compose DashboardFilters in every runner (B3-7)

### DIFF
--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -60,14 +60,16 @@ public static class AnalyticsRenderingServiceCollectionExtensions
             .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
             .ToList())
         {
-            services.AddSingleton<IQueryAggregateRunner>(sp =>
+            services.AddScoped<IQueryAggregateRunner>(sp =>
             {
                 IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
                 Type runnerType = typeof(QueryAggregateRunner<>).MakeGenericType(d.EntityType);
                 object queryableSource = sp.GetRequiredService(
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+                object engine = sp.GetRequiredService(
+                    typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
 
-                return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource)!;
+                return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource, engine)!;
             });
 
             services.AddScoped<ITableRunner>(sp =>

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -40,13 +40,14 @@ internal sealed class ChartRunner<TEntity>(
         string groupBy,
         AggregateFunction aggregation,
         string? field,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(groupBy);
 
         if (aggregation == AggregateFunction.Count)
         {
-            return await ExecuteCountAsync(groupBy, cancellationToken).ConfigureAwait(false);
+            return await ExecuteCountAsync(groupBy, dashboardFilters, cancellationToken).ConfigureAwait(false);
         }
 
         if (string.IsNullOrWhiteSpace(field))
@@ -56,12 +57,17 @@ internal sealed class ChartRunner<TEntity>(
                 nameof(field));
         }
 
-        return await ExecuteNumericAsync(groupBy, aggregation, field, cancellationToken).ConfigureAwait(false);
+        return await ExecuteNumericAsync(groupBy, aggregation, field, dashboardFilters, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<ChartRunnerResult> ExecuteCountAsync(string groupBy, CancellationToken ct)
+    private async Task<ChartRunnerResult> ExecuteCountAsync(
+        string groupBy, IReadOnlyDictionary<string, string>? dashboardFilters, CancellationToken ct)
     {
-        QueryRequest request = new() { GroupBy = groupBy };
+        QueryRequest request = new()
+        {
+            GroupBy = groupBy,
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
 
         GroupedResult<TEntity> result = await _engine
             .ExecuteGroupedAsync(_source.GetQueryable(), request, ct)
@@ -74,7 +80,8 @@ internal sealed class ChartRunner<TEntity>(
     }
 
     private async Task<ChartRunnerResult> ExecuteNumericAsync(
-        string groupBy, AggregateFunction aggregation, string field, CancellationToken ct)
+        string groupBy, AggregateFunction aggregation, string field,
+        IReadOnlyDictionary<string, string>? dashboardFilters, CancellationToken ct)
     {
         PropertyInfo groupProp = ResolveProperty(groupBy, nameof(groupBy));
         PropertyInfo valueProp = ResolveProperty(field, nameof(field));
@@ -87,9 +94,12 @@ internal sealed class ChartRunner<TEntity>(
                 $"Aggregation '{aggregation}' on field '{valueProp.Name}' (type '{valueUnderlying.Name}') is not supported. Supported types: int, long, decimal, double."));
         }
 
-        // Apply filter pipeline (multi-tenancy, soft-delete, dashboard filters once
-        // they wire through). Same set of rows the admin grid would see.
-        QueryRequest request = new();
+        // Apply filter pipeline (multi-tenancy, soft-delete, dashboard filters).
+        // Same set of rows the admin grid would see.
+        QueryRequest request = new()
+        {
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
         IQueryable<TEntity> filtered = _engine.BuildFilteredQuery(_source.GetQueryable(), request);
 
         List<GroupAggregateExecutor.GroupBucket> raw = await GroupAggregateExecutor

--- a/src/Granit.Analytics.Endpoints/Internal/DashboardFilterTranslator.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/DashboardFilterTranslator.cs
@@ -1,0 +1,55 @@
+using Granit.QueryEngine;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Translates the dashboard-level filter dictionary carried by
+/// <c>WidgetRenderContext.DashboardFilters</c> into the <c>field.operator</c>
+/// keyed dictionary <see cref="QueryRequest.Filter"/> consumes. Dashboard
+/// filters use a simple <c>{ field: value }</c> shape; missing operators are
+/// defaulted to equality (<c>.eq</c>) so the common case is one keystroke per
+/// binding from the frontend.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keys that already encode an operator (i.e. contain a <c>.</c>) pass through
+/// unchanged — a caller that wants <c>Amount.gte</c> / <c>Status.in</c> can
+/// supply the encoded form directly. The QueryEngine's
+/// <c>FilterableField</c> rules apply downstream: unknown fields and
+/// non-whitelisted operators are silently dropped, so a malformed filter
+/// cannot smuggle in arbitrary SQL.
+/// </para>
+/// <para>
+/// Empty or null input returns <see langword="null"/>, which the QueryEngine
+/// treats as "no filter" — same as the inline <c>POST /metrics/{name}</c>
+/// endpoint's no-filter call.
+/// </para>
+/// </remarks>
+internal static class DashboardFilterTranslator
+{
+    /// <summary>
+    /// Translates <paramref name="dashboardFilters"/> into a QueryRequest
+    /// filter dictionary. Each <c>field → value</c> pair becomes
+    /// <c>field.eq → value</c>; pairs whose key already contains <c>.</c>
+    /// pass through unchanged.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string>? ToQueryRequestFilter(
+        IReadOnlyDictionary<string, string>? dashboardFilters)
+    {
+        if (dashboardFilters is null || dashboardFilters.Count == 0)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> result = new(dashboardFilters.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, string> entry in dashboardFilters)
+        {
+            string key = entry.Key.Contains('.', StringComparison.Ordinal)
+                ? entry.Key
+                : $"{entry.Key}.eq";
+            result[key] = entry.Value;
+        }
+
+        return result;
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
@@ -52,6 +52,7 @@ internal interface IChartRunner
     /// <param name="groupBy">Group-by field name (case-insensitive).</param>
     /// <param name="aggregation">Aggregation function applied per group.</param>
     /// <param name="field">Field aggregated; required for non-Count aggregations, ignored for <see cref="AggregateFunction.Count"/>.</param>
+    /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the QueryDefinition's filter pipeline — see <see cref="DashboardFilterTranslator"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="ArgumentException">Group-by is null/empty, or non-Count aggregation is missing a field, or the field is not a property of the entity.</exception>
     /// <exception cref="NotSupportedException">Field's primitive type is not one of int / long / decimal / double.</exception>
@@ -59,6 +60,7 @@ internal interface IChartRunner
         string groupBy,
         AggregateFunction aggregation,
         string? field,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken);
 }
 

--- a/src/Granit.Analytics.Endpoints/Internal/IMetricRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IMetricRunner.cs
@@ -26,7 +26,18 @@ internal interface IMetricRunner
     /// runner takes care of applying the period filter through
     /// <see cref="PeriodFilterBuilder"/> when <see cref="SupportsPeriod"/> is true.
     /// </summary>
-    Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken);
+    /// <param name="period">Resolved period window, or <see langword="null"/> for non-period metrics.</param>
+    /// <param name="dashboardFilters">
+    /// Dashboard-level filter spec layered on top of the metric's <c>BaseFilter</c>.
+    /// Keyed by field name (or <c>field.operator</c>) — see <see cref="DashboardFilterTranslator"/>.
+    /// <see langword="null"/> for the inline <c>POST /metrics/{name}</c> path which has no
+    /// dashboard context.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<decimal?> ExecuteAsync(
+        ResolvedPeriod? period,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken);
 
     /// <summary>The metric's value kind (count, currency, percentage, ...).</summary>
     MetricValueKind ValueKind { get; }

--- a/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
@@ -47,11 +47,13 @@ internal interface IQueryAggregateRunner
     /// </summary>
     /// <param name="aggregation">Aggregation function to run.</param>
     /// <param name="field">Field name for non-Count aggregations; required (not validated when <paramref name="aggregation"/> is <see cref="AggregateFunction.Count"/>). Resolved against the closed entity type reflectively (case-insensitive); unknown field throws.</param>
+    /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the underlying QueryDefinition's filter pipeline — see <see cref="DashboardFilterTranslator"/>. <see langword="null"/> when called outside a dashboard render.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="ArgumentException">Field is null/empty for a non-Count aggregation, or field is not a property of the entity.</exception>
     /// <exception cref="NotSupportedException">Field's primitive type is not one of int / long / decimal / double.</exception>
     Task<decimal?> ExecuteAsync(
         AggregateFunction aggregation,
         string? field,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken);
 }

--- a/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
@@ -22,11 +22,13 @@ internal interface ITableRunner
     /// </summary>
     /// <param name="visibleColumns">Subset of column property names to surface; <see langword="null"/> = every visible column declared on the <c>QueryDefinition</c>.</param>
     /// <param name="pageSize">Maximum rows to return. Clamped against the QueryDefinition's <c>MaxPageSize</c>.</param>
+    /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the QueryDefinition's filter pipeline — see <see cref="DashboardFilterTranslator"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="ArgumentException">A column name in <paramref name="visibleColumns"/> is not declared by the <c>QueryDefinition</c>.</exception>
     Task<TableRunnerResult> ExecuteAsync(
         IReadOnlyList<string>? visibleColumns,
         int pageSize,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken);
 }
 

--- a/src/Granit.Analytics.Endpoints/Internal/MetricEndpointService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MetricEndpointService.cs
@@ -114,12 +114,13 @@ internal sealed class MetricEndpointService(
         long startTimestamp = Stopwatch.GetTimestamp();
         if (ttl <= TimeSpan.Zero)
         {
-            return await runner.ExecuteAsync(period, cancellationToken).ConfigureAwait(false);
+            // Inline /metrics/{name} path — no dashboard filter context.
+            return await runner.ExecuteAsync(period, dashboardFilters: null, cancellationToken).ConfigureAwait(false);
         }
 
         decimal? value = await _cache.GetOrSetAsync<decimal?>(
             key,
-            async (_, ct) => await runner.ExecuteAsync(period, ct).ConfigureAwait(false),
+            async (_, ct) => await runner.ExecuteAsync(period, dashboardFilters: null, ct).ConfigureAwait(false),
             new FusionCacheEntryOptions { Duration = ttl },
             token: cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Analytics.Endpoints/Internal/MetricRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MetricRunner.cs
@@ -33,7 +33,10 @@ internal sealed class MetricRunner<TEntity, TValue>(
 
     public bool IsHigherBetter => _definition.IsHigherBetter;
 
-    public async Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken)
+    public async Task<decimal?> ExecuteAsync(
+        ResolvedPeriod? period,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken)
     {
         IQueryable<TEntity> queryable = _source.GetQueryable();
 
@@ -42,7 +45,15 @@ internal sealed class MetricRunner<TEntity, TValue>(
             queryable = PeriodFilterBuilder.ApplyPeriod(queryable, _definition.PeriodSelector, resolved);
         }
 
-        TValue? raw = await _executor.ExecuteAsync(_definition, queryable, new QueryRequest(), cancellationToken)
+        // Dashboard filters layer on top of the metric's BaseFilter via the
+        // QueryEngine pipeline — so a "Status=Open" dashboard filter narrows
+        // the SAME way the admin grid does, no duplicate predicate logic.
+        QueryRequest request = new()
+        {
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
+
+        TValue? raw = await _executor.ExecuteAsync(_definition, queryable, request, cancellationToken)
             .ConfigureAwait(false);
 
         return raw.HasValue

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
@@ -16,28 +16,40 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// without further runtime branching).
 /// </summary>
 /// <remarks>
-/// Wraps the entity's <see cref="IQueryableSource{TEntity}"/> directly. The
-/// dashboard render path does <b>not</b> push the dashboard's filter spec
-/// through the QueryEngine pipeline yet — KPIs that need filtering should
-/// bind to a <c>MetricDatasource</c> with a <c>BaseFilter</c> declared
-/// (well-tested empty-set semantics). Filter-spec composition for query
-/// aggregates is a follow-up slice.
+/// Wraps the entity's <see cref="IQueryableSource{TEntity}"/>. Dashboard
+/// filters layer on top via <see cref="IQueryEngine{TEntity}.BuildFilteredQuery"/>
+/// — same filter pipeline as the admin grid, so a <c>"Status=Open"</c>
+/// dashboard filter narrows the KPI tile the same way it narrows the table
+/// next to it.
 /// </remarks>
 internal sealed class QueryAggregateRunner<TEntity>(
     string name,
-    IQueryableSource<TEntity> source) : IQueryAggregateRunner
+    IQueryableSource<TEntity> source,
+    IQueryEngine<TEntity> engine) : IQueryAggregateRunner
     where TEntity : class
 {
     private readonly IQueryableSource<TEntity> _source = source;
+    private readonly IQueryEngine<TEntity> _engine = engine;
 
     public string Name { get; } = name;
 
     public async Task<decimal?> ExecuteAsync(
         AggregateFunction aggregation,
         string? field,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken)
     {
-        IQueryable<TEntity> queryable = _source.GetQueryable();
+        IQueryable<TEntity> rawQueryable = _source.GetQueryable();
+
+        // Layer dashboard filters via the QueryEngine pipeline so a "Status=Open"
+        // dashboard filter narrows the KPI tile the same way the admin grid does.
+        QueryRequest filterRequest = new()
+        {
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
+        IQueryable<TEntity> queryable = filterRequest.Filter is { Count: > 0 }
+            ? _engine.BuildFilteredQuery(rawQueryable, filterRequest)
+            : rawQueryable;
 
         if (aggregation == AggregateFunction.Count)
         {

--- a/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
@@ -48,6 +48,7 @@ internal sealed class TableRunner<TEntity>(
     public async Task<TableRunnerResult> ExecuteAsync(
         IReadOnlyList<string>? visibleColumns,
         int pageSize,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<ColumnDescriptor> selectedColumns = ResolveColumns(visibleColumns);
@@ -56,6 +57,7 @@ internal sealed class TableRunner<TEntity>(
         {
             Page = 1,
             PageSize = pageSize,
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
         };
 
         PagedResult<TEntity> page = await _engine

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
@@ -74,7 +74,7 @@ internal sealed class ChartWidgetInstanceRenderer(
         }
 
         ChartRunnerResult result = await runner
-            .ExecuteAsync(config.GroupBy, config.Aggregation, config.Field, cancellationToken)
+            .ExecuteAsync(config.GroupBy, config.Aggregation, config.Field, context.DashboardFilters, cancellationToken)
             .ConfigureAwait(false);
 
         ChartWidgetSnapshot snapshot = new(

--- a/src/Granit.Analytics.Endpoints/Rendering/MetricDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MetricDatasourceEvaluator.cs
@@ -53,7 +53,9 @@ internal sealed class MetricDatasourceEvaluator(MetricEndpointService metricServ
 
         ResolvedPeriod? period = runner.SupportsPeriod ? context.Period : null;
 
-        decimal? value = await runner.ExecuteAsync(period, cancellationToken).ConfigureAwait(false);
+        decimal? value = await runner
+            .ExecuteAsync(period, context.DashboardFilters, cancellationToken)
+            .ConfigureAwait(false);
 
         MetricSnapshotPayload payload = new(
             value,

--- a/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
@@ -44,7 +44,7 @@ internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService qu
         // (ADR-039 §3.c). The dashboard render still returns 200; the
         // misconfigured widget alone is surfaced as Error.
         decimal? value = await runner
-            .ExecuteAsync(datasource.Aggregation, datasource.Field, cancellationToken)
+            .ExecuteAsync(datasource.Aggregation, datasource.Field, context.DashboardFilters, cancellationToken)
             .ConfigureAwait(false);
 
         // Empty-set semantics (locked by tests #1374):

--- a/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
@@ -73,7 +73,7 @@ internal sealed class TableWidgetInstanceRenderer(
             : DefaultPageSize;
 
         TableRunnerResult result = await runner
-            .ExecuteAsync(config.VisibleColumns, pageSize, cancellationToken)
+            .ExecuteAsync(config.VisibleColumns, pageSize, context.DashboardFilters, cancellationToken)
             .ConfigureAwait(false);
 
         TableWidgetSnapshot snapshot = new(

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -61,7 +61,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Count,
             field: null,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel["Open"].ShouldBe(3m);
@@ -81,7 +81,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Sum,
             field: "Amount",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel["Open"].ShouldBe(60m);
@@ -100,7 +100,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Avg,
             field: "Amount",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel["Open"].ShouldBe(20m);  // (10 + 20 + 30) / 3
@@ -122,7 +122,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: aggregation,
             field: "Amount",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel["Open"].ShouldBe(openExpected);
@@ -146,7 +146,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Sum,
             field: "Bonus",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Buckets.Single().Value.ShouldBe(0m);
     }
@@ -170,7 +170,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: aggregation,
             field: "Bonus",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Buckets.Single().Value.ShouldBeNull();
     }
@@ -191,7 +191,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Sum,
             field: field,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel["Open"].ShouldBe(expectedOpenSum);
@@ -211,7 +211,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             groupBy: "Status",
             aggregation: AggregateFunction.Sum,
             field: "Amount",
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
         byLabel.ShouldContainKey("(null)");
@@ -229,7 +229,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
                 groupBy: "NotAField",
                 aggregation: AggregateFunction.Sum,
                 field: "Amount",
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("NotAField");
     }
@@ -244,7 +244,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
                 groupBy: "Status",
                 aggregation: AggregateFunction.Sum,
                 field: "NotAColumn",
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("NotAColumn");
     }
@@ -262,7 +262,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
                 groupBy: "Amount",
                 aggregation: AggregateFunction.Sum,
                 field: "Status",
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
                 groupBy: "Status",
                 aggregation: AggregateFunction.Sum,
                 field: null,
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -290,7 +290,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
                 groupBy: groupBy,
                 aggregation: AggregateFunction.Count,
                 field: null,
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -298,6 +298,56 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     {
         ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource(_db), _engine);
         runner.Name.ShouldBe("Granit.Test.Items");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_DashboardFilter_NarrowsTheGroupedResult()
+    {
+        // SeedFive yields three Open + two Paid. A dashboard filter
+        // { "Amount.gte": "30" } narrows to one Open (30) and two Paid
+        // (50 + 100) — Count per group reflects the filtered set.
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Count,
+            field: null,
+            dashboardFilters: new Dictionary<string, string> { ["Amount.gte"] = "30" },
+            TestContext.Current.CancellationToken);
+
+        var byLabel = result.Buckets.ToDictionary(b => b.Label, b => b.Value);
+        byLabel["Open"].ShouldBe(1m);
+        byLabel["Paid"].ShouldBe(2m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_DashboardFilter_NarrowsTheNumericAggregation()
+    {
+        // Same five rows. Filter Status=Open + Amount.gte=20 narrows to two
+        // Open rows (20 + 30). Sum = 50.
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Sum,
+            field: "Amount",
+            dashboardFilters: new Dictionary<string, string>
+            {
+                ["Status"] = "Open",       // bare key -> Status.eq=Open
+                ["Amount.gte"] = "20",
+            },
+            TestContext.Current.CancellationToken);
+
+        // Only the Open group survives; Paid is filtered out entirely.
+        result.Buckets.Count.ShouldBe(1);
+        result.Buckets[0].Label.ShouldBe("Open");
+        result.Buckets[0].Value.ShouldBe(50m);  // 20 + 30
     }
 
     private void SeedFive()
@@ -352,8 +402,8 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
         {
             builder
-                .Column(x => x.Status, c => c.Label("Status"))
-                .Column(x => x.Amount, c => c.Label("Amount"))
+                .Column(x => x.Status, c => c.Label("Status").Filterable())
+                .Column(x => x.Amount, c => c.Label("Amount").Filterable())
                 .AllowGroupBy(x => x.Status);
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/DashboardFilterTranslatorTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/DashboardFilterTranslatorTests.cs
@@ -1,0 +1,68 @@
+using Granit.Analytics.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Pins <see cref="DashboardFilterTranslator"/> shape — bare <c>field</c>
+/// keys default to <c>field.eq</c>, pre-encoded <c>field.operator</c> keys
+/// pass through, null/empty input produces null.
+/// </summary>
+public sealed class DashboardFilterTranslatorTests
+{
+    [Fact]
+    public void ToQueryRequestFilter_NullInput_ReturnsNull()
+    {
+        DashboardFilterTranslator.ToQueryRequestFilter(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToQueryRequestFilter_EmptyInput_ReturnsNull()
+    {
+        DashboardFilterTranslator.ToQueryRequestFilter(new Dictionary<string, string>()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToQueryRequestFilter_BareFieldKey_DefaultsToEqualityOperator()
+    {
+        IReadOnlyDictionary<string, string>? result = DashboardFilterTranslator.ToQueryRequestFilter(
+            new Dictionary<string, string> { ["Status"] = "Open" });
+
+        result.ShouldNotBeNull();
+        result!.Count.ShouldBe(1);
+        result["Status.eq"].ShouldBe("Open");
+    }
+
+    [Fact]
+    public void ToQueryRequestFilter_OperatorEncodedKey_PassesThroughUnchanged()
+    {
+        // Caller wants gte/contains/in — pass the encoded form directly.
+        IReadOnlyDictionary<string, string>? result = DashboardFilterTranslator.ToQueryRequestFilter(
+            new Dictionary<string, string>
+            {
+                ["Amount.gte"] = "100",
+                ["Name.contains"] = "Acme",
+            });
+
+        result.ShouldNotBeNull();
+        result!["Amount.gte"].ShouldBe("100");
+        result["Name.contains"].ShouldBe("Acme");
+    }
+
+    [Fact]
+    public void ToQueryRequestFilter_MixedKeys_ProducesCanonicalDictionary()
+    {
+        IReadOnlyDictionary<string, string>? result = DashboardFilterTranslator.ToQueryRequestFilter(
+            new Dictionary<string, string>
+            {
+                ["Status"] = "Open",
+                ["Amount.gte"] = "100",
+            });
+
+        result.ShouldNotBeNull();
+        result!.Count.ShouldBe(2);
+        result["Status.eq"].ShouldBe("Open");
+        result["Amount.gte"].ShouldBe("100");
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/MetricEndpointServiceTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/MetricEndpointServiceTests.cs
@@ -192,7 +192,10 @@ public sealed class MetricEndpointServiceTests
         public string? CurrencyCode => null;
         public bool IsHigherBetter => true;
 
-        public Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken) =>
+        public Task<decimal?> ExecuteAsync(
+            ResolvedPeriod? period,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
+            CancellationToken cancellationToken) =>
             Task.FromResult(returns);
     }
 
@@ -210,7 +213,10 @@ public sealed class MetricEndpointServiceTests
 
         public void Enqueue(decimal? value) => _values.Enqueue(value);
 
-        public Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken)
+        public Task<decimal?> ExecuteAsync(
+            ResolvedPeriod? period,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
+            CancellationToken cancellationToken)
         {
             CallCount++;
             return Task.FromResult(_values.Dequeue());

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
@@ -18,6 +18,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
 {
     private SqliteConnection _connection = null!;
     private TestDbContext _db = null!;
+    private readonly IQueryEngine<TestItem> _engine = NSubstitute.Substitute.For<IQueryEngine<TestItem>>();
 
     public async ValueTask InitializeAsync()
     {
@@ -44,10 +45,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Count, field: null, TestContext.Current.CancellationToken);
+            AggregateFunction.Count, field: null, dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(3m);
     }
@@ -57,10 +58,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     {
         // Locked semantics shared with MetricExecutor (story #1374): Count over
         // an empty set is always 0, never null.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Count, field: null, TestContext.Current.CancellationToken);
+            AggregateFunction.Count, field: null, dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(0m);
     }
@@ -71,10 +72,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "Amount", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(60m); // 10 + 20 + 30
     }
@@ -83,10 +84,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     public async Task ExecuteAsync_Sum_OverEmptySet_ReturnsZero_NotNull()
     {
         // Sum-of-empty is 0 (mathematical identity). Never null.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "Amount", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(0m);
     }
@@ -97,10 +98,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Avg, field: "Amount", TestContext.Current.CancellationToken);
+            AggregateFunction.Avg, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(20m); // (10 + 20 + 30) / 3
     }
@@ -109,10 +110,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     public async Task ExecuteAsync_Avg_OverEmptySet_ReturnsNull()
     {
         // Avg-of-empty is undefined (division by zero). Never zero.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Avg, field: "Amount", TestContext.Current.CancellationToken);
+            AggregateFunction.Avg, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -125,10 +126,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            aggregation, field: "Amount", TestContext.Current.CancellationToken);
+            aggregation, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(expected);
     }
@@ -138,10 +139,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     [InlineData(AggregateFunction.Max)]
     public async Task ExecuteAsync_MinMax_OverEmptySet_ReturnsNull(AggregateFunction aggregation)
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            aggregation, field: "Amount", TestContext.Current.CancellationToken);
+            aggregation, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -152,10 +153,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "Quantity", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "Quantity", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(6m); // 1 + 2 + 3
     }
@@ -166,10 +167,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "Score", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "Score", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(6m); // 1.0 + 2.0 + 3.0
     }
@@ -184,10 +185,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Amount = 0m, Quantity = 0, Score = 0d, Bonus = null });
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "Bonus", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "Bonus", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(0m);
     }
@@ -195,11 +196,11 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_UnknownField_Throws()
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
-                AggregateFunction.Sum, field: "NotAColumn", TestContext.Current.CancellationToken));
+                AggregateFunction.Sum, field: "NotAColumn", dashboardFilters: null, TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("NotAColumn");
         ex.Message.ShouldContain(nameof(TestItem));
@@ -211,21 +212,21 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         // Aggregating Sum over a string column makes no sense — surface a clear
         // error so the dashboard renderer's per-widget isolation surfaces it
         // as Error (config bug, not data bug).
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
-                AggregateFunction.Sum, field: "Label", TestContext.Current.CancellationToken));
+                AggregateFunction.Sum, field: "Label", dashboardFilters: null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
-                AggregateFunction.Sum, field: null, TestContext.Current.CancellationToken));
+                AggregateFunction.Sum, field: null, dashboardFilters: null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -234,10 +235,10 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db));
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
 
         decimal? result = await runner.ExecuteAsync(
-            AggregateFunction.Sum, field: "amount", TestContext.Current.CancellationToken);
+            AggregateFunction.Sum, field: "amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.ShouldBe(60m);
     }
@@ -250,7 +251,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Amount = 30m, Quantity = 3, Score = 3.0d, Label = "c", Bonus = 15m });
     }
 
-    private sealed class TestItem
+    public sealed class TestItem
     {
         public Guid Id { get; set; }
         public decimal Amount { get; set; }
@@ -260,7 +261,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         public decimal? Bonus { get; set; }
     }
 
-    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    public sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
     {
         public DbSet<TestItem> Items => Set<TestItem>();
 
@@ -278,7 +279,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         }
     }
 
-    private sealed class TestItemSource(TestDbContext db) : IQueryableSource<TestItem>
+    public sealed class TestItemSource(TestDbContext db) : IQueryableSource<TestItem>
     {
         public IQueryable<TestItem> GetQueryable() => db.Items.AsQueryable();
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
@@ -27,7 +27,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: null,
             pageSize: 10,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Columns.Select(c => c.Name).ShouldBe(["name", "amount"]);
         result.Columns[0].LabelLocalizationKey.ShouldBe("Column:Name");
@@ -46,7 +46,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: ["Amount", "Name"],
             pageSize: 10,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Columns.Select(c => c.Name).ShouldBe(["amount", "name"]);
     }
@@ -60,7 +60,7 @@ public sealed class TableRunnerTests
             await runner.ExecuteAsync(
                 visibleColumns: ["NotAColumn"],
                 pageSize: 10,
-                TestContext.Current.CancellationToken));
+                dashboardFilters: null, TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("NotAColumn");
         ex.Message.ShouldContain("Test.Items");
@@ -74,7 +74,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: null,
             pageSize: 10,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Rows.ShouldBeEmpty();
         result.TotalRowCount.ShouldBe(0);
@@ -93,7 +93,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: null,
             pageSize: 5,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         result.Rows.Count.ShouldBe(1);
         result.TotalRowCount.ShouldBe(142);
@@ -111,7 +111,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: null,
             pageSize: 10,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         string raw = result.Rows[0].GetRawText();
         raw.Contains("\"name\":\"Alice\"", StringComparison.Ordinal).ShouldBeTrue(raw);
@@ -129,7 +129,7 @@ public sealed class TableRunnerTests
         TableRunnerResult result = await runner.ExecuteAsync(
             visibleColumns: ["Name"],
             pageSize: 10,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         JsonElement nameValue = result.Rows[0].GetProperty("name");
         nameValue.ValueKind.ShouldBe(JsonValueKind.Null);
@@ -148,11 +148,44 @@ public sealed class TableRunnerTests
         await runner.ExecuteAsync(
             visibleColumns: null,
             pageSize: 7,
-            TestContext.Current.CancellationToken);
+            dashboardFilters: null, TestContext.Current.CancellationToken);
 
         await engine.Received(1).ExecuteAsync(
             Arg.Any<IQueryable<TestItem>>(),
             Arg.Is<QueryRequest>(r => r.PageSize == 7 && r.Page == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DashboardFilters_AreTranslatedAndPassedOnTheRequest()
+    {
+        // Bare-key filters default to .eq; encoded keys pass through.
+        // The runner forwards the translated dictionary to the QueryEngine
+        // unchanged — actual narrowing happens inside the QueryEngine pipeline
+        // (its own SQLite suite covers that).
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteAsync(Arg.Any<IQueryable<TestItem>>(), Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<TestItem>([], TotalCount: 0, HasMore: false));
+
+        TableRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
+
+        await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 10,
+            dashboardFilters: new Dictionary<string, string>
+            {
+                ["Name"] = "Alice",        // bare -> Name.eq
+                ["Amount.gte"] = "100",
+            },
+            TestContext.Current.CancellationToken);
+
+        await engine.Received(1).ExecuteAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Is<QueryRequest>(r =>
+                r.Filter != null
+                && r.Filter["Name.eq"] == "Alice"
+                && r.Filter["Amount.gte"] == "100"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
@@ -203,16 +203,19 @@ public sealed class ChartWidgetInstanceRendererTests
         public string? LastGroupBy { get; private set; }
         public AggregateFunction LastAggregation { get; private set; }
         public string? LastField { get; private set; }
+        public IReadOnlyDictionary<string, string>? LastDashboardFilters { get; private set; }
 
         public Task<ChartRunnerResult> ExecuteAsync(
             string groupBy,
             AggregateFunction aggregation,
             string? field,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
             CancellationToken cancellationToken)
         {
             LastGroupBy = groupBy;
             LastAggregation = aggregation;
             LastField = field;
+            LastDashboardFilters = dashboardFilters;
             return Task.FromResult(new ChartRunnerResult(buckets));
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
@@ -208,10 +208,15 @@ public sealed class MetricDatasourceEvaluatorTests
         public string? CurrencyCode { get; }
         public bool IsHigherBetter { get; }
         public ResolvedPeriod? LastPeriod { get; private set; }
+        public IReadOnlyDictionary<string, string>? LastDashboardFilters { get; private set; }
 
-        public Task<decimal?> ExecuteAsync(ResolvedPeriod? period, CancellationToken cancellationToken)
+        public Task<decimal?> ExecuteAsync(
+            ResolvedPeriod? period,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
+            CancellationToken cancellationToken)
         {
             LastPeriod = period;
+            LastDashboardFilters = dashboardFilters;
             return Task.FromResult(_value);
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -145,6 +145,7 @@ public sealed class StubDatasourceEvaluatorsTests
         public Task<decimal?> ExecuteAsync(
             AggregateFunction aggregation,
             string? field,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
             CancellationToken cancellationToken) =>
             Task.FromResult(value);
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
@@ -169,14 +169,17 @@ public sealed class TableWidgetInstanceRendererTests
 
         public IReadOnlyList<string>? LastVisibleColumns { get; private set; }
         public int LastPageSize { get; private set; }
+        public IReadOnlyDictionary<string, string>? LastDashboardFilters { get; private set; }
 
         public Task<TableRunnerResult> ExecuteAsync(
             IReadOnlyList<string>? visibleColumns,
             int pageSize,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
             CancellationToken cancellationToken)
         {
             LastVisibleColumns = visibleColumns;
             LastPageSize = pageSize;
+            LastDashboardFilters = dashboardFilters;
             return Task.FromResult(new TableRunnerResult(columns, rows, totalRowCount));
         }
 


### PR DESCRIPTION
## Summary

Threads the dashboard-level filter spec carried by \`WidgetRenderContext.DashboardFilters\` through every data-bound runner (Metric / QueryAggregate / Table / Chart). A \`\"Status=Open\"\` filter on the dashboard now narrows the KPI tile, the table next to it and the chart below it identically — same QueryEngine pipeline as the admin grid, no duplicate predicate logic.

## Implementation

- **\`DashboardFilterTranslator\`** translates the dashboard filter dict (\`{ field: value }\`) into the QueryRequest filter dict (\`{ field.eq: value }\`). Bare keys default to equality; pre-encoded \`field.operator\` keys (e.g. \`Amount.gte\`) pass through unchanged
- Each runner interface gains an \`IReadOnlyDictionary<string, string>? dashboardFilters\` parameter (positioned before \`CancellationToken\`)
- **\`IMetricRunner\`**: filters merge into the \`QueryRequest\` the runner passes to \`MetricExecutor.BuildFilteredQuery\` — they layer on top of the metric's \`BaseFilter\`. Inline \`/metrics/{name}\` continues to pass null since it has no dashboard context
- **\`IQueryAggregateRunner\`**: gains an \`IQueryEngine<TEntity>\` dependency so it can call \`BuildFilteredQuery\` when filters are present (still uses the raw queryable when filters are null/empty for zero overhead)
- **\`ITableRunner\`** / **\`IChartRunner\`**: filters merge into the \`QueryRequest\` passed to \`ExecuteAsync\` / \`ExecuteGroupedAsync\` / \`BuildFilteredQuery\`
- All four evaluators / renderers forward \`context.DashboardFilters\` to the underlying runner

## Operator semantics

Filter keys default to \`.eq\`. Callers that want richer operators encode them in the key directly:

\`\`\`json
{
  \"Status\": \"Open\",         // becomes Status.eq=Open
  \"Amount.gte\": \"100\",
  \"Name.contains\": \"Acme\"
}
\`\`\`

The QueryEngine's \`FilterableField\` rules apply downstream — unknown fields and non-whitelisted operators are silently dropped, so a malformed dashboard filter cannot smuggle in arbitrary SQL.

## Test plan

- [x] 5 \`DashboardFilterTranslator\` unit tests — null/empty input, bare-key \`.eq\` defaulting, encoded-key pass-through, mixed dictionary
- [x] 1 \`TableRunnerTests\` test — verifies the translated filter reaches the QueryEngine via NSubstitute \`Arg.Is\`
- [x] 2 \`ChartRunnerTests\` SQLite-backed integration tests — Count and Sum filters narrow the per-group result
- [x] Existing test stubs updated for the new signature
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 128 passing (0 regressions, 8 new)
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 189 passing
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- Currency-aware aggregations (metadata on \`ColumnDescriptor\` exposes ISO 4217)
- B3-6 Pivot renderer (Postgres integration test for multi-level pivots)
- B7-2 Map renderer (PostGIS opt-in)