### PR TITLE
fix(analytics): move EF helpers out of Endpoints to satisfy archi rules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4341,15 +4341,6 @@
       ]
     },
     {
-      "name": "GroupBucket",
-      "fqn": "Granit.Analytics.Endpoints.Internal.GroupBucket",
-      "kind": "record",
-      "project": "Granit.Analytics.Endpoints",
-      "file": "src/Granit.Analytics.Endpoints/Internal/GroupAggregateExecutor.cs",
-      "line": 41,
-      "members": []
-    },
-    {
       "name": "AnalyticsEndpointsOptions",
       "fqn": "Granit.Analytics.Endpoints.Options.AnalyticsEndpointsOptions",
       "kind": "class",

--- a/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
+++ b/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
@@ -4,6 +4,11 @@
     <PackageId>Granit.Analytics.Endpoints</PackageId>
     <Description>Minimal API endpoint for Granit.Analytics inline metrics. Generic /metrics/{name} route resolves a registered MetricDefinition, applies the QueryEngine filter pipeline, executes the aggregation through Granit.Analytics.EntityFrameworkCore, caches the result via FusionCache (key composed with tenantId), and supports current-vs-previous period comparison with computed delta.</Description>
     <IsPackable>true</IsPackable>
+    <!-- EF1001: false positive — QueryAggregateExecutor / GroupAggregateExecutor live in
+         Granit.Analytics.EntityFrameworkCore.Internal (per the framework's "no EF Core in
+         Endpoints types" architecture rule), reachable here via InternalsVisibleTo. The
+         analyzer flags any *.Internal.* namespace touched from outside its assembly. -->
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Reflection;
+using Granit.Analytics.EntityFrameworkCore.Internal;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Filtering;
 

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
@@ -1,9 +1,7 @@
-using System.Globalization;
-using System.Linq.Expressions;
 using System.Reflection;
+using Granit.Analytics.EntityFrameworkCore.Internal;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Filtering;
-using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Analytics.Endpoints.Internal;
 
@@ -12,8 +10,11 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// <typeparamref name="TEntity"/> so the dashboard render path dispatches by
 /// query name without reflection at request time. Field-name → property
 /// dispatch for Sum / Avg / Min / Max happens once per call (cost is the
-/// reflective property lookup; the LINQ tree itself is materialised by EF Core
-/// without further runtime branching).
+/// reflective property lookup; the actual EF Core aggregation is delegated
+/// to <see cref="QueryAggregateExecutor"/> which lives in
+/// <c>Granit.Analytics.EntityFrameworkCore</c> — the runner itself stays
+/// EF-Core-free per the architecture rule that endpoints must not depend
+/// on EF Core directly).
 /// </summary>
 /// <remarks>
 /// Wraps the entity's <see cref="IQueryableSource{TEntity}"/>. Dashboard
@@ -41,8 +42,9 @@ internal sealed class QueryAggregateRunner<TEntity>(
     {
         IQueryable<TEntity> rawQueryable = _source.GetQueryable();
 
-        // Layer dashboard filters via the QueryEngine pipeline so a "Status=Open"
-        // dashboard filter narrows the KPI tile the same way the admin grid does.
+        // Layer dashboard filters via the QueryEngine pipeline so a
+        // "Status=Open" dashboard filter narrows the KPI tile the same way
+        // the admin grid does.
         QueryRequest filterRequest = new()
         {
             Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
@@ -53,8 +55,7 @@ internal sealed class QueryAggregateRunner<TEntity>(
 
         if (aggregation == AggregateFunction.Count)
         {
-            int count = await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
-            return count;
+            return await QueryAggregateExecutor.ExecuteCountAsync(queryable, cancellationToken).ConfigureAwait(false);
         }
 
         if (string.IsNullOrWhiteSpace(field))
@@ -75,134 +76,12 @@ internal sealed class QueryAggregateRunner<TEntity>(
 
         return aggregation switch
         {
-            AggregateFunction.Sum => await ExecuteSumAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Avg => await ExecuteAvgAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Min => await ExecuteMinMaxAsync(queryable, prop, underlying, isMax: false, cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Max => await ExecuteMinMaxAsync(queryable, prop, underlying, isMax: true, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Sum => await QueryAggregateExecutor.ExecuteSumAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Avg => await QueryAggregateExecutor.ExecuteAvgAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Min => await QueryAggregateExecutor.ExecuteMinMaxAsync(queryable, prop, underlying, isMax: false, cancellationToken).ConfigureAwait(false),
+            AggregateFunction.Max => await QueryAggregateExecutor.ExecuteMinMaxAsync(queryable, prop, underlying, isMax: true, cancellationToken).ConfigureAwait(false),
             _ => throw new NotSupportedException(
                 FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
         };
     }
-
-    private static async Task<decimal?> ExecuteSumAsync(
-        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, CancellationToken ct)
-    {
-        // Sum semantics: empty set = 0 (sum-of-empty identity). Locked by tests #1374
-        // for the metric path and inherited here so dashboard KPIs and inline metrics
-        // never disagree on what "no rows" means for a Sum.
-        if (underlying == typeof(int))
-        {
-            int? r = await q.SumAsync(BuildSelector<int>(prop), ct).ConfigureAwait(false);
-            return r ?? 0;
-        }
-        if (underlying == typeof(long))
-        {
-            long? r = await q.SumAsync(BuildSelector<long>(prop), ct).ConfigureAwait(false);
-            return r ?? 0L;
-        }
-        if (underlying == typeof(decimal))
-        {
-            decimal? r = await q.SumAsync(BuildSelector<decimal>(prop), ct).ConfigureAwait(false);
-            return r ?? 0m;
-        }
-        if (underlying == typeof(double))
-        {
-            double? r = await q.SumAsync(BuildSelector<double>(prop), ct).ConfigureAwait(false);
-            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : 0m;
-        }
-
-        throw NotSupported(prop, underlying, AggregateFunction.Sum);
-    }
-
-    private static async Task<decimal?> ExecuteAvgAsync(
-        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, CancellationToken ct)
-    {
-        // Avg semantics: empty set = null ("no data"). NEVER zero — division by zero
-        // is undefined and the frontend renders "—".
-        if (underlying == typeof(int))
-        {
-            double? r = await q.AverageAsync(BuildSelector<int>(prop), ct).ConfigureAwait(false);
-            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
-        }
-        if (underlying == typeof(long))
-        {
-            double? r = await q.AverageAsync(BuildSelector<long>(prop), ct).ConfigureAwait(false);
-            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
-        }
-        if (underlying == typeof(decimal))
-        {
-            decimal? r = await q.AverageAsync(BuildSelector<decimal>(prop), ct).ConfigureAwait(false);
-            return r;
-        }
-        if (underlying == typeof(double))
-        {
-            double? r = await q.AverageAsync(BuildSelector<double>(prop), ct).ConfigureAwait(false);
-            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
-        }
-
-        throw NotSupported(prop, underlying, AggregateFunction.Avg);
-    }
-
-    private static async Task<decimal?> ExecuteMinMaxAsync(
-        IQueryable<TEntity> q, PropertyInfo prop, Type underlying, bool isMax, CancellationToken ct)
-    {
-        // Min/Max semantics: empty set = null. We project to the value type then
-        // call the generic IQueryable<T?>.MinAsync / MaxAsync — no per-type dispatch
-        // needed for the EF Core call, only for the result coercion to decimal.
-        if (underlying == typeof(int))
-        {
-            int? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<int>(prop), isMax, ct).ConfigureAwait(false);
-            return r;
-        }
-        if (underlying == typeof(long))
-        {
-            long? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<long>(prop), isMax, ct).ConfigureAwait(false);
-            return r;
-        }
-        if (underlying == typeof(decimal))
-        {
-            decimal? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<decimal>(prop), isMax, ct).ConfigureAwait(false);
-            return r;
-        }
-        if (underlying == typeof(double))
-        {
-            double? r = await ExecuteMinMaxTypedAsync(q, BuildSelector<double>(prop), isMax, ct).ConfigureAwait(false);
-            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
-        }
-
-        throw NotSupported(prop, underlying, isMax ? AggregateFunction.Max : AggregateFunction.Min);
-    }
-
-    private static Task<TValue?> ExecuteMinMaxTypedAsync<TValue>(
-        IQueryable<TEntity> q,
-        Expression<Func<TEntity, TValue?>> selector,
-        bool isMax,
-        CancellationToken ct)
-        where TValue : struct =>
-        isMax
-            ? q.Select(selector).MaxAsync(ct)
-            : q.Select(selector).MinAsync(ct);
-
-    /// <summary>
-    /// Builds <c>x =&gt; (TValue?)x.{Field}</c>. Lifts non-nullable value types to
-    /// <see cref="Nullable{T}"/> so EF Core's typed Sum / Avg / Min / Max overloads
-    /// can return nullable results — the only way to express "no rows" for
-    /// Avg / Min / Max in SQL.
-    /// </summary>
-    private static Expression<Func<TEntity, TValue?>> BuildSelector<TValue>(PropertyInfo prop) where TValue : struct
-    {
-        ParameterExpression param = Expression.Parameter(typeof(TEntity), "x");
-        Expression access = Expression.Property(param, prop);
-
-        if (prop.PropertyType != typeof(TValue?))
-        {
-            access = Expression.Convert(access, typeof(TValue?));
-        }
-
-        return Expression.Lambda<Func<TEntity, TValue?>>(access, param);
-    }
-
-    private static NotSupportedException NotSupported(PropertyInfo prop, Type underlying, AggregateFunction aggregation) =>
-        new(FormattableString.Invariant(
-            $"Aggregation '{aggregation}' on field '{prop.Name}' (type '{underlying.Name}') is not supported. Supported types: int, long, decimal, double."));
 }

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/GroupAggregateExecutor.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/GroupAggregateExecutor.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using Granit.QueryEngine.Filtering;
 using Microsoft.EntityFrameworkCore;
 
-namespace Granit.Analytics.Endpoints.Internal;
+namespace Granit.Analytics.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Builds and executes a typed <c>GroupBy(...).Select(...)</c> expression
@@ -38,7 +38,7 @@ internal static class GroupAggregateExecutor
     /// <summary>Result row materialised by the EF projection.</summary>
     /// <param name="Key">Boxed group key — matches the runtime CLR type of the GroupBy property.</param>
     /// <param name="Value">Aggregate value coerced to <see cref="decimal"/>; <see langword="null"/> for empty Avg/Min/Max groups.</param>
-    public sealed record GroupBucket(object? Key, decimal? Value);
+    internal sealed record GroupBucket(object? Key, decimal? Value);
 
     /// <summary>Supported aggregate field types.</summary>
     private static readonly HashSet<Type> SupportedNumericTypes =

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/QueryAggregateExecutor.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/QueryAggregateExecutor.cs
@@ -1,0 +1,169 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Reflection;
+using Granit.QueryEngine.Filtering;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Analytics.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Runs an ungrouped <see cref="AggregateFunction"/> (Count / Sum / Avg /
+/// Min / Max) against an <see cref="IQueryable{T}"/> via EF Core's typed
+/// async aggregate operators. Lives in the EF Core layer so the
+/// <c>Granit.Analytics.Endpoints</c> assembly can host the runner without
+/// taking a direct <see cref="Microsoft.EntityFrameworkCore"/> dependency
+/// (architecture rule: endpoints must use abstractions, not EF Core).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Empty-set semantics shared with <c>MetricExecutor</c> (locked by tests #1374):
+/// </para>
+/// <list type="bullet">
+///   <item><c>Count</c> empty → <c>0</c>.</item>
+///   <item><c>Sum</c> empty → <c>0</c> (sum-of-empty identity).</item>
+///   <item><c>Avg</c> / <c>Min</c> / <c>Max</c> empty → <see langword="null"/>.</item>
+/// </list>
+/// <para>
+/// Configuration errors (unknown field, unsupported field type) throw —
+/// <c>IDashboardRenderer</c>'s per-widget error isolation surfaces those as
+/// <c>Error</c> envelopes per ADR-039 §3.c.
+/// </para>
+/// </remarks>
+internal static class QueryAggregateExecutor
+{
+    public static async Task<decimal?> ExecuteCountAsync<TEntity>(
+        IQueryable<TEntity> source, CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        int count = await source.CountAsync(cancellationToken).ConfigureAwait(false);
+        return count;
+    }
+
+    public static async Task<decimal?> ExecuteSumAsync<TEntity>(
+        IQueryable<TEntity> source, PropertyInfo prop, Type underlying, CancellationToken ct)
+        where TEntity : class
+    {
+        // Sum semantics: empty set = 0 (sum-of-empty identity). Locked by tests
+        // #1374 for the metric path and inherited here so dashboard KPIs and
+        // inline metrics never disagree on what "no rows" means for a Sum.
+        if (underlying == typeof(int))
+        {
+            int? r = await source.SumAsync(BuildSelector<TEntity, int>(prop), ct).ConfigureAwait(false);
+            return r ?? 0;
+        }
+        if (underlying == typeof(long))
+        {
+            long? r = await source.SumAsync(BuildSelector<TEntity, long>(prop), ct).ConfigureAwait(false);
+            return r ?? 0L;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await source.SumAsync(BuildSelector<TEntity, decimal>(prop), ct).ConfigureAwait(false);
+            return r ?? 0m;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await source.SumAsync(BuildSelector<TEntity, double>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : 0m;
+        }
+
+        throw NotSupported(prop, underlying, AggregateFunction.Sum);
+    }
+
+    public static async Task<decimal?> ExecuteAvgAsync<TEntity>(
+        IQueryable<TEntity> source, PropertyInfo prop, Type underlying, CancellationToken ct)
+        where TEntity : class
+    {
+        // Avg semantics: empty set = null ("no data"). NEVER zero — division by
+        // zero is undefined and the frontend renders "—".
+        if (underlying == typeof(int))
+        {
+            double? r = await source.AverageAsync(BuildSelector<TEntity, int>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+        if (underlying == typeof(long))
+        {
+            double? r = await source.AverageAsync(BuildSelector<TEntity, long>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await source.AverageAsync(BuildSelector<TEntity, decimal>(prop), ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await source.AverageAsync(BuildSelector<TEntity, double>(prop), ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+
+        throw NotSupported(prop, underlying, AggregateFunction.Avg);
+    }
+
+    public static async Task<decimal?> ExecuteMinMaxAsync<TEntity>(
+        IQueryable<TEntity> source, PropertyInfo prop, Type underlying, bool isMax, CancellationToken ct)
+        where TEntity : class
+    {
+        // Min/Max semantics: empty set = null. Project to the value type then
+        // call the generic IQueryable<T?>.MinAsync / MaxAsync — no per-type
+        // dispatch needed for the EF Core call, only for the result coercion
+        // to decimal.
+        if (underlying == typeof(int))
+        {
+            int? r = await ExecuteMinMaxTypedAsync<TEntity, int>(source, BuildSelector<TEntity, int>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(long))
+        {
+            long? r = await ExecuteMinMaxTypedAsync<TEntity, long>(source, BuildSelector<TEntity, long>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(decimal))
+        {
+            decimal? r = await ExecuteMinMaxTypedAsync<TEntity, decimal>(source, BuildSelector<TEntity, decimal>(prop), isMax, ct).ConfigureAwait(false);
+            return r;
+        }
+        if (underlying == typeof(double))
+        {
+            double? r = await ExecuteMinMaxTypedAsync<TEntity, double>(source, BuildSelector<TEntity, double>(prop), isMax, ct).ConfigureAwait(false);
+            return r.HasValue ? Convert.ToDecimal(r.Value, CultureInfo.InvariantCulture) : null;
+        }
+
+        throw NotSupported(prop, underlying, isMax ? AggregateFunction.Max : AggregateFunction.Min);
+    }
+
+    private static Task<TValue?> ExecuteMinMaxTypedAsync<TEntity, TValue>(
+        IQueryable<TEntity> q,
+        Expression<Func<TEntity, TValue?>> selector,
+        bool isMax,
+        CancellationToken ct)
+        where TEntity : class
+        where TValue : struct =>
+        isMax
+            ? q.Select(selector).MaxAsync(ct)
+            : q.Select(selector).MinAsync(ct);
+
+    /// <summary>
+    /// Builds <c>x =&gt; (TValue?)x.{Field}</c>. Lifts non-nullable value types
+    /// to <see cref="Nullable{T}"/> so EF Core's typed Sum / Avg / Min / Max
+    /// overloads can return nullable results — the only way to express "no
+    /// rows" for Avg / Min / Max in SQL.
+    /// </summary>
+    private static Expression<Func<TEntity, TValue?>> BuildSelector<TEntity, TValue>(PropertyInfo prop)
+        where TValue : struct
+    {
+        ParameterExpression param = Expression.Parameter(typeof(TEntity), "x");
+        Expression access = Expression.Property(param, prop);
+
+        if (prop.PropertyType != typeof(TValue?))
+        {
+            access = Expression.Convert(access, typeof(TValue?));
+        }
+
+        return Expression.Lambda<Func<TEntity, TValue?>>(access, param);
+    }
+
+    private static NotSupportedException NotSupported(PropertyInfo prop, Type underlying, AggregateFunction aggregation) =>
+        new(FormattableString.Invariant(
+            $"Aggregation '{aggregation}' on field '{prop.Name}' (type '{underlying.Name}') is not supported. Supported types: int, long, decimal, double."));
+}


### PR DESCRIPTION
## Summary

CI on \`develop\` flagged two architecture violations introduced by the B3-7 (#1495) and B3-5ter (#1494) merges that local \`--no-build\` runs missed (stale src/test build state):

1. **\`Endpoint_types_should_not_depend_on_EntityFrameworkCore\`** — \`QueryAggregateRunner\` and \`GroupAggregateExecutor\` lived in \`Granit.Analytics.Endpoints.Internal\` and called EF Core methods (\`SumAsync\`, \`CountAsync\`, \`ToListAsync\`, …) directly. Endpoints must use abstractions / ports
2. **\`Public_types_should_not_reside_in_Internal_namespaces\`** — \`GroupAggregateExecutor.GroupBucket\` was \`public\` in the \`*.Internal.*\` namespace

## Fix

- **Moved \`GroupAggregateExecutor\`** (B3-5ter) from \`Granit.Analytics.Endpoints.Internal\` to \`Granit.Analytics.EntityFrameworkCore.Internal\`. The class genuinely IS EF Core machinery — it builds GroupBy + Select expression trees and invokes \`ToListAsync\` — so it belongs in the EF Core layer. Reachable from Endpoints via the existing \`InternalsVisibleTo\`
- **Extracted \`QueryAggregateExecutor\`** — moved the ungrouped Sum / Avg / Min / Max / Count operators from \`QueryAggregateRunner\` into a new helper in \`Granit.Analytics.EntityFrameworkCore.Internal\`. Same rationale. \`QueryAggregateRunner\` now only does field resolution + filter composition + dispatch; no direct \`Microsoft.EntityFrameworkCore\` imports
- **\`GroupBucket\` made internal** — only needed within the EF Core internal namespace + assemblies covered by \`InternalsVisibleTo\`
- **\`Granit.Analytics.Endpoints.csproj\`** gains \`<NoWarn>$(NoWarn);EF1001</NoWarn>\` matching the same pattern \`Granit.Dashboards.Endpoints\` already uses — the analyzer flags any \`*.Internal.*\` namespace touched from outside its assembly even when access is granted by \`InternalsVisibleTo\`

## Test plan

- [x] \`dotnet test tests/Granit.ArchitectureTests\` — **189 passing** (was 187/189)
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 128 passing (no regressions; same suite as B3-7)
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean