### PR TITLE
feat(analytics): Pivot widget renderer (B3-6)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4443,6 +4443,24 @@
       ]
     },
     {
+      "name": "PivotCell",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.PivotCell",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "PivotWidgetSnapshot",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.PivotWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "TableWidgetColumn",
       "fqn": "Granit.Analytics.Endpoints.Rendering.TableWidgetColumn",
       "kind": "record",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -29,7 +29,12 @@ public static class AnalyticsRenderingServiceCollectionExtensions
     ///         <c>pageSize</c> rows.</item>
     ///   <item><c>"Chart"</c> — runs the named <c>QueryDefinition</c>'s
     ///         <c>ExecuteGroupedAsync</c> pipeline, returns one bucket per
-    ///         group (Count only in B3-5; Sum/Avg/Min/Max in a follow-up).</item>
+    ///         group (Count via SQL, numeric aggregations via SQL-level
+    ///         GroupBy + Select expression trees).</item>
+    ///   <item><c>"Pivot"</c> — streams the named <c>QueryDefinition</c>
+    ///         through <c>ExecuteStreamAsync</c> and pivots in-memory by
+    ///         a (row-tuple × column-tuple) composite key. Bounded by the
+    ///         QueryDefinition's <c>MaxStreamSize</c>.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -55,6 +60,7 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         services.TryAddScoped<QueryAggregateService>();
         services.TryAddScoped<TableService>();
         services.TryAddScoped<ChartService>();
+        services.TryAddScoped<PivotService>();
 
         foreach (ServiceDescriptor descriptor in services
             .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
@@ -99,11 +105,25 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                 return (IChartRunner)Activator.CreateInstance(
                     runnerType, d.Name, queryableSource, engine)!;
             });
+
+            services.AddScoped<IPivotRunner>(sp =>
+            {
+                IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
+                Type runnerType = typeof(PivotRunner<>).MakeGenericType(d.EntityType);
+                object queryableSource = sp.GetRequiredService(
+                    typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+                object engine = sp.GetRequiredService(
+                    typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+
+                return (IPivotRunner)Activator.CreateInstance(
+                    runnerType, d.Name, queryableSource, engine)!;
+            });
         }
 
         services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, TableWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, ChartWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, PivotWidgetInstanceRenderer>();
 
         return services;
     }

--- a/src/Granit.Analytics.Endpoints/Internal/IPivotRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IPivotRunner.cs
@@ -1,0 +1,70 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Non-generic façade over a typed <c>QueryDefinition&lt;TEntity&gt;</c> that
+/// runs a multi-axis pivot aggregation (rows × columns × value) against the
+/// entity's queryable. One runner is registered per query definition by
+/// <c>AddGranitAnalyticsWidgetRenderers</c> at startup; the dashboard render
+/// path resolves it by query name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// B3-6 streams the filtered entity set through
+/// <c>IQueryEngine.ExecuteStreamAsync</c> (capped by <c>MaxStreamSize</c>) and
+/// pivots in memory. Acceptable for dashboard tiles which are bounded data
+/// products; future optimisation can push the multi-key GroupBy to SQL via
+/// dynamic anonymous-type construction (mirrors the B3-5bis → B3-5ter
+/// progression for charts).
+/// </para>
+/// <para>
+/// Empty-set semantics shared with <c>MetricExecutor</c> (locked by tests #1374):
+/// </para>
+/// <list type="bullet">
+///   <item><c>Count</c> / <c>Sum</c> over empty cells → <c>0</c>.</item>
+///   <item><c>Avg</c> / <c>Min</c> / <c>Max</c> over empty cells → <see langword="null"/> on the cell value (frontend renders "—").</item>
+/// </list>
+/// </remarks>
+internal interface IPivotRunner
+{
+    /// <summary>The query definition's unique name.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Runs the pivot aggregation. Returns one cell per (row-key tuple,
+    /// column-key tuple) pair found in the data, in stream-arrival order.
+    /// </summary>
+    /// <param name="rowFields">Row-axis field names (case-insensitive). Must be a non-empty list of properties on the entity.</param>
+    /// <param name="columnFields">Column-axis field names. Empty list means a single column dimension (one bucket per row tuple).</param>
+    /// <param name="valueField">Field aggregated; required for non-Count aggregations, ignored for <see cref="AggregateFunction.Count"/>.</param>
+    /// <param name="aggregation">Aggregation applied to <paramref name="valueField"/> per (row × column) cell.</param>
+    /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the QueryDefinition's filter pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="ArgumentException">A field name is unknown, or non-Count aggregation is missing a value field, or rowFields is empty.</exception>
+    /// <exception cref="NotSupportedException">Value field's primitive type is not one of int / long / decimal / double.</exception>
+    Task<PivotRunnerResult> ExecuteAsync(
+        IReadOnlyList<string> rowFields,
+        IReadOnlyList<string> columnFields,
+        string? valueField,
+        AggregateFunction aggregation,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of an <see cref="IPivotRunner.ExecuteAsync"/> call.
+/// </summary>
+/// <param name="Cells">Per-cell results in stream-arrival order. Each cell carries the row-key tuple and column-key tuple plus the aggregated value.</param>
+internal sealed record PivotRunnerResult(IReadOnlyList<PivotRunnerCell> Cells);
+
+/// <summary>
+/// One cell of the pivot matrix.
+/// </summary>
+/// <param name="RowKeys">Row-axis key values, ordered as in <c>rowFields</c>. Null property values surface as <c>"(null)"</c>.</param>
+/// <param name="ColumnKeys">Column-axis key values, ordered as in <c>columnFields</c>. Empty when no column fields were requested.</param>
+/// <param name="Value">Aggregate value. <see langword="null"/> when the aggregation is <c>Avg</c>/<c>Min</c>/<c>Max</c> over a cell with no usable values.</param>
+internal sealed record PivotRunnerCell(
+    IReadOnlyList<string> RowKeys,
+    IReadOnlyList<string> ColumnKeys,
+    decimal? Value);

--- a/src/Granit.Analytics.Endpoints/Internal/PivotRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/PivotRunner.cs
@@ -1,0 +1,200 @@
+using System.Globalization;
+using System.Reflection;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Typed implementation of <see cref="IPivotRunner"/> — closes over
+/// <typeparamref name="TEntity"/> so dispatch by query name stays
+/// reflection-free. Streams the filtered entity set through
+/// <see cref="IQueryEngine{TEntity}.ExecuteStreamAsync"/> (multi-tenancy,
+/// soft-delete, MaxStreamSize cap apply) and accumulates each row into the
+/// (row-tuple, column-tuple) bucket it belongs to.
+/// </summary>
+internal sealed class PivotRunner<TEntity>(
+    string name,
+    IQueryableSource<TEntity> source,
+    IQueryEngine<TEntity> engine) : IPivotRunner
+    where TEntity : class
+{
+    /// <summary>Composite-key delimiter (ASCII unit separator). Unlikely in real entity values; collisions in dashboard tile data are negligible.</summary>
+    private const char KeyDelimiter = '';
+
+    /// <summary>Sentinel surfaced on the wire for null property values.</summary>
+    private const string NullKey = "(null)";
+
+    private readonly IQueryableSource<TEntity> _source = source;
+    private readonly IQueryEngine<TEntity> _engine = engine;
+
+    public string Name { get; } = name;
+
+    public async Task<PivotRunnerResult> ExecuteAsync(
+        IReadOnlyList<string> rowFields,
+        IReadOnlyList<string> columnFields,
+        string? valueField,
+        AggregateFunction aggregation,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rowFields);
+        ArgumentNullException.ThrowIfNull(columnFields);
+
+        if (rowFields.Count == 0)
+        {
+            throw new ArgumentException(
+                $"Pivot for query '{Name}' requires at least one RowField.",
+                nameof(rowFields));
+        }
+
+        PropertyInfo[] rowProps = ResolveProperties(rowFields, nameof(rowFields));
+        PropertyInfo[] colProps = ResolveProperties(columnFields, nameof(columnFields));
+
+        PropertyInfo? valueProp = null;
+        Type? valueUnderlying = null;
+        if (aggregation != AggregateFunction.Count)
+        {
+            if (string.IsNullOrWhiteSpace(valueField))
+            {
+                throw new ArgumentException(
+                    $"Aggregation '{aggregation}' on pivot for query '{Name}' requires a ValueField — was null or empty.",
+                    nameof(valueField));
+            }
+
+            valueProp = ResolveProperty(valueField, nameof(valueField));
+            valueUnderlying = Nullable.GetUnderlyingType(valueProp.PropertyType) ?? valueProp.PropertyType;
+
+            if (!IsSupportedNumericType(valueUnderlying))
+            {
+                throw new NotSupportedException(FormattableString.Invariant(
+                    $"Aggregation '{aggregation}' on field '{valueProp.Name}' (type '{valueUnderlying.Name}') is not supported. Supported types: int, long, decimal, double."));
+            }
+        }
+
+        // Same QueryRequest the chart and table runners use — dashboard filters
+        // layer in the same way and the QueryEngine pipeline (multi-tenancy,
+        // soft-delete) applies upstream of streaming.
+        QueryRequest request = new()
+        {
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
+
+        Dictionary<string, CellAccumulator> cells = new(StringComparer.Ordinal);
+
+        await foreach (TEntity entity in _engine
+            .ExecuteStreamAsync(_source.GetQueryable(), request, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            string[] rowKeys = ProjectKeys(rowProps, entity);
+            string[] colKeys = ProjectKeys(colProps, entity);
+            string compositeKey = BuildCompositeKey(rowKeys, colKeys);
+
+            if (!cells.TryGetValue(compositeKey, out CellAccumulator? acc))
+            {
+                acc = new CellAccumulator(rowKeys, colKeys);
+                cells[compositeKey] = acc;
+            }
+
+            if (valueProp is not null)
+            {
+                object? rawValue = valueProp.GetValue(entity);
+                if (rawValue is not null)
+                {
+                    acc.AddValue(Convert.ToDecimal(rawValue, CultureInfo.InvariantCulture));
+                }
+            }
+            else
+            {
+                // Count path — no value field, just bump the counter.
+                acc.IncrementCount();
+            }
+        }
+
+        IReadOnlyList<PivotRunnerCell> result = [..
+            cells.Values.Select(acc => new PivotRunnerCell(
+                RowKeys: acc.RowKeys,
+                ColumnKeys: acc.ColumnKeys,
+                Value: acc.Compute(aggregation)))];
+
+        return new PivotRunnerResult(result);
+    }
+
+    private static PropertyInfo[] ResolveProperties(IReadOnlyList<string> fieldNames, string paramName)
+    {
+        var resolved = new PropertyInfo[fieldNames.Count];
+        for (int i = 0; i < fieldNames.Count; i++)
+        {
+            resolved[i] = ResolveProperty(fieldNames[i], paramName);
+        }
+        return resolved;
+    }
+
+    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
+    {
+        PropertyInfo? prop = typeof(TEntity).GetProperty(
+            fieldName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        return prop ?? throw new ArgumentException(
+            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
+            paramName);
+    }
+
+    private static bool IsSupportedNumericType(Type underlying) =>
+        underlying == typeof(int) || underlying == typeof(long)
+        || underlying == typeof(decimal) || underlying == typeof(double);
+
+    private static string[] ProjectKeys(PropertyInfo[] props, TEntity entity)
+    {
+        if (props.Length == 0)
+        {
+            return [];
+        }
+
+        string[] keys = new string[props.Length];
+        for (int i = 0; i < props.Length; i++)
+        {
+            object? raw = props[i].GetValue(entity);
+            keys[i] = raw is null
+                ? NullKey
+                : Convert.ToString(raw, CultureInfo.InvariantCulture) ?? NullKey;
+        }
+        return keys;
+    }
+
+    private static string BuildCompositeKey(string[] rowKeys, string[] colKeys)
+    {
+        // Two-section composite — row-section then column-section, separated
+        // by a sentinel. ASCII unit separator () is unlikely in real
+        // values; same delimiter strategy as Granit's other internal keys.
+        return string.Concat(
+            string.Join(KeyDelimiter, rowKeys),
+            "",   // record separator between row and column sections
+            string.Join(KeyDelimiter, colKeys));
+    }
+
+    private sealed class CellAccumulator(string[] rowKeys, string[] colKeys)
+    {
+        private readonly List<decimal> _values = [];
+        private int _count;
+
+        public string[] RowKeys { get; } = rowKeys;
+        public string[] ColumnKeys { get; } = colKeys;
+
+        public void AddValue(decimal value) => _values.Add(value);
+        public void IncrementCount() => _count++;
+
+        public decimal? Compute(AggregateFunction aggregation) =>
+            aggregation switch
+            {
+                AggregateFunction.Count => _count,
+                AggregateFunction.Sum => _values.Count == 0 ? 0m : _values.Sum(),
+                AggregateFunction.Avg => _values.Count == 0 ? null : _values.Average(),
+                AggregateFunction.Min => _values.Count == 0 ? null : _values.Min(),
+                AggregateFunction.Max => _values.Count == 0 ? null : _values.Max(),
+                _ => throw new NotSupportedException(
+                    FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
+            };
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Internal/PivotService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/PivotService.cs
@@ -1,0 +1,17 @@
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Registry of <see cref="IPivotRunner"/>s keyed by query name. Mirrors
+/// <see cref="QueryAggregateService"/> / <see cref="TableService"/> /
+/// <see cref="ChartService"/> for the pivot side: a single point of
+/// resolution so the dashboard render path stays reflection-free at
+/// request time.
+/// </summary>
+internal sealed class PivotService(IEnumerable<IPivotRunner> runners)
+{
+    private readonly Dictionary<string, IPivotRunner> _byName =
+        runners.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetRunner(string queryName, out IPivotRunner runner) =>
+        _byName.TryGetValue(queryName, out runner!);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetInstanceRenderer.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Granit.Timing;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Pivot"</c> widget kind.
+/// Resolves the registered <see cref="IPivotRunner"/> by query name, runs it
+/// with the configured row / column dimensions plus the value aggregation,
+/// and shapes the result into a <see cref="PivotWidgetSnapshot"/>. Per-widget
+/// permission gate + error isolation already apply upstream
+/// (<see cref="IDashboardRenderer"/> / ADR-039 §3); this renderer is
+/// responsible for the body shape only.
+/// </summary>
+internal sealed class PivotWidgetInstanceRenderer(
+    PivotService pivotService,
+    IClock clock) : IWidgetInstanceRenderer
+{
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly PivotService _pivotService = pivotService;
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Pivot";
+
+    public async Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        PivotConfig config = JsonSerializer.Deserialize<PivotConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Pivot') has empty ConfigJson — pivot config cannot be resolved.");
+
+        if (string.IsNullOrWhiteSpace(widget.QueryName))
+        {
+            throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Pivot') has no QueryName — Pivot widgets must reference a registered QueryDefinition.");
+        }
+
+        DateTimeOffset emittedAt = _clock.Now;
+
+        if (!_pivotService.TryGetRunner(widget.QueryName, out IPivotRunner runner))
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
+        }
+
+        IReadOnlyList<string> rowFields = config.RowFields ?? [];
+        IReadOnlyList<string> columnFields = config.ColumnFields ?? [];
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: rowFields,
+            columnFields: columnFields,
+            valueField: config.ValueField,
+            aggregation: config.ValueAggregation,
+            dashboardFilters: context.DashboardFilters,
+            cancellationToken).ConfigureAwait(false);
+
+        PivotWidgetSnapshot snapshot = new(
+            RowFields: rowFields,
+            ColumnFields: columnFields,
+            ValueField: config.ValueField,
+            Aggregation: config.ValueAggregation,
+            Cells: [.. result.Cells.Select(c => new PivotCell(c.RowKeys, c.ColumnKeys, c.Value))]);
+
+        return WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: emittedAt,
+            refreshHint: RefreshHint.Dynamic);
+    }
+
+    private sealed record PivotConfig(
+        IReadOnlyList<string>? RowFields,
+        IReadOnlyList<string>? ColumnFields,
+        string? ValueField,
+        AggregateFunction ValueAggregation);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs
@@ -1,0 +1,37 @@
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Pivot"</c> widget kind. Echoes the
+/// declarative configuration (<see cref="RowFields"/>, <see cref="ColumnFields"/>,
+/// <see cref="ValueField"/>, <see cref="Aggregation"/>) so the frontend
+/// renders without re-reading the widget config, and ships one
+/// <see cref="PivotCell"/> per (row-tuple × column-tuple) bucket as a flat
+/// list — the frontend pivots into a matrix client-side.
+/// </summary>
+/// <param name="RowFields">Row-axis field names, in the order they were declared on the widget.</param>
+/// <param name="ColumnFields">Column-axis field names, in declared order. Empty when the widget has only row dimensions.</param>
+/// <param name="ValueField">Aggregated field; <see langword="null"/> for <see cref="AggregateFunction.Count"/>.</param>
+/// <param name="Aggregation">Aggregation applied per cell — drives the value-axis label client-side.</param>
+/// <param name="Cells">Per-cell results. Order is preserved as the underlying stream produces them; the frontend pivots into a row-major matrix.</param>
+public sealed record PivotWidgetSnapshot(
+    IReadOnlyList<string> RowFields,
+    IReadOnlyList<string> ColumnFields,
+    string? ValueField,
+    AggregateFunction Aggregation,
+    IReadOnlyList<PivotCell> Cells);
+
+/// <summary>One cell of the pivot matrix.</summary>
+/// <param name="RowKeys">Row-axis key tuple matching <see cref="PivotWidgetSnapshot.RowFields"/>. Null property values surface as <c>"(null)"</c>.</param>
+/// <param name="ColumnKeys">Column-axis key tuple matching <see cref="PivotWidgetSnapshot.ColumnFields"/>. Empty when no column fields were requested.</param>
+/// <param name="Value">
+/// Aggregate value for the cell. <see langword="null"/> when the aggregation
+/// is <c>Avg</c>/<c>Min</c>/<c>Max</c> over a cell with no usable values —
+/// the frontend renders "—" for that data point. <c>Count</c> and <c>Sum</c>
+/// always carry a non-null value (zero for empty cells).
+/// </param>
+public sealed record PivotCell(
+    IReadOnlyList<string> RowKeys,
+    IReadOnlyList<string> ColumnKeys,
+    decimal? Value);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/PivotRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/PivotRunnerTests.cs
@@ -1,0 +1,374 @@
+using System.Runtime.CompilerServices;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="PivotRunner{TEntity}"/> — substitute the
+/// <see cref="IQueryEngine{TEntity}.ExecuteStreamAsync"/> path with NSubstitute
+/// so the streaming + in-memory pivot logic is exercised against a known
+/// dataset, independent of EF Core translation. The QueryEngine pipeline
+/// already has its own SQLite suite covering filter-pipeline application.
+/// </summary>
+public sealed class PivotRunnerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_OneRowAxis_OneColumnAxis_Sum_ProducesOneCellPerCombo()
+    {
+        // 4 rows: (Open, EU, 10), (Open, US, 20), (Paid, EU, 30), (Open, EU, 5).
+        // Pivot by row=Status, col=Region, Sum(Amount):
+        //   (Open, EU) → 15, (Open, US) → 20, (Paid, EU) → 30.
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", Amount = 10m },
+            new() { Status = "Open", Region = "US", Amount = 20m },
+            new() { Status = "Paid", Region = "EU", Amount = 30m },
+            new() { Status = "Open", Region = "EU", Amount = 5m },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        Dictionary<(string row, string col), decimal?> byCell =
+            result.Cells.ToDictionary(c => (c.RowKeys[0], c.ColumnKeys[0]), c => c.Value);
+
+        byCell[("Open", "EU")].ShouldBe(15m);
+        byCell[("Open", "US")].ShouldBe(20m);
+        byCell[("Paid", "EU")].ShouldBe(30m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoColumnAxis_DegradesToOneBucketPerRowTuple()
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", Amount = 10m },
+            new() { Status = "Open", Region = "US", Amount = 20m },
+            new() { Status = "Paid", Region = "EU", Amount = 30m },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: [],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        var byRow = result.Cells.ToDictionary(c => c.RowKeys[0], c => c.Value);
+        byRow["Open"].ShouldBe(30m);
+        byRow["Paid"].ShouldBe(30m);
+
+        result.Cells[0].ColumnKeys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleRowFields_KeysTuple_ReflectsAllDimensions()
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", Year = 2025, Amount = 10m },
+            new() { Status = "Open", Region = "EU", Year = 2026, Amount = 20m },
+            new() { Status = "Open", Region = "EU", Year = 2025, Amount = 5m },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status", "Region"],
+            columnFields: ["Year"],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        // Cells keyed on (Status, Region, Year)
+        var byKey =
+            result.Cells.ToDictionary(c => $"{c.RowKeys[0]}|{c.RowKeys[1]}|{c.ColumnKeys[0]}", c => c.Value);
+
+        byKey["Open|EU|2025"].ShouldBe(15m);
+        byKey["Open|EU|2026"].ShouldBe(20m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_IgnoresValueField_AndReturnsRowCountPerCell()
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU" },
+            new() { Status = "Open", Region = "EU" },
+            new() { Status = "Open", Region = "US" },
+            new() { Status = "Paid", Region = "EU" },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: null,
+            aggregation: AggregateFunction.Count,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        Dictionary<(string row, string col), decimal?> byCell =
+            result.Cells.ToDictionary(c => (c.RowKeys[0], c.ColumnKeys[0]), c => c.Value);
+
+        byCell[("Open", "EU")].ShouldBe(2m);
+        byCell[("Open", "US")].ShouldBe(1m);
+        byCell[("Paid", "EU")].ShouldBe(1m);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Avg, 15)]
+    [InlineData(AggregateFunction.Min, 10)]
+    [InlineData(AggregateFunction.Max, 20)]
+    public async Task ExecuteAsync_AvgMinMax_OverPopulatedCell_ReturnsExpectedValue(
+        AggregateFunction aggregation, int expected)
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", Amount = 10m },
+            new() { Status = "Open", Region = "EU", Amount = 20m },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "Amount",
+            aggregation: aggregation,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Cells[0].Value.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(AggregateFunction.Avg)]
+    [InlineData(AggregateFunction.Min)]
+    [InlineData(AggregateFunction.Max)]
+    public async Task ExecuteAsync_AvgMinMax_OverAllNullCell_ReturnsNull(AggregateFunction aggregation)
+    {
+        // Cell exists (the row tuple appears) but every value is null.
+        // Locked semantics from #1374: Avg/Min/Max → null on the cell value.
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", BonusNullable = null },
+            new() { Status = "Open", Region = "EU", BonusNullable = null },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "BonusNullable",
+            aggregation: aggregation,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Cells[0].Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Sum_OverAllNullCell_ReturnsZero_NotNull()
+    {
+        TestItem[] items =
+        [
+            new() { Status = "Open", Region = "EU", BonusNullable = null },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "BonusNullable",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Cells[0].Value.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullPropertyValue_SurfacesAsNullSentinelKey()
+    {
+        TestItem[] items =
+        [
+            new() { Status = null!, Region = "EU", Amount = 10m },
+            new() { Status = "Open", Region = "EU", Amount = 20m },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        var byRow = result.Cells.ToDictionary(c => c.RowKeys[0], c => c.Value);
+        byRow.ShouldContainKey("(null)");
+        byRow["(null)"].ShouldBe(10m);
+        byRow["Open"].ShouldBe(20m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyRowFields_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                rowFields: [],
+                columnFields: ["Region"],
+                valueField: "Amount",
+                aggregation: AggregateFunction.Sum,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownRowField_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                rowFields: ["NotAField"],
+                columnFields: [],
+                valueField: "Amount",
+                aggregation: AggregateFunction.Sum,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAField");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonCount_WithoutValueField_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                rowFields: ["Status"],
+                columnFields: [],
+                valueField: null,
+                aggregation: AggregateFunction.Sum,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnsupportedValueFieldType_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await runner.ExecuteAsync(
+                rowFields: ["Status"],
+                columnFields: [],
+                valueField: "Region", // string field → unsupported
+                aggregation: AggregateFunction.Sum,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DashboardFilter_PassedAsQueryRequestFilter()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: new Dictionary<string, string> { ["Status"] = "Open" },
+            TestContext.Current.CancellationToken);
+
+        engine.Received(1).ExecuteStreamAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Is<QueryRequest>(r => r.Filter != null && r.Filter["Status.eq"] == "Open"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Name_IsSetFromConstructor()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        PivotRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine);
+        runner.Name.ShouldBe("Granit.Test.Items");
+    }
+
+    private static IQueryEngine<TestItem> ConfigureStream(IReadOnlyList<TestItem> items)
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteStreamAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => YieldAsync(items, default));
+        return engine;
+    }
+
+    private static async IAsyncEnumerable<TestItem> YieldAsync(
+        IReadOnlyList<TestItem> items, [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (TestItem item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public sealed class TestItem
+    {
+        public Guid Id { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string Region { get; set; } = string.Empty;
+        public int Year { get; set; }
+        public decimal Amount { get; set; }
+        public decimal? BonusNullable { get; set; }
+    }
+
+    public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/PivotWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/PivotWidgetInstanceRendererTests.cs
@@ -1,0 +1,198 @@
+using System.Security.Claims;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// Unit tests for <see cref="PivotWidgetInstanceRenderer"/> — substitute the
+/// <see cref="PivotService"/>'s underlying <see cref="IPivotRunner"/> so the
+/// renderer's envelope shaping is exercised against a known result. Runner
+/// projection logic is covered separately by
+/// <see cref="Internal.PivotRunnerTests"/>.
+/// </summary>
+public sealed class PivotWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public PivotWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsPivot()
+    {
+        new PivotWidgetInstanceRenderer(new PivotService([]), _clock).WidgetType.ShouldBe("Pivot");
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownQueryName_ReturnsUnavailable()
+    {
+        PivotWidgetInstanceRenderer renderer = new(new PivotService([]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.MissingQuery",
+                "{\"rowFields\":[\"Status\"],\"columnFields\":[\"Region\"],\"valueField\":\"Amount\",\"valueAggregation\":\"Sum\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.WidgetType.ShouldBe("Pivot");
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+    }
+
+    [Fact]
+    public async Task RenderAsync_HappyPath_BuildsPivotWidgetSnapshot()
+    {
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            cells:
+            [
+                new PivotRunnerCell(["Open"], ["EU"], 15m),
+                new PivotRunnerCell(["Open"], ["US"], 20m),
+                new PivotRunnerCell(["Paid"], ["EU"], 30m),
+            ]);
+
+        PivotWidgetInstanceRenderer renderer = new(new PivotService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"rowFields\":[\"Status\"],\"columnFields\":[\"Region\"],\"valueField\":\"Amount\",\"valueAggregation\":\"Sum\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Pivot");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        envelope.EmittedAt.ShouldBe(Now);
+        envelope.Sequence.ShouldBe(1);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        System.Text.Json.JsonElement snap = envelope.Snapshot!.Value;
+        snap.GetProperty("aggregation").GetString().ShouldBe("Sum");
+        snap.GetProperty("valueField").GetString().ShouldBe("Amount");
+        snap.GetProperty("rowFields")[0].GetString().ShouldBe("Status");
+        snap.GetProperty("columnFields")[0].GetString().ShouldBe("Region");
+        snap.GetProperty("cells").GetArrayLength().ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task RenderAsync_PassesConfigOnToRunner()
+    {
+        StubRunner runner = new("Granit.Test.Items", cells: []);
+        PivotWidgetInstanceRenderer renderer = new(new PivotService([runner]), _clock);
+
+        await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"rowFields\":[\"Status\",\"Region\"],\"columnFields\":[\"Year\"],\"valueField\":\"Amount\",\"valueAggregation\":\"Avg\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        runner.LastRowFields.ShouldBe(["Status", "Region"]);
+        runner.LastColumnFields.ShouldBe(["Year"]);
+        runner.LastValueField.ShouldBe("Amount");
+        runner.LastAggregation.ShouldBe(AggregateFunction.Avg);
+    }
+
+    [Fact]
+    public async Task RenderAsync_NullCellValue_SerialisesAsJsonNull()
+    {
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            cells: [new PivotRunnerCell(["Open"], ["EU"], null)]);
+
+        PivotWidgetInstanceRenderer renderer = new(new PivotService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"rowFields\":[\"Status\"],\"columnFields\":[\"Region\"],\"valueField\":\"Amount\",\"valueAggregation\":\"Avg\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        System.Text.Json.JsonElement cell = envelope.Snapshot!.Value.GetProperty("cells")[0];
+        cell.GetProperty("value").ValueKind.ShouldBe(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task RenderAsync_SnapshotShape_IsCamelCase()
+    {
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            cells: [new PivotRunnerCell(["Open"], ["EU"], 15m)]);
+
+        PivotWidgetInstanceRenderer renderer = new(new PivotService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                "{\"rowFields\":[\"Status\"],\"columnFields\":[\"Region\"],\"valueField\":\"Amount\",\"valueAggregation\":\"Sum\"}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        string raw = envelope.Snapshot!.Value.GetRawText();
+        raw.Contains("\"rowFields\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"columnFields\"", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"rowKeys\":[\"Open\"]", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"columnKeys\":[\"EU\"]", StringComparison.Ordinal).ShouldBeTrue(raw);
+        raw.Contains("\"RowFields\"", StringComparison.Ordinal).ShouldBeFalse(raw);
+    }
+
+    private static WidgetInstance BuildWidget(string queryName, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Pivot",
+            position: 0,
+            width: 6,
+            height: 3,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson,
+            queryName: queryName);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class StubRunner(string name, IReadOnlyList<PivotRunnerCell> cells) : IPivotRunner
+    {
+        public string Name { get; } = name;
+
+        public IReadOnlyList<string>? LastRowFields { get; private set; }
+        public IReadOnlyList<string>? LastColumnFields { get; private set; }
+        public string? LastValueField { get; private set; }
+        public AggregateFunction LastAggregation { get; private set; }
+
+        public Task<PivotRunnerResult> ExecuteAsync(
+            IReadOnlyList<string> rowFields,
+            IReadOnlyList<string> columnFields,
+            string? valueField,
+            AggregateFunction aggregation,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
+            CancellationToken cancellationToken)
+        {
+            LastRowFields = rowFields;
+            LastColumnFields = columnFields;
+            LastValueField = valueField;
+            LastAggregation = aggregation;
+            return Task.FromResult(new PivotRunnerResult(cells));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the dashboard widget catalogue: Markdown / Text / Image / Kpi / Chart / Table / **Pivot** all shipped. The classic OLAP shape — rows × columns × value cells — now renders against any registered \`QueryDefinition\` with the same multi-tenancy / soft-delete / dashboard filter semantics as the admin grid.

## Implementation

\`IPivotRunner\` / \`PivotRunner<TEntity>\` / \`PivotService\` mirror the runner-registry pattern established by the other data-bound renderers. Streams the filtered entity set through \`IQueryEngine.ExecuteStreamAsync\` (capped by \`MaxStreamSize\`, applies multi-tenancy + soft-delete + dashboard filters via \`QueryRequest\`) then pivots in-memory by composite (row-tuple × column-tuple) key.

Acceptable for dashboard tile contexts which are bounded data products; future B3-6ter could SQL-optimise via dynamic anonymous-key GroupBy mirroring the B3-5bis → B3-5ter progression for charts. Tracked as a follow-up.

Composite key uses ASCII unit separator (\`\\u001f\`) between row keys and record separator (\`\\u001e\`) between row and column sections — unlikely collisions in real entity values, simple to construct.

## Wire shape (\`PivotWidgetSnapshot\`)

\`\`\`jsonc
{
  \"rowFields\": [\"Status\", \"Region\"],
  \"columnFields\": [\"Year\"],
  \"valueField\": \"Amount\",
  \"aggregation\": \"Sum\",
  \"cells\": [
    { \"rowKeys\": [\"Open\", \"EU\"], \"columnKeys\": [\"2025\"], \"value\": 15.0 },
    { \"rowKeys\": [\"Open\", \"EU\"], \"columnKeys\": [\"2026\"], \"value\": 20.0 },
    { \"rowKeys\": [\"Paid\", \"EU\"], \"columnKeys\": [\"2025\"], \"value\": 30.0 }
  ]
}
\`\`\`

- Cells flatten the matrix — frontend pivots row-major client-side
- Each cell carries its full row-key + column-key tuples (multi-dimension friendly)

## Empty-set semantics (locked by #1374)

- \`Count\` over an empty cell → \`0\`
- \`Sum\` over a cell with all-null values → \`0\` (mathematical identity)
- \`Avg\` / \`Min\` / \`Max\` over a cell with no usable values → \`null\` on the cell value (frontend renders \"—\")

## Configuration paths

- Unknown query name → \`Unavailable(\"Widget:Unavailable.QueryNotFound\")\`
- Empty \`rowFields\` / unknown row or column field / non-Count missing \`valueField\` / unsupported field type → throw, surfaced by \`IDashboardRenderer\`'s per-widget isolation as \`Error\` per ADR-039 §3.c
- Dashboard filters compose via \`DashboardFilterTranslator\` (B3-7) — same contract as the other data-bound runners

## Test plan

- [x] 14 \`PivotRunner\` unit tests — one row × one col axis, multi-row dimensions, no-column-axis degraded mode, every aggregation including empty-cell semantics, null-property-key sentinel, every config-error path, dashboard filter forwarding
- [x] 5 \`PivotWidgetInstanceRenderer\` tests — \`WidgetType=\"Pivot\"\`, unknown query, happy-path snapshot shape, config pass-through, null cell value JSON serialisation, camelCase wire shape
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 152 passing (24 new)
- [x] \`dotnet build tests/Granit.ArchitectureTests && dotnet test --no-build\` — 189 passing (fresh build per the lessons-learned from #1496)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- B3-6ter: SQL-level Pivot Sum/Avg/Min/Max via dynamic anonymous-key GroupBy (drop-in replacement for the in-memory accumulator without changing the contract)
- B7-2: Map widget renderer (PostGIS opt-in for \`MapPointSource.Geography\`)
- Currency-aware aggregations (ISO 4217 metadata on \`ColumnDescriptor\`)
- Layer 3 OData (#1389-1394)