### PR TITLE
feat(analytics): currency-aware QueryAggregate KPIs (B3-8)

### DIFF
--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -74,8 +74,10 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
                 object engine = sp.GetRequiredService(
                     typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+                object definition = sp.GetRequiredService(
+                    typeof(QueryDefinition<>).MakeGenericType(d.EntityType));
 
-                return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource, engine)!;
+                return (IQueryAggregateRunner)Activator.CreateInstance(runnerType, d.Name, queryableSource, engine, definition)!;
             });
 
             services.AddScoped<ITableRunner>(sp =>

--- a/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IQueryAggregateRunner.cs
@@ -51,9 +51,20 @@ internal interface IQueryAggregateRunner
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="ArgumentException">Field is null/empty for a non-Count aggregation, or field is not a property of the entity.</exception>
     /// <exception cref="NotSupportedException">Field's primitive type is not one of int / long / decimal / double.</exception>
-    Task<decimal?> ExecuteAsync(
+    Task<QueryAggregateRunnerResult> ExecuteAsync(
         AggregateFunction aggregation,
         string? field,
         IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// Outcome of an <see cref="IQueryAggregateRunner.ExecuteAsync"/> call.
+/// Bundles the projected value with the column's ISO 4217 currency code
+/// (when declared on the QueryDefinition's column descriptor), so the
+/// evaluator can promote the snapshot to <c>MetricValueKind.Currency</c>
+/// without re-traversing the query metadata.
+/// </summary>
+/// <param name="Value">Projected aggregate value, coerced to <see cref="decimal"/>; <see langword="null"/> for empty Avg/Min/Max.</param>
+/// <param name="CurrencyCode">ISO 4217 alpha-3 code from the underlying column's <c>Currency(...)</c> declaration; <see langword="null"/> for non-monetary aggregations and for <c>Count</c>.</param>
+internal sealed record QueryAggregateRunnerResult(decimal? Value, string? CurrencyCode);

--- a/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/QueryAggregateRunner.cs
@@ -26,15 +26,17 @@ namespace Granit.Analytics.Endpoints.Internal;
 internal sealed class QueryAggregateRunner<TEntity>(
     string name,
     IQueryableSource<TEntity> source,
-    IQueryEngine<TEntity> engine) : IQueryAggregateRunner
+    IQueryEngine<TEntity> engine,
+    QueryDefinition<TEntity> definition) : IQueryAggregateRunner
     where TEntity : class
 {
     private readonly IQueryableSource<TEntity> _source = source;
     private readonly IQueryEngine<TEntity> _engine = engine;
+    private readonly QueryDefinition<TEntity> _definition = definition;
 
     public string Name { get; } = name;
 
-    public async Task<decimal?> ExecuteAsync(
+    public async Task<QueryAggregateRunnerResult> ExecuteAsync(
         AggregateFunction aggregation,
         string? field,
         IReadOnlyDictionary<string, string>? dashboardFilters,
@@ -55,7 +57,10 @@ internal sealed class QueryAggregateRunner<TEntity>(
 
         if (aggregation == AggregateFunction.Count)
         {
-            return await QueryAggregateExecutor.ExecuteCountAsync(queryable, cancellationToken).ConfigureAwait(false);
+            // Count never carries a currency — the projected value is a row
+            // count, not a monetary amount.
+            decimal? count = await QueryAggregateExecutor.ExecuteCountAsync(queryable, cancellationToken).ConfigureAwait(false);
+            return new QueryAggregateRunnerResult(count, CurrencyCode: null);
         }
 
         if (string.IsNullOrWhiteSpace(field))
@@ -74,7 +79,7 @@ internal sealed class QueryAggregateRunner<TEntity>(
 
         Type underlying = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
 
-        return aggregation switch
+        decimal? value = aggregation switch
         {
             AggregateFunction.Sum => await QueryAggregateExecutor.ExecuteSumAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
             AggregateFunction.Avg => await QueryAggregateExecutor.ExecuteAvgAsync(queryable, prop, underlying, cancellationToken).ConfigureAwait(false),
@@ -83,5 +88,20 @@ internal sealed class QueryAggregateRunner<TEntity>(
             _ => throw new NotSupportedException(
                 FormattableString.Invariant($"Aggregation '{aggregation}' is not supported.")),
         };
+
+        // Look up the column descriptor for the aggregated field — its
+        // declared CurrencyCode propagates to the wire envelope so the
+        // frontend formats e.g. €1,234.56 instead of bare 1234.56.
+        string? currencyCode = ResolveCurrencyCode(prop);
+
+        return new QueryAggregateRunnerResult(value, currencyCode);
+    }
+
+    private string? ResolveCurrencyCode(PropertyInfo prop)
+    {
+        IReadOnlyList<ColumnDescriptor> columns = _definition.GetColumns();
+        ColumnDescriptor? match = columns.FirstOrDefault(c =>
+            string.Equals(c.PropertyName, prop.Name, StringComparison.Ordinal));
+        return match?.CurrencyCode;
     }
 }

--- a/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/QueryAggregateDatasourceEvaluator.cs
@@ -43,7 +43,7 @@ internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService qu
         // are caught by IDashboardRenderer's per-widget error isolation
         // (ADR-039 §3.c). The dashboard render still returns 200; the
         // misconfigured widget alone is surfaced as Error.
-        decimal? value = await runner
+        QueryAggregateRunnerResult result = await runner
             .ExecuteAsync(datasource.Aggregation, datasource.Field, context.DashboardFilters, cancellationToken)
             .ConfigureAwait(false);
 
@@ -52,15 +52,23 @@ internal sealed class QueryAggregateDatasourceEvaluator(QueryAggregateService qu
         // - Avg / Min / Max: null when no rows — NoData true so the frontend
         //   renders the "—" placeholder instead of "0" (which would imply a
         //   real measurement).
-        bool noData = !value.HasValue;
-        MetricValueKind valueKind = datasource.Aggregation == AggregateFunction.Count
-            ? MetricValueKind.Count
-            : MetricValueKind.Number;
+        bool noData = !result.Value.HasValue;
+
+        // ValueKind precedence:
+        //  1. Count -> Count (always; Count never carries a currency)
+        //  2. Currency code declared on the column -> Currency
+        //  3. Otherwise -> Number
+        MetricValueKind valueKind = datasource.Aggregation switch
+        {
+            AggregateFunction.Count => MetricValueKind.Count,
+            _ when result.CurrencyCode is not null => MetricValueKind.Currency,
+            _ => MetricValueKind.Number,
+        };
 
         MetricSnapshotPayload payload = new(
-            value,
+            result.Value,
             ValueKind: valueKind,
-            Currency: null,
+            Currency: result.CurrencyCode,
             IsHigherBetter: true,
             NoData: noData,
             Previous: null);

--- a/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
@@ -16,6 +16,7 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     internal bool IsVisibleValue { get; private set; } = true;
     internal string? FormatValue { get; private set; }
     internal LookupDescriptor? LookupValue { get; private set; }
+    internal string? CurrencyCodeValue { get; private set; }
 
     /// <summary>
     /// Sets the user-facing label for this column.
@@ -129,6 +130,28 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         LookupValue = descriptor;
+        return this;
+    }
+
+    /// <summary>
+    /// Tags this column as a monetary amount in the supplied ISO 4217 currency
+    /// (e.g. <c>"EUR"</c>, <c>"USD"</c>, <c>"JPY"</c>). Surfaced on the wire so
+    /// dashboard renderers (KPI / Chart / Table / Pivot) emit the
+    /// <c>"Currency"</c> value-kind with the right currency code, letting the
+    /// frontend pick the matching locale + symbol when formatting.
+    /// </summary>
+    /// <remarks>
+    /// Per-column metadata (not per-entity) — different columns on the same
+    /// entity can carry different currencies (e.g. <c>AmountEur</c> /
+    /// <c>AmountUsd</c>). The framework treats the code as opaque text;
+    /// downstream rendering may validate against the ISO 4217 list. Use the
+    /// uppercase three-letter code by convention.
+    /// </remarks>
+    /// <param name="isoCode">ISO 4217 alpha-3 currency code.</param>
+    public ColumnBuilder<TEntity> Currency(string isoCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(isoCode);
+        CurrencyCodeValue = isoCode;
         return this;
     }
 }

--- a/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
@@ -35,6 +35,15 @@ public sealed class ColumnDescriptor
     public string? Format { get; init; }
 
     /// <summary>
+    /// ISO 4217 alpha-3 currency code (e.g. <c>"EUR"</c>, <c>"USD"</c>) when
+    /// the column carries a monetary amount; <c>null</c> for non-monetary
+    /// columns. Set via <see cref="ColumnBuilder{TEntity}.Currency(string)"/>.
+    /// Drives the <c>"Currency"</c> value-kind on dashboard widget snapshots
+    /// so the frontend formats values with the right symbol + locale.
+    /// </summary>
+    public string? CurrencyCode { get; init; }
+
+    /// <summary>
     /// Whether this column maps to an EF Core Shadow Property (not a CLR property).
     /// Shadow columns are accessed via <c>EF.Property&lt;T&gt;(entity, name)</c> instead of
     /// direct member access.

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -67,6 +67,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
+            CurrencyCode = builder.CurrencyCodeValue,
         });
 
         return this;
@@ -100,6 +101,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
+            CurrencyCode = builder.CurrencyCodeValue,
             IsShadowProperty = true,
         });
 
@@ -135,6 +137,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
             Lookup = builder.LookupValue,
+            CurrencyCode = builder.CurrencyCodeValue,
             IsShadowProperty = true,
         });
 

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
@@ -45,12 +45,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Count, field: null, dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(3m);
+        result.Value.ShouldBe(3m);
     }
 
     [Fact]
@@ -58,12 +58,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     {
         // Locked semantics shared with MetricExecutor (story #1374): Count over
         // an empty set is always 0, never null.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Count, field: null, dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(0m);
+        result.Value.ShouldBe(0m);
     }
 
     [Fact]
@@ -72,24 +72,24 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(60m); // 10 + 20 + 30
+        result.Value.ShouldBe(60m); // 10 + 20 + 30
     }
 
     [Fact]
     public async Task ExecuteAsync_Sum_OverEmptySet_ReturnsZero_NotNull()
     {
         // Sum-of-empty is 0 (mathematical identity). Never null.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(0m);
+        result.Value.ShouldBe(0m);
     }
 
     [Fact]
@@ -98,24 +98,24 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Avg, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(20m); // (10 + 20 + 30) / 3
+        result.Value.ShouldBe(20m); // (10 + 20 + 30) / 3
     }
 
     [Fact]
     public async Task ExecuteAsync_Avg_OverEmptySet_ReturnsNull()
     {
         // Avg-of-empty is undefined (division by zero). Never zero.
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Avg, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBeNull();
+        result.Value.ShouldBeNull();
     }
 
     [Theory]
@@ -126,12 +126,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             aggregation, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(expected);
+        result.Value.ShouldBe(expected);
     }
 
     [Theory]
@@ -139,12 +139,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     [InlineData(AggregateFunction.Max)]
     public async Task ExecuteAsync_MinMax_OverEmptySet_ReturnsNull(AggregateFunction aggregation)
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             aggregation, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBeNull();
+        result.Value.ShouldBeNull();
     }
 
     [Fact]
@@ -153,12 +153,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "Quantity", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(6m); // 1 + 2 + 3
+        result.Value.ShouldBe(6m); // 1 + 2 + 3
     }
 
     [Fact]
@@ -167,12 +167,12 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "Score", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(6m); // 1.0 + 2.0 + 3.0
+        result.Value.ShouldBe(6m); // 1.0 + 2.0 + 3.0
     }
 
     [Fact]
@@ -185,18 +185,18 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Amount = 0m, Quantity = 0, Score = 0d, Bonus = null });
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "Bonus", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(0m);
+        result.Value.ShouldBe(0m);
     }
 
     [Fact]
     public async Task ExecuteAsync_UnknownField_Throws()
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -212,7 +212,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         // Aggregating Sum over a string column makes no sense — surface a clear
         // error so the dashboard renderer's per-widget isolation surfaces it
         // as Error (config bug, not data bug).
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
@@ -222,7 +222,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
     {
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -235,12 +235,87 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
         SeedThree();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        QueryAggregateRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
-        decimal? result = await runner.ExecuteAsync(
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
             AggregateFunction.Sum, field: "amount", dashboardFilters: null, TestContext.Current.CancellationToken);
 
-        result.ShouldBe(60m);
+        result.Value.ShouldBe(60m);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FieldWithCurrencyDeclaration_PropagatesCurrencyCode()
+    {
+        // CurrencyAwareQueryDefinition declares Amount with .Currency("EUR").
+        // Sum/Avg/Min/Max over it must surface "EUR" on the result so the
+        // evaluator can promote the snapshot to MetricValueKind.Currency.
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
+
+        result.Value.ShouldBe(60m);
+        result.CurrencyCode.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FieldWithoutCurrencyDeclaration_PropagatesNullCurrencyCode()
+    {
+        // Quantity has no .Currency(...) — the result's CurrencyCode is null,
+        // so the evaluator picks MetricValueKind.Number, not Currency.
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Quantity", dashboardFilters: null, TestContext.Current.CancellationToken);
+
+        result.Value.ShouldBe(6m);
+        result.CurrencyCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_NeverCarriesCurrency_EvenIfDefinitionHasCurrencyColumns()
+    {
+        // Count is a row count, not a monetary aggregation — no currency
+        // applies even when the definition declares Amount as EUR.
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        QueryAggregateRunnerResult result = await runner.ExecuteAsync(
+            AggregateFunction.Count, field: null, dashboardFilters: null, TestContext.Current.CancellationToken);
+
+        result.Value.ShouldBe(3m);
+        result.CurrencyCode.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DifferentCurrenciesPerColumn_AreIndependent()
+    {
+        // Amount → EUR, Bonus → USD on the same definition. Each aggregation
+        // surfaces its own column's currency.
+        SeedThree();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        QueryAggregateRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        QueryAggregateRunnerResult amount = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Amount", dashboardFilters: null, TestContext.Current.CancellationToken);
+        QueryAggregateRunnerResult bonus = await runner.ExecuteAsync(
+            AggregateFunction.Sum, field: "Bonus", dashboardFilters: null, TestContext.Current.CancellationToken);
+
+        amount.CurrencyCode.ShouldBe("EUR");
+        bonus.CurrencyCode.ShouldBe("USD");
     }
 
     private void SeedThree()
@@ -282,5 +357,35 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
     public sealed class TestItemSource(TestDbContext db) : IQueryableSource<TestItem>
     {
         public IQueryable<TestItem> GetQueryable() => db.Items.AsQueryable();
+    }
+
+    public sealed class TestQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Amount, c => c.Label("Amount"))
+                .Column(x => x.Quantity, c => c.Label("Quantity"))
+                .Column(x => x.Score, c => c.Label("Score"))
+                .Column(x => x.Label, c => c.Label("Label"))
+                .Column(x => x.Bonus, c => c.Label("Bonus"));
+        }
+    }
+
+    public sealed class CurrencyAwareQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Amount, c => c.Label("Amount").Currency("EUR"))
+                .Column(x => x.Quantity, c => c.Label("Quantity"))
+                .Column(x => x.Score, c => c.Label("Score"))
+                .Column(x => x.Label, c => c.Label("Label"))
+                .Column(x => x.Bonus, c => c.Label("Bonus").Currency("USD"));
+        }
     }
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -110,6 +110,51 @@ public sealed class StubDatasourceEvaluatorsTests
         result.Payload.NoData.ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task QueryAggregateEvaluator_RunnerReturnsCurrencyCode_PromotesValueKindToCurrency()
+    {
+        // The runner surfaces "EUR" alongside the aggregated value (column has
+        // Currency("EUR") on its QueryDefinition column descriptor). The
+        // evaluator must promote ValueKind from Number to Currency and forward
+        // the code so the frontend formats e.g. €1,234.56.
+        StubRunner runner = new("Granit.Test.Query", value: 1234.56m, currencyCode: "EUR");
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: AggregateFunction.Sum,
+                Field: "Amount"),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.Value.ShouldBe(1234.56m);
+        result.Payload.ValueKind.ShouldBe(MetricValueKind.Currency);
+        result.Payload.Currency.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public async Task QueryAggregateEvaluator_Count_KeepsValueKindCount_EvenWithCurrencyOnRunner()
+    {
+        // Defensive: even if the runner surfaces a currency (it shouldn't for
+        // Count, but the evaluator must not promote Count → Currency anyway).
+        StubRunner runner = new("Granit.Test.Query", value: 42m, currencyCode: "EUR");
+        QueryAggregateDatasourceEvaluator evaluator = new(new QueryAggregateService([runner]));
+
+        KpiEvaluation result = await evaluator.EvaluateAsync(
+            new QueryAggregateDatasource(
+                QueryName: "Granit.Test.Query",
+                Aggregation: AggregateFunction.Count),
+            BuildWidget("Kpi"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        result.Payload.ShouldNotBeNull();
+        result.Payload!.ValueKind.ShouldBe(MetricValueKind.Count);
+    }
+
     [Theory]
     [InlineData(AggregateFunction.Avg)]
     [InlineData(AggregateFunction.Min)]
@@ -138,16 +183,16 @@ public sealed class StubDatasourceEvaluatorsTests
         result.Payload.ValueKind.ShouldBe(MetricValueKind.Number);
     }
 
-    private sealed class StubRunner(string name, decimal? value) : IQueryAggregateRunner
+    private sealed class StubRunner(string name, decimal? value, string? currencyCode = null) : IQueryAggregateRunner
     {
         public string Name { get; } = name;
 
-        public Task<decimal?> ExecuteAsync(
+        public Task<QueryAggregateRunnerResult> ExecuteAsync(
             AggregateFunction aggregation,
             string? field,
             IReadOnlyDictionary<string, string>? dashboardFilters,
             CancellationToken cancellationToken) =>
-            Task.FromResult(value);
+            Task.FromResult(new QueryAggregateRunnerResult(value, currencyCode));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Surfaces ISO 4217 currency codes from a \`QueryDefinition\`'s column declaration onto the dashboard render envelope. A \"Total revenue\" KPI backed by a \`QueryAggregateDatasource\` over an \`Amount\` column declared \`.Currency(\"EUR\")\` now renders **€1,234.56** with the right symbol + locale instead of the bare number 1234.56.

## Three additive changes

1. **\`ColumnBuilder<T>.Currency(string isoCode)\`** — fluent declaration on QueryDefinition columns. Stored in \`ColumnBuilder.CurrencyCodeValue\` then forwarded to \`ColumnDescriptor.CurrencyCode\` by \`QueryDefinitionBuilder\`. Per-column metadata: different columns can carry different currencies (e.g. \`AmountEur\` / \`AmountUsd\`)

2. **\`IQueryAggregateRunner.ExecuteAsync\`** now returns \`QueryAggregateRunnerResult { decimal? Value, string? CurrencyCode }\` instead of bare \`decimal?\`. \`QueryAggregateRunner\` injects the typed \`QueryDefinition<TEntity>\` (already wired for other runners) and resolves the aggregated field's column descriptor to read its declared \`CurrencyCode\`. **Count never carries a currency** (it's a row count, not a monetary amount)

3. **\`QueryAggregateDatasourceEvaluator\`** promotes the snapshot's \`ValueKind\` from \`Number\` to \`Currency\` when the runner surfaces a code:

   - \`Count\` → \`ValueKind.Count\` (always; Count never carries currency)
   - Currency declared → \`ValueKind.Currency\` + \`Currency=<code>\`
   - Otherwise → \`ValueKind.Number\`

## Wire shape change (additive)

\`MetricSnapshotPayload.Currency\` was already there (previously always null on the QueryAggregate path); it now carries the column's declared code when relevant. **No frontend break** — clients that ignored the field still ignore it; clients that read it now get real data.

## Test plan

- [x] 4 new SQLite-backed \`QueryAggregateRunner\` tests pin the currency propagation matrix:
  - Sum/Avg/Min/Max over an EUR column → \`CurrencyCode = \"EUR\"\`
  - Sum over a no-currency column → \`CurrencyCode = null\`
  - Count over a currency-bearing definition → \`CurrencyCode = null\` (defensive)
  - Two columns with different currencies on one definition → each aggregation surfaces its own column's currency
- [x] 2 new \`QueryAggregateDatasourceEvaluator\` tests pin the snapshot promotion:
  - Sum + currency on runner → \`ValueKind.Currency\` + \`Currency = \"EUR\"\`
  - Count + currency on runner → \`ValueKind.Count\` (no promotion; Count is per-definition above the value field)
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 158 passing (6 new)
- [x] \`dotnet build tests/Granit.ArchitectureTests && dotnet test --no-build\` — 189 passing (fresh build)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

- Extend Chart / Table / Pivot to surface currency:
  - Chart: per-bucket value shares the value-field's currency → add to \`ChartWidgetSnapshot\`
  - Table: per-column → add \`CurrencyCode\` to \`TableWidgetColumn\`
  - Pivot: per-cell shares the value-field's currency → add to \`PivotWidgetSnapshot\`
- B3-6ter SQL-level Pivot Sum/Avg/Min/Max
- B7-2 Map renderer (PostGIS opt-in)
- Layer 3 OData (#1389-1394)