### PR TITLE
feat(analytics): currency-aware Chart / Table / Pivot snapshots (B3-8b)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4398,7 +4398,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs",
-      "line": 33,
+      "line": 35,
       "members": []
     },
     {
@@ -4407,7 +4407,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -4448,7 +4448,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs",
-      "line": 34,
+      "line": 36,
       "members": []
     },
     {
@@ -4457,7 +4457,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -4466,7 +4466,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs",
-      "line": 24,
+      "line": 25,
       "members": []
     },
     {

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -103,9 +103,11 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
                 object engine = sp.GetRequiredService(
                     typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+                object definition = sp.GetRequiredService(
+                    typeof(QueryDefinition<>).MakeGenericType(d.EntityType));
 
                 return (IChartRunner)Activator.CreateInstance(
-                    runnerType, d.Name, queryableSource, engine)!;
+                    runnerType, d.Name, queryableSource, engine, definition)!;
             });
 
             services.AddScoped<IPivotRunner>(sp =>
@@ -116,9 +118,11 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
                 object engine = sp.GetRequiredService(
                     typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+                object definition = sp.GetRequiredService(
+                    typeof(QueryDefinition<>).MakeGenericType(d.EntityType));
 
                 return (IPivotRunner)Activator.CreateInstance(
-                    runnerType, d.Name, queryableSource, engine)!;
+                    runnerType, d.Name, queryableSource, engine, definition)!;
             });
         }
 

--- a/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ChartRunner.cs
@@ -29,11 +29,13 @@ namespace Granit.Analytics.Endpoints.Internal;
 internal sealed class ChartRunner<TEntity>(
     string name,
     IQueryableSource<TEntity> source,
-    IQueryEngine<TEntity> engine) : IChartRunner
+    IQueryEngine<TEntity> engine,
+    QueryDefinition<TEntity> definition) : IChartRunner
     where TEntity : class
 {
     private readonly IQueryableSource<TEntity> _source = source;
     private readonly IQueryEngine<TEntity> _engine = engine;
+    private readonly QueryDefinition<TEntity> _definition = definition;
 
     public string Name { get; } = name;
 
@@ -110,7 +112,20 @@ internal sealed class ChartRunner<TEntity>(
         IReadOnlyList<ChartRunnerBucket> buckets = [..
             raw.Select(b => new ChartRunnerBucket(LabelOf(b.Key), b.Value))];
 
-        return new ChartRunnerResult(buckets);
+        // All buckets aggregate the same value field — share its declared
+        // currency code (if any). Count never carries a currency (handled
+        // upstream in ExecuteCountAsync, which leaves the result CurrencyCode null).
+        string? currencyCode = ResolveCurrencyCode(valueProp);
+
+        return new ChartRunnerResult(buckets, currencyCode);
+    }
+
+    private string? ResolveCurrencyCode(PropertyInfo prop)
+    {
+        IReadOnlyList<ColumnDescriptor> columns = _definition.GetColumns();
+        ColumnDescriptor? match = columns.FirstOrDefault(c =>
+            string.Equals(c.PropertyName, prop.Name, StringComparison.Ordinal));
+        return match?.CurrencyCode;
     }
 
     private static PropertyInfo ResolveProperty(string fieldName, string paramName)

--- a/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IChartRunner.cs
@@ -70,7 +70,10 @@ internal interface IChartRunner
 /// <see cref="ChartRunnerBucket.Value"/> is the projected aggregate value.
 /// </summary>
 /// <param name="Buckets">Group-aggregate results in the order surfaced by the underlying query.</param>
-internal sealed record ChartRunnerResult(IReadOnlyList<ChartRunnerBucket> Buckets);
+/// <param name="CurrencyCode">ISO 4217 alpha-3 code from the value field's column descriptor (declared via <c>ColumnBuilder.Currency</c>); <see langword="null"/> for non-monetary aggregations and for <c>Count</c>. All buckets in the series share the same currency since they aggregate the same value field.</param>
+internal sealed record ChartRunnerResult(
+    IReadOnlyList<ChartRunnerBucket> Buckets,
+    string? CurrencyCode = null);
 
 /// <summary>One group's contribution to the chart series.</summary>
 /// <param name="Label">String-friendly group key. Null group keys surface as <c>"(null)"</c>.</param>

--- a/src/Granit.Analytics.Endpoints/Internal/IPivotRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IPivotRunner.cs
@@ -56,7 +56,10 @@ internal interface IPivotRunner
 /// Outcome of an <see cref="IPivotRunner.ExecuteAsync"/> call.
 /// </summary>
 /// <param name="Cells">Per-cell results in stream-arrival order. Each cell carries the row-key tuple and column-key tuple plus the aggregated value.</param>
-internal sealed record PivotRunnerResult(IReadOnlyList<PivotRunnerCell> Cells);
+/// <param name="CurrencyCode">ISO 4217 alpha-3 code from the value field's <c>ColumnBuilder.Currency(...)</c> declaration; <see langword="null"/> when the value field is not monetary or for <c>Count</c>. All cells share this currency since they aggregate the same value field.</param>
+internal sealed record PivotRunnerResult(
+    IReadOnlyList<PivotRunnerCell> Cells,
+    string? CurrencyCode = null);
 
 /// <summary>
 /// One cell of the pivot matrix.

--- a/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/ITableRunner.cs
@@ -50,4 +50,5 @@ internal sealed record TableRunnerResult(
 /// <summary>Column metadata surfaced on the wire envelope.</summary>
 /// <param name="Name">Column property name (camelCase to match the row payload keys).</param>
 /// <param name="LabelLocalizationKey">Localization key for the header, or <see langword="null"/> when the source <c>QueryDefinition</c> declared no localized label.</param>
-internal sealed record TableRunnerColumn(string Name, string? LabelLocalizationKey);
+/// <param name="CurrencyCode">ISO 4217 alpha-3 code from <c>ColumnBuilder.Currency(...)</c>; <see langword="null"/> for non-monetary columns. Drives per-cell currency formatting on the frontend.</param>
+internal sealed record TableRunnerColumn(string Name, string? LabelLocalizationKey, string? CurrencyCode = null);

--- a/src/Granit.Analytics.Endpoints/Internal/PivotRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/PivotRunner.cs
@@ -16,7 +16,8 @@ namespace Granit.Analytics.Endpoints.Internal;
 internal sealed class PivotRunner<TEntity>(
     string name,
     IQueryableSource<TEntity> source,
-    IQueryEngine<TEntity> engine) : IPivotRunner
+    IQueryEngine<TEntity> engine,
+    QueryDefinition<TEntity> definition) : IPivotRunner
     where TEntity : class
 {
     /// <summary>Composite-key delimiter (ASCII unit separator). Unlikely in real entity values; collisions in dashboard tile data are negligible.</summary>
@@ -27,6 +28,7 @@ internal sealed class PivotRunner<TEntity>(
 
     private readonly IQueryableSource<TEntity> _source = source;
     private readonly IQueryEngine<TEntity> _engine = engine;
+    private readonly QueryDefinition<TEntity> _definition = definition;
 
     public string Name { get; } = name;
 
@@ -117,7 +119,21 @@ internal sealed class PivotRunner<TEntity>(
                 ColumnKeys: acc.ColumnKeys,
                 Value: acc.Compute(aggregation)))];
 
-        return new PivotRunnerResult(result);
+        // All cells aggregate the same value field — share its declared
+        // currency code. Count never carries a currency (no value field).
+        string? currencyCode = valueProp is not null
+            ? ResolveCurrencyCode(valueProp)
+            : null;
+
+        return new PivotRunnerResult(result, currencyCode);
+    }
+
+    private string? ResolveCurrencyCode(PropertyInfo prop)
+    {
+        IReadOnlyList<ColumnDescriptor> columns = _definition.GetColumns();
+        ColumnDescriptor? match = columns.FirstOrDefault(c =>
+            string.Equals(c.PropertyName, prop.Name, StringComparison.Ordinal));
+        return match?.CurrencyCode;
     }
 
     private static PropertyInfo[] ResolveProperties(IReadOnlyList<string> fieldNames, string paramName)

--- a/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/TableRunner.cs
@@ -68,7 +68,8 @@ internal sealed class TableRunner<TEntity>(
         IReadOnlyList<TableRunnerColumn> columns = [..
             selectedColumns.Select(c => new TableRunnerColumn(
                 Name: ToCamelCase(c.PropertyName),
-                LabelLocalizationKey: c.LabelKey))];
+                LabelLocalizationKey: c.LabelKey,
+                CurrencyCode: c.CurrencyCode))];
 
         return new TableRunnerResult(columns, rows, page.TotalCount ?? page.Items.Count);
     }

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetInstanceRenderer.cs
@@ -82,7 +82,8 @@ internal sealed class ChartWidgetInstanceRenderer(
             GroupBy: config.GroupBy,
             Aggregation: config.Aggregation,
             Field: config.Field,
-            Buckets: [.. result.Buckets.Select(b => new ChartBucket(b.Label, b.Value))]);
+            Buckets: [.. result.Buckets.Select(b => new ChartBucket(b.Label, b.Value))],
+            Currency: result.CurrencyCode);
 
         return WidgetSnapshotEnvelope.ForSnapshot(
             widgetType: WidgetType,

--- a/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/ChartWidgetSnapshot.cs
@@ -15,12 +15,14 @@ namespace Granit.Analytics.Endpoints.Rendering;
 /// <param name="Aggregation">Aggregation applied per bucket — drives the value-axis label.</param>
 /// <param name="Field">Aggregated field; <see langword="null"/> for <see cref="AggregateFunction.Count"/>.</param>
 /// <param name="Buckets">Group-aggregate series. Order is preserved as the underlying group-by produces it.</param>
+/// <param name="Currency">ISO 4217 alpha-3 currency code from the value field's <c>ColumnBuilder.Currency(...)</c> declaration; <see langword="null"/> when the field is not monetary or for <c>Count</c>. All buckets share this currency since they aggregate the same value field.</param>
 public sealed record ChartWidgetSnapshot(
     ChartType ChartType,
     string GroupBy,
     AggregateFunction Aggregation,
     string? Field,
-    IReadOnlyList<ChartBucket> Buckets);
+    IReadOnlyList<ChartBucket> Buckets,
+    string? Currency = null);
 
 /// <summary>One data point on the chart's category axis.</summary>
 /// <param name="Label">String-friendly group key (e.g. <c>"Open"</c>, <c>"Paid"</c>, <c>"2026-04"</c>). Null group keys surface as <c>"(null)"</c>.</param>

--- a/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetInstanceRenderer.cs
@@ -84,7 +84,8 @@ internal sealed class PivotWidgetInstanceRenderer(
             ColumnFields: columnFields,
             ValueField: config.ValueField,
             Aggregation: config.ValueAggregation,
-            Cells: [.. result.Cells.Select(c => new PivotCell(c.RowKeys, c.ColumnKeys, c.Value))]);
+            Cells: [.. result.Cells.Select(c => new PivotCell(c.RowKeys, c.ColumnKeys, c.Value))],
+            Currency: result.CurrencyCode);
 
         return WidgetSnapshotEnvelope.ForSnapshot(
             widgetType: WidgetType,

--- a/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/PivotWidgetSnapshot.cs
@@ -15,12 +15,14 @@ namespace Granit.Analytics.Endpoints.Rendering;
 /// <param name="ValueField">Aggregated field; <see langword="null"/> for <see cref="AggregateFunction.Count"/>.</param>
 /// <param name="Aggregation">Aggregation applied per cell — drives the value-axis label client-side.</param>
 /// <param name="Cells">Per-cell results. Order is preserved as the underlying stream produces them; the frontend pivots into a row-major matrix.</param>
+/// <param name="Currency">ISO 4217 alpha-3 code from the value field's <c>ColumnBuilder.Currency(...)</c> declaration; <see langword="null"/> when the field is not monetary or for <c>Count</c>. All cells share this currency since they aggregate the same value field.</param>
 public sealed record PivotWidgetSnapshot(
     IReadOnlyList<string> RowFields,
     IReadOnlyList<string> ColumnFields,
     string? ValueField,
     AggregateFunction Aggregation,
-    IReadOnlyList<PivotCell> Cells);
+    IReadOnlyList<PivotCell> Cells,
+    string? Currency = null);
 
 /// <summary>One cell of the pivot matrix.</summary>
 /// <param name="RowKeys">Row-axis key tuple matching <see cref="PivotWidgetSnapshot.RowFields"/>. Null property values surface as <c>"(null)"</c>.</param>

--- a/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TableWidgetInstanceRenderer.cs
@@ -77,7 +77,7 @@ internal sealed class TableWidgetInstanceRenderer(
             .ConfigureAwait(false);
 
         TableWidgetSnapshot snapshot = new(
-            Columns: [.. result.Columns.Select(c => new TableWidgetColumn(c.Name, c.LabelLocalizationKey))],
+            Columns: [.. result.Columns.Select(c => new TableWidgetColumn(c.Name, c.LabelLocalizationKey, c.CurrencyCode))],
             Rows: result.Rows,
             TotalRowCount: result.TotalRowCount);
 

--- a/src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/TableWidgetSnapshot.cs
@@ -21,4 +21,5 @@ public sealed record TableWidgetSnapshot(
 /// <summary>One column header on the wire envelope.</summary>
 /// <param name="Name">Column property name (camelCase — matches the key in every row payload).</param>
 /// <param name="LabelLocalizationKey">Localization key for the header. <see langword="null"/> when the source <c>QueryDefinition</c> declared no localized label — the frontend falls back to the property name.</param>
-public sealed record TableWidgetColumn(string Name, string? LabelLocalizationKey);
+/// <param name="CurrencyCode">ISO 4217 alpha-3 currency code from the column's <c>ColumnBuilder.Currency(...)</c> declaration. When present the frontend formats the column's row values with the matching currency symbol + locale; <see langword="null"/> for non-monetary columns.</param>
+public sealed record TableWidgetColumn(string Name, string? LabelLocalizationKey, string? CurrencyCode = null);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -55,7 +55,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -75,7 +75,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -94,7 +94,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -116,7 +116,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -140,7 +140,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null });
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -164,7 +164,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 0m, Bonus = null });
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -185,7 +185,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -205,7 +205,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             new TestItem { Id = Guid.NewGuid(), Status = "Open", Amount = 20m });
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -222,7 +222,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_UnknownGroupByField_Throws()
     {
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -237,7 +237,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_UnknownAggregateField_Throws()
     {
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -255,7 +255,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         // Aggregating Sum over a string column makes no sense — surface a
         // clear NotSupportedException so the dashboard renderer's per-widget
         // isolation surfaces it as Error (config bug, not data bug).
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
@@ -268,7 +268,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     [Fact]
     public async Task ExecuteAsync_NonCountAggregation_WithoutField_Throws()
     {
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -283,7 +283,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     [InlineData("   ")]
     public async Task ExecuteAsync_EmptyGroupBy_Throws(string groupBy)
     {
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -294,9 +294,52 @@ public sealed class ChartRunnerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteAsync_NumericAggregation_OnCurrencyColumn_PropagatesCurrencyCode()
+    {
+        // CurrencyAwareQueryDefinition declares Amount with .Currency("EUR")
+        // — Sum/Avg/Min/Max over it must surface "EUR" on the result so the
+        // renderer promotes the wire snapshot to Currency.
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Sum,
+            field: "Amount",
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.CurrencyCode.ShouldBe("EUR");
+        result.Buckets.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_DoesNotCarryCurrency()
+    {
+        // Count is a row count regardless of column metadata.
+        SeedFive();
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ChartRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(_db), _engine, new CurrencyAwareQueryDefinition());
+
+        ChartRunnerResult result = await runner.ExecuteAsync(
+            groupBy: "Status",
+            aggregation: AggregateFunction.Count,
+            field: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.CurrencyCode.ShouldBeNull();
+    }
+
+    [Fact]
     public void Name_IsSetFromConstructor()
     {
-        ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
         runner.Name.ShouldBe("Granit.Test.Items");
     }
 
@@ -309,7 +352,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -331,7 +374,7 @@ public sealed class ChartRunnerTests : IAsyncLifetime
         SeedFive();
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine);
+        ChartRunner<TestItem> runner = new("Test.Items", new TestItemSource(_db), _engine, new TestQueryDefinition());
 
         ChartRunnerResult result = await runner.ExecuteAsync(
             groupBy: "Status",
@@ -404,6 +447,19 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             builder
                 .Column(x => x.Status, c => c.Label("Status").Filterable())
                 .Column(x => x.Amount, c => c.Label("Amount").Filterable())
+                .AllowGroupBy(x => x.Status);
+        }
+    }
+
+    public sealed class CurrencyAwareQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Status, c => c.Label("Status").Filterable())
+                .Column(x => x.Amount, c => c.Label("Amount").Filterable().Currency("EUR"))
                 .AllowGroupBy(x => x.Status);
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/PivotRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/PivotRunnerTests.cs
@@ -32,7 +32,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -61,7 +61,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -89,7 +89,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status", "Region"],
@@ -119,7 +119,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -151,7 +151,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -179,7 +179,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -201,7 +201,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -224,7 +224,7 @@ public sealed class PivotRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition());
 
         PivotRunnerResult result = await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -244,7 +244,7 @@ public sealed class PivotRunnerTests
     public async Task ExecuteAsync_EmptyRowFields_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -260,7 +260,7 @@ public sealed class PivotRunnerTests
     public async Task ExecuteAsync_UnknownRowField_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -278,7 +278,7 @@ public sealed class PivotRunnerTests
     public async Task ExecuteAsync_NonCount_WithoutValueField_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -294,7 +294,7 @@ public sealed class PivotRunnerTests
     public async Task ExecuteAsync_UnsupportedValueFieldType_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
@@ -310,7 +310,7 @@ public sealed class PivotRunnerTests
     public async Task ExecuteAsync_DashboardFilter_PassedAsQueryRequestFilter()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
 
         await runner.ExecuteAsync(
             rowFields: ["Status"],
@@ -327,10 +327,51 @@ public sealed class PivotRunnerTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_NumericAggregation_OnCurrencyColumn_PropagatesCurrencyCode()
+    {
+        // CurrencyAwareQueryDefinition declares Amount with .Currency("EUR").
+        TestItem[] items = [new() { Status = "Open", Region = "EU", Amount = 10m }];
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+
+        PivotRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(items), engine, new CurrencyAwareQueryDefinition());
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: "Amount",
+            aggregation: AggregateFunction.Sum,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.CurrencyCode.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Count_DoesNotCarryCurrency()
+    {
+        TestItem[] items = [new() { Status = "Open", Region = "EU" }];
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+
+        PivotRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(items), engine, new CurrencyAwareQueryDefinition());
+
+        PivotRunnerResult result = await runner.ExecuteAsync(
+            rowFields: ["Status"],
+            columnFields: ["Region"],
+            valueField: null,
+            aggregation: AggregateFunction.Count,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.CurrencyCode.ShouldBeNull();
+    }
+
+    [Fact]
     public void Name_IsSetFromConstructor()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        PivotRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine);
+        PivotRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine, new TestQueryDefinition());
         runner.Name.ShouldBe("Granit.Test.Items");
     }
 
@@ -370,5 +411,35 @@ public sealed class PivotRunnerTests
     public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
     {
         public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+
+    public sealed class TestQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Status, c => c.Label("Status"))
+                .Column(x => x.Region, c => c.Label("Region"))
+                .Column(x => x.Year, c => c.Label("Year"))
+                .Column(x => x.Amount, c => c.Label("Amount"))
+                .Column(x => x.BonusNullable, c => c.Label("Bonus"));
+        }
+    }
+
+    public sealed class CurrencyAwareQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Status, c => c.Label("Status"))
+                .Column(x => x.Region, c => c.Label("Region"))
+                .Column(x => x.Year, c => c.Label("Year"))
+                .Column(x => x.Amount, c => c.Label("Amount").Currency("EUR"))
+                .Column(x => x.BonusNullable, c => c.Label("Bonus").Currency("USD"));
+        }
     }
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/TableRunnerTests.cs
@@ -189,6 +189,30 @@ public sealed class TableRunnerTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ColumnsCarryDeclaredCurrencyCode()
+    {
+        // CurrencyAwareQueryDefinition declares Amount with .Currency("EUR").
+        // Surface that on the TableRunnerColumn so the wire snapshot can
+        // render values with the right symbol per column.
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteAsync(Arg.Any<IQueryable<TestItem>>(), Arg.Any<QueryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<TestItem>([], TotalCount: 0, HasMore: false));
+
+        TableRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource([]), engine, new CurrencyAwareQueryDefinition());
+
+        TableRunnerResult result = await runner.ExecuteAsync(
+            visibleColumns: null,
+            pageSize: 10,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        var currencyByName = result.Columns.ToDictionary(c => c.Name, c => c.CurrencyCode);
+        currencyByName["amount"].ShouldBe("EUR");
+        currencyByName["name"].ShouldBeNull();
+    }
+
     private static TableRunner<TestItem> BuildRunner(IReadOnlyList<TestItem> entities, int totalCount)
     {
         IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
@@ -218,6 +242,18 @@ public sealed class TableRunnerTests
             builder
                 .Column(x => x.Name, c => c.Label("Name").LabelKey("Column:Name"))
                 .Column(x => x.Amount, c => c.Label("Amount").LabelKey("Column:Amount"));
+        }
+    }
+
+    public sealed class CurrencyAwareQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Name, c => c.Label("Name"))
+                .Column(x => x.Amount, c => c.Label("Amount").Currency("EUR"));
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends B3-8 (#1498) to the three remaining data-bound widget kinds. The dashboard's \"revenue per month\" chart, \"top customers\" table, \"region × quarter revenue\" pivot now all surface ISO 4217 currency codes from each value field's column declaration — frontend formats with locale-aware symbols (€ / \$ / £) instead of bare numbers.

## Three parallel additions (matching B3-8 pattern)

1. **Chart** — \`IChartRunner.ChartRunnerResult\` gains \`CurrencyCode\` (string?, default null). \`ChartRunner<TEntity>\` injects \`QueryDefinition<TEntity>\` (parity with \`TableRunner\` / B3-8 \`QueryAggregateRunner\`) and resolves the value field's column descriptor for non-Count aggregations. \`ChartWidgetSnapshot.Currency\` surfaces it on the wire envelope. All buckets in the series share the value-field's currency

2. **Table** — \`ColumnDescriptor.CurrencyCode\` flows through \`TableRunner\`'s existing column-projection pipeline. \`TableRunnerColumn\` / \`TableWidgetColumn\` gain a \`CurrencyCode\` property. **Per-column** metadata: a table mixing \`AmountEur\` and \`AmountUsd\` surfaces both independently on the wire

3. **Pivot** — \`PivotRunnerResult\` gains \`CurrencyCode\`. \`PivotRunner<TEntity>\` injects \`QueryDefinition<TEntity>\` and resolves the value field's currency code for non-Count aggregations. \`PivotWidgetSnapshot.Currency\` surfaces it on the wire envelope

## Wire shape (additive)

\`Currency\` / \`CurrencyCode\` default to null on every snapshot record — existing frontends ignoring the field continue to work; new frontends can opt in.

\`\`\`jsonc
// ChartWidgetSnapshot
{ \"chartType\": \"Bar\", \"groupBy\": \"Month\", \"aggregation\": \"Sum\",
  \"field\": \"Amount\", \"buckets\": [...], \"currency\": \"EUR\" }

// TableWidgetSnapshot
{ \"columns\": [
    { \"name\": \"customer\",  \"labelLocalizationKey\": \"Column:Customer\",      \"currencyCode\": null },
    { \"name\": \"amount\",    \"labelLocalizationKey\": \"Column:Amount\",        \"currencyCode\": \"EUR\" }
  ], ... }

// PivotWidgetSnapshot
{ \"rowFields\": [\"Region\"], \"columnFields\": [\"Quarter\"], \"valueField\": \"Amount\",
  \"aggregation\": \"Sum\", \"cells\": [...], \"currency\": \"EUR\" }
\`\`\`

## Test plan

- [x] 2 \`ChartRunnerTests\` — numeric aggregation on currency column propagates code; Count never carries currency even on currency-bearing definition
- [x] 2 \`PivotRunnerTests\` — numeric aggregation on currency column propagates code; Count never carries currency
- [x] 1 \`TableRunnerTests\` — per-column currency forwarding (only the \"amount\" column surfaces \"EUR\")
- [x] Existing tests updated to inject \`TestQueryDefinition\`
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 163 passing (5 new)
- [x] \`dotnet build tests/Granit.ArchitectureTests && dotnet test --no-build\` — 189 passing (fresh build)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

Closes the currency follow-up from #1498. Remaining BI epic items:

- B3-6ter SQL-level Pivot Sum/Avg/Min/Max
- B7-2 Map renderer (PostGIS opt-in)
- Layer 3 OData (#1389–1394)