### PR TITLE
feat(analytics): Map widget renderer — LatLng path (B7-2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4443,6 +4443,33 @@
       ]
     },
     {
+      "name": "MapCenterPayload",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.MapCenterPayload",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
+      "line": 39,
+      "members": []
+    },
+    {
+      "name": "MapPoint",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.MapPoint",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "MapWidgetSnapshot",
+      "fqn": "Granit.Analytics.Endpoints.Rendering.MapWidgetSnapshot",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
+      "line": 17,
+      "members": []
+    },
+    {
       "name": "PivotCell",
       "fqn": "Granit.Analytics.Endpoints.Rendering.PivotCell",
       "kind": "record",

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -35,6 +35,10 @@ public static class AnalyticsRenderingServiceCollectionExtensions
     ///         through <c>ExecuteStreamAsync</c> and pivots in-memory by
     ///         a (row-tuple × column-tuple) composite key. Bounded by the
     ///         QueryDefinition's <c>MaxStreamSize</c>.</item>
+    ///   <item><c>"Map"</c> — streams the named <c>QueryDefinition</c> and
+    ///         projects each row into a map marker. B7-2 ships the
+    ///         <c>LatLng</c> path (decimal columns); the PostGIS
+    ///         <c>Geography</c> path is deferred and surfaces Unavailable.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -61,6 +65,7 @@ public static class AnalyticsRenderingServiceCollectionExtensions
         services.TryAddScoped<TableService>();
         services.TryAddScoped<ChartService>();
         services.TryAddScoped<PivotService>();
+        services.TryAddScoped<MapService>();
 
         foreach (ServiceDescriptor descriptor in services
             .Where(d => d.ServiceType == typeof(IQueryDefinitionDescriptor))
@@ -124,12 +129,26 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                 return (IPivotRunner)Activator.CreateInstance(
                     runnerType, d.Name, queryableSource, engine, definition)!;
             });
+
+            services.AddScoped<IMapRunner>(sp =>
+            {
+                IQueryDefinitionDescriptor d = ResolveDescriptor(sp, descriptor);
+                Type runnerType = typeof(MapRunner<>).MakeGenericType(d.EntityType);
+                object queryableSource = sp.GetRequiredService(
+                    typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
+                object engine = sp.GetRequiredService(
+                    typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+
+                return (IMapRunner)Activator.CreateInstance(
+                    runnerType, d.Name, queryableSource, engine)!;
+            });
         }
 
         services.AddScoped<IWidgetInstanceRenderer, KpiWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, TableWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, ChartWidgetInstanceRenderer>();
         services.AddScoped<IWidgetInstanceRenderer, PivotWidgetInstanceRenderer>();
+        services.AddScoped<IWidgetInstanceRenderer, MapWidgetInstanceRenderer>();
 
         return services;
     }

--- a/src/Granit.Analytics.Endpoints/Internal/IMapRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IMapRunner.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Non-generic façade over a typed <c>QueryDefinition&lt;TEntity&gt;</c> that
+/// materialises geocoded query rows into map markers. One runner is registered
+/// per query definition by <c>AddGranitAnalyticsWidgetRenderers</c> at startup;
+/// the dashboard render path resolves it by query name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// B7-2 ships the <c>MapPointSource.LatLng</c> path (decimal latitude /
+/// longitude columns) — works on any database. The PostGIS
+/// <c>MapPointSource.Geography</c> path is deferred (handled by the renderer
+/// returning <c>Unavailable</c>) until <c>granit-iot</c> ships the
+/// NetTopologySuite plumbing.
+/// </para>
+/// <para>
+/// Streams the filtered entity set through
+/// <c>IQueryEngine.ExecuteStreamAsync</c> (multi-tenancy + soft-delete +
+/// dashboard filters apply, cap at <c>MaxStreamSize</c>). Acceptable for
+/// dashboard tile contexts which are bounded data products.
+/// </para>
+/// </remarks>
+internal interface IMapRunner
+{
+    /// <summary>The query definition's unique name.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Loads geocoded rows as map markers. Each marker carries lat/lng
+    /// coordinates, an optional entity id (read from a <c>Guid Id</c>
+    /// property when present), and an optional popup payload restricted to
+    /// the whitelisted <paramref name="popupColumns"/>.
+    /// </summary>
+    /// <param name="latitudeColumn">Property name of the latitude column on the entity.</param>
+    /// <param name="longitudeColumn">Property name of the longitude column on the entity.</param>
+    /// <param name="popupColumns">Whitelisted columns surfaced in the marker popup. <see langword="null"/> = no popup payload (only id + coords).</param>
+    /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the QueryDefinition's filter pipeline — see <see cref="DashboardFilterTranslator"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="ArgumentException">Latitude/longitude/popup column not declared on the entity, or coordinate column type is not <c>double</c> or <c>decimal</c>.</exception>
+    Task<MapRunnerResult> ExecuteAsync(
+        string latitudeColumn,
+        string longitudeColumn,
+        IReadOnlyList<string>? popupColumns,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>Outcome of an <see cref="IMapRunner.ExecuteAsync"/> call.</summary>
+/// <param name="Points">Materialised map markers in stream-arrival order.</param>
+internal sealed record MapRunnerResult(IReadOnlyList<MapRunnerPoint> Points);
+
+/// <summary>One map marker.</summary>
+/// <param name="Id">Entity primary key when the entity exposes a <c>Guid Id</c> property; <see langword="null"/> otherwise. Drives the click-through to <c>DetailRoute</c>.</param>
+/// <param name="Latitude">Latitude in decimal degrees.</param>
+/// <param name="Longitude">Longitude in decimal degrees.</param>
+/// <param name="Popup">Whitelisted column subset for the marker popup, serialised as a camelCase JSON object. <see langword="null"/> when no popup columns were requested.</param>
+internal sealed record MapRunnerPoint(
+    Guid? Id,
+    double Latitude,
+    double Longitude,
+    JsonElement? Popup);

--- a/src/Granit.Analytics.Endpoints/Internal/MapRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MapRunner.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using Granit.QueryEngine;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Typed implementation of <see cref="IMapRunner"/> — closes over
+/// <typeparamref name="TEntity"/> so dispatch by query name stays
+/// reflection-free at request time. Streams the filtered entity set through
+/// <see cref="IQueryEngine{TEntity}.ExecuteStreamAsync"/> and projects each
+/// row into a <see cref="MapRunnerPoint"/> by reflecting the latitude /
+/// longitude columns and (optionally) the popup columns.
+/// </summary>
+internal sealed class MapRunner<TEntity>(
+    string name,
+    IQueryableSource<TEntity> source,
+    IQueryEngine<TEntity> engine) : IMapRunner
+    where TEntity : class
+{
+    private static readonly JsonSerializerOptions PopupJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly IQueryableSource<TEntity> _source = source;
+    private readonly IQueryEngine<TEntity> _engine = engine;
+
+    public string Name { get; } = name;
+
+    public async Task<MapRunnerResult> ExecuteAsync(
+        string latitudeColumn,
+        string longitudeColumn,
+        IReadOnlyList<string>? popupColumns,
+        IReadOnlyDictionary<string, string>? dashboardFilters,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(latitudeColumn);
+        ArgumentException.ThrowIfNullOrWhiteSpace(longitudeColumn);
+
+        PropertyInfo latProp = ResolveCoordinateProperty(latitudeColumn, nameof(latitudeColumn));
+        PropertyInfo lngProp = ResolveCoordinateProperty(longitudeColumn, nameof(longitudeColumn));
+
+        PropertyInfo? idProp = typeof(TEntity).GetProperty(
+            "Id",
+            BindingFlags.Public | BindingFlags.Instance);
+        // Only treat Id as the marker key when it's a Guid — non-Guid Id
+        // columns (string codes, ints) are domain-specific and surface
+        // through the popup payload when included there.
+        if (idProp is not null && idProp.PropertyType != typeof(Guid))
+        {
+            idProp = null;
+        }
+
+        PropertyInfo[] popupProps = popupColumns is { Count: > 0 }
+            ? ResolvePopupProperties(popupColumns)
+            : [];
+
+        QueryRequest request = new()
+        {
+            Filter = DashboardFilterTranslator.ToQueryRequestFilter(dashboardFilters),
+        };
+
+        List<MapRunnerPoint> points = [];
+
+        await foreach (TEntity entity in _engine
+            .ExecuteStreamAsync(_source.GetQueryable(), request, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            object? latRaw = latProp.GetValue(entity);
+            object? lngRaw = lngProp.GetValue(entity);
+
+            // Skip rows missing coordinates entirely — the marker would be
+            // pinned to (0, 0) which is misleading. Frontend never sees them.
+            if (latRaw is null || lngRaw is null)
+            {
+                continue;
+            }
+
+            double latitude = Convert.ToDouble(latRaw, CultureInfo.InvariantCulture);
+            double longitude = Convert.ToDouble(lngRaw, CultureInfo.InvariantCulture);
+
+            Guid? id = idProp is not null
+                ? (Guid)(idProp.GetValue(entity) ?? Guid.Empty)
+                : null;
+
+            JsonElement? popup = popupProps.Length > 0
+                ? BuildPopup(entity, popupProps)
+                : null;
+
+            points.Add(new MapRunnerPoint(id, latitude, longitude, popup));
+        }
+
+        return new MapRunnerResult(points);
+    }
+
+    private static PropertyInfo ResolveCoordinateProperty(string fieldName, string paramName)
+    {
+        PropertyInfo prop = ResolveProperty(fieldName, paramName);
+        Type underlying = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+        if (underlying != typeof(double) && underlying != typeof(decimal))
+        {
+            throw new ArgumentException(
+                FormattableString.Invariant(
+                    $"Coordinate column '{prop.Name}' on entity '{typeof(TEntity).Name}' is of type '{underlying.Name}'. Map widgets require double or decimal latitude/longitude columns."),
+                paramName);
+        }
+        return prop;
+    }
+
+    private static PropertyInfo[] ResolvePopupProperties(IReadOnlyList<string> popupColumns)
+    {
+        var resolved = new PropertyInfo[popupColumns.Count];
+        for (int i = 0; i < popupColumns.Count; i++)
+        {
+            resolved[i] = ResolveProperty(popupColumns[i], nameof(popupColumns));
+        }
+        return resolved;
+    }
+
+    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
+    {
+        PropertyInfo? prop = typeof(TEntity).GetProperty(
+            fieldName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        return prop ?? throw new ArgumentException(
+            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
+            paramName);
+    }
+
+    private static JsonElement BuildPopup(TEntity entity, PropertyInfo[] popupProps)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (PropertyInfo prop in popupProps)
+        {
+            dict[prop.Name] = prop.GetValue(entity);
+        }
+        return JsonSerializer.SerializeToElement(dict, PopupJsonOptions);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Internal/MapService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MapService.cs
@@ -1,0 +1,16 @@
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Registry of <see cref="IMapRunner"/>s keyed by query name. Mirrors the
+/// other widget-runner registries (Metric / QueryAggregate / Table / Chart /
+/// Pivot): single point of resolution so the dashboard render path stays
+/// reflection-free at request time.
+/// </summary>
+internal sealed class MapService(IEnumerable<IMapRunner> runners)
+{
+    private readonly Dictionary<string, IMapRunner> _byName =
+        runners.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetRunner(string queryName, out IMapRunner runner) =>
+        _byName.TryGetValue(queryName, out runner!);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// <see cref="IWidgetInstanceRenderer"/> for the <c>"Map"</c> widget kind.
+/// Resolves the registered <see cref="IMapRunner"/> by query name, runs it
+/// with the configured latitude/longitude columns plus the popup whitelist,
+/// and shapes the result into a <see cref="MapWidgetSnapshot"/>. Per-widget
+/// permission gate + error isolation already apply upstream
+/// (<see cref="IDashboardRenderer"/> / ADR-039 §3); this renderer is
+/// responsible for the body shape only.
+/// </summary>
+/// <remarks>
+/// B7-2 ships <see cref="MapPointSource.LatLng"/> (decimal lat/lng columns,
+/// works on any database). The PostGIS <see cref="MapPointSource.Geography"/>
+/// path is deferred — the renderer surfaces
+/// <c>Widget:Unavailable.MapGeographyNotImplemented</c> until
+/// <c>granit-iot</c> ships the NetTopologySuite plumbing.
+/// </remarks>
+internal sealed class MapWidgetInstanceRenderer(
+    MapService mapService,
+    IClock clock) : IWidgetInstanceRenderer
+{
+    private static readonly JsonSerializerOptions ConfigJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly MapService _mapService = mapService;
+    private readonly IClock _clock = clock;
+
+    public string WidgetType => "Map";
+
+    public async Task<WidgetSnapshotEnvelope> RenderAsync(
+        WidgetInstance widget,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widget);
+
+        MapConfig config = JsonSerializer.Deserialize<MapConfig>(widget.ConfigJson, ConfigJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Map') has empty ConfigJson — map config cannot be resolved.");
+
+        if (string.IsNullOrWhiteSpace(widget.QueryName))
+        {
+            throw new InvalidOperationException(
+                $"Widget {widget.Id} ('Map') has no QueryName — Map widgets must reference a registered QueryDefinition.");
+        }
+
+        DateTimeOffset emittedAt = _clock.Now;
+
+        // PostGIS path is deferred until granit-iot ships NetTopologySuite
+        // plumbing — the renderer never throws on the Geography pointSource;
+        // it surfaces a typed Unavailable so the dashboard renders the rest
+        // of its widgets normally.
+        if (config.PointSource is not MapPointSource.LatLng latLng)
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.MapGeographyNotImplemented");
+        }
+
+        if (!_mapService.TryGetRunner(widget.QueryName, out IMapRunner runner))
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
+        }
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: latLng.LatitudeColumn,
+            longitudeColumn: latLng.LongitudeColumn,
+            popupColumns: config.PopupColumns,
+            dashboardFilters: context.DashboardFilters,
+            cancellationToken).ConfigureAwait(false);
+
+        MapCenterPayload? defaultCenter = config.DefaultCenter is { } center
+            ? new MapCenterPayload(center.Latitude, center.Longitude)
+            : null;
+
+        MapWidgetSnapshot snapshot = new(
+            Points: [.. result.Points.Select(p => new MapPoint(p.Id, p.Latitude, p.Longitude, p.Popup))],
+            DefaultZoom: config.DefaultZoom,
+            DefaultCenter: defaultCenter,
+            ClusterThreshold: config.ClusterThreshold,
+            DetailRoute: config.DetailRoute,
+            TileUrlTemplate: config.TileUrlTemplate);
+
+        return WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: WidgetType,
+            snapshot: JsonSerializer.SerializeToElement(snapshot, SnapshotJsonOptions),
+            sequence: 1,
+            emittedAt: emittedAt,
+            refreshHint: RefreshHint.Dynamic);
+    }
+
+    private sealed record MapConfig(
+        MapPointSource PointSource,
+        IReadOnlyList<string>? PopupColumns,
+        int DefaultZoom,
+        MapCenterConfig? DefaultCenter,
+        int ClusterThreshold,
+        string? DetailRoute,
+        string? TileUrlTemplate);
+
+    /// <summary>
+    /// Wire shape for <see cref="MapWidgetDefinition.DefaultCenter"/> in the
+    /// persisted ConfigJson — a plain pair of doubles, no validation here
+    /// (the import path validated against <see cref="MapCenter"/>).
+    /// </summary>
+    private sealed record MapCenterConfig(double Latitude, double Longitude);
+}

--- a/src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+
+namespace Granit.Analytics.Endpoints.Rendering;
+
+/// <summary>
+/// Wire-shape snapshot for the <c>"Map"</c> widget kind. Carries the rendered
+/// markers plus the camera / clustering / detail-route hints the frontend
+/// needs to bootstrap the Leaflet (or equivalent) map without a second HTTP
+/// round-trip.
+/// </summary>
+/// <param name="Points">Geocoded markers in stream-arrival order. Cap is bounded by the QueryDefinition's <c>MaxStreamSize</c> upstream.</param>
+/// <param name="DefaultZoom">Initial zoom level (Leaflet scale: 0 world → 18 building).</param>
+/// <param name="DefaultCenter">Initial map center; <see langword="null"/> means the frontend should fit the bounding box of <see cref="Points"/>.</param>
+/// <param name="ClusterThreshold">Marker count above which the frontend activates clustering.</param>
+/// <param name="DetailRoute">Optional route template invoked on marker click (<c>{id}</c> substituted with the row's primary key).</param>
+/// <param name="TileUrlTemplate">Optional Leaflet tile-URL override; <see langword="null"/> falls back to the host's default (typically OpenStreetMap).</param>
+public sealed record MapWidgetSnapshot(
+    IReadOnlyList<MapPoint> Points,
+    int DefaultZoom,
+    MapCenterPayload? DefaultCenter,
+    int ClusterThreshold,
+    string? DetailRoute,
+    string? TileUrlTemplate);
+
+/// <summary>One marker on the map.</summary>
+/// <param name="Id">Entity primary key when the entity exposes a <c>Guid Id</c> property; <see langword="null"/> otherwise. Drives the click-through to <c>DetailRoute</c>.</param>
+/// <param name="Latitude">Latitude in decimal degrees.</param>
+/// <param name="Longitude">Longitude in decimal degrees.</param>
+/// <param name="Popup">Whitelisted column subset for the marker popup body. <see langword="null"/> when no popup columns were configured on the widget.</param>
+public sealed record MapPoint(
+    Guid? Id,
+    double Latitude,
+    double Longitude,
+    JsonElement? Popup);
+
+/// <summary>Wire shape for <see cref="MapWidgetSnapshot.DefaultCenter"/>.</summary>
+/// <param name="Latitude">Latitude in decimal degrees.</param>
+/// <param name="Longitude">Longitude in decimal degrees.</param>
+public sealed record MapCenterPayload(double Latitude, double Longitude);

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
@@ -1,0 +1,282 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="MapRunner{TEntity}"/> — substitute the
+/// <see cref="IQueryEngine{TEntity}.ExecuteStreamAsync"/> path with NSubstitute
+/// so the streaming + reflection-based projection logic is exercised against
+/// a known dataset, independent of EF Core translation. Skip-row semantics
+/// (null lat/lng), id resolution, popup whitelist, dashboard filter
+/// forwarding, and every config-error path are pinned here.
+/// </summary>
+public sealed class MapRunnerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_PopulatedRows_ProjectsToMapPoints()
+    {
+        TestItem[] items =
+        [
+            new() { Id = Guid.NewGuid(), Name = "Paris", Latitude = 48.85, Longitude = 2.35 },
+            new() { Id = Guid.NewGuid(), Name = "London", Latitude = 51.50, Longitude = -0.12 },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "Latitude",
+            longitudeColumn: "Longitude",
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points.Count.ShouldBe(2);
+        result.Points[0].Latitude.ShouldBe(48.85);
+        result.Points[0].Longitude.ShouldBe(2.35);
+        result.Points[1].Latitude.ShouldBe(51.50);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RowsWithNullCoordinates_AreSkipped()
+    {
+        // A row missing lat or lng would be pinned at (0, 0) — that's
+        // misleading. The runner drops it entirely so the frontend never
+        // shows a misplaced marker.
+        TestItem[] items =
+        [
+            new() { Id = Guid.NewGuid(), Name = "Paris", Latitude = 48.85, Longitude = 2.35 },
+            new() { Id = Guid.NewGuid(), Name = "Mystery", LatitudeNullable = null, LongitudeNullable = null },
+        ];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "LatitudeNullable",
+            longitudeColumn: "LongitudeNullable",
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        // Both rows have null nullable coords on the second item → only
+        // the first row had coordinates set on the canonical Latitude /
+        // Longitude. So neither row contributes to the nullable path.
+        result.Points.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GuidIdProperty_PropagatesAsMarkerId()
+    {
+        var id = Guid.NewGuid();
+        TestItem[] items = [new() { Id = id, Latitude = 48.85, Longitude = 2.35 }];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "Latitude",
+            longitudeColumn: "Longitude",
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points[0].Id.ShouldBe(id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PopupColumns_ProjectWhitelistedFields()
+    {
+        TestItem[] items = [new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Paris",
+            Country = "FR",
+            Latitude = 48.85,
+            Longitude = 2.35,
+        }];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "Latitude",
+            longitudeColumn: "Longitude",
+            popupColumns: ["Name", "Country"],
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points[0].Popup.ShouldNotBeNull();
+        JsonElement popup = result.Points[0].Popup!.Value;
+        popup.GetProperty("name").GetString().ShouldBe("Paris");
+        popup.GetProperty("country").GetString().ShouldBe("FR");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoPopupColumns_LeavesPopupNull()
+    {
+        TestItem[] items = [new() { Id = Guid.NewGuid(), Latitude = 0d, Longitude = 0d }];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "Latitude",
+            longitudeColumn: "Longitude",
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points[0].Popup.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DecimalCoordinateColumns_AreSupported()
+    {
+        // Some entities use decimal lat/lng (financial-grade precision).
+        // The runner should accept either double or decimal.
+        TestItem[] items = [new()
+        {
+            Id = Guid.NewGuid(),
+            LatitudeDecimal = 48.85m,
+            LongitudeDecimal = 2.35m,
+        }];
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            latitudeColumn: "LatitudeDecimal",
+            longitudeColumn: "LongitudeDecimal",
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points[0].Latitude.ShouldBe(48.85);
+        result.Points[0].Longitude.ShouldBe(2.35);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonNumericCoordinateColumn_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                latitudeColumn: "Name", // string column
+                longitudeColumn: "Longitude",
+                popupColumns: null,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownLatitudeColumn_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                latitudeColumn: "NotAColumn",
+                longitudeColumn: "Longitude",
+                popupColumns: null,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAColumn");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownPopupColumn_Throws()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                latitudeColumn: "Latitude",
+                longitudeColumn: "Longitude",
+                popupColumns: ["NotAColumn"],
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("NotAColumn");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DashboardFilter_PassedAsQueryRequestFilter()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine);
+
+        await runner.ExecuteAsync(
+            latitudeColumn: "Latitude",
+            longitudeColumn: "Longitude",
+            popupColumns: null,
+            dashboardFilters: new Dictionary<string, string> { ["Country"] = "FR" },
+            TestContext.Current.CancellationToken);
+
+        engine.Received(1).ExecuteStreamAsync(
+            Arg.Any<IQueryable<TestItem>>(),
+            Arg.Is<QueryRequest>(r => r.Filter != null && r.Filter["Country.eq"] == "FR"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Name_IsSetFromConstructor()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine);
+        runner.Name.ShouldBe("Granit.Test.Items");
+    }
+
+    private static IQueryEngine<TestItem> ConfigureStream(IReadOnlyList<TestItem> items)
+    {
+        IQueryEngine<TestItem> engine = Substitute.For<IQueryEngine<TestItem>>();
+        engine.ExecuteStreamAsync(
+                Arg.Any<IQueryable<TestItem>>(),
+                Arg.Any<QueryRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => YieldAsync(items, default));
+        return engine;
+    }
+
+    private static async IAsyncEnumerable<TestItem> YieldAsync(
+        IReadOnlyList<TestItem> items, [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (TestItem item in items)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public sealed class TestItem
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public double? LatitudeNullable { get; set; }
+        public double? LongitudeNullable { get; set; }
+        public decimal LatitudeDecimal { get; set; }
+        public decimal LongitudeDecimal { get; set; }
+    }
+
+    public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
+    {
+        public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
@@ -1,0 +1,184 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.Analytics;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Endpoints.Rendering;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Rendering;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Rendering;
+
+/// <summary>
+/// Unit tests for <see cref="MapWidgetInstanceRenderer"/> — substitute the
+/// <see cref="MapService"/>'s underlying <see cref="IMapRunner"/> so the
+/// renderer's envelope shaping is exercised against a known result. Runner
+/// projection logic is covered separately by
+/// <see cref="Internal.MapRunnerTests"/>.
+/// </summary>
+public sealed class MapWidgetInstanceRendererTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public MapWidgetInstanceRendererTests() => _clock.Now.Returns(Now);
+
+    [Fact]
+    public void WidgetType_IsMap()
+    {
+        new MapWidgetInstanceRenderer(new MapService([]), _clock).WidgetType.ShouldBe("Map");
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownQueryName_ReturnsUnavailable()
+    {
+        MapWidgetInstanceRenderer renderer = new(new MapService([]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.MissingQuery",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Latitude"",""longitudeColumn"":""Longitude""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.WidgetType.ShouldBe("Map");
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+    }
+
+    [Fact]
+    public async Task RenderAsync_GeographyPointSource_ReturnsUnavailableUntilFollowUp()
+    {
+        // PostGIS path is deferred — surface a typed Unavailable so the
+        // dashboard renders the rest of its widgets normally.
+        StubRunner runner = new("Granit.Test.Items", points: []);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""geography"",""geographyColumn"":""Position""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MapGeographyNotImplemented");
+    }
+
+    [Fact]
+    public async Task RenderAsync_HappyPath_BuildsMapWidgetSnapshot()
+    {
+        var id = Guid.NewGuid();
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            points:
+            [
+                new MapRunnerPoint(id, 48.85, 2.35, JsonSerializer.SerializeToElement(new { name = "Paris" })),
+                new MapRunnerPoint(null, 51.50, -0.12, null),
+            ]);
+
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Latitude"",""longitudeColumn"":""Longitude""},""popupColumns"":[""Name""],""defaultZoom"":7,""defaultCenter"":{""latitude"":50.0,""longitude"":1.0},""clusterThreshold"":150,""detailRoute"":""/cities/{id}"",""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        envelope.WidgetType.ShouldBe("Map");
+        envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+
+        envelope.Snapshot.ShouldNotBeNull();
+        JsonElement snap = envelope.Snapshot!.Value;
+        snap.GetProperty("defaultZoom").GetInt32().ShouldBe(7);
+        snap.GetProperty("clusterThreshold").GetInt32().ShouldBe(150);
+        snap.GetProperty("detailRoute").GetString().ShouldBe("/cities/{id}");
+        snap.GetProperty("defaultCenter").GetProperty("latitude").GetDouble().ShouldBe(50.0);
+        snap.GetProperty("defaultCenter").GetProperty("longitude").GetDouble().ShouldBe(1.0);
+        snap.GetProperty("points").GetArrayLength().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task RenderAsync_DefaultCenterNull_SerialisesAsNullOnTheWire()
+    {
+        StubRunner runner = new("Granit.Test.Items", points: []);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Latitude"",""longitudeColumn"":""Longitude""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Snapshot!.Value.GetProperty("defaultCenter").ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task RenderAsync_PassesPopupColumnsAndCoordinatesToRunner()
+    {
+        StubRunner runner = new("Granit.Test.Items", points: []);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Lat"",""longitudeColumn"":""Lng""},""popupColumns"":[""Name"",""Country""],""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        runner.LastLatitudeColumn.ShouldBe("Lat");
+        runner.LastLongitudeColumn.ShouldBe("Lng");
+        runner.LastPopupColumns.ShouldBe(["Name", "Country"]);
+    }
+
+    private static WidgetInstance BuildWidget(string queryName, string configJson) =>
+        WidgetInstance.Create(
+            id: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            widgetType: "Map",
+            position: 0,
+            width: 6,
+            height: 4,
+            titleLocalizationKey: "Widget:Test",
+            configJson: configJson,
+            queryName: queryName);
+
+    private static WidgetRenderContext BuildContext() =>
+        new(
+            TenantId: null,
+            User: new ClaimsPrincipal(new ClaimsIdentity()),
+            Period: null,
+            Locale: "en",
+            DashboardFilters: new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+    private sealed class StubRunner(string name, IReadOnlyList<MapRunnerPoint> points) : IMapRunner
+    {
+        public string Name { get; } = name;
+
+        public string? LastLatitudeColumn { get; private set; }
+        public string? LastLongitudeColumn { get; private set; }
+        public IReadOnlyList<string>? LastPopupColumns { get; private set; }
+
+        public Task<MapRunnerResult> ExecuteAsync(
+            string latitudeColumn,
+            string longitudeColumn,
+            IReadOnlyList<string>? popupColumns,
+            IReadOnlyDictionary<string, string>? dashboardFilters,
+            CancellationToken cancellationToken)
+        {
+            LastLatitudeColumn = latitudeColumn;
+            LastLongitudeColumn = longitudeColumn;
+            LastPopupColumns = popupColumns;
+            return Task.FromResult(new MapRunnerResult(points));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the dashboard widget catalogue: Markdown / Text / Image / Kpi / Chart / Table / Pivot / **Map** all shipped end-to-end. Geocoded query rows render as interactive map markers with Leaflet-friendly config (default zoom + center, cluster threshold, optional detail route + tile-URL override).

## Implementation

\`IMapRunner\` / \`MapRunner<TEntity>\` / \`MapService\` follow the runner-registry pattern established by the other data-bound renderers. Streams the filtered entity set through \`IQueryEngine.ExecuteStreamAsync\` (multi-tenancy + soft-delete + dashboard filters apply, capped by \`MaxStreamSize\`) and projects each row by reflecting:

- **Latitude / longitude columns** (double or decimal) — required. Rows with null coordinates are silently dropped (a marker pinned at (0, 0) would be misleading)
- **Optional \`Guid Id\` property** — propagates as the marker id, drives click-through to the configured \`DetailRoute\`
- **Whitelisted \`PopupColumns\`** — projected to a camelCase JSON object on the marker's \`Popup\` field. null when no popup columns were configured

## Wire shape (\`MapWidgetSnapshot\`)

\`\`\`jsonc
{
  \"points\": [
    { \"id\": \"...\", \"latitude\": 48.85, \"longitude\": 2.35,
      \"popup\": { \"name\": \"Paris\", \"country\": \"FR\" } }
  ],
  \"defaultZoom\": 7,
  \"defaultCenter\": { \"latitude\": 50.0, \"longitude\": 1.0 },
  \"clusterThreshold\": 150,
  \"detailRoute\": \"/cities/{id}\",
  \"tileUrlTemplate\": null
}
\`\`\`

## Scope split

- ✅ **\`LatLng\` path** (decimal lat/lng columns) — fully wired, works on any database
- ⏳ **\`Geography\` path** (PostGIS \`geography(Point)\` column) — deferred until \`granit-iot\` ships the NetTopologySuite plumbing. The renderer surfaces \`Widget:Unavailable.MapGeographyNotImplemented\` so the dashboard renders the rest of its widgets normally

## Test plan

- [x] 11 \`MapRunner\` unit tests — happy-path projection, null-coord skip, Guid-Id propagation, popup whitelist, decimal coord support, non-numeric coord rejection, unknown-field error paths, dashboard filter forwarding
- [x] 5 \`MapWidgetInstanceRenderer\` tests — envelope shape, geography-deferred path, query-not-found, default-center null serialisation, runner config pass-through
- [x] \`dotnet build .github/shard-filters/business.slnf\` clean
- [x] \`dotnet test tests/Granit.Analytics.Endpoints.Tests\` — 180 passing (17 new)
- [x] \`dotnet build tests/Granit.ArchitectureTests && dotnet test --no-build\` — 189 passing (fresh build)
- [x] \`dotnet format .github/shard-filters/business.slnf --verify-no-changes\` clean

## Follow-ups

Closes the framework-side widget catalogue. Remaining BI epic items:

- **B7-2bis**: PostGIS \`Geography\` path (NetTopologySuite, server-side spatial filters \`ST_DWithin\` etc.) — likely lands in \`granit-iot\`
- **B3-6ter**: SQL-level Pivot Sum/Avg/Min/Max (current in-memory aggregator OK for tile-sized data)
- **Layer 3 OData** (#1389–1394)