### PR TITLE
test(archi): pair WidgetDefinition with WidgetInstanceRenderer (ADR-039 §7)

### DIFF
--- a/tests/Granit.ArchitectureTests/WidgetRendererPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/WidgetRendererPairingTests.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+using Granit.Dashboards;
+using Granit.Dashboards.Rendering;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces ADR-039 §7: every concrete <see cref="WidgetDefinition"/> shipped
+/// by the framework MUST have a matching <see cref="IWidgetInstanceRenderer"/>
+/// in the same build. Adding a new widget kind without a renderer would let
+/// the dashboard render endpoint surface every instance of it as
+/// <see cref="WidgetSnapshotStatus.Error"/> at runtime — caught at build time
+/// here instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pairing rule uses the naming convention:
+/// <c>{Prefix}WidgetDefinition</c> ↔ <c>{Prefix}WidgetInstanceRenderer</c>.
+/// All eight framework-shipped kinds (Kpi / Chart / Table / Pivot / Map +
+/// Markdown / Image / Text) follow it; the convention is now load-bearing.
+/// </para>
+/// <para>
+/// The check looks at TYPES present in the loaded framework assemblies, not
+/// at DI registrations. A renderer type that exists but is not registered
+/// would still pass this rule — DI registration is verified by the existing
+/// renderer pipeline tests (e.g. <c>DashboardRendererTests</c>). The two
+/// checks are complementary: this rule catches "forgot to write the
+/// renderer", DI tests catch "wrote the renderer but forgot to register it".
+/// </para>
+/// </remarks>
+public sealed class WidgetRendererPairingTests
+{
+    private const string DefinitionSuffix = "WidgetDefinition";
+    private const string RendererSuffix = "WidgetInstanceRenderer";
+
+    [Fact]
+    public void Every_WidgetDefinition_should_have_a_matching_WidgetInstanceRenderer()
+    {
+        Assembly[] assemblies = LoadFrameworkAssemblies();
+
+        IReadOnlyList<Type> definitions = ScanConcreteSubtypes<WidgetDefinition>(assemblies)
+            .Where(t => t.Name.EndsWith(DefinitionSuffix, StringComparison.Ordinal))
+            .ToList();
+
+        var rendererPrefixes = ScanConcreteSubtypes<IWidgetInstanceRenderer>(assemblies)
+            .Where(t => t.Name.EndsWith(RendererSuffix, StringComparison.Ordinal))
+            .Select(t => t.Name[..^RendererSuffix.Length])
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<string> missing = [];
+        foreach (Type definition in definitions)
+        {
+            string prefix = definition.Name[..^DefinitionSuffix.Length];
+            if (!rendererPrefixes.Contains(prefix))
+            {
+                missing.Add($"{definition.FullName} has no matching {prefix}{RendererSuffix}");
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            $"ADR-039 §7: every {DefinitionSuffix} must ship with a {RendererSuffix} " +
+            $"following the {{Prefix}}{DefinitionSuffix} ↔ {{Prefix}}{RendererSuffix} naming convention. " +
+            "Either add the missing renderer or drop the widget kind." + Environment.NewLine +
+            string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
+    }
+
+    [Fact]
+    public void Every_WidgetInstanceRenderer_should_have_a_matching_WidgetDefinition()
+    {
+        // Inverse rule — catches an orphaned renderer (definition was renamed
+        // or removed but the renderer survived). Less catastrophic than the
+        // forward rule (the orphan just never fires), but still wasteful and
+        // a good signal of dead code.
+        Assembly[] assemblies = LoadFrameworkAssemblies();
+
+        IReadOnlyList<Type> renderers = ScanConcreteSubtypes<IWidgetInstanceRenderer>(assemblies)
+            .Where(t => t.Name.EndsWith(RendererSuffix, StringComparison.Ordinal))
+            .ToList();
+
+        var definitionPrefixes = ScanConcreteSubtypes<WidgetDefinition>(assemblies)
+            .Where(t => t.Name.EndsWith(DefinitionSuffix, StringComparison.Ordinal))
+            .Select(t => t.Name[..^DefinitionSuffix.Length])
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<string> orphans = [];
+        foreach (Type renderer in renderers)
+        {
+            string prefix = renderer.Name[..^RendererSuffix.Length];
+            if (!definitionPrefixes.Contains(prefix))
+            {
+                orphans.Add($"{renderer.FullName} has no matching {prefix}{DefinitionSuffix}");
+            }
+        }
+
+        orphans.ShouldBeEmpty(
+            "Orphaned renderers (no matching WidgetDefinition) — likely dead code from " +
+            "a kind rename or removal." + Environment.NewLine +
+            string.Join(Environment.NewLine, orphans.Order(StringComparer.Ordinal)));
+    }
+
+    private static Assembly[] LoadFrameworkAssemblies()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(WidgetRendererPairingTests).Assembly.Location)!;
+
+        return Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)
+            .ToArray()!;
+    }
+
+    private static IEnumerable<Type> ScanConcreteSubtypes<TBase>(Assembly[] assemblies)
+    {
+        foreach (Assembly assembly in assemblies)
+        {
+            Type[] types;
+            try { types = assembly.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = [.. ex.Types.Where(t => t is not null)!]; }
+
+            foreach (Type type in types)
+            {
+                if (type.IsAbstract || type.IsInterface || !type.IsClass)
+                {
+                    continue;
+                }
+
+                if (typeof(TBase).IsAssignableFrom(type))
+                {
+                    yield return type;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two complementary architecture rules under \`WidgetRendererPairingTests\`:

1. **Forward** — every concrete \`WidgetDefinition\` shipped by the framework must have a matching \`IWidgetInstanceRenderer\`. Catches the \"added a new widget kind, forgot to write the renderer\" failure mode at build time. Without this rule, the dashboard render endpoint would surface every instance of the orphaned kind as \`Error\` envelopes silently
2. **Inverse** — every \`IWidgetInstanceRenderer\` must have a matching \`WidgetDefinition\`. Catches dead-code orphans where a definition was renamed or removed but the renderer survived

Both rules use the load-bearing naming convention \`{Prefix}WidgetDefinition\` ↔ \`{Prefix}WidgetInstanceRenderer\`. All eight framework-shipped kinds (Kpi / Chart / Table / Pivot / Map + Markdown / Image / Text) follow it today.

## Why now

Closes ADR-039 §7 (\"every kind that ships in \`Granit.Analytics\` without its renderer fails the build\"). Now that the widget catalogue is complete (B7-2 #1500 was the last one), the rule is load-bearing — any future kind addition is mechanically forced to ship its renderer in the same PR.

## Relation to existing rules

- \`DashboardWidgetReferenceTests\` (#1382 / B1) checks that a widget *reference* resolves to a registered metric/query
- This rule checks that the widget *kind itself* is renderable

The two checks are independent — a \`KpiWidgetDefinition\` can reference an existing \`MetricDefinition\` AND have a registered \`KpiWidgetInstanceRenderer\`. Both rules must pass.

## Scope (intentional limit)

Type-level check (not DI-level): a renderer that *exists* but isn't *registered* in \`AddGranitAnalyticsWidgetRenderers\` would still pass this rule. DI registration is verified by \`DashboardRendererTests\` and the per-kind renderer tests. Two complementary layers — this rule catches \"forgot to write the renderer\", DI tests catch \"wrote the renderer but forgot to register it\".

## Test plan

- [x] Both new rules pass against the current 8 framework-shipped kinds
- [x] \`dotnet build tests/Granit.ArchitectureTests && dotnet test --no-build\` — 191 passing (was 189; +2 new)
- [x] \`dotnet format .github/shard-filters/architecture.slnf --verify-no-changes\` clean