### PR TITLE
feat(dashboards): localize Widget:Unavailable.* reason keys (15 cultures)

### DIFF
--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
@@ -1,9 +1,15 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Dashboards": "Dashboardy",
     "Permission:Dashboards.Catalog.Read": "Procházet katalog dashboardů (zobrazit seznam všech registrovaných DashboardDefinition)",
     "Permission:Dashboards.Instances.Manage": "Spravovat dashboardy nájemce (importovat z definice, upravit, publikovat, archivovat, obnovit)",
-    "Permission:Dashboards.Instances.Read": "Číst dashboardy nájemce (seznam a čtení podle id, včetně detekce odchylek)"
+    "Permission:Dashboards.Instances.Read": "Číst dashboardy nájemce (seznam a čtení podle id, včetně detekce odchylek)",
+    "PermissionGroup:Dashboards": "Dashboardy",
+    "Widget:Unavailable": "Widget není k dispozici",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Widgety map PostGIS zatím nejsou podporovány",
+    "Widget:Unavailable.MetricNotFound": "Metrika nebyla nalezena",
+    "Widget:Unavailable.QueryAggregateNotFound": "Dotaz nebyl nalezen",
+    "Widget:Unavailable.QueryNotFound": "Dotaz nebyl nalezen",
+    "Widget:Unavailable.TelemetryNotImplemented": "Zdroj telemetrie zatím není podporován"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
@@ -1,9 +1,15 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Den Dashboard-Katalog durchsuchen (alle registrierten DashboardDefinitions auflisten)",
     "Permission:Dashboards.Instances.Manage": "Tenant-spezifische Dashboards verwalten (aus Definition importieren, bearbeiten, veröffentlichen, archivieren, wiederherstellen)",
-    "Permission:Dashboards.Instances.Read": "Tenant-spezifische Dashboards lesen (Liste und Lesen anhand der ID, einschließlich Drift-Erkennung)"
+    "Permission:Dashboards.Instances.Read": "Tenant-spezifische Dashboards lesen (Liste und Lesen anhand der ID, einschließlich Drift-Erkennung)",
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Unavailable": "Widget nicht verfügbar",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-Karten-Widgets noch nicht unterstützt",
+    "Widget:Unavailable.MetricNotFound": "Metrik nicht gefunden",
+    "Widget:Unavailable.QueryAggregateNotFound": "Abfrage nicht gefunden",
+    "Widget:Unavailable.QueryNotFound": "Abfrage nicht gefunden",
+    "Widget:Unavailable.TelemetryNotImplemented": "Telemetrie-Datenquelle noch nicht unterstützt"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
@@ -1,9 +1,15 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Browse the dashboard catalogue (list every registered DashboardDefinition)",
     "Permission:Dashboards.Instances.Manage": "Manage tenant-scoped dashboards (import from definition, edit, publish, archive, restore)",
-    "Permission:Dashboards.Instances.Read": "Read tenant-scoped dashboards (list and read-by-id, including drift detection)"
+    "Permission:Dashboards.Instances.Read": "Read tenant-scoped dashboards (list and read-by-id, including drift detection)",
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Unavailable": "Widget unavailable",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS map widgets not yet supported",
+    "Widget:Unavailable.MetricNotFound": "Metric not found",
+    "Widget:Unavailable.QueryAggregateNotFound": "Query not found",
+    "Widget:Unavailable.QueryNotFound": "Query not found",
+    "Widget:Unavailable.TelemetryNotImplemented": "Telemetry data source not yet supported"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
@@ -1,9 +1,15 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Dashboards": "Paneles",
     "Permission:Dashboards.Catalog.Read": "Explorar el catálogo de paneles (listar todas las DashboardDefinition registradas)",
     "Permission:Dashboards.Instances.Manage": "Gestionar paneles del inquilino (importar desde definición, editar, publicar, archivar, restaurar)",
-    "Permission:Dashboards.Instances.Read": "Leer paneles del inquilino (lista y lectura por identificador, incluida la detección de desviaciones)"
+    "Permission:Dashboards.Instances.Read": "Leer paneles del inquilino (lista y lectura por identificador, incluida la detección de desviaciones)",
+    "PermissionGroup:Dashboards": "Paneles",
+    "Widget:Unavailable": "Widget no disponible",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Widgets de mapa PostGIS aún no compatibles",
+    "Widget:Unavailable.MetricNotFound": "Métrica no encontrada",
+    "Widget:Unavailable.QueryAggregateNotFound": "Consulta no encontrada",
+    "Widget:Unavailable.QueryNotFound": "Consulta no encontrada",
+    "Widget:Unavailable.TelemetryNotImplemented": "Fuente de telemetría aún no compatible"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
@@ -1,9 +1,15 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Dashboards": "Tableaux de bord",
     "Permission:Dashboards.Catalog.Read": "Parcourir le catalogue des tableaux de bord (lister chaque DashboardDefinition enregistrée)",
     "Permission:Dashboards.Instances.Manage": "Gérer les tableaux de bord du locataire (importer depuis une définition, éditer, publier, archiver, restaurer)",
-    "Permission:Dashboards.Instances.Read": "Lire les tableaux de bord du locataire (liste et lecture par identifiant, détection de dérive)"
+    "Permission:Dashboards.Instances.Read": "Lire les tableaux de bord du locataire (liste et lecture par identifiant, détection de dérive)",
+    "PermissionGroup:Dashboards": "Tableaux de bord",
+    "Widget:Unavailable": "Widget indisponible",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Cartes PostGIS non encore prises en charge",
+    "Widget:Unavailable.MetricNotFound": "Métrique introuvable",
+    "Widget:Unavailable.QueryAggregateNotFound": "Requête introuvable",
+    "Widget:Unavailable.QueryNotFound": "Requête introuvable",
+    "Widget:Unavailable.TelemetryNotImplemented": "Source de télémétrie non encore prise en charge"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
@@ -1,9 +1,15 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Dashboards": "डैशबोर्ड",
     "Permission:Dashboards.Catalog.Read": "डैशबोर्ड कैटलॉग देखें (सभी पंजीकृत DashboardDefinition की सूची बनाएँ)",
     "Permission:Dashboards.Instances.Manage": "टेनेंट डैशबोर्ड प्रबंधित करें (परिभाषा से आयात, संपादन, प्रकाशन, संग्रह, पुनर्स्थापन)",
-    "Permission:Dashboards.Instances.Read": "टेनेंट डैशबोर्ड पढ़ें (सूची और आईडी द्वारा पढ़ना, ड्रिफ्ट डिटेक्शन सहित)"
+    "Permission:Dashboards.Instances.Read": "टेनेंट डैशबोर्ड पढ़ें (सूची और आईडी द्वारा पढ़ना, ड्रिफ्ट डिटेक्शन सहित)",
+    "PermissionGroup:Dashboards": "डैशबोर्ड",
+    "Widget:Unavailable": "विजेट अनुपलब्ध",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS मानचित्र विजेट अभी तक समर्थित नहीं हैं",
+    "Widget:Unavailable.MetricNotFound": "मेट्रिक नहीं मिली",
+    "Widget:Unavailable.QueryAggregateNotFound": "क्वेरी नहीं मिली",
+    "Widget:Unavailable.QueryNotFound": "क्वेरी नहीं मिली",
+    "Widget:Unavailable.TelemetryNotImplemented": "टेलीमेट्री डेटा स्रोत अभी तक समर्थित नहीं है"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
@@ -1,9 +1,15 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Dashboards": "Dashboard",
     "Permission:Dashboards.Catalog.Read": "Sfogliare il catalogo dei dashboard (elencare ogni DashboardDefinition registrata)",
     "Permission:Dashboards.Instances.Manage": "Gestire i dashboard del tenant (importare dalla definizione, modificare, pubblicare, archiviare, ripristinare)",
-    "Permission:Dashboards.Instances.Read": "Leggere i dashboard del tenant (elenco e lettura per id, inclusa la rilevazione del drift)"
+    "Permission:Dashboards.Instances.Read": "Leggere i dashboard del tenant (elenco e lettura per id, inclusa la rilevazione del drift)",
+    "PermissionGroup:Dashboards": "Dashboard",
+    "Widget:Unavailable": "Widget non disponibile",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Widget mappa PostGIS non ancora supportati",
+    "Widget:Unavailable.MetricNotFound": "Metrica non trovata",
+    "Widget:Unavailable.QueryAggregateNotFound": "Query non trovata",
+    "Widget:Unavailable.QueryNotFound": "Query non trovata",
+    "Widget:Unavailable.TelemetryNotImplemented": "Origine dati di telemetria non ancora supportata"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
@@ -1,9 +1,15 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Dashboards": "ダッシュボード",
     "Permission:Dashboards.Catalog.Read": "ダッシュボードカタログを参照する（登録済みの DashboardDefinition をすべて一覧表示）",
     "Permission:Dashboards.Instances.Manage": "テナントスコープのダッシュボードを管理する（定義からインポート、編集、公開、アーカイブ、復元）",
-    "Permission:Dashboards.Instances.Read": "テナントスコープのダッシュボードを読み取る（一覧、ID 単一読み取り、ドリフト検出を含む）"
+    "Permission:Dashboards.Instances.Read": "テナントスコープのダッシュボードを読み取る（一覧、ID 単一読み取り、ドリフト検出を含む）",
+    "PermissionGroup:Dashboards": "ダッシュボード",
+    "Widget:Unavailable": "ウィジェットを利用できません",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS マップ ウィジェットはまだサポートされていません",
+    "Widget:Unavailable.MetricNotFound": "メトリックが見つかりません",
+    "Widget:Unavailable.QueryAggregateNotFound": "クエリが見つかりません",
+    "Widget:Unavailable.QueryNotFound": "クエリが見つかりません",
+    "Widget:Unavailable.TelemetryNotImplemented": "テレメトリ データ ソースはまだサポートされていません"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
@@ -1,9 +1,15 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Dashboards": "대시보드",
     "Permission:Dashboards.Catalog.Read": "대시보드 카탈로그 탐색(등록된 모든 DashboardDefinition 나열)",
     "Permission:Dashboards.Instances.Manage": "테넌트 범위 대시보드 관리(정의에서 가져오기, 편집, 게시, 보관, 복원)",
-    "Permission:Dashboards.Instances.Read": "테넌트 범위 대시보드 읽기(목록 및 ID 단일 조회, 드리프트 감지 포함)"
+    "Permission:Dashboards.Instances.Read": "테넌트 범위 대시보드 읽기(목록 및 ID 단일 조회, 드리프트 감지 포함)",
+    "PermissionGroup:Dashboards": "대시보드",
+    "Widget:Unavailable": "위젯을 사용할 수 없습니다",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS 지도 위젯은 아직 지원되지 않습니다",
+    "Widget:Unavailable.MetricNotFound": "메트릭을 찾을 수 없음",
+    "Widget:Unavailable.QueryAggregateNotFound": "쿼리를 찾을 수 없음",
+    "Widget:Unavailable.QueryNotFound": "쿼리를 찾을 수 없음",
+    "Widget:Unavailable.TelemetryNotImplemented": "텔레메트리 데이터 원본은 아직 지원되지 않습니다"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
@@ -1,9 +1,15 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Dashboards": "Dashboards",
     "Permission:Dashboards.Catalog.Read": "Door de dashboard-catalogus bladeren (alle geregistreerde DashboardDefinitions weergeven)",
     "Permission:Dashboards.Instances.Manage": "Beheer huurder-specifieke dashboards (importeren vanuit definitie, bewerken, publiceren, archiveren, herstellen)",
-    "Permission:Dashboards.Instances.Read": "Huurder-specifieke dashboards lezen (lijst en lezen op id, inclusief driftdetectie)"
+    "Permission:Dashboards.Instances.Read": "Huurder-specifieke dashboards lezen (lijst en lezen op id, inclusief driftdetectie)",
+    "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Unavailable": "Widget niet beschikbaar",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-kaartwidgets nog niet ondersteund",
+    "Widget:Unavailable.MetricNotFound": "Metriek niet gevonden",
+    "Widget:Unavailable.QueryAggregateNotFound": "Query niet gevonden",
+    "Widget:Unavailable.QueryNotFound": "Query niet gevonden",
+    "Widget:Unavailable.TelemetryNotImplemented": "Telemetriebron nog niet ondersteund"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
@@ -1,9 +1,15 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Dashboards": "Pulpity",
     "Permission:Dashboards.Catalog.Read": "Przeglądanie katalogu pulpitów (lista wszystkich zarejestrowanych DashboardDefinition)",
     "Permission:Dashboards.Instances.Manage": "Zarządzanie pulpitami dzierżawcy (importowanie z definicji, edycja, publikowanie, archiwizowanie, przywracanie)",
-    "Permission:Dashboards.Instances.Read": "Odczyt pulpitów dzierżawcy (lista i odczyt po identyfikatorze, w tym wykrywanie dryfu)"
+    "Permission:Dashboards.Instances.Read": "Odczyt pulpitów dzierżawcy (lista i odczyt po identyfikatorze, w tym wykrywanie dryfu)",
+    "PermissionGroup:Dashboards": "Pulpity",
+    "Widget:Unavailable": "Widget niedostępny",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Widżety map PostGIS jeszcze nieobsługiwane",
+    "Widget:Unavailable.MetricNotFound": "Nie znaleziono metryki",
+    "Widget:Unavailable.QueryAggregateNotFound": "Nie znaleziono zapytania",
+    "Widget:Unavailable.QueryNotFound": "Nie znaleziono zapytania",
+    "Widget:Unavailable.TelemetryNotImplemented": "Źródło telemetrii jeszcze nieobsługiwane"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
@@ -1,9 +1,15 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Dashboards": "Painéis",
     "Permission:Dashboards.Catalog.Read": "Navegar pelo catálogo de painéis (listar todas as DashboardDefinition registadas)",
     "Permission:Dashboards.Instances.Manage": "Gerir painéis do inquilino (importar a partir de definição, editar, publicar, arquivar, restaurar)",
-    "Permission:Dashboards.Instances.Read": "Ler painéis do inquilino (lista e leitura por id, incluindo deteção de desvio)"
+    "Permission:Dashboards.Instances.Read": "Ler painéis do inquilino (lista e leitura por id, incluindo deteção de desvio)",
+    "PermissionGroup:Dashboards": "Painéis",
+    "Widget:Unavailable": "Widget indisponível",
+    "Widget:Unavailable.MapGeographyNotImplemented": "Widgets de mapa PostGIS ainda não suportados",
+    "Widget:Unavailable.MetricNotFound": "Métrica não encontrada",
+    "Widget:Unavailable.QueryAggregateNotFound": "Consulta não encontrada",
+    "Widget:Unavailable.QueryNotFound": "Consulta não encontrada",
+    "Widget:Unavailable.TelemetryNotImplemented": "Fonte de telemetria ainda não suportada"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
@@ -1,9 +1,15 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Dashboards": "Instrumentpaneler",
     "Permission:Dashboards.Catalog.Read": "Bläddra i instrumentpanelskatalogen (lista alla registrerade DashboardDefinition)",
     "Permission:Dashboards.Instances.Manage": "Hantera klientspecifika instrumentpaneler (importera från definition, redigera, publicera, arkivera, återställa)",
-    "Permission:Dashboards.Instances.Read": "Läsa klientspecifika instrumentpaneler (lista och läs efter id, inklusive driftdetektion)"
+    "Permission:Dashboards.Instances.Read": "Läsa klientspecifika instrumentpaneler (lista och läs efter id, inklusive driftdetektion)",
+    "PermissionGroup:Dashboards": "Instrumentpaneler",
+    "Widget:Unavailable": "Widgeten är inte tillgänglig",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-kartwidgetar stöds inte ännu",
+    "Widget:Unavailable.MetricNotFound": "Mätvärdet hittades inte",
+    "Widget:Unavailable.QueryAggregateNotFound": "Frågan hittades inte",
+    "Widget:Unavailable.QueryNotFound": "Frågan hittades inte",
+    "Widget:Unavailable.TelemetryNotImplemented": "Telemetridatakällan stöds inte ännu"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
@@ -1,9 +1,15 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Dashboards": "Panolar",
     "Permission:Dashboards.Catalog.Read": "Pano kataloğunu görüntüleme (kayıtlı her DashboardDefinition'ı listeleme)",
     "Permission:Dashboards.Instances.Manage": "Kiracıya özel panoları yönet (tanımdan içe aktar, düzenle, yayınla, arşivle, geri yükle)",
-    "Permission:Dashboards.Instances.Read": "Kiracıya özel panoları oku (liste ve id ile okuma, sürüm sapması tespiti dâhil)"
+    "Permission:Dashboards.Instances.Read": "Kiracıya özel panoları oku (liste ve id ile okuma, sürüm sapması tespiti dâhil)",
+    "PermissionGroup:Dashboards": "Panolar",
+    "Widget:Unavailable": "Widget kullanılamıyor",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS harita widget'ları henüz desteklenmiyor",
+    "Widget:Unavailable.MetricNotFound": "Metrik bulunamadı",
+    "Widget:Unavailable.QueryAggregateNotFound": "Sorgu bulunamadı",
+    "Widget:Unavailable.QueryNotFound": "Sorgu bulunamadı",
+    "Widget:Unavailable.TelemetryNotImplemented": "Telemetri veri kaynağı henüz desteklenmiyor"
   }
 }

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
@@ -1,9 +1,15 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Dashboards": "仪表板",
     "Permission:Dashboards.Catalog.Read": "浏览仪表板目录（列出每个已注册的 DashboardDefinition）",
     "Permission:Dashboards.Instances.Manage": "管理租户范围的仪表板（从定义导入、编辑、发布、归档、恢复）",
-    "Permission:Dashboards.Instances.Read": "读取租户范围的仪表板（列表与按 id 读取，含偏移检测）"
+    "Permission:Dashboards.Instances.Read": "读取租户范围的仪表板（列表与按 id 读取，含偏移检测）",
+    "PermissionGroup:Dashboards": "仪表板",
+    "Widget:Unavailable": "小组件不可用",
+    "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS 地图小组件尚不支持",
+    "Widget:Unavailable.MetricNotFound": "未找到指标",
+    "Widget:Unavailable.QueryAggregateNotFound": "未找到查询",
+    "Widget:Unavailable.QueryNotFound": "未找到查询",
+    "Widget:Unavailable.TelemetryNotImplemented": "尚不支持遥测数据源"
   }
 }


### PR DESCRIPTION
## Summary

Six new localization keys surface the Unavailable reasons emitted by the widget renderers shipped in B3-2…B7-2:

- `Widget:Unavailable` — generic fallback
- `Widget:Unavailable.MetricNotFound`
- `Widget:Unavailable.QueryNotFound`
- `Widget:Unavailable.QueryAggregateNotFound`
- `Widget:Unavailable.TelemetryNotImplemented`
- `Widget:Unavailable.MapGeographyNotImplemented`

Translated across the 15 base cultures (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi). The 3 regional files (fr-CA, en-GB, pt-BR) stay empty because the translations match the parent locale exactly — Granit convention is to only override when the regional wording differs.

## Why localization lives in `Granit.Dashboards.Endpoints`

The keys are *emitted* from `IWidgetInstanceRenderer` implementations shipped in `Granit.Analytics.Endpoints` (KPI / Chart / Table / Pivot / Map), and will soon be emitted from `Granit.Telemetry.Endpoints` too. They are *resolved* against the `DashboardsEndpoints` localization resource because the user-facing presentation of "why this tile is empty" belongs to the dashboard render endpoint, not to whichever module produced the renderer.

This means:

- Adding a new renderer in another module (e.g. an IoT GIS renderer in `granit-iot`) only requires registering the localization key here, not in the producing module's resource.
- Apps that load `Granit.Analytics.Endpoints` without `Granit.Dashboards.Endpoints` (theoretical — the renderer pipeline requires the dashboard endpoint) would not need these keys.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` — embedded JSON resources compile cleanly
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests --no-build` — 104 passed
- [x] `dotnet format src/Granit.Dashboards.Endpoints --verify-no-changes` — clean
- [x] Manual diff review across all 15 base cultures (verified the QueryAggregateNotFound/TelemetryNotImplemented translations are aligned, not swapped)