### PR TITLE
feat(dashboards): localize Error envelope reasons + symmetric Reason naming

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13726,7 +13726,7 @@
         {
           "name": "Error",
           "kind": "method",
-          "signature": "Error(string widgetType, long sequence, DateTimeOffset emittedAt, RefreshHint refreshHint)",
+          "signature": "Error(string widgetType, long sequence, DateTimeOffset emittedAt, RefreshHint refreshHint, string reasonLocalizationKey = \"Widget:Error\")",
           "returnType": "WidgetSnapshotEnvelope"
         }
       ]

--- a/docs-site/src/content/docs/dotnet/architecture/adr/039-widget-renderer-architecture.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/039-widget-renderer-architecture.md
@@ -102,13 +102,13 @@ public sealed record WidgetSnapshotEnvelope(
     long Sequence,
     DateTimeOffset EmittedAt,
     RefreshHint RefreshHint,
-    string? UnavailableReasonLocalizationKey = null);
+    string? ReasonLocalizationKey = null);          // set on Unavailable AND Error; null on Snapshot
 
 public enum WidgetSnapshotStatus
 {
     Snapshot,       // Snapshot is non-null, the typed payload for the kind
-    Unavailable,    // Permission denied — UnavailableReasonLocalizationKey is set
-    Error,          // Renderer threw an unexpected exception — Snapshot is null
+    Unavailable,    // Permission denied or referenced datasource missing — ReasonLocalizationKey is set
+    Error,          // Renderer threw or WidgetType unknown — Snapshot is null, ReasonLocalizationKey is set
 }
 ```
 
@@ -354,7 +354,7 @@ unchanged — one source of truth for "this metric, this tenant, this period".
       "sequence": 1,
       "refreshHint": "Dynamic",
       "snapshot": null,
-      "unavailableReasonLocalizationKey": "Widget:Unavailable"
+      "reasonLocalizationKey": "Widget:Unavailable"
     }
   ]
 }
@@ -470,7 +470,7 @@ internal sealed class KpiWidgetInstanceRenderer(
                 sequence: 1, emittedAt: clock.Now, refreshHint: evaluation.RefreshHint)
             : WidgetSnapshotEnvelope.Unavailable(WidgetType,
                 sequence: 1, emittedAt: clock.Now, refreshHint: evaluation.RefreshHint,
-                reasonLocalizationKey: evaluation.UnavailableReasonLocalizationKey ?? "Widget:Unavailable");
+                reasonLocalizationKey: evaluation.ReasonLocalizationKey ?? "Widget:Unavailable");
     }
 }
 
@@ -486,7 +486,7 @@ public interface IDatasourceEvaluator<TDatasource> where TDatasource : Datasourc
 public sealed record KpiEvaluation(
     MetricSnapshotPayload? Payload,                      // null when unavailable
     RefreshHint RefreshHint,
-    string? UnavailableReasonLocalizationKey = null);    // surfaced when Payload is null
+    string? ReasonLocalizationKey = null);               // surfaced when Payload is null
 ```
 
 The evaluator returns `KpiEvaluation` (envelope-shaped) rather than

--- a/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
@@ -237,7 +237,7 @@ Status codes:
       "emittedAt": "2026-04-29T12:34:56.789Z",
       "refreshHint": "Dynamic",
       "snapshot": { "value": 12, "valueKind": "Count", "noData": false, /* ... */ },
-      "unavailableReasonLocalizationKey": null
+      "reasonLocalizationKey": null
     },
     {
       "id": "...",
@@ -256,7 +256,7 @@ Status codes:
       "emittedAt": "2026-04-29T12:34:56.789Z",
       "refreshHint": "Static",
       "snapshot": null,
-      "unavailableReasonLocalizationKey": "Widget:Unavailable"
+      "reasonLocalizationKey": "Widget:Unavailable"
     }
   ]
 }

--- a/src/Granit.Analytics.Endpoints/Rendering/KpiEvaluation.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/KpiEvaluation.cs
@@ -23,11 +23,11 @@ namespace Granit.Analytics.Endpoints.Rendering;
 /// </remarks>
 /// <param name="Payload">The KPI snapshot payload — non-null when the evaluation succeeded; <see langword="null"/> when the datasource yielded no usable result.</param>
 /// <param name="RefreshHint">The refresh hint surfaced on the wire envelope. For metric paths it mirrors the underlying <c>MetricDefinition.RefreshHint</c>; for stub paths it is <see cref="RefreshHint.Static"/>.</param>
-/// <param name="UnavailableReasonLocalizationKey">Localization key surfaced on the unavailable envelope. Ignored when <paramref name="Payload"/> is non-null. Defaults to <c>Widget:Unavailable</c> when null on an unavailable result.</param>
+/// <param name="ReasonLocalizationKey">Localization key surfaced on the unavailable envelope. Ignored when <paramref name="Payload"/> is non-null. Defaults to <c>Widget:Unavailable</c> when null on an unavailable result.</param>
 public sealed record KpiEvaluation(
     MetricSnapshotPayload? Payload,
     RefreshHint RefreshHint,
-    string? UnavailableReasonLocalizationKey = null)
+    string? ReasonLocalizationKey = null)
 {
     /// <summary>Builds a successful evaluation carrying the supplied payload.</summary>
     public static KpiEvaluation Snapshot(MetricSnapshotPayload payload, RefreshHint refreshHint)

--- a/src/Granit.Analytics.Endpoints/Rendering/KpiWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/KpiWidgetInstanceRenderer.cs
@@ -83,6 +83,6 @@ internal sealed class KpiWidgetInstanceRenderer(
                 sequence: 1,
                 emittedAt: emittedAt,
                 refreshHint: evaluation.RefreshHint,
-                reasonLocalizationKey: evaluation.UnavailableReasonLocalizationKey ?? "Widget:Unavailable");
+                reasonLocalizationKey: evaluation.ReasonLocalizationKey ?? "Widget:Unavailable");
     }
 }

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -43,7 +43,7 @@ public sealed record DashboardRenderPeriodResponse(DateTimeOffset From, DateTime
 /// <param name="EmittedAt">Server-side timestamp of the widget's computation.</param>
 /// <param name="RefreshHint">Pull / push transport hint — drives the frontend's per-widget cache TTL.</param>
 /// <param name="Snapshot">Pre-serialised typed payload. <see langword="null"/> when <see cref="Status"/> is not <see cref="WidgetSnapshotStatus.Snapshot"/>.</param>
-/// <param name="UnavailableReasonLocalizationKey">Localization key for the user-facing reason when <see cref="Status"/> is <see cref="WidgetSnapshotStatus.Unavailable"/>; <see langword="null"/> otherwise.</param>
+/// <param name="ReasonLocalizationKey">Localization key for the user-facing reason — set on <see cref="WidgetSnapshotStatus.Unavailable"/> and <see cref="WidgetSnapshotStatus.Error"/>; <see langword="null"/> on <see cref="WidgetSnapshotStatus.Snapshot"/>. Resolved client-side so the same envelope can be cached across user locales.</param>
 public sealed record DashboardRenderedWidgetResponse(
     Guid Id,
     string WidgetType,
@@ -52,4 +52,4 @@ public sealed record DashboardRenderedWidgetResponse(
     DateTimeOffset EmittedAt,
     RefreshHint RefreshHint,
     JsonElement? Snapshot,
-    string? UnavailableReasonLocalizationKey = null);
+    string? ReasonLocalizationKey = null);

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -29,7 +29,7 @@ internal static class DashboardRenderProjection
                 EmittedAt: rw.Envelope.EmittedAt,
                 RefreshHint: rw.Envelope.RefreshHint,
                 Snapshot: rw.Envelope.Snapshot,
-                UnavailableReasonLocalizationKey: rw.Envelope.UnavailableReasonLocalizationKey))];
+                ReasonLocalizationKey: rw.Envelope.ReasonLocalizationKey))];
 
         return new DashboardRenderResponse(
             DashboardId: result.DashboardId,

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
@@ -68,7 +68,8 @@ internal sealed partial class DashboardRenderer(
                     widgetType: widget.WidgetType,
                     sequence: 1,
                     emittedAt: emittedAt,
-                    refreshHint: RefreshHint.Static)));
+                    refreshHint: RefreshHint.Static,
+                    reasonLocalizationKey: "Widget:Error.UnknownWidgetType")));
                 continue;
             }
 

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/cs.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Spravovat dashboardy nájemce (importovat z definice, upravit, publikovat, archivovat, obnovit)",
     "Permission:Dashboards.Instances.Read": "Číst dashboardy nájemce (seznam a čtení podle id, včetně detekce odchylek)",
     "PermissionGroup:Dashboards": "Dashboardy",
+    "Widget:Error": "Vykreslení widgetu se nezdařilo",
+    "Widget:Error.UnknownWidgetType": "Typ widgetu není k dispozici — modul, který jej poskytuje, mohl být uvolněn",
     "Widget:Unavailable": "Widget není k dispozici",
     "Widget:Unavailable.MapGeographyNotImplemented": "Widgety map PostGIS zatím nejsou podporovány",
     "Widget:Unavailable.MetricNotFound": "Metrika nebyla nalezena",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/de.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Tenant-spezifische Dashboards verwalten (aus Definition importieren, bearbeiten, veröffentlichen, archivieren, wiederherstellen)",
     "Permission:Dashboards.Instances.Read": "Tenant-spezifische Dashboards lesen (Liste und Lesen anhand der ID, einschließlich Drift-Erkennung)",
     "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Error": "Widget konnte nicht gerendert werden",
+    "Widget:Error.UnknownWidgetType": "Widgettyp nicht verfügbar — das bereitstellende Modul wurde möglicherweise entladen",
     "Widget:Unavailable": "Widget nicht verfügbar",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-Karten-Widgets noch nicht unterstützt",
     "Widget:Unavailable.MetricNotFound": "Metrik nicht gefunden",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/en.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Manage tenant-scoped dashboards (import from definition, edit, publish, archive, restore)",
     "Permission:Dashboards.Instances.Read": "Read tenant-scoped dashboards (list and read-by-id, including drift detection)",
     "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Error": "Widget failed to render",
+    "Widget:Error.UnknownWidgetType": "Widget kind is unavailable — the module that ships it may have been unloaded",
     "Widget:Unavailable": "Widget unavailable",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS map widgets not yet supported",
     "Widget:Unavailable.MetricNotFound": "Metric not found",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/es.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Gestionar paneles del inquilino (importar desde definición, editar, publicar, archivar, restaurar)",
     "Permission:Dashboards.Instances.Read": "Leer paneles del inquilino (lista y lectura por identificador, incluida la detección de desviaciones)",
     "PermissionGroup:Dashboards": "Paneles",
+    "Widget:Error": "Error al representar el widget",
+    "Widget:Error.UnknownWidgetType": "Tipo de widget no disponible — es posible que el módulo que lo proporciona se haya descargado",
     "Widget:Unavailable": "Widget no disponible",
     "Widget:Unavailable.MapGeographyNotImplemented": "Widgets de mapa PostGIS aún no compatibles",
     "Widget:Unavailable.MetricNotFound": "Métrica no encontrada",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/fr.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Gérer les tableaux de bord du locataire (importer depuis une définition, éditer, publier, archiver, restaurer)",
     "Permission:Dashboards.Instances.Read": "Lire les tableaux de bord du locataire (liste et lecture par identifiant, détection de dérive)",
     "PermissionGroup:Dashboards": "Tableaux de bord",
+    "Widget:Error": "Échec du rendu du widget",
+    "Widget:Error.UnknownWidgetType": "Type de widget indisponible — le module qui le fournit a peut-être été déchargé",
     "Widget:Unavailable": "Widget indisponible",
     "Widget:Unavailable.MapGeographyNotImplemented": "Cartes PostGIS non encore prises en charge",
     "Widget:Unavailable.MetricNotFound": "Métrique introuvable",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/hi.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "टेनेंट डैशबोर्ड प्रबंधित करें (परिभाषा से आयात, संपादन, प्रकाशन, संग्रह, पुनर्स्थापन)",
     "Permission:Dashboards.Instances.Read": "टेनेंट डैशबोर्ड पढ़ें (सूची और आईडी द्वारा पढ़ना, ड्रिफ्ट डिटेक्शन सहित)",
     "PermissionGroup:Dashboards": "डैशबोर्ड",
+    "Widget:Error": "विजेट रेंडर करने में विफल",
+    "Widget:Error.UnknownWidgetType": "विजेट प्रकार अनुपलब्ध — इसे प्रदान करने वाला मॉड्यूल अनलोड हो सकता है",
     "Widget:Unavailable": "विजेट अनुपलब्ध",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS मानचित्र विजेट अभी तक समर्थित नहीं हैं",
     "Widget:Unavailable.MetricNotFound": "मेट्रिक नहीं मिली",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/it.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Gestire i dashboard del tenant (importare dalla definizione, modificare, pubblicare, archiviare, ripristinare)",
     "Permission:Dashboards.Instances.Read": "Leggere i dashboard del tenant (elenco e lettura per id, inclusa la rilevazione del drift)",
     "PermissionGroup:Dashboards": "Dashboard",
+    "Widget:Error": "Errore di rendering del widget",
+    "Widget:Error.UnknownWidgetType": "Tipo di widget non disponibile — il modulo che lo fornisce potrebbe essere stato scaricato",
     "Widget:Unavailable": "Widget non disponibile",
     "Widget:Unavailable.MapGeographyNotImplemented": "Widget mappa PostGIS non ancora supportati",
     "Widget:Unavailable.MetricNotFound": "Metrica non trovata",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ja.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "テナントスコープのダッシュボードを管理する（定義からインポート、編集、公開、アーカイブ、復元）",
     "Permission:Dashboards.Instances.Read": "テナントスコープのダッシュボードを読み取る（一覧、ID 単一読み取り、ドリフト検出を含む）",
     "PermissionGroup:Dashboards": "ダッシュボード",
+    "Widget:Error": "ウィジェットのレンダリングに失敗しました",
+    "Widget:Error.UnknownWidgetType": "ウィジェット タイプを利用できません — 提供元のモジュールがアンロードされている可能性があります",
     "Widget:Unavailable": "ウィジェットを利用できません",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS マップ ウィジェットはまだサポートされていません",
     "Widget:Unavailable.MetricNotFound": "メトリックが見つかりません",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/ko.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "테넌트 범위 대시보드 관리(정의에서 가져오기, 편집, 게시, 보관, 복원)",
     "Permission:Dashboards.Instances.Read": "테넌트 범위 대시보드 읽기(목록 및 ID 단일 조회, 드리프트 감지 포함)",
     "PermissionGroup:Dashboards": "대시보드",
+    "Widget:Error": "위젯 렌더링에 실패했습니다",
+    "Widget:Error.UnknownWidgetType": "위젯 종류를 사용할 수 없음 — 해당 모듈이 언로드되었을 수 있음",
     "Widget:Unavailable": "위젯을 사용할 수 없습니다",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS 지도 위젯은 아직 지원되지 않습니다",
     "Widget:Unavailable.MetricNotFound": "메트릭을 찾을 수 없음",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/nl.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Beheer huurder-specifieke dashboards (importeren vanuit definitie, bewerken, publiceren, archiveren, herstellen)",
     "Permission:Dashboards.Instances.Read": "Huurder-specifieke dashboards lezen (lijst en lezen op id, inclusief driftdetectie)",
     "PermissionGroup:Dashboards": "Dashboards",
+    "Widget:Error": "Widget kon niet worden weergegeven",
+    "Widget:Error.UnknownWidgetType": "Widgettype niet beschikbaar — de module die het levert is mogelijk uitgeladen",
     "Widget:Unavailable": "Widget niet beschikbaar",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-kaartwidgets nog niet ondersteund",
     "Widget:Unavailable.MetricNotFound": "Metriek niet gevonden",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pl.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Zarządzanie pulpitami dzierżawcy (importowanie z definicji, edycja, publikowanie, archiwizowanie, przywracanie)",
     "Permission:Dashboards.Instances.Read": "Odczyt pulpitów dzierżawcy (lista i odczyt po identyfikatorze, w tym wykrywanie dryfu)",
     "PermissionGroup:Dashboards": "Pulpity",
+    "Widget:Error": "Nie udało się wyrenderować widżetu",
+    "Widget:Error.UnknownWidgetType": "Typ widżetu niedostępny — moduł, który go dostarcza, mógł zostać wyładowany",
     "Widget:Unavailable": "Widget niedostępny",
     "Widget:Unavailable.MapGeographyNotImplemented": "Widżety map PostGIS jeszcze nieobsługiwane",
     "Widget:Unavailable.MetricNotFound": "Nie znaleziono metryki",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/pt.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Gerir painéis do inquilino (importar a partir de definição, editar, publicar, arquivar, restaurar)",
     "Permission:Dashboards.Instances.Read": "Ler painéis do inquilino (lista e leitura por id, incluindo deteção de desvio)",
     "PermissionGroup:Dashboards": "Painéis",
+    "Widget:Error": "Falha ao renderizar o widget",
+    "Widget:Error.UnknownWidgetType": "Tipo de widget indisponível — o módulo que o fornece pode ter sido descarregado",
     "Widget:Unavailable": "Widget indisponível",
     "Widget:Unavailable.MapGeographyNotImplemented": "Widgets de mapa PostGIS ainda não suportados",
     "Widget:Unavailable.MetricNotFound": "Métrica não encontrada",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/sv.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Hantera klientspecifika instrumentpaneler (importera från definition, redigera, publicera, arkivera, återställa)",
     "Permission:Dashboards.Instances.Read": "Läsa klientspecifika instrumentpaneler (lista och läs efter id, inklusive driftdetektion)",
     "PermissionGroup:Dashboards": "Instrumentpaneler",
+    "Widget:Error": "Det gick inte att rendera widgeten",
+    "Widget:Error.UnknownWidgetType": "Widgettypen är inte tillgänglig — modulen som tillhandahåller den kan ha laddats ur",
     "Widget:Unavailable": "Widgeten är inte tillgänglig",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS-kartwidgetar stöds inte ännu",
     "Widget:Unavailable.MetricNotFound": "Mätvärdet hittades inte",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/tr.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "Kiracıya özel panoları yönet (tanımdan içe aktar, düzenle, yayınla, arşivle, geri yükle)",
     "Permission:Dashboards.Instances.Read": "Kiracıya özel panoları oku (liste ve id ile okuma, sürüm sapması tespiti dâhil)",
     "PermissionGroup:Dashboards": "Panolar",
+    "Widget:Error": "Widget oluşturulamadı",
+    "Widget:Error.UnknownWidgetType": "Widget türü kullanılamıyor — onu sağlayan modül kaldırılmış olabilir",
     "Widget:Unavailable": "Widget kullanılamıyor",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS harita widget'ları henüz desteklenmiyor",
     "Widget:Unavailable.MetricNotFound": "Metrik bulunamadı",

--- a/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
+++ b/src/Granit.Dashboards.Endpoints/Localization/DashboardsEndpoints/zh.json
@@ -5,6 +5,8 @@
     "Permission:Dashboards.Instances.Manage": "管理租户范围的仪表板（从定义导入、编辑、发布、归档、恢复）",
     "Permission:Dashboards.Instances.Read": "读取租户范围的仪表板（列表与按 id 读取，含偏移检测）",
     "PermissionGroup:Dashboards": "仪表板",
+    "Widget:Error": "小组件渲染失败",
+    "Widget:Error.UnknownWidgetType": "小组件类型不可用 — 提供该类型的模块可能已被卸载",
     "Widget:Unavailable": "小组件不可用",
     "Widget:Unavailable.MapGeographyNotImplemented": "PostGIS 地图小组件尚不支持",
     "Widget:Unavailable.MetricNotFound": "未找到指标",

--- a/src/Granit.Dashboards/Rendering/WidgetSnapshotEnvelope.cs
+++ b/src/Granit.Dashboards/Rendering/WidgetSnapshotEnvelope.cs
@@ -24,7 +24,7 @@ namespace Granit.Dashboards.Rendering;
 /// <param name="Sequence">Always <c>1</c> in pull mode; future push transport increments per (widget instance, tenant). Locked v1 per EPIC #1366 invariant #2.</param>
 /// <param name="EmittedAt">Server-side timestamp of the computation.</param>
 /// <param name="RefreshHint">Pull / push transport hint inherited from the underlying definition.</param>
-/// <param name="UnavailableReasonLocalizationKey">Localization key for the user-facing reason (e.g. <c>"Widget:Unavailable"</c>) when <see cref="Status"/> is <see cref="WidgetSnapshotStatus.Unavailable"/>; <see langword="null"/> otherwise.</param>
+/// <param name="ReasonLocalizationKey">Localization key for the user-facing reason — set on <see cref="WidgetSnapshotStatus.Unavailable"/> (e.g. <c>"Widget:Unavailable.MetricNotFound"</c>) and on <see cref="WidgetSnapshotStatus.Error"/> (e.g. <c>"Widget:Error.UnknownWidgetType"</c>); <see langword="null"/> on <see cref="WidgetSnapshotStatus.Snapshot"/>. The dashboard render endpoint never resolves the key server-side — the frontend is the only translation point so the same envelope can be cached across user locales.</param>
 public sealed record WidgetSnapshotEnvelope(
     WidgetSnapshotStatus Status,
     string WidgetType,
@@ -32,7 +32,7 @@ public sealed record WidgetSnapshotEnvelope(
     long Sequence,
     DateTimeOffset EmittedAt,
     RefreshHint RefreshHint,
-    string? UnavailableReasonLocalizationKey = null)
+    string? ReasonLocalizationKey = null)
 {
     /// <summary>Snapshot envelope — the typed payload is in <paramref name="snapshot"/>, status is <see cref="WidgetSnapshotStatus.Snapshot"/>.</summary>
     public static WidgetSnapshotEnvelope ForSnapshot(
@@ -52,11 +52,12 @@ public sealed record WidgetSnapshotEnvelope(
         string reasonLocalizationKey = "Widget:Unavailable")
         => new(WidgetSnapshotStatus.Unavailable, widgetType, Snapshot: null, sequence, emittedAt, refreshHint, reasonLocalizationKey);
 
-    /// <summary>Error envelope — the renderer threw. The dashboard bundle stays 200; the error is logged server-side, never surfaced verbatim to the client.</summary>
+    /// <summary>Error envelope — the renderer threw, or the widget's <c>WidgetType</c> has no registered renderer. The dashboard bundle stays 200; the error is logged server-side, never surfaced verbatim to the client.</summary>
     public static WidgetSnapshotEnvelope Error(
         string widgetType,
         long sequence,
         DateTimeOffset emittedAt,
-        RefreshHint refreshHint)
-        => new(WidgetSnapshotStatus.Error, widgetType, Snapshot: null, sequence, emittedAt, refreshHint);
+        RefreshHint refreshHint,
+        string reasonLocalizationKey = "Widget:Error")
+        => new(WidgetSnapshotStatus.Error, widgetType, Snapshot: null, sequence, emittedAt, refreshHint, reasonLocalizationKey);
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/ChartWidgetInstanceRendererTests.cs
@@ -49,7 +49,7 @@ public sealed class ChartWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Chart");
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
     }
 
     [Fact]

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/KpiWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/KpiWidgetInstanceRendererTests.cs
@@ -66,7 +66,7 @@ public sealed class KpiWidgetInstanceRendererTests
         envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
         envelope.EmittedAt.ShouldBe(Now);
         envelope.Sequence.ShouldBe(1);
-        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+        envelope.ReasonLocalizationKey.ShouldBeNull();
 
         envelope.Snapshot.ShouldNotBeNull();
         envelope.Snapshot!.Value.GetProperty("value").GetDecimal().ShouldBe(42m);
@@ -91,7 +91,7 @@ public sealed class KpiWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Kpi");
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotImplemented");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotImplemented");
         envelope.Snapshot.ShouldBeNull();
     }
 
@@ -112,7 +112,7 @@ public sealed class KpiWidgetInstanceRendererTests
         _telemetryEvaluator.LastDatasource.TelemetryKey.ShouldBe("temperature");
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public sealed class KpiWidgetInstanceRendererTests
         _metricEvaluator.Result = new KpiEvaluation(
             Payload: null,
             RefreshHint: RefreshHint.Static,
-            UnavailableReasonLocalizationKey: null);
+            ReasonLocalizationKey: null);
 
         WidgetSnapshotEnvelope envelope = await BuildRenderer().RenderAsync(
             BuildWidget("{\"kind\":\"metric\",\"metricName\":\"Granit.Test.Count\"}"),
@@ -132,7 +132,7 @@ public sealed class KpiWidgetInstanceRendererTests
             TestContext.Current.CancellationToken);
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable");
     }
 
     [Fact]

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
@@ -48,7 +48,7 @@ public sealed class MapWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Map");
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public sealed class MapWidgetInstanceRendererTests
             TestContext.Current.CancellationToken);
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MapGeographyNotImplemented");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.MapGeographyNotImplemented");
     }
 
     [Fact]

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MetricDatasourceEvaluatorTests.cs
@@ -52,7 +52,7 @@ public sealed class MetricDatasourceEvaluatorTests
         result.Payload.NoData.ShouldBeFalse();
         result.Payload.Previous.ShouldBeNull();
         result.RefreshHint.ShouldBe(RefreshHint.Dynamic);
-        result.UnavailableReasonLocalizationKey.ShouldBeNull();
+        result.ReasonLocalizationKey.ShouldBeNull();
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public sealed class MetricDatasourceEvaluatorTests
             TestContext.Current.CancellationToken);
 
         result.Payload.ShouldBeNull();
-        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
+        result.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
         result.RefreshHint.ShouldBe(RefreshHint.Static);
     }
 

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/PivotWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/PivotWidgetInstanceRendererTests.cs
@@ -48,7 +48,7 @@ public sealed class PivotWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Pivot");
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
     }
 
     [Fact]

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/StubDatasourceEvaluatorsTests.cs
@@ -59,7 +59,7 @@ public sealed class StubDatasourceEvaluatorsTests
             TestContext.Current.CancellationToken);
 
         result.Payload.ShouldBeNull();
-        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotFound");
+        result.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryAggregateNotFound");
         result.RefreshHint.ShouldBe(RefreshHint.Static);
     }
 
@@ -209,7 +209,7 @@ public sealed class StubDatasourceEvaluatorsTests
             TestContext.Current.CancellationToken);
 
         result.Payload.ShouldBeNull();
-        result.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
+        result.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.TelemetryNotImplemented");
         result.RefreshHint.ShouldBe(RefreshHint.Static);
     }
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/TableWidgetInstanceRendererTests.cs
@@ -49,7 +49,7 @@ public sealed class TableWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Table");
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.QueryNotFound");
     }
 
     [Fact]

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -58,7 +58,7 @@ public sealed class DashboardRenderProjectionTests
         w.RefreshHint.ShouldBe(RefreshHint.Dynamic);
         w.Snapshot.ShouldNotBeNull();
         w.Snapshot!.Value.GetProperty("value").GetInt32().ShouldBe(42);
-        w.UnavailableReasonLocalizationKey.ShouldBeNull();
+        w.ReasonLocalizationKey.ShouldBeNull();
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public sealed class DashboardRenderProjectionTests
         DashboardRenderedWidgetResponse w = response.Widgets[0];
         w.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         w.Snapshot.ShouldBeNull();
-        w.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
+        w.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.MetricNotFound");
     }
 
     [Theory]

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRendererTests.cs
@@ -103,6 +103,7 @@ public sealed class DashboardRendererTests
 
         result.Widgets[0].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Error);
         result.Widgets[0].Envelope.WidgetType.ShouldBe("PhantomKind");
+        result.Widgets[0].Envelope.ReasonLocalizationKey.ShouldBe("Widget:Error.UnknownWidgetType");
     }
 
     [Fact]
@@ -124,6 +125,7 @@ public sealed class DashboardRendererTests
         result.Widgets[0].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
         result.Widgets[1].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Error);
         result.Widgets[1].Envelope.WidgetType.ShouldBe("Boom");
+        result.Widgets[1].Envelope.ReasonLocalizationKey.ShouldBe("Widget:Error");
         result.Widgets[2].Envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
     }
 

--- a/tests/Granit.Dashboards.Endpoints.Tests/Rendering/MarkdownWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Rendering/MarkdownWidgetInstanceRendererTests.cs
@@ -40,7 +40,7 @@ public sealed class MarkdownWidgetInstanceRendererTests
         envelope.RefreshHint.ShouldBe(RefreshHint.Static);
         envelope.EmittedAt.ShouldBe(Now);
         envelope.Sequence.ShouldBe(1);
-        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+        envelope.ReasonLocalizationKey.ShouldBeNull();
 
         envelope.Snapshot.ShouldNotBeNull();
         envelope.Snapshot!.Value

--- a/tests/Granit.Dashboards.Tests/Rendering/WidgetSnapshotEnvelopeTests.cs
+++ b/tests/Granit.Dashboards.Tests/Rendering/WidgetSnapshotEnvelopeTests.cs
@@ -40,7 +40,7 @@ public sealed class WidgetSnapshotEnvelopeTests
         envelope.Sequence.ShouldBe(1);
         envelope.EmittedAt.ShouldBe(SampleTime);
         envelope.RefreshHint.ShouldBe(RefreshHint.Dynamic);
-        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+        envelope.ReasonLocalizationKey.ShouldBeNull();
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public sealed class WidgetSnapshotEnvelopeTests
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.WidgetType.ShouldBe("Chart");
         envelope.Snapshot.ShouldBeNull();
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable");
     }
 
     [Fact]
@@ -68,11 +68,11 @@ public sealed class WidgetSnapshotEnvelopeTests
             refreshHint: RefreshHint.Static,
             reasonLocalizationKey: "Widget:Unavailable.AliasUnresolved");
 
-        envelope.UnavailableReasonLocalizationKey.ShouldBe("Widget:Unavailable.AliasUnresolved");
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.AliasUnresolved");
     }
 
     [Fact]
-    public void Error_BuildsEnvelopeWithoutSnapshotOrReasonKey()
+    public void Error_BuildsEnvelopeWithoutSnapshot_AndDefaultReasonKey()
     {
         var envelope = WidgetSnapshotEnvelope.Error(
             widgetType: "Map",
@@ -83,7 +83,20 @@ public sealed class WidgetSnapshotEnvelopeTests
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Error);
         envelope.WidgetType.ShouldBe("Map");
         envelope.Snapshot.ShouldBeNull();
-        envelope.UnavailableReasonLocalizationKey.ShouldBeNull();
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Error");
+    }
+
+    [Fact]
+    public void Error_AcceptsCustomReasonKey()
+    {
+        var envelope = WidgetSnapshotEnvelope.Error(
+            widgetType: "Kpi",
+            sequence: 1,
+            emittedAt: SampleTime,
+            refreshHint: RefreshHint.Static,
+            reasonLocalizationKey: "Widget:Error.UnknownWidgetType");
+
+        envelope.ReasonLocalizationKey.ShouldBe("Widget:Error.UnknownWidgetType");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The dashboard render envelope's `Error` status had no localization key — only a status code. The frontend had to either hardcode a generic message or have a fallback. This PR closes that gap and aligns the field name with its actual semantics.

### Changes

1. **Rename `UnavailableReasonLocalizationKey` → `ReasonLocalizationKey`** on `WidgetSnapshotEnvelope`, the `DashboardRenderedWidgetResponse` DTO, and `KpiEvaluation`. The field is now used by both `Unavailable` and `Error` envelopes; the old name was misleading.
2. **`WidgetSnapshotEnvelope.Error()` now accepts an optional `reasonLocalizationKey`** (default `\"Widget:Error\"`). `DashboardRenderer` passes `\"Widget:Error.UnknownWidgetType\"` on the WidgetType-not-registered path, so the frontend can distinguish *module unloaded / version mismatch* from a generic *renderer crashed*.
3. **Two new localization keys** (`Widget:Error`, `Widget:Error.UnknownWidgetType`) added to the 15 base culture files of `Granit.Dashboards.Endpoints`. Regional files stay empty (translations match the parent locale, per Granit convention).
4. **Docs updated**: ADR-039 (envelope shape + status comments) and `dashboards/endpoints.mdx` (sample render payload).

### Why a wire rename is OK

Pre-1.0 — no consumer of the dashboard render endpoint exists yet (frontend integration is story B5, not yet started). Renaming `unavailableReasonLocalizationKey` → `reasonLocalizationKey` on the wire is a clean break with zero downstream impact.

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — green
- [x] `dotnet test  .github/shard-filters/business.slnf --no-build` — all green
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `WidgetSnapshotEnvelopeTests` — added a case for `Error_AcceptsCustomReasonKey`, updated the default-reason test to expect `\"Widget:Error\"`
- [x] `DashboardRendererTests` — pinned the two distinct error reason keys (UnknownWidgetType vs renderer-threw)