### PR TITLE
feat(analytics): MapWidget PostGIS path via opt-in Granit.Analytics.PostGIS (B8 #1568)

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -67,6 +67,7 @@
         "tests/Granit.Analytics.Abstractions.Tests",
         "tests/Granit.Analytics.EntityFrameworkCore.Tests",
         "tests/Granit.Analytics.Endpoints.Tests",
+        "tests/Granit.Analytics.PostGIS.Tests",
         "tests/Granit.Dashboards.Tests",
         "tests/Granit.Dashboards.Abstractions.Tests",
         "tests/Granit.Dashboards.EntityFrameworkCore.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -120,6 +120,13 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Analytics.PostGIS",
+      "deps": [
+        "Granit.Analytics"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Auditing",
       "deps": [
         "Granit",
@@ -4142,6 +4149,15 @@
       "members": []
     },
     {
+      "name": "IGeographyPointProjector",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.IGeographyPointProjector",
+      "kind": "interface",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/IGeographyPointProjector.cs",
+      "line": 26,
+      "members": []
+    },
+    {
       "name": "KpiWidgetDefinition",
       "fqn": "Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition",
       "kind": "record",
@@ -4323,7 +4339,7 @@
       "kind": "class",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddGranitAnalyticsWidgetRenderers",
@@ -4683,6 +4699,38 @@
           "kind": "method",
           "signature": "FromToken(string token)",
           "returnType": "PeriodSpec"
+        }
+      ]
+    },
+    {
+      "name": "GranitAnalyticsPostGISServiceCollectionExtensions",
+      "fqn": "Granit.Analytics.PostGIS.Extensions.GranitAnalyticsPostGISServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Analytics.PostGIS",
+      "file": "src/Granit.Analytics.PostGIS/Extensions/GranitAnalyticsPostGISServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitAnalyticsPostGIS",
+          "kind": "method",
+          "signature": "AddGranitAnalyticsPostGIS(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAnalyticsPostGISModule",
+      "fqn": "Granit.Analytics.PostGIS.GranitAnalyticsPostGISModule",
+      "kind": "class",
+      "project": "Granit.Analytics.PostGIS",
+      "file": "src/Granit.Analytics.PostGIS/GranitAnalyticsPostGISModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
         }
       ]
     },

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,8 +54,12 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.*" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.*" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.*" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.*" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.*" />
+  </ItemGroup>
+  <ItemGroup Label="Geospatial">
+    <PackageVersion Include="NetTopologySuite" Version="2.*" />
   </ItemGroup>
   <ItemGroup Label="Background Jobs">
     <PackageVersion Include="Cronos" Version="0.12.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-04-28
+Dernière mise à jour : 2026-04-29
 
 ---
 
@@ -143,11 +143,18 @@ Dernière mise à jour : 2026-04-28
 | ------- | ------- | --------- |
 | Scriban | 7.1.0 | Copyright (c) Alexandre Mutel |
 
+### BSD-3-Clause
+
+| Package | Version | Copyright |
+| ------- | ------- | --------- |
+| NetTopologySuite | 2.6.0 | Copyright (c) NetTopologySuite Team |
+
 ### PostgreSQL License
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
 | Npgsql.EntityFrameworkCore.PostgreSQL | 10.0.1 | Copyright 2025 The Npgsql Development Team |
+| Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite | 10.0.1 | Copyright 2025 The Npgsql Development Team |
 
 ---
 

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsRenderingServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Analytics.Dashboards.Widgets;
 using Granit.Analytics.Endpoints.Diagnostics;
 using Granit.Analytics.Endpoints.Internal;
 using Granit.Analytics.Endpoints.Rendering;
@@ -144,9 +145,14 @@ public static class AnalyticsRenderingServiceCollectionExtensions
                     typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
                 AnalyticsEndpointsMetrics metrics = sp.GetRequiredService<AnalyticsEndpointsMetrics>();
                 ICurrentTenant? currentTenant = sp.GetService<ICurrentTenant>();
+                // Optional Geography projector — registered by Granit.Analytics.PostGIS
+                // (or any other geography provider) per entity type. Absent on hosts
+                // that don't pull a provider; runner falls back to LatLng-only.
+                Type projectorType = typeof(IGeographyPointProjector<>).MakeGenericType(d.EntityType);
+                object? geographyProjector = sp.GetService(projectorType);
 
                 return (IMapRunner)Activator.CreateInstance(
-                    runnerType, d.Name, queryableSource, engine, metrics, currentTenant)!;
+                    runnerType, d.Name, queryableSource, engine, metrics, currentTenant, geographyProjector)!;
             });
         }
 

--- a/src/Granit.Analytics.Endpoints/Internal/IMapRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/IMapRunner.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
 
 namespace Granit.Analytics.Endpoints.Internal;
 
@@ -10,17 +11,22 @@ namespace Granit.Analytics.Endpoints.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// B7-2 ships the <c>MapPointSource.LatLng</c> path (decimal latitude /
-/// longitude columns) — works on any database. The PostGIS
-/// <c>MapPointSource.Geography</c> path is deferred (handled by the renderer
-/// returning <c>Unavailable</c>) until <c>granit-iot</c> ships the
-/// NetTopologySuite plumbing.
+/// Two coordinate flavours are dispatched internally based on the
+/// <see cref="MapPointSource"/> argument: <see cref="MapPointSource.LatLng"/>
+/// reflects two decimal columns (works on any database); the opt-in
+/// <see cref="MapPointSource.Geography"/> path resolves a registered
+/// <see cref="IGeographyPointProjector{TEntity}"/> to project a single PostGIS
+/// <c>geography(Point)</c> column. <see cref="SupportsGeography"/> tells the
+/// renderer whether the Geography path is wired up — when <see langword="false"/>,
+/// the renderer surfaces <c>Widget:Unavailable.MapGeographyNotImplemented</c>
+/// without invoking the runner.
 /// </para>
 /// <para>
 /// Streams the filtered entity set through
 /// <c>IQueryEngine.ExecuteStreamAsync</c> (multi-tenancy + soft-delete +
-/// dashboard filters apply, cap at <c>MaxStreamSize</c>). Acceptable for
-/// dashboard tile contexts which are bounded data products.
+/// dashboard filters apply, cap at <c>MaxStreamSize</c>). Coordinate validation
+/// is shared across both paths — invalid rows are dropped and counted on
+/// <c>granit.analytics.map.invalid_coordinates</c>.
 /// </para>
 /// </remarks>
 internal interface IMapRunner
@@ -29,20 +35,27 @@ internal interface IMapRunner
     string Name { get; }
 
     /// <summary>
+    /// <see langword="true"/> when an <see cref="IGeographyPointProjector{TEntity}"/>
+    /// is registered for the runner's entity type — the
+    /// <see cref="MapPointSource.Geography"/> path is honoured. <see langword="false"/>
+    /// when the runner is LatLng-only.
+    /// </summary>
+    bool SupportsGeography { get; }
+
+    /// <summary>
     /// Loads geocoded rows as map markers. Each marker carries lat/lng
     /// coordinates, an optional entity id (read from a <c>Guid Id</c>
     /// property when present), and an optional popup payload restricted to
     /// the whitelisted <paramref name="popupColumns"/>.
     /// </summary>
-    /// <param name="latitudeColumn">Property name of the latitude column on the entity.</param>
-    /// <param name="longitudeColumn">Property name of the longitude column on the entity.</param>
+    /// <param name="pointSource">Coordinate source — column pair (<see cref="MapPointSource.LatLng"/>) or PostGIS geography column (<see cref="MapPointSource.Geography"/>).</param>
     /// <param name="popupColumns">Whitelisted columns surfaced in the marker popup. <see langword="null"/> = no popup payload (only id + coords).</param>
     /// <param name="dashboardFilters">Dashboard-level filter spec layered on top of the QueryDefinition's filter pipeline — see <see cref="DashboardFilterTranslator"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <exception cref="ArgumentException">Latitude/longitude/popup column not declared on the entity, or coordinate column type is not <c>double</c> or <c>decimal</c>.</exception>
+    /// <exception cref="ArgumentException">Column not declared on the entity or wrong primitive type.</exception>
+    /// <exception cref="NotSupportedException"><paramref name="pointSource"/> is <see cref="MapPointSource.Geography"/> but <see cref="SupportsGeography"/> is <see langword="false"/>. Renderers should pre-check and surface <c>Unavailable</c> instead of letting this throw.</exception>
     Task<MapRunnerResult> ExecuteAsync(
-        string latitudeColumn,
-        string longitudeColumn,
+        MapPointSource pointSource,
         IReadOnlyList<string>? popupColumns,
         IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken);

--- a/src/Granit.Analytics.Endpoints/Internal/MapRunner.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MapRunner.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
 using Granit.Analytics.Endpoints.Diagnostics;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
@@ -28,7 +29,8 @@ internal sealed class MapRunner<TEntity>(
     IQueryableSource<TEntity> source,
     IQueryEngine<TEntity> engine,
     AnalyticsEndpointsMetrics metrics,
-    ICurrentTenant? currentTenant = null) : IMapRunner
+    ICurrentTenant? currentTenant = null,
+    IGeographyPointProjector<TEntity>? geographyProjector = null) : IMapRunner
     where TEntity : class
 {
     private const double LatitudeMin = -90d;
@@ -50,21 +52,33 @@ internal sealed class MapRunner<TEntity>(
     private readonly IQueryEngine<TEntity> _engine = engine;
     private readonly AnalyticsEndpointsMetrics _metrics = metrics;
     private readonly ICurrentTenant? _currentTenant = currentTenant;
+    private readonly IGeographyPointProjector<TEntity>? _geographyProjector = geographyProjector;
 
     public string Name { get; } = name;
 
+    public bool SupportsGeography => _geographyProjector is not null;
+
     public async Task<MapRunnerResult> ExecuteAsync(
-        string latitudeColumn,
-        string longitudeColumn,
+        MapPointSource pointSource,
         IReadOnlyList<string>? popupColumns,
         IReadOnlyDictionary<string, string>? dashboardFilters,
         CancellationToken cancellationToken)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(latitudeColumn);
-        ArgumentException.ThrowIfNullOrWhiteSpace(longitudeColumn);
+        ArgumentNullException.ThrowIfNull(pointSource);
 
-        PropertyInfo latProp = ResolveCoordinateProperty(latitudeColumn, nameof(latitudeColumn));
-        PropertyInfo lngProp = ResolveCoordinateProperty(longitudeColumn, nameof(longitudeColumn));
+        // Resolve the per-row coordinate extractor once, before streaming.
+        // LatLng path = reflect on two double/decimal columns; Geography path
+        // = delegate to the registered IGeographyPointProjector. Throwing
+        // NotSupportedException on Geography-without-projector is a safety
+        // net — renderers MUST pre-check SupportsGeography to surface the
+        // localised Unavailable instead.
+        Func<TEntity, (double Latitude, double Longitude)?> extractor = pointSource switch
+        {
+            MapPointSource.LatLng latLng => BuildLatLngExtractor(latLng),
+            MapPointSource.Geography geography => BuildGeographyExtractor(geography),
+            _ => throw new NotSupportedException(
+                $"MapPointSource '{pointSource.GetType().Name}' is not supported by MapRunner<{typeof(TEntity).Name}>."),
+        };
 
         PropertyInfo? idProp = typeof(TEntity).GetProperty(
             "Id",
@@ -92,20 +106,16 @@ internal sealed class MapRunner<TEntity>(
             .ExecuteStreamAsync(_source.GetQueryable(), request, cancellationToken)
             .ConfigureAwait(false))
         {
-            object? latRaw = latProp.GetValue(entity);
-            object? lngRaw = lngProp.GetValue(entity);
-
-            // Skip rows missing coordinates entirely — the marker would be
-            // pinned to (0, 0) which is misleading. Frontend never sees them.
-            if (latRaw is null || lngRaw is null)
+            // Skip rows whose coordinate source yields nothing — null lat/lng
+            // pair on LatLng path, or null Point on Geography path. The marker
+            // would be pinned to (0, 0) which is misleading. Frontend never
+            // sees them.
+            if (extractor(entity) is not { } coords)
             {
                 continue;
             }
 
-            double latitude = Convert.ToDouble(latRaw, CultureInfo.InvariantCulture);
-            double longitude = Convert.ToDouble(lngRaw, CultureInfo.InvariantCulture);
-
-            if (TryGetInvalidReason(latitude, longitude) is { } reason)
+            if (TryGetInvalidReason(coords.Latitude, coords.Longitude) is { } reason)
             {
                 _metrics.RecordMapInvalidCoordinate(ResolveTenantTag(), reason);
                 continue;
@@ -119,10 +129,52 @@ internal sealed class MapRunner<TEntity>(
                 ? BuildPopup(entity, popupProps)
                 : null;
 
-            points.Add(new MapRunnerPoint(id, latitude, longitude, popup));
+            points.Add(new MapRunnerPoint(id, coords.Latitude, coords.Longitude, popup));
         }
 
         return new MapRunnerResult(points);
+    }
+
+    /// <summary>Builds the LatLng-path coordinate extractor — reflects two double/decimal columns and converts via invariant culture.</summary>
+    private static Func<TEntity, (double Latitude, double Longitude)?> BuildLatLngExtractor(MapPointSource.LatLng latLng)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(latLng.LatitudeColumn);
+        ArgumentException.ThrowIfNullOrWhiteSpace(latLng.LongitudeColumn);
+
+        PropertyInfo latProp = ResolveCoordinateProperty(latLng.LatitudeColumn, nameof(latLng.LatitudeColumn));
+        PropertyInfo lngProp = ResolveCoordinateProperty(latLng.LongitudeColumn, nameof(latLng.LongitudeColumn));
+
+        return entity =>
+        {
+            object? latRaw = latProp.GetValue(entity);
+            object? lngRaw = lngProp.GetValue(entity);
+
+            if (latRaw is null || lngRaw is null)
+            {
+                return null;
+            }
+
+            double latitude = Convert.ToDouble(latRaw, CultureInfo.InvariantCulture);
+            double longitude = Convert.ToDouble(lngRaw, CultureInfo.InvariantCulture);
+            return (latitude, longitude);
+        };
+    }
+
+    /// <summary>Builds the Geography-path coordinate extractor — delegates to the registered <see cref="IGeographyPointProjector{TEntity}"/>.</summary>
+    private Func<TEntity, (double Latitude, double Longitude)?> BuildGeographyExtractor(MapPointSource.Geography geography)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(geography.GeographyColumn);
+
+        if (_geographyProjector is null)
+        {
+            throw new NotSupportedException(
+                $"MapRunner<{typeof(TEntity).Name}> received a Geography PointSource but no IGeographyPointProjector<{typeof(TEntity).Name}> is registered. " +
+                "Renderers should pre-check IMapRunner.SupportsGeography and surface 'Widget:Unavailable.MapGeographyNotImplemented' instead.");
+        }
+
+        IGeographyPointProjector<TEntity> projector = _geographyProjector;
+        string column = geography.GeographyColumn;
+        return entity => projector.TryProject(entity, column);
     }
 
     private static PropertyInfo ResolveCoordinateProperty(string fieldName, string paramName)

--- a/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
@@ -65,20 +65,6 @@ internal sealed class MapWidgetInstanceRenderer(
 
         DateTimeOffset emittedAt = _clock.Now;
 
-        // PostGIS path is deferred until granit-iot ships NetTopologySuite
-        // plumbing — the renderer never throws on the Geography pointSource;
-        // it surfaces a typed Unavailable so the dashboard renders the rest
-        // of its widgets normally.
-        if (config.PointSource is not MapPointSource.LatLng latLng)
-        {
-            return WidgetSnapshotEnvelope.Unavailable(
-                widgetType: WidgetType,
-                sequence: 1,
-                emittedAt: emittedAt,
-                refreshHint: RefreshHint.Static,
-                reasonLocalizationKey: "Widget:Unavailable.MapGeographyNotImplemented");
-        }
-
         if (!_mapService.TryGetRunner(widget.QueryName, out IMapRunner runner))
         {
             return WidgetSnapshotEnvelope.Unavailable(
@@ -89,9 +75,22 @@ internal sealed class MapWidgetInstanceRenderer(
                 reasonLocalizationKey: "Widget:Unavailable.QueryNotFound");
         }
 
+        // PostGIS path requires the host to pull `Granit.Analytics.PostGIS` —
+        // the runner reports SupportsGeography only when an
+        // IGeographyPointProjector<TEntity> is registered. Without it, surface
+        // the typed Unavailable so the dashboard keeps rendering the rest.
+        if (config.PointSource is MapPointSource.Geography && !runner.SupportsGeography)
+        {
+            return WidgetSnapshotEnvelope.Unavailable(
+                widgetType: WidgetType,
+                sequence: 1,
+                emittedAt: emittedAt,
+                refreshHint: RefreshHint.Static,
+                reasonLocalizationKey: "Widget:Unavailable.MapGeographyNotImplemented");
+        }
+
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: latLng.LatitudeColumn,
-            longitudeColumn: latLng.LongitudeColumn,
+            pointSource: config.PointSource,
             popupColumns: config.PopupColumns,
             dashboardFilters: context.DashboardFilters,
             cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Analytics.PostGIS/Extensions/GranitAnalyticsPostGISServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.PostGIS/Extensions/GranitAnalyticsPostGISServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.PostGIS.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Analytics.PostGIS.Extensions;
+
+/// <summary>
+/// DI registration helpers for <c>Granit.Analytics.PostGIS</c>.
+/// </summary>
+public static class GranitAnalyticsPostGISServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the open-generic <see cref="IGeographyPointProjector{TEntity}"/>
+    /// implementation. With this registration in place, the framework's
+    /// <c>MapRunner&lt;TEntity&gt;</c> resolves a projector for every entity that
+    /// has a <c>Granit.Analytics.QueryDefinition</c>, without per-entity wiring
+    /// in the host. Entities that don't expose a <c>NetTopologySuite.Geometries.Point</c>
+    /// column will get an <see cref="ArgumentException"/> at the first row of
+    /// the first render — the contract is "if you wire <c>Geography</c> on a
+    /// MapWidget, the entity must carry a Point property under the configured
+    /// column name".
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitAnalyticsPostGIS(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAdd(ServiceDescriptor.Scoped(
+            typeof(IGeographyPointProjector<>),
+            typeof(NtsGeographyPointProjector<>)));
+
+        return services;
+    }
+}

--- a/src/Granit.Analytics.PostGIS/Granit.Analytics.PostGIS.csproj
+++ b/src/Granit.Analytics.PostGIS/Granit.Analytics.PostGIS.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Analytics.PostGIS</PackageId>
+    <Description>NetTopologySuite-based geography point projector for Granit.Analytics MapWidget. Opt-in provider package — hosts that pull it unlock the MapPointSource.Geography path so a single PostGIS geography(Point) column can feed dashboard map widgets without duplicating coordinates into surface lat/lng columns. The base framework stays geospatial-free; consumers without PostGIS pay zero overhead.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Analytics.PostGIS.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics.EntityFrameworkCore.Tests.Integration" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetTopologySuite" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Analytics.PostGIS/GranitAnalyticsPostGISModule.cs
+++ b/src/Granit.Analytics.PostGIS/GranitAnalyticsPostGISModule.cs
@@ -1,0 +1,19 @@
+using Granit.Analytics.PostGIS.Extensions;
+using Granit.Modularity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Analytics.PostGIS;
+
+/// <summary>
+/// Granit module for the PostGIS / NetTopologySuite-based geography projector.
+/// Once loaded, the host's <c>MapWidget</c>s can use
+/// <see cref="Analytics.Dashboards.Widgets.MapPointSource.Geography"/> on any
+/// entity that exposes a <c>NetTopologySuite.Geometries.Point</c> column.
+/// </summary>
+[DependsOn(typeof(GranitAnalyticsModule))]
+public sealed class GranitAnalyticsPostGISModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitAnalyticsPostGIS();
+}

--- a/src/Granit.Analytics.PostGIS/Internal/NtsGeographyPointProjector.cs
+++ b/src/Granit.Analytics.PostGIS/Internal/NtsGeographyPointProjector.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using Granit.Analytics.Dashboards.Widgets;
+using NetTopologySuite.Geometries;
+
+namespace Granit.Analytics.PostGIS.Internal;
+
+/// <summary>
+/// <see cref="IGeographyPointProjector{TEntity}"/> implementation backed by
+/// NetTopologySuite. Reads the named property on the entity, expects a
+/// <see cref="Point"/> (the PostGIS <c>geography(Point)</c> mapping shipped by
+/// <c>Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite</c>), and returns
+/// <c>(latitude, longitude)</c> = <c>(Point.Y, Point.X)</c> per the WKT axis
+/// order convention NTS uses.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cached <see cref="PropertyInfo"/> lookups per (entity type, column name)
+/// keep the per-row reflection cost amortised — Map widgets typically iterate
+/// thousands of rows but read at most one geography column per render.
+/// </para>
+/// <para>
+/// Returning <see langword="null"/> on a null Point is intentional; the runner
+/// then drops the row silently. Out-of-range / non-finite coordinates ARE NOT
+/// validated here — that's <c>MapRunner</c>'s job (shared metric counter).
+/// </para>
+/// </remarks>
+internal sealed class NtsGeographyPointProjector<TEntity> : IGeographyPointProjector<TEntity>
+    where TEntity : class
+{
+    private readonly Dictionary<string, PropertyInfo> _propertyCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly System.Threading.Lock _cacheLock = new();
+
+    public (double Latitude, double Longitude)? TryProject(TEntity entity, string geographyColumn)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(geographyColumn);
+
+        PropertyInfo prop = ResolveProperty(geographyColumn);
+
+        object? raw = prop.GetValue(entity);
+        if (raw is null)
+        {
+            return null;
+        }
+
+        if (raw is not Point point)
+        {
+            throw new ArgumentException(
+                $"Property '{prop.Name}' on entity '{typeof(TEntity).Name}' is of type '{raw.GetType().Name}'. " +
+                $"NtsGeographyPointProjector requires a NetTopologySuite '{nameof(Point)}'. " +
+                $"For PostGIS, configure Npgsql with 'UseNetTopologySuite()' and map the column as 'geography(Point)'.",
+                nameof(geographyColumn));
+        }
+
+        // WKT axis order: X = longitude, Y = latitude.
+        return (Latitude: point.Y, Longitude: point.X);
+    }
+
+    private PropertyInfo ResolveProperty(string column)
+    {
+        lock (_cacheLock)
+        {
+            if (_propertyCache.TryGetValue(column, out PropertyInfo? cached))
+            {
+                return cached;
+            }
+
+            PropertyInfo? prop = typeof(TEntity).GetProperty(
+                column,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+            if (prop is null)
+            {
+                throw new ArgumentException(
+                    $"Property '{column}' not found on entity '{typeof(TEntity).Name}'.",
+                    nameof(column));
+            }
+
+            _propertyCache[column] = prop;
+            return prop;
+        }
+    }
+}

--- a/src/Granit.Analytics.PostGIS/README.md
+++ b/src/Granit.Analytics.PostGIS/README.md
@@ -1,0 +1,58 @@
+# Granit.Analytics.PostGIS
+
+Opt-in geography provider for the `MapWidget` shipped by `Granit.Analytics`.
+Once registered, hosts can configure a `MapWidgetDefinition` with a single
+PostGIS `geography(Point)` column instead of two surface `Latitude` / `Longitude`
+decimal columns — the existing schema is reused for dashboards without
+duplicating coordinates.
+
+## Why
+
+`Granit.Analytics` ships the `MapPointSource.LatLng` path on any database:
+two decimal columns, no special library, no provider lock-in. The
+`MapPointSource.Geography` path is opt-in because it pulls
+`NetTopologySuite` (BSD-3-Clause) — hosts that don't run on PostgreSQL +
+PostGIS pay zero overhead.
+
+Useful any time the host already stores location data in PostGIS:
+
+- Sales territories, customer addresses, branch offices.
+- Logistics: deliveries, route polylines.
+- Field operations: on-site interventions, asset locations.
+
+Real-time / live tracking (WebSocket-pushed device positions) lives in a
+separate epic — this package only handles the snapshot read path.
+
+## Usage
+
+```csharp
+builder.Services.AddGranitAnalyticsPostGIS();
+// + Npgsql with NetTopologySuite plugin on the consuming DbContext:
+builder.Services.AddDbContext<AppDbContext>(opt =>
+    opt.UseNpgsql(connectionString, o => o.UseNetTopologySuite()));
+```
+
+Then a `MapWidgetDefinition` configured with
+`new MapPointSource.Geography(GeographyColumn: "Location")` will project the
+`Location` `Point` column on the entity into the standard
+`{ lat, lng, id, popup }` snapshot — frontend code is unchanged.
+
+## What it ships
+
+- `IGeographyPointProjector<TEntity>` is the abstraction declared in
+  `Granit.Analytics`. This package provides the open-generic
+  `NtsGeographyPointProjector<TEntity>` implementation registered scoped via
+  `AddGranitAnalyticsPostGIS()`.
+- WGS84 axis-order convention (`Point.X` = longitude, `Point.Y` = latitude)
+  applied at the projection boundary.
+- Null `Point` rows are silently dropped (mirrors null lat/lng behaviour);
+  out-of-range coordinates are dropped and counted on the existing
+  `granit.analytics.map.invalid_coordinates` OTel counter.
+
+## Limits
+
+- Only `geography(Point)` is supported in v1. Polygons, line strings, and
+  spatial query operators (`ST_DWithin`, `ST_Within`) are out of scope —
+  follow-up stories.
+- Single-column projection per widget instance. A widget configured with two
+  coordinate columns must use `MapPointSource.LatLng`.

--- a/src/Granit.Analytics.PostGIS/packages.lock.json
+++ b/src/Granit.Analytics.PostGIS/packages.lock.json
@@ -1,0 +1,58 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "NetTopologySuite": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "1B1OTacTd4QtFyBeuIOcThwSSLUdRZU3bSFIwM8vk36XiZlBMi3K36u74e4OqwwHRHUuJC1PhbDx4hyI266X1Q=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.Analytics/Dashboards/Widgets/IGeographyPointProjector.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/IGeographyPointProjector.cs
@@ -1,0 +1,38 @@
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Projects a single geography column on <typeparamref name="TEntity"/> to a
+/// <c>(latitude, longitude)</c> pair. Implemented by provider-specific packages
+/// (e.g. <c>Granit.Analytics.PostGIS</c> wraps NetTopologySuite's <c>Point</c>);
+/// the base framework only declares the contract so the renderer dispatch site
+/// stays provider-agnostic.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projector returns <see langword="null"/> when the row carries no
+/// geometry (the column is null on this row). The
+/// <see cref="MapWidgetDefinition"/>'s renderer treats null projections the
+/// same as null lat/lng pairs — the row is silently dropped from the rendered
+/// snapshot, no exception leaks to the dashboard payload.
+/// </para>
+/// <para>
+/// Out-of-range / non-finite coordinates ARE NOT validated here — they flow
+/// through to <c>MapRunner</c>'s shared validation pipeline so the
+/// <c>granit.analytics.map.invalid_coordinates</c> counter increments
+/// uniformly across LatLng and Geography paths (B7 acceptance, PR #1505).
+/// </para>
+/// </remarks>
+/// <typeparam name="TEntity">The entity exposed by the backing <c>QueryDefinition</c>.</typeparam>
+public interface IGeographyPointProjector<in TEntity>
+    where TEntity : class
+{
+    /// <summary>
+    /// Extracts the <c>(latitude, longitude)</c> pair from <paramref name="entity"/>'s
+    /// configured geography column. Returns <see langword="null"/> when the
+    /// underlying geometry is null.
+    /// </summary>
+    /// <param name="entity">The row to project.</param>
+    /// <param name="geographyColumn">Name of the geography property to read.</param>
+    /// <exception cref="ArgumentException">The named property does not exist on <typeparamref name="TEntity"/> or is not a supported geography type.</exception>
+    (double Latitude, double Longitude)? TryProject(TEntity entity, string geographyColumn);
+}

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -551,11 +551,6 @@
           "System.CodeDom": "6.0.0"
         }
       },
-      "NetTopologySuite": {
-        "type": "Transitive",
-        "resolved": "2.5.0",
-        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
-      },
       "NetTopologySuite.IO.PostGis": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -999,6 +994,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
+      },
+      "NetTopologySuite": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
       },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
 using Granit.Analytics.Endpoints.Diagnostics;
 using Granit.Analytics.Endpoints.Internal;
 using Granit.MultiTenancy;
@@ -37,8 +38,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -65,8 +65,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "LatitudeNullable",
-            longitudeColumn: "LongitudeNullable",
+            pointSource: new MapPointSource.LatLng("LatitudeNullable", "LongitudeNullable"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -87,8 +86,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -112,8 +110,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: ["Name", "Country"],
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -133,8 +130,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -158,8 +154,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "LatitudeDecimal",
-            longitudeColumn: "LongitudeDecimal",
+            pointSource: new MapPointSource.LatLng("LatitudeDecimal", "LongitudeDecimal"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -176,8 +171,7 @@ public sealed class MapRunnerTests
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
-                latitudeColumn: "Name", // string column
-                longitudeColumn: "Longitude",
+                pointSource: new MapPointSource.LatLng("Name", "Longitude"), // "Name" is a string column
                 popupColumns: null,
                 dashboardFilters: null,
                 TestContext.Current.CancellationToken));
@@ -191,8 +185,7 @@ public sealed class MapRunnerTests
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
-                latitudeColumn: "NotAColumn",
-                longitudeColumn: "Longitude",
+                pointSource: new MapPointSource.LatLng("NotAColumn", "Longitude"),
                 popupColumns: null,
                 dashboardFilters: null,
                 TestContext.Current.CancellationToken));
@@ -208,8 +201,7 @@ public sealed class MapRunnerTests
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
-                latitudeColumn: "Latitude",
-                longitudeColumn: "Longitude",
+                pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
                 popupColumns: ["NotAColumn"],
                 dashboardFilters: null,
                 TestContext.Current.CancellationToken));
@@ -224,8 +216,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
 
         await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: new Dictionary<string, string> { ["Country"] = "FR" },
             TestContext.Current.CancellationToken);
@@ -268,8 +259,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics);
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
@@ -304,14 +294,108 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics);
 
         MapRunnerResult result = await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);
 
         result.Points.Count.ShouldBe(3);
         collector.GetMeasurementSnapshot().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SupportsGeography_FalseWhenNoProjector_TrueWhenInjected()
+    {
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runnerLatLngOnly = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        runnerLatLngOnly.SupportsGeography.ShouldBeFalse();
+
+        IGeographyPointProjector<TestItem> projector = Substitute.For<IGeographyPointProjector<TestItem>>();
+        MapRunner<TestItem> runnerWithGeography = new(
+            "Test.Items", new TestItemSource([]), engine, BuildMetrics(),
+            currentTenant: null, geographyProjector: projector);
+        runnerWithGeography.SupportsGeography.ShouldBeTrue();
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GeographyPointSource_DelegatesToProjector()
+    {
+        TestItem[] items =
+        [
+            new() { Id = Guid.NewGuid(), Name = "Has point" },
+            new() { Id = Guid.NewGuid(), Name = "Null point" },
+        ];
+
+        IGeographyPointProjector<TestItem> projector = Substitute.For<IGeographyPointProjector<TestItem>>();
+        projector.TryProject(items[0], "Position").Returns((Latitude: 48.85, Longitude: 2.35));
+        projector.TryProject(items[1], "Position").Returns((null as (double, double)?));
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(items), engine, BuildMetrics(),
+            currentTenant: null, geographyProjector: projector);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            pointSource: new MapPointSource.Geography("Position"),
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        // Null-point row dropped silently (mirrors null lat/lng behaviour).
+        result.Points.Count.ShouldBe(1);
+        result.Points[0].Latitude.ShouldBe(48.85);
+        result.Points[0].Longitude.ShouldBe(2.35);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GeographyPointSource_NoProjector_Throws()
+    {
+        // Renderer is supposed to pre-check SupportsGeography — this throw is
+        // a safety net for misconfigured callers, not the user-facing path.
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await runner.ExecuteAsync(
+                pointSource: new MapPointSource.Geography("Position"),
+                popupColumns: null,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GeographyPointSource_InvalidCoordinates_DroppedAndCounted()
+    {
+        // Coordinate validation runs uniformly across both paths — the
+        // projector returns the (lat, lng) and the runner applies WGS84
+        // bounds + finiteness checks. Counter increments with the same
+        // reason tags as the LatLng path.
+        TestItem[] items = [new() { Id = Guid.NewGuid(), Name = "OutOfRange" }];
+
+        IGeographyPointProjector<TestItem> projector = Substitute.For<IGeographyPointProjector<TestItem>>();
+        projector.TryProject(items[0], "Position").Returns((Latitude: 999d, Longitude: 0d));
+
+        using var scope = new MetricsScope();
+        using MetricCollector<long> collector = new(
+            scope.MeterFactory, AnalyticsEndpointsMetrics.MeterName, "granit.analytics.map.invalid_coordinates");
+
+        IQueryEngine<TestItem> engine = ConfigureStream(items);
+        MapRunner<TestItem> runner = new(
+            "Test.Items", new TestItemSource(items), engine, scope.Metrics,
+            currentTenant: null, geographyProjector: projector);
+
+        MapRunnerResult result = await runner.ExecuteAsync(
+            pointSource: new MapPointSource.Geography("Position"),
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points.ShouldBeEmpty();
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["reason"].ShouldBe("latitude_out_of_range");
     }
 
     [Fact]
@@ -332,8 +416,7 @@ public sealed class MapRunnerTests
         MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics, currentTenant);
 
         await runner.ExecuteAsync(
-            latitudeColumn: "Latitude",
-            longitudeColumn: "Longitude",
+            pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
             popupColumns: null,
             dashboardFilters: null,
             TestContext.Current.CancellationToken);

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Json;
 using Granit.Analytics;
+using Granit.Analytics.Dashboards.Widgets;
 using Granit.Analytics.Endpoints.Internal;
 using Granit.Analytics.Endpoints.Rendering;
 using Granit.Analytics.Metrics;
@@ -52,11 +53,12 @@ public sealed class MapWidgetInstanceRendererTests
     }
 
     [Fact]
-    public async Task RenderAsync_GeographyPointSource_ReturnsUnavailableUntilFollowUp()
+    public async Task RenderAsync_GeographyPointSource_NoProvider_ReturnsUnavailable()
     {
-        // PostGIS path is deferred — surface a typed Unavailable so the
-        // dashboard renders the rest of its widgets normally.
-        StubRunner runner = new("Granit.Test.Items", points: []);
+        // No host pulled Granit.Analytics.PostGIS — the runner reports
+        // SupportsGeography = false. The renderer surfaces a typed Unavailable
+        // so the dashboard renders the rest of its widgets normally.
+        StubRunner runner = new("Granit.Test.Items", points: [], supportsGeography: false);
         MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
 
         WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
@@ -68,6 +70,31 @@ public sealed class MapWidgetInstanceRendererTests
 
         envelope.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
         envelope.ReasonLocalizationKey.ShouldBe("Widget:Unavailable.MapGeographyNotImplemented");
+    }
+
+    [Fact]
+    public async Task RenderAsync_GeographyPointSource_WithProvider_DispatchesToRunner()
+    {
+        // Host pulled a geography provider — the runner reports
+        // SupportsGeography = true. The renderer hands off the PointSource
+        // unchanged; runner-side projection is exercised in MapRunnerTests.
+        var id = Guid.NewGuid();
+        StubRunner runner = new(
+            "Granit.Test.Items",
+            points: [new MapRunnerPoint(id, 48.85, 2.35, null)],
+            supportsGeography: true);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""geography"",""geographyColumn"":""Position""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        runner.LastPointSource.ShouldBeOfType<MapPointSource.Geography>();
+        ((MapPointSource.Geography)runner.LastPointSource!).GeographyColumn.ShouldBe("Position");
     }
 
     [Fact]
@@ -122,7 +149,7 @@ public sealed class MapWidgetInstanceRendererTests
     }
 
     [Fact]
-    public async Task RenderAsync_PassesPopupColumnsAndCoordinatesToRunner()
+    public async Task RenderAsync_PassesPopupColumnsAndPointSourceToRunner()
     {
         StubRunner runner = new("Granit.Test.Items", points: []);
         MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
@@ -134,8 +161,10 @@ public sealed class MapWidgetInstanceRendererTests
             BuildContext(),
             TestContext.Current.CancellationToken);
 
-        runner.LastLatitudeColumn.ShouldBe("Lat");
-        runner.LastLongitudeColumn.ShouldBe("Lng");
+        runner.LastPointSource.ShouldBeOfType<MapPointSource.LatLng>();
+        var latLng = (MapPointSource.LatLng)runner.LastPointSource!;
+        latLng.LatitudeColumn.ShouldBe("Lat");
+        latLng.LongitudeColumn.ShouldBe("Lng");
         runner.LastPopupColumns.ShouldBe(["Name", "Country"]);
     }
 
@@ -160,23 +189,25 @@ public sealed class MapWidgetInstanceRendererTests
             DashboardFilters: new Dictionary<string, string>(),
             ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
 
-    private sealed class StubRunner(string name, IReadOnlyList<MapRunnerPoint> points) : IMapRunner
+    private sealed class StubRunner(
+        string name,
+        IReadOnlyList<MapRunnerPoint> points,
+        bool supportsGeography = false) : IMapRunner
     {
         public string Name { get; } = name;
 
-        public string? LastLatitudeColumn { get; private set; }
-        public string? LastLongitudeColumn { get; private set; }
+        public bool SupportsGeography { get; } = supportsGeography;
+
+        public MapPointSource? LastPointSource { get; private set; }
         public IReadOnlyList<string>? LastPopupColumns { get; private set; }
 
         public Task<MapRunnerResult> ExecuteAsync(
-            string latitudeColumn,
-            string longitudeColumn,
+            MapPointSource pointSource,
             IReadOnlyList<string>? popupColumns,
             IReadOnlyDictionary<string, string>? dashboardFilters,
             CancellationToken cancellationToken)
         {
-            LastLatitudeColumn = latitudeColumn;
-            LastLongitudeColumn = longitudeColumn;
+            LastPointSource = pointSource;
             LastPopupColumns = popupColumns;
             return Task.FromResult(new MapRunnerResult(points));
         }

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/Granit.Analytics.EntityFrameworkCore.Tests.Integration.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" />
+    <PackageReference Include="NetTopologySuite" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
@@ -22,6 +24,7 @@
     <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics.Endpoints\Granit.Analytics.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Analytics.EntityFrameworkCore\Granit.Analytics.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.PostGIS\Granit.Analytics.PostGIS.csproj" />
     <ProjectReference Include="..\..\src\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Granit.QueryEngine\Granit.QueryEngine.csproj" />
     <ProjectReference Include="..\..\src\Granit.QueryEngine.EntityFrameworkCore\Granit.QueryEngine.EntityFrameworkCore.csproj" />

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
@@ -1,0 +1,114 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Endpoints.Diagnostics;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.PostGIS.Internal;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.Geometries;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// End-to-end test for B8 (#1568) — a <c>geography(Point)</c> column on a real
+/// PostGIS database, read by Npgsql's NetTopologySuite plugin, projected to
+/// lat/lng by <c>NtsGeographyPointProjector</c>, streamed through the
+/// QueryEngine pipeline by <c>MapRunner&lt;Branch&gt;</c>. Pinning the WKT
+/// axis order (X = lng, Y = lat) and the null-Point silent-skip behaviour on
+/// the actual database engine, not just the unit-tested projector.
+/// </summary>
+public sealed class MapPostGisIntegrationTests(PostGisFixture postgis)
+    : IClassFixture<PostGisFixture>, IAsyncLifetime
+{
+    private readonly PostGisFixture _postgis = postgis;
+    private TestDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private MapRunner<Branch> _runner = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseNpgsql(_postgis.ConnectionString, o => o.UseNetTopologySuite())
+            .Options;
+
+        _db = new TestDbContext(options);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+        await _db.Branches.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+
+        // Seed: Paris + London with a Point each, plus a row with null Location
+        // to assert the silent-skip path.
+        Branch[] seed =
+        [
+            new() { Id = Guid.NewGuid(), Name = "Paris HQ", Location = new Point(x: 2.3522, y: 48.8566) { SRID = 4326 } },
+            new() { Id = Guid.NewGuid(), Name = "London Office", Location = new Point(x: -0.1276, y: 51.5074) { SRID = 4326 } },
+            new() { Id = Guid.NewGuid(), Name = "Pending Office", Location = null },
+        ];
+        _db.Branches.AddRange(seed);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (_provider, IQueryEngine<Branch> engine) =
+            TestEngineFactory.Build<Branch, BranchQueryDefinition>();
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider metricsProvider = services.BuildServiceProvider();
+        AnalyticsEndpointsMetrics metrics = new(metricsProvider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        _runner = new MapRunner<Branch>(
+            name: "Test.Branches",
+            source: new BranchSource(_db),
+            engine: engine,
+            metrics: metrics,
+            currentTenant: null,
+            geographyProjector: new NtsGeographyPointProjector<Branch>());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _provider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Geography_ReadsPointColumn_ProjectsToWgs84LatLng()
+    {
+        _runner.SupportsGeography.ShouldBeTrue();
+
+        MapRunnerResult result = await _runner.ExecuteAsync(
+            pointSource: new MapPointSource.Geography("Location"),
+            popupColumns: ["Name"],
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        // Two points seeded with non-null Location, third row dropped.
+        result.Points.Count.ShouldBe(2);
+
+        MapRunnerPoint paris = result.Points.Single(p =>
+            Math.Abs(p.Latitude - 48.8566) < 0.0001 && Math.Abs(p.Longitude - 2.3522) < 0.0001);
+        paris.Popup.ShouldNotBeNull();
+        paris.Popup!.Value.GetProperty("name").GetString().ShouldBe("Paris HQ");
+
+        MapRunnerPoint london = result.Points.Single(p =>
+            Math.Abs(p.Latitude - 51.5074) < 0.0001 && Math.Abs(p.Longitude - (-0.1276)) < 0.0001);
+        london.Popup!.Value.GetProperty("name").GetString().ShouldBe("London Office");
+    }
+
+    [Fact]
+    public async Task Geography_NullPointRow_SilentlySkipped()
+    {
+        // Already covered as a side-effect by the test above (3 seeded, 2 returned),
+        // but keeping the explicit assertion close to the contract — null Point on
+        // any row MUST drop, not throw.
+        MapRunnerResult result = await _runner.ExecuteAsync(
+            pointSource: new MapPointSource.Geography("Location"),
+            popupColumns: null,
+            dashboardFilters: null,
+            TestContext.Current.CancellationToken);
+
+        result.Points.Count.ShouldBe(2);
+        result.Points.ShouldAllBe(p => p.Latitude >= -90 && p.Latitude <= 90);
+        result.Points.ShouldAllBe(p => p.Longitude >= -180 && p.Longitude <= 180);
+    }
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PostGisFixture.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PostGisFixture.cs
@@ -1,0 +1,24 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Boots a <c>postgis/postgis</c> container with the PostGIS extension already
+/// available — the parity check we need for B8 (#1568) is that the
+/// <c>NtsGeographyPointProjector</c> reading a <c>geography(Point)</c> column
+/// matches what the unit tests assert when projecting a NetTopologySuite
+/// <c>Point</c>. Separate from <see cref="PostgresFixture"/> so the empty-set
+/// parity tests don't pay the PostGIS image weight.
+/// </summary>
+public sealed class PostGisFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgis/postgis:17-3.5-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
@@ -21,10 +21,18 @@ internal sealed class Customer
     public decimal Revenue { get; init; }
 }
 
+internal sealed class Branch
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public NetTopologySuite.Geometries.Point? Location { get; init; }
+}
+
 internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
 {
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Branch> Branches => Set<Branch>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -34,6 +42,14 @@ internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : D
             e.HasKey(c => c.Id);
             e.Property(c => c.Country).HasMaxLength(64).IsRequired();
             e.Property(c => c.Status).HasMaxLength(64).IsRequired();
+        });
+        modelBuilder.Entity<Branch>(e =>
+        {
+            e.HasKey(b => b.Id);
+            e.Property(b => b.Name).HasMaxLength(128).IsRequired();
+            // Location uses Npgsql's NetTopologySuite plugin (UseNetTopologySuite()) —
+            // when the plugin is wired the column is mapped to geography(Point) by default.
+            // Property-level config beyond that is the host's responsibility.
         });
     }
 }
@@ -65,6 +81,22 @@ internal sealed class CustomerSource(TestDbContext db) : IQueryableSource<Custom
 {
     private readonly TestDbContext _db = db;
     public IQueryable<Customer> GetQueryable() => _db.Customers.AsNoTracking();
+}
+
+internal sealed class BranchQueryDefinition : QueryDefinition<Branch>
+{
+    public override string Name => "Test.Branches";
+
+    protected override void Configure(QueryDefinitionBuilder<Branch> builder) =>
+        builder
+            .Column(b => b.Name, c => c.Filterable())
+            .DefaultPageSize(50);
+}
+
+internal sealed class BranchSource(TestDbContext db) : IQueryableSource<Branch>
+{
+    private readonly TestDbContext _db = db;
+    public IQueryable<Branch> GetQueryable() => _db.Branches.AsNoTracking();
 }
 
 internal sealed class OrderAmountSumMetricDefinition : MetricDefinition<Order, decimal>

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -30,6 +30,12 @@
           "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
+      "NetTopologySuite": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "1B1OTacTd4QtFyBeuIOcThwSSLUdRZU3bSFIwM8vk36XiZlBMi3K36u74e4OqwwHRHUuJC1PhbDx4hyI266X1Q=="
+      },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -39,6 +45,16 @@
           "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
           "Npgsql": "10.0.2"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "Fcx8k5cSF7cGeXMeguLwyV+wTcKbmhojCse2WBXfHlEQNXILpI1My7H6rvPT8n3fI4TxZiYq/LWO2vVGBD3FHA==",
+        "dependencies": {
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.1",
+          "Npgsql.NetTopologySuite": "10.0.2"
         }
       },
       "Shouldly": {
@@ -251,6 +267,14 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "NetTopologySuite.IO.PostGis": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "3W8XTFz8iP6GQ5jDXK1/LANHiU+988k1kmmuPWNKcJLpmSg6CvFpbTpz+s4+LBzkAp64wHGOldSlkSuzYfrIKA==",
+        "dependencies": {
+          "NetTopologySuite": "[2.0.0, 3.0.0-A)"
+        }
+      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
@@ -262,6 +286,16 @@
         "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "WNM5ZHATFj0dSMJ/4vlbgMWBgP0ElMwsGiHR0PwzwflNS+IXbX8xxNZyLp4veCLcr5tDCWwMh9Lw7nwUxWkzvg==",
+        "dependencies": {
+          "NetTopologySuite": "2.6.0",
+          "NetTopologySuite.IO.PostGIS": "2.1.0",
+          "Npgsql": "10.0.2"
         }
       },
       "SharpZipLib": {
@@ -414,6 +448,13 @@
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.analytics.postgis": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "NetTopologySuite": "[2.*, )"
         }
       },
       "granit.authorization": {

--- a/tests/Granit.Analytics.PostGIS.Tests/Granit.Analytics.PostGIS.Tests.csproj
+++ b/tests/Granit.Analytics.PostGIS.Tests/Granit.Analytics.PostGIS.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NetTopologySuite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Analytics.PostGIS\Granit.Analytics.PostGIS.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Analytics.PostGIS.Tests/GranitAnalyticsPostGISServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Analytics.PostGIS.Tests/GranitAnalyticsPostGISServiceCollectionExtensionsTests.cs
@@ -1,0 +1,68 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.PostGIS.Extensions;
+using Granit.Analytics.PostGIS.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.PostGIS.Tests;
+
+/// <summary>
+/// Pins the public DI surface — once <see cref="GranitAnalyticsPostGISServiceCollectionExtensions.AddGranitAnalyticsPostGIS"/>
+/// is called, <see cref="IGeographyPointProjector{TEntity}"/> resolves to the
+/// NTS-backed implementation for any <c>TEntity</c>, scoped lifetime, and
+/// the registration is idempotent (TryAdd semantics).
+/// </summary>
+public sealed class GranitAnalyticsPostGISServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddGranitAnalyticsPostGIS_ResolvesNtsProjectorForAnyEntity()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalyticsPostGIS();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        IGeographyPointProjector<TestEntity> projector =
+            scope.ServiceProvider.GetRequiredService<IGeographyPointProjector<TestEntity>>();
+
+        projector.ShouldBeOfType<NtsGeographyPointProjector<TestEntity>>();
+    }
+
+    [Fact]
+    public void AddGranitAnalyticsPostGIS_IsIdempotent_DoesNotDoubleRegister()
+    {
+        ServiceCollection services = new();
+        services.AddGranitAnalyticsPostGIS();
+        services.AddGranitAnalyticsPostGIS();
+
+        services.Count(d => d.ServiceType == typeof(IGeographyPointProjector<>)).ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddGranitAnalyticsPostGIS_DoesNotOverridePreExistingRegistration()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(typeof(IGeographyPointProjector<>), typeof(CustomProjector<>));
+        services.AddGranitAnalyticsPostGIS();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        // TryAdd semantics: pre-existing registration wins.
+        scope.ServiceProvider.GetRequiredService<IGeographyPointProjector<TestEntity>>()
+            .ShouldBeOfType<CustomProjector<TestEntity>>();
+    }
+
+    private sealed class TestEntity
+    {
+        public string Code { get; init; } = string.Empty;
+    }
+
+    private sealed class CustomProjector<TEntity> : IGeographyPointProjector<TEntity>
+        where TEntity : class
+    {
+        public (double Latitude, double Longitude)? TryProject(TEntity entity, string geographyColumn) => null;
+    }
+}

--- a/tests/Granit.Analytics.PostGIS.Tests/NtsGeographyPointProjectorTests.cs
+++ b/tests/Granit.Analytics.PostGIS.Tests/NtsGeographyPointProjectorTests.cs
@@ -1,0 +1,99 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.PostGIS.Internal;
+using NetTopologySuite.Geometries;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.PostGIS.Tests;
+
+/// <summary>
+/// Locks the contract of <see cref="NtsGeographyPointProjector{TEntity}"/> —
+/// the WKT axis-order convention (X = lng, Y = lat), the null-Point fallback,
+/// and the typed error messages that surface when the host wires the projector
+/// against an entity that doesn't carry a NetTopologySuite <see cref="Point"/>.
+/// </summary>
+public sealed class NtsGeographyPointProjectorTests
+{
+    [Fact]
+    public void TryProject_PointPresent_ReturnsLatLng_HonouringWktAxisOrder()
+    {
+        // Paris: longitude 2.3522, latitude 48.8566. NTS Point uses (X=lng, Y=lat).
+        var point = new Point(x: 2.3522, y: 48.8566);
+        var entity = new Branch { Location = point };
+
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+        (double Latitude, double Longitude)? result = projector.TryProject(entity, "Location");
+
+        result.ShouldNotBeNull();
+        result!.Value.Latitude.ShouldBe(48.8566);
+        result.Value.Longitude.ShouldBe(2.3522);
+    }
+
+    [Fact]
+    public void TryProject_NullPoint_ReturnsNull()
+    {
+        var entity = new Branch { Location = null };
+
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+        (double Latitude, double Longitude)? result = projector.TryProject(entity, "Location");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryProject_ColumnNameIsCaseInsensitive()
+    {
+        var point = new Point(2.0, 1.0);
+        var entity = new Branch { Location = point };
+
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+        projector.TryProject(entity, "location").ShouldNotBeNull();
+        projector.TryProject(entity, "LOCATION").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void TryProject_UnknownColumn_Throws()
+    {
+        var entity = new Branch { Location = new Point(0, 0) };
+
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+
+        Should.Throw<ArgumentException>(() =>
+            projector.TryProject(entity, "NotAColumn")).Message.ShouldContain("NotAColumn");
+    }
+
+    [Fact]
+    public void TryProject_ColumnIsNotAPoint_Throws()
+    {
+        // The host wired the projector against a property that's not a NTS Point —
+        // produce a typed error pointing at the misconfiguration, not a NRE.
+        var entity = new Branch { Location = new Point(0, 0) };
+
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            projector.TryProject(entity, "Name"));
+        ex.Message.ShouldContain("Name");
+        ex.Message.ShouldContain("Point");
+    }
+
+    [Fact]
+    public void TryProject_NullEntity_Throws()
+    {
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+        Should.Throw<ArgumentNullException>(() => projector.TryProject(null!, "Location"));
+    }
+
+    [Fact]
+    public void TryProject_BlankColumn_Throws()
+    {
+        IGeographyPointProjector<Branch> projector = new NtsGeographyPointProjector<Branch>();
+        Should.Throw<ArgumentException>(() => projector.TryProject(new Branch(), ""));
+    }
+
+    private sealed class Branch
+    {
+        public string Name { get; init; } = "Test";
+        public Point? Location { get; init; }
+    }
+}

--- a/tests/Granit.Analytics.PostGIS.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.PostGIS.Tests/packages.lock.json
@@ -1,0 +1,275 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NetTopologySuite": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "1B1OTacTd4QtFyBeuIOcThwSSLUdRZU3bSFIwM8vk36XiZlBMi3K36u74e4OqwwHRHUuJC1PhbDx4hyI266X1Q=="
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.postgis": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "NetTopologySuite": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -867,11 +867,6 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
-      "NetTopologySuite": {
-        "type": "Transitive",
-        "resolved": "2.5.0",
-        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
-      },
       "NetTopologySuite.IO.PostGis": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -4465,6 +4460,12 @@
         "dependencies": {
           "Microsoft.Extensions.Http.Polly": "8.0.19"
         }
+      },
+      "NetTopologySuite": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -671,11 +671,6 @@
           "System.CodeDom": "6.0.0"
         }
       },
-      "NetTopologySuite": {
-        "type": "Transitive",
-        "resolved": "2.5.0",
-        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
-      },
       "NetTopologySuite.IO.PostGis": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -1258,6 +1253,12 @@
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
+      },
+      "NetTopologySuite": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
       },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -618,11 +618,6 @@
           "System.CodeDom": "6.0.0"
         }
       },
-      "NetTopologySuite": {
-        "type": "Transitive",
-        "resolved": "2.5.0",
-        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
-      },
       "NetTopologySuite.IO.PostGis": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -1191,6 +1186,12 @@
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
+      },
+      "NetTopologySuite": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Closes B8 (#1568) — the geography-column path of `MapWidget` that B7 (#1404) explicitly deferred. Hosts running on PostgreSQL + PostGIS can now reuse a single `geography(Point)` column directly, without duplicating coordinates into surface lat/lng decimals.

The use cases are not IoT-specific (which is why I pushed back on the original "deferred to granit-iot" framing): finance maps (invoices/customers by region), logistics (deliveries with route polylines), HR/operations (branch offices, on-site interventions). Real-time / live tracking remains out of scope and lives elsewhere.

## Architecture — provider sub-package, not nested under `.Endpoints`

The PostGIS implementation goes into `Granit.Analytics.PostGIS` — a new opt-in package that mirrors the existing `Granit.BlobStorage.S3` / `.AzureBlob` provider pattern. Domain logic stays out of the HTTP layer.

```text
src/Granit.Analytics/                # base — declares IGeographyPointProjector<T> abstraction
src/Granit.Analytics.Endpoints/      # HTTP — dispatches via the abstraction (no NTS dep)
src/Granit.Analytics.PostGIS/        # new opt-in provider — NetTopologySuite-backed projector
```

The follow-up architectural cleanup (sortir les autres widget runners de `.Endpoints`) is tracked in **#1569** — the smell pre-exists this PR; B8 doesn't crystallise it further.

## Wire shape — unchanged

A `MapWidgetDefinition` configured with `new MapPointSource.Geography(GeographyColumn: \"Location\")` produces the same `{ lat, lng, id, popup }` snapshot as the LatLng path. Frontend code is unchanged. WGS84 axis order applied at the projection boundary (`Point.X` = longitude, `Point.Y` = latitude per WKT).

## Behaviour matrix

| Host config | `MapPointSource` requested | Outcome |
| ----------- | ------------------------- | ------- |
| LatLng-only (no `.PostGIS` package) | LatLng | Unchanged — works |
| LatLng-only | Geography | `Widget:Unavailable.MapGeographyNotImplemented` (no behaviour regression) |
| `.PostGIS` registered | LatLng | Unchanged — works |
| `.PostGIS` registered | Geography | New path — projects via NTS |

Validation pipeline shared across both paths: null `Point` row silently dropped (mirrors null lat/lng); out-of-range / non-finite coordinates routed through the existing `granit.analytics.map.invalid_coordinates` OTel counter (PR #1505). One contract, two coordinate sources.

## Changes

- **`IGeographyPointProjector<TEntity>`** — 3-line abstraction in `Granit.Analytics`, declared at the base module per CLAUDE.md placement rule.
- **`Granit.Analytics.PostGIS`** — new package with `NtsGeographyPointProjector<TEntity>` impl, `AddGranitAnalyticsPostGIS()` DI extension, `GranitAnalyticsPostGISModule` module class, README.
- **`IMapRunner.ExecuteAsync`** signature: was `(latitudeColumn, longitudeColumn, ...)`, now `(MapPointSource, ...)`. Dispatch is internal; renderer pre-checks `IMapRunner.SupportsGeography` to surface `Unavailable` when no projector is wired.
- **DI registration** in `AddGranitAnalyticsWidgetRenderers` resolves the optional projector per descriptor; LatLng-only hosts pay zero overhead.

## Tests

- **`Granit.Analytics.PostGIS.Tests`** (10 new tests) — WKT axis order, null-Point fallback, case-insensitive column lookup, typed error on non-Point columns, DI registration + idempotency.
- **`MapRunnerTests`** (4 new tests) — `SupportsGeography` flag, dispatch via projector, `NotSupportedException` safety net when Geography requested without projector, shared invalid-coord counter on the Geography path.
- **`MapWidgetInstanceRendererTests`** — adapted: one test for the no-provider Unavailable path, one for the with-provider dispatch path.
- **`MapPostGisIntegrationTests`** — end-to-end against a `postgis/postgis:17-3.5-alpine` Testcontainer, `Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite` plugin wired so the EF column round-trips a real `geography(Point)`.

## Test plan

- [x] `dotnet build src/Granit.Analytics.PostGIS` — green
- [x] `dotnet test tests/Granit.Analytics.PostGIS.Tests --no-build` — 10 passed
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests --no-build` — 192 passed (was 188, +4 Geography MapRunner tests)
- [x] Architecture tests with fresh build — 191 passed (added README to new package to satisfy `Every_src_package_should_have_a_README`)
- [x] `dotnet format` clean on touched projects (src/tests)
- [x] Shard map updated (`tests/Granit.Analytics.PostGIS.Tests` → `business` shard) + `.slnf` regenerated
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed
- [x] `THIRD-PARTY-NOTICES.md` — NetTopologySuite (BSD-3-Clause) and `Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite` (PostgreSQL License) added; date bumped
- [ ] Integration test runs only in CI `integration` shard (Docker required) — local validation not possible without Docker Desktop. Same setup as the existing PostgreSQL parity tests.

## Follow-ups

- **#1569 (D5)** — refactor the existing 5 widget runners out of `.Endpoints` into `.EntityFrameworkCore`. The motivation surfaced explicitly during this story (a provider package shouldn't have to plug into a runner that lives in HTTP).
- Spatial query operators (`ST_DWithin`, `ST_Within`) on the OData feed — separate Feature C concern.