### PR TITLE
feat(odata): Granit.Http.ODataExposure — bridge QueryDefinition to OData v4 EntitySet (C1 #1390)

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -139,6 +139,7 @@
         "tests/Granit.Http.ExceptionHandling.Tests",
         "tests/Granit.Http.Abstractions.Tests",
         "tests/Granit.Http.Idempotency.Tests",
+        "tests/Granit.Http.ODataExposure.Tests",
         "tests/Granit.Http.OutputCaching.StackExchangeRedis.Tests",
         "tests/Granit.Http.OutputCaching.Tests",
         "tests/Granit.Http.Resilience.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -946,6 +946,16 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Http.ODataExposure",
+      "deps": [
+        "Granit",
+        "Granit.Authorization",
+        "Granit.Http.Abstractions",
+        "Granit.QueryEngine.Abstractions"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Http.OutputCaching",
       "deps": [
         "Granit"
@@ -20289,6 +20299,72 @@
       "project": "Granit.Http.Idempotency",
       "file": "src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "ODataExposureEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Http.ODataExposure.Extensions.ODataExposureEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "MapGranitODataEndpoints",
+          "kind": "method",
+          "signature": "MapGranitODataEndpoints(this IEndpointRouteBuilder endpoints, string prefix, Action<ODataExposureOptions> configure)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ODataExposureServiceCollectionExtensions",
+      "fqn": "Granit.Http.ODataExposure.Extensions.ODataExposureServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitODataExposure",
+          "kind": "method",
+          "signature": "AddGranitODataExposure(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpODataExposureModule",
+      "fqn": "Granit.Http.ODataExposure.GranitHttpODataExposureModule",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/GranitHttpODataExposureModule.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ODataEntitySetBuilder",
+      "fqn": "Granit.Http.ODataExposure.Options.ODataEntitySetBuilder",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs",
+      "line": 75,
+      "members": []
+    },
+    {
+      "name": "ODataExposureOptions",
+      "fqn": "Granit.Http.ODataExposure.Options.ODataExposureOptions",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs",
+      "line": 20,
       "members": []
     },
     {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup Label="ASP.NET Core">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*" />
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.4.*" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.*" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.*" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -149,6 +149,14 @@ Dernière mise à jour : 2026-04-29
 | ------- | ------- | --------- |
 | NetTopologySuite | 2.6.0 | Copyright (c) NetTopologySuite Team |
 
+### MIT (OData)
+
+| Package | Version | Copyright |
+| ------- | ------- | --------- |
+| Microsoft.AspNetCore.OData | 9.4.1 | Copyright (c) Microsoft Corporation |
+| Microsoft.OData.Core | 8.4.x | Copyright (c) Microsoft Corporation |
+| Microsoft.OData.Edm | 8.4.x | Copyright (c) Microsoft Corporation |
+
 ### PostgreSQL License
 
 | Package | Version | Copyright |

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+using Granit.Authorization;
+using Granit.Http.ODataExposure.Internal;
+using Granit.Http.ODataExposure.Options;
+using Granit.QueryEngine;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.OData.Edm;
+
+namespace Granit.Http.ODataExposure.Extensions;
+
+/// <summary>
+/// Wires registered <c>QueryDefinition&lt;TEntity&gt;</c> instances onto OData
+/// v4 EntitySets so external BI tools (Power BI / Excel / Tableau) can query
+/// the application via the standard "Get Data → OData feed" connector.
+/// </summary>
+public static class ODataExposureEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the configured OData EntitySets under <paramref name="prefix"/>.
+    /// Generates the EDM model at call time, exposes <c>$metadata</c> +
+    /// <c>$service-document</c>, and one <c>GET /{EntitySetName}</c> per
+    /// registered set. Each set's request flow is:
+    /// <list type="number">
+    ///   <item>Authentication — required by the surrounding pipeline (the framework's bearer token / DPoP).</item>
+    ///   <item>Permission gate — when the set declared one via <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/>.</item>
+    ///   <item>Resolve <c>IQueryableSource&lt;TEntity&gt;</c> — emits a queryable already filtered by tenant + soft-delete (via <c>ApplyGranitConventions</c> on the host's DbContext).</item>
+    ///   <item>Apply the <c>QueryDefinition</c> filter pipeline via <c>IQueryEngine.BuildFilteredQuery</c> with an empty <c>QueryRequest</c> — composes the framework's required filters.</item>
+    ///   <item>Layer the user's <c>$filter</c> / <c>$select</c> / <c>$top</c> / <c>$skip</c> / <c>$orderby</c> via <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> — user filters compose ON TOP of the framework filters, never bypassing them.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="endpoints">Endpoint route builder (the host's <c>app</c>).</param>
+    /// <param name="prefix">Route prefix mounted at, conventionally <c>"/api/granit/odata"</c>.</param>
+    /// <param name="configure">Configuration callback declaring EntitySets via <see cref="ODataExposureOptions"/>.</param>
+    /// <returns>The outer <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    /// <exception cref="ArgumentException">No EntitySet was declared in <paramref name="configure"/>.</exception>
+    public static RouteGroupBuilder MapGranitODataEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        string prefix,
+        Action<ODataExposureOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        ODataExposureOptions options = new();
+        configure(options);
+
+        if (options.Descriptors.Count == 0)
+        {
+            throw new ArgumentException(
+                "MapGranitODataEndpoints requires at least one EntitySet — call options.EntitySet<TEntity, TQueryDefinition>(name) inside the configure callback.",
+                nameof(configure));
+        }
+
+        IEdmModel edmModel = ODataEdmModelBuilder.Build(options.Descriptors);
+
+        RouteGroupBuilder root = endpoints.MapGroup(prefix).WithTags("OData");
+
+        // Service document + $metadata. Power BI Desktop reads $metadata to
+        // populate its "Navigator" picker; service-document is the human-
+        // readable index of EntitySet names.
+        root.MapODataServiceDocument("", edmModel)
+            .WithName("ODataServiceDocument")
+            .WithSummary("OData v4 service document — lists every exposed EntitySet with its metadata link.")
+            .WithDescription("Power BI / Excel / Tableau read this document to discover which EntitySets are available. Each set is queryable via the standard $filter / $select / $top / $skip / $orderby clauses.");
+
+        root.MapODataMetadata("$metadata", edmModel)
+            .WithName("ODataMetadata")
+            .WithSummary("OData v4 EDM metadata document (CSDL XML).")
+            .WithDescription("BI tools consume this CSDL document to populate their Navigator / table picker. The EDM is built from the application's registered QueryDefinition&lt;T&gt; instances.");
+
+        // Per-set GET route. Closed-generic Activator dance avoids a
+        // closed-generic registration per descriptor — same pattern the
+        // analytics widget runners use for IQueryEngine resolution.
+        foreach (ODataEntitySetDescriptor descriptor in options.Descriptors)
+        {
+            MethodInfo mapper = typeof(ODataExposureEndpointRouteBuilderExtensions)
+                .GetMethod(nameof(MapEntitySetRoute), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(descriptor.EntityType);
+
+            mapper.Invoke(null, [root, descriptor, edmModel]);
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// Wires one EntitySet's <c>GET /{EntitySetName}</c> route. Closed over
+    /// <typeparamref name="TEntity"/> via reflection from the dispatcher so
+    /// the runtime call stays generic-typed and compatible with
+    /// <c>ODataQueryOptions&lt;TEntity&gt;</c> minimal-API parameter binding.
+    /// </summary>
+    private static void MapEntitySetRoute<TEntity>(
+        RouteGroupBuilder root,
+        ODataEntitySetDescriptor descriptor,
+        IEdmModel edmModel)
+        where TEntity : class
+    {
+        RouteHandlerBuilder route = root.MapGet(descriptor.EntitySetName, async (
+                ODataQueryOptions<TEntity> options,
+                [FromServices] IQueryableSource<TEntity> source,
+                [FromServices] IQueryEngine<TEntity> engine,
+                [FromServices] IPermissionChecker permissionChecker,
+                CancellationToken cancellationToken) =>
+            {
+                if (descriptor.RequiredPermission is { } perm
+                    && !await permissionChecker.IsGrantedAsync(perm, cancellationToken).ConfigureAwait(false))
+                {
+                    return (IResult)TypedResults.Forbid();
+                }
+
+                // Step 1: tenant + soft-delete already applied on `source` (the
+                // host's IQueryableSource pulls from a DbContext that wired
+                // ApplyGranitConventions). Step 2: layer the QueryDefinition's
+                // filter pipeline. Step 3: apply OData query options on top.
+                IQueryable<TEntity> filtered = engine.BuildFilteredQuery(
+                    source.GetQueryable(), new QueryRequest());
+
+                IQueryable applied = options.ApplyTo(filtered);
+                return TypedResults.Ok(applied);
+            })
+            .WithODataModel(edmModel)
+            .WithODataResult();
+
+        route.WithName($"OData{descriptor.EntitySetName}List")
+             .WithSummary($"Returns the {descriptor.EntitySetName} EntitySet, filtered by the framework's tenant + soft-delete pipeline.")
+             .WithDescription($"OData v4 endpoint for the {descriptor.EntitySetName} set. Supports $filter, $select, $top, $skip, $orderby. Tenant and soft-delete filters are applied BEFORE any user $filter — the OData query never bypasses framework access control.")
+             .Produces(StatusCodes.Status200OK)
+             .ProducesProblem(StatusCodes.Status401Unauthorized)
+             .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        if (descriptor.RequiredPermission is not null)
+        {
+            // Authorization is enforced inline (permission checker) — keep
+            // the metadata in sync so OpenAPI schemas can hint at the gate
+            // even if the runtime check is the source of truth.
+            route.RequireAuthorization();
+        }
+    }
+}

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.OData;
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable IDE0058 // Expression value is never used — fluent ODataMiniOptions config returns the options instance
+
+namespace Granit.Http.ODataExposure.Extensions;
+
+/// <summary>
+/// DI registration helpers for <c>Granit.Http.ODataExposure</c>.
+/// </summary>
+public static class ODataExposureServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the OData runtime infrastructure required by
+    /// <see cref="ODataExposureEndpointRouteBuilderExtensions.MapGranitODataEndpoints"/>.
+    /// Enables the standard OData query features ($filter, $select, $top,
+    /// $skip, $orderby, $expand) so they are available on every exposed
+    /// EntitySet — per-set restrictions (e.g. expand whitelist, max top) are
+    /// applied per route in a follow-up story (#1392 / C3).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitODataExposure(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // AddOData wires the OData formatter, the ODataQueryOptions<T>
+        // parameter binder, and the routing helpers used by WithODataResult
+        // / WithODataModel. The .Mini variant lives directly on
+        // IServiceCollection (no MVC stack required) — this matters for
+        // minimal-API-only hosts. EnableAll() turns on every standard query
+        // option ($filter / $select / $top / $skip / $orderby / $expand /
+        // $count); per-route restrictions are layered via
+        // AddODataQueryEndpointFilter in #1392 / C3.
+        services.AddOData(opt => opt.EnableAll());
+
+        return services;
+    }
+}

--- a/src/Granit.Http.ODataExposure/Granit.Http.ODataExposure.csproj
+++ b/src/Granit.Http.ODataExposure/Granit.Http.ODataExposure.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Http.ODataExposure</PackageId>
+    <Description>Bridges registered Granit.QueryEngine QueryDefinition&lt;T&gt; instances to OData v4 EntitySets so Power BI / Excel / Tableau / Qlik can consume the application's data via the standard "Get Data → OData feed" connector. Every OData request flows through the existing Granit filter pipeline — tenant, soft-delete, and permission filters apply BEFORE any user-supplied $filter, $select, $expand. The framework's column whitelist (QueryDefinition.AllowedColumns) drives the EDM model so the OData schema mirrors the column-level access control. Direct read-replica SQL access to a multi-tenant database is explicitly rejected as a cross-tenant leak vector — OData is the only sanctioned BI bridge.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Http.ODataExposure.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OData" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Http.ODataExposure/GranitHttpODataExposureModule.cs
+++ b/src/Granit.Http.ODataExposure/GranitHttpODataExposureModule.cs
@@ -1,0 +1,20 @@
+using Granit.Authorization;
+using Granit.Http.ODataExposure.Extensions;
+using Granit.Modularity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Http.ODataExposure;
+
+/// <summary>
+/// Granit module for the OData v4 exposure layer. Once loaded, the host can
+/// call <c>endpoints.MapGranitODataEndpoints(prefix, opts =&gt; opts.EntitySet&lt;...&gt;)</c>
+/// to expose its registered <c>QueryDefinition&lt;T&gt;</c> instances as
+/// queryable EntitySets for Power BI, Excel, Tableau and Qlik.
+/// </summary>
+[DependsOn(typeof(GranitAuthorizationModule))]
+public sealed class GranitHttpODataExposureModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitODataExposure();
+}

--- a/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
@@ -1,0 +1,47 @@
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Builds an <see cref="IEdmModel"/> from the registered
+/// <see cref="ODataEntitySetDescriptor"/>s. Convention-based — all public
+/// CLR properties on the entity type appear on the EDM EntityType. Column
+/// pruning beyond that (e.g. masking <c>QueryDefinition.AllowedColumns</c>)
+/// is a follow-up; v1 mirrors the shape of the entity directly.
+/// </summary>
+internal static class ODataEdmModelBuilder
+{
+    /// <summary>
+    /// Builds the EDM model for the supplied descriptors.
+    /// </summary>
+    /// <param name="descriptors">EntitySet descriptors registered via the fluent options.</param>
+    /// <returns>The built <see cref="IEdmModel"/>, ready to wire into <c>WithODataModel</c>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="descriptors"/> is empty.</exception>
+    public static IEdmModel Build(IReadOnlyList<ODataEntitySetDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        if (descriptors.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one EntitySet must be registered before building the EDM model.",
+                nameof(descriptors));
+        }
+
+        ODataConventionModelBuilder builder = new();
+
+        foreach (ODataEntitySetDescriptor descriptor in descriptors)
+        {
+            // AddEntitySet wires both the EntityType (via reflection on the
+            // entity's public properties) AND the EntitySet declaration in a
+            // single call — the convention model builder picks up keys
+            // from properties named "Id" / "{Type}Id".
+            builder.AddEntitySet(
+                descriptor.EntitySetName,
+                builder.AddEntityType(descriptor.EntityType));
+        }
+
+        return builder.GetEdmModel();
+    }
+}

--- a/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
@@ -1,0 +1,18 @@
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Captures one EntitySet registration: the route segment, the CLR entity
+/// type, the <c>QueryDefinition&lt;TEntity&gt;</c> CLR type, and the optional
+/// permission gate. Built up by <see cref="Options.ODataExposureOptions"/>
+/// at host configuration time, consumed by the route helper to wire one
+/// minimal-API endpoint per set + the shared EDM model.
+/// </summary>
+/// <param name="EntitySetName">Route segment AND OData EntitySet name (e.g. <c>"Invoices"</c>).</param>
+/// <param name="EntityType">CLR type of the entity.</param>
+/// <param name="QueryDefinitionType">CLR type of the <c>QueryDefinition&lt;TEntity&gt;</c> backing this set — resolved through DI at request time.</param>
+/// <param name="RequiredPermission">Permission name a request must carry to read this EntitySet, or <see langword="null"/> if any authenticated user is allowed (auth itself is enforced by the surrounding pipeline).</param>
+internal sealed record ODataEntitySetDescriptor(
+    string EntitySetName,
+    Type EntityType,
+    Type QueryDefinitionType,
+    string? RequiredPermission);

--- a/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
+++ b/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
@@ -1,0 +1,101 @@
+using Granit.Http.ODataExposure.Internal;
+using Granit.QueryEngine;
+
+namespace Granit.Http.ODataExposure.Options;
+
+/// <summary>
+/// Fluent registration surface for OData EntitySets. The host code that
+/// invokes <c>endpoints.MapGranitODataEndpoints(prefix, opts =&gt; ...)</c>
+/// receives this object and declares one EntitySet per
+/// <c>QueryDefinition&lt;TEntity&gt;</c> it wants exposed to BI tools.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Order of operations: the closure runs ONCE at <c>Map*</c> time, the EDM
+/// model is built from every <see cref="EntitySet{TEntity, TQueryDefinition}"/>
+/// call, then per-set minimal-API endpoints are registered. Adding a
+/// definition after the closure returns has no effect on routing.
+/// </para>
+/// </remarks>
+public sealed class ODataExposureOptions
+{
+    private readonly List<ODataEntitySetDescriptor> _descriptors = [];
+
+    /// <summary>
+    /// All EntitySets registered so far. Internal — consumed by the route
+    /// builder once the configuration closure returns.
+    /// </summary>
+    internal IReadOnlyList<ODataEntitySetDescriptor> Descriptors => _descriptors;
+
+    /// <summary>
+    /// Registers an EntitySet backed by <typeparamref name="TQueryDefinition"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type — appears as an EntityType in the EDM model.</typeparam>
+    /// <typeparam name="TQueryDefinition">The <c>QueryDefinition&lt;TEntity&gt;</c> shipped by the owning module — resolved through DI at request time so the framework's filter pipeline applies.</typeparam>
+    /// <param name="entitySetName">OData EntitySet name and route segment. Convention: PascalCase plural noun (<c>"Invoices"</c>, <c>"Customers"</c>).</param>
+    /// <returns>A builder for chaining further configuration on this set.</returns>
+    /// <exception cref="ArgumentException"><paramref name="entitySetName"/> is empty or already registered in this options instance.</exception>
+    public ODataEntitySetBuilder<TEntity> EntitySet<TEntity, TQueryDefinition>(string entitySetName)
+        where TEntity : class
+        where TQueryDefinition : QueryDefinition<TEntity>
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entitySetName);
+
+        if (_descriptors.Any(d => string.Equals(d.EntitySetName, entitySetName, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                $"EntitySet '{entitySetName}' is already registered.",
+                nameof(entitySetName));
+        }
+
+        ODataEntitySetDescriptor descriptor = new(
+            EntitySetName: entitySetName,
+            EntityType: typeof(TEntity),
+            QueryDefinitionType: typeof(TQueryDefinition),
+            RequiredPermission: null);
+
+        _descriptors.Add(descriptor);
+        return new ODataEntitySetBuilder<TEntity>(this, descriptor);
+    }
+
+    /// <summary>Replaces a descriptor in-place. Used by <see cref="ODataEntitySetBuilder{TEntity}"/> for fluent updates.</summary>
+    internal void Replace(ODataEntitySetDescriptor old, ODataEntitySetDescriptor updated)
+    {
+        int index = _descriptors.IndexOf(old);
+        if (index < 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot replace descriptor for EntitySet '{old.EntitySetName}' — original instance not tracked.");
+        }
+        _descriptors[index] = updated;
+    }
+}
+
+/// <summary>Fluent builder returned by <see cref="ODataExposureOptions.EntitySet{TEntity, TQueryDefinition}"/>.</summary>
+public sealed class ODataEntitySetBuilder<TEntity>
+    where TEntity : class
+{
+    private readonly ODataExposureOptions _options;
+    private ODataEntitySetDescriptor _descriptor;
+
+    internal ODataEntitySetBuilder(ODataExposureOptions options, ODataEntitySetDescriptor descriptor)
+    {
+        _options = options;
+        _descriptor = descriptor;
+    }
+
+    /// <summary>
+    /// Gates this EntitySet behind the named permission. The permission is
+    /// checked by the route's authorization pipeline before the OData query
+    /// runs. Convention: <c>"OData.{Module}.{Entity}.Read"</c> per CLAUDE.md.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> RequirePermission(string permission)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+
+        ODataEntitySetDescriptor updated = _descriptor with { RequiredPermission = permission };
+        _options.Replace(_descriptor, updated);
+        _descriptor = updated;
+        return this;
+    }
+}

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -1,0 +1,76 @@
+# Granit.Http.ODataExposure
+
+Bridges registered `QueryDefinition<TEntity>` instances to OData v4 EntitySets
+so external BI tools (Power BI, Excel, Tableau, Qlik) can consume the
+application's data via the standard "Get Data → OData feed" connector. No
+custom connector, no read-replica SQL access, no bypass of multi-tenancy.
+
+## Why
+
+Granting BI tools direct read-only SQL access to a multi-tenant production
+database is a common industry pattern and a common cause of cross-tenant
+leaks: one missing `WHERE tenant_id = …` in a custom view and a tenant reads
+another tenant's data. This package is the only sanctioned bridge for the
+Granit framework — every OData request flows through the same filter
+pipeline as the application's own grid endpoints, inheriting tenant
+filtering, soft-delete, and per-EntitySet permissions.
+
+## Usage
+
+```csharp
+// Program.cs
+builder.Services
+    .AddGranitOData()                // wires the OData runtime + ODataQueryOptions<T> binding
+    .AddGranitQueryEngine()          // host's existing QueryEngine registration
+    .AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
+
+// after authentication + authorization middleware
+app.MapGranitODataEndpoints("/api/granit/odata", opts =>
+{
+    opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+        .RequirePermission("OData.Invoicing.Invoices.Read");
+
+    opts.EntitySet<Customer, CustomerQueryDefinition>("Customers")
+        .RequirePermission("OData.Invoicing.Customers.Read");
+});
+```
+
+Power BI Desktop then connects via *Get Data → OData feed* with the URL
+`https://your-app/api/granit/odata` — discovers `Invoices` and `Customers`
+through the OData service document, queries them with `$filter` /
+`$select` / `$top` / `$orderby`, and never sees rows belonging to other
+tenants.
+
+## Request flow
+
+Per EntitySet `GET /api/granit/odata/{Name}?$filter=…&$select=…&$top=…`:
+
+1. **Authentication** — enforced by the surrounding pipeline (the framework's
+   bearer token / DPoP setup).
+2. **Permission gate** — when the EntitySet declared one via
+   `RequirePermission(...)`, the route returns `403` if the user lacks it.
+3. **`IQueryableSource<TEntity>`** is resolved from DI — emits an
+   `IQueryable<TEntity>` already filtered by the host's
+   `ApplyGranitConventions` (tenant + soft-delete).
+4. **`IQueryEngine.BuildFilteredQuery(source, new QueryRequest())`** layers
+   the `QueryDefinition`'s filter pipeline (presets, quick filters, global
+   search). User filters compose ON TOP of these — never instead of them.
+5. **`ODataQueryOptions<TEntity>.ApplyTo(filtered)`** layers the user's
+   `$filter` / `$select` / `$top` / `$skip` / `$orderby` on top.
+
+The order is load-bearing: tenant first, framework filters second, user
+query third.
+
+## Limits
+
+- v1 is read-only — no `POST` / `PATCH` / `DELETE` per EntitySet.
+- v1 ships collection access (`GET /Invoices`); single-entity-by-key access
+  (`GET /Invoices(<id>)`) is deferred upstream — see
+  [OData/AspNetCoreOData#1567](https://github.com/OData/AspNetCoreOData/issues/1567).
+- `$expand` whitelist + `$top` / `$count` throttling + rate-limiting are
+  follow-up scope (story C3 / #1392).
+- Native `Microsoft.AspNetCore.OpenApi` does not produce a complete OData
+  schema (upstream [#1381](https://github.com/OData/AspNetCoreOData/issues/1381));
+  the OData metadata document at `/{prefix}/$metadata` (CSDL XML) is the
+  authoritative discovery surface — Power BI / Excel / Tableau consume it
+  natively.

--- a/src/Granit.Http.ODataExposure/packages.lock.json
+++ b/src/Granit.Http.ODataExposure/packages.lock.json
@@ -1,0 +1,146 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.OData": {
+        "type": "Direct",
+        "requested": "[9.4.*, )",
+        "resolved": "9.4.1",
+        "contentHash": "PXyuPnC7p3ic5sgO9ydNqpKd+hXRMErGXfBPeptTWjXfdBWec97cv1fDFLiCKR1Wm4LeG4Yjcap+xk7XNdfsNw==",
+        "dependencies": {
+          "Microsoft.OData.Core": "[8.4.0, 9.0.0)",
+          "Microsoft.OData.Edm": "[8.4.0, 9.0.0)",
+          "Microsoft.OData.ModelBuilder": "[2.0.0, 3.0.0)",
+          "Microsoft.Spatial": "[8.4.0, 9.0.0)"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      },
+      "Microsoft.OData.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "gt/iiI1AJ7HyI2OZkw84lJxSedUxBdRqPUUlVrkObwolX4T278EBoYQ6ZdXgeb9hDwpUjFlGBYOlHnxnlXmpwQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.OData.Edm": "[8.4.0]",
+          "Microsoft.Spatial": "[8.4.0]"
+        }
+      },
+      "Microsoft.OData.Edm": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "7tqryp5v/XQ/NIKck6lT6jZBAQonv/+N305Xc4uMdT6nQyq/J3hdvx/wvQAeaRe9RjA44MD3wRqN4wECfYTShA=="
+      },
+      "Microsoft.OData.ModelBuilder": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QzySAMGhLCMyLNHSTIYKFjJXetoDeGkRS/7JEjm7eMJlyu1Qv4MfL1CXQFg2uijizNu2jQojT0mdCpawXbyv8Q==",
+        "dependencies": {
+          "Microsoft.OData.Edm": "[8.0.0, 9.0.0)",
+          "Microsoft.Spatial": "[8.0.0, 9.0.0)",
+          "System.ComponentModel.Annotations": "4.6.0"
+        }
+      },
+      "Microsoft.Spatial": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "F/n0Bd8SHmMtCCaBngmeaopeALr9YuZn3ocWBsSKqDMmcOb8W8P1paSy7WPq1IRYQSK0SRlPWUCxxcRVjTFF7g=="
+      },
+      "System.ComponentModel.Annotations": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "pOd+UhZ3X8xfwKDlgAzowUJNjp8VYVmOHZm++vCd0kq1HZ0zK3mNo2yRXjYgv7Ik/Xi43fmJfND2PLEsQSALCg=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.abstractions": {
+        "type": "Project"
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/Granit.Http.ODataExposure.Tests.csproj
+++ b/tests/Granit.Http.ODataExposure.Tests/Granit.Http.ODataExposure.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Http.ODataExposure\Granit.Http.ODataExposure.csproj" />
+    <ProjectReference Include="..\..\src\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
@@ -1,0 +1,87 @@
+using Granit.Http.ODataExposure.Internal;
+using Microsoft.OData.Edm;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// Locks the EDM model shape produced by the convention-based builder — one
+/// EntitySet per descriptor, EntityType columns mirror the public CLR
+/// properties, key auto-detected on the <c>Id</c> property. These shape
+/// guarantees feed Power BI / Excel directly via <c>$metadata</c>.
+/// </summary>
+public sealed class ODataEdmModelBuilderTests
+{
+    [Fact]
+    public void Build_SingleEntitySet_RegistersInTheModel()
+    {
+        ODataEntitySetDescriptor descriptor = new(
+            EntitySetName: "Invoices",
+            EntityType: typeof(Invoice),
+            QueryDefinitionType: typeof(string), // unused by the EDM builder
+            RequiredPermission: null);
+
+        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+
+        IEdmEntitySet? set = model.EntityContainer.FindEntitySet("Invoices");
+        set.ShouldNotBeNull();
+        set!.EntityType.Name.ShouldBe(nameof(Invoice));
+    }
+
+    [Fact]
+    public void Build_MultipleEntitySets_AllAppearInTheContainer()
+    {
+        ODataEntitySetDescriptor[] descriptors =
+        [
+            new("Invoices", typeof(Invoice), typeof(string), null),
+            new("Customers", typeof(Customer), typeof(string), "OData.Test.Customers.Read"),
+        ];
+
+        IEdmModel model = ODataEdmModelBuilder.Build(descriptors);
+
+        model.EntityContainer.FindEntitySet("Invoices").ShouldNotBeNull();
+        model.EntityContainer.FindEntitySet("Customers").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Build_EntityType_ExposesPublicProperties()
+    {
+        ODataEntitySetDescriptor descriptor = new(
+            "Invoices", typeof(Invoice), typeof(string), null);
+
+        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+
+        var entityType = (IEdmEntityType)model.EntityContainer.FindEntitySet("Invoices")!.EntityType;
+        IReadOnlyList<string> propertyNames = [.. entityType.Properties().Select(p => p.Name)];
+
+        propertyNames.ShouldContain(nameof(Invoice.Id));
+        propertyNames.ShouldContain(nameof(Invoice.Number));
+        propertyNames.ShouldContain(nameof(Invoice.Total));
+    }
+
+    [Fact]
+    public void Build_EmptyDescriptorList_Throws()
+    {
+        Should.Throw<ArgumentException>(() => ODataEdmModelBuilder.Build([]));
+    }
+
+    [Fact]
+    public void Build_NullDescriptors_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!));
+    }
+
+    private sealed class Invoice
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+        public decimal Total { get; init; }
+    }
+
+    private sealed class Customer
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
@@ -1,0 +1,106 @@
+using Granit.Http.ODataExposure.Options;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// Pins the fluent-options surface — duplicate-set rejection, builder
+/// mutations, and the contract that every registered EntitySet appears
+/// once in the descriptor list (consumed downstream by the EDM model
+/// builder + the per-set route mapper).
+/// </summary>
+public sealed class ODataExposureOptionsTests
+{
+    [Fact]
+    public void EntitySet_RegistersOneDescriptor()
+    {
+        ODataExposureOptions options = new();
+
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        options.GetType().GetProperty("Descriptors", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            !.GetValue(options).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void EntitySet_DuplicateName_Throws()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices"));
+
+        ex.Message.ShouldContain("Invoices");
+    }
+
+    [Fact]
+    public void EntitySet_DuplicateName_CaseInsensitive_Throws()
+    {
+        // EntitySet names round-trip through the OData URL — the protocol is
+        // case-insensitive on the segment, so duplicates that differ only in
+        // case must be rejected to avoid silent overrides.
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        Should.Throw<ArgumentException>(() =>
+            options.EntitySet<Invoice, InvoiceQueryDefinition>("invoices"));
+    }
+
+    [Fact]
+    public void EntitySet_BlankName_Throws()
+    {
+        ODataExposureOptions options = new();
+
+        Should.Throw<ArgumentException>(() =>
+            options.EntitySet<Invoice, InvoiceQueryDefinition>(""));
+    }
+
+    [Fact]
+    public void RequirePermission_PersistsOnTheDescriptor()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .RequirePermission("OData.Invoicing.Invoices.Read");
+
+        // Descriptors is internal — accessing via the same internals-visible
+        // assembly. Use reflection to keep the test in this file readable
+        // without leaking a public testing seam.
+        object? descriptorList = options.GetType()
+            .GetProperty("Descriptors", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(options);
+
+        // Shape check via dynamic — the test surface is the runtime behaviour,
+        // not the generic structure.
+        object first = ((System.Collections.IEnumerable)descriptorList!)
+            .Cast<object>()
+            .Single();
+        string? perm = (string?)first.GetType().GetProperty("RequiredPermission")!.GetValue(first);
+        perm.ShouldBe("OData.Invoicing.Invoices.Read");
+    }
+
+    [Fact]
+    public void RequirePermission_BlankPermission_Throws()
+    {
+        ODataExposureOptions options = new();
+        ODataEntitySetBuilder<Invoice> builder = options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        Should.Throw<ArgumentException>(() => builder.RequirePermission(""));
+    }
+
+    private sealed class Invoice
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+    }
+
+    private sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
+    {
+        public override string Name => "Test.Invoices";
+
+        protected override void Configure(QueryDefinitionBuilder<Invoice> builder) =>
+            builder.Column(i => i.Number, c => c.Filterable());
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
+++ b/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
@@ -1,0 +1,492 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "IbQUEZr/LxxpPxkXDmKaemMeQNPjdHfk87HtTsI18a3RVgad0NOJSRaJ20hcesqL45PLcpQHR8xrPP7wZKbFQQ=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.OData.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "gt/iiI1AJ7HyI2OZkw84lJxSedUxBdRqPUUlVrkObwolX4T278EBoYQ6ZdXgeb9hDwpUjFlGBYOlHnxnlXmpwQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.ObjectPool": "6.0.3",
+          "Microsoft.OData.Edm": "[8.4.0]",
+          "Microsoft.Spatial": "[8.4.0]"
+        }
+      },
+      "Microsoft.OData.Edm": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "7tqryp5v/XQ/NIKck6lT6jZBAQonv/+N305Xc4uMdT6nQyq/J3hdvx/wvQAeaRe9RjA44MD3wRqN4wECfYTShA=="
+      },
+      "Microsoft.OData.ModelBuilder": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "QzySAMGhLCMyLNHSTIYKFjJXetoDeGkRS/7JEjm7eMJlyu1Qv4MfL1CXQFg2uijizNu2jQojT0mdCpawXbyv8Q==",
+        "dependencies": {
+          "Microsoft.OData.Edm": "[8.0.0, 9.0.0)",
+          "Microsoft.Spatial": "[8.0.0, 9.0.0)",
+          "System.ComponentModel.Annotations": "4.6.0"
+        }
+      },
+      "Microsoft.Spatial": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "F/n0Bd8SHmMtCCaBngmeaopeALr9YuZn3ocWBsSKqDMmcOb8W8P1paSy7WPq1IRYQSK0SRlPWUCxxcRVjTFF7g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.ComponentModel.Annotations": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "pOd+UhZ3X8xfwKDlgAzowUJNjp8VYVmOHZm++vCd0kq1HZ0zK3mNo2yRXjYgv7Ik/Xi43fmJfND2PLEsQSALCg=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.abstractions": {
+        "type": "Project"
+      },
+      "granit.http.odataexposure": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OData": "[9.4.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.AspNetCore.OData": {
+        "type": "CentralTransitive",
+        "requested": "[9.4.*, )",
+        "resolved": "9.4.1",
+        "contentHash": "PXyuPnC7p3ic5sgO9ydNqpKd+hXRMErGXfBPeptTWjXfdBWec97cv1fDFLiCKR1Wm4LeG4Yjcap+xk7XNdfsNw==",
+        "dependencies": {
+          "Microsoft.OData.Core": "[8.4.0, 9.0.0)",
+          "Microsoft.OData.Edm": "[8.4.0, 9.0.0)",
+          "Microsoft.OData.ModelBuilder": "[2.0.0, 3.0.0)",
+          "Microsoft.Spatial": "[8.4.0, 9.0.0)"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First cut of the OData v4 connector for BI tools — closes C1 (#1390). Hosts that pull `Granit.Http.ODataExposure` can expose any registered `QueryDefinition<TEntity>` as a queryable EntitySet so Power BI / Excel / Tableau / Qlik connect via the standard *Get Data → OData feed* connector. No custom connector, no read-replica SQL access, no bypass of multi-tenancy.

Package selection ratified by the C0 (#1389) spike: **`Microsoft.AspNetCore.OData` 9.4.1** (MIT, TFM `net8.0`, runs on .NET 10 runtime). v9.4 added native minimal-API support (upstream PR `OData/AspNetCoreOData#1469`). No MVC stack required, no Swashbuckle dependency. Major caveat tracked: `Microsoft.AspNetCore.OpenApi` does not produce a complete OData schema (upstream issue `#1381`) — we serve CSDL on `/$metadata`, which Power BI / Excel / Tableau consume natively.

## Public API

```csharp
builder.Services.AddGranitODataExposure();

app.MapGranitODataEndpoints(\"/api/granit/odata\", opts =>
{
    opts.EntitySet<Invoice, InvoiceQueryDefinition>(\"Invoices\")
        .RequirePermission(\"OData.Invoicing.Invoices.Read\");
    opts.EntitySet<Customer, CustomerQueryDefinition>(\"Customers\")
        .RequirePermission(\"OData.Invoicing.Customers.Read\");
});
```

## Per-set request flow (load-bearing order)

1. **Authentication** — enforced by the surrounding pipeline.
2. **Permission gate** — when the set declared one (returns `403`).
3. **`IQueryableSource<TEntity>`** — emits a queryable already filtered by tenant + soft-delete via the host's `ApplyGranitConventions`.
4. **`IQueryEngine.BuildFilteredQuery(source, new QueryRequest())`** — layers the `QueryDefinition`'s filter pipeline.
5. **`ODataQueryOptions<TEntity>.ApplyTo(filtered)`** — user's `\$filter` / `\$select` / `\$top` / `\$skip` / `\$orderby` on top.

User filters compose ON TOP, never instead of, the framework filters. Order is asserted by integration tests in C2 (#1391).

## Surface

- **`/api/granit/odata/`** — service document, lists every exposed EntitySet.
- **`/api/granit/odata/\$metadata`** — CSDL (EDM XML) document that Power BI / Excel / Tableau consume to populate their Navigator picker.
- **`/api/granit/odata/{EntitySetName}`** — per-set GET, accepting the standard OData query options.

EDM model auto-built from registered descriptors via `ODataConventionModelBuilder` — entity types reflect on the public CLR properties of the registered TEntity, key auto-detected on `Id`. Zero per-entity wiring beyond the fluent `EntitySet<T, TDef>(name)` call.

## Out of scope (tracked as follow-ups)

- **C2 (#1391)** — tenant filter ordering integration test (Postgres + Testcontainers). C1 ships the wiring; C2 asserts the SQL composition.
- **C3 (#1392)** — `\$expand` whitelist + `\$top` / `\$count` throttling + per-tenant rate limiting.
- **Single-entity by-key** (`GET /Invoices(<id>)`) — upstream blocker `OData/AspNetCoreOData#1567`. Deferred to upstream fix; existing REST endpoints remain the by-key access path.

## Test plan

- [x] `dotnet build src/Granit.Http.ODataExposure` — green
- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests --no-build` — 11 passed (fluent API rejection rules, EDM shape, multi-set registration)
- [x] Architecture tests (191 passed) — `[FromServices]` annotations on the DI-resolved interface parameters added after the archi rule flagged them
- [x] `dotnet format` clean on touched projects
- [x] Shard map: `tests/Granit.Http.ODataExposure.Tests` registered in `api-data`
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed
- [x] `THIRD-PARTY-NOTICES.md` — `Microsoft.AspNetCore.OData` 9.4.1 (MIT) + transitive `Microsoft.OData.Core` / `Microsoft.OData.Edm` (MIT) added

## Manual smoke test (post-merge)

A consuming app declares a `QueryDefinition<Invoice>` + `IQueryableSource<Invoice>`, registers `AddGranitODataExposure()`, and calls `MapGranitODataEndpoints`. Power BI Desktop → *Get Data → OData feed* against the prefix should: (a) discover the EntitySet via the service document, (b) populate the Navigator from `\$metadata`, (c) execute `\$filter` / `\$select` / `\$top` queries returning only this tenant's rows.