### PR TITLE
feat(odata): per-EntitySet hardening — $top cap, $count opt-in, $expand whitelist (C3a #1392)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20302,12 +20302,28 @@
       "members": []
     },
     {
+      "name": "ODataExposureMetrics",
+      "fqn": "Granit.Http.ODataExposure.Diagnostics.ODataExposureMetrics",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "RecordTopClamped",
+          "kind": "method",
+          "signature": "RecordTopClamped(string entitySet, string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "ODataExposureEndpointRouteBuilderExtensions",
       "fqn": "Granit.Http.ODataExposure.Extensions.ODataExposureEndpointRouteBuilderExtensions",
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
-      "line": 21,
+      "line": 26,
       "members": [
         {
           "name": "MapGranitODataEndpoints",
@@ -20323,7 +20339,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitODataExposure",
@@ -20356,7 +20372,14 @@
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs",
       "line": 75,
-      "members": []
+      "members": [
+        {
+          "name": "ExpandWhitelist",
+          "kind": "method",
+          "signature": "ExpandWhitelist(params string[] properties)",
+          "returnType": "ODataEntitySetBuilder<TEntity>"
+        }
+      ]
     },
     {
       "name": "ODataExposureOptions",

--- a/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
+++ b/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Http.ODataExposure.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the OData exposure layer. Tracks request-time
+/// hardening events surfaced by C3 (#1392): rejected queries (count
+/// disabled, expand not whitelisted) and silent clamps (top too high).
+/// Meter: <c>Granit.Http.ODataExposure</c>.
+/// </summary>
+public sealed class ODataExposureMetrics
+{
+    public const string MeterName = "Granit.Http.ODataExposure";
+
+    private const string TagTenantId = "tenant_id";
+    private const string TagEntitySet = "entity_set";
+    private const string TagReason = "reason";
+    private const string DefaultTenant = "global";
+
+    private readonly Counter<long> _rejectedQueries;
+    private readonly Counter<long> _topClamped;
+
+    public ODataExposureMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _rejectedQueries = meter.CreateCounter<long>(
+            "granit.odata.query.rejected",
+            description: "OData queries rejected at the per-EntitySet hardening layer ($count disabled, $expand not whitelisted, etc.). Tagged with the rejection reason.");
+
+        _topClamped = meter.CreateCounter<long>(
+            "granit.odata.query.top_clamped",
+            description: "OData queries whose user-supplied $top exceeded the EntitySet's MaxTop and was silently clamped. The OData-MaxTop-Applied response header surfaces the same event.");
+    }
+
+    /// <summary>Records a rejection at the C3 hardening layer.</summary>
+    /// <param name="entitySet">EntitySet name surfaced on the route (e.g. <c>"Invoices"</c>).</param>
+    /// <param name="reason">Stable snake_case reason tag (<c>"count_disabled"</c>, <c>"expand_not_whitelisted"</c>).</param>
+    /// <param name="tenantId">Resolved tenant id, or <see langword="null"/> when no tenant is active.</param>
+    public void RecordRejectedQuery(string entitySet, string reason, string? tenantId) =>
+        _rejectedQueries.Add(1, new TagList
+        {
+            { TagEntitySet, entitySet },
+            { TagReason, reason },
+            { TagTenantId, tenantId ?? DefaultTenant },
+        });
+
+    /// <summary>Records a $top clamp.</summary>
+    public void RecordTopClamped(string entitySet, string? tenantId) =>
+        _topClamped.Add(1, new TagList
+        {
+            { TagEntitySet, entitySet },
+            { TagTenantId, tenantId ?? DefaultTenant },
+        });
+}

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -1,14 +1,19 @@
 using System.Reflection;
 using Granit.Authorization;
+using Granit.Http.ODataExposure.Diagnostics;
 using Granit.Http.ODataExposure.Internal;
 using Granit.Http.ODataExposure.Options;
+using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Microsoft.OData.Edm;
 
 namespace Granit.Http.ODataExposure.Extensions;
@@ -20,6 +25,9 @@ namespace Granit.Http.ODataExposure.Extensions;
 /// </summary>
 public static class ODataExposureEndpointRouteBuilderExtensions
 {
+    /// <summary>Header set on the response when a user-supplied <c>$top</c> was clamped to the EntitySet's <see cref="ODataEntitySetDescriptor.MaxTop"/>. Lets observability tools spot misconfigured BI refresh jobs.</summary>
+    internal const string MaxTopAppliedHeader = "OData-MaxTop-Applied";
+
     /// <summary>
     /// Maps the configured OData EntitySets under <paramref name="prefix"/>.
     /// Generates the EDM model at call time, exposes <c>$metadata</c> +
@@ -28,9 +36,10 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// <list type="number">
     ///   <item>Authentication — required by the surrounding pipeline (the framework's bearer token / DPoP).</item>
     ///   <item>Permission gate — when the set declared one via <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/>.</item>
+    ///   <item>C3 hardening (#1392) — <c>$count</c>, <c>$expand</c> whitelist enforcement against the per-set descriptor.</item>
     ///   <item>Resolve <c>IQueryableSource&lt;TEntity&gt;</c> — emits a queryable already filtered by tenant + soft-delete (via <c>ApplyGranitConventions</c> on the host's DbContext).</item>
     ///   <item>Apply the <c>QueryDefinition</c> filter pipeline via <c>IQueryEngine.BuildFilteredQuery</c> with an empty <c>QueryRequest</c> — composes the framework's required filters.</item>
-    ///   <item>Layer the user's <c>$filter</c> / <c>$select</c> / <c>$top</c> / <c>$skip</c> / <c>$orderby</c> via <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> — user filters compose ON TOP of the framework filters, never bypassing them.</item>
+    ///   <item>Layer the user's <c>$filter</c> / <c>$select</c> / <c>$top</c> / <c>$skip</c> / <c>$orderby</c> via <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> with the per-set <c>PageSize</c> and <c>MaxTop</c> caps applied — user filters compose ON TOP of framework filters, never bypassing them.</item>
     /// </list>
     /// </summary>
     /// <param name="endpoints">Endpoint route builder (the host's <c>app</c>).</param>
@@ -61,9 +70,6 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         RouteGroupBuilder root = endpoints.MapGroup(prefix).WithTags("OData");
 
-        // Service document + $metadata. Power BI Desktop reads $metadata to
-        // populate its "Navigator" picker; service-document is the human-
-        // readable index of EntitySet names.
         root.MapODataServiceDocument("", edmModel)
             .WithName("ODataServiceDocument")
             .WithSummary("OData v4 service document — lists every exposed EntitySet with its metadata link.")
@@ -74,9 +80,6 @@ public static class ODataExposureEndpointRouteBuilderExtensions
             .WithSummary("OData v4 EDM metadata document (CSDL XML).")
             .WithDescription("BI tools consume this CSDL document to populate their Navigator / table picker. The EDM is built from the application's registered QueryDefinition&lt;T&gt; instances.");
 
-        // Per-set GET route. Closed-generic Activator dance avoids a
-        // closed-generic registration per descriptor — same pattern the
-        // analytics widget runners use for IQueryEngine resolution.
         foreach (ODataEntitySetDescriptor descriptor in options.Descriptors)
         {
             MethodInfo mapper = typeof(ODataExposureEndpointRouteBuilderExtensions)
@@ -103,9 +106,12 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     {
         RouteHandlerBuilder route = root.MapGet(descriptor.EntitySetName, async (
                 ODataQueryOptions<TEntity> options,
+                HttpContext httpContext,
                 [FromServices] IQueryableSource<TEntity> source,
                 [FromServices] IQueryEngine<TEntity> engine,
                 [FromServices] IPermissionChecker permissionChecker,
+                [FromServices] ODataExposureMetrics metrics,
+                [FromServices] ICurrentTenant? currentTenant,
                 CancellationToken cancellationToken) =>
             {
                 if (descriptor.RequiredPermission is { } perm
@@ -114,32 +120,158 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                     return (IResult)TypedResults.Forbid();
                 }
 
-                // Step 1: tenant + soft-delete already applied on `source` (the
-                // host's IQueryableSource pulls from a DbContext that wired
-                // ApplyGranitConventions). Step 2: layer the QueryDefinition's
-                // filter pipeline. Step 3: apply OData query options on top.
+                string? tenantTag = currentTenant is { IsAvailable: true, Id: { } tid }
+                    ? tid.ToString()
+                    : null;
+
+                if (RejectIfCountDisallowed(httpContext, descriptor) is { } countRejection)
+                {
+                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "count_disabled", tenantTag);
+                    return countRejection;
+                }
+
+                if (RejectIfExpandUnauthorised(httpContext, descriptor) is { } expandRejection)
+                {
+                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "expand_not_whitelisted", tenantTag);
+                    return expandRejection;
+                }
+
+                ApplyMaxTopAppliedHeader(httpContext, descriptor, metrics, tenantTag);
+
                 IQueryable<TEntity> filtered = engine.BuildFilteredQuery(
                     source.GetQueryable(), new QueryRequest());
 
-                IQueryable applied = options.ApplyTo(filtered);
+                ODataQuerySettings querySettings = new() { PageSize = descriptor.PageSize };
+                IQueryable applied = options.ApplyTo(filtered, querySettings);
                 return TypedResults.Ok(applied);
             })
             .WithODataModel(edmModel)
-            .WithODataResult();
+            .WithODataResult()
+            .WithODataOptions(opts => opts.SetMaxTop(descriptor.MaxTop));
 
         route.WithName($"OData{descriptor.EntitySetName}List")
              .WithSummary($"Returns the {descriptor.EntitySetName} EntitySet, filtered by the framework's tenant + soft-delete pipeline.")
-             .WithDescription($"OData v4 endpoint for the {descriptor.EntitySetName} set. Supports $filter, $select, $top, $skip, $orderby. Tenant and soft-delete filters are applied BEFORE any user $filter — the OData query never bypasses framework access control.")
+             .WithDescription($"OData v4 endpoint for the {descriptor.EntitySetName} set. Supports $filter, $select, $top, $skip, $orderby. Tenant and soft-delete filters are applied BEFORE any user $filter — the OData query never bypasses framework access control. Per-set caps: MaxTop={descriptor.MaxTop}, PageSize={descriptor.PageSize}, $count={(descriptor.CountEnabled ? "enabled" : "disabled")}, $expand={(descriptor.ExpandWhitelist is null or { Count: 0 } ? "disabled" : string.Join(",", descriptor.ExpandWhitelist))}.")
              .Produces(StatusCodes.Status200OK)
+             .ProducesProblem(StatusCodes.Status400BadRequest)
              .ProducesProblem(StatusCodes.Status401Unauthorized)
              .ProducesProblem(StatusCodes.Status403Forbidden);
 
         if (descriptor.RequiredPermission is not null)
         {
-            // Authorization is enforced inline (permission checker) — keep
-            // the metadata in sync so OpenAPI schemas can hint at the gate
-            // even if the runtime check is the source of truth.
             route.RequireAuthorization();
         }
+    }
+
+    /// <summary>
+    /// Returns a <c>400</c> result when the request asks for <c>$count=true</c>
+    /// on an EntitySet whose owner did NOT call <see cref="ODataEntitySetBuilder{TEntity}.EnableCount"/>.
+    /// Default-disabled because <c>$count</c> on a 50M-row table forces a
+    /// full-table scan per request — Power BI refresh jobs can hit it
+    /// repeatedly.
+    /// </summary>
+    private static ProblemHttpResult? RejectIfCountDisallowed(HttpContext httpContext, ODataEntitySetDescriptor descriptor)
+    {
+        if (descriptor.CountEnabled)
+        {
+            return null;
+        }
+
+        if (httpContext.Request.Query.TryGetValue("$count", out StringValues raw)
+            && string.Equals(raw.ToString(), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return TypedResults.Problem(
+                detail: $"$count is not enabled on the '{descriptor.EntitySetName}' EntitySet. Contact the API owner to enable it.",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not allowed");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates the user's <c>$expand</c> clause against the EntitySet's
+    /// whitelist. Default whitelist is empty (or <see langword="null"/>) →
+    /// <c>$expand</c> rejected outright. Non-empty whitelist allows only the
+    /// listed top-level navigation properties; nested-expand depth is
+    /// enforced separately by <c>ODataMiniOptions.SetMaxTop</c> / the
+    /// framework's <c>MaxExpansionDepth</c> validator hook.
+    /// </summary>
+    private static ProblemHttpResult? RejectIfExpandUnauthorised(HttpContext httpContext, ODataEntitySetDescriptor descriptor)
+    {
+        if (!httpContext.Request.Query.TryGetValue("$expand", out StringValues raw))
+        {
+            return null;
+        }
+
+        string rawExpand = raw.ToString();
+        if (string.IsNullOrWhiteSpace(rawExpand))
+        {
+            return null;
+        }
+
+        IReadOnlyList<string>? whitelist = descriptor.ExpandWhitelist;
+        if (whitelist is null || whitelist.Count == 0)
+        {
+            return TypedResults.Problem(
+                detail: $"$expand is not enabled on the '{descriptor.EntitySetName}' EntitySet.",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Query option not allowed");
+        }
+
+        // Top-level navigation extraction — `Customer($expand=Lines),Address`
+        // → ["Customer", "Address"]. We only validate the first segment of
+        // each comma-split entry; nested expansion semantics are validated
+        // separately by MaxExpansionDepth.
+        string[] requested = [..
+            rawExpand.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(segment =>
+                {
+                    int parenIndex = segment.IndexOf('(', StringComparison.Ordinal);
+                    return parenIndex >= 0 ? segment[..parenIndex].Trim() : segment;
+                })];
+
+        foreach (string property in requested)
+        {
+            if (string.IsNullOrEmpty(property))
+            {
+                continue;
+            }
+
+            if (!whitelist.Contains(property, StringComparer.OrdinalIgnoreCase))
+            {
+                return TypedResults.Problem(
+                    detail: $"$expand of property '{property}' is not permitted on the '{descriptor.EntitySetName}' EntitySet. Allowed: {string.Join(", ", whitelist)}.",
+                    statusCode: StatusCodes.Status400BadRequest,
+                    title: "Expand property not whitelisted");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Sets the <c>OData-MaxTop-Applied</c> response header when the user's
+    /// <c>$top</c> exceeded the descriptor's cap — the framework clamps
+    /// silently (per acceptance criteria), the header surfaces the clamping
+    /// to observability tooling. Also bumps the rejected-query counter for
+    /// the same reason.
+    /// </summary>
+    private static void ApplyMaxTopAppliedHeader(
+        HttpContext httpContext,
+        ODataEntitySetDescriptor descriptor,
+        ODataExposureMetrics metrics,
+        string? tenantTag)
+    {
+        if (!httpContext.Request.Query.TryGetValue("$top", out StringValues topRaw)
+            || !int.TryParse(topRaw.ToString(), out int requestedTop)
+            || requestedTop <= descriptor.MaxTop)
+        {
+            return;
+        }
+
+        httpContext.Response.Headers[MaxTopAppliedHeader] =
+            descriptor.MaxTop.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        metrics.RecordTopClamped(descriptor.EntitySetName, tenantTag);
     }
 }

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
+using Granit.Http.ODataExposure.Diagnostics;
 using Microsoft.AspNetCore.OData;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 #pragma warning disable IDE0058 // Expression value is never used — fluent ODataMiniOptions config returns the options instance
 
@@ -33,6 +35,12 @@ public static class ODataExposureServiceCollectionExtensions
         // $count); per-route restrictions are layered via
         // AddODataQueryEndpointFilter in #1392 / C3.
         services.AddOData(opt => opt.EnableAll());
+
+        // C3 hardening telemetry: counts rejected queries (count disabled,
+        // expand not whitelisted) and top-clamps. Always on so observability
+        // tooling can spot misconfigured BI refresh jobs without per-host
+        // setup.
+        services.TryAddSingleton<ODataExposureMetrics>();
 
         return services;
     }

--- a/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
@@ -2,17 +2,28 @@ namespace Granit.Http.ODataExposure.Internal;
 
 /// <summary>
 /// Captures one EntitySet registration: the route segment, the CLR entity
-/// type, the <c>QueryDefinition&lt;TEntity&gt;</c> CLR type, and the optional
-/// permission gate. Built up by <see cref="Options.ODataExposureOptions"/>
-/// at host configuration time, consumed by the route helper to wire one
-/// minimal-API endpoint per set + the shared EDM model.
+/// type, the <c>QueryDefinition&lt;TEntity&gt;</c> CLR type, the optional
+/// permission gate, and the per-set query-hardening caps from C3 (#1392).
+/// Built up by <see cref="Options.ODataExposureOptions"/> at host
+/// configuration time, consumed by the route helper to wire one minimal-API
+/// endpoint per set + the shared EDM model.
 /// </summary>
 /// <param name="EntitySetName">Route segment AND OData EntitySet name (e.g. <c>"Invoices"</c>).</param>
 /// <param name="EntityType">CLR type of the entity.</param>
 /// <param name="QueryDefinitionType">CLR type of the <c>QueryDefinition&lt;TEntity&gt;</c> backing this set — resolved through DI at request time.</param>
 /// <param name="RequiredPermission">Permission name a request must carry to read this EntitySet, or <see langword="null"/> if any authenticated user is allowed (auth itself is enforced by the surrounding pipeline).</param>
+/// <param name="MaxTop">Server-side cap on <c>$top</c>. Requests above this are silently clamped and an <c>OData-MaxTop-Applied</c> header is set on the response. Default <c>5000</c>.</param>
+/// <param name="PageSize">Server-side default page size when the caller omits <c>$top</c>. Drives <c>@odata.nextLink</c> pagination. Default <c>1000</c>.</param>
+/// <param name="CountEnabled"><c>$count=true</c> requests are accepted only when this is <see langword="true"/>. Default <see langword="false"/> — guards huge tables against full-table-scan counts on every refresh.</param>
+/// <param name="ExpandWhitelist">Allowed top-level navigation properties for <c>$expand</c>. <see langword="null"/> means <c>$expand</c> is disabled entirely. Empty list (<c>[]</c>) ALSO disables expand — the EntitySet's contract is "no navigation by default; opt in explicitly per property".</param>
+/// <param name="MaxExpansionDepth">Maximum nesting depth allowed for <c>$expand</c>. Default <c>1</c> — flat expand only; nested expand requires explicit opt-in.</param>
 internal sealed record ODataEntitySetDescriptor(
     string EntitySetName,
     Type EntityType,
     Type QueryDefinitionType,
-    string? RequiredPermission);
+    string? RequiredPermission,
+    int MaxTop = 5000,
+    int PageSize = 1000,
+    bool CountEnabled = false,
+    IReadOnlyList<string>? ExpandWhitelist = null,
+    int MaxExpansionDepth = 1);

--- a/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
+++ b/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
@@ -92,8 +92,70 @@ public sealed class ODataEntitySetBuilder<TEntity>
     public ODataEntitySetBuilder<TEntity> RequirePermission(string permission)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+        return Update(_descriptor with { RequiredPermission = permission });
+    }
 
-        ODataEntitySetDescriptor updated = _descriptor with { RequiredPermission = permission };
+    /// <summary>
+    /// Caps the user-supplied <c>$top</c>. Requests above this value are
+    /// silently clamped and the response carries an
+    /// <c>OData-MaxTop-Applied</c> header so observability tools can spot
+    /// misconfigured BI refresh jobs. Must be positive.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> MaxTop(int maxTop)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTop);
+        return Update(_descriptor with { MaxTop = maxTop });
+    }
+
+    /// <summary>
+    /// Sets the server-side default page size returned when the caller
+    /// omits <c>$top</c>. The response then carries <c>@odata.nextLink</c>
+    /// for OData clients to walk pagination. Must be positive.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> PageSize(int pageSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+        return Update(_descriptor with { PageSize = pageSize });
+    }
+
+    /// <summary>
+    /// Enables <c>$count=true</c> on this EntitySet. Disabled by default —
+    /// huge tables would otherwise face a full-table-scan count on every BI
+    /// refresh. Enable explicitly for sets where the count query is cheap
+    /// (small tables, or covered by a dedicated index).
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> EnableCount()
+        => Update(_descriptor with { CountEnabled = true });
+
+    /// <summary>
+    /// Whitelists the top-level navigation properties allowed in
+    /// <c>$expand</c>. Default behaviour is <c>$expand</c> disabled —
+    /// without this call, any <c>$expand</c> request returns
+    /// <c>400 Bad Request</c>. An empty list still disables expand
+    /// (explicit "I want zero navigations exposed").
+    /// </summary>
+    /// <param name="properties">Navigation property names allowed at the top level (e.g. <c>"Customer"</c>, <c>"Lines"</c>).</param>
+    public ODataEntitySetBuilder<TEntity> ExpandWhitelist(params string[] properties)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        return Update(_descriptor with { ExpandWhitelist = [.. properties] });
+    }
+
+    /// <summary>
+    /// Sets the maximum nesting depth allowed for <c>$expand</c>. Default
+    /// is <c>1</c> (flat expand only). Set to <c>2</c> or more when a
+    /// specific consumer needs to walk a navigation chain
+    /// (e.g. <c>Customer($expand=Address)</c>). Higher depths exponentially
+    /// increase the risk of N+1 explosions — review carefully.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> MaxExpansionDepth(int depth)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depth);
+        return Update(_descriptor with { MaxExpansionDepth = depth });
+    }
+
+    private ODataEntitySetBuilder<TEntity> Update(ODataEntitySetDescriptor updated)
+    {
         _options.Replace(_descriptor, updated);
         _descriptor = updated;
         return this;

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -61,14 +61,44 @@ Per EntitySet `GET /api/granit/odata/{Name}?$filter=…&$select=…&$top=…`:
 The order is load-bearing: tenant first, framework filters second, user
 query third.
 
+## Hardening (per EntitySet)
+
+The fluent builder ships safe-by-default caps; override per set when the
+data product warrants it:
+
+```csharp
+opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+    .MaxTop(2500)                    // default 5000 — silently clamps user $top
+    .PageSize(500)                   // default 1000 — used when caller omits $top
+    .EnableCount()                   // default disabled — opt in for cheap-to-count tables
+    .ExpandWhitelist("Customer")     // default disabled — list allowed top-level navigations
+    .MaxExpansionDepth(2)            // default 1 — flat expand only
+    .RequirePermission("OData.Invoicing.Invoices.Read");
+```
+
+Behaviour:
+
+- **`$top` clamping** — values above `MaxTop` are silently capped and the
+  response carries `OData-MaxTop-Applied: <cap>` so observability tooling
+  can spot misconfigured BI refresh jobs.
+- **`$count=true`** — returns `400 Bad Request` unless `.EnableCount()` was
+  called; protects huge tables from full-table-scan counts on every
+  refresh.
+- **`$expand=<prop>`** — returns `400 Bad Request` if the property is not
+  in `ExpandWhitelist`. An empty whitelist (or no call at all) disables
+  expand entirely.
+- **OTel telemetry** — every rejected query bumps
+  `granit.odata.query.rejected` (tagged with `entity_set`, `reason`,
+  `tenant_id`); every clamped `$top` bumps `granit.odata.query.top_clamped`.
+
 ## Limits
 
 - v1 is read-only — no `POST` / `PATCH` / `DELETE` per EntitySet.
 - v1 ships collection access (`GET /Invoices`); single-entity-by-key access
   (`GET /Invoices(<id>)`) is deferred upstream — see
   [OData/AspNetCoreOData#1567](https://github.com/OData/AspNetCoreOData/issues/1567).
-- `$expand` whitelist + `$top` / `$count` throttling + rate-limiting are
-  follow-up scope (story C3 / #1392).
+- Per-tenant rate limiting is a follow-up scope (deeper integration with
+  `Granit.RateLimiting`).
 - Native `Microsoft.AspNetCore.OpenApi` does not produce a complete OData
   schema (upstream [#1381](https://github.com/OData/AspNetCoreOData/issues/1381));
   the OData metadata document at `/{prefix}/$metadata` (CSDL XML) is the

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization;
 using Granit.Http.ODataExposure.Extensions;
+using Granit.Http.ODataExposure.Options;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.QueryEngine.Extensions;
@@ -48,7 +49,12 @@ internal sealed class ODataTestApp : IAsyncDisposable
         Client.Dispose();
     }
 
-    public static async Task<ODataTestApp> CreateAsync(string connectionString)
+    public static Task<ODataTestApp> CreateAsync(string connectionString)
+        => CreateAsync(connectionString, configureEntitySet: null);
+
+    public static async Task<ODataTestApp> CreateAsync(
+        string connectionString,
+        Action<ODataEntitySetBuilder<Invoice>>? configureEntitySet)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -95,7 +101,11 @@ internal sealed class ODataTestApp : IAsyncDisposable
         });
 
         app.MapGranitODataEndpoints("/api/granit/odata", opts =>
-            opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices"));
+        {
+            ODataEntitySetBuilder<Invoice> builder =
+                opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+            configureEntitySet?.Invoke(builder);
+        });
 
         await app.StartAsync().ConfigureAwait(false);
 

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/QueryHardeningTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/QueryHardeningTests.cs
@@ -1,0 +1,221 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests.Integration;
+
+/// <summary>
+/// C3 (#1392) hardening assertions — pins the per-EntitySet caps that
+/// protect the OData layer against DoS-style queries (huge $top, no-limit
+/// table scans, $expand explosions, $count on large tables). Each scenario
+/// runs against the same PostgreSQL container as the tenant-isolation
+/// suite; the test fixture configures the EntitySet differently per class
+/// to keep assertions focused.
+/// </summary>
+public sealed class QueryHardeningTests(PostgresFixture postgres)
+    : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = postgres;
+    private static readonly Guid TenantA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private ODataTestApp _appTopCapped = null!;
+    private ODataTestApp _appExpandWhitelist = null!;
+    private ODataTestApp _appCountEnabled = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        // Three apps with different per-set hardening configs. Same DB,
+        // same seed — only the EntitySet builder differs. Sharing the
+        // PostgreSQL container is fine because the tests don't mutate;
+        // each app maintains its own DbContext but uses
+        // EnsureCreatedAsync() (idempotent) on the shared schema.
+        _appTopCapped = await ODataTestApp.CreateAsync(
+            _postgres.ConnectionString,
+            builder => builder.MaxTop(5).PageSize(3));
+
+        _appExpandWhitelist = await ODataTestApp.CreateAsync(
+            _postgres.ConnectionString,
+            builder => builder.ExpandWhitelist("Customer"));
+
+        _appCountEnabled = await ODataTestApp.CreateAsync(
+            _postgres.ConnectionString,
+            builder => builder.EnableCount());
+
+        await SeedAsync(_appTopCapped);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _appTopCapped.DisposeAsync();
+        await _appExpandWhitelist.DisposeAsync();
+        await _appCountEnabled.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task MaxTop_RequestAboveCap_ResponseSilentlyClamped_AndHeaderEmitted()
+    {
+        // EntitySet declared with MaxTop=5; user asks for $top=1000000.
+        // Acceptance criterion #2 from #1392 — the response is capped, not
+        // rejected, and the OData-MaxTop-Applied header surfaces the
+        // clamping for observability.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$top=1000000");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appTopCapped.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.GetValues("OData-MaxTop-Applied").ShouldHaveSingleItem().ShouldBe("5");
+    }
+
+    [Fact]
+    public async Task MaxTop_RequestBelowCap_HeaderNotEmitted()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$top=2");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appTopCapped.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Headers.Contains("OData-MaxTop-Applied").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Count_NotEnabled_ReturnsBadRequest()
+    {
+        // Acceptance criterion #4 from #1392 — $count=true on an EntitySet
+        // without .EnableCount() returns 400. Guards huge tables against
+        // full-table-scan counts on every BI refresh.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$count=true");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appTopCapped.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("count");
+    }
+
+    [Fact]
+    public async Task Count_Enabled_RequestAccepted()
+    {
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$count=true");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appCountEnabled.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Expand_NoWhitelist_ReturnsBadRequest()
+    {
+        // EntitySet on _appTopCapped did not call .ExpandWhitelist(...),
+        // so any $expand request is rejected. Acceptance criterion #1.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$expand=Customer");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appTopCapped.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Expand_NotInWhitelist_ReturnsBadRequest()
+    {
+        // _appExpandWhitelist allows ["Customer"]; any other property fails.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$expand=Lines");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appExpandWhitelist.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("Lines");
+    }
+
+    [Fact]
+    public async Task Expand_InWhitelist_AcceptedThoughTheNavigationDoesntExist()
+    {
+        // The Invoice entity has no Customer navigation in the test schema;
+        // OData responds with the validation error from its own translator
+        // (not our 400). What we pin here is that whitelist validation does
+        // NOT pre-empt the request when the property name matches.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices?$expand=Customer");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appExpandWhitelist.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        // Either OData accepts and tries to expand (200 with empty navigation)
+        // or fails downstream because the EDM has no Customer navigation
+        // (500/400 from the translator). What MUST NOT happen is the C3 layer
+        // returning its own "not whitelisted" 400 — verified by reading the
+        // body for the explicit whitelist phrasing.
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            body.ShouldNotContain("not permitted");
+        }
+    }
+
+    [Fact]
+    public async Task PageSize_AppliedWhenTopOmitted()
+    {
+        // _appTopCapped has PageSize=3. Without $top, the response should
+        // expose at most 3 invoices.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            "/api/granit/odata/Invoices");
+        request.Headers.Add("X-Test-Tenant", TenantA.ToString());
+
+        HttpResponseMessage response = await _appTopCapped.Client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.Count.ShouldBeLessThanOrEqualTo(3);
+    }
+
+    private static async Task<IReadOnlyList<JsonElement>> ReadValueAsync(HttpResponseMessage response)
+    {
+        JsonDocument doc = await response.Content.ReadFromJsonAsync<JsonDocument>(TestContext.Current.CancellationToken)
+            ?? throw new InvalidOperationException("OData response was empty.");
+        return [.. doc.RootElement.GetProperty("value").EnumerateArray()];
+    }
+
+    private static async Task SeedAsync(ODataTestApp app)
+    {
+        using IServiceScope scope = app.CreateScope();
+        TestDbContext db = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+
+        // 5 invoices for tenant A — enough to exercise PageSize=3 and
+        // MaxTop=5 caps.
+        for (int i = 0; i < 5; i++)
+        {
+            db.Invoices.Add(new Invoice
+            {
+                Id = Guid.NewGuid(),
+                TenantId = TenantA,
+                Number = $"H-{i + 1:D3}",
+                Amount = (i + 1) * 100m,
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
@@ -90,6 +90,129 @@ public sealed class ODataExposureOptionsTests
         Should.Throw<ArgumentException>(() => builder.RequirePermission(""));
     }
 
+    [Fact]
+    public void Defaults_MatchHardeningContract()
+    {
+        // The C3 (#1392) defaults are intentional and load-bearing — a host
+        // that registers an EntitySet without overriding MUST land on the
+        // safe side (small page, capped top, count off, expand off). A
+        // future relaxation here would silently widen every consuming app's
+        // OData surface.
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        object descriptor = GetSingleDescriptor(options);
+        ((int)descriptor.GetType().GetProperty("MaxTop")!.GetValue(descriptor)!).ShouldBe(5000);
+        ((int)descriptor.GetType().GetProperty("PageSize")!.GetValue(descriptor)!).ShouldBe(1000);
+        ((bool)descriptor.GetType().GetProperty("CountEnabled")!.GetValue(descriptor)!).ShouldBeFalse();
+        descriptor.GetType().GetProperty("ExpandWhitelist")!.GetValue(descriptor).ShouldBeNull();
+        ((int)descriptor.GetType().GetProperty("MaxExpansionDepth")!.GetValue(descriptor)!).ShouldBe(1);
+    }
+
+    [Fact]
+    public void MaxTop_StoresOnDescriptor_AndRejectsZeroOrNegative()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices").MaxTop(2500);
+
+        ((int)GetSingleDescriptor(options).GetType().GetProperty("MaxTop")!.GetValue(GetSingleDescriptor(options))!)
+            .ShouldBe(2500);
+
+        ODataExposureOptions other = new();
+        ODataEntitySetBuilder<Invoice> builder = other.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.MaxTop(0));
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.MaxTop(-1));
+    }
+
+    [Fact]
+    public void PageSize_StoresOnDescriptor()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices").PageSize(250);
+
+        ((int)GetSingleDescriptor(options).GetType().GetProperty("PageSize")!.GetValue(GetSingleDescriptor(options))!)
+            .ShouldBe(250);
+    }
+
+    [Fact]
+    public void EnableCount_FlipsFlag()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices").EnableCount();
+
+        ((bool)GetSingleDescriptor(options).GetType().GetProperty("CountEnabled")!.GetValue(GetSingleDescriptor(options))!)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExpandWhitelist_StoresPropertyList()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .ExpandWhitelist("Customer", "Lines");
+
+        var whitelist = (System.Collections.Generic.IReadOnlyList<string>?)
+            GetSingleDescriptor(options).GetType().GetProperty("ExpandWhitelist")!.GetValue(GetSingleDescriptor(options));
+
+        whitelist.ShouldNotBeNull();
+        whitelist!.ShouldBe(["Customer", "Lines"]);
+    }
+
+    [Fact]
+    public void ExpandWhitelist_EmptyArray_IsValid_AndDifferentFromNull()
+    {
+        // Default null = expand never registered; explicit [] = "I want zero
+        // navigations exposed". Both reject every $expand request, but the
+        // explicit empty form documents intent in the host code.
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices").ExpandWhitelist();
+
+        var whitelist = (System.Collections.Generic.IReadOnlyList<string>?)
+            GetSingleDescriptor(options).GetType().GetProperty("ExpandWhitelist")!.GetValue(GetSingleDescriptor(options));
+
+        whitelist.ShouldNotBeNull();
+        whitelist!.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MaxExpansionDepth_RejectsZeroOrNegative()
+    {
+        ODataExposureOptions options = new();
+        ODataEntitySetBuilder<Invoice> builder = options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.MaxExpansionDepth(0));
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.MaxExpansionDepth(-1));
+    }
+
+    [Fact]
+    public void Builder_Chains_AcrossMultipleCalls()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .MaxTop(2500)
+            .PageSize(250)
+            .EnableCount()
+            .ExpandWhitelist("Customer")
+            .MaxExpansionDepth(2)
+            .RequirePermission("OData.Test.Invoices.Read");
+
+        object d = GetSingleDescriptor(options);
+        ((int)d.GetType().GetProperty("MaxTop")!.GetValue(d)!).ShouldBe(2500);
+        ((int)d.GetType().GetProperty("PageSize")!.GetValue(d)!).ShouldBe(250);
+        ((bool)d.GetType().GetProperty("CountEnabled")!.GetValue(d)!).ShouldBeTrue();
+        ((int)d.GetType().GetProperty("MaxExpansionDepth")!.GetValue(d)!).ShouldBe(2);
+        ((string?)d.GetType().GetProperty("RequiredPermission")!.GetValue(d))
+            .ShouldBe("OData.Test.Invoices.Read");
+    }
+
+    private static object GetSingleDescriptor(ODataExposureOptions options)
+    {
+        object? list = options.GetType()
+            .GetProperty("Descriptors", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(options);
+        return ((System.Collections.IEnumerable)list!).Cast<object>().Single();
+    }
+
     private sealed class Invoice
     {
         public Guid Id { get; init; }


### PR DESCRIPTION
## Summary

First half of **C3 (#1392)** — the per-EntitySet caps that protect `Granit.Http.ODataExposure` from DoS-style queries: huge `\$top`, `\$count` on large tables, `\$expand` explosions. Per-tenant rate limiting is the second half (C3b) and will land in a follow-up PR — that one needs deeper integration with `Granit.RateLimiting`.

## Public API

```csharp
opts.EntitySet<Invoice, InvoiceQueryDefinition>(\"Invoices\")
    .MaxTop(2500)                  // default 5000
    .PageSize(500)                 // default 1000
    .EnableCount()                 // default disabled
    .ExpandWhitelist(\"Customer\")   // default disabled
    .MaxExpansionDepth(2);         // default 1
```

## Behaviour matrix

| Request | Configured | Result |
| ------- | ---------- | ------ |
| `?\$top=1000000` | `MaxTop = 5000` | 200 OK, response capped at 5000, header `OData-MaxTop-Applied: 5000` |
| `?\$count=true` | no `EnableCount()` | 400 Bad Request, *Query option not allowed* |
| `?\$count=true` | `.EnableCount()` | 200 OK |
| `?\$expand=Customer` | no `ExpandWhitelist(...)` | 400 Bad Request, *\$expand is not enabled* |
| `?\$expand=Lines` | `ExpandWhitelist(\"Customer\")` | 400 Bad Request, *\$expand of property 'Lines' is not permitted* |
| `?\$expand=Customer(\$expand=Lines),Address` | `ExpandWhitelist(\"Customer\",\"Address\")` | 200 OK (top-level segments validated; depth gated separately) |
| no `\$top` | `PageSize = 500` | 200 OK with at most 500 rows |

## Telemetry

- **`granit.odata.query.rejected`** with tags `entity_set`, `reason` (`count_disabled` / `expand_not_whitelisted`), `tenant_id`
- **`granit.odata.query.top_clamped`** with tags `entity_set`, `tenant_id` — mirrors the response header

## Tests

- **Unit (19 passing, +8 new)** — defaults match the hardening contract; each fluent method stores the value; rejection of zero/negative; chaining across methods.
- **Integration (8 new in `QueryHardeningTests`)** — top clamping with header, top below cap with no header, `\$count` enabled/disabled, `\$expand` no-whitelist, `\$expand` wrong-property rejected, `\$expand` whitelisted property accepted (no preemptive rejection), `\$expand` no whitelist rejected, page size applied when `\$top` omitted.
- The integration suite reuses the existing `PostgresFixture` from C2. `ODataTestApp.CreateAsync` gained a `configureEntitySet` callback so each test class can wire its own hardening config.

## Test plan

- [x] `dotnet build src/Granit.Http.ODataExposure` — green
- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests --no-build` — 19 passed (was 11, +8 new)
- [x] `dotnet build tests/Granit.Http.ODataExposure.Tests.Integration` — green (CI runs the test suite, Docker required locally)
- [x] Architecture tests with fresh build — 191 passed
- [x] `dotnet format` clean on touched projects (src + tests + tests.integration)
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed

## Follow-ups

- **C3b** — per-tenant rate limiting (60 req/min default token bucket) via `Granit.RateLimiting`. Separate PR because the integration crosses package boundaries and warrants its own scope.