### PR TITLE
feat(dashboards): MapWidget per-widget DefaultLayerKind hint (B7-3 #1577)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4192,7 +4192,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
-      "line": 88,
+      "line": 90,
       "members": [
         {
           "name": "MapCenter",
@@ -4225,12 +4225,21 @@
       ]
     },
     {
+      "name": "MapTileLayerKind",
+      "fqn": "Granit.Analytics.Dashboards.Widgets.MapTileLayerKind",
+      "kind": "enum",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Dashboards/Widgets/MapTileLayerKind.cs",
+      "line": 24,
+      "members": []
+    },
+    {
       "name": "MapWidgetDefinition",
       "fqn": "Granit.Analytics.Dashboards.Widgets.MapWidgetDefinition",
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
-      "line": 67,
+      "line": 68,
       "members": [
         {
           "name": "MapCenter",
@@ -4484,7 +4493,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
-      "line": 39,
+      "line": 42,
       "members": []
     },
     {
@@ -4493,7 +4502,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
-      "line": 30,
+      "line": 33,
       "members": []
     },
     {
@@ -4502,7 +4511,7 @@
       "kind": "record",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs",
-      "line": 17,
+      "line": 19,
       "members": []
     },
     {

--- a/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
@@ -353,11 +353,14 @@ Per-column currency: a single table can mix `AmountEur` and `AmountUsd` on diffe
   "defaultCenter": { "latitude": 50.0, "longitude": 1.0 },
   "clusterThreshold": 150,
   "detailRoute": "/cities/{id}",
-  "tileUrlTemplate": null            // null = host's default (typically OpenStreetMap)
+  "tileUrlTemplate": null,           // null = host's default (typically OpenStreetMap)
+  "defaultLayerKind": "Satellite"    // optional preferred layer; null = no preference
 }
 ```
 
-LatLng path (`double` / `decimal` lat-lng columns) works on any database. Geography path (PostGIS `geography(Point)`) is deferred to `granit-iot` — the renderer surfaces `Widget:Unavailable.MapGeographyNotImplemented` until then.
+LatLng path (`double` / `decimal` lat-lng columns) works on any database. PostGIS path (`geography(Point)`) is opt-in via the `Granit.Analytics.PostGIS` package; without it the renderer surfaces `Widget:Unavailable.MapGeographyNotImplemented`.
+
+`defaultLayerKind` (B7-3) is a per-widget preference — `Plan`, `Satellite`, `Hybrid`, `Topo`, or `Custom`, PascalCase on the wire. The frontend resolves it against the active `MapTileProvider`: matching layer wins, otherwise the provider's first layer is used. Useful when a single host registers multiple providers (OSM + SPW Wallonia + ArcGIS) and wants delivery-tracking widgets to default to satellite while parcel maps default to plan.
 
 #### `Markdown` / `Text` / `Image` — static content
 

--- a/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MapWidgetInstanceRenderer.cs
@@ -105,7 +105,8 @@ internal sealed class MapWidgetInstanceRenderer(
             DefaultCenter: defaultCenter,
             ClusterThreshold: config.ClusterThreshold,
             DetailRoute: config.DetailRoute,
-            TileUrlTemplate: config.TileUrlTemplate);
+            TileUrlTemplate: config.TileUrlTemplate,
+            DefaultLayerKind: config.DefaultLayerKind);
 
         return WidgetSnapshotEnvelope.ForSnapshot(
             widgetType: WidgetType,
@@ -122,7 +123,8 @@ internal sealed class MapWidgetInstanceRenderer(
         MapCenterConfig? DefaultCenter,
         int ClusterThreshold,
         string? DetailRoute,
-        string? TileUrlTemplate);
+        string? TileUrlTemplate,
+        MapTileLayerKind? DefaultLayerKind = null);
 
     /// <summary>
     /// Wire shape for <see cref="MapWidgetDefinition.DefaultCenter"/> in the

--- a/src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs
+++ b/src/Granit.Analytics.Endpoints/Rendering/MapWidgetSnapshot.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
 
 namespace Granit.Analytics.Endpoints.Rendering;
 
@@ -14,13 +15,15 @@ namespace Granit.Analytics.Endpoints.Rendering;
 /// <param name="ClusterThreshold">Marker count above which the frontend activates clustering.</param>
 /// <param name="DetailRoute">Optional route template invoked on marker click (<c>{id}</c> substituted with the row's primary key).</param>
 /// <param name="TileUrlTemplate">Optional Leaflet tile-URL override; <see langword="null"/> falls back to the host's default (typically OpenStreetMap).</param>
+/// <param name="DefaultLayerKind">Optional preferred layer kind from the widget definition (B7-3 #1577). The frontend resolves it against the active <c>MapTileProvider</c>: matching layer wins, otherwise the provider's first layer is used. <see langword="null"/> means "no preference — use the provider default".</param>
 public sealed record MapWidgetSnapshot(
     IReadOnlyList<MapPoint> Points,
     int DefaultZoom,
     MapCenterPayload? DefaultCenter,
     int ClusterThreshold,
     string? DetailRoute,
-    string? TileUrlTemplate);
+    string? TileUrlTemplate,
+    MapTileLayerKind? DefaultLayerKind);
 
 /// <summary>One marker on the map.</summary>
 /// <param name="Id">Entity primary key when the entity exposes a <c>Guid Id</c> property; <see langword="null"/> otherwise. Drives the click-through to <c>DetailRoute</c>.</param>

--- a/src/Granit.Analytics/Dashboards/Widgets/MapTileLayerKind.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/MapTileLayerKind.cs
@@ -1,0 +1,40 @@
+namespace Granit.Analytics.Dashboards.Widgets;
+
+/// <summary>
+/// Logical kind of map tile layer a <see cref="MapWidgetDefinition"/> wants
+/// to default to. Decoupled from any specific tile provider id (OSM, SPW
+/// Wallonia, ArcGIS, …) so a widget can declare "show satellite imagery"
+/// without binding to a vendor — the frontend picks the actual layer URL
+/// from whichever <c>MapTileProvider</c> the host has registered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire format is PascalCase per ADR-039 §6.1 — the framework's standard
+/// <c>JsonStringEnumConverter()</c> uses the default naming policy, so
+/// <see cref="Plan"/> serialises as <c>"Plan"</c>. Frontend mirror lives in
+/// <c>granit-front/packages/@granit/react-map/src/types.ts</c> as the
+/// TypeScript union <c>'Plan' | 'Satellite' | 'Hybrid' | 'Topo' | 'Custom'</c>.
+/// </para>
+/// <para>
+/// Resolution rule on the frontend: when the active <c>MapTileProvider</c>
+/// has a layer matching the requested kind, that layer becomes active;
+/// otherwise the provider's first layer is used (graceful fallback).
+/// </para>
+/// </remarks>
+public enum MapTileLayerKind
+{
+    /// <summary>Cartographic / road-map style — typically the default for navigation use cases (parcel maps, address pickers).</summary>
+    Plan = 0,
+
+    /// <summary>Aerial / orthophoto imagery — best for delivery tracking, infrastructure inspection, agricultural overlays.</summary>
+    Satellite = 1,
+
+    /// <summary>Satellite imagery overlaid with road / label vectors — combines the recognisability of <see cref="Plan"/> with the realism of <see cref="Satellite"/>.</summary>
+    Hybrid = 2,
+
+    /// <summary>Topographic style — relief shading, contour lines, terrain. Useful for outdoor / GIS / hiking-style use cases.</summary>
+    Topo = 3,
+
+    /// <summary>Provider-specific layer that doesn't fit the standard kinds. The frontend treats it as opaque and uses whichever layer the provider exposes under that name.</summary>
+    Custom = 4,
+}

--- a/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
@@ -59,6 +59,7 @@ public abstract record MapPointSource
 /// <param name="ClusterThreshold">Row count above which marker clustering activates automatically. Defaults to <c>200</c>.</param>
 /// <param name="DetailRoute">Optional route template invoked on marker click — <c>{id}</c> is substituted with the row's primary key. Example: <c>/customers/{id}</c>.</param>
 /// <param name="TileUrlTemplate">Optional Leaflet tile-URL template overriding the OpenStreetMap default. Frontend hosts MUST keep a visible attribution that matches the tile provider's licence.</param>
+/// <param name="DefaultLayerKind">Optional preferred layer kind (plan / satellite / hybrid / topo / custom). When set, the frontend picks the matching layer from whatever <c>MapTileProvider</c> the host registered; <see langword="null"/> falls back to the provider's default. See <see cref="MapTileLayerKind"/>.</param>
 /// <param name="Position">See <see cref="WidgetDefinition.Position"/>.</param>
 /// <param name="Size">Defaults to <see cref="WidgetSize.MediaTile"/> — maps usually want square real-estate.</param>
 /// <param name="RequiredPermission">See <see cref="WidgetDefinition.RequiredPermission"/>.</param>
@@ -75,6 +76,7 @@ public sealed record MapWidgetDefinition(
     int ClusterThreshold = 200,
     string? DetailRoute = null,
     string? TileUrlTemplate = null,
+    MapTileLayerKind? DefaultLayerKind = null,
     WidgetSize? Size = null,
     string? RequiredPermission = null,
     DashboardTimeWindow? TimeWindowOverride = null,

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/WidgetDefinitionToInstanceMapper.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/WidgetDefinitionToInstanceMapper.cs
@@ -89,6 +89,28 @@ internal static class WidgetDefinitionToInstanceMapper
                 },
                 JsonOptions)),
 
+        MapWidgetDefinition map => new(
+            "Map", null, map.QueryName,
+            JsonSerializer.Serialize(
+                new
+                {
+                    pointSource = SerializeMapPointSource(map.PointSource),
+                    popupColumns = map.PopupColumns,
+                    defaultZoom = map.DefaultZoom,
+                    defaultCenter = map.DefaultCenter is { } c
+                        ? new { latitude = c.Latitude, longitude = c.Longitude }
+                        : null,
+                    clusterThreshold = map.ClusterThreshold,
+                    detailRoute = map.DetailRoute,
+                    tileUrlTemplate = map.TileUrlTemplate,
+                    // B7-3 (#1577) — preferred layer kind is part of the persisted
+                    // contract; the renderer round-trips it onto MapWidgetSnapshot
+                    // and the frontend resolves the matching layer from whichever
+                    // MapTileProvider the host registered.
+                    defaultLayerKind = map.DefaultLayerKind?.ToString(),
+                },
+                JsonOptions)),
+
         _ => throw new InvalidOperationException(
             $"No persisted-shape mapping registered for widget kind '{widget.GetType().Name}'. "
             + "Custom widget kinds shipped by downstream packages (Granit.IoT.Dashboards, ...) "
@@ -105,5 +127,22 @@ internal static class WidgetDefinitionToInstanceMapper
     {
         QueryAggregateDatasource qa => qa.QueryName,
         _ => null,
+    };
+
+    private static object SerializeMapPointSource(MapPointSource source) => source switch
+    {
+        MapPointSource.LatLng latLng => new
+        {
+            kind = "lat-lng",
+            latitudeColumn = latLng.LatitudeColumn,
+            longitudeColumn = latLng.LongitudeColumn,
+        },
+        MapPointSource.Geography geo => new
+        {
+            kind = "geography",
+            geographyColumn = geo.GeographyColumn,
+        },
+        _ => throw new InvalidOperationException(
+            $"Unknown MapPointSource subtype '{source.GetType().Name}'."),
     };
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Rendering/MapWidgetInstanceRendererTests.cs
@@ -133,6 +133,47 @@ public sealed class MapWidgetInstanceRendererTests
     }
 
     [Fact]
+    public async Task RenderAsync_DefaultLayerKindOmitted_SerialisesAsNullOnTheWire()
+    {
+        // Acceptance criterion #2 from B7-3 (#1577) — when the persisted
+        // ConfigJson has no defaultLayerKind, the snapshot wire field is
+        // null. Frontend treats absence as "no preference" and falls back
+        // to the active provider's first layer.
+        StubRunner runner = new("Granit.Test.Items", points: []);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Latitude"",""longitudeColumn"":""Longitude""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Snapshot!.Value.GetProperty("defaultLayerKind").ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task RenderAsync_DefaultLayerKindSet_PropagatesAsPascalCaseString()
+    {
+        // Acceptance criterion #1 from B7-3 (#1577) — Satellite on the
+        // definition becomes "Satellite" on the wire (PascalCase via the
+        // framework's standard JsonStringEnumConverter()). The frontend
+        // matches this string against its layer registry to pick the active
+        // tile URL.
+        StubRunner runner = new("Granit.Test.Items", points: []);
+        MapWidgetInstanceRenderer renderer = new(new MapService([runner]), _clock);
+
+        WidgetSnapshotEnvelope envelope = await renderer.RenderAsync(
+            BuildWidget(
+                "Granit.Test.Items",
+                @"{""pointSource"":{""kind"":""lat-lng"",""latitudeColumn"":""Latitude"",""longitudeColumn"":""Longitude""},""popupColumns"":null,""defaultZoom"":5,""defaultCenter"":null,""clusterThreshold"":200,""detailRoute"":null,""tileUrlTemplate"":null,""defaultLayerKind"":""Satellite""}"),
+            BuildContext(),
+            TestContext.Current.CancellationToken);
+
+        envelope.Snapshot!.Value.GetProperty("defaultLayerKind").GetString().ShouldBe("Satellite");
+    }
+
+    [Fact]
     public async Task RenderAsync_DefaultCenterNull_SerialisesAsNullOnTheWire()
     {
         StubRunner runner = new("Granit.Test.Items", points: []);

--- a/tests/Granit.Analytics.Tests/Dashboards/MapTileLayerKindTests.cs
+++ b/tests/Granit.Analytics.Tests/Dashboards/MapTileLayerKindTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Granit.Analytics.Dashboards.Widgets;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Tests.Dashboards;
+
+/// <summary>
+/// Pins the wire format of <see cref="MapTileLayerKind"/> per ADR-039 §6.1
+/// (PascalCase enum strings via the framework's standard
+/// <c>JsonStringEnumConverter()</c>). The frontend mirror in
+/// <c>granit-front/packages/@granit/react-map/src/types.ts</c> consumes the
+/// exact strings asserted here — any drift is a breaking wire change.
+/// </summary>
+public sealed class MapTileLayerKindTests
+{
+    private static readonly JsonSerializerOptions PascalCaseEnumOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    [Theory]
+    [InlineData(MapTileLayerKind.Plan, "\"Plan\"")]
+    [InlineData(MapTileLayerKind.Satellite, "\"Satellite\"")]
+    [InlineData(MapTileLayerKind.Hybrid, "\"Hybrid\"")]
+    [InlineData(MapTileLayerKind.Topo, "\"Topo\"")]
+    [InlineData(MapTileLayerKind.Custom, "\"Custom\"")]
+    public void Serializes_AsPascalCaseString(MapTileLayerKind kind, string expected)
+    {
+        string json = JsonSerializer.Serialize(kind, PascalCaseEnumOptions);
+        json.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("\"Plan\"", MapTileLayerKind.Plan)]
+    [InlineData("\"Satellite\"", MapTileLayerKind.Satellite)]
+    [InlineData("\"Hybrid\"", MapTileLayerKind.Hybrid)]
+    [InlineData("\"Topo\"", MapTileLayerKind.Topo)]
+    [InlineData("\"Custom\"", MapTileLayerKind.Custom)]
+    public void Deserializes_FromPascalCaseString(string json, MapTileLayerKind expected)
+    {
+        MapTileLayerKind result = JsonSerializer.Deserialize<MapTileLayerKind>(json, PascalCaseEnumOptions);
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Nullable_RoundTripsAsNull()
+    {
+        // Wire shape on MapWidgetSnapshot is nullable — ensure the null
+        // round-trip is byte-identical so the frontend can rely on absence
+        // = "no preference".
+        MapTileLayerKind? input = null;
+
+        string json = JsonSerializer.Serialize(input, PascalCaseEnumOptions);
+        json.ShouldBe("null");
+
+        MapTileLayerKind? back = JsonSerializer.Deserialize<MapTileLayerKind?>(json, PascalCaseEnumOptions);
+        back.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/WidgetDefinitionToInstanceMapperTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/WidgetDefinitionToInstanceMapperTests.cs
@@ -165,6 +165,11 @@ public sealed class WidgetDefinitionToInstanceMapperTests
             new ChartWidgetDefinition("C", "Q1", "g", AggregateFunction.Count, null, ChartType.Bar, Position: 4),
             new TableWidgetDefinition("Tab", "Q1", null, 10, Position: 5),
             new PivotWidgetDefinition("P", "Q1", ["r"], ["c"], null, AggregateFunction.Count, Position: 6),
+            new MapWidgetDefinition(
+                "M2", "Q1",
+                new MapPointSource.LatLng("Lat", "Lng"),
+                PopupColumns: null,
+                Position: 7),
         ];
 
         foreach (WidgetDefinition widget in widgets)
@@ -175,5 +180,75 @@ public sealed class WidgetDefinitionToInstanceMapperTests
             using var doc = JsonDocument.Parse(result.ConfigJson);
             doc.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
         }
+    }
+
+    [Fact]
+    public void Map_MapsToMapType_WithLatLngPointSource_PersistedAsKindKey()
+    {
+        // Persisted ConfigJson follows the same JSON polymorphism convention
+        // as the renderer's MapConfig deserialiser — the discriminator field
+        // is "kind" with values "lat-lng" / "geography" (kebab-case to mirror
+        // MapPointSource.JsonPolymorphic attribute on the abstraction).
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new MapWidgetDefinition(
+                    "Customers",
+                    "Test.Customers",
+                    new MapPointSource.LatLng("Latitude", "Longitude"),
+                    PopupColumns: ["Name", "Country"],
+                    Position: 0));
+
+        result.WidgetType.ShouldBe("Map");
+        result.QueryName.ShouldBe("Test.Customers");
+
+        using var doc = JsonDocument.Parse(result.ConfigJson);
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("pointSource").GetProperty("kind").GetString().ShouldBe("lat-lng");
+        root.GetProperty("pointSource").GetProperty("latitudeColumn").GetString().ShouldBe("Latitude");
+        root.GetProperty("pointSource").GetProperty("longitudeColumn").GetString().ShouldBe("Longitude");
+        root.GetProperty("popupColumns").EnumerateArray().Select(e => e.GetString()).ShouldBe(["Name", "Country"]);
+
+        // DefaultLayerKind absent on the definition → null on the wire.
+        root.GetProperty("defaultLayerKind").ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void Map_DefaultLayerKind_RoundTripsAsPascalCaseString()
+    {
+        // B7-3 (#1577) — the persisted ConfigJson MUST carry the layer kind
+        // as a PascalCase string ("Satellite", not "SATELLITE", not "1") so
+        // the renderer can deserialise it via JsonStringEnumConverter() into
+        // MapTileLayerKind without a custom converter.
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new MapWidgetDefinition(
+                    "Deliveries",
+                    "Test.Deliveries",
+                    new MapPointSource.LatLng("Lat", "Lng"),
+                    PopupColumns: null,
+                    Position: 0,
+                    DefaultLayerKind: MapTileLayerKind.Satellite));
+
+        using var doc = JsonDocument.Parse(result.ConfigJson);
+        doc.RootElement.GetProperty("defaultLayerKind").GetString().ShouldBe("Satellite");
+    }
+
+    [Fact]
+    public void Map_GeographyPointSource_PersistedWithGeographyDiscriminator()
+    {
+        WidgetDefinitionToInstanceMapper.Mapping result =
+            WidgetDefinitionToInstanceMapper.Map(
+                new MapWidgetDefinition(
+                    "Branches",
+                    "Test.Branches",
+                    new MapPointSource.Geography("Location"),
+                    PopupColumns: null,
+                    Position: 0));
+
+        using var doc = JsonDocument.Parse(result.ConfigJson);
+        JsonElement pointSource = doc.RootElement.GetProperty("pointSource");
+        pointSource.GetProperty("kind").GetString().ShouldBe("geography");
+        pointSource.GetProperty("geographyColumn").GetString().ShouldBe("Location");
     }
 }


### PR DESCRIPTION
## Summary

Closes B7-3 (#1577). Per-widget preference for the map tile layer (`Plan` / `Satellite` / `Hybrid` / `Topo` / `Custom`). Lets dashboard composers default delivery-tracking widgets to satellite while parcel maps default to plan, **without** forcing the whole app onto a single tile provider/layer. Frontend resolution rule (already shipped in granit-front PR #269): match the kind against the active `MapTileProvider`; matching layer wins, otherwise the provider's first layer is used.

## Changes

- **`MapTileLayerKind` enum** in `Granit.Analytics.Dashboards.Widgets`: `Plan = 0`, `Satellite = 1`, `Hybrid = 2`, `Topo = 3`, `Custom = 4`. PascalCase wire via the framework's standard `JsonStringEnumConverter()` (ADR-039 §6.1). Frontend mirror in `granit-front/packages/@granit/react-map/src/types.ts`.
- **`MapWidgetDefinition.DefaultLayerKind: MapTileLayerKind?`** — optional, defaults `null`.
- **`MapWidgetSnapshot.DefaultLayerKind`** — propagated through the renderer's `MapConfig` deserialiser. `null` on the wire = no preference, frontend uses provider default.

## Pre-existing gap closed inside this story

`WidgetDefinitionToInstanceMapper` had **no case for `MapWidgetDefinition`** — importing a Map definition threw *\"no persisted-shape mapping registered\"*. B7-3's renderer-propagation tests are meaningless without an import path that round-trips `DefaultLayerKind` through `ConfigJson`, so the mapping is added here:

- Polymorphic `MapPointSource` serialisation (`\"kind\": \"lat-lng\" | \"geography\"` discriminator)
- `popupColumns`, `defaultZoom`, `defaultCenter`, `clusterThreshold`, `detailRoute`, `tileUrlTemplate`, `defaultLayerKind`
- Four new mapper tests covering LatLng + Geography shapes + DefaultLayerKind round-trip + full all-kinds enumeration extended to include Map.

## Tests

- **`MapTileLayerKindTests` (11 tests)** — serialise + deserialise + nullable round-trip, all 5 enum values pinned to their PascalCase wire string.
- **`MapWidgetInstanceRendererTests` (+2 new)** — DefaultLayerKind omitted on ConfigJson → `null` on snapshot; `\"Satellite\"` on ConfigJson → `\"Satellite\"` on snapshot.
- **`WidgetDefinitionToInstanceMapperTests` (+4 new)** — LatLng + Geography point-source shapes; DefaultLayerKind PascalCase round-trip; all-kinds enumeration extended.

## Test plan

- [x] `dotnet build src/Granit.Analytics`, `src/Granit.Analytics.Endpoints`, `src/Granit.Dashboards.EntityFrameworkCore` — green
- [x] `dotnet test tests/Granit.Analytics.Tests --no-build --filter MapTileLayer` — 11 passed
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests --no-build --filter MapWidgetInstance` — 9 passed
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests --no-build --filter WidgetDefinitionToInstanceMapper` — 13 passed
- [x] Architecture tests with fresh build — 191 passed
- [x] `dotnet format` clean on touched src + tests projects
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed
- [x] Docs: `dashboards/endpoints.mdx` Map snapshot block updated with `defaultLayerKind` field + resolution rule note

## Compatibility

- Wire field is **nullable** — pre-B7-3 frontend code that doesn't read `defaultLayerKind` keeps working.
- The mapper case for Map is additive — no host shipped a Map widget that depended on the previous (broken) throw.