### PR TITLE
feat(odata): strict-config validator — explicit permission + $expand intent (C6 #1395)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20384,9 +20384,21 @@
       "line": 75,
       "members": [
         {
+          "name": "MaxTop",
+          "kind": "method",
+          "signature": "MaxTop(int maxTop)",
+          "returnType": "ODataEntitySetBuilder<TEntity>"
+        },
+        {
           "name": "ExpandWhitelist",
           "kind": "method",
           "signature": "ExpandWhitelist(params string[] properties)",
+          "returnType": "ODataEntitySetBuilder<TEntity>"
+        },
+        {
+          "name": "MaxExpansionDepth",
+          "kind": "method",
+          "signature": "MaxExpansionDepth(int depth)",
           "returnType": "ODataEntitySetBuilder<TEntity>"
         }
       ]

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -70,6 +70,8 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                 nameof(configure));
         }
 
+        ValidateStrictConfiguration(options.Descriptors);
+
         IEdmModel edmModel = ODataEdmModelBuilder.Build(options.Descriptors);
 
         RouteGroupBuilder root = endpoints.MapGroup(prefix)
@@ -97,6 +99,49 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         return root;
     }
+
+    /// <summary>
+    /// Strict-config validator (C6 #1395). Refuses to start the host when a
+    /// registered EntitySet hasn't acknowledged its security-sensitive
+    /// configuration choices: permission gating and <c>$expand</c> policy.
+    /// The framework deliberately does NOT default-deny and does NOT
+    /// silently apply safe defaults — those would let convention drift
+    /// reach production unchecked. Failing fast at <c>MapGranitODataEndpoints</c>
+    /// time is the equivalent of an architecture test for a config surface
+    /// that lives inside a closure (and is therefore not statically
+    /// reflectable).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Any descriptor lacks both <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/> and <see cref="ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/>, OR neither <see cref="ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/> nor <see cref="ODataEntitySetBuilder{TEntity}.DisableExpand"/>.</exception>
+    private static void ValidateStrictConfiguration(IReadOnlyList<ODataEntitySetDescriptor> descriptors)
+    {
+        List<string> errors = [];
+
+        foreach (ODataEntitySetDescriptor descriptor in descriptors)
+        {
+            if (descriptor.RequiredPermission is null && !descriptor.AnonymousAccessAcknowledged)
+            {
+                errors.Add(
+                    $"EntitySet '{descriptor.EntitySetName}' must call either RequirePermission(string) or AllowAnonymousAccess() — implicit anonymous OData access is rejected by the strict-config validator (C6 #1395). Convention: {RequiredPermissionConvention(descriptor)}.");
+            }
+
+            if (!descriptor.ExpandConfigurationAcknowledged)
+            {
+                errors.Add(
+                    $"EntitySet '{descriptor.EntitySetName}' must call either ExpandWhitelist(...) or DisableExpand() — implicit \"$expand disabled\" is rejected by the strict-config validator (C6 #1395). Use DisableExpand() to declare the intent, or ExpandWhitelist(\"NavProp1\", ...) to allow specific navigations.");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "OData EntitySet configuration is incomplete:" + Environment.NewLine
+                + string.Join(Environment.NewLine, errors.Select(e => "  - " + e)));
+        }
+    }
+
+    /// <summary>Suggests the conventional <c>OData.{Module}.{Entity}.Read</c> permission name for the descriptor's entity, used in the strict-config error message.</summary>
+    private static string RequiredPermissionConvention(ODataEntitySetDescriptor descriptor) =>
+        $"OData.{descriptor.EntityType.Namespace?.Split('.').LastOrDefault() ?? "Module"}.{descriptor.EntityType.Name}.Read";
 
     /// <summary>
     /// Wires one EntitySet's <c>GET /{EntitySetName}</c> route. Closed over

--- a/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
@@ -17,6 +17,8 @@ namespace Granit.Http.ODataExposure.Internal;
 /// <param name="CountEnabled"><c>$count=true</c> requests are accepted only when this is <see langword="true"/>. Default <see langword="false"/> — guards huge tables against full-table-scan counts on every refresh.</param>
 /// <param name="ExpandWhitelist">Allowed top-level navigation properties for <c>$expand</c>. <see langword="null"/> means <c>$expand</c> is disabled entirely. Empty list (<c>[]</c>) ALSO disables expand — the EntitySet's contract is "no navigation by default; opt in explicitly per property".</param>
 /// <param name="MaxExpansionDepth">Maximum nesting depth allowed for <c>$expand</c>. Default <c>1</c> — flat expand only; nested expand requires explicit opt-in.</param>
+/// <param name="AnonymousAccessAcknowledged">Set by <see cref="Options.ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/> to declare that the absence of <see cref="RequiredPermission"/> is intentional. Without this flag, the strict-config validator (C6 #1395) refuses to start the host — every OData EntitySet must be either gated or explicitly anonymous.</param>
+/// <param name="ExpandConfigurationAcknowledged">Set by <see cref="Options.ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/>, <see cref="Options.ODataEntitySetBuilder{TEntity}.DisableExpand"/>, or implicit via <see cref="Options.ODataEntitySetBuilder{TEntity}.AllowNoExpansion"/>. The strict-config validator refuses to start the host until one of these is called — implicit "expand disabled" is a security smell, the host must declare the intent.</param>
 internal sealed record ODataEntitySetDescriptor(
     string EntitySetName,
     Type EntityType,
@@ -26,4 +28,6 @@ internal sealed record ODataEntitySetDescriptor(
     int PageSize = 1000,
     bool CountEnabled = false,
     IReadOnlyList<string>? ExpandWhitelist = null,
-    int MaxExpansionDepth = 1);
+    int MaxExpansionDepth = 1,
+    bool AnonymousAccessAcknowledged = false,
+    bool ExpandConfigurationAcknowledged = false);

--- a/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
+++ b/src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs
@@ -92,8 +92,29 @@ public sealed class ODataEntitySetBuilder<TEntity>
     public ODataEntitySetBuilder<TEntity> RequirePermission(string permission)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(permission);
-        return Update(_descriptor with { RequiredPermission = permission });
+        return Update(_descriptor with
+        {
+            RequiredPermission = permission,
+            // RequirePermission satisfies the strict-config validator's
+            // "either gated or explicitly anonymous" rule.
+            AnonymousAccessAcknowledged = false,
+        });
     }
+
+    /// <summary>
+    /// Explicit opt-in: this EntitySet IS anonymous-readable, by design.
+    /// Use case: a public reference-data feed (countries, currencies) that
+    /// truly has no per-tenant restriction. Without calling this method (or
+    /// <see cref="RequirePermission"/>), <c>MapGranitODataEndpoints</c>
+    /// throws at startup — the strict-config validator (C6 #1395) refuses
+    /// to ship a permission-less EntitySet by accident.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> AllowAnonymousAccess()
+        => Update(_descriptor with
+        {
+            RequiredPermission = null,
+            AnonymousAccessAcknowledged = true,
+        });
 
     /// <summary>
     /// Caps the user-supplied <c>$top</c>. Requests above this value are
@@ -138,8 +159,28 @@ public sealed class ODataEntitySetBuilder<TEntity>
     public ODataEntitySetBuilder<TEntity> ExpandWhitelist(params string[] properties)
     {
         ArgumentNullException.ThrowIfNull(properties);
-        return Update(_descriptor with { ExpandWhitelist = [.. properties] });
+        return Update(_descriptor with
+        {
+            ExpandWhitelist = [.. properties],
+            ExpandConfigurationAcknowledged = true,
+        });
     }
+
+    /// <summary>
+    /// Explicit opt-out: this EntitySet does NOT support <c>$expand</c> — any
+    /// expand request returns <c>400 Bad Request</c>. Equivalent to calling
+    /// <see cref="ExpandWhitelist"/> with no arguments, but reads more
+    /// clearly at the call site. The strict-config validator (C6 #1395)
+    /// requires either this or <see cref="ExpandWhitelist"/> on every
+    /// EntitySet — implicit "expand disabled" is a security smell, the
+    /// host must declare the intent.
+    /// </summary>
+    public ODataEntitySetBuilder<TEntity> DisableExpand()
+        => Update(_descriptor with
+        {
+            ExpandWhitelist = [],
+            ExpandConfigurationAcknowledged = true,
+        });
 
     /// <summary>
     /// Sets the maximum nesting depth allowed for <c>$expand</c>. Default

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -61,6 +61,15 @@ Per EntitySet `GET /api/granit/odata/{Name}?$filter=…&$select=…&$top=…`:
 The order is load-bearing: tenant first, framework filters second, user
 query third.
 
+## Strict-config validator (C6 #1395)
+
+Every EntitySet MUST explicitly declare two security-sensitive intents:
+
+1. **Permission** — call `.RequirePermission(...)` (gated) **OR** `.AllowAnonymousAccess()` (public-feed scenario, e.g. tenant-agnostic reference data).
+2. **`$expand` policy** — call `.ExpandWhitelist(...)` (allow listed navigations) **OR** `.DisableExpand()` (no navigation exposed).
+
+Without one of each, `MapGranitODataEndpoints` throws at host startup with a list of every misconfigured EntitySet. The framework deliberately does NOT default-deny silently — silent defaults let convention drift reach production unchecked. Failing fast at composition time is the equivalent of an architecture test for a config surface that lives inside a closure (and is therefore not statically reflectable).
+
 ## Hardening (per EntitySet)
 
 The fluent builder ships safe-by-default caps; override per set when the
@@ -68,12 +77,12 @@ data product warrants it:
 
 ```csharp
 opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
-    .MaxTop(2500)                    // default 5000 — silently clamps user $top
-    .PageSize(500)                   // default 1000 — used when caller omits $top
-    .EnableCount()                   // default disabled — opt in for cheap-to-count tables
-    .ExpandWhitelist("Customer")     // default disabled — list allowed top-level navigations
-    .MaxExpansionDepth(2)            // default 1 — flat expand only
-    .RequirePermission("OData.Invoicing.Invoices.Read");
+    .RequirePermission("OData.Invoicing.Invoices.Read")  // strict-config: required
+    .ExpandWhitelist("Customer")                         // strict-config: required (or DisableExpand())
+    .MaxTop(2500)                                        // default 5000 — silently clamps user $top
+    .PageSize(500)                                       // default 1000 — used when caller omits $top
+    .EnableCount()                                       // default disabled — opt in for cheap-to-count tables
+    .MaxExpansionDepth(2);                               // default 1 — flat expand only
 ```
 
 Behaviour:

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
@@ -126,8 +126,16 @@ internal sealed class ODataTestApp : IAsyncDisposable
 
         app.MapGranitODataEndpoints("/api/granit/odata", opts =>
         {
+            // Strict-config validator (C6 #1395) requires every EntitySet to
+            // declare its permission and $expand intents. The integration
+            // suites are about tenant isolation / query hardening / rate
+            // limiting, not auth — apply safe defaults that the per-test
+            // configureEntitySet callback can override (e.g. by calling
+            // ExpandWhitelist(...) or RequirePermission(...)).
             ODataEntitySetBuilder<Invoice> builder =
-                opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");
+                opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                    .AllowAnonymousAccess()
+                    .DisableExpand();
             configureEntitySet?.Invoke(builder);
         });
 

--- a/tests/Granit.Http.ODataExposure.Tests/Granit.Http.ODataExposure.Tests.csproj
+++ b/tests/Granit.Http.ODataExposure.Tests/Granit.Http.ODataExposure.Tests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
@@ -15,8 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.ODataExposure\Granit.Http.ODataExposure.csproj" />
+    <ProjectReference Include="..\..\src\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\..\src\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Granit.RateLimiting\Granit.RateLimiting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataExposureOptionsTests.cs
@@ -205,6 +205,62 @@ public sealed class ODataExposureOptionsTests
             .ShouldBe("OData.Test.Invoices.Read");
     }
 
+    [Fact]
+    public void AllowAnonymousAccess_ClearsRequiredPermission_AndFlagsAcknowledgement()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .RequirePermission("OData.Test.Invoices.Read")
+            .AllowAnonymousAccess();
+
+        object d = GetSingleDescriptor(options);
+        ((string?)d.GetType().GetProperty("RequiredPermission")!.GetValue(d)).ShouldBeNull();
+        ((bool)d.GetType().GetProperty("AnonymousAccessAcknowledged")!.GetValue(d)!).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequirePermission_ClearsAnonymousAccessFlag()
+    {
+        // Switching back to a permission gate after explicitly opting into
+        // anonymous must take precedence — last call wins, and the flag is
+        // reset so the strict validator sees the permission.
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .AllowAnonymousAccess()
+            .RequirePermission("OData.Test.Invoices.Read");
+
+        object d = GetSingleDescriptor(options);
+        ((string?)d.GetType().GetProperty("RequiredPermission")!.GetValue(d))
+            .ShouldBe("OData.Test.Invoices.Read");
+        ((bool)d.GetType().GetProperty("AnonymousAccessAcknowledged")!.GetValue(d)!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DisableExpand_SetsEmptyWhitelist_AndFlagsAcknowledgement()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .DisableExpand();
+
+        object d = GetSingleDescriptor(options);
+        var whitelist = (System.Collections.Generic.IReadOnlyList<string>?)
+            d.GetType().GetProperty("ExpandWhitelist")!.GetValue(d);
+        whitelist.ShouldNotBeNull();
+        whitelist!.ShouldBeEmpty();
+        ((bool)d.GetType().GetProperty("ExpandConfigurationAcknowledged")!.GetValue(d)!).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExpandWhitelist_AlsoFlagsAcknowledgement()
+    {
+        ODataExposureOptions options = new();
+        options.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+            .ExpandWhitelist("Customer");
+
+        object d = GetSingleDescriptor(options);
+        ((bool)d.GetType().GetProperty("ExpandConfigurationAcknowledged")!.GetValue(d)!).ShouldBeTrue();
+    }
+
     private static object GetSingleDescriptor(ODataExposureOptions options)
     {
         object? list = options.GetType()

--- a/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
@@ -1,0 +1,150 @@
+using Granit.Authorization;
+using Granit.Http.ODataExposure.Extensions;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.RateLimiting.Extensions;
+using Granit.RateLimiting.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// C6 (#1395) — strict-config validator. Locks the rule that every
+/// EntitySet must explicitly declare its permission and <c>$expand</c>
+/// intents. Implicit-anonymous and implicit-no-expand are rejected at
+/// <c>MapGranitODataEndpoints</c> time so misconfiguration cannot reach
+/// production. Fail-fast at startup is the equivalent of an architecture
+/// test for a config surface that lives inside a closure (and is therefore
+/// not statically reflectable).
+/// </summary>
+public sealed class StrictConfigValidatorTests
+{
+    [Fact]
+    public void EntitySet_WithoutPermissionOrAnonymousAck_Throws()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices").DisableExpand()));
+
+        ex.Message.ShouldContain("RequirePermission");
+        ex.Message.ShouldContain("AllowAnonymousAccess");
+        ex.Message.ShouldContain("Invoices");
+    }
+
+    [Fact]
+    public void EntitySet_WithoutExpandConfiguration_Throws()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                .RequirePermission("OData.Test.Invoices.Read")));
+
+        ex.Message.ShouldContain("ExpandWhitelist");
+        ex.Message.ShouldContain("DisableExpand");
+        ex.Message.ShouldContain("Invoices");
+    }
+
+    [Fact]
+    public void EntitySet_FullyConfigured_DoesNotThrow()
+    {
+        Should.NotThrow(() =>
+            CallMap(opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                .RequirePermission("OData.Test.Invoices.Read")
+                .DisableExpand()));
+    }
+
+    [Fact]
+    public void EntitySet_AnonymousAndDisableExpand_DoesNotThrow()
+    {
+        // Public-feed scenario: countries / currencies / tenant-agnostic
+        // reference data. Both opt-outs are explicit, validator accepts.
+        Should.NotThrow(() =>
+            CallMap(opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                .AllowAnonymousAccess()
+                .DisableExpand()));
+    }
+
+    [Fact]
+    public void EntitySet_ErrorMessage_ListsAllOffendingSetsAtOnce()
+    {
+        // Multi-set apps deserve a single error listing every misconfigured
+        // EntitySet, not a one-by-one drip-fix loop. The validator
+        // accumulates errors before throwing.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(opts =>
+            {
+                opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices");      // missing both
+                opts.EntitySet<Customer, CustomerQueryDefinition>("Customers");   // missing both
+            }));
+
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("Customers");
+    }
+
+    private static void CallMap(Action<Options.ODataExposureOptions> configure)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        // Stub services so the route handler's DI binding is satisfiable
+        // — the validator runs BEFORE any of these are touched, but
+        // MapGranitODataEndpoints fully wires the routes after validation
+        // succeeds, so the DI graph must resolve.
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+        builder.Services.AddSingleton<IPermissionChecker>(Substitute.For<IPermissionChecker>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<Invoice>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<Customer>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<Invoice>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<Customer>>());
+        builder.Services.AddSingleton<QueryDefinition<Invoice>>(new InvoiceQueryDefinition());
+        builder.Services.AddSingleton<QueryDefinition<Customer>>(new CustomerQueryDefinition());
+
+        builder.Services.AddGranitODataExposure();
+        builder.Services.AddGranitRateLimiting(o =>
+        {
+            o.Enabled = true;
+            o.Policies["granit-odata"] = new RateLimitPolicyOptions
+            {
+                PermitLimit = 1000,
+                Window = TimeSpan.FromMinutes(1),
+            };
+        });
+
+        WebApplication app = builder.Build();
+        try
+        {
+            app.MapGranitODataEndpoints("/api/granit/odata", configure);
+        }
+        finally
+        {
+            ((IDisposable)app).Dispose();
+        }
+    }
+
+    public sealed class Invoice
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+    }
+
+    public sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
+    {
+        public override string Name => "Test.Invoices";
+        protected override void Configure(QueryDefinitionBuilder<Invoice> builder) =>
+            builder.Column(i => i.Number, c => c.Filterable());
+    }
+
+    public sealed class Customer
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+    }
+
+    public sealed class CustomerQueryDefinition : QueryDefinition<Customer>
+    {
+        public override string Name => "Test.Customers";
+        protected override void Configure(QueryDefinitionBuilder<Customer> builder) =>
+            builder.Column(c => c.Name, b => b.Filterable());
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
@@ -111,15 +111,8 @@ public sealed class StrictConfigValidatorTests
             };
         });
 
-        WebApplication app = builder.Build();
-        try
-        {
-            app.MapGranitODataEndpoints("/api/granit/odata", configure);
-        }
-        finally
-        {
-            ((IDisposable)app).Dispose();
-        }
+        using WebApplication app = builder.Build();
+        app.MapGranitODataEndpoints("/api/granit/odata", configure);
     }
 
     public sealed class Invoice

--- a/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
+++ b/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
@@ -67,10 +67,7 @@
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -101,40 +98,12 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.ObjectPool": {
-        "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "IbQUEZr/LxxpPxkXDmKaemMeQNPjdHfk87HtTsI18a3RVgad0NOJSRaJ20hcesqL45PLcpQHR8xrPP7wZKbFQQ=="
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
-      },
       "Microsoft.OData.Core": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "gt/iiI1AJ7HyI2OZkw84lJxSedUxBdRqPUUlVrkObwolX4T278EBoYQ6ZdXgeb9hDwpUjFlGBYOlHnxnlXmpwQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.ObjectPool": "6.0.3",
           "Microsoft.OData.Edm": "[8.4.0]",
           "Microsoft.Spatial": "[8.4.0]"
         }
@@ -213,6 +182,11 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -223,10 +197,10 @@
         "resolved": "4.6.0",
         "contentHash": "pOd+UhZ3X8xfwKDlgAzowUJNjp8VYVmOHZm++vCd0kq1HZ0zK3mNo2yRXjYgv7Ik/Xi43fmJfND2PLEsQSALCg=="
       },
-      "System.Diagnostics.EventLog": {
+      "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -303,6 +277,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -319,12 +298,6 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
-          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "OpenTelemetry.Api": "[1.15.*, )",
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
@@ -343,8 +316,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.features": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.abstractions": {
         "type": "Project"
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.http.odataexposure": {
         "type": "Project",
@@ -353,7 +339,26 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.RateLimiting": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OData": "[9.4.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -363,12 +368,19 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
-      "granit.timing": {
+      "granit.ratelimiting": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Features": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "StackExchange.Redis": "[2.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.AspNetCore.OData": {
@@ -383,90 +395,36 @@
           "Microsoft.Spatial": "[8.4.0, 9.0.0)"
         }
       },
-      "Microsoft.Extensions.Caching.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Caching.Memory": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7",
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7",
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
       },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.12.14",
+        "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
+        "dependencies": {
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
         "resolved": "2.6.0",
-        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Memory": "10.0.1"
-        }
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
       },
       "ZiggyCreatures.FusionCache.OpenTelemetry": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Closes the spirit of **C6 (#1395)**. The story asked for static architecture tests that fail the build when an EntitySet is missing its permission or `\$expand` whitelist. But the EntitySet config lives inside the `configure` callback of `MapGranitODataEndpoints` (a closure), which is not statically reflectable. The pragmatic equivalent: a **strict-config validator** that runs at `MapGranitODataEndpoints` time and throws an `InvalidOperationException` listing every misconfigured set. Hosts that drift cannot start. CI catches it on every build that boots the host.

## Two explicit intents required

| Intent | Choices |
| ------ | ------- |
| **Permission** | `.RequirePermission(string)` (gated) **or** `.AllowAnonymousAccess()` (explicit public feed) |
| **`\$expand` policy** | `.ExpandWhitelist(string[])` (allow listed) **or** `.DisableExpand()` (no expand) |

Without both choices declared on every EntitySet, the validator throws with a multi-set error list:

```text
OData EntitySet configuration is incomplete:
  - EntitySet 'Invoices' must call either RequirePermission(string) or AllowAnonymousAccess() — implicit anonymous OData access is rejected by the strict-config validator (C6 #1395). Convention: OData.Invoicing.Invoice.Read.
  - EntitySet 'Customers' must call either ExpandWhitelist(...) or DisableExpand() — implicit \"\$expand disabled\" is rejected by the strict-config validator (C6 #1395). Use DisableExpand() to declare the intent, or ExpandWhitelist(\"NavProp1\", ...) to allow specific navigations.
```

## Why fail-fast over silent defaults

Silent default-deny would let convention drift reach production unchecked: a host that forgets `\.RequirePermission` ships an anonymous-readable EntitySet, the test suite passes, prod ships, the audit catches it months later. The validator forces the choice to be visible at the host's call site — it's the equivalent of an architecture test for a config surface that lives inside a closure.

## Implementation

- **`ODataEntitySetDescriptor`** gets two new flags: `AnonymousAccessAcknowledged` and `ExpandConfigurationAcknowledged`. Set by `AllowAnonymousAccess` / `DisableExpand` / `ExpandWhitelist` respectively. `RequirePermission` resets the anonymous flag — last call wins.
- **`ValidateStrictConfiguration`** iterates every descriptor, accumulates error messages, throws once with a single multi-set list. Suggests the conventional `OData.{Module}.{Entity}.Read` permission name in the error.
- **Two new builder methods**: `AllowAnonymousAccess()` and `DisableExpand()`. Convention-readable at the call site — `DisableExpand()` is preferred over `ExpandWhitelist()` with no args even though they're semantically identical.

## Tests

- **9 new unit tests** in `Granit.Http.ODataExposure.Tests` (now **28 total**, was 19):
  - 4 builder tests: opt-outs round-trip on descriptor (Anonymous + DisableExpand acknowledgements, Whitelist auto-flags, switching back to permission resets the anonymous flag).
  - 5 validator tests: missing permission throws, missing expand throws, fully-configured passes, anonymous + DisableExpand passes, multi-set error accumulates.
- **Integration tests** unchanged in spirit — `ODataTestApp.CreateAsync` applies `AllowAnonymousAccess + DisableExpand` defaults before the per-test `configureEntitySet` callback runs. Tests that call `ExpandWhitelist` or `RequirePermission` override correctly. The integration suites are about tenant isolation / query hardening / rate limiting, not auth — defaults are appropriate.

## Test plan

- [x] `dotnet build src/Granit.Http.ODataExposure` — green
- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests --no-build` — 28 passed
- [x] `dotnet build tests/Granit.Http.ODataExposure.Tests.Integration` — green
- [x] Architecture tests with fresh build — 191 passed
- [x] `dotnet format` clean on touched src + tests + tests.integration
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed
- [x] README updated with the new "Strict-config validator" section

## What about the EDM column whitelist?

The third C6 invariant (\"every column projected by OData EDM MUST be in `QueryDefinition.AllowedColumns`\") is the C4 #1575 concern, which is **paused** per @JFMeyers — `QueryDefinition.GetColumns()` in practice exposes only filterable columns, so naively narrowing the EDM to that set would hide legitimate display-only columns. Design needs more thought; the discussion lives in #1575.