### PR TITLE
ci: dedicated docs-site job — frozen lockfile + Astro build + markdownlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,48 @@ jobs:
           exit-code: 1
           format: table
 
+  # ---------------------------------------------------------------------------
+  # DOCS-SITE: lockfile drift + Astro build + markdownlint
+  # Runs in parallel with the .NET build/test matrix. Keeps the docs-site
+  # green-light fast: lockfile drift surfaces at PR time (not "next time
+  # someone runs pnpm install") and broken Astro pages don't ship.
+  # ---------------------------------------------------------------------------
+  docs-site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@latest --activate
+
+      - name: pnpm cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('docs-site/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      # --frozen-lockfile fails if pnpm-lock.yaml is out of sync with
+      # package.json — catches Dependabot's partial lockfile updates that
+      # would otherwise drift into a 500+ line `pnpm install` re-resolve
+      # the next time anyone touches the docs locally.
+      - name: Install dependencies
+        working-directory: docs-site
+        run: pnpm install --frozen-lockfile
+
+      - name: Astro build
+        working-directory: docs-site
+        run: npx astro build
+
+      - name: Markdownlint
+        run: npx markdownlint-cli2 "**/*.md"
+
   # NuGet audit feed: complements Trivy (different CVE source, also catches
   # transitive dependencies disclosed AFTER lockfile generation).
   # Sharded the same way as build/test — restoring + auditing the full solution


### PR DESCRIPTION
## Summary

Adds a small CI job that catches three classes of regression at PR time that were previously invisible:

1. **pnpm-lock drift** — Dependabot's npm bumps do partial lockfile updates (patch the direct reference, leave transitive `(foo@old(...))` references in the resolution graph). The next \`pnpm install\` without \`--frozen-lockfile\` re-resolves the full graph and produces a 500+ line diff. **Last instance**: PR #1582 (C5 docs) churned 539 lines of \`pnpm-lock.yaml\` without touching \`package.json\`. \`--frozen-lockfile\` fails when the lockfile is out of sync, so subsequent Dependabot PRs that don't fully re-lock will be rejected at PR time.

2. **Astro build regressions** — \`npx astro build\` exercises every \`.mdx\` page, validates internal links, fails on broken syntax. Previously only run inside the SonarCloud job (which is gated by secrets, runs only on main pushes, and has nothing to do with docs).

3. **Markdownlint regressions** — runs against every \`.md\` in the repo (with the existing \`.markdownlint-cli2.jsonc\` config and \`.markdownlintignore\` exclusions for `AnalyzerReleases.*.md`).

## Job shape

- Runs on every PR and push, parallel with the .NET build/test matrix
- ubuntu-latest, 10-minute timeout
- pnpm cache keyed on \`docs-site/pnpm-lock.yaml\` hash → ~10s on warm cache, ~30s cold
- Steps: setup Node 22 → corepack pnpm → \`pnpm install --frozen-lockfile\` → \`npx astro build\` → \`npx markdownlint-cli2 "**/*.md"\`

## Verified locally

- \`pnpm install --frozen-lockfile\` — clean (lockfile already in sync after C5 work)
- \`npx astro build\` — 445 pages, 0 errors (matches PR #1582)
- \`npx markdownlint-cli2\` — clean on plain markdown (MDX inline-component lints already accepted state per existing committed mdx files in the repo)

## Diagnosis context

The pnpm-lock churn pattern is documented in the discussion of PR #1585 (the Wolverine SG fix). This PR is the second leg of the small "transverse infrastructure" cleanup batch (option B of the EPIC #1366 close-out discussion).