### PR TITLE
feat(subscriptions): ship 8 MetricDefinitions for Subscription / Plan / PlanPrice

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2287,6 +2287,7 @@
       "name": "Granit.Subscriptions",
       "deps": [
         "Granit",
+        "Granit.Analytics",
         "Granit.Parties.Abstractions",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
@@ -46729,7 +46730,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs",
-      "line": 21,
+      "line": 23,
       "members": [
         {
           "name": "AddGranitSubscriptions",
@@ -47256,6 +47257,398 @@
           "kind": "method",
           "signature": "CreateInvoiceAsync(CreateUsageInvoiceRequest request, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ActivePlanCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.ActivePlanCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/ActivePlanCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Plan, int?>>? Selector",
+          "returnType": "Expression<Func<Plan, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Plan, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Plan, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Plan, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Plan, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "ActivePlanPriceCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.ActivePlanPriceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/ActivePlanPriceCountMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PlanPrice, int?>>? Selector",
+          "returnType": "Expression<Func<PlanPrice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PlanPrice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PlanPrice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PlanPrice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PlanPrice, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "ActiveSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.ActiveSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/ActiveSubscriptionCountMetricDefinition.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "CancelAtPeriodEndSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.CancelAtPeriodEndSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/CancelAtPeriodEndSubscriptionCountMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "CancelledSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.CancelledSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/CancelledSubscriptionCountMetricDefinition.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "DunningSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.DunningSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/DunningSubscriptionCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PastDueSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.PastDueSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/PastDueSubscriptionCountMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "TrialSubscriptionCountMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.TrialSubscriptionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/TrialSubscriptionCountMetricDefinition.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, int?>>? Selector",
+          "returnType": "Expression<Func<Subscription, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Subscription, DateTimeOffset>>?"
         }
       ]
     },

--- a/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
@@ -83,6 +83,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.backgroundjobs": {
         "type": "Project",
         "dependencies": {
@@ -112,6 +128,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -205,6 +237,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Builtin/packages.lock.json
+++ b/src/Granit.Subscriptions.Builtin/packages.lock.json
@@ -83,6 +83,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -98,6 +114,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -191,6 +223,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -44,6 +44,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -61,6 +77,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -192,6 +224,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
@@ -113,6 +113,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -128,6 +144,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -267,6 +299,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Features/packages.lock.json
+++ b/src/Granit.Subscriptions.Features/packages.lock.json
@@ -83,6 +83,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -98,6 +114,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -198,6 +230,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Notifications/packages.lock.json
+++ b/src/Granit.Subscriptions.Notifications/packages.lock.json
@@ -83,6 +83,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -98,6 +114,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -198,6 +230,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Analytics.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Metering;
@@ -7,6 +8,7 @@ using Granit.Subscriptions.Diagnostics;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Exports;
 using Granit.Subscriptions.Internal;
+using Granit.Subscriptions.Metrics;
 using Granit.Subscriptions.Queries;
 using Granit.Workflow.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +53,15 @@ public static class SubscriptionsHostApplicationBuilderExtensions
         builder.Services.AddExportDefinition<Subscription, SubscriptionExportDefinition>();
         builder.Services.AddExportDefinition<Plan, PlanExportDefinition>();
         builder.Services.AddExportDefinition<PlanPrice, PlanPriceExportDefinition>();
+
+        builder.Services.AddMetricDefinition<Subscription, int, ActiveSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, int, TrialSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, int, PastDueSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, int, CancelledSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, int, DunningSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, int, CancelAtPeriodEndSubscriptionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Plan, int, ActivePlanCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<PlanPrice, int, ActivePlanPriceCountMetricDefinition>();
 
         return builder;
     }

--- a/src/Granit.Subscriptions/Granit.Subscriptions.csproj
+++ b/src/Granit.Subscriptions/Granit.Subscriptions.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\Granit.Parties.Abstractions\Granit.Parties.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />

--- a/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
@@ -1,6 +1,14 @@
 {
   "culture": "cs",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktivní plány",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktivní ceny plánů",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktivní předplatná",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Předplatná rušená na konci období",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Zrušená předplatná",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Předplatná ve vymáhání",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Předplatná po splatnosti",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Zkušební předplatná",
     "Subscriptions.Columns.BillingCycleAnchor": "Ukotvení fakturačního cyklu",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Zrušit na konci období",
     "Subscriptions.Columns.CancellationReason": "Důvod zrušení",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/de.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/de.json
@@ -1,6 +1,14 @@
 {
   "culture": "de",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktive Pläne",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktive Planpreise",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktive Abonnements",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnements zur Stornierung am Periodenende",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Stornierte Abonnements",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnements im Mahnverfahren",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Überfällige Abonnements",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Test-Abonnements",
     "Subscriptions.Columns.BillingCycleAnchor": "Abrechnungszyklusanker",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Am Periodenende kündigen",
     "Subscriptions.Columns.CancellationReason": "Stornogrund",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/en.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/en.json
@@ -1,6 +1,14 @@
 {
   "culture": "en",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Active plans",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Active plan prices",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Active subscriptions",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Subscriptions cancelling at period end",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Cancelled subscriptions",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Subscriptions in dunning",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Past-due subscriptions",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Trial subscriptions",
     "Subscriptions.Columns.BillingCycleAnchor": "Billing Cycle Anchor",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
     "Subscriptions.Columns.CancellationReason": "Cancellation Reason",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/es.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/es.json
@@ -1,6 +1,14 @@
 {
   "culture": "es",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planes activos",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Precios de plan activos",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Suscripciones activas",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Suscripciones que se cancelarán al final del período",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Suscripciones canceladas",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Suscripciones en reclamación",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Suscripciones vencidas",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Suscripciones en prueba",
     "Subscriptions.Columns.BillingCycleAnchor": "Anclaje del ciclo de facturación",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Cancelar al final del período",
     "Subscriptions.Columns.CancellationReason": "Motivo de cancelación",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
@@ -1,6 +1,14 @@
 {
   "culture": "fr",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Plans actifs",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Tarifs de plan actifs",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abonnements actifs",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnements à annuler en fin de période",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Abonnements annulés",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnements en relance",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Abonnements en retard de paiement",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Abonnements en essai",
     "Subscriptions.Columns.BillingCycleAnchor": "Ancrage du cycle de facturation",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Annuler en fin de période",
     "Subscriptions.Columns.CancellationReason": "Motif d'annulation",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
@@ -1,6 +1,14 @@
 {
   "culture": "hi",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "सक्रिय योजनाएँ",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "सक्रिय योजना मूल्य",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "सक्रिय सदस्यताएँ",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "अवधि के अंत में रद्द होने वाली सदस्यताएँ",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "रद्द की गई सदस्यताएँ",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "तकाजे में सदस्यताएँ",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "बकाया सदस्यताएँ",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "परीक्षण सदस्यताएँ",
     "Subscriptions.Columns.BillingCycleAnchor": "बिलिंग चक्र एंकर",
     "Subscriptions.Columns.CancelAtPeriodEnd": "अवधि समाप्ति पर रद्द करें",
     "Subscriptions.Columns.CancellationReason": "रद्द करने का कारण",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/it.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/it.json
@@ -1,6 +1,14 @@
 {
   "culture": "it",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Piani attivi",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Prezzi di piano attivi",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abbonamenti attivi",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abbonamenti in annullamento a fine periodo",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Abbonamenti annullati",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abbonamenti in sollecito",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Abbonamenti scaduti",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Abbonamenti in prova",
     "Subscriptions.Columns.BillingCycleAnchor": "Ancoraggio del ciclo di fatturazione",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Annulla a fine periodo",
     "Subscriptions.Columns.CancellationReason": "Motivo di annullamento",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
@@ -1,6 +1,14 @@
 {
   "culture": "ja",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "有効なプラン",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "有効なプラン価格",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "有効なサブスクリプション",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "期間末にキャンセル予定のサブスクリプション",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "キャンセルされたサブスクリプション",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "督促中のサブスクリプション",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "支払い遅延中のサブスクリプション",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "トライアル中のサブスクリプション",
     "Subscriptions.Columns.BillingCycleAnchor": "請求サイクル基準日",
     "Subscriptions.Columns.CancelAtPeriodEnd": "期間終了時にキャンセル",
     "Subscriptions.Columns.CancellationReason": "キャンセル理由",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
@@ -1,6 +1,14 @@
 {
   "culture": "ko",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "활성 플랜",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "활성 플랜 가격",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "활성 구독",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "기간 종료 시 취소될 구독",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "취소된 구독",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "독촉 중인 구독",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "연체 구독",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "체험 구독",
     "Subscriptions.Columns.BillingCycleAnchor": "청구 주기 기준일",
     "Subscriptions.Columns.CancelAtPeriodEnd": "기간 종료 시 취소",
     "Subscriptions.Columns.CancellationReason": "취소 사유",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
@@ -1,6 +1,14 @@
 {
   "culture": "nl",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Actieve plannen",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Actieve planprijzen",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Actieve abonnementen",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnementen te annuleren bij einde periode",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Geannuleerde abonnementen",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnementen in aanmaning",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Achterstallige abonnementen",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Proefabonnementen",
     "Subscriptions.Columns.BillingCycleAnchor": "Anker factureringscyclus",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Annuleren aan einde periode",
     "Subscriptions.Columns.CancellationReason": "Reden van annulering",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
@@ -1,6 +1,14 @@
 {
   "culture": "pl",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktywne plany",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktywne ceny planów",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktywne subskrypcje",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Subskrypcje do anulowania na koniec okresu",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Anulowane subskrypcje",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Subskrypcje w windykacji",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Subskrypcje zaległe",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Subskrypcje próbne",
     "Subscriptions.Columns.BillingCycleAnchor": "Punkt odniesienia cyklu rozliczeniowego",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Anuluj na koniec okresu",
     "Subscriptions.Columns.CancellationReason": "Powód anulowania",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
@@ -1,6 +1,14 @@
 {
   "culture": "pt",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planos ativos",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Preços de plano ativos",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Assinaturas ativas",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Assinaturas a cancelar no fim do período",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Assinaturas canceladas",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Assinaturas em cobrança",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Assinaturas em atraso",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Assinaturas em avaliação",
     "Subscriptions.Columns.BillingCycleAnchor": "Âncora do ciclo de faturamento",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Cancelar no fim do período",
     "Subscriptions.Columns.CancellationReason": "Motivo do cancelamento",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
@@ -1,6 +1,14 @@
 {
   "culture": "sv",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktiva planer",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktiva planpriser",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktiva prenumerationer",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Prenumerationer som avbryts vid periodens slut",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Avbrutna prenumerationer",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Prenumerationer i påminnelseflöde",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Förfallna prenumerationer",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Provprenumerationer",
     "Subscriptions.Columns.BillingCycleAnchor": "Ankarpunkt faktureringscykel",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Avsluta vid periodens slut",
     "Subscriptions.Columns.CancellationReason": "Avbokningsorsak",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
@@ -1,6 +1,14 @@
 {
   "culture": "tr",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktif planlar",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktif plan fiyatları",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktif abonelikler",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Dönem sonunda iptal edilecek abonelikler",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "İptal edilen abonelikler",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Tahsilat sürecindeki abonelikler",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Vadesi geçmiş abonelikler",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Deneme abonelikleri",
     "Subscriptions.Columns.BillingCycleAnchor": "Faturalandırma döngüsü çapası",
     "Subscriptions.Columns.CancelAtPeriodEnd": "Dönem sonunda iptal et",
     "Subscriptions.Columns.CancellationReason": "İptal nedeni",

--- a/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
@@ -1,6 +1,14 @@
 {
   "culture": "zh",
   "texts": {
+    "Metric:Granit.Subscriptions.ActivePlanCountMetric": "活跃计划",
+    "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "活跃套餐价格",
+    "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "活跃订阅",
+    "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "周期末取消的订阅",
+    "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "已取消的订阅",
+    "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "催收中的订阅",
+    "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "逾期订阅",
+    "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "试用订阅",
     "Subscriptions.Columns.BillingCycleAnchor": "计费周期锚点",
     "Subscriptions.Columns.CancelAtPeriodEnd": "周期结束时取消",
     "Subscriptions.Columns.CancellationReason": "取消原因",

--- a/src/Granit.Subscriptions/Metrics/ActivePlanCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/ActivePlanCountMetricDefinition.cs
@@ -1,0 +1,35 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+using Granit.Workflow.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of plans currently in <see cref="WorkflowLifecycleStatus.Published"/> —
+/// catalog breadth available to new and existing subscribers. Drafts and archived
+/// plans are excluded.
+/// </summary>
+public sealed class ActivePlanCountMetricDefinition : MetricDefinition<Plan, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.ActivePlanCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Plan, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Plan, bool>>? BaseFilter
+        => p => p.LifecycleStatus == WorkflowLifecycleStatus.Published;
+
+    /// <inheritdoc />
+    public override Expression<Func<Plan, DateTimeOffset>>? PeriodSelector
+        => p => p.CreatedAt;
+}

--- a/src/Granit.Subscriptions/Metrics/ActivePlanPriceCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/ActivePlanPriceCountMetricDefinition.cs
@@ -1,0 +1,34 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of plan prices currently in effect — those that have NOT been replaced
+/// by a newer pricing version (<see cref="PlanPrice.ReplacedAt"/> is <c>null</c>).
+/// Reflects the active pricing surface offered to subscribers.
+/// </summary>
+public sealed class ActivePlanPriceCountMetricDefinition : MetricDefinition<PlanPrice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.ActivePlanPriceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<PlanPrice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PlanPrice, bool>>? BaseFilter
+        => p => p.ReplacedAt == null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PlanPrice, DateTimeOffset>>? PeriodSelector
+        => p => p.EffectiveFrom;
+}

--- a/src/Granit.Subscriptions/Metrics/ActiveSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/ActiveSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,33 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions currently in <see cref="SubscriptionStatus.Active"/>.
+/// The headline SaaS health KPI — directly tracks paying-customer count.
+/// </summary>
+public sealed class ActiveSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.ActiveSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.Status == SubscriptionStatus.Active;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+}

--- a/src/Granit.Subscriptions/Metrics/CancelAtPeriodEndSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/CancelAtPeriodEndSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions flagged to cancel at the end of the current billing
+/// period — leading indicator of upcoming churn. Useful to anticipate next-period
+/// MRR loss before the cancellation actually fires.
+/// </summary>
+public sealed class CancelAtPeriodEndSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.CancelAtPeriodEnd && s.Status == SubscriptionStatus.Active;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Subscriptions/Metrics/CancelledSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/CancelledSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,42 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions cancelled in the period. Period selector is
+/// <see cref="Subscription.CancelledAt"/> — when called with <c>?period=mtd</c>,
+/// counts cancellations that happened during the current month-to-date.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="SubscriptionStatus.Cancelled"/> count — the cancelled
+/// status is terminal (no further state change), so the all-time count grows
+/// monotonically. The period-bounded view answers "how many churned this month?".
+/// </remarks>
+public sealed class CancelledSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.CancelledSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.CancelledAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CancelledAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Subscriptions/Metrics/DunningSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/DunningSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions currently in dunning — at least one failed payment
+/// retry attempt has occurred. Tracks the active recovery workload separately
+/// from <c>PastDueSubscriptionCount</c> (status-based) since dunning may begin
+/// before the status flips.
+/// </summary>
+public sealed class DunningSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.DunningSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.DunningAttempt > 0;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Subscriptions/Metrics/PastDueSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/PastDueSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions currently in <see cref="SubscriptionStatus.PastDue"/> —
+/// payment failed at least once and the subscription is in its grace period before
+/// suspension. Operational signal: high values warrant intervention from billing ops.
+/// </summary>
+public sealed class PastDueSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.PastDueSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.Status == SubscriptionStatus.PastDue;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Subscriptions/Metrics/TrialSubscriptionCountMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/TrialSubscriptionCountMetricDefinition.cs
@@ -1,0 +1,33 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Number of subscriptions currently in <see cref="SubscriptionStatus.Trial"/>.
+/// Pipeline indicator — large trial cohort foreshadows revenue (or churn) ahead.
+/// </summary>
+public sealed class TrialSubscriptionCountMetricDefinition : MetricDefinition<Subscription, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.TrialSubscriptionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.Status == SubscriptionStatus.Trial;
+
+    /// <inheritdoc />
+    public override Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+}

--- a/src/Granit.Subscriptions/packages.lock.json
+++ b/src/Granit.Subscriptions/packages.lock.json
@@ -108,6 +108,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -123,6 +139,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
@@ -69,9 +69,6 @@ public sealed class QueryMetricPairingTests
         "Granit.Payments.Domain.PaymentTransaction",                                      // [BACKLOG] success-rate / volume
         "Granit.Payments.Domain.Refund",                                                  // [BACKLOG] refund-volume KPIs
         "Granit.Payments.SepaDirectDebit.Domain.Mandate",                                 // [BACKLOG] active-mandate count
-        "Granit.Subscriptions.Domain.Plan",                                               // [BACKLOG] active-plan count
-        "Granit.Subscriptions.Domain.PlanPrice",                                          // [BACKLOG] active-pricing count
-        "Granit.Subscriptions.Domain.Subscription",                                       // [BACKLOG] MRR / ARR / churn rate
         "Granit.Webhooks.Domain.WebhookDeliveryAttempt",                                  // [BACKLOG] delivery failure rate
         "Granit.Webhooks.Domain.WebhookSubscription",                                     // [BACKLOG] active-subscription count
     };

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3488,6 +3488,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Tests/packages.lock.json
@@ -315,6 +315,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -330,6 +346,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -423,6 +455,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

First module of the 12-module metric rollout — ships 8 `MetricDefinition`s for the Subscriptions module and removes 3 entries from the `QueryMetricPairingTests.MetricBacklog`. Same shape as the existing Invoicing reference (`UnpaidInvoiceCountMetric` / `UnpaidInvoiceTotalMetric`).

| Entity | Metric | Aggregation | Filter | Period | Higher better? |
| ------ | ------ | ----------- | ------ | ------ | -------------- |
| Subscription | `ActiveSubscriptionCount` | Count | `Status == Active` | `CreatedAt` | yes |
| Subscription | `TrialSubscriptionCount` | Count | `Status == Trial` | `CreatedAt` | yes |
| Subscription | `PastDueSubscriptionCount` | Count | `Status == PastDue` | `CreatedAt` | no |
| Subscription | `CancelledSubscriptionCount` | Count | `CancelledAt != null` | `CancelledAt` | no |
| Subscription | `DunningSubscriptionCount` | Count | `DunningAttempt > 0` | `CreatedAt` | no |
| Subscription | `CancelAtPeriodEndSubscriptionCount` | Count | `CancelAtPeriodEnd && Status == Active` | `CreatedAt` | no |
| Plan | `ActivePlanCount` | Count | `LifecycleStatus == Published` | `CreatedAt` | yes |
| PlanPrice | `ActivePlanPriceCount` | Count | `ReplacedAt == null` | `EffectiveFrom` | yes |

`Name` follows the existing pattern with the `Metric` suffix (matches `Granit.Invoicing.UnpaidInvoiceCountMetric`).

## MRR / ARR — deferred

The canonical SaaS measures (`MonthlyRecurringRevenue`, `AnnualRecurringRevenue`) are intentionally NOT in this batch. Computing them needs to read `Amount` and `BillingInterval` from `PlanPrice`, but the current `MetricDefinition<TEntity, TValue>` abstraction takes a single-table `Selector` expression. Two viable paths for the follow-up story:

1. **Aggregate-join extension** — extend `MetricExecutor` so a metric over `Subscription` can declare a join expression to `PlanPrice` and project `(Amount, Interval) → monthly_equivalent` in EF.
2. **Denormalised projection** — store `Subscription.MonthlyAmount` (computed at create / plan-change time) so the metric becomes a vanilla `Sum(s => s.MonthlyAmount)`.

Either is a non-trivial framework change; not in scope here.

## Wiring

- `Granit.Subscriptions.csproj` adds `<ProjectReference Include="..\Granit.Analytics\..." />` (matches `Granit.Invoicing.csproj`).
- `AddGranitSubscriptions` registers the 8 metrics via `AddMetricDefinition<TEntity, TValue, TDefinition>`.
- 8 new `Metric:Granit.Subscriptions.*Metric` keys added across all 15 base cultures (regional `en-GB` / `fr-CA` / `pt-BR` files unchanged per existing convention). Files alphabetised for stable diffs.

## Architecture-test impact

`tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs` — removes 3 backlog entries:

```diff
- "Granit.Subscriptions.Domain.Plan",        // [BACKLOG] active-plan count
- "Granit.Subscriptions.Domain.PlanPrice",   // [BACKLOG] active-pricing count
- "Granit.Subscriptions.Domain.Subscription", // [BACKLOG] MRR / ARR / churn rate
```

The MRR/ARR justification on the Subscription line is preserved as a tracking note in this PR's description rather than the test (the entity itself is now paired, just not with MRR yet).

## Test plan

- [x] `dotnet build src/Granit.Subscriptions` clean (added Granit.Analytics ProjectReference).
- [x] `dotnet format src/Granit.Subscriptions --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Subscriptions.Tests` — **151 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing** (D1 pairing now satisfied for Subscription / Plan / PlanPrice).
- [ ] CI shard pipeline green (saas + architecture).

## Next

Module 2/12: `Granit.Payments` — 9 metrics (PaymentTransaction, PaymentMethod, Refund, Dispute). Each subsequent module is an independent PR off `develop`; they will rebase trivially on each other since they touch disjoint files except for one HashSet entry each in `QueryMetricPairingTests.cs`.
