### PR TITLE
feat(payments): ship 9 MetricDefinitions + bootstrap Granit.Payments localization

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1872,11 +1872,13 @@
     {
       "name": "Granit.Payments",
       "deps": [
+        "Granit.Analytics",
         "Granit.Caching",
         "Granit",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
         "Granit.Invoicing.Abstractions",
+        "Granit.Localization",
         "Granit.Payments.Abstractions",
         "Granit.QueryEngine.Abstractions",
         "Granit.Timing"
@@ -37309,7 +37311,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitPayments",
@@ -37784,6 +37786,450 @@
           "kind": "method",
           "signature": "ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DefaultPaymentMethodCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.DefaultPaymentMethodCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/DefaultPaymentMethodCountMetricDefinition.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentMethod, int?>>? Selector",
+          "returnType": "Expression<Func<PaymentMethod, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentMethod, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PaymentMethod, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentMethod, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PaymentMethod, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "FailedPaymentTransactionCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.FailedPaymentTransactionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/FailedPaymentTransactionCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, int?>>? Selector",
+          "returnType": "Expression<Func<PaymentTransaction, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PaymentTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PaymentTransaction, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "OpenDisputeCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.OpenDisputeCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/OpenDisputeCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, int?>>? Selector",
+          "returnType": "Expression<Func<Dispute, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Dispute, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Dispute, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "OpenDisputeTotalMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.OpenDisputeTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/OpenDisputeTotalMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, decimal?>>? Selector",
+          "returnType": "Expression<Func<Dispute, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Dispute, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Dispute, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Dispute, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PendingPaymentTransactionCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.PendingPaymentTransactionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/PendingPaymentTransactionCountMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, int?>>? Selector",
+          "returnType": "Expression<Func<PaymentTransaction, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PaymentTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PaymentTransaction, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "SuccessfulPaymentTransactionCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.SuccessfulPaymentTransactionCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/SuccessfulPaymentTransactionCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, int?>>? Selector",
+          "returnType": "Expression<Func<PaymentTransaction, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PaymentTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PaymentTransaction, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "SuccessfulPaymentTransactionTotalMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.SuccessfulPaymentTransactionTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/SuccessfulPaymentTransactionTotalMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, decimal?>>? Selector",
+          "returnType": "Expression<Func<PaymentTransaction, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<PaymentTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<PaymentTransaction, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "SuccessfulRefundCountMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.SuccessfulRefundCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/SuccessfulRefundCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, int?>>? Selector",
+          "returnType": "Expression<Func<Refund, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Refund, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Refund, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "SuccessfulRefundTotalMetricDefinition",
+      "fqn": "Granit.Payments.Metrics.SuccessfulRefundTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Metrics/SuccessfulRefundTotalMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, decimal?>>? Selector",
+          "returnType": "Expression<Func<Refund, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Refund, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Refund, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Refund, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.Payments.Endpoints/packages.lock.json
+++ b/src/Granit.Payments.Endpoints/packages.lock.json
@@ -44,6 +44,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -61,6 +77,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -157,10 +189,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"

--- a/src/Granit.Payments.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Payments.EntityFrameworkCore/packages.lock.json
@@ -105,8 +105,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -123,6 +144,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -157,14 +194,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -286,6 +337,24 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -323,6 +392,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.Mollie/packages.lock.json
+++ b/src/Granit.Payments.Mollie/packages.lock.json
@@ -121,8 +121,29 @@
           "Polly": "7.1.0"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -139,6 +160,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -167,14 +204,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -253,6 +304,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -290,6 +359,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.Notifications/packages.lock.json
+++ b/src/Granit.Payments.Notifications/packages.lock.json
@@ -47,8 +47,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -65,6 +86,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -93,6 +130,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -104,10 +153,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -202,6 +253,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -239,6 +308,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.SepaDirectDebit.Builtin/packages.lock.json
+++ b/src/Granit.Payments.SepaDirectDebit.Builtin/packages.lock.json
@@ -47,8 +47,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -65,6 +86,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -93,14 +130,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -190,6 +241,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -227,6 +296,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.SepaDirectDebit.GoCardless/packages.lock.json
+++ b/src/Granit.Payments.SepaDirectDebit.GoCardless/packages.lock.json
@@ -109,8 +109,29 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -127,6 +148,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -155,14 +192,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -252,6 +303,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -289,6 +358,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.SepaDirectDebit.Twikey/packages.lock.json
+++ b/src/Granit.Payments.SepaDirectDebit.Twikey/packages.lock.json
@@ -89,8 +89,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -107,6 +128,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -135,14 +172,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -232,6 +283,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -269,6 +338,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.SepaDirectDebit/packages.lock.json
+++ b/src/Granit.Payments.SepaDirectDebit/packages.lock.json
@@ -47,8 +47,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -65,6 +86,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -93,14 +130,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -179,6 +230,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -216,6 +285,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.SepaTransfer/packages.lock.json
+++ b/src/Granit.Payments.SepaTransfer/packages.lock.json
@@ -47,8 +47,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -65,6 +86,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -93,14 +130,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -179,6 +230,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -216,6 +285,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments.Stripe/packages.lock.json
+++ b/src/Granit.Payments.Stripe/packages.lock.json
@@ -252,8 +252,29 @@
         "resolved": "8.0.0",
         "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -270,6 +291,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -305,6 +342,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.mergeable": {
         "type": "Project",
         "dependencies": {
@@ -334,10 +383,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -427,6 +478,24 @@
           "Microsoft.Extensions.Resilience": "10.5.0"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -464,6 +533,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Analytics.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Invoicing;
@@ -5,6 +6,7 @@ using Granit.Payments.Diagnostics;
 using Granit.Payments.Domain;
 using Granit.Payments.Exports;
 using Granit.Payments.Internal;
+using Granit.Payments.Metrics;
 using Granit.Payments.Queries;
 using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +39,16 @@ public static class PaymentsHostApplicationBuilderExtensions
         builder.Services.AddExportDefinition<PaymentMethod, PaymentMethodExportDefinition>();
         builder.Services.AddExportDefinition<Refund, RefundExportDefinition>();
         builder.Services.AddExportDefinition<Dispute, DisputeExportDefinition>();
+
+        builder.Services.AddMetricDefinition<PaymentTransaction, int, SuccessfulPaymentTransactionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<PaymentTransaction, decimal, SuccessfulPaymentTransactionTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<PaymentTransaction, int, FailedPaymentTransactionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<PaymentTransaction, int, PendingPaymentTransactionCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<PaymentMethod, int, DefaultPaymentMethodCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Refund, int, SuccessfulRefundCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Refund, decimal, SuccessfulRefundTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Dispute, int, OpenDisputeCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Dispute, decimal, OpenDisputeTotalMetricDefinition>();
 
         return builder;
     }

--- a/src/Granit.Payments/Granit.Payments.csproj
+++ b/src/Granit.Payments/Granit.Payments.csproj
@@ -17,14 +17,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
     <ProjectReference Include="..\Granit.Payments.Abstractions\Granit.Payments.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Payments/Internal/PaymentsLocalizationResource.cs
+++ b/src/Granit.Payments/Internal/PaymentsLocalizationResource.cs
@@ -1,0 +1,9 @@
+using Granit.Localization;
+
+namespace Granit.Payments.Internal;
+
+/// <summary>
+/// Localization resource for Granit.Payments — metric labels and other base-module L10n keys.
+/// </summary>
+[LocalizationResourceName("Payments")]
+internal sealed class PaymentsLocalizationResource;

--- a/src/Granit.Payments/Localization/Payments/cs.json
+++ b/src/Granit.Payments/Localization/Payments/cs.json
@@ -1,0 +1,14 @@
+{
+  "culture": "cs",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Výchozí platební metody",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Neúspěšné platby",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Otevřené spory",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Částka v otevřených sporech",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Probíhající platby",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Úspěšné platby",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Celkem inkasováno",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Dokončené refundace",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Celkem refundováno"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/de.json
+++ b/src/Granit.Payments/Localization/Payments/de.json
@@ -1,0 +1,14 @@
+{
+  "culture": "de",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Standard-Zahlungsmethoden",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Fehlgeschlagene Zahlungen",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Offene Streitfälle",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Streitwert offener Fälle",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Ausstehende Zahlungen",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Erfolgreiche Zahlungen",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Gezahlte Summe",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Abgeschlossene Erstattungen",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Gesamterstattungen"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/en-GB.json
+++ b/src/Granit.Payments/Localization/Payments/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Payments/Localization/Payments/en.json
+++ b/src/Granit.Payments/Localization/Payments/en.json
@@ -1,0 +1,14 @@
+{
+  "culture": "en",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Default payment methods",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Failed payments",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Open disputes",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Open dispute exposure",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Pending payments",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Successful payments",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Total payments captured",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Refunds completed",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Total refunds issued"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/es.json
+++ b/src/Granit.Payments/Localization/Payments/es.json
@@ -1,0 +1,14 @@
+{
+  "culture": "es",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Métodos de pago predeterminados",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Pagos fallidos",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Disputas abiertas",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Importe en disputa",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Pagos en curso",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Pagos correctos",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Total cobrado",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Reembolsos realizados",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Total reembolsado"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/fr-CA.json
+++ b/src/Granit.Payments/Localization/Payments/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.Payments/Localization/Payments/fr.json
+++ b/src/Granit.Payments/Localization/Payments/fr.json
@@ -1,0 +1,14 @@
+{
+  "culture": "fr",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Moyens de paiement par défaut",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Paiements échoués",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Litiges ouverts",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Montant des litiges ouverts",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Paiements en cours",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Paiements réussis",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Total des paiements encaissés",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Remboursements effectués",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Total des remboursements"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/hi.json
+++ b/src/Granit.Payments/Localization/Payments/hi.json
@@ -1,0 +1,14 @@
+{
+  "culture": "hi",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "डिफ़ॉल्ट भुगतान तरीके",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "विफल भुगतान",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "खुले विवाद",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "खुले विवादों की राशि",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "लंबित भुगतान",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "सफल भुगतान",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "कुल वसूली",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "पूरी की गई वापसी",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "कुल वापसी राशि"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/it.json
+++ b/src/Granit.Payments/Localization/Payments/it.json
@@ -1,0 +1,14 @@
+{
+  "culture": "it",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Metodi di pagamento predefiniti",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Pagamenti falliti",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Contestazioni aperte",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Importo in contestazione",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Pagamenti in corso",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Pagamenti riusciti",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Totale incassato",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Rimborsi completati",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Totale rimborsato"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/ja.json
+++ b/src/Granit.Payments/Localization/Payments/ja.json
@@ -1,0 +1,14 @@
+{
+  "culture": "ja",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "既定の支払い方法",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "失敗した支払い",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "未解決の係争",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "係争中の金額",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "処理中の支払い",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "成功した支払い",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "回収額合計",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "完了した返金",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "返金額合計"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/ko.json
+++ b/src/Granit.Payments/Localization/Payments/ko.json
@@ -1,0 +1,14 @@
+{
+  "culture": "ko",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "기본 결제 수단",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "실패한 결제",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "진행 중인 분쟁",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "진행 중인 분쟁 금액",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "처리 중인 결제",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "성공한 결제",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "결제 회수 총액",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "완료된 환불",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "환불 총액"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/nl.json
+++ b/src/Granit.Payments/Localization/Payments/nl.json
@@ -1,0 +1,14 @@
+{
+  "culture": "nl",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Standaardbetaalmethoden",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Mislukte betalingen",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Lopende geschillen",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Openstaand bedrag in geschillen",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Lopende betalingen",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Geslaagde betalingen",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Totaal geïnd",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Voltooide terugbetalingen",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Totaal terugbetaald"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/pl.json
+++ b/src/Granit.Payments/Localization/Payments/pl.json
@@ -1,0 +1,14 @@
+{
+  "culture": "pl",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Domyślne metody płatności",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Nieudane płatności",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Otwarte spory",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Kwota otwartych sporów",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Oczekujące płatności",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Pomyślne płatności",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Łączna suma pobrana",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Zrealizowane zwroty",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Łączna kwota zwrotów"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/pt-BR.json
+++ b/src/Granit.Payments/Localization/Payments/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.Payments/Localization/Payments/pt.json
+++ b/src/Granit.Payments/Localization/Payments/pt.json
@@ -1,0 +1,14 @@
+{
+  "culture": "pt",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Métodos de pagamento padrão",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Pagamentos com falha",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Disputas abertas",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Valor em disputa",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Pagamentos pendentes",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Pagamentos bem-sucedidos",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Total recebido",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Reembolsos concluídos",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Total reembolsado"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/sv.json
+++ b/src/Granit.Payments/Localization/Payments/sv.json
@@ -1,0 +1,14 @@
+{
+  "culture": "sv",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Standardbetalningssätt",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Misslyckade betalningar",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Öppna tvister",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Belopp under tvist",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Pågående betalningar",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Lyckade betalningar",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Totalt inkasserat",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Genomförda återbetalningar",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Totalt återbetalat"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/tr.json
+++ b/src/Granit.Payments/Localization/Payments/tr.json
@@ -1,0 +1,14 @@
+{
+  "culture": "tr",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "Varsayılan ödeme yöntemleri",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "Başarısız ödemeler",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "Açık itirazlar",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "Açık itirazların tutarı",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "Bekleyen ödemeler",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "Başarılı ödemeler",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "Tahsil edilen toplam",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "Tamamlanan iadeler",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "Toplam iade edilen tutar"
+  }
+}

--- a/src/Granit.Payments/Localization/Payments/zh.json
+++ b/src/Granit.Payments/Localization/Payments/zh.json
@@ -1,0 +1,14 @@
+{
+  "culture": "zh",
+  "texts": {
+    "Metric:Granit.Payments.DefaultPaymentMethodCountMetric": "默认付款方式",
+    "Metric:Granit.Payments.FailedPaymentTransactionCountMetric": "失败的付款",
+    "Metric:Granit.Payments.OpenDisputeCountMetric": "未结争议",
+    "Metric:Granit.Payments.OpenDisputeTotalMetric": "未结争议金额",
+    "Metric:Granit.Payments.PendingPaymentTransactionCountMetric": "处理中付款",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionCountMetric": "成功付款",
+    "Metric:Granit.Payments.SuccessfulPaymentTransactionTotalMetric": "已收款总额",
+    "Metric:Granit.Payments.SuccessfulRefundCountMetric": "已完成退款",
+    "Metric:Granit.Payments.SuccessfulRefundTotalMetric": "退款总额"
+  }
+}

--- a/src/Granit.Payments/Metrics/DefaultPaymentMethodCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/DefaultPaymentMethodCountMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of payment methods flagged as <see cref="PaymentMethod.IsDefault"/> for
+/// their party — proxy for "parties with a configured default payment method", a
+/// useful KPI for collection automation coverage. PaymentMethod has no intrinsic
+/// active/inactive flag (only <see cref="PaymentMethod.ExpiresAt"/>), so a
+/// time-of-day "active count" is intentionally not exposed here — it would require
+/// referencing <c>UtcNow</c> in the expression, which CLAUDE.md forbids
+/// (TimeProvider / IClock convention).
+/// </summary>
+public sealed class DefaultPaymentMethodCountMetricDefinition : MetricDefinition<PaymentMethod, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.DefaultPaymentMethodCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentMethod, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentMethod, bool>>? BaseFilter
+        => m => m.IsDefault;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentMethod, DateTimeOffset>>? PeriodSelector
+        => m => m.CreatedAt;
+}

--- a/src/Granit.Payments/Metrics/FailedPaymentTransactionCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/FailedPaymentTransactionCountMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of payment transactions in <see cref="PaymentStatus.Failed"/> state — the
+/// payment was attempted but rejected by the provider (declined card, expired card,
+/// insufficient funds, etc.). High counts in a short window typically indicate
+/// either a provider outage or fraud attempts.
+/// </summary>
+public sealed class FailedPaymentTransactionCountMetricDefinition : MetricDefinition<PaymentTransaction, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.FailedPaymentTransactionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, bool>>? BaseFilter
+        => t => t.Status == PaymentStatus.Failed;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Payments/Metrics/OpenDisputeCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/OpenDisputeCountMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of payment disputes currently in <see cref="DisputeStatus.Open"/> state —
+/// the live workload for the chargeback team. Period selector is
+/// <see cref="Dispute.CreatedAt"/> so <c>?period=mtd</c> answers "how many disputes
+/// were filed this month?". Lower is better.
+/// </summary>
+public sealed class OpenDisputeCountMetricDefinition : MetricDefinition<Dispute, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.OpenDisputeCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, bool>>? BaseFilter
+        => d => d.Status == DisputeStatus.Open;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, DateTimeOffset>>? PeriodSelector
+        => d => d.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Payments/Metrics/OpenDisputeTotalMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/OpenDisputeTotalMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Total monetary amount under dispute in <see cref="DisputeStatus.Open"/> state —
+/// sum of <see cref="Dispute.Amount"/> across open chargebacks. The metric tracks
+/// the cash exposure: every euro counted here may be reversed if the cardholder wins.
+/// </summary>
+public sealed class OpenDisputeTotalMetricDefinition : MetricDefinition<Dispute, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.OpenDisputeTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, decimal?>>? Selector
+        => d => d.Amount;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, bool>>? BaseFilter
+        => d => d.Status == DisputeStatus.Open;
+
+    /// <inheritdoc />
+    public override Expression<Func<Dispute, DateTimeOffset>>? PeriodSelector
+        => d => d.CreatedAt;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Payments/Metrics/PendingPaymentTransactionCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/PendingPaymentTransactionCountMetricDefinition.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of payment transactions in <see cref="PaymentStatus.Processing"/> state —
+/// asynchronous captures that the provider has accepted but not yet finalised
+/// (typical for SEPA bank transfers, ACH, hosted-page redirects awaiting return).
+/// Sustained high counts may indicate stuck reconciliation rather than ongoing
+/// activity.
+/// </summary>
+public sealed class PendingPaymentTransactionCountMetricDefinition : MetricDefinition<PaymentTransaction, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.PendingPaymentTransactionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, bool>>? BaseFilter
+        => t => t.Status == PaymentStatus.Processing;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.CreatedAt;
+}

--- a/src/Granit.Payments/Metrics/SuccessfulPaymentTransactionCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/SuccessfulPaymentTransactionCountMetricDefinition.cs
@@ -1,0 +1,35 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of payment transactions in <see cref="PaymentStatus.Succeeded"/> state —
+/// captures the volume of successful captures over the period. Period selector is
+/// <see cref="PaymentTransaction.SucceededAt"/> so <c>?period=last_30d</c> answers
+/// "how many payments completed in the last 30 days?".
+/// </summary>
+public sealed class SuccessfulPaymentTransactionCountMetricDefinition : MetricDefinition<PaymentTransaction, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.SuccessfulPaymentTransactionCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, bool>>? BaseFilter
+        => t => t.Status == PaymentStatus.Succeeded;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.SucceededAt!.Value;
+}

--- a/src/Granit.Payments/Metrics/SuccessfulPaymentTransactionTotalMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/SuccessfulPaymentTransactionTotalMetricDefinition.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Total monetary amount of payment transactions in
+/// <see cref="PaymentStatus.Succeeded"/> state — sum of
+/// <see cref="PaymentTransaction.Amount"/> per successful capture. Currency is
+/// intentionally not declared at the metric level since transactions across a tenant
+/// may carry different ISO 4217 codes; the host renders with its tenant currency.
+/// </summary>
+public sealed class SuccessfulPaymentTransactionTotalMetricDefinition : MetricDefinition<PaymentTransaction, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.SuccessfulPaymentTransactionTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, decimal?>>? Selector
+        => t => t.Amount;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, bool>>? BaseFilter
+        => t => t.Status == PaymentStatus.Succeeded;
+
+    /// <inheritdoc />
+    public override Expression<Func<PaymentTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.SucceededAt!.Value;
+}

--- a/src/Granit.Payments/Metrics/SuccessfulRefundCountMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/SuccessfulRefundCountMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Number of refunds in <see cref="RefundStatus.Succeeded"/> state — captures the
+/// volume of completed money-back operations. Period selector is
+/// <see cref="Refund.CompletedAt"/> so a rolling 30-day window answers "how many
+/// refunds we honoured this month?". Lower is better — refunds are a cost.
+/// </summary>
+public sealed class SuccessfulRefundCountMetricDefinition : MetricDefinition<Refund, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.SuccessfulRefundCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, bool>>? BaseFilter
+        => r => r.Status == RefundStatus.Succeeded;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, DateTimeOffset>>? PeriodSelector
+        => r => r.CompletedAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Payments/Metrics/SuccessfulRefundTotalMetricDefinition.cs
+++ b/src/Granit.Payments/Metrics/SuccessfulRefundTotalMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Payments.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Payments.Metrics;
+
+/// <summary>
+/// Total monetary amount refunded successfully in the period — sum of
+/// <see cref="Refund.Amount"/> across refunds in <see cref="RefundStatus.Succeeded"/>.
+/// Lower is better; reconciles with the negative side of net revenue.
+/// </summary>
+public sealed class SuccessfulRefundTotalMetricDefinition : MetricDefinition<Refund, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Payments.SuccessfulRefundTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, decimal?>>? Selector
+        => r => r.Amount;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, bool>>? BaseFilter
+        => r => r.Status == RefundStatus.Succeeded;
+
+    /// <inheritdoc />
+    public override Expression<Func<Refund, DateTimeOffset>>? PeriodSelector
+        => r => r.CompletedAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Payments/packages.lock.json
+++ b/src/Granit.Payments/packages.lock.json
@@ -60,8 +60,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -78,6 +99,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -104,6 +141,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.payments.abstractions": {
@@ -165,6 +214,24 @@
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -202,6 +269,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
@@ -64,10 +64,6 @@ public sealed class QueryMetricPairingTests
         "Granit.Metering.Domain.UsageAggregate",                                          // [BACKLOG] usage trends
         "Granit.Notifications.Domain.UserNotification",                                   // [BACKLOG] delivery / read-rate KPIs
         "Granit.Parties.Domain.Party",                                                    // [BACKLOG] active-party count
-        "Granit.Payments.Domain.Dispute",                                                 // [BACKLOG] open-dispute count / total
-        "Granit.Payments.Domain.PaymentMethod",                                           // [BACKLOG] active-method count
-        "Granit.Payments.Domain.PaymentTransaction",                                      // [BACKLOG] success-rate / volume
-        "Granit.Payments.Domain.Refund",                                                  // [BACKLOG] refund-volume KPIs
         "Granit.Payments.SepaDirectDebit.Domain.Mandate",                                 // [BACKLOG] active-mandate count
         "Granit.Webhooks.Domain.WebhookDeliveryAttempt",                                  // [BACKLOG] delivery failure rate
         "Granit.Webhooks.Domain.WebhookSubscription",                                     // [BACKLOG] active-subscription count

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3110,10 +3110,12 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"

--- a/tests/Granit.Payments.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Tests/packages.lock.json
@@ -279,8 +279,29 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -297,6 +318,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -325,14 +362,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.payments": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.payments": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -411,6 +462,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -448,6 +517,15 @@
         "requested": "[1.15.*, )",
         "resolved": "1.15.3",
         "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -315,6 +315,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.backgroundjobs": {
         "type": "Project",
         "dependencies": {
@@ -344,6 +360,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -437,6 +469,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
@@ -315,6 +315,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -330,6 +346,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -423,6 +455,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -524,6 +524,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -547,6 +563,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -684,6 +716,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -373,6 +373,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -388,6 +404,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -527,6 +559,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -331,6 +331,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -346,6 +362,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -485,6 +517,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -315,6 +315,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -330,6 +346,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -430,6 +462,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -315,6 +315,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -330,6 +346,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -430,6 +462,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Module 2/12 of the BI metric rollout (epic #1366). Ships 9 `MetricDefinition`s for the Payments module covering the four backlog-tracked entities, and bootstraps localisation for `Granit.Payments` (was previously missing the `Localization/` scaffolding).

Removes 4 entries from `QueryMetricPairingTests.MetricBacklog`: `PaymentTransaction`, `PaymentMethod`, `Refund`, `Dispute`.

| Entity | Metric | Aggregation | Filter | Period | Higher better? |
| ------ | ------ | ----------- | ------ | ------ | -------------- |
| PaymentTransaction | `SuccessfulPaymentTransactionCount` | Count | `Status == Succeeded` | `SucceededAt` | yes |
| PaymentTransaction | `SuccessfulPaymentTransactionTotal` | Sum(Amount) | `Status == Succeeded` | `SucceededAt` | yes |
| PaymentTransaction | `FailedPaymentTransactionCount` | Count | `Status == Failed` | `CreatedAt` | no |
| PaymentTransaction | `PendingPaymentTransactionCount` | Count | `Status == Processing` | `CreatedAt` | yes |
| PaymentMethod | `DefaultPaymentMethodCount` | Count | `IsDefault == true` | `CreatedAt` | yes |
| Refund | `SuccessfulRefundCount` | Count | `Status == Succeeded` | `CompletedAt` | no |
| Refund | `SuccessfulRefundTotal` | Sum(Amount) | `Status == Succeeded` | `CompletedAt` | no |
| Dispute | `OpenDisputeCount` | Count | `Status == Open` | `CreatedAt` | no |
| Dispute | `OpenDisputeTotal` | Sum(Amount) | `Status == Open` | `CreatedAt` | no |

## PaymentMethod active count — deferred

There is no intrinsic active/inactive flag on `PaymentMethod` (only `ExpiresAt`). A "currently-active" metric would need `UtcNow` inside the `Selector` expression, which CLAUDE.md forbids (`TimeProvider` / `IClock` convention). `DefaultPaymentMethodCount` proxies for "parties with collection automation configured" instead — the most operationally meaningful signal short of a runtime-aware filter.

## Localisation bootstrap

`Granit.Payments` had no `Localization/` scaffolding. This PR adds:

- `<ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />` in the csproj.
- `<EmbeddedResource Include="Localization\**\*.json" />` in the csproj.
- `Internal/PaymentsLocalizationResource.cs` with `[LocalizationResourceName("Payments")]`.
- `Localization/Payments/{en,fr,nl,de,es,it,pt,zh,ja,pl,tr,ko,sv,cs,hi}.json` (15 base cultures) with all 9 `Metric:Granit.Payments.*Metric` keys translated.
- `Localization/Payments/{en-GB,fr-CA,pt-BR}.json` (3 regional variants) — empty stubs that match parent culture per existing convention.

D2 #1397 is enforced by `MetricLocalizationCompletenessTests` — it scans every `MetricDefinition` discovered in the build output and asserts a `Metric:{Name}` key exists in all 15 base cultures of the owning module's `Localization/`. Without the bootstrap, the test fails immediately on this PR's metrics.

## Wiring

- Added `<ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />` to `Granit.Payments.csproj` (matches `Granit.Invoicing.csproj` / `Granit.Subscriptions.csproj` shape).
- `AddGranitPayments` now registers the 9 metrics via `AddMetricDefinition<TEntity, TValue, TDefinition>` after the existing query/export registrations.

## Architecture-test impact

`tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs` — removes 4 backlog entries (Dispute, PaymentMethod, PaymentTransaction, Refund). One backlog entry remains for the Payments family overall: `Granit.Payments.SepaDirectDebit.Domain.Mandate` (covered by module 4 of this rollout).

## Test plan

- [x] `dotnet build src/Granit.Payments` clean.
- [x] `dotnet format src/Granit.Payments --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Payments.Tests` — **100 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing** (D1 pairing + D2 localisation satisfied for the 4 entities).
- [ ] CI shard pipeline green (saas + architecture).

## Next

Module 3/12: `Granit.Payments.SepaDirectDebit` — 3 metrics on `Mandate` (active / pending / cancelled).
