### PR TITLE
feat(customer-balance): ship 4 MetricDefinitions + bootstrap localization

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -571,6 +571,8 @@
       "name": "Granit.CustomerBalance",
       "deps": [
         "Granit",
+        "Granit.Analytics",
+        "Granit.Localization",
         "Granit.Parties.Abstractions",
         "Granit.DataExchange.Abstractions",
         "Granit.Guids",
@@ -12375,7 +12377,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance",
       "file": "src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitCustomerBalance",
@@ -12588,6 +12590,178 @@
           "kind": "method",
           "signature": "CreditOverpaymentAsync(Guid tenantId, PartyId partyId, string currency, decimal amount, Guid invoiceId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BalanceAccountCountMetricDefinition",
+      "fqn": "Granit.CustomerBalance.Metrics.BalanceAccountCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Metrics/BalanceAccountCountMetricDefinition.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceAccount, int?>>? Selector",
+          "returnType": "Expression<Func<BalanceAccount, int?>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceAccount, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<BalanceAccount, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "BalanceAccountTotalMetricDefinition",
+      "fqn": "Granit.CustomerBalance.Metrics.BalanceAccountTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Metrics/BalanceAccountTotalMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceAccount, decimal?>>? Selector",
+          "returnType": "Expression<Func<BalanceAccount, decimal?>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceAccount, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<BalanceAccount, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "CreditBalanceTransactionTotalMetricDefinition",
+      "fqn": "Granit.CustomerBalance.Metrics.CreditBalanceTransactionTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Metrics/CreditBalanceTransactionTotalMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, decimal?>>? Selector",
+          "returnType": "Expression<Func<BalanceTransaction, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<BalanceTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<BalanceTransaction, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "DebitBalanceTransactionTotalMetricDefinition",
+      "fqn": "Granit.CustomerBalance.Metrics.DebitBalanceTransactionTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.CustomerBalance",
+      "file": "src/Granit.CustomerBalance/Metrics/DebitBalanceTransactionTotalMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, decimal?>>? Selector",
+          "returnType": "Expression<Func<BalanceTransaction, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, bool>>? BaseFilter",
+          "returnType": "Expression<Func<BalanceTransaction, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<BalanceTransaction, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<BalanceTransaction, DateTimeOffset>>?"
         }
       ]
     },

--- a/src/Granit.CustomerBalance.BackgroundJobs/packages.lock.json
+++ b/src/Granit.CustomerBalance.BackgroundJobs/packages.lock.json
@@ -47,8 +47,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.backgroundjobs": {
         "type": "Project",
@@ -64,17 +85,52 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Parties.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -101,6 +157,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.parties.abstractions": {
@@ -130,6 +198,28 @@
         "resolved": "0.12.0",
         "contentHash": "rOBW2cimLtkRoyLIZWZx1uM300cNI2wUKOUbLbGLnNQRly5R/YK3VdC1mk3Wvt24J4k9PY5j+9WL4smv0RIZvA=="
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -158,6 +248,24 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
@@ -189,6 +297,49 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/src/Granit.CustomerBalance.Endpoints/packages.lock.json
+++ b/src/Granit.CustomerBalance.Endpoints/packages.lock.json
@@ -34,6 +34,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -57,12 +73,30 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Parties.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/packages.lock.json
@@ -43,6 +43,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -96,20 +105,76 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Parties.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -142,6 +207,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.mergeable": {
@@ -239,6 +316,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -268,6 +355,24 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -285,6 +390,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance/Extensions/CustomerBalanceHostApplicationBuilderExtensions.cs
@@ -1,7 +1,9 @@
+using Granit.Analytics.Extensions;
 using Granit.CustomerBalance.Diagnostics;
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Exports;
 using Granit.CustomerBalance.Internal;
+using Granit.CustomerBalance.Metrics;
 using Granit.CustomerBalance.Options;
 using Granit.CustomerBalance.Queries;
 using Granit.DataExchange.Extensions;
@@ -51,6 +53,11 @@ public static class CustomerBalanceHostApplicationBuilderExtensions
         builder.Services.AddQueryDefinition<BalanceTransaction, BalanceTransactionQueryDefinition>();
         builder.Services.AddExportDefinition<BalanceAccount, BalanceAccountExportDefinition>();
         builder.Services.AddExportDefinition<BalanceTransaction, BalanceTransactionExportDefinition>();
+
+        builder.Services.AddMetricDefinition<BalanceAccount, int, BalanceAccountCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<BalanceAccount, decimal, BalanceAccountTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<BalanceTransaction, decimal, CreditBalanceTransactionTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<BalanceTransaction, decimal, DebitBalanceTransactionTotalMetricDefinition>();
 
         return builder;
     }

--- a/src/Granit.CustomerBalance/Granit.CustomerBalance.csproj
+++ b/src/Granit.CustomerBalance/Granit.CustomerBalance.csproj
@@ -19,12 +19,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
     <ProjectReference Include="..\Granit.Parties.Abstractions\Granit.Parties.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.CustomerBalance/Internal/CustomerBalanceLocalizationResource.cs
+++ b/src/Granit.CustomerBalance/Internal/CustomerBalanceLocalizationResource.cs
@@ -1,0 +1,9 @@
+using Granit.Localization;
+
+namespace Granit.CustomerBalance.Internal;
+
+/// <summary>
+/// Localization resource for Granit.CustomerBalance — metric labels and other base-module L10n keys.
+/// </summary>
+[LocalizationResourceName("CustomerBalance")]
+internal sealed class CustomerBalanceLocalizationResource;

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/cs.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/cs.json
@@ -1,0 +1,9 @@
+{
+  "culture": "cs",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Účty zůstatku",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Celkový zůstatek zákazníků",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Udělené kredity",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Spotřebované kredity"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/de.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/de.json
@@ -1,0 +1,9 @@
+{
+  "culture": "de",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Guthabenkonten",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Gesamtguthaben Kunden",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Gewährte Gutschriften",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Verbrauchte Gutschriften"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/en-GB.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/en.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/en.json
@@ -1,0 +1,9 @@
+{
+  "culture": "en",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Balance accounts",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Total customer balance",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Credits granted",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Credits consumed"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/es.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/es.json
@@ -1,0 +1,9 @@
+{
+  "culture": "es",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Cuentas de saldo",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Saldo total de clientes",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Créditos otorgados",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Créditos consumidos"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/fr-CA.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/fr.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/fr.json
@@ -1,0 +1,9 @@
+{
+  "culture": "fr",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Comptes de solde",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Solde client total",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Crédits accordés",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Crédits consommés"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/hi.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/hi.json
@@ -1,0 +1,9 @@
+{
+  "culture": "hi",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "शेष खाते",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "कुल ग्राहक शेष",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "प्रदान किए गए क्रेडिट",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "उपयोग किए गए क्रेडिट"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/it.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/it.json
@@ -1,0 +1,9 @@
+{
+  "culture": "it",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Conti di saldo",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Saldo totale clienti",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Crediti concessi",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Crediti consumati"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/ja.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/ja.json
@@ -1,0 +1,9 @@
+{
+  "culture": "ja",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "残高アカウント",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "顧客残高合計",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "付与されたクレジット",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "使用されたクレジット"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/ko.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/ko.json
@@ -1,0 +1,9 @@
+{
+  "culture": "ko",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "잔액 계정",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "고객 잔액 총액",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "지급된 크레딧",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "사용된 크레딧"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/nl.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/nl.json
@@ -1,0 +1,9 @@
+{
+  "culture": "nl",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Saldo-rekeningen",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Totaal klantsaldo",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Toegekende tegoeden",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Verbruikte tegoeden"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/pl.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/pl.json
@@ -1,0 +1,9 @@
+{
+  "culture": "pl",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Konta salda",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Łączne saldo klientów",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Przyznane środki",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Wykorzystane środki"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/pt-BR.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/pt.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/pt.json
@@ -1,0 +1,9 @@
+{
+  "culture": "pt",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Contas de saldo",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Saldo total de clientes",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Créditos concedidos",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Créditos consumidos"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/sv.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/sv.json
@@ -1,0 +1,9 @@
+{
+  "culture": "sv",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Saldokonton",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Totalt kundsaldo",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Beviljade krediter",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Förbrukade krediter"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/tr.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/tr.json
@@ -1,0 +1,9 @@
+{
+  "culture": "tr",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "Bakiye hesapları",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "Toplam müşteri bakiyesi",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "Verilen krediler",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "Kullanılan krediler"
+  }
+}

--- a/src/Granit.CustomerBalance/Localization/CustomerBalance/zh.json
+++ b/src/Granit.CustomerBalance/Localization/CustomerBalance/zh.json
@@ -1,0 +1,9 @@
+{
+  "culture": "zh",
+  "texts": {
+    "Metric:Granit.CustomerBalance.BalanceAccountCountMetric": "余额账户",
+    "Metric:Granit.CustomerBalance.BalanceAccountTotalMetric": "客户余额总额",
+    "Metric:Granit.CustomerBalance.CreditBalanceTransactionTotalMetric": "授予的额度",
+    "Metric:Granit.CustomerBalance.DebitBalanceTransactionTotalMetric": "已使用额度"
+  }
+}

--- a/src/Granit.CustomerBalance/Metrics/BalanceAccountCountMetricDefinition.cs
+++ b/src/Granit.CustomerBalance/Metrics/BalanceAccountCountMetricDefinition.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.CustomerBalance.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.CustomerBalance.Metrics;
+
+/// <summary>
+/// Number of balance accounts on file. One per (party × currency) tuple, so this
+/// counts both customer coverage breadth and currency spread.
+/// </summary>
+public sealed class BalanceAccountCountMetricDefinition : MetricDefinition<BalanceAccount, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.CustomerBalance.BalanceAccountCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceAccount, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceAccount, DateTimeOffset>>? PeriodSelector
+        => a => a.CreatedAt;
+}

--- a/src/Granit.CustomerBalance/Metrics/BalanceAccountTotalMetricDefinition.cs
+++ b/src/Granit.CustomerBalance/Metrics/BalanceAccountTotalMetricDefinition.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.CustomerBalance.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.CustomerBalance.Metrics;
+
+/// <summary>
+/// Sum of every balance account's <see cref="BalanceAccount.Balance"/> — total
+/// outstanding credit liability the platform owes its customers. Multi-currency
+/// tenants carry mixed currencies; the host renders the value with its tenant's
+/// configured currency for display.
+/// </summary>
+public sealed class BalanceAccountTotalMetricDefinition : MetricDefinition<BalanceAccount, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.CustomerBalance.BalanceAccountTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceAccount, decimal?>>? Selector
+        => a => a.Balance;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceAccount, DateTimeOffset>>? PeriodSelector
+        => a => a.CreatedAt;
+}

--- a/src/Granit.CustomerBalance/Metrics/CreditBalanceTransactionTotalMetricDefinition.cs
+++ b/src/Granit.CustomerBalance/Metrics/CreditBalanceTransactionTotalMetricDefinition.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.CustomerBalance.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.CustomerBalance.Metrics;
+
+/// <summary>
+/// Sum of <see cref="BalanceTransaction.Amount"/> for ledger entries of type
+/// <see cref="TransactionType.Credit"/> in the period — the credit-side volume
+/// (promotional grants, manual adjustments, overpayment surplus) that flowed into
+/// customer balances.
+/// </summary>
+public sealed class CreditBalanceTransactionTotalMetricDefinition : MetricDefinition<BalanceTransaction, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.CustomerBalance.CreditBalanceTransactionTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, decimal?>>? Selector
+        => t => t.Amount;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, bool>>? BaseFilter
+        => t => t.Type == TransactionType.Credit;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.CreatedAt;
+}

--- a/src/Granit.CustomerBalance/Metrics/DebitBalanceTransactionTotalMetricDefinition.cs
+++ b/src/Granit.CustomerBalance/Metrics/DebitBalanceTransactionTotalMetricDefinition.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.CustomerBalance.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.CustomerBalance.Metrics;
+
+/// <summary>
+/// Sum of <see cref="BalanceTransaction.Amount"/> for ledger entries of type
+/// <see cref="TransactionType.Debit"/> in the period — the debit-side volume
+/// (credits consumed against invoices, manual deductions). Reads as the actual
+/// monetary value of credit applied during the window.
+/// </summary>
+public sealed class DebitBalanceTransactionTotalMetricDefinition : MetricDefinition<BalanceTransaction, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.CustomerBalance.DebitBalanceTransactionTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, decimal?>>? Selector
+        => t => t.Amount;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, bool>>? BaseFilter
+        => t => t.Type == TransactionType.Debit;
+
+    /// <inheritdoc />
+    public override Expression<Func<BalanceTransaction, DateTimeOffset>>? PeriodSelector
+        => t => t.CreatedAt;
+}

--- a/src/Granit.CustomerBalance/packages.lock.json
+++ b/src/Granit.CustomerBalance/packages.lock.json
@@ -21,6 +21,15 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -51,8 +60,62 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -80,6 +143,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.parties.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -101,11 +176,61 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
@@ -124,6 +249,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/QueryMetricPairingTests.cs
@@ -59,8 +59,6 @@ public sealed class QueryMetricPairingTests
     {
         "Granit.BlobStorage.Domain.BlobDescriptor",                                       // [BACKLOG] storage-usage KPIs
         "Granit.Catalog.Domain.Product",                                                  // [BACKLOG] catalog count / activation
-        "Granit.CustomerBalance.Domain.BalanceAccount",                                   // [BACKLOG] balance totals
-        "Granit.CustomerBalance.Domain.BalanceTransaction",                               // [BACKLOG] credit / debit volume
         "Granit.Metering.Domain.UsageAggregate",                                          // [BACKLOG] usage trends
         "Granit.Notifications.Domain.UserNotification",                                   // [BACKLOG] delivery / read-rate KPIs
         "Granit.Parties.Domain.Party",                                                    // [BACKLOG] active-party count

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1920,9 +1920,11 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Parties.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"

--- a/tests/Granit.CustomerBalance.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.Tests/packages.lock.json
@@ -101,6 +101,15 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -270,20 +279,76 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.customerbalance": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Parties.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -312,6 +377,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.parties.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -333,6 +410,38 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -352,6 +461,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -369,6 +496,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }


### PR DESCRIPTION
## Summary

Module 4/12 of the BI metric rollout (epic #1366). Ships 4 `MetricDefinition`s on the customer-balance ledger and removes 2 backlog entries (`BalanceAccount`, `BalanceTransaction`).

| Entity | Metric | Aggregation | Filter | Period |
| ------ | ------ | ----------- | ------ | ------ |
| BalanceAccount | `BalanceAccountCount` | Count | — | `CreatedAt` |
| BalanceAccount | `BalanceAccountTotal` | Sum(`Balance`) | — | `CreatedAt` |
| BalanceTransaction | `CreditBalanceTransactionTotal` | Sum(`Amount`) | `Type == Credit` | `CreatedAt` |
| BalanceTransaction | `DebitBalanceTransactionTotal` | Sum(`Amount`) | `Type == Debit` | `CreatedAt` |

Mixed-currency tenants: the host renders sums against the tenant's display currency. Same posture as Invoicing / Payments / SepaDirectDebit metrics.

## Localisation bootstrap

`Granit.CustomerBalance` had no `Localization/` scaffolding. Added the same shape as the previous modules:

- `<ProjectReference Include="..\Granit.Analytics\..." />` and `Granit.Localization` in csproj.
- `<EmbeddedResource Include="Localization\**\*.json" />`.
- `Internal/CustomerBalanceLocalizationResource.cs` with `[LocalizationResourceName("CustomerBalance")]`.
- `Localization/CustomerBalance/{15 base + 3 regional}.json` with the 4 `Metric:*` keys translated.

## Architecture-test impact

Removes 2 backlog entries (`BalanceAccount`, `BalanceTransaction`) from `QueryMetricPairingTests.MetricBacklog`.

## Test plan

- [x] `dotnet build src/Granit.CustomerBalance` clean.
- [x] `dotnet format src/Granit.CustomerBalance --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.CustomerBalance.Tests` — **58 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing** (D1 + D2 satisfied).

## Next

Module 5/12: `Granit.Catalog` — 2 metrics on `Product`.