### PR TITLE
feat(dashboards-render): P1 — extend DashboardRenderedWidget envelope with structural metadata + Actions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13599,7 +13599,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 32,
+      "line": 33,
       "members": []
     },
     {
@@ -13617,7 +13617,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -13626,7 +13626,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 47,
+      "line": 60,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Granit.Analytics.Metrics;
+using Granit.Dashboards;
 using Granit.Dashboards.Rendering;
 
 namespace Granit.Dashboards.Endpoints.Dtos;
@@ -33,11 +34,23 @@ public sealed record DashboardRenderPeriodResponse(DateTimeOffset From, DateTime
 
 /// <summary>
 /// One widget's slot in the bundle. Flattens the widget id alongside the
-/// envelope fields surfaced by <see cref="WidgetSnapshotEnvelope"/> — the wire
-/// shape ADR-039 §6 locks for every framework dashboard endpoint.
+/// structural metadata of the persisted <c>WidgetInstance</c>, the declarative
+/// click-handlers from the source <c>WidgetDefinition</c>, and the envelope
+/// fields produced by <see cref="WidgetSnapshotEnvelope"/>. The wire shape
+/// ADR-039 §6 locks for every framework dashboard endpoint — both the bundle
+/// path (<c>POST /dashboards/{id}/render</c>) and the per-widget single-render
+/// path (<c>POST /widgets/{kind}/render</c>) project to this same record so
+/// frontend renderers can be wrapped identically across the two paths.
 /// </summary>
 /// <param name="Id">Persisted <c>WidgetInstance.Id</c>.</param>
 /// <param name="WidgetType">Declarative kind discriminator — mirrors <c>WidgetDefinition</c>'s <c>[JsonDerivedType]</c> tag (<c>"Kpi"</c>, <c>"Markdown"</c>, …).</param>
+/// <param name="Slug">Per-widget slug, extracted from <see cref="TitleLocalizationKey"/> (<c>"Widget:{DashboardName}.{Slug}"</c>). Surfaced flat so the frontend's action dispatcher can address the widget without re-parsing the key.</param>
+/// <param name="Position">0-based dense-ranked grid position; matches <c>WidgetInstance.Position</c>.</param>
+/// <param name="Width">Grid columns spanned by the widget; matches <c>WidgetInstance.Width</c>.</param>
+/// <param name="Height">Grid rows spanned by the widget; matches <c>WidgetInstance.Height</c>.</param>
+/// <param name="TitleLocalizationKey">Localization key for the widget title (<c>Widget:{DashboardName}.{Slug}</c>); the frontend resolves it client-side.</param>
+/// <param name="Actions">Declarative click-handlers from the source <c>WidgetDefinition</c>. <see langword="null"/> when the widget declared none — the frontend dispatcher ignores it.</param>
+/// <param name="RequiredPermission">Optional per-widget permission gate; mirrors <c>WidgetInstance.RequiredPermission</c>. Already enforced server-side (lacking the permission yields <see cref="WidgetSnapshotStatus.Unavailable"/>); echoed here for the frontend's defensive UI.</param>
 /// <param name="Status">Runtime outcome (<see cref="WidgetSnapshotStatus.Snapshot"/> / <see cref="WidgetSnapshotStatus.Unavailable"/> / <see cref="WidgetSnapshotStatus.Error"/>).</param>
 /// <param name="Sequence">Always <c>1</c> in pull mode; future push transport increments per (widget, tenant). EPIC #1366 invariant #2.</param>
 /// <param name="EmittedAt">Server-side timestamp of the widget's computation.</param>
@@ -47,6 +60,13 @@ public sealed record DashboardRenderPeriodResponse(DateTimeOffset From, DateTime
 public sealed record DashboardRenderedWidgetResponse(
     Guid Id,
     string WidgetType,
+    string Slug,
+    int Position,
+    int Width,
+    int Height,
+    string TitleLocalizationKey,
+    IReadOnlyList<WidgetAction>? Actions,
+    string? RequiredPermission,
     WidgetSnapshotStatus Status,
     long Sequence,
     DateTimeOffset EmittedAt,

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Granit.Analytics;
+using Granit.Dashboards;
 using Granit.Dashboards.Domain;
 using Granit.Dashboards.Endpoints.Dtos;
 using Granit.Dashboards.Endpoints.Internal;
@@ -50,6 +51,7 @@ internal static class DashboardRenderEndpoints
         [FromBody] DashboardRenderRequest? request,
         [FromServices] DashboardReader reader,
         [FromServices] IDashboardRenderer renderer,
+        [FromServices] IDashboardDefinitionRegistry definitionRegistry,
         ClaimsPrincipal user,
         CancellationToken cancellationToken)
     {
@@ -81,6 +83,7 @@ internal static class DashboardRenderEndpoints
             .RenderAsync(dashboard, context, cancellationToken)
             .ConfigureAwait(false);
 
-        return TypedResults.Ok(DashboardRenderProjection.ToResponse(result, body.PeriodToken));
+        return TypedResults.Ok(DashboardRenderProjection.ToResponse(
+            result, dashboard, definitionRegistry, body.PeriodToken));
     }
 }

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -1,4 +1,6 @@
 using Granit.Analytics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
 using Granit.Dashboards.Endpoints.Dtos;
 using Granit.Dashboards.Rendering;
 
@@ -12,24 +14,66 @@ namespace Granit.Dashboards.Endpoints.Internal;
 /// </summary>
 internal static class DashboardRenderProjection
 {
-    public static DashboardRenderResponse ToResponse(DashboardRenderResult result, string? periodToken)
+    /// <summary>
+    /// Composes the wire response from the renderer's pipeline result, the
+    /// persisted <see cref="Dashboard"/> aggregate (source of structural metadata
+    /// — <c>Position</c>, <c>Width</c>, <c>Height</c>, <c>TitleLocalizationKey</c>,
+    /// <c>RequiredPermission</c>), and an <see cref="IDashboardDefinitionRegistry"/>
+    /// look-up that surfaces the declarative <see cref="WidgetAction"/> list from
+    /// the source <see cref="WidgetDefinition"/>.
+    /// </summary>
+    /// <remarks>
+    /// Actions are looked up by <see cref="Dashboard.SourceDefinitionName"/> +
+    /// per-widget slug — when the source definition is no longer registered (or
+    /// the dashboard was custom-built without a source definition),
+    /// <see cref="DashboardRenderedWidgetResponse.Actions"/> is <see langword="null"/>.
+    /// Definition / persisted-aggregate version drift is intentionally accepted
+    /// for v1: the look-up uses the latest registered version even when
+    /// <see cref="Dashboard.SourceDefinitionVersion"/> differs. See ADR-038
+    /// "drift detection" deferred work.
+    /// </remarks>
+    public static DashboardRenderResponse ToResponse(
+        DashboardRenderResult result,
+        Dashboard dashboard,
+        IDashboardDefinitionRegistry definitionRegistry,
+        string? periodToken)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(dashboard);
+        ArgumentNullException.ThrowIfNull(definitionRegistry);
 
         DashboardRenderPeriodResponse? period = result.Period is { } p
             ? new DashboardRenderPeriodResponse(p.From, p.To, periodToken)
             : null;
 
+        Dictionary<string, IReadOnlyList<WidgetAction>?> actionsBySlug =
+            ResolveActionsBySlug(dashboard, definitionRegistry);
+
+        var instanceById = dashboard.Widgets.ToDictionary(w => w.Id);
+
         DashboardRenderedWidgetResponse[] widgets = [.. result.Widgets.Select(rw =>
-            new DashboardRenderedWidgetResponse(
+        {
+            WidgetInstance instance = instanceById[rw.WidgetId];
+            string slug = ExtractSlug(instance.TitleLocalizationKey, dashboard.SourceDefinitionName);
+            actionsBySlug.TryGetValue(slug, out IReadOnlyList<WidgetAction>? actions);
+
+            return new DashboardRenderedWidgetResponse(
                 Id: rw.WidgetId,
                 WidgetType: rw.Envelope.WidgetType,
+                Slug: slug,
+                Position: instance.Position,
+                Width: instance.Width,
+                Height: instance.Height,
+                TitleLocalizationKey: instance.TitleLocalizationKey,
+                Actions: actions,
+                RequiredPermission: instance.RequiredPermission,
                 Status: rw.Envelope.Status,
                 Sequence: rw.Envelope.Sequence,
                 EmittedAt: rw.Envelope.EmittedAt,
                 RefreshHint: rw.Envelope.RefreshHint,
                 Snapshot: rw.Envelope.Snapshot,
-                ReasonLocalizationKey: rw.Envelope.ReasonLocalizationKey))];
+                ReasonLocalizationKey: rw.Envelope.ReasonLocalizationKey);
+        })];
 
         return new DashboardRenderResponse(
             DashboardId: result.DashboardId,
@@ -48,5 +92,75 @@ internal static class DashboardRenderProjection
         }
 
         return null;
+    }
+
+    private static Dictionary<string, IReadOnlyList<WidgetAction>?> ResolveActionsBySlug(
+        Dashboard dashboard,
+        IDashboardDefinitionRegistry registry)
+    {
+        Dictionary<string, IReadOnlyList<WidgetAction>?> map = new(StringComparer.Ordinal);
+
+        if (dashboard.SourceDefinitionName is not { } sourceName)
+        {
+            return map;
+        }
+
+        IDashboardDefinitionDescriptor? descriptor = registry.Find(sourceName);
+        if (descriptor is null)
+        {
+            return map;
+        }
+
+        // A dashboard's persisted widgets came from one of: (a) the descriptor's
+        // top-level Widgets pool, or (b) one named DashboardView's pool. Walk
+        // every reachable pool and project Slug -> Actions; later pools win on
+        // duplicate slugs (definition authors shouldn't reuse slugs across views,
+        // but this never throws if they do).
+        AddPool(map, descriptor.Widgets);
+        if (descriptor.Views is { } views)
+        {
+            foreach (DashboardView view in views)
+            {
+                AddPool(map, view.Widgets);
+            }
+        }
+
+        return map;
+
+        static void AddPool(
+            Dictionary<string, IReadOnlyList<WidgetAction>?> map,
+            IReadOnlyList<WidgetDefinition> pool)
+        {
+            foreach (WidgetDefinition widget in pool)
+            {
+                map[widget.Slug] = widget.Actions;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the per-widget slug from <c>TitleLocalizationKey</c> by stripping
+    /// the <c>"Widget:{SourceDefinitionName}."</c> prefix when present, otherwise
+    /// stripping just <c>"Widget:"</c>. The frontend uses the slug to address
+    /// the widget in its <c>WidgetAction</c> dispatcher.
+    /// </summary>
+    private static string ExtractSlug(string titleLocalizationKey, string? sourceDefinitionName)
+    {
+        if (sourceDefinitionName is { Length: > 0 })
+        {
+            string prefix = $"Widget:{sourceDefinitionName}.";
+            if (titleLocalizationKey.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return titleLocalizationKey[prefix.Length..];
+            }
+        }
+
+        const string GenericPrefix = "Widget:";
+        if (titleLocalizationKey.StartsWith(GenericPrefix, StringComparison.Ordinal))
+        {
+            return titleLocalizationKey[GenericPrefix.Length..];
+        }
+
+        return titleLocalizationKey;
     }
 }

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -1,9 +1,13 @@
 using System.Text.Json;
 using Granit.Analytics;
 using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
 using Granit.Dashboards.Endpoints.Dtos;
 using Granit.Dashboards.Endpoints.Internal;
 using Granit.Dashboards.Rendering;
+using Granit.Dashboards.Widgets;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -18,21 +22,32 @@ namespace Granit.Dashboards.Endpoints.Tests.Internal;
 /// </summary>
 public sealed class DashboardRenderProjectionTests
 {
+    private const string SourceDefinitionName = "Granit.Test.SampleDashboard";
     private static readonly DateTimeOffset RenderedAt = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
 
     [Fact]
     public void ToResponse_MapsEnvelopeFieldsOntoFlattenedWidgetRecords()
     {
-        var widgetId = Guid.NewGuid();
+        Dashboard dashboard = NewDashboard();
+        WidgetInstance widget = dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 4,
+            height: 2,
+            titleLocalizationKey: $"Widget:{SourceDefinitionName}.unpaid-total",
+            configJson: "{}",
+            requiredPermission: "Invoicing.Invoices.Read");
+
         JsonElement payload = JsonSerializer.SerializeToElement(new { value = 42 });
 
         DashboardRenderResult result = new(
-            DashboardId: Guid.NewGuid(),
+            DashboardId: dashboard.Id,
             RenderedAt: RenderedAt,
             Period: new ResolvedPeriod(RenderedAt.AddDays(-7), RenderedAt),
             Widgets:
             [
-                new RenderedWidget(widgetId, WidgetSnapshotEnvelope.ForSnapshot(
+                new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
                     widgetType: "Kpi",
                     snapshot: payload,
                     sequence: 1,
@@ -40,9 +55,12 @@ public sealed class DashboardRenderProjectionTests
                     refreshHint: RefreshHint.Dynamic)),
             ]);
 
-        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: "mtd");
+        IDashboardDefinitionRegistry registry = EmptyRegistry();
 
-        response.DashboardId.ShouldBe(result.DashboardId);
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, registry, periodToken: "mtd");
+
+        response.DashboardId.ShouldBe(dashboard.Id);
         response.RenderedAt.ShouldBe(RenderedAt);
         response.Period.ShouldNotBeNull();
         response.Period!.From.ShouldBe(RenderedAt.AddDays(-7));
@@ -51,8 +69,15 @@ public sealed class DashboardRenderProjectionTests
 
         response.Widgets.Count.ShouldBe(1);
         DashboardRenderedWidgetResponse w = response.Widgets[0];
-        w.Id.ShouldBe(widgetId);
+        w.Id.ShouldBe(widget.Id);
         w.WidgetType.ShouldBe("Kpi");
+        w.Slug.ShouldBe("unpaid-total");
+        w.Position.ShouldBe(0);
+        w.Width.ShouldBe(4);
+        w.Height.ShouldBe(2);
+        w.TitleLocalizationKey.ShouldBe($"Widget:{SourceDefinitionName}.unpaid-total");
+        w.RequiredPermission.ShouldBe("Invoicing.Invoices.Read");
+        w.Actions.ShouldBeNull();
         w.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
         w.Sequence.ShouldBe(1);
         w.RefreshHint.ShouldBe(RefreshHint.Dynamic);
@@ -62,15 +87,110 @@ public sealed class DashboardRenderProjectionTests
     }
 
     [Fact]
+    public void ToResponse_ProjectsWidgetActionsFromRegisteredDefinition()
+    {
+        Dashboard dashboard = NewDashboard();
+        WidgetInstance widget = dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 4,
+            height: 2,
+            titleLocalizationKey: $"Widget:{SourceDefinitionName}.click-target",
+            configJson: "{}");
+
+        IReadOnlyList<WidgetAction> actions =
+        [
+            new WidgetAction(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/invoicing?status=unpaid"),
+        ];
+
+        IDashboardDefinitionDescriptor descriptor = Substitute.For<IDashboardDefinitionDescriptor>();
+        descriptor.Widgets.Returns(new[]
+        {
+            FakeWidgetDefinition("click-target", actions),
+            FakeWidgetDefinition("unrelated", null),
+        });
+
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(SourceDefinitionName).Returns(descriptor);
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id,
+            RenderedAt: RenderedAt,
+            Period: null,
+            Widgets:
+            [
+                new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                    widgetType: "Kpi",
+                    snapshot: JsonSerializer.SerializeToElement(new { value = 1 }),
+                    sequence: 1,
+                    emittedAt: RenderedAt,
+                    refreshHint: RefreshHint.Dynamic)),
+            ]);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, registry, periodToken: null);
+
+        DashboardRenderedWidgetResponse w = response.Widgets[0];
+        w.Slug.ShouldBe("click-target");
+        w.Actions.ShouldNotBeNull();
+        w.Actions!.Count.ShouldBe(1);
+        w.Actions[0].Trigger.ShouldBe(WidgetActionTrigger.Click);
+        w.Actions[0].Kind.ShouldBe(WidgetActionKind.Navigate);
+        w.Actions[0].Target.ShouldBe("/invoicing?status=unpaid");
+    }
+
+    [Fact]
+    public void ToResponse_DashboardWithoutSourceDefinition_ReturnsNullActions()
+    {
+        // Custom-built dashboard (no SourceDefinitionName) — registry never queried.
+        var dashboard = Dashboard.Create(
+            id: Guid.NewGuid(),
+            name: "Adhoc",
+            category: DashboardCategory.General);
+        WidgetInstance widget = dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Markdown",
+            position: 0,
+            width: 12,
+            height: 1,
+            titleLocalizationKey: "Widget:Adhoc.banner",
+            configJson: "{}");
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id,
+            RenderedAt: RenderedAt,
+            Period: null,
+            Widgets:
+            [
+                new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                    widgetType: "Markdown",
+                    snapshot: JsonSerializer.SerializeToElement(new { body = "hi" }),
+                    sequence: 1,
+                    emittedAt: RenderedAt,
+                    refreshHint: RefreshHint.Static)),
+            ]);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, EmptyRegistry(), periodToken: null);
+
+        DashboardRenderedWidgetResponse w = response.Widgets[0];
+        w.Actions.ShouldBeNull();
+        w.Slug.ShouldBe("Adhoc.banner");                              // generic Widget: prefix stripped
+    }
+
+    [Fact]
     public void ToResponse_NullPeriod_OmitsPeriodEnvelopeField()
     {
+        Dashboard dashboard = NewDashboard();
         DashboardRenderResult result = new(
-            DashboardId: Guid.NewGuid(),
+            DashboardId: dashboard.Id,
             RenderedAt: RenderedAt,
             Period: null,
             Widgets: []);
 
-        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: null);
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, EmptyRegistry(), periodToken: null);
 
         response.Period.ShouldBeNull();
     }
@@ -78,13 +198,23 @@ public sealed class DashboardRenderProjectionTests
     [Fact]
     public void ToResponse_UnavailableEnvelope_PreservesReasonKey()
     {
+        Dashboard dashboard = NewDashboard();
+        WidgetInstance widget = dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 4,
+            height: 2,
+            titleLocalizationKey: $"Widget:{SourceDefinitionName}.gated",
+            configJson: "{}");
+
         DashboardRenderResult result = new(
-            DashboardId: Guid.NewGuid(),
+            DashboardId: dashboard.Id,
             RenderedAt: RenderedAt,
             Period: null,
             Widgets:
             [
-                new RenderedWidget(Guid.NewGuid(), WidgetSnapshotEnvelope.Unavailable(
+                new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.Unavailable(
                     widgetType: "Kpi",
                     sequence: 1,
                     emittedAt: RenderedAt,
@@ -92,7 +222,8 @@ public sealed class DashboardRenderProjectionTests
                     reasonLocalizationKey: "Widget:Unavailable.MetricNotFound")),
             ]);
 
-        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(result, periodToken: null);
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, EmptyRegistry(), periodToken: null);
 
         DashboardRenderedWidgetResponse w = response.Widgets[0];
         w.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
@@ -125,4 +256,25 @@ public sealed class DashboardRenderProjectionTests
             expectedToken.ShouldNotBeNull();
         }
     }
+
+    private static Dashboard NewDashboard() => Dashboard.Create(
+        id: Guid.NewGuid(),
+        name: "SampleDashboard",
+        category: DashboardCategory.Finance,
+        sourceDefinitionName: SourceDefinitionName,
+        sourceDefinitionVersion: "1.0.0");
+
+    private static IDashboardDefinitionRegistry EmptyRegistry()
+    {
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(Arg.Any<string>()).Returns((IDashboardDefinitionDescriptor?)null);
+        return registry;
+    }
+
+    private static MarkdownWidgetDefinition FakeWidgetDefinition(string slug, IReadOnlyList<WidgetAction>? actions) =>
+        new(
+            Slug: slug,
+            ContentLocalizationKey: $"Widget:{SourceDefinitionName}.{slug}.Body",
+            Position: 0,
+            Actions: actions);
 }


### PR DESCRIPTION
## Summary

P1 of the frontend BI gap fixes — the bundle path's `<RenderedDashboard>` could not reconstruct titles, layout, or wire `WidgetAction` dispatch because `DashboardRenderedWidget` was missing structural metadata that the definition path's `WidgetInstanceResponse` already carries. This PR closes that gap with a strictly additive change to the wire shape.

## Wire shape additions

`DashboardRenderedWidgetResponse` (in `Granit.Dashboards.Endpoints.Dtos`) gains 7 new fields:

| Field | Source | Notes |
| ----- | ------ | ----- |
| `Slug` | extracted from `WidgetInstance.TitleLocalizationKey` | strips the `Widget:{DashboardName}.` prefix |
| `Position` | `WidgetInstance.Position` | 0-based dense-ranked grid order |
| `Width` | `WidgetInstance.Width` | grid columns |
| `Height` | `WidgetInstance.Height` | grid rows |
| `TitleLocalizationKey` | `WidgetInstance.TitleLocalizationKey` | resolved client-side |
| `Actions` | `WidgetDefinition.Actions` via `IDashboardDefinitionRegistry` | `null` when none declared / source unregistered |
| `RequiredPermission` | `WidgetInstance.RequiredPermission` | already enforced server-side; echoed for defensive UI |

Strictly additive — the existing fields stay in the same order, the new ones come in BEFORE the snapshot/status/sequence trailing block so the wire JSON groups "structural metadata" before "runtime envelope" naturally.

## Implementation

Projection happens in the wire layer (`DashboardRenderProjection.ToResponse`), not inside the renderer pipeline. The renderer stays focused on snapshot computation and exposes `RenderedWidget(WidgetId, Envelope)` unchanged. The projection now:

1. Joins each pipeline result with its persisted `WidgetInstance` (by id) — gives `Position`, `Width`, `Height`, `TitleLocalizationKey`, `RequiredPermission` straight off the aggregate.
2. Looks up the source `IDashboardDefinitionDescriptor` via `IDashboardDefinitionRegistry.Find(dashboard.SourceDefinitionName)` and walks its `Widgets` + `Views[*].Widgets` pools to build a `Slug → Actions` map.
3. Extracts the per-widget `Slug` from the `Widget:{DashboardName}.{Slug}` localisation-key convention so the frontend's action dispatcher can address the widget without re-parsing.

## Drift handling

The registry look-up uses the latest registered version of the dashboard definition even when `Dashboard.SourceDefinitionVersion` differs from the registered one. v1 accepts this drift; the ADR-038 "drift detection" deferred work tracks the longer-term solution. Custom-built dashboards (no `SourceDefinitionName`) yield `Actions: null` — never throws.

## Frontend impact

Three PRs in `granit-fx/granit-front` (and one in `granit-showcase-admin-react`) are unblocked by this:

- `<RenderedDashboard>` can apply layout from `width × height × position` instead of falling back to a hardcoded `md:grid-cols-2 xl:grid-cols-3` grid.
- `<RenderedWidget>` resolves the widget title via `titleLocalizationKey` (no more empty header on bundle path).
- Snapshot-path widgets (KPI / Chart / Table / Pivot / Map) can dispatch `WidgetAction`s through the framework dispatcher — the same code path the definition path already uses.

## P2 + P3 (next, separate PRs)

This PR pairs with P2 (`ViewName` on request, `ActiveViewName` on response) and P3 (`POST /widgets/{kind}/render` per-widget endpoints). Each is independent off `develop`. P3 will return the same `DashboardRenderedWidgetResponse` shape this PR locks — symmetry between bundle path and single-render path so the frontend wraps the same snapshot widgets in both.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` clean.
- [x] `dotnet format src/Granit.Dashboards.Endpoints --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — **109 passing** (3 new tests cover end-to-end projection of all 7 fields, Actions look-up via registry, custom dashboard with no source definition).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing**.
- [ ] CI green on full shard pipeline (api-data + business shards).