### PR TITLE
refactor(validation): extract IJsonSchemaWriter from FluentValidationSchemaTransformer

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13599,7 +13599,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 33,
+      "line": 42,
       "members": []
     },
     {
@@ -13608,7 +13608,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs",
-      "line": 29,
+      "line": 38,
       "members": []
     },
     {
@@ -13617,7 +13617,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 19,
+      "line": 27,
       "members": []
     },
     {
@@ -13626,7 +13626,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 60,
+      "line": 69,
       "members": []
     },
     {
@@ -13990,7 +13990,7 @@
       "kind": "record",
       "project": "Granit.Dashboards",
       "file": "src/Granit.Dashboards/Rendering/IDashboardRenderer.cs",
-      "line": 43,
+      "line": 69,
       "members": []
     },
     {
@@ -14014,6 +14014,12 @@
           "name": "RenderAsync",
           "kind": "method",
           "signature": "RenderAsync(Dashboard dashboard, WidgetRenderContext context, CancellationToken cancellationToken)",
+          "returnType": "Task<DashboardRenderResult>"
+        },
+        {
+          "name": "RenderAsync",
+          "kind": "method",
+          "signature": "RenderAsync(Guid dashboardId, IReadOnlyList<WidgetInstance> widgets, WidgetRenderContext context, CancellationToken cancellationToken)",
           "returnType": "Task<DashboardRenderResult>"
         }
       ]
@@ -14040,7 +14046,7 @@
       "kind": "record",
       "project": "Granit.Dashboards",
       "file": "src/Granit.Dashboards/Rendering/IDashboardRenderer.cs",
-      "line": 56,
+      "line": 82,
       "members": []
     },
     {
@@ -52544,7 +52550,7 @@
       "kind": "class",
       "project": "Granit.Validation",
       "file": "src/Granit.Validation/GranitValidationModule.cs",
-      "line": 34,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -52562,6 +52568,22 @@
       "file": "src/Granit.Validation/GranitValidator.cs",
       "line": 23,
       "members": []
+    },
+    {
+      "name": "IJsonSchemaWriter",
+      "fqn": "Granit.Validation.JsonSchema.IJsonSchemaWriter",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/JsonSchema/IJsonSchemaWriter.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Write",
+          "kind": "method",
+          "signature": "Write(Type type)",
+          "returnType": "JsonObject?"
+        }
+      ]
     },
     {
       "name": "AmericanAddressValidatorExtensions",

--- a/src/Granit.Validation/GranitValidationModule.cs
+++ b/src/Granit.Validation/GranitValidationModule.cs
@@ -6,6 +6,7 @@ using Granit.Localization.Options;
 using Granit.Modularity;
 using Granit.Validation.Extensions;
 using Granit.Validation.Internal;
+using Granit.Validation.JsonSchema;
 using Granit.Validation.OpenApi;
 using Granit.Validation.ServerValidation;
 using Microsoft.AspNetCore.OpenApi;
@@ -70,6 +71,11 @@ public sealed class GranitValidationModule : GranitModule
         }
 
         context.Services.AddSingleton<ServerValidatorRegistry>();
+
+        // Reusable JSON Schema writer that projects FluentValidation rules onto a
+        // JSON Schema Draft 7 fragment. Consumed by the OpenAPI transformer below
+        // and by Granit.Entities (manifest schema facet).
+        context.Services.AddSingleton<IJsonSchemaWriter, JsonSchemaWriter>();
 
         // Enrich OpenAPI schemas with FluentValidation constraints
         // (maxLength, minLength, pattern, required, etc.)

--- a/src/Granit.Validation/JsonSchema/IJsonSchemaWriter.cs
+++ b/src/Granit.Validation/JsonSchema/IJsonSchemaWriter.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Nodes;
+
+namespace Granit.Validation.JsonSchema;
+
+/// <summary>
+/// Writes a JSON Schema fragment describing the validation constraints declared
+/// on a type via FluentValidation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Maps FluentValidation rules to JSON Schema Draft 7 keywords:
+/// <c>maxLength</c>, <c>minLength</c>, <c>pattern</c>, <c>minimum</c>, <c>maximum</c>,
+/// <c>exclusiveMinimum</c>, <c>exclusiveMaximum</c>, <c>format</c>, and the parent
+/// <c>required</c> array.
+/// </para>
+/// <para>
+/// Custom Granit validators (IBAN, E.164, etc.) are exposed as
+/// <c>x-granit-validator</c> string properties carrying the structured error code
+/// (e.g. <c>Granit:Validation:InvalidIban</c>). Pattern hint validators emit a
+/// companion <c>x-granit-pattern-hint</c> property alongside <c>pattern</c>.
+/// </para>
+/// <para>
+/// Async validators (<c>MustAsync</c>) and complex custom validators without
+/// declarative constraints are silently ignored — they have no JSON Schema equivalent.
+/// </para>
+/// </remarks>
+public interface IJsonSchemaWriter
+{
+    /// <summary>
+    /// Writes a JSON Schema fragment for the validation constraints declared on the
+    /// given type. Returns <see langword="null"/> when no <see cref="FluentValidation.IValidator{T}"/>
+    /// is registered for the type.
+    /// </summary>
+    /// <param name="type">The type whose validator should be inspected.</param>
+    /// <returns>
+    /// A JSON object shaped like a JSON Schema fragment with <c>properties</c> and the
+    /// optional <c>required</c> array, or <see langword="null"/> if no validator is registered.
+    /// Property names use the JSON-friendly camelCase convention.
+    /// </returns>
+    JsonObject? Write(Type type);
+}

--- a/src/Granit.Validation/JsonSchema/JsonSchemaWriter.cs
+++ b/src/Granit.Validation/JsonSchema/JsonSchemaWriter.cs
@@ -1,0 +1,209 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using FluentValidation;
+using FluentValidation.Internal;
+using FluentValidation.Validators;
+using Granit.Validation.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Validation.JsonSchema;
+
+/// <summary>
+/// Default <see cref="IJsonSchemaWriter"/> implementation. Resolves the registered
+/// <see cref="IValidator{T}"/> for the requested type and projects its rules onto a
+/// JSON Schema Draft 7 <see cref="JsonObject"/>.
+/// </summary>
+internal sealed class JsonSchemaWriter(IServiceScopeFactory scopeFactory) : IJsonSchemaWriter
+{
+    private static readonly ConcurrentDictionary<Type, Type> ValidatorTypeCache = new();
+
+    /// <inheritdoc />
+    public JsonObject? Write(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        Type validatorType = ValidatorTypeCache.GetOrAdd(
+            type,
+            static t => typeof(IValidator<>).MakeGenericType(t));
+
+        using IServiceScope scope = scopeFactory.CreateScope();
+
+        if (scope.ServiceProvider.GetService(validatorType) is not IValidator validator)
+        {
+            return null;
+        }
+
+        IValidatorDescriptor descriptor = validator.CreateDescriptor();
+
+        JsonObject schema = new();
+        JsonObject properties = new();
+        JsonArray? required = null;
+
+        foreach (System.Reflection.PropertyInfo prop in type.GetProperties())
+        {
+            string camelName = ToCamelCase(prop.Name);
+            JsonObject propertySchema = new();
+            string? patternHint = null;
+
+            foreach ((IPropertyValidator propertyValidator, IRuleComponent component)
+                in descriptor.GetValidatorsForMember(prop.Name))
+            {
+                if (propertyValidator is IPatternHintProvider hintProvider)
+                {
+                    patternHint = hintProvider.HintKey;
+                    continue;
+                }
+
+                ApplyConstraint(
+                    propertySchema,
+                    ref required,
+                    propertyValidator,
+                    component,
+                    camelName);
+            }
+
+            if (patternHint is not null && propertySchema.ContainsKey("pattern"))
+            {
+                propertySchema["x-granit-pattern-hint"] = patternHint;
+            }
+
+            if (propertySchema.Count > 0)
+            {
+                properties[camelName] = propertySchema;
+            }
+        }
+
+        if (properties.Count > 0)
+        {
+            schema["properties"] = properties;
+        }
+
+        if (required is { Count: > 0 })
+        {
+            schema["required"] = required;
+        }
+
+        return schema;
+    }
+
+    private static void ApplyConstraint(
+        JsonObject propertySchema,
+        ref JsonArray? required,
+        IPropertyValidator validator,
+        IRuleComponent component,
+        string propertyName)
+    {
+        switch (validator)
+        {
+            case INotNullValidator or INotEmptyValidator:
+                required ??= [];
+                if (!required.Any(node => node?.GetValue<string>() == propertyName))
+                {
+                    required.Add(propertyName);
+                }
+
+                break;
+
+            case IMaximumLengthValidator maxLength:
+                propertySchema["maxLength"] = maxLength.Max;
+                break;
+
+            case IMinimumLengthValidator minLength:
+                propertySchema["minLength"] = minLength.Min;
+                break;
+
+            case ILengthValidator length:
+                propertySchema["minLength"] = length.Min;
+                propertySchema["maxLength"] = length.Max;
+                break;
+
+            case IBetweenValidator between:
+                if (TryGetNumericNode(between.From) is { } fromNode)
+                {
+                    propertySchema["minimum"] = fromNode;
+                }
+
+                if (TryGetNumericNode(between.To) is { } toNode)
+                {
+                    propertySchema["maximum"] = toNode;
+                }
+
+                break;
+
+            case IComparisonValidator comparison:
+                ApplyComparisonConstraint(propertySchema, comparison);
+                break;
+
+            case IRegularExpressionValidator regex:
+                propertySchema["pattern"] = regex.Expression;
+                break;
+
+            case IEmailValidator:
+                propertySchema["format"] = "email";
+                break;
+
+            default:
+                string? errorCode = component.ErrorCode;
+                if (errorCode?.StartsWith("Granit:Validation:", StringComparison.Ordinal) == true)
+                {
+                    propertySchema["x-granit-validator"] = errorCode;
+                }
+
+                break;
+        }
+    }
+
+    private static void ApplyComparisonConstraint(
+        JsonObject propertySchema,
+        IComparisonValidator comparison)
+    {
+        if (TryGetNumericNode(comparison.ValueToCompare) is not { } node)
+        {
+            return;
+        }
+
+        switch (comparison.Comparison)
+        {
+            case Comparison.GreaterThanOrEqual:
+                propertySchema["minimum"] = node;
+                break;
+            case Comparison.GreaterThan:
+                propertySchema["exclusiveMinimum"] = node;
+                break;
+            case Comparison.LessThanOrEqual:
+                propertySchema["maximum"] = node;
+                break;
+            case Comparison.LessThan:
+                propertySchema["exclusiveMaximum"] = node;
+                break;
+        }
+    }
+
+    private static JsonValue? TryGetNumericNode(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            int i => JsonValue.Create(i),
+            long l => JsonValue.Create(l),
+            short s => JsonValue.Create(s),
+            byte b => JsonValue.Create(b),
+            decimal m => JsonValue.Create(m),
+            double d => JsonValue.Create(d),
+            float f => JsonValue.Create(f),
+            IConvertible convertible => JsonValue.Create(
+                convertible.ToString(CultureInfo.InvariantCulture)),
+            _ => null,
+        };
+    }
+
+    private static string ToCamelCase(string pascalName) =>
+        pascalName.Length == 0
+            ? pascalName
+            : char.ToLowerInvariant(pascalName[0]) + pascalName[1..];
+}

--- a/src/Granit.Validation/OpenApi/FluentValidationSchemaTransformer.cs
+++ b/src/Granit.Validation/OpenApi/FluentValidationSchemaTransformer.cs
@@ -1,192 +1,174 @@
-using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.Json.Nodes;
-using FluentValidation;
-using FluentValidation.Internal;
-using FluentValidation.Validators;
+using Granit.Validation.JsonSchema;
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
 
 namespace Granit.Validation.OpenApi;
 
 /// <summary>
 /// OpenAPI schema transformer that enriches schemas with validation constraints
-/// extracted from registered <see cref="IValidator{T}"/> instances.
+/// extracted from registered <see cref="FluentValidation.IValidator{T}"/> instances.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Maps FluentValidation rules to standard OpenAPI schema properties:
-/// <c>maxLength</c>, <c>minLength</c>, <c>pattern</c>, <c>minimum</c>, <c>maximum</c>,
-/// <c>required</c>, and <c>format</c>.
-/// </para>
-/// <para>
-/// Custom domain validators (IBAN, E.164, etc.) that have no standard OpenAPI equivalent
-/// are exposed as <c>x-granit-validator</c> extension properties containing the structured
-/// error code (e.g. <c>Granit:Validation:InvalidIban</c>).
-/// </para>
-/// <para>
-/// Async validators (<c>MustAsync</c>) and complex custom validators without static
-/// constraints are silently ignored — they have no declarative OpenAPI equivalent.
+/// Delegates constraint extraction to <see cref="IJsonSchemaWriter"/> and projects
+/// the resulting JSON Schema fragment onto the in-place <see cref="OpenApiSchema"/>.
+/// Behavior is identical to the prior in-house implementation: <c>maxLength</c>,
+/// <c>minLength</c>, <c>pattern</c>, <c>minimum</c>, <c>maximum</c>, <c>required</c>,
+/// <c>format</c>, plus the <c>x-granit-validator</c> and <c>x-granit-pattern-hint</c>
+/// extensions.
 /// </para>
 /// </remarks>
-internal sealed class FluentValidationSchemaTransformer(
-    IServiceScopeFactory scopeFactory) : IOpenApiSchemaTransformer
+internal sealed class FluentValidationSchemaTransformer(IJsonSchemaWriter writer) : IOpenApiSchemaTransformer
 {
-    private static readonly ConcurrentDictionary<Type, Type> ValidatorTypeCache = new();
-
     /// <inheritdoc/>
     public Task TransformAsync(
         OpenApiSchema schema,
         OpenApiSchemaTransformerContext context,
         CancellationToken cancellationToken)
     {
-        Type schemaType = context.JsonTypeInfo.Type;
-
-        Type validatorType = ValidatorTypeCache.GetOrAdd(
-            schemaType,
-            static t => typeof(IValidator<>).MakeGenericType(t));
-
-        using IServiceScope scope = scopeFactory.CreateScope();
-
-        if (scope.ServiceProvider.GetService(validatorType) is not IValidator validator)
-        {
-            return Task.CompletedTask;
-        }
-
-        IValidatorDescriptor descriptor = validator.CreateDescriptor();
-
         if (schema.Properties is null || schema.Properties.Count == 0)
         {
             return Task.CompletedTask;
         }
 
-        foreach (KeyValuePair<string, IOpenApiSchema> property in schema.Properties)
+        JsonObject? jsonSchema = writer.Write(context.JsonTypeInfo.Type);
+        if (jsonSchema is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        Project(schema, jsonSchema);
+        return Task.CompletedTask;
+    }
+
+    private static void Project(OpenApiSchema schema, JsonObject jsonSchema)
+    {
+        if (jsonSchema["required"] is JsonArray requiredArray)
+        {
+            foreach (JsonNode? node in requiredArray)
+            {
+                if (node?.GetValue<string>() is { } name)
+                {
+                    schema.Required ??= new HashSet<string>();
+                    schema.Required.Add(name);
+                }
+            }
+        }
+
+        if (jsonSchema["properties"] is not JsonObject jsonProperties)
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<string, IOpenApiSchema> property in schema.Properties!)
         {
             if (property.Value is not OpenApiSchema propertySchema)
             {
                 continue;
             }
 
-            // OpenAPI uses camelCase, FluentValidation uses PascalCase
-            string pascalName = char.ToUpperInvariant(property.Key[0]) + property.Key[1..];
-
-            string? patternHint = null;
-
-            foreach ((IPropertyValidator propertyValidator, IRuleComponent component)
-                in descriptor.GetValidatorsForMember(pascalName))
+            if (jsonProperties[property.Key] is not JsonObject constraints)
             {
-                if (propertyValidator is IPatternHintProvider hintProvider)
-                {
-                    patternHint = hintProvider.HintKey;
-                    continue;
-                }
-
-                ApplyConstraint(schema, propertySchema, propertyValidator, component, property.Key);
+                continue;
             }
 
-            if (patternHint is not null && propertySchema.Pattern is not null)
-            {
-                propertySchema.Extensions ??= new Dictionary<string, IOpenApiExtension>();
-                propertySchema.Extensions["x-granit-pattern-hint"] =
-                    new JsonNodeExtension(JsonValue.Create(patternHint)!);
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    private static void ApplyConstraint(
-        OpenApiSchema parentSchema,
-        OpenApiSchema propertySchema,
-        IPropertyValidator validator,
-        IRuleComponent component,
-        string propertyName)
-    {
-        switch (validator)
-        {
-            case INotNullValidator or INotEmptyValidator:
-                parentSchema.Required ??= new HashSet<string>();
-                parentSchema.Required.Add(propertyName);
-                break;
-
-            case IMaximumLengthValidator maxLength:
-                propertySchema.MaxLength = maxLength.Max;
-                break;
-
-            case IMinimumLengthValidator minLength:
-                propertySchema.MinLength = minLength.Min;
-                break;
-
-            case ILengthValidator length:
-                propertySchema.MinLength = length.Min;
-                propertySchema.MaxLength = length.Max;
-                break;
-
-            case IBetweenValidator between:
-                if (between.From is IConvertible fromValue)
-                {
-                    propertySchema.Minimum = fromValue.ToString(CultureInfo.InvariantCulture);
-                }
-
-                if (between.To is IConvertible toValue)
-                {
-                    propertySchema.Maximum = toValue.ToString(CultureInfo.InvariantCulture);
-                }
-
-                break;
-
-            case IComparisonValidator comparison:
-                ApplyComparisonConstraint(propertySchema, comparison);
-                break;
-
-            case IRegularExpressionValidator regex:
-                propertySchema.Pattern = regex.Expression;
-                break;
-
-            case IEmailValidator:
-                propertySchema.Format = "email";
-                break;
-
-            default:
-                // Custom Granit validators — expose via extension using the error code
-                string? errorCode = component.ErrorCode;
-                if (errorCode?.StartsWith("Granit:Validation:", StringComparison.Ordinal) == true)
-                {
-                    propertySchema.Extensions ??= new Dictionary<string, IOpenApiExtension>();
-                    propertySchema.Extensions["x-granit-validator"] =
-                        new JsonNodeExtension(JsonValue.Create(errorCode)!);
-                }
-
-                break;
+            ProjectProperty(propertySchema, constraints);
         }
     }
 
-    private static void ApplyComparisonConstraint(
-        OpenApiSchema propertySchema,
-        IComparisonValidator comparison)
+    private static void ProjectProperty(OpenApiSchema propertySchema, JsonObject constraints)
     {
-        if (comparison.ValueToCompare is not IConvertible convertible)
+        if (constraints["maxLength"]?.GetValue<int>() is { } maxLength)
         {
-            return;
+            propertySchema.MaxLength = maxLength;
         }
 
-        string value = convertible.ToString(CultureInfo.InvariantCulture);
-
-        switch (comparison.Comparison)
+        if (constraints["minLength"]?.GetValue<int>() is { } minLength)
         {
-            case Comparison.GreaterThanOrEqual:
-                propertySchema.Minimum = value;
-                break;
-            case Comparison.GreaterThan:
-                propertySchema.ExclusiveMinimum = value;
-                break;
-            case Comparison.LessThanOrEqual:
-                propertySchema.Maximum = value;
-                break;
-            case Comparison.LessThan:
-                propertySchema.ExclusiveMaximum = value;
-                break;
+            propertySchema.MinLength = minLength;
         }
+
+        if (constraints["pattern"]?.GetValue<string>() is { } pattern)
+        {
+            propertySchema.Pattern = pattern;
+        }
+
+        if (constraints["format"]?.GetValue<string>() is { } format)
+        {
+            propertySchema.Format = format;
+        }
+
+        if (FormatNumeric(constraints["minimum"]) is { } minimum)
+        {
+            propertySchema.Minimum = minimum;
+        }
+
+        if (FormatNumeric(constraints["maximum"]) is { } maximum)
+        {
+            propertySchema.Maximum = maximum;
+        }
+
+        if (FormatNumeric(constraints["exclusiveMinimum"]) is { } exclusiveMin)
+        {
+            propertySchema.ExclusiveMinimum = exclusiveMin;
+        }
+
+        if (FormatNumeric(constraints["exclusiveMaximum"]) is { } exclusiveMax)
+        {
+            propertySchema.ExclusiveMaximum = exclusiveMax;
+        }
+
+        if (constraints["x-granit-validator"]?.GetValue<string>() is { } validatorCode)
+        {
+            propertySchema.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+            propertySchema.Extensions["x-granit-validator"] =
+                new JsonNodeExtension(JsonValue.Create(validatorCode)!);
+        }
+
+        if (constraints["x-granit-pattern-hint"]?.GetValue<string>() is { } hintKey)
+        {
+            propertySchema.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+            propertySchema.Extensions["x-granit-pattern-hint"] =
+                new JsonNodeExtension(JsonValue.Create(hintKey)!);
+        }
+    }
+
+    private static string? FormatNumeric(JsonNode? node)
+    {
+        if (node is not JsonValue value)
+        {
+            return null;
+        }
+
+        // Match the prior behavior: numeric bounds are surfaced as
+        // invariant-culture strings on OpenApiSchema.
+        if (value.TryGetValue(out int intValue))
+        {
+            return intValue.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetValue(out long longValue))
+        {
+            return longValue.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetValue(out decimal decimalValue))
+        {
+            return decimalValue.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetValue(out double doubleValue))
+        {
+            return doubleValue.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (value.TryGetValue(out string? stringValue))
+        {
+            return stringValue;
+        }
+
+        return null;
     }
 }

--- a/tests/Granit.Validation.Tests/FluentValidationSchemaTransformerTests.cs
+++ b/tests/Granit.Validation.Tests/FluentValidationSchemaTransformerTests.cs
@@ -16,6 +16,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using FluentValidation;
 using Granit.Validation.Extensions;
+using Granit.Validation.JsonSchema;
 using Granit.Validation.OpenApi;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
@@ -172,8 +173,9 @@ public sealed class FluentValidationSchemaTransformerTests
         services.AddScoped<IValidator<TRequest>, TValidator>();
         ServiceProvider provider = services.BuildServiceProvider();
 
-        FluentValidationSchemaTransformer transformer = new(
+        IJsonSchemaWriter writer = new JsonSchemaWriter(
             provider.GetRequiredService<IServiceScopeFactory>());
+        FluentValidationSchemaTransformer transformer = new(writer);
 
         OpenApiSchema schema = CreateSchemaForType<TRequest>();
         OpenApiSchemaTransformerContext context = CreateContext<TRequest>();
@@ -188,8 +190,9 @@ public sealed class FluentValidationSchemaTransformerTests
         ServiceCollection services = new();
         ServiceProvider provider = services.BuildServiceProvider();
 
-        FluentValidationSchemaTransformer transformer = new(
+        IJsonSchemaWriter writer = new JsonSchemaWriter(
             provider.GetRequiredService<IServiceScopeFactory>());
+        FluentValidationSchemaTransformer transformer = new(writer);
 
         OpenApiSchema schema = CreateSchemaForType<TRequest>();
         OpenApiSchemaTransformerContext context = CreateContext<TRequest>();

--- a/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
+++ b/tests/Granit.Validation.Tests/JsonSchemaWriterTests.cs
@@ -1,0 +1,382 @@
+// =============================================================================
+// Tests - JsonSchemaWriter
+// =============================================================================
+// Verifies the JSON Schema Draft 7 projection of FluentValidation rules:
+//   - No validator → null
+//   - NotEmpty → required[]
+//   - MaximumLength → maxLength
+//   - MinimumLength → minLength
+//   - Length(min,max) → both
+//   - GreaterThan → exclusiveMinimum
+//   - GreaterThanOrEqualTo → minimum
+//   - LessThan → exclusiveMaximum
+//   - LessThanOrEqualTo → maximum
+//   - InclusiveBetween → minimum + maximum
+//   - Matches → pattern
+//   - EmailAddress → format: "email"
+//   - Pattern + WithPatternHint → x-granit-pattern-hint
+//   - Custom Granit error code → x-granit-validator
+//   - Multiple properties + multiple constraints per property
+// =============================================================================
+
+using System.Text.Json.Nodes;
+using FluentValidation;
+using Granit.Validation.Extensions;
+using Granit.Validation.JsonSchema;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Validation.Tests;
+
+public sealed class JsonSchemaWriterTests
+{
+    [Fact]
+    public void Write_NoValidatorRegistered_ReturnsNull()
+    {
+        JsonSchemaWriter writer = CreateWriter<NoValidatorRequest>(registerValidator: false);
+
+        JsonObject? schema = writer.Write(typeof(NoValidatorRequest));
+
+        schema.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Write_NotEmpty_AddsToRequiredArray()
+    {
+        JsonSchemaWriter writer = CreateWriter<RequiredRequest, RequiredRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(RequiredRequest))!;
+
+        JsonArray required = schema["required"]!.AsArray();
+        required.Select(n => n!.GetValue<string>()).ShouldContain("name");
+    }
+
+    [Fact]
+    public void Write_MaximumLength_SetsMaxLength()
+    {
+        JsonSchemaWriter writer = CreateWriter<MaxLengthRequest, MaxLengthRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(MaxLengthRequest))!;
+
+        schema["properties"]!["name"]!["maxLength"]!.GetValue<int>().ShouldBe(100);
+    }
+
+    [Fact]
+    public void Write_MinimumLength_SetsMinLength()
+    {
+        JsonSchemaWriter writer = CreateWriter<MinLengthRequest, MinLengthRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(MinLengthRequest))!;
+
+        schema["properties"]!["name"]!["minLength"]!.GetValue<int>().ShouldBe(3);
+    }
+
+    [Fact]
+    public void Write_Length_SetsBothMinAndMax()
+    {
+        JsonSchemaWriter writer = CreateWriter<LengthRequest, LengthRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(LengthRequest))!;
+
+        JsonNode prop = schema["properties"]!["code"]!;
+        prop["minLength"]!.GetValue<int>().ShouldBe(2);
+        prop["maxLength"]!.GetValue<int>().ShouldBe(8);
+    }
+
+    [Fact]
+    public void Write_GreaterThan_SetsExclusiveMinimum()
+    {
+        JsonSchemaWriter writer = CreateWriter<GreaterThanRequest, GreaterThanRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(GreaterThanRequest))!;
+
+        schema["properties"]!["age"]!["exclusiveMinimum"]!.GetValue<int>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void Write_GreaterThanOrEqualTo_SetsMinimum()
+    {
+        JsonSchemaWriter writer = CreateWriter<GreaterThanOrEqualRequest, GreaterThanOrEqualRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(GreaterThanOrEqualRequest))!;
+
+        schema["properties"]!["age"]!["minimum"]!.GetValue<int>().ShouldBe(18);
+    }
+
+    [Fact]
+    public void Write_LessThan_SetsExclusiveMaximum()
+    {
+        JsonSchemaWriter writer = CreateWriter<LessThanRequest, LessThanRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(LessThanRequest))!;
+
+        schema["properties"]!["age"]!["exclusiveMaximum"]!.GetValue<int>().ShouldBe(120);
+    }
+
+    [Fact]
+    public void Write_LessThanOrEqualTo_SetsMaximum()
+    {
+        JsonSchemaWriter writer = CreateWriter<LessThanOrEqualRequest, LessThanOrEqualRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(LessThanOrEqualRequest))!;
+
+        schema["properties"]!["age"]!["maximum"]!.GetValue<int>().ShouldBe(150);
+    }
+
+    [Fact]
+    public void Write_InclusiveBetween_SetsMinimumAndMaximum()
+    {
+        JsonSchemaWriter writer = CreateWriter<BetweenRequest, BetweenRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(BetweenRequest))!;
+
+        JsonNode prop = schema["properties"]!["score"]!;
+        prop["minimum"]!.GetValue<int>().ShouldBe(0);
+        prop["maximum"]!.GetValue<int>().ShouldBe(100);
+    }
+
+    [Fact]
+    public void Write_Matches_SetsPattern()
+    {
+        JsonSchemaWriter writer = CreateWriter<PatternRequest, PatternRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(PatternRequest))!;
+
+        schema["properties"]!["code"]!["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]{3}$");
+    }
+
+    [Fact]
+    public void Write_EmailAddress_SetsFormatEmail()
+    {
+        JsonSchemaWriter writer = CreateWriter<EmailRequest, EmailRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(EmailRequest))!;
+
+        schema["properties"]!["email"]!["format"]!.GetValue<string>().ShouldBe("email");
+    }
+
+    [Fact]
+    public void Write_PatternWithHint_AddsXGranitPatternHint()
+    {
+        JsonSchemaWriter writer = CreateWriter<PatternHintRequest, PatternHintRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(PatternHintRequest))!;
+
+        JsonNode prop = schema["properties"]!["code"]!;
+        prop["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]{2}$");
+        prop["x-granit-pattern-hint"]!.GetValue<string>().ShouldBe("Granit:Validation:Hints:Alpha2Code");
+    }
+
+    [Fact]
+    public void Write_PatternWithoutHint_DoesNotEmitHintExtension()
+    {
+        JsonSchemaWriter writer = CreateWriter<PatternRequest, PatternRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(PatternRequest))!;
+
+        JsonObject prop = schema["properties"]!["code"]!.AsObject();
+        prop.ContainsKey("x-granit-pattern-hint").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Write_CustomGranitErrorCode_EmitsXGranitValidator()
+    {
+        JsonSchemaWriter writer = CreateWriter<CustomCodeRequest, CustomCodeRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(CustomCodeRequest))!;
+
+        schema["properties"]!["value"]!["x-granit-validator"]!
+            .GetValue<string>()
+            .ShouldBe("Granit:Validation:CustomFoo");
+    }
+
+    [Fact]
+    public void Write_MultipleConstraintsOnSameProperty_EmitsAllOfThem()
+    {
+        JsonSchemaWriter writer = CreateWriter<CompositeRequest, CompositeRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(CompositeRequest))!;
+
+        JsonNode prop = schema["properties"]!["code"]!;
+        prop["minLength"]!.GetValue<int>().ShouldBe(2);
+        prop["maxLength"]!.GetValue<int>().ShouldBe(8);
+        prop["pattern"]!.GetValue<string>().ShouldBe(@"^[A-Z]+$");
+        schema["required"]!.AsArray().Select(n => n!.GetValue<string>()).ShouldContain("code");
+    }
+
+    [Fact]
+    public void Write_MultipleProperties_EmitsAllInProperties()
+    {
+        JsonSchemaWriter writer = CreateWriter<TwoFieldsRequest, TwoFieldsRequestValidator>();
+
+        JsonObject schema = writer.Write(typeof(TwoFieldsRequest))!;
+
+        JsonObject properties = schema["properties"]!.AsObject();
+        properties.ContainsKey("name").ShouldBeTrue();
+        properties.ContainsKey("age").ShouldBeTrue();
+        properties["name"]!["maxLength"]!.GetValue<int>().ShouldBe(50);
+        properties["age"]!["exclusiveMinimum"]!.GetValue<int>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void Write_NullType_Throws()
+    {
+        JsonSchemaWriter writer = CreateWriter<NoValidatorRequest>(registerValidator: false);
+
+        Should.Throw<ArgumentNullException>(() => writer.Write(null!));
+    }
+
+    [Fact]
+    public void JsonSchemaWriter_Implements_IJsonSchemaWriter()
+    {
+        // Sanity check — Granit.Entities and other consumers depend on the
+        // interface, not the concrete implementation.
+        typeof(IJsonSchemaWriter).IsAssignableFrom(typeof(JsonSchemaWriter)).ShouldBeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static JsonSchemaWriter CreateWriter<TRequest, TValidator>()
+        where TValidator : class, IValidator<TRequest>, new()
+    {
+        ServiceCollection services = new();
+        services.AddScoped<IValidator<TRequest>, TValidator>();
+        ServiceProvider provider = services.BuildServiceProvider();
+        return new JsonSchemaWriter(provider.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    private static JsonSchemaWriter CreateWriter<TRequest>(bool registerValidator)
+    {
+        ServiceCollection services = new();
+        ServiceProvider provider = services.BuildServiceProvider();
+        return new JsonSchemaWriter(provider.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    // -------------------------------------------------------------------------
+    // Test types
+    // -------------------------------------------------------------------------
+
+    private sealed record NoValidatorRequest(string Name);
+
+    private sealed record RequiredRequest(string Name);
+
+    private sealed class RequiredRequestValidator : GranitValidator<RequiredRequest>
+    {
+        public RequiredRequestValidator() => RuleFor(x => x.Name).NotEmpty();
+    }
+
+    private sealed record MaxLengthRequest(string Name);
+
+    private sealed class MaxLengthRequestValidator : GranitValidator<MaxLengthRequest>
+    {
+        public MaxLengthRequestValidator() => RuleFor(x => x.Name).MaximumLength(100);
+    }
+
+    private sealed record MinLengthRequest(string Name);
+
+    private sealed class MinLengthRequestValidator : GranitValidator<MinLengthRequest>
+    {
+        public MinLengthRequestValidator() => RuleFor(x => x.Name).MinimumLength(3);
+    }
+
+    private sealed record LengthRequest(string Code);
+
+    private sealed class LengthRequestValidator : GranitValidator<LengthRequest>
+    {
+        public LengthRequestValidator() => RuleFor(x => x.Code).Length(2, 8);
+    }
+
+    private sealed record GreaterThanRequest(int Age);
+
+    private sealed class GreaterThanRequestValidator : GranitValidator<GreaterThanRequest>
+    {
+        public GreaterThanRequestValidator() => RuleFor(x => x.Age).GreaterThan(0);
+    }
+
+    private sealed record GreaterThanOrEqualRequest(int Age);
+
+    private sealed class GreaterThanOrEqualRequestValidator : GranitValidator<GreaterThanOrEqualRequest>
+    {
+        public GreaterThanOrEqualRequestValidator() => RuleFor(x => x.Age).GreaterThanOrEqualTo(18);
+    }
+
+    private sealed record LessThanRequest(int Age);
+
+    private sealed class LessThanRequestValidator : GranitValidator<LessThanRequest>
+    {
+        public LessThanRequestValidator() => RuleFor(x => x.Age).LessThan(120);
+    }
+
+    private sealed record LessThanOrEqualRequest(int Age);
+
+    private sealed class LessThanOrEqualRequestValidator : GranitValidator<LessThanOrEqualRequest>
+    {
+        public LessThanOrEqualRequestValidator() => RuleFor(x => x.Age).LessThanOrEqualTo(150);
+    }
+
+    private sealed record BetweenRequest(int Score);
+
+    private sealed class BetweenRequestValidator : GranitValidator<BetweenRequest>
+    {
+        public BetweenRequestValidator() => RuleFor(x => x.Score).InclusiveBetween(0, 100);
+    }
+
+    private sealed record PatternRequest(string Code);
+
+    private sealed class PatternRequestValidator : GranitValidator<PatternRequest>
+    {
+        public PatternRequestValidator() => RuleFor(x => x.Code).Matches(@"^[A-Z]{3}$");
+    }
+
+    private sealed record EmailRequest(string Email);
+
+    private sealed class EmailRequestValidator : GranitValidator<EmailRequest>
+    {
+        public EmailRequestValidator() => RuleFor(x => x.Email).EmailAddress();
+    }
+
+    private sealed record PatternHintRequest(string Code);
+
+    private sealed class PatternHintRequestValidator : GranitValidator<PatternHintRequest>
+    {
+        public PatternHintRequestValidator() =>
+            RuleFor(x => x.Code)
+                .Matches(@"^[A-Z]{2}$")
+                .WithPatternHint("Granit:Validation:Hints:Alpha2Code");
+    }
+
+    private sealed record CustomCodeRequest(string Value);
+
+    private sealed class CustomCodeRequestValidator : GranitValidator<CustomCodeRequest>
+    {
+        public CustomCodeRequestValidator() =>
+            RuleFor(x => x.Value)
+                .Must(v => v?.StartsWith('X') == true)
+                .WithErrorCode("Granit:Validation:CustomFoo");
+    }
+
+    private sealed record CompositeRequest(string Code);
+
+    private sealed class CompositeRequestValidator : GranitValidator<CompositeRequest>
+    {
+        public CompositeRequestValidator() =>
+            RuleFor(x => x.Code)
+                .NotEmpty()
+                .Length(2, 8)
+                .Matches(@"^[A-Z]+$");
+    }
+
+    private sealed record TwoFieldsRequest(string Name, int Age);
+
+    private sealed class TwoFieldsRequestValidator : GranitValidator<TwoFieldsRequest>
+    {
+        public TwoFieldsRequestValidator()
+        {
+            RuleFor(x => x.Name).MaximumLength(50);
+            RuleFor(x => x.Age).GreaterThan(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `IJsonSchemaWriter` (public) from the FluentValidation OpenAPI transformer so the JSON Schema Draft 7 projection becomes reusable. Will feed the upcoming `Granit.Entities` manifest's `schema` facet.
- Refactors `FluentValidationSchemaTransformer` to delegate to the writer and project the resulting `JsonObject` onto `OpenApiSchema` — **zero behavior change** for OpenAPI consumers.
- Registers `IJsonSchemaWriter` as a singleton in `GranitValidationModule`.

Closes #1517 — first commit of Phase 0 of the Refonte UI Hybride master plan (#1506).

## Acceptance criteria — story #1517

- [x] `IJsonSchemaWriter` interface defined with the minimal surface needed (`JsonObject? Write(Type)`).
- [x] Default implementation handles required/maxLength/minLength/length/pattern/email/comparison(>,>=,<,<=)/range/custom Granit error code/pattern hint.
- [x] All existing OpenAPI tests pass without behavior change (9 transformer tests still green).
- [x] New unit tests for `IJsonSchemaWriter` cover **14 rule kinds across 19 tests** (well over the 8-kind acceptance bar).
- [x] DI registration in `GranitValidationModule` exposes `IJsonSchemaWriter` as singleton.

## Test plan

- [x] `dotnet test tests/Granit.Validation.Tests` — 513 tests pass
- [x] `dotnet build .github/shard-filters/core-ai.slnf` — green
- [x] `dotnet test .github/shard-filters/core-ai.slnf` — all green
- [x] `dotnet format` + `dotnet format style` — clean on both packages
- [x] No public surface breaking change beyond adding the new interface

## Architecture note

The split is `extract → project`:

- `JsonSchemaWriter` walks the FluentValidation descriptor once and emits a JSON Schema fragment.
- `FluentValidationSchemaTransformer` consumes that fragment and projects the relevant keywords onto the in-place `OpenApiSchema`.

`Granit.Entities` (Phase 1) will consume the writer directly to populate the manifest's `schema` facet, without any OpenAPI coupling.