### PR TITLE
feat(dashboards-render): P2 — multi-view dispatch on bundle path (ViewName / ActiveViewName)

### DIFF
--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderRequest.cs
@@ -26,9 +26,19 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// <param name="PeriodToken">Optional named token (e.g. <c>"mtd"</c>) — echoed in the response for client convenience; the renderer never re-resolves it server-side.</param>
 /// <param name="Locale">Active BCP-47 locale tag (e.g. <c>"en"</c>, <c>"fr-CA"</c>). Defaults to <c>"en"</c> when omitted.</param>
 /// <param name="Filters">Dashboard-level filter bindings. <see langword="null"/> = no filters; the typed renderers apply their own defaults.</param>
+/// <param name="ViewName">
+/// Active <c>DashboardView.Name</c> the caller wants rendered. <see langword="null"/>
+/// (default) falls back to <c>DashboardDefinition.DefaultView</c>, then to the first
+/// declared view, then to the dashboard's top-level widget pool when the source
+/// definition has no views — mirrors the frontend's <c>resolveActiveView</c> chain
+/// (story P2.1) so the bundle path now honours view switches just like the
+/// definition path. Single-view dashboards ignore this parameter; the response's
+/// <c>ActiveViewName</c> echoes <see langword="null"/> in that case.
+/// </param>
 public sealed record DashboardRenderRequest(
     DateTimeOffset? PeriodFrom = null,
     DateTimeOffset? PeriodTo = null,
     string? PeriodToken = null,
     string? Locale = null,
-    IReadOnlyDictionary<string, string>? Filters = null);
+    IReadOnlyDictionary<string, string>? Filters = null,
+    string? ViewName = null);

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -15,11 +15,20 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// <param name="DashboardId">Dashboard identifier — matches <c>Dashboard.Id</c>.</param>
 /// <param name="RenderedAt">Server-side timestamp at which the bundle was composed.</param>
 /// <param name="Period">Period the renderer ran against. <see langword="null"/> when the request omitted period bounds.</param>
-/// <param name="Widgets">One flat record per widget, in <c>WidgetInstance.Position</c> order.</param>
+/// <param name="ActiveViewName">
+/// Name of the <c>DashboardView</c> the renderer actually served. Reflects the
+/// fallback chain from <c>DashboardRenderRequest.ViewName</c> through
+/// <c>DefaultView</c> through first-view; <see langword="null"/> when the source
+/// definition has no views (single-view dashboard) or when the dashboard has no
+/// registered source definition. The frontend's TanStack cache partitions per
+/// <c>(dashboardId, ActiveViewName)</c> tuple so view switches invalidate cleanly.
+/// </param>
+/// <param name="Widgets">One flat record per widget, in <c>WidgetInstance.Position</c> order. Reflects the active view only.</param>
 public sealed record DashboardRenderResponse(
     Guid DashboardId,
     DateTimeOffset RenderedAt,
     DashboardRenderPeriodResponse? Period,
+    string? ActiveViewName,
     IReadOnlyList<DashboardRenderedWidgetResponse> Widgets);
 
 /// <summary>

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
@@ -79,11 +79,20 @@ internal static class DashboardRenderEndpoints
             DashboardFilters: body.Filters ?? new Dictionary<string, string>(),
             ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
 
+        // P2.1 multi-view dispatch — resolve the active view and the matching
+        // widget pool. Single-view dashboards short-circuit to dashboard.Widgets
+        // with ActiveViewName: null; non-entry views materialise ephemeral
+        // WidgetInstances from the source DashboardDefinition.
+        IDashboardDefinitionDescriptor? descriptor = dashboard.SourceDefinitionName is { } sn
+            ? definitionRegistry.Find(sn)
+            : null;
+        ResolvedRenderTarget target = ActiveViewResolver.Resolve(dashboard, descriptor, body.ViewName);
+
         DashboardRenderResult result = await renderer
-            .RenderAsync(dashboard, context, cancellationToken)
+            .RenderAsync(dashboard.Id, target.Widgets, context, cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.Ok(DashboardRenderProjection.ToResponse(
-            result, dashboard, definitionRegistry, body.PeriodToken));
+            result, dashboard, target, definitionRegistry, body.PeriodToken));
     }
 }

--- a/src/Granit.Dashboards.Endpoints/Internal/ActiveViewResolver.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/ActiveViewResolver.cs
@@ -1,0 +1,155 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Widgets;
+
+namespace Granit.Dashboards.Endpoints.Internal;
+
+/// <summary>
+/// Resolves the active <see cref="DashboardView"/> requested by a render call,
+/// and materialises an ephemeral widget pool when the resolved view is NOT the
+/// dashboard's entry view. P2.1 multi-view dispatch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The fallback chain mirrors the frontend's <c>resolveActiveView</c>:
+/// requested <c>ViewName</c> → <c>DashboardDefinition.DefaultView</c> → first
+/// declared view. Single-view dashboards (no <see cref="IDashboardDefinitionDescriptor.Views"/>)
+/// short-circuit to the persisted top-level pool with
+/// <c>ActiveViewName: null</c>.
+/// </para>
+/// <para>
+/// "Entry view" — the view whose widgets the importer persisted on the
+/// <see cref="Dashboard"/>. v1 assumption: <c>descriptor.DefaultView</c> (or the
+/// first view when <c>DefaultView</c> is null) was the entry view at import
+/// time. When the active view matches the entry view, <see cref="Dashboard.Widgets"/>
+/// is rendered directly so per-instance overrides survive. For non-entry views
+/// the renderer falls through to definitions and materialises ephemeral
+/// <see cref="WidgetInstance"/>s with deterministic ids derived from
+/// <c>(dashboardId, viewName, slug)</c> so the frontend's TanStack cache can
+/// partition cleanly across views.
+/// </para>
+/// </remarks>
+internal static class ActiveViewResolver
+{
+    /// <summary>
+    /// Determines the widget pool to render and the active view name to echo on
+    /// the response.
+    /// </summary>
+    public static ResolvedRenderTarget Resolve(
+        Dashboard dashboard,
+        IDashboardDefinitionDescriptor? descriptor,
+        string? requestedViewName)
+    {
+        ArgumentNullException.ThrowIfNull(dashboard);
+
+        if (descriptor?.Views is not { Count: > 0 } views)
+        {
+            // Single-view dashboard or no registered source: render the persisted
+            // pool. ActiveViewName is null — the frontend treats this as
+            // "single-view, no view selector".
+            return new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null);
+        }
+
+        // Resolve the active view: request value → DefaultView → first.
+        DashboardView active =
+            (requestedViewName is { Length: > 0 }
+                ? views.FirstOrDefault(v => string.Equals(v.Name, requestedViewName, StringComparison.Ordinal))
+                : null)
+            ?? (descriptor.DefaultView is { Length: > 0 }
+                ? views.FirstOrDefault(v => string.Equals(v.Name, descriptor.DefaultView, StringComparison.Ordinal))
+                : null)
+            ?? views[0];
+
+        // Entry view assumption: descriptor.DefaultView (or views[0] when
+        // DefaultView is null) is the view whose widgets the importer pinned on
+        // the persisted dashboard. v1 accepts drift if DefaultView changed
+        // post-import — see ADR-038 deferred drift detection.
+        string entryViewName = descriptor.DefaultView is { Length: > 0 } d
+            && views.Any(v => string.Equals(v.Name, d, StringComparison.Ordinal))
+            ? d
+            : views[0].Name;
+
+        bool isEntryView = string.Equals(active.Name, entryViewName, StringComparison.Ordinal);
+
+        IReadOnlyList<WidgetInstance> widgets = isEntryView
+            ? dashboard.Widgets
+            : Materialise(dashboard.Id, descriptor.Name, active);
+
+        return new ResolvedRenderTarget(widgets, active.Name);
+    }
+
+    private static List<WidgetInstance> Materialise(
+        Guid dashboardId,
+        string definitionName,
+        DashboardView view)
+    {
+        var widgets = new List<WidgetInstance>(view.Widgets.Count);
+
+        foreach (WidgetDefinition definition in view.Widgets)
+        {
+            WidgetDefinitionToInstanceMapper.Mapping mapping =
+                WidgetDefinitionToInstanceMapper.Map(definition);
+
+            // Stable id derived from (dashboardId, viewName, slug) — RFC 9562 v8
+            // (custom name-based UUID) using SHA-256 truncated to 16 bytes. Lets
+            // the frontend cache per-view on a stable widget id without needing
+            // per-view persistence.
+            Guid id = DeriveId(dashboardId, view.Name, definition.Slug);
+
+            widgets.Add(WidgetInstance.Create(
+                id: id,
+                dashboardId: dashboardId,
+                widgetType: mapping.WidgetType,
+                position: definition.Position,
+                width: definition.Size.Width,
+                height: definition.Size.Height,
+                titleLocalizationKey: $"Widget:{definitionName}.{definition.Slug}",
+                configJson: mapping.ConfigJson,
+                metricName: mapping.MetricName,
+                queryName: mapping.QueryName,
+                requiredPermission: definition.RequiredPermission));
+        }
+
+        return widgets;
+    }
+
+    private static Guid DeriveId(Guid dashboardId, string viewName, string slug)
+    {
+        // Deterministic per (dashboardId, viewName, slug) so view switches don't
+        // generate fresh ids on every render — the frontend's TanStack cache
+        // keys per (dashboardId, viewName, widgetId) and stays warm across
+        // re-fetches. SHA-256 chosen over SHA-1 (CA5350) — this is purely an
+        // identifier-derivation function with no security boundary.
+        int seedLength = 16 + Encoding.UTF8.GetByteCount(viewName) + Encoding.UTF8.GetByteCount(slug);
+        Span<byte> seed = seedLength <= 256 ? stackalloc byte[seedLength] : new byte[seedLength];
+        dashboardId.TryWriteBytes(seed[..16]);
+        int offset = 16;
+        offset += Encoding.UTF8.GetBytes(viewName, seed[offset..]);
+        offset += Encoding.UTF8.GetBytes(slug, seed[offset..]);
+
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(seed[..offset], hash);
+
+        // RFC 9562 §5.8 (UUID version 8 — custom name-based). Set version 8 in
+        // the high nibble of byte 6 and the IETF variant bits (10xx) in byte 8.
+        Span<byte> guidBytes = stackalloc byte[16];
+        hash[..16].CopyTo(guidBytes);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x80);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+
+        return new Guid(guidBytes);
+    }
+}
+
+/// <summary>
+/// Output of <see cref="ActiveViewResolver.Resolve"/> — a widget pool to render
+/// plus the active view name to echo on <see cref="Dtos.DashboardRenderResponse.ActiveViewName"/>.
+/// </summary>
+/// <param name="Widgets">Widgets to render — either persisted or materialised.</param>
+/// <param name="ActiveViewName"><c>null</c> for single-view dashboards; the resolved view name otherwise.</param>
+internal sealed record ResolvedRenderTarget(
+    IReadOnlyList<WidgetInstance> Widgets,
+    string? ActiveViewName);

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -35,11 +35,13 @@ internal static class DashboardRenderProjection
     public static DashboardRenderResponse ToResponse(
         DashboardRenderResult result,
         Dashboard dashboard,
+        ResolvedRenderTarget target,
         IDashboardDefinitionRegistry definitionRegistry,
         string? periodToken)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(dashboard);
+        ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(definitionRegistry);
 
         DashboardRenderPeriodResponse? period = result.Period is { } p
@@ -49,7 +51,12 @@ internal static class DashboardRenderProjection
         Dictionary<string, IReadOnlyList<WidgetAction>?> actionsBySlug =
             ResolveActionsBySlug(dashboard, definitionRegistry);
 
-        var instanceById = dashboard.Widgets.ToDictionary(w => w.Id);
+        // The widget pool actually rendered is the resolved render target's pool —
+        // either persisted (entry view / single-view) or materialised (non-entry).
+        // The structural metadata (Position, Width, Height, ...) on each
+        // RenderedWidget therefore comes from `target.Widgets`, not from
+        // `dashboard.Widgets` (which only carries the entry view).
+        var instanceById = target.Widgets.ToDictionary(w => w.Id);
 
         DashboardRenderedWidgetResponse[] widgets = [.. result.Widgets.Select(rw =>
         {
@@ -79,6 +86,7 @@ internal static class DashboardRenderProjection
             DashboardId: result.DashboardId,
             RenderedAt: result.RenderedAt,
             Period: period,
+            ActiveViewName: target.ActiveViewName,
             Widgets: widgets);
     }
 

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderer.cs
@@ -27,19 +27,29 @@ internal sealed partial class DashboardRenderer(
     private readonly IClock _clock = clock;
     private readonly ILogger<DashboardRenderer> _logger = logger;
 
-    public async Task<DashboardRenderResult> RenderAsync(
+    public Task<DashboardRenderResult> RenderAsync(
         Dashboard dashboard,
         WidgetRenderContext context,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(dashboard);
+        return RenderAsync(dashboard.Id, dashboard.Widgets, context, cancellationToken);
+    }
+
+    public async Task<DashboardRenderResult> RenderAsync(
+        Guid dashboardId,
+        IReadOnlyList<WidgetInstance> widgets,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(widgets);
         ArgumentNullException.ThrowIfNull(context);
 
-        List<RenderedWidget> results = new(dashboard.Widgets.Count);
+        List<RenderedWidget> results = new(widgets.Count);
 
         // Project to a stable List in Position order BEFORE iterating — keeps the
         // outbound order deterministic regardless of which renderer is faster.
-        WidgetInstance[] ordered = [.. dashboard.Widgets.OrderBy(w => w.Position)];
+        WidgetInstance[] ordered = [.. widgets.OrderBy(w => w.Position)];
 
         foreach (WidgetInstance widget in ordered)
         {
@@ -100,7 +110,7 @@ internal sealed partial class DashboardRenderer(
         }
 
         return new DashboardRenderResult(
-            DashboardId: dashboard.Id,
+            DashboardId: dashboardId,
             RenderedAt: _clock.Now,
             Period: context.Period,
             Widgets: results);

--- a/src/Granit.Dashboards/Granit.Dashboards.csproj
+++ b/src/Granit.Dashboards/Granit.Dashboards.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
     <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
+    <InternalsVisibleTo Include="Granit.Dashboards.Endpoints" />
     <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.Dashboards/Rendering/IDashboardRenderer.cs
+++ b/src/Granit.Dashboards/Rendering/IDashboardRenderer.cs
@@ -19,13 +19,39 @@ public interface IDashboardRenderer
 {
     /// <summary>
     /// Renders the supplied dashboard against <paramref name="context"/>, returning
-    /// one envelope per widget plus the surrounding bundle metadata.
+    /// one envelope per widget plus the surrounding bundle metadata. Convenience
+    /// wrapper around
+    /// <see cref="RenderAsync(Guid, IReadOnlyList{WidgetInstance}, WidgetRenderContext, CancellationToken)"/>
+    /// — equivalent to passing <see cref="Dashboard.Id"/> and
+    /// <see cref="Dashboard.Widgets"/>.
     /// </summary>
     /// <param name="dashboard">The dashboard aggregate (already loaded from persistence).</param>
     /// <param name="context">Per-render context — see <see cref="WidgetRenderContext"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<DashboardRenderResult> RenderAsync(
         Dashboard dashboard,
+        WidgetRenderContext context,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Renders an arbitrary widget pool under the given <paramref name="dashboardId"/>
+    /// — used by the endpoint layer when serving a non-entry view of a multi-view
+    /// dashboard (P2.1 multi-view dispatch). The widgets MAY be ephemeral, e.g.
+    /// materialised from a <c>WidgetDefinition</c> at render time with deterministic
+    /// ids derived from <c>(dashboardId, viewName, slug)</c>; they need not be
+    /// persisted.
+    /// </summary>
+    /// <remarks>
+    /// All three guarantees from the persisted-dashboard overload hold here too:
+    /// permission gate, error isolation, deterministic ordering.
+    /// </remarks>
+    /// <param name="dashboardId">Dashboard identifier echoed in the result.</param>
+    /// <param name="widgets">The widget pool to render — typically <see cref="Dashboard.Widgets"/> for the entry view, or a materialised pool for a non-entry view.</param>
+    /// <param name="context">Per-render context — see <see cref="WidgetRenderContext"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DashboardRenderResult> RenderAsync(
+        Guid dashboardId,
+        IReadOnlyList<WidgetInstance> widgets,
         WidgetRenderContext context,
         CancellationToken cancellationToken);
 }

--- a/src/Granit.Metering.Notifications/packages.lock.json
+++ b/src/Granit.Metering.Notifications/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -38,8 +47,62 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -53,11 +116,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -109,6 +186,38 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -128,6 +237,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -145,6 +272,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/ActiveViewResolverTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/ActiveViewResolverTests.cs
@@ -1,0 +1,202 @@
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Internal;
+using Granit.Dashboards.Widgets;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Pins the P2.1 multi-view dispatch fallback chain — request <c>ViewName</c> →
+/// <c>DefaultView</c> → first declared view → top-level pool. Covers the four
+/// renderer paths the endpoint dispatches through:
+/// <list type="number">
+///   <item>Single-view dashboard (no Views): <c>dashboard.Widgets</c>, <c>ActiveViewName: null</c>.</item>
+///   <item>Multi-view dashboard, ViewName matches entry: persisted widgets, view name echoed.</item>
+///   <item>Multi-view dashboard, ViewName matches non-entry: materialised widgets with stable ids.</item>
+///   <item>Multi-view dashboard, missing source descriptor: persisted fallback.</item>
+/// </list>
+/// </summary>
+public sealed class ActiveViewResolverTests
+{
+    private const string DefinitionName = "Granit.Test.MultiViewDashboard";
+
+    [Fact]
+    public void Resolve_NoDescriptor_FallsBackToPersistedWidgets_NullViewName()
+    {
+        Dashboard dashboard = NewDashboard();
+        WidgetInstance persisted = AddBanner(dashboard, "banner");
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor: null, requestedViewName: "Anything");
+
+        result.Widgets.Count.ShouldBe(1);
+        result.Widgets[0].Id.ShouldBe(persisted.Id);
+        result.ActiveViewName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_DescriptorWithoutViews_FallsBackToPersistedWidgets()
+    {
+        Dashboard dashboard = NewDashboard();
+        AddBanner(dashboard, "banner");
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(views: null);
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: null);
+
+        result.ActiveViewName.ShouldBeNull();
+        result.Widgets.ShouldBe(dashboard.Widgets);
+    }
+
+    [Fact]
+    public void Resolve_RequestedViewMatchesEntry_RendersPersistedWidgets()
+    {
+        Dashboard dashboard = NewDashboard();
+        WidgetInstance persisted = AddBanner(dashboard, "entry-banner");
+
+        DashboardView entryView = new("Entry",
+            [new MarkdownWidgetDefinition("entry-banner", $"Widget:{DefinitionName}.entry-banner.Body", 0)]);
+        DashboardView altView = new("Alt",
+            [new MarkdownWidgetDefinition("alt-banner", $"Widget:{DefinitionName}.alt-banner.Body", 0)]);
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(
+            views: [entryView, altView],
+            defaultView: "Entry");
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: "Entry");
+
+        result.ActiveViewName.ShouldBe("Entry");
+        result.Widgets.Count.ShouldBe(1);
+        result.Widgets[0].Id.ShouldBe(persisted.Id);                                  // persisted, not materialised
+    }
+
+    [Fact]
+    public void Resolve_RequestedViewIsNonEntry_MaterialisesEphemeralWidgets()
+    {
+        Dashboard dashboard = NewDashboard();
+        AddBanner(dashboard, "entry-banner");
+
+        DashboardView entryView = new("Entry",
+            [new MarkdownWidgetDefinition("entry-banner", $"Widget:{DefinitionName}.entry-banner.Body", 0)]);
+        DashboardView altView = new("Alt",
+            [new MarkdownWidgetDefinition("alt-banner", $"Widget:{DefinitionName}.alt-banner.Body", 0)]);
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(
+            views: [entryView, altView],
+            defaultView: "Entry");
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: "Alt");
+
+        result.ActiveViewName.ShouldBe("Alt");
+        result.Widgets.Count.ShouldBe(1);
+        WidgetInstance materialised = result.Widgets[0];
+        materialised.WidgetType.ShouldBe("Markdown");
+        materialised.TitleLocalizationKey.ShouldBe($"Widget:{DefinitionName}.alt-banner");
+        // Materialised id is deterministic and DIFFERENT from any persisted id —
+        // it lives only for the render call, but the same call again gives the
+        // same id (frontend cache stays warm across re-fetches).
+        materialised.Id.ShouldNotBe(dashboard.Widgets[0].Id);
+
+        ResolvedRenderTarget secondCall = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: "Alt");
+        secondCall.Widgets[0].Id.ShouldBe(materialised.Id);
+    }
+
+    [Fact]
+    public void Resolve_RequestedViewMissing_FallsThroughToDefaultThenFirst()
+    {
+        Dashboard dashboard = NewDashboard();
+        AddBanner(dashboard, "entry-banner");
+
+        DashboardView entryView = new("Entry",
+            [new MarkdownWidgetDefinition("entry-banner", $"Widget:{DefinitionName}.entry-banner.Body", 0)]);
+        DashboardView altView = new("Alt",
+            [new MarkdownWidgetDefinition("alt-banner", $"Widget:{DefinitionName}.alt-banner.Body", 0)]);
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(
+            views: [entryView, altView],
+            defaultView: "Entry");
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: "DoesNotExist");
+
+        result.ActiveViewName.ShouldBe("Entry");                                      // fell back to DefaultView
+    }
+
+    [Fact]
+    public void Resolve_NullViewName_PicksDefaultView()
+    {
+        Dashboard dashboard = NewDashboard();
+        AddBanner(dashboard, "entry-banner");
+
+        DashboardView a = new("A",
+            [new MarkdownWidgetDefinition("a", $"Widget:{DefinitionName}.a.Body", 0)]);
+        DashboardView b = new("B",
+            [new MarkdownWidgetDefinition("b", $"Widget:{DefinitionName}.b.Body", 0)]);
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(
+            views: [a, b],
+            defaultView: "B");
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: null);
+
+        result.ActiveViewName.ShouldBe("B");
+    }
+
+    [Fact]
+    public void Resolve_NullViewNameAndNoDefault_PicksFirstView()
+    {
+        Dashboard dashboard = NewDashboard();
+        AddBanner(dashboard, "entry-banner");
+
+        DashboardView a = new("A",
+            [new MarkdownWidgetDefinition("a", $"Widget:{DefinitionName}.a.Body", 0)]);
+        DashboardView b = new("B",
+            [new MarkdownWidgetDefinition("b", $"Widget:{DefinitionName}.b.Body", 0)]);
+
+        IDashboardDefinitionDescriptor descriptor = StubDescriptor(
+            views: [a, b],
+            defaultView: null);
+
+        ResolvedRenderTarget result = ActiveViewResolver.Resolve(
+            dashboard, descriptor, requestedViewName: null);
+
+        result.ActiveViewName.ShouldBe("A");                                          // first view wins when DefaultView null
+    }
+
+    private static Dashboard NewDashboard() => Dashboard.Create(
+        id: Guid.NewGuid(),
+        name: "MultiViewDashboard",
+        category: DashboardCategory.General,
+        sourceDefinitionName: DefinitionName,
+        sourceDefinitionVersion: "1.0.0");
+
+    private static WidgetInstance AddBanner(Dashboard dashboard, string slug) =>
+        dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Markdown",
+            position: 0,
+            width: 12,
+            height: 1,
+            titleLocalizationKey: $"Widget:{DefinitionName}.{slug}",
+            configJson: "{}");
+
+    private static IDashboardDefinitionDescriptor StubDescriptor(
+        IReadOnlyList<DashboardView>? views,
+        string? defaultView = null)
+    {
+        IDashboardDefinitionDescriptor descriptor = Substitute.For<IDashboardDefinitionDescriptor>();
+        descriptor.Name.Returns(DefinitionName);
+        descriptor.Widgets.Returns(Array.Empty<WidgetDefinition>());
+        descriptor.Views.Returns(views);
+        descriptor.DefaultView.Returns(defaultView);
+        return descriptor;
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -57,8 +57,9 @@ public sealed class DashboardRenderProjectionTests
 
         IDashboardDefinitionRegistry registry = EmptyRegistry();
 
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
         DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
-            result, dashboard, registry, periodToken: "mtd");
+            result, dashboard, target, registry, periodToken: "mtd");
 
         response.DashboardId.ShouldBe(dashboard.Id);
         response.RenderedAt.ShouldBe(RenderedAt);
@@ -128,8 +129,9 @@ public sealed class DashboardRenderProjectionTests
                     refreshHint: RefreshHint.Dynamic)),
             ]);
 
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
         DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
-            result, dashboard, registry, periodToken: null);
+            result, dashboard, target, registry, periodToken: null);
 
         DashboardRenderedWidgetResponse w = response.Widgets[0];
         w.Slug.ShouldBe("click-target");
@@ -171,8 +173,9 @@ public sealed class DashboardRenderProjectionTests
                     refreshHint: RefreshHint.Static)),
             ]);
 
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
         DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
-            result, dashboard, EmptyRegistry(), periodToken: null);
+            result, dashboard, target, EmptyRegistry(), periodToken: null);
 
         DashboardRenderedWidgetResponse w = response.Widgets[0];
         w.Actions.ShouldBeNull();
@@ -189,8 +192,9 @@ public sealed class DashboardRenderProjectionTests
             Period: null,
             Widgets: []);
 
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
         DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
-            result, dashboard, EmptyRegistry(), periodToken: null);
+            result, dashboard, target, EmptyRegistry(), periodToken: null);
 
         response.Period.ShouldBeNull();
     }
@@ -222,8 +226,9 @@ public sealed class DashboardRenderProjectionTests
                     reasonLocalizationKey: "Widget:Unavailable.MetricNotFound")),
             ]);
 
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
         DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
-            result, dashboard, EmptyRegistry(), periodToken: null);
+            result, dashboard, target, EmptyRegistry(), periodToken: null);
 
         DashboardRenderedWidgetResponse w = response.Widgets[0];
         w.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);

--- a/tests/Granit.Metering.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Metering.BackgroundJobs.Tests/packages.lock.json
@@ -279,8 +279,29 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       },
       "granit.backgroundjobs": {
         "type": "Project",
@@ -294,6 +315,39 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -316,11 +370,25 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -371,6 +439,28 @@
         "resolved": "0.12.0",
         "contentHash": "rOBW2cimLtkRoyLIZWZx1uM300cNI2wUKOUbLbGLnNQRly5R/YK3VdC1mk3Wvt24J4k9PY5j+9WL4smv0RIZvA=="
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -399,6 +489,24 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
@@ -430,6 +538,49 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
@@ -514,6 +514,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -537,6 +553,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -608,7 +640,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
@@ -331,6 +331,22 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -346,6 +362,22 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.abstractions": {
@@ -408,7 +440,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Metering.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Notifications.Tests/packages.lock.json
@@ -101,6 +101,15 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -270,8 +279,62 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -285,11 +348,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -349,6 +426,38 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -368,6 +477,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -385,6 +512,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -420,7 +420,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
@@ -406,7 +406,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -648,7 +648,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -477,7 +477,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -435,7 +435,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -413,7 +413,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -406,7 +406,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Tests/packages.lock.json
@@ -406,7 +406,9 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

P2 of the frontend BI gap fixes — the bundle path's `<RenderedDashboard>` could not honour view switches because `DashboardRenderResponse` always returned the entry view's widgets regardless of which view the frontend wanted active. This PR closes that gap with a strictly additive request/response extension and an internal materialisation step that lets the renderer serve any declared `DashboardView`.

## Wire shape additions

| DTO | Field | Type | Default |
| --- | ----- | ---- | ------- |
| `DashboardRenderRequest` | `ViewName` | `string?` | `null` |
| `DashboardRenderResponse` | `ActiveViewName` | `string?` | `null` (single-view) |

Resolution chain (mirrors the frontend's P2.1 `resolveActiveView`):

```
request.ViewName -> DashboardDefinition.DefaultView -> first declared view
```

Single-view dashboards (no `Views`) short-circuit to the persisted top-level pool with `ActiveViewName: null`.

## Implementation

- **New renderer overload.** `IDashboardRenderer.RenderAsync(Guid dashboardId, IReadOnlyList<WidgetInstance> widgets, ctx, ct)` accepts an arbitrary widget pool. The existing `Dashboard`-typed overload is preserved as a thin wrapper — no callers had to change.
- **`ActiveViewResolver`** (new, internal in `Granit.Dashboards.Endpoints`) builds a `ResolvedRenderTarget(widgets, ActiveViewName)` from `(dashboard, descriptor, requestedViewName)`. For non-entry views it materialises ephemeral `WidgetInstance`s from `DashboardDefinition.Views[name]` via `WidgetDefinitionToInstanceMapper`.
- **Stable widget ids.** Materialised ids are deterministic per `(dashboardId, viewName, slug)` — RFC 9562 v8 (custom name-based UUID) using SHA-256 truncated to 16 bytes. View switches reuse the same id across re-fetches so the frontend's TanStack cache keys per `(dashboardId, viewName, widgetId)` partition cleanly.
- **Projection.** `DashboardRenderProjection.ToResponse` now takes a `ResolvedRenderTarget` and reads structural metadata from `target.Widgets` rather than `dashboard.Widgets` — the response carries the active view's widgets, not the entry view's.

### Entry-view assumption (v1)

`descriptor.DefaultView` (or `views[0]` when `DefaultView` is null) is treated as the view whose widgets the importer pinned on the persisted `Dashboard`. When the active view matches the entry view, `dashboard.Widgets` is rendered directly so per-instance overrides survive. When the active view is non-entry, we materialise from the descriptor — per-instance edits don't apply (acceptable v1 trade-off; see ADR-038 deferred drift detection).

### Visibility

Added `<InternalsVisibleTo Include=\"Granit.Dashboards.Endpoints\" />` to `Granit.Dashboards.csproj` so the resolver can call the existing `internal WidgetInstance.Create(...)`. No new public API; the materialisation path stays internal.

## Lockfile hygiene

The PR also bundles 13 transitive `packages.lock.json` refreshes for `Granit.Metering.*` and `Granit.Subscriptions.*` test projects. These were left dangling by earlier metric-module PRs (#1589 and #1597) — their respective base modules picked up `Granit.Analytics`, but the lockfiles for downstream test projects weren't regenerated at the time. Resync'd here so CI's `--locked-mode` restore stays green; isolated in a separate `chore(lockfiles)` commit so reviewers can ignore it.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` clean.
- [x] `dotnet format src/Granit.Dashboards.Endpoints` clean.
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — **116 passing** (7 new `ActiveViewResolverTests` cover the full fallback chain and materialisation determinism).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing**.
- [ ] CI green on full shard pipeline (api-data + business shards).

## Frontend impact

Once merged, the frontend can wire `useDashboardRender(id, { viewName })` into `<RenderedDashboard currentView=... onViewChange=...>`. Cache invalidation per view falls out naturally because `ActiveViewName` flows back into the TanStack key.

## Next

P3 (option B): per-widget render endpoints (`POST /widgets/{kind}/render`) — independent PR off `develop`.