### PR TITLE
feat(analytics-render): P3 — per-widget render endpoints (KPI/Chart/Table/Pivot/Map, option B)

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -18,6 +18,7 @@
       "src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj",
       "src/Granit.CustomerBalance/Granit.CustomerBalance.csproj",
       "src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj",
+      "src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj",
       "src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj",
       "src/Granit.Dashboards/Granit.Dashboards.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -104,6 +104,8 @@
         "Granit.Authorization",
         "Granit.Caching",
         "Granit.Dashboards",
+        "Granit.Dashboards.EntityFrameworkCore",
+        "Granit.Dashboards.Endpoints",
         "Granit.Http.Abstractions",
         "Granit.MultiTenancy",
         "Granit.Timing",
@@ -4315,6 +4317,60 @@
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Dtos/MetricResponse.cs",
       "line": 20,
+      "members": []
+    },
+    {
+      "name": "ChartWidgetRenderRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.ChartWidgetRenderRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "KpiWidgetRenderRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.KpiWidgetRenderRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MapWidgetRenderRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.MapWidgetRenderRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs",
+      "line": 41,
+      "members": []
+    },
+    {
+      "name": "PivotWidgetRenderRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.PivotWidgetRenderRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "TableWidgetRenderRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.TableWidgetRenderRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "WidgetRenderContextRequest",
+      "fqn": "Granit.Analytics.Endpoints.Dtos.Widgets.WidgetRenderContextRequest",
+      "kind": "record",
+      "project": "Granit.Analytics.Endpoints",
+      "file": "src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderContextRequest.cs",
+      "line": 28,
       "members": []
     },
     {

--- a/src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderContextRequest.cs
+++ b/src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderContextRequest.cs
@@ -1,0 +1,33 @@
+namespace Granit.Analytics.Endpoints.Dtos.Widgets;
+
+/// <summary>
+/// Per-render context shared by every <c>POST /widgets/{kind}/render</c> endpoint —
+/// the period window, locale, and dashboard-level filter bindings the typed
+/// renderer applies on top of the supplied <c>WidgetDefinition</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the field set of <c>DashboardRenderRequest</c> (the bundle path) but
+/// is nested under <c>Context</c> on the per-widget request envelopes — keeps
+/// the wire shape symmetric across the two paths and lets a frontend hook
+/// reuse the same context-builder for both. Aliases land here in a future
+/// story (P3.3 variable substitution) — not in scope for v1.
+/// </para>
+/// <para>
+/// Both period bounds must be supplied together; supplying only one yields a
+/// 400 from the validator, same convention as the bundle path. The named
+/// <see cref="PeriodToken"/> is echoed back unchanged on the response — the
+/// renderer never re-resolves it server-side.
+/// </para>
+/// </remarks>
+/// <param name="PeriodFrom">Inclusive lower bound (UTC). Required when <see cref="PeriodTo"/> is supplied.</param>
+/// <param name="PeriodTo">Exclusive upper bound (UTC). Required when <see cref="PeriodFrom"/> is supplied.</param>
+/// <param name="PeriodToken">Optional named token (e.g. <c>"mtd"</c>) — echoed in the response for client convenience.</param>
+/// <param name="Locale">Active BCP-47 locale tag (e.g. <c>"en"</c>, <c>"fr-CA"</c>). Defaults to <c>"en"</c> when omitted.</param>
+/// <param name="Filters">Dashboard-level filter bindings. <see langword="null"/> = no filters; the typed renderers apply their own defaults.</param>
+public sealed record WidgetRenderContextRequest(
+    DateTimeOffset? PeriodFrom = null,
+    DateTimeOffset? PeriodTo = null,
+    string? PeriodToken = null,
+    string? Locale = null,
+    IReadOnlyDictionary<string, string>? Filters = null);

--- a/src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs
+++ b/src/Granit.Analytics.Endpoints/Dtos/Widgets/WidgetRenderRequests.cs
@@ -1,0 +1,43 @@
+using Granit.Analytics.Dashboards.Widgets;
+
+namespace Granit.Analytics.Endpoints.Dtos.Widgets;
+
+/// <summary>
+/// Body of <c>POST /widgets/kpi/render</c> — a typed
+/// <see cref="KpiWidgetDefinition"/> (with its embedded <c>Datasource</c>) plus
+/// an optional render context. Lets the frontend's edition / preview /
+/// catalogue paths fetch a single KPI snapshot without persisting the widget.
+/// </summary>
+/// <param name="Definition">The widget definition to render — same shape ADRs land at module-time.</param>
+/// <param name="Context">Optional per-render context (period, locale, filters).</param>
+public sealed record KpiWidgetRenderRequest(
+    KpiWidgetDefinition Definition,
+    WidgetRenderContextRequest? Context = null);
+
+/// <summary>Body of <c>POST /widgets/chart/render</c>.</summary>
+/// <param name="Definition">Typed chart widget definition.</param>
+/// <param name="Context">Optional per-render context.</param>
+public sealed record ChartWidgetRenderRequest(
+    ChartWidgetDefinition Definition,
+    WidgetRenderContextRequest? Context = null);
+
+/// <summary>Body of <c>POST /widgets/table/render</c>.</summary>
+/// <param name="Definition">Typed table widget definition.</param>
+/// <param name="Context">Optional per-render context.</param>
+public sealed record TableWidgetRenderRequest(
+    TableWidgetDefinition Definition,
+    WidgetRenderContextRequest? Context = null);
+
+/// <summary>Body of <c>POST /widgets/pivot/render</c>.</summary>
+/// <param name="Definition">Typed pivot widget definition.</param>
+/// <param name="Context">Optional per-render context.</param>
+public sealed record PivotWidgetRenderRequest(
+    PivotWidgetDefinition Definition,
+    WidgetRenderContextRequest? Context = null);
+
+/// <summary>Body of <c>POST /widgets/map/render</c>.</summary>
+/// <param name="Definition">Typed map widget definition.</param>
+/// <param name="Context">Optional per-render context.</param>
+public sealed record MapWidgetRenderRequest(
+    MapWidgetDefinition Definition,
+    WidgetRenderContextRequest? Context = null);

--- a/src/Granit.Analytics.Endpoints/Endpoints/WidgetRenderEndpoints.cs
+++ b/src/Granit.Analytics.Endpoints/Endpoints/WidgetRenderEndpoints.cs
@@ -1,0 +1,131 @@
+using System.Security.Claims;
+using Granit.Analytics.Endpoints.Dtos.Widgets;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Rendering;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Analytics.Endpoints.Endpoints;
+
+/// <summary>
+/// HTTP handlers for the per-widget render endpoints
+/// (<c>POST /widgets/{kind}/render</c>) — a typed
+/// <see cref="Granit.Dashboards.WidgetDefinition"/> in, a
+/// <see cref="DashboardRenderedWidgetResponse"/> out (same shape the bundle
+/// path emits, so the frontend can wrap the same snapshot widgets across the
+/// definition path and the bundle path).
+/// </summary>
+/// <remarks>
+/// <para>
+/// One endpoint per kind keeps the OpenAPI typed end-to-end — the alternative
+/// (a single polymorphic <c>WidgetDefinition</c> body) flows fine through
+/// System.Text.Json's <c>[JsonPolymorphic]</c> discriminator but Swagger /
+/// Scalar struggle to render it without authoring a custom schema transformer.
+/// </para>
+/// <para>
+/// Permission gating mirrors the bundle path: the typed renderer surface
+/// raises <see cref="Granit.Analytics.Metrics.WidgetSnapshotStatus.Unavailable"/>
+/// when the user lacks the widget-level permission — never a 403 for the
+/// whole call. Authorization on the route group itself is still required to
+/// reach the handler.
+/// </para>
+/// </remarks>
+internal static class WidgetRenderEndpoints
+{
+    internal static RouteGroupBuilder MapWidgetRenderEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/widgets/kpi/render", RenderKpiAsync)
+            .WithName("RenderGranitKpiWidget")
+            .WithSummary("Renders a single KPI widget definition.")
+            .WithDescription(
+                "Used by the dashboard composer / catalogue / preview paths to fetch a "
+                + "KPI snapshot without persisting the widget. Body carries the typed "
+                + "KpiWidgetDefinition (with its embedded Datasource — MetricDatasource "
+                + "or QueryAggregateDatasource) plus an optional render context. "
+                + "Returns the same DashboardRenderedWidgetResponse shape the bundle path emits.")
+            .Produces<DashboardRenderedWidgetResponse>()
+            .ProducesValidationProblem();
+
+        group.MapPost("/widgets/chart/render", RenderChartAsync)
+            .WithName("RenderGranitChartWidget")
+            .WithSummary("Renders a single chart widget definition.")
+            .WithDescription(
+                "Used by the dashboard composer / catalogue / preview paths to fetch a "
+                + "chart snapshot without persisting the widget. Body carries the typed "
+                + "ChartWidgetDefinition plus an optional render context. Returns the "
+                + "same DashboardRenderedWidgetResponse shape the bundle path emits.")
+            .Produces<DashboardRenderedWidgetResponse>()
+            .ProducesValidationProblem();
+
+        group.MapPost("/widgets/table/render", RenderTableAsync)
+            .WithName("RenderGranitTableWidget")
+            .WithSummary("Renders a single table widget definition.")
+            .WithDescription(
+                "Used by the dashboard composer / catalogue / preview paths to fetch a "
+                + "table snapshot without persisting the widget. Body carries the typed "
+                + "TableWidgetDefinition plus an optional render context.")
+            .Produces<DashboardRenderedWidgetResponse>()
+            .ProducesValidationProblem();
+
+        group.MapPost("/widgets/pivot/render", RenderPivotAsync)
+            .WithName("RenderGranitPivotWidget")
+            .WithSummary("Renders a single pivot widget definition.")
+            .WithDescription(
+                "Used by the dashboard composer / catalogue / preview paths to fetch a "
+                + "pivot snapshot without persisting the widget. Body carries the typed "
+                + "PivotWidgetDefinition plus an optional render context.")
+            .Produces<DashboardRenderedWidgetResponse>()
+            .ProducesValidationProblem();
+
+        group.MapPost("/widgets/map/render", RenderMapAsync)
+            .WithName("RenderGranitMapWidget")
+            .WithSummary("Renders a single map widget definition.")
+            .WithDescription(
+                "Used by the dashboard composer / catalogue / preview paths to fetch a "
+                + "map snapshot without persisting the widget. Body carries the typed "
+                + "MapWidgetDefinition plus an optional render context.")
+            .Produces<DashboardRenderedWidgetResponse>()
+            .ProducesValidationProblem();
+
+        return group;
+    }
+
+    private static Task<Ok<DashboardRenderedWidgetResponse>> RenderKpiAsync(
+        [FromBody] KpiWidgetRenderRequest request,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken) =>
+        WidgetRenderHelper.RenderAsync(request.Definition, request.Context, renderer, user, cancellationToken);
+
+    private static Task<Ok<DashboardRenderedWidgetResponse>> RenderChartAsync(
+        [FromBody] ChartWidgetRenderRequest request,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken) =>
+        WidgetRenderHelper.RenderAsync(request.Definition, request.Context, renderer, user, cancellationToken);
+
+    private static Task<Ok<DashboardRenderedWidgetResponse>> RenderTableAsync(
+        [FromBody] TableWidgetRenderRequest request,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken) =>
+        WidgetRenderHelper.RenderAsync(request.Definition, request.Context, renderer, user, cancellationToken);
+
+    private static Task<Ok<DashboardRenderedWidgetResponse>> RenderPivotAsync(
+        [FromBody] PivotWidgetRenderRequest request,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken) =>
+        WidgetRenderHelper.RenderAsync(request.Definition, request.Context, renderer, user, cancellationToken);
+
+    private static Task<Ok<DashboardRenderedWidgetResponse>> RenderMapAsync(
+        [FromBody] MapWidgetRenderRequest request,
+        [FromServices] IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken) =>
+        WidgetRenderHelper.RenderAsync(request.Definition, request.Context, renderer, user, cancellationToken);
+}

--- a/src/Granit.Analytics.Endpoints/Extensions/AnalyticsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Analytics.Endpoints/Extensions/AnalyticsEndpointRouteBuilderExtensions.cs
@@ -40,6 +40,12 @@ public static class AnalyticsEndpointRouteBuilderExtensions
             .WithTags(options.MetricsTagName);
 
         group.RequireAuthorization(AnalyticsPermissions.Metrics.Read).MapMetricEndpoints();
+        // Per-widget render endpoints (P3 / option B) — single widget rendered
+        // ad-hoc from a typed WidgetDefinition body, returning the same
+        // DashboardRenderedWidgetResponse shape the bundle path emits. Gated
+        // by the same Metrics.Read permission since the snapshot semantics
+        // mirror the bundle path's per-widget envelope.
+        group.RequireAuthorization(AnalyticsPermissions.Metrics.Read).MapWidgetRenderEndpoints();
 
         return group;
     }

--- a/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
+++ b/src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj
@@ -27,6 +27,8 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Dashboards\Granit.Dashboards.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.Dashboards.Endpoints\Granit.Dashboards.Endpoints.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />

--- a/src/Granit.Analytics.Endpoints/Internal/WidgetRenderHelper.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/WidgetRenderHelper.cs
@@ -1,0 +1,142 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Analytics.Endpoints.Dtos.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Domain;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.EntityFrameworkCore.Internal;
+using Granit.Dashboards.Rendering;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Granit.Analytics.Endpoints.Internal;
+
+/// <summary>
+/// Shared rendering pipeline for the per-widget endpoints
+/// (<c>POST /widgets/{kind}/render</c>). Materialises an ephemeral
+/// <see cref="WidgetInstance"/> from the typed <see cref="WidgetDefinition"/>
+/// supplied in the request body, dispatches it through the existing
+/// <see cref="IDashboardRenderer"/> machinery (reusing the Guid-based overload
+/// shipped in P2.1), and projects the resulting envelope onto the same
+/// <see cref="DashboardRenderedWidgetResponse"/> shape the bundle path emits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Design intent — symmetry with the bundle path. The frontend wraps the same
+/// snapshot widgets (KpiSnapshotTile / ChartSnapshotWidget / ...) in both the
+/// definition path (per-widget single render) and the bundle path
+/// (<c>RenderedDashboard</c>). Returning the full <see cref="DashboardRenderedWidgetResponse"/>
+/// here — not just the snapshot payload — means a frontend dispatcher does not
+/// have to know which path the envelope came from.
+/// </para>
+/// <para>
+/// Ephemeral identifiers. The widget is rendered without a persisted dashboard;
+/// the dashboard id is <see cref="Guid.Empty"/> and the widget id is derived
+/// deterministically from <see cref="WidgetDefinition.Slug"/> via SHA-256
+/// (RFC 9562 v8 — custom name-based UUID). Stable across re-fetches so the
+/// frontend's TanStack cache stays warm; never collides with persisted ids
+/// because <see cref="Guid.Empty"/> as the dashboard component anchors the
+/// hash to the ad-hoc namespace.
+/// </para>
+/// </remarks>
+internal static class WidgetRenderHelper
+{
+    // GRAPI003 false positive — this is a helper invoked by endpoint handlers
+    // that themselves decorate the renderer parameter with [FromServices]; the
+    // analyzer can't see through the call. Suppress per-method.
+#pragma warning disable GRAPI003
+    public static async Task<Ok<DashboardRenderedWidgetResponse>> RenderAsync(
+        WidgetDefinition definition,
+        WidgetRenderContextRequest? contextRequest,
+        IDashboardRenderer renderer,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+#pragma warning restore GRAPI003
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(renderer);
+        ArgumentNullException.ThrowIfNull(user);
+
+        // Materialise an ephemeral WidgetInstance from the typed definition. The
+        // mapper produces (WidgetType, MetricName?, QueryName?, ConfigJson) — the
+        // exact shape the persisted aggregate carries, so the existing
+        // IWidgetInstanceRenderer dispatch table works unchanged.
+        WidgetDefinitionToInstanceMapper.Mapping mapping =
+            WidgetDefinitionToInstanceMapper.Map(definition);
+
+        Guid widgetId = DeriveWidgetId(definition.Slug);
+        string titleLocalizationKey = $"Widget:{definition.Slug}";
+
+        var widget = WidgetInstance.Create(
+            id: widgetId,
+            dashboardId: Guid.Empty,                                            // ad-hoc render — no persisted dashboard
+            widgetType: mapping.WidgetType,
+            position: definition.Position,
+            width: definition.Size.Width,
+            height: definition.Size.Height,
+            titleLocalizationKey: titleLocalizationKey,
+            configJson: mapping.ConfigJson,
+            metricName: mapping.MetricName,
+            queryName: mapping.QueryName,
+            requiredPermission: definition.RequiredPermission);
+
+        ResolvedPeriod? period = (contextRequest?.PeriodFrom is { } from && contextRequest?.PeriodTo is { } to)
+            ? new ResolvedPeriod(from, to)
+            : null;
+
+        WidgetRenderContext context = new(
+            TenantId: null,                                                     // populated upstream via ICurrentTenant when wired into the host
+            User: user,
+            Period: period,
+            Locale: contextRequest?.Locale ?? "en",
+            DashboardFilters: contextRequest?.Filters ?? new Dictionary<string, string>(),
+            ResolvedEntityAliases: new Dictionary<string, EntityAliasBinding>());
+
+        DashboardRenderResult result = await renderer
+            .RenderAsync(Guid.Empty, [widget], context, cancellationToken)
+            .ConfigureAwait(false);
+
+        RenderedWidget rendered = result.Widgets[0];
+
+        return TypedResults.Ok(new DashboardRenderedWidgetResponse(
+            Id: rendered.WidgetId,
+            WidgetType: rendered.Envelope.WidgetType,
+            Slug: definition.Slug,
+            Position: definition.Position,
+            Width: definition.Size.Width,
+            Height: definition.Size.Height,
+            TitleLocalizationKey: titleLocalizationKey,
+            // Actions come straight from the request body — no descriptor look-up
+            // needed since the caller passed the whole WidgetDefinition, including
+            // its declarative click-handlers.
+            Actions: definition.Actions,
+            RequiredPermission: definition.RequiredPermission,
+            Status: rendered.Envelope.Status,
+            Sequence: rendered.Envelope.Sequence,
+            EmittedAt: rendered.Envelope.EmittedAt,
+            RefreshHint: rendered.Envelope.RefreshHint,
+            Snapshot: rendered.Envelope.Snapshot,
+            ReasonLocalizationKey: rendered.Envelope.ReasonLocalizationKey));
+    }
+
+    private static Guid DeriveWidgetId(string slug)
+    {
+        // RFC 9562 v8 custom name-based UUID over the slug. Deterministic so
+        // refetching the same definition reuses the same widget id and the
+        // frontend's TanStack cache stays warm across renders.
+        int seedLength = Encoding.UTF8.GetByteCount(slug);
+        Span<byte> seed = seedLength <= 256 ? stackalloc byte[seedLength] : new byte[seedLength];
+        Encoding.UTF8.GetBytes(slug, seed);
+
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(seed, hash);
+
+        Span<byte> guidBytes = stackalloc byte[16];
+        hash[..16].CopyTo(guidBytes);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x80);                    // version 8
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);                    // IETF variant
+
+        return new Guid(guidBytes);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/Validators/WidgetRenderRequestValidators.cs
+++ b/src/Granit.Analytics.Endpoints/Validators/WidgetRenderRequestValidators.cs
@@ -1,0 +1,93 @@
+using FluentValidation;
+using Granit.Analytics.Endpoints.Dtos.Widgets;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Analytics.Endpoints.Validators;
+
+/// <summary>
+/// Validates the per-render context shared by every <c>POST /widgets/{kind}/render</c>
+/// endpoint. Both period bounds must be supplied together (or both omitted);
+/// supplying only one yields a 400. Mirrors the bundle path's
+/// <c>DashboardRenderRequestValidator</c>.
+/// </summary>
+internal sealed class WidgetRenderContextRequestValidator : GranitValidator<WidgetRenderContextRequest>
+{
+    public WidgetRenderContextRequestValidator()
+    {
+        RuleFor(x => x)
+            .Must(HasBothBoundsOrNone)
+            .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecBoundsCode");
+
+        RuleFor(x => x)
+            .Must(FromBeforeTo)
+            .When(x => x.PeriodFrom is not null && x.PeriodTo is not null)
+            .WithErrorCodeAndMessage("Granit:Validation:PeriodSpecOrderingCode");
+    }
+
+    private static bool HasBothBoundsOrNone(WidgetRenderContextRequest c) =>
+        c.PeriodFrom is null == c.PeriodTo is null;
+
+    private static bool FromBeforeTo(WidgetRenderContextRequest c) =>
+        c.PeriodFrom!.Value < c.PeriodTo!.Value;
+}
+
+/// <summary>Validates <see cref="KpiWidgetRenderRequest"/> — definition is required, context is optional.</summary>
+internal sealed class KpiWidgetRenderRequestValidator : GranitValidator<KpiWidgetRenderRequest>
+{
+    public KpiWidgetRenderRequestValidator()
+    {
+        RuleFor(x => x.Definition).NotNull();
+        RuleFor(x => x.Context!)
+            .SetValidator(new WidgetRenderContextRequestValidator())
+            .When(x => x.Context is not null);
+    }
+}
+
+/// <summary>Validates <see cref="ChartWidgetRenderRequest"/>.</summary>
+internal sealed class ChartWidgetRenderRequestValidator : GranitValidator<ChartWidgetRenderRequest>
+{
+    public ChartWidgetRenderRequestValidator()
+    {
+        RuleFor(x => x.Definition).NotNull();
+        RuleFor(x => x.Context!)
+            .SetValidator(new WidgetRenderContextRequestValidator())
+            .When(x => x.Context is not null);
+    }
+}
+
+/// <summary>Validates <see cref="TableWidgetRenderRequest"/>.</summary>
+internal sealed class TableWidgetRenderRequestValidator : GranitValidator<TableWidgetRenderRequest>
+{
+    public TableWidgetRenderRequestValidator()
+    {
+        RuleFor(x => x.Definition).NotNull();
+        RuleFor(x => x.Context!)
+            .SetValidator(new WidgetRenderContextRequestValidator())
+            .When(x => x.Context is not null);
+    }
+}
+
+/// <summary>Validates <see cref="PivotWidgetRenderRequest"/>.</summary>
+internal sealed class PivotWidgetRenderRequestValidator : GranitValidator<PivotWidgetRenderRequest>
+{
+    public PivotWidgetRenderRequestValidator()
+    {
+        RuleFor(x => x.Definition).NotNull();
+        RuleFor(x => x.Context!)
+            .SetValidator(new WidgetRenderContextRequestValidator())
+            .When(x => x.Context is not null);
+    }
+}
+
+/// <summary>Validates <see cref="MapWidgetRenderRequest"/>.</summary>
+internal sealed class MapWidgetRenderRequestValidator : GranitValidator<MapWidgetRenderRequest>
+{
+    public MapWidgetRenderRequestValidator()
+    {
+        RuleFor(x => x.Definition).NotNull();
+        RuleFor(x => x.Context!)
+            .SetValidator(new WidgetRenderContextRequestValidator())
+            .When(x => x.Context is not null);
+    }
+}

--- a/src/Granit.Analytics.Endpoints/packages.lock.json
+++ b/src/Granit.Analytics.Endpoints/packages.lock.json
@@ -91,6 +91,28 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.dashboards.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Dashboards.Endpoints" />
     <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Dashboards.EntityFrameworkCore.Tests" />

--- a/src/Granit.Dashboards/Granit.Dashboards.csproj
+++ b/src/Granit.Dashboards/Granit.Dashboards.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Dashboards.Tests" />
+    <InternalsVisibleTo Include="Granit.Analytics.Endpoints" />
     <InternalsVisibleTo Include="Granit.Analytics.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Dashboards.Endpoints" />
     <InternalsVisibleTo Include="Granit.Dashboards.Endpoints.Tests" />

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/WidgetRenderHelperTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/WidgetRenderHelperTests.cs
@@ -1,0 +1,198 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Analytics.Endpoints.Dtos.Widgets;
+using Granit.Analytics.Endpoints.Internal;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Granit.Dashboards.Endpoints.Dtos;
+using Granit.Dashboards.Rendering;
+using Granit.QueryEngine.Filtering;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.Endpoints.Tests.Internal;
+
+/// <summary>
+/// Pins the wire-shape symmetry between the bundle path
+/// (<c>POST /dashboards/{id}/render</c>) and the per-widget path
+/// (<c>POST /widgets/{kind}/render</c>) — both projects emit the same
+/// <see cref="DashboardRenderedWidgetResponse"/> so a frontend dispatcher
+/// can wrap snapshot widgets identically across the two paths.
+/// </summary>
+public sealed class WidgetRenderHelperTests
+{
+    private static readonly DateTimeOffset RenderedAt = new(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+    private static readonly ClaimsPrincipal AnonymousUser = new(new ClaimsIdentity());
+
+    [Fact]
+    public async Task RenderAsync_ProjectsEnvelopeOntoDashboardRenderedWidgetResponse()
+    {
+        ChartWidgetDefinition definition = new(
+            Slug: "unpaid-by-month",
+            QueryName: "Granit.Invoicing.InvoiceQuery",
+            GroupBy: "IssuedAtMonth",
+            Aggregation: AggregateFunction.Sum,
+            Field: "AmountRemaining",
+            ChartType: ChartType.Bar,
+            Position: 3,
+            Actions: [new WidgetAction(WidgetActionTrigger.Click, WidgetActionKind.Navigate, "/invoicing")]);
+
+        IDashboardRenderer renderer = Substitute.For<IDashboardRenderer>();
+        renderer.RenderAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>(),
+            Arg.Any<WidgetRenderContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                Guid dashboardId = call.Arg<Guid>();
+                IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance> widgets =
+                    call.Arg<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>();
+                Granit.Dashboards.Domain.WidgetInstance widget = widgets[0];
+                return new DashboardRenderResult(
+                    dashboardId,
+                    RenderedAt,
+                    Period: null,
+                    Widgets: [
+                        new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                            widgetType: widget.WidgetType,
+                            snapshot: JsonSerializer.SerializeToElement(new { categories = new[] { "Jan" }, values = new[] { 42 } }),
+                            sequence: 1,
+                            emittedAt: RenderedAt,
+                            refreshHint: RefreshHint.Dynamic)),
+                    ]);
+            });
+
+        Ok<DashboardRenderedWidgetResponse> result = await WidgetRenderHelper.RenderAsync(
+            definition,
+            contextRequest: new WidgetRenderContextRequest(Locale: "fr-CA"),
+            renderer,
+            AnonymousUser,
+            TestContext.Current.CancellationToken);
+
+        DashboardRenderedWidgetResponse response = result.Value!;
+
+        // Structural metadata projected straight from the request body — no
+        // descriptor lookup needed since the caller passed the full definition.
+        response.Slug.ShouldBe("unpaid-by-month");
+        response.WidgetType.ShouldBe("Chart");
+        response.Position.ShouldBe(3);
+        response.Width.ShouldBe(WidgetSize.StandardChart.Width);
+        response.Height.ShouldBe(WidgetSize.StandardChart.Height);
+        response.TitleLocalizationKey.ShouldBe("Widget:unpaid-by-month");
+        response.RequiredPermission.ShouldBeNull();
+
+        // Actions echo the body's declarative click-handlers — frontend dispatcher
+        // sees the same shape as the bundle path emits.
+        response.Actions.ShouldNotBeNull();
+        response.Actions!.Count.ShouldBe(1);
+        response.Actions[0].Trigger.ShouldBe(WidgetActionTrigger.Click);
+        response.Actions[0].Kind.ShouldBe(WidgetActionKind.Navigate);
+        response.Actions[0].Target.ShouldBe("/invoicing");
+
+        // Renderer envelope flowed through unchanged.
+        response.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
+        response.Sequence.ShouldBe(1);
+        response.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        response.Snapshot.ShouldNotBeNull();
+        response.ReasonLocalizationKey.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RenderAsync_DerivesStableWidgetIdAcrossInvocations()
+    {
+        ChartWidgetDefinition definition = new(
+            Slug: "deterministic-id",
+            QueryName: "Granit.Test.Q",
+            GroupBy: "x",
+            Aggregation: AggregateFunction.Count,
+            Field: null,
+            ChartType: ChartType.Bar,
+            Position: 0);
+
+        IDashboardRenderer renderer = Substitute.For<IDashboardRenderer>();
+        renderer.RenderAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>(),
+            Arg.Any<WidgetRenderContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                Guid dashboardId = call.Arg<Guid>();
+                IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance> widgets =
+                    call.Arg<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>();
+                Granit.Dashboards.Domain.WidgetInstance widget = widgets[0];
+                return new DashboardRenderResult(
+                    dashboardId,
+                    RenderedAt,
+                    null,
+                    [new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                        widget.WidgetType,
+                        JsonSerializer.SerializeToElement(new { v = 1 }),
+                        1, RenderedAt, RefreshHint.Static))]);
+            });
+
+        Ok<DashboardRenderedWidgetResponse> first = await WidgetRenderHelper.RenderAsync(
+            definition, null, renderer, AnonymousUser, TestContext.Current.CancellationToken);
+        Ok<DashboardRenderedWidgetResponse> second = await WidgetRenderHelper.RenderAsync(
+            definition, null, renderer, AnonymousUser, TestContext.Current.CancellationToken);
+
+        // Same slug -> same widget id -> frontend's TanStack cache key stays warm.
+        first.Value!.Id.ShouldBe(second.Value!.Id);
+    }
+
+    [Fact]
+    public async Task RenderAsync_PassesPeriodAndLocaleToRenderer()
+    {
+        ChartWidgetDefinition definition = new(
+            Slug: "period-test",
+            QueryName: "Granit.Test.Q",
+            GroupBy: "x",
+            Aggregation: AggregateFunction.Count,
+            Field: null,
+            ChartType: ChartType.Bar,
+            Position: 0);
+
+        IDashboardRenderer renderer = Substitute.For<IDashboardRenderer>();
+        WidgetRenderContext? capturedContext = null;
+        renderer.RenderAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>(),
+            Arg.Do<WidgetRenderContext>(c => capturedContext = c),
+            Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                Guid dashboardId = call.Arg<Guid>();
+                IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance> widgets =
+                    call.Arg<IReadOnlyList<Granit.Dashboards.Domain.WidgetInstance>>();
+                Granit.Dashboards.Domain.WidgetInstance widget = widgets[0];
+                return new DashboardRenderResult(
+                    dashboardId,
+                    RenderedAt,
+                    null,
+                    [new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                        widget.WidgetType,
+                        JsonSerializer.SerializeToElement(new { }),
+                        1, RenderedAt, RefreshHint.Static))]);
+            });
+
+        DateTimeOffset from = new(2026, 4, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset to = new(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await WidgetRenderHelper.RenderAsync(
+            definition,
+            new WidgetRenderContextRequest(PeriodFrom: from, PeriodTo: to, Locale: "fr"),
+            renderer,
+            AnonymousUser,
+            TestContext.Current.CancellationToken);
+
+        capturedContext.ShouldNotBeNull();
+        capturedContext!.Period.ShouldNotBeNull();
+        capturedContext.Period!.Value.From.ShouldBe(from);
+        capturedContext.Period.Value.To.ShouldBe(to);
+        capturedContext.Locale.ShouldBe("fr");
+    }
+}

--- a/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Analytics.Endpoints.Tests/packages.lock.json
@@ -454,6 +454,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.Endpoints": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -508,6 +510,29 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.dataexchange.abstractions": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1502,6 +1502,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.Endpoints": "[0.1.0-dev, )",
+          "Granit.Dashboards.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
@@ -4631,8 +4633,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.7",
-        "contentHash": "rdLjUXpXp4MExDM07P9iArj/bm49foe+QJm14XCsZs0R51y4r6tIa7O2ILFCnhD7KNWWDQNTkD2T+qx+7NimcQ=="
+        "resolved": "2.14.8",
+        "contentHash": "v9afCyheCy+t5zXQvAF5JMqXt6BMCEQuqxtBl/52eGiwan3xGeDKpuUNH+DdKyY+LrSjIecCwCCUGaPbdtiuwg=="
       },
       "Scriban": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

P3 of the frontend BI gap fixes — closes the definition-side renderer gap so the dashboard composer / catalogue / preview paths can fetch a single widget's snapshot without persisting it. Five new endpoints under `MapGranitAnalytics`, one per widget kind, all returning the same `DashboardRenderedWidgetResponse` shape the bundle path emits (P1 #1598). Implements **option B** from the architectural choices we agreed on.

## Endpoints

| Method | Route | Body |
| ------ | ----- | ---- |
| POST | `/widgets/kpi/render` | `KpiWidgetRenderRequest` (typed `KpiWidgetDefinition` + optional context) |
| POST | `/widgets/chart/render` | `ChartWidgetRenderRequest` |
| POST | `/widgets/table/render` | `TableWidgetRenderRequest` |
| POST | `/widgets/pivot/render` | `PivotWidgetRenderRequest` |
| POST | `/widgets/map/render` | `MapWidgetRenderRequest` |

Each request body is `{ definition: <typed WidgetDefinition>, context?: WidgetRenderContextRequest }`. The `WidgetRenderContextRequest` mirrors the bundle path's `DashboardRenderRequest` field set (period bounds, locale, filters) so the same client-side context-builder can drive both paths. All five endpoints are gated by `AnalyticsPermissions.Metrics.Read` on the route group and return `DashboardRenderedWidgetResponse` — same shape as bundle, including the P1 structural metadata + Actions.

## Implementation

- **`WidgetRenderHelper`** materialises an ephemeral `WidgetInstance` from the typed definition via `WidgetDefinitionToInstanceMapper`, then dispatches it through the existing `IDashboardRenderer.RenderAsync(Guid, IReadOnlyList<WidgetInstance>, ...)` overload added in P2 #1600. No new dispatch code path — the existing `IWidgetInstanceRenderer` chain handles every kind unchanged.
- **Stable widget ids** derived deterministically from the slug via SHA-256 + RFC 9562 v8 (custom name-based UUID). Repeat renders reuse the same id so the frontend's TanStack cache stays warm across re-fetches.
- **Actions** flow straight from the request body's `Definition.Actions` — no descriptor lookup needed since the caller passes the full definition. Symmetric with how the bundle path sources actions from the registered `DashboardDefinition` for persisted widgets.

## Wiring

- `Granit.Analytics.Endpoints.csproj` adds project references to `Granit.Dashboards.Endpoints` (for `DashboardRenderedWidgetResponse`) and `Granit.Dashboards.EntityFrameworkCore` (for the `internal` mapper).
- `Granit.Dashboards` + `Granit.Dashboards.EntityFrameworkCore` add `<InternalsVisibleTo Include="Granit.Analytics.Endpoints" />` so the helper can call `WidgetInstance.Create` / `WidgetDefinitionToInstanceMapper.Map`. No new public API on `Granit.Dashboards`.
- 6 `GranitValidator<T>` implementations (one per request type plus the shared `WidgetRenderContextRequest`) keep the `ValidationConventionTests` archi rule green.

## Wire-shape symmetry — what unblocks on the frontend

```ts
// Definition path (per-widget single render)
const { data } = useChartWidgetRender(chartDefinition, { period, filters });
// → DashboardRenderedWidget — same as the bundle path emits per widget

// Bundle path (existing)
const { data } = useDashboardRender(dashboardId, { period, filters });
// → DashboardRenderResponse, where each widget is the same DashboardRenderedWidget
```

Frontend wraps the same `KpiSnapshotTile` / `ChartSnapshotWidget` / `TableSnapshotWidget` / etc. across both paths — zero per-kind transformation duplicated client-side.

## Test plan

- [x] `dotnet build src/Granit.Analytics.Endpoints` clean.
- [x] `dotnet format src/Granit.Analytics.Endpoints --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests` — **198 passing** (3 new `WidgetRenderHelperTests` cover end-to-end projection of all 7 envelope fields, deterministic widget-id derivation across invocations, and period/locale plumbing into `WidgetRenderContext`).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **193 passing** (validator-pairing rule satisfied for all 6 new request types).
- [ ] CI green on full shard pipeline (api-data + business shards).

## Frontend impact

Unblocks the definition-side renderers `<KpiTile>` / `<ChartTile>` / `<TableTile>` / `<PivotTile>` / `<MapTile>` and the showcase composer's "live preview" mode. Each renders against `useWidgetRender(definition, context)` against these endpoints — symmetric with the bundle path.

## Closes the BI EPIC #1366 frontend gap trio

| Gap | PR | Status |
| --- | -- | ------ |
| P1 — bundle envelope metadata | #1598 | merged |
| P2 — multi-view dispatch | #1600 | merged |
| P3 — per-widget render endpoints | this PR | open |