### PR TITLE
chore(parties): move Party QueryDefinition + ExportDefinition registration to base module per ADR-020

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36230,7 +36230,7 @@
       "kind": "class",
       "project": "Granit.Parties.Endpoints",
       "file": "src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36704,7 +36704,7 @@
       "kind": "class",
       "project": "Granit.Parties",
       "file": "src/Granit.Parties/Extensions/PartiesHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitParties",

--- a/src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs
+++ b/src/Granit.Parties.Endpoints/GranitPartiesEndpointsModule.cs
@@ -1,11 +1,7 @@
 using Granit.Authorization;
-using Granit.DataExchange.Extensions;
 using Granit.Modularity;
 using Granit.Parties.Endpoints.Internal;
 using Granit.Parties.Endpoints.Options;
-using Granit.Parties.Exports;
-using Granit.Parties.Queries;
-using Granit.QueryEngine.Extensions;
 using Granit.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -13,6 +9,12 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Granit.Parties.Endpoints;
 
 /// <summary>Admin REST API for the Granit.Parties module.</summary>
+/// <remarks>
+/// Per ADR-020, the QueryDefinition / ExportDefinition registrations live in
+/// <c>AddGranitParties</c> on the base module, NOT here — concrete declarative
+/// definitions are part of the module's domain contract and stay reachable
+/// without taking a runtime dependency on <c>.Endpoints</c>.
+/// </remarks>
 [DependsOn(
     typeof(GranitAuthorizationModule),
     typeof(GranitPartiesModule),
@@ -24,11 +26,6 @@ public sealed class GranitPartiesEndpointsModule : GranitModule
     {
         context.Services.AddOptions<PartyEndpointsOptions>()
             .BindConfiguration(PartyEndpointsOptions.SectionName);
-
-        // Mandatory pairing per Granit convention: every admin-visible aggregate must
-        // ship both a QueryDefinition and an ExportDefinition, registered together.
-        context.Services.AddQueryDefinition<Domain.Party, PartyQueryDefinition>();
-        context.Services.AddExportDefinition<Domain.Party, PartyExportDefinition>();
 
         // Audit writer for the Party merge endpoint. Resolves IAuditingWriter +
         // ICurrentUserService at runtime so hosts that haven't enabled auditing get a

--- a/src/Granit.Parties/Extensions/PartiesHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties/Extensions/PartiesHostApplicationBuilderExtensions.cs
@@ -1,8 +1,12 @@
 using Granit.Analytics.Extensions;
+using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Parties.Diagnostics;
 using Granit.Parties.Domain;
+using Granit.Parties.Exports;
 using Granit.Parties.Metrics;
+using Granit.Parties.Queries;
+using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -13,7 +17,8 @@ namespace Granit.Parties.Extensions;
 public static class PartiesHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Adds the Granit parties module — diagnostics (metrics + ActivitySource), KPI
+    /// Adds the Granit parties module — diagnostics (metrics + ActivitySource), the
+    /// Party admin-grid <c>QueryDefinition</c> + <c>ExportDefinition</c>, the KPI
     /// metric definitions, and any shared singletons. Persistence
     /// (<c>Granit.Parties.EntityFrameworkCore</c>), endpoints, and privacy handlers
     /// register their own services.
@@ -22,6 +27,10 @@ public static class PartiesHostApplicationBuilderExtensions
     {
         builder.Services.TryAddSingleton<PartiesMetrics>();
         GranitActivitySourceRegistry.Register(PartiesActivitySource.Name);
+
+        // ADR-020: declarative definitions live with the domain, not the HTTP layer.
+        builder.Services.AddQueryDefinition<Party, PartyQueryDefinition>();
+        builder.Services.AddExportDefinition<Party, PartyExportDefinition>();
 
         builder.Services.AddMetricDefinition<Party, int, ActivePartyCountMetricDefinition>();
         builder.Services.AddMetricDefinition<Party, int, PartyCountMetricDefinition>();


### PR DESCRIPTION
## Summary

Pre-existing inconsistency noted on PR #1594 — `PartyQueryDefinition` and `PartyExportDefinition` were registered in `Granit.Parties.Endpoints` rather than the base module, in violation of ADR-020 ("Concrete `*QueryDefinition` / `*ExportDefinition` classes MUST live in the base module").

The classes themselves were already in the right place under `Granit.Parties/Queries/` and `Granit.Parties/Exports/`; only the `AddQueryDefinition` / `AddExportDefinition` call sites were misplaced.

This PR moves the two registrations from `GranitPartiesEndpointsModule.ConfigureServices` to `AddGranitParties` on the base `IHostApplicationBuilder` extension.

## Behaviour change

None. Hosts that pull both `AddGranitParties()` AND `MapGranitParties()` land the registrations in the same DI container at composition time. The Endpoints module's `[DependsOn(typeof(GranitPartiesModule))]` attribute already ensures `AddGranitParties()` runs before any endpoint mapping.

## Test plan

- [x] `dotnet build src/Granit.Parties` clean.
- [x] `dotnet build src/Granit.Parties.Endpoints` clean.
- [x] `dotnet format` clean on both projects.
- [x] `dotnet test tests/Granit.Parties.Tests` — **155 passing**.
- [x] `dotnet test tests/Granit.Parties.Endpoints.Tests` — **63 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **197 passing**.