### PR TITLE
test(arch): cover Granit.Dashboards.Abstractions in AbstractionsPurityTests

### DIFF
--- a/tests/Granit.ArchitectureTests/AbstractionsPurityTests.cs
+++ b/tests/Granit.ArchitectureTests/AbstractionsPurityTests.cs
@@ -18,6 +18,7 @@ public sealed partial class AbstractionsPurityTests
 
     [Theory]
     [InlineData("Granit.Workflow.Abstractions")]
+    [InlineData("Granit.Dashboards.Abstractions")]
     public void Abstractions_csproj_should_only_reference_other_abstractions_or_Granit_root(string packageName)
     {
         string csproj = Path.Join(RepoRoot, "src", packageName, $"{packageName}.csproj");
@@ -49,6 +50,7 @@ public sealed partial class AbstractionsPurityTests
 
     [Theory]
     [InlineData("Granit.Workflow.Abstractions")]
+    [InlineData("Granit.Dashboards.Abstractions")]
     public void Abstractions_csproj_should_not_reference_aspnetcore_efcore_or_hosting(string packageName)
     {
         string csproj = Path.Join(RepoRoot, "src", packageName, $"{packageName}.csproj");


### PR DESCRIPTION
## Summary

- Audit outcome of Phase 0 story #1519: **Granit.Dashboards.Abstractions already exists**, no split needed.
- Extends `AbstractionsPurityTests` (introduced alongside #1518) to also enforce the structural invariants on `Granit.Dashboards.Abstractions`.

Closes #1519 — third commit of Phase 0 of the Refonte UI Hybride master plan (#1506).

## Audit findings

Full audit posted as a comment on the issue. Headlines:

- `src/Granit.Dashboards.Abstractions/` exists with `IsPackable=true`, `GranitDashboardsAbstractionsModule` marker, README, and a `Granit.Dashboards.Abstractions.Tests` test project (12 test files).
- ProjectReferences are clean: only `Granit` (modularity) + `Granit.Analytics.Abstractions` + `Granit.QueryEngine.Abstractions`. No AspNetCore / EF Core / Hosting / FluentValidation.
- Surface includes: `DashboardDefinition`, `WidgetDefinition`, `IDashboardDefinitionRegistry`, `Datasource` (Metric/QueryAggregate/Telemetry), `EntityAlias`, `EntityAliasResolver`, presentation widgets (Markdown/Image/Text), layout / size / time-window / view value objects. Exactly the surface a Phase 1 `EntityDefinition.Dashboard<X>()` reference will need.

## What this PR changes

A single 2-line addition: `[InlineData("Granit.Dashboards.Abstractions")]` on the two theory tests in `AbstractionsPurityTests`. The architecture-test count goes from 2 (Workflow only) to 4 (Workflow + Dashboards × 2 rules). All four pass.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests --filter "AbstractionsPurity"` — 4 tests pass
- [x] `dotnet format` + `dotnet format style` — clean
- [x] No source code change beyond the test file

## Future Phase 1 packages

`Granit.Entities.Abstractions` and `Granit.Workspaces.Abstractions` will be added to the same `[InlineData]` set as they land in Phase 1 — the architecture test infrastructure is now in place.