### PR TITLE
feat(invoicing): ship 8 extension MetricDefinitions for Invoice

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -26710,6 +26710,398 @@
       ]
     },
     {
+      "name": "CreditNoteTotalMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.CreditNoteTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/CreditNoteTotalMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, decimal?>>? Selector",
+          "returnType": "Expression<Func<Invoice, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IssuedInvoiceCountMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.IssuedInvoiceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/IssuedInvoiceCountMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, int?>>? Selector",
+          "returnType": "Expression<Func<Invoice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "IssuedInvoiceTotalMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.IssuedInvoiceTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/IssuedInvoiceTotalMetricDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, decimal?>>? Selector",
+          "returnType": "Expression<Func<Invoice, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "OverdueInvoiceCountMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.OverdueInvoiceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/OverdueInvoiceCountMetricDefinition.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, int?>>? Selector",
+          "returnType": "Expression<Func<Invoice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "OverdueInvoiceTotalMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.OverdueInvoiceTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/OverdueInvoiceTotalMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, decimal?>>? Selector",
+          "returnType": "Expression<Func<Invoice, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "OverpaidInvoiceCountMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.OverpaidInvoiceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/OverpaidInvoiceCountMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, int?>>? Selector",
+          "returnType": "Expression<Func<Invoice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PaidInvoiceCountMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.PaidInvoiceCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/PaidInvoiceCountMetricDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, int?>>? Selector",
+          "returnType": "Expression<Func<Invoice, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
+      "name": "PaidInvoiceTotalMetricDefinition",
+      "fqn": "Granit.Invoicing.Metrics.PaidInvoiceTotalMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Metrics/PaidInvoiceTotalMetricDefinition.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, decimal?>>? Selector",
+          "returnType": "Expression<Func<Invoice, decimal?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Invoice, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Invoice, DateTimeOffset>>?"
+        }
+      ]
+    },
+    {
       "name": "UnpaidInvoiceCountMetricDefinition",
       "fqn": "Granit.Invoicing.Metrics.UnpaidInvoiceCountMetricDefinition",
       "kind": "class",

--- a/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
@@ -30,6 +30,14 @@ public static class InvoicingHostApplicationBuilderExtensions
         builder.Services.AddExportDefinition<Invoice, InvoiceExportDefinition>();
         builder.Services.AddMetricDefinition<Invoice, int, UnpaidInvoiceCountMetricDefinition>();
         builder.Services.AddMetricDefinition<Invoice, decimal, UnpaidInvoiceTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, int, OverdueInvoiceCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, decimal, OverdueInvoiceTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, int, IssuedInvoiceCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, decimal, IssuedInvoiceTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, int, PaidInvoiceCountMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, decimal, PaidInvoiceTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, decimal, CreditNoteTotalMetricDefinition>();
+        builder.Services.AddMetricDefinition<Invoice, int, OverpaidInvoiceCountMetricDefinition>();
         GranitActivitySourceRegistry.Register(InvoicingActivitySource.Name);
         return builder;
     }

--- a/src/Granit.Invoicing/Localization/Invoicing/cs.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/cs.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Daň celkem",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Dobropisy celkem",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Vystavené faktury",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Celkem fakturováno",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Faktury po splatnosti",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Částka po splatnosti",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Přeplacené faktury",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Zaplacené faktury",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Celkem inkasováno",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Neuhrazené faktury",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Součet neuhrazených faktur"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/de.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/de.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Steuerbetrag gesamt",
     "Invoicing.Columns.Tenant": "Mandant",
     "Invoicing.Columns.Total": "Gesamt",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Gutschriften gesamt",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Ausgestellte Rechnungen",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Gesamtbetrag fakturiert",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Überfällige Rechnungen",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Überfälliger Betrag",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Überzahlte Rechnungen",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Bezahlte Rechnungen",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Gesamtbetrag eingenommen",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unbezahlte Rechnungen",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Gesamtsumme unbezahlter Rechnungen"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/en.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/en.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Tax Total",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Credit notes total",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Invoices issued",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Total billed",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Overdue invoices",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Overdue amount",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Overpaid invoices",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Invoices paid",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total collected",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unpaid invoices",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Unpaid invoices total"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/es.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/es.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Total de impuestos",
     "Invoicing.Columns.Tenant": "Inquilino",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Total de notas de crédito",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Facturas emitidas",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Total facturado",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Facturas vencidas",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Importe vencido",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Facturas pagadas en exceso",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Facturas pagadas",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total cobrado",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Facturas impagadas",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total de facturas impagadas"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/fr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/fr.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Total TVA",
     "Invoicing.Columns.Tenant": "Locataire",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Total des avoirs",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Factures émises",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Total facturé",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Factures en retard",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Montant en retard",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Factures surpayées",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Factures payées",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total encaissé",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Factures impayées",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total des factures impayées"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/hi.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/hi.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "कुल कर",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "क्रेडिट नोट कुल",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "जारी चालान",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "कुल बिल राशि",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "बकाया चालान",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "बकाया राशि",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "अधिक भुगतान किए गए चालान",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "भुगतान किए गए चालान",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "कुल वसूली",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "अवैतनिक चालान",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "अवैतनिक चालानों का कुल"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/it.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/it.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Totale imposte",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Totale note di credito",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Fatture emesse",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Totale fatturato",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Fatture scadute",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Importo scaduto",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Fatture sovrappagate",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Fatture pagate",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totale incassato",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Fatture non pagate",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totale delle fatture non pagate"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/ja.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ja.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "税額合計",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "クレジットノート合計",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "発行された請求書",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "請求総額",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "支払い遅延の請求書",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "支払い遅延額",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "過払いの請求書",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "支払い済みの請求書",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "回収総額",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未払い請求書",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未払い請求書の合計"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/ko.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ko.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "세금 합계",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "대변 메모 총액",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "발행된 청구서",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "총 청구액",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "연체된 청구서",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "연체 금액",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "초과 지급 청구서",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "지불된 청구서",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "총 수금액",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "미지급 청구서",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "미지급 청구서 합계"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/nl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/nl.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Btw-totaal",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Totaal",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Totaal creditnota's",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Uitgegeven facturen",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Totaal gefactureerd",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Achterstallige facturen",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Achterstallig bedrag",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Te veel betaalde facturen",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Betaalde facturen",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totaal geïnd",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Onbetaalde facturen",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totaal van onbetaalde facturen"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/pl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pl.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Razem podatek",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Łączna suma not kredytowych",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Wystawione faktury",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Łączna kwota wystawiona",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Zaległe faktury",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Kwota zaległa",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Faktury nadpłacone",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Opłacone faktury",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Łączna kwota pobrana",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Niezapłacone faktury",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Suma niezapłaconych faktur"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/pt.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pt.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Total de impostos",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Total de notas de crédito",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Faturas emitidas",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Total faturado",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Faturas vencidas",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Valor vencido",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Faturas pagas a mais",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Faturas pagas",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total recebido",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Faturas por pagar",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total das faturas por pagar"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/sv.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/sv.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Total moms",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Kreditfakturor totalt",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Utfärdade fakturor",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Totalt fakturerat",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Förfallna fakturor",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Förfallet belopp",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Överbetalda fakturor",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Betalda fakturor",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totalt inkasserat",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Obetalda fakturor",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totalsumma obetalda fakturor"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/tr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/tr.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "Toplam vergi",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "Alacak dekontu toplamı",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "Düzenlenen faturalar",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "Toplam faturalanan",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "Vadesi geçmiş faturalar",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "Vadesi geçmiş tutar",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "Fazla ödenen faturalar",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Ödenen faturalar",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Tahsil edilen toplam",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Ödenmemiş faturalar",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Ödenmemiş faturaların toplamı"
   }

--- a/src/Granit.Invoicing/Localization/Invoicing/zh.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/zh.json
@@ -23,6 +23,14 @@
     "Invoicing.Columns.TaxTotal": "税额合计",
     "Invoicing.Columns.Tenant": "Tenant",
     "Invoicing.Columns.Total": "Total",
+    "Metric:Granit.Invoicing.CreditNoteTotalMetric": "贷记凭证总额",
+    "Metric:Granit.Invoicing.IssuedInvoiceCountMetric": "已开具发票",
+    "Metric:Granit.Invoicing.IssuedInvoiceTotalMetric": "开票总额",
+    "Metric:Granit.Invoicing.OverdueInvoiceCountMetric": "逾期发票",
+    "Metric:Granit.Invoicing.OverdueInvoiceTotalMetric": "逾期金额",
+    "Metric:Granit.Invoicing.OverpaidInvoiceCountMetric": "多付发票",
+    "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "已支付发票",
+    "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "已收款总额",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未付款发票",
     "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未付款发票总额"
   }

--- a/src/Granit.Invoicing/Metrics/CreditNoteTotalMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/CreditNoteTotalMetricDefinition.cs
@@ -1,0 +1,42 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Total monetary amount of credit notes issued in the period — sum of
+/// <see cref="Invoice.Total"/> across <see cref="InvoiceDocumentType.CreditNote"/>
+/// documents finalised in the window. Reads as the negative-revenue
+/// counterpart of <c>IssuedInvoiceTotal</c>; high values usually indicate
+/// disputed invoices, partial refunds, or pricing errors. Lower is better.
+/// </summary>
+public sealed class CreditNoteTotalMetricDefinition : MetricDefinition<Invoice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.CreditNoteTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, decimal?>>? Selector
+        => i => i.Total;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.DocumentType == InvoiceDocumentType.CreditNote
+             && i.Status != InvoiceStatus.Draft
+             && i.IssuedAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/Metrics/IssuedInvoiceCountMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/IssuedInvoiceCountMetricDefinition.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Number of <see cref="InvoiceDocumentType.Invoice"/> documents finalised in
+/// the period — drafts excluded. Period selector is
+/// <see cref="Invoice.IssuedAt"/> so <c>?period=mtd</c> answers "how many
+/// invoices did we issue this month?".
+/// </summary>
+public sealed class IssuedInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.IssuedInvoiceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.DocumentType == InvoiceDocumentType.Invoice
+             && i.Status != InvoiceStatus.Draft
+             && i.IssuedAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+}

--- a/src/Granit.Invoicing/Metrics/IssuedInvoiceTotalMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/IssuedInvoiceTotalMetricDefinition.cs
@@ -1,0 +1,38 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Total billed amount in the period — sum of <see cref="Invoice.Total"/>
+/// across <see cref="InvoiceDocumentType.Invoice"/> documents finalised in
+/// the period (drafts excluded). Headline revenue indicator for the
+/// invoicing module.
+/// </summary>
+public sealed class IssuedInvoiceTotalMetricDefinition : MetricDefinition<Invoice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.IssuedInvoiceTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, decimal?>>? Selector
+        => i => i.Total;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.DocumentType == InvoiceDocumentType.Invoice
+             && i.Status != InvoiceStatus.Draft
+             && i.IssuedAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.IssuedAt!.Value;
+}

--- a/src/Granit.Invoicing/Metrics/OverdueInvoiceCountMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/OverdueInvoiceCountMetricDefinition.cs
@@ -1,0 +1,45 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Number of invoices in <see cref="InvoiceStatus.Open"/> whose <c>DueAt</c>
+/// falls in the period — answers "how many open invoices are overdue?" when
+/// the caller asks for a backward-looking window
+/// (<c>?period=last_30d</c> ⇒ "overdue in the last 30 days"). Lower is better.
+/// </summary>
+/// <remarks>
+/// The "now" comparison that defines overdue strictly cannot live in the
+/// expression tree (<c>UtcNow</c> is forbidden by CLAUDE.md). Instead we
+/// surface a period-bounded variant: callers pin the "as-of-now" by passing
+/// a window ending at the current instant. The frontend's period-token
+/// resolver does this transparently.
+/// </remarks>
+public sealed class OverdueInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.OverdueInvoiceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Open && i.DueAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.DueAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/Metrics/OverdueInvoiceTotalMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/OverdueInvoiceTotalMetricDefinition.cs
@@ -1,0 +1,40 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Total monetary amount overdue in the period — sum of
+/// <see cref="Invoice.AmountRemaining"/> across <see cref="InvoiceStatus.Open"/>
+/// invoices whose <c>DueAt</c> falls in the period window. The cash-exposure
+/// counterpart of <c>OverdueInvoiceCount</c>; combine the two to compute
+/// average overdue amount client-side. Lower is better.
+/// </summary>
+public sealed class OverdueInvoiceTotalMetricDefinition : MetricDefinition<Invoice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.OverdueInvoiceTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, decimal?>>? Selector
+        => i => i.AmountRemaining;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Open && i.DueAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.DueAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/Metrics/OverpaidInvoiceCountMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/OverpaidInvoiceCountMetricDefinition.cs
@@ -1,0 +1,39 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Number of invoices carrying a non-zero <see cref="Invoice.Overpayment"/>
+/// in the period — invoices where the customer paid more than the billed
+/// amount. Each overpayment requires reconciliation (refund, customer
+/// credit, or write-off); high counts indicate friction in the
+/// pay-and-reconcile flow. Lower is better.
+/// </summary>
+public sealed class OverpaidInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.OverpaidInvoiceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Overpayment > 0m && i.PaidAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.PaidAt!.Value;
+
+    /// <inheritdoc />
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Invoicing/Metrics/PaidInvoiceCountMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/PaidInvoiceCountMetricDefinition.cs
@@ -1,0 +1,34 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Number of invoices that reached <see cref="InvoiceStatus.Paid"/> in the
+/// period. Period selector is <see cref="Invoice.PaidAt"/> so the result
+/// answers "how many got paid this window", not "how many were issued".
+/// </summary>
+public sealed class PaidInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.PaidInvoiceCountMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, int?>>? Selector => null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Paid && i.PaidAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.PaidAt!.Value;
+}

--- a/src/Granit.Invoicing/Metrics/PaidInvoiceTotalMetricDefinition.cs
+++ b/src/Granit.Invoicing/Metrics/PaidInvoiceTotalMetricDefinition.cs
@@ -1,0 +1,37 @@
+using System.Linq.Expressions;
+using Granit.Analytics.Metrics;
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Metrics;
+
+/// <summary>
+/// Total amount actually collected in the period — sum of
+/// <see cref="Invoice.AmountPaid"/> across invoices that reached
+/// <see cref="InvoiceStatus.Paid"/> in the window. Reads as the realised
+/// cash side of <c>IssuedInvoiceTotal</c>; the gap between issued and paid
+/// is the receivables ageing.
+/// </summary>
+public sealed class PaidInvoiceTotalMetricDefinition : MetricDefinition<Invoice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.PaidInvoiceTotalMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, decimal?>>? Selector
+        => i => i.AmountPaid;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, bool>>? BaseFilter
+        => i => i.Status == InvoiceStatus.Paid && i.PaidAt != null;
+
+    /// <inheritdoc />
+    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
+        => i => i.PaidAt!.Value;
+}


### PR DESCRIPTION
## Summary

Completes the original 51-metric plan for the Invoicing module — adds 8 metrics on top of the 2 baseline ones (`UnpaidInvoiceCount` / `UnpaidInvoiceTotal` already shipped via story A4 #1377).

| Metric | Aggregation | Filter | Period | Higher better? |
| ------ | ----------- | ------ | ------ | -------------- |
| `OverdueInvoiceCount` | Count | `Status == Open && DueAt != null` | `DueAt` | no |
| `OverdueInvoiceTotal` | Sum(`AmountRemaining`) | same | `DueAt` | no |
| `IssuedInvoiceCount` | Count | `DocumentType == Invoice && Status != Draft` | `IssuedAt` | yes |
| `IssuedInvoiceTotal` | Sum(`Total`) | same | `IssuedAt` | yes |
| `PaidInvoiceCount` | Count | `Status == Paid` | `PaidAt` | yes |
| `PaidInvoiceTotal` | Sum(`AmountPaid`) | `Status == Paid` | `PaidAt` | yes |
| `CreditNoteTotal` | Sum(`Total`) | `DocumentType == CreditNote && Status != Draft` | `IssuedAt` | no |
| `OverpaidInvoiceCount` | Count | `Overpayment > 0 && PaidAt != null` | `PaidAt` | no |

## Notable choices

**Overdue without `UtcNow`.** CLAUDE.md forbids `UtcNow` inside expression trees (TimeProvider/IClock convention). The Overdue metrics surface a period-bounded variant: callers pin "as-of-now" by passing a window ending at the current instant (`?period=last_30d` ⇒ "overdue in the last 30 days"). The frontend's period-token resolver does this transparently.

**`InvoicePaymentDelayAverage` deferred.** A `TimeSpan`-based aggregation across `(PaidAt - DueAt).TotalDays` translates inconsistently across EF Core 10 providers (Postgres / SQLite differ on `TotalDays` translation). It deserves its own validation pass against the `MetricExecutorPostgresParityTests` story-A3 contract — tracked as a follow-up.

## Localisation

8 new `Metric:Granit.Invoicing.*Metric` keys added to the existing 15 base culture files (regional `en-GB` / `fr-CA` / `pt-BR` files unchanged). Files alphabetised for stable diffs.

## Architecture-test impact

None — Invoicing was already paired (via the 2 baseline metrics) so no `MetricBacklog` change. The pairing rule already passed before this PR; D2 #1397 localisation now satisfied for the 8 new metric names.

## Test plan

- [x] `dotnet build src/Granit.Invoicing` clean.
- [x] `dotnet format src/Granit.Invoicing --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Invoicing.Tests` — **57 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **197 passing**.