### PR TITLE
feat(dashboards): ship first-wave DashboardDefinitions across Invoicing / Subscriptions / BlobStorage / Webhooks

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10192,6 +10192,34 @@
       ]
     },
     {
+      "name": "BlobStorageOperationsDashboardDefinition",
+      "fqn": "Granit.BlobStorage.Dashboards.BlobStorageOperationsDashboardDefinition",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Dashboards/BlobStorageOperationsDashboardDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Category",
+          "kind": "property",
+          "signature": "DashboardCategory Category",
+          "returnType": "DashboardCategory"
+        },
+        {
+          "name": "MarkdownWidgetDefinition",
+          "kind": "method",
+          "signature": "MarkdownWidgetDefinition(Slug: \"banner\", ContentLocalizationKey: \"Widget:Granit.BlobStorage.StorageOperations.banner.Body\", Position: 0)",
+          "returnType": "IReadOnlyList<WidgetDefinition> Widgets { get; } ="
+        }
+      ]
+    },
+    {
       "name": "DatabaseBlobContent",
       "fqn": "Granit.BlobStorage.Database.Entities.DatabaseBlobContent",
       "kind": "class",
@@ -10764,7 +10792,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
-      "line": 32,
+      "line": 34,
       "members": [
         {
           "name": "ConfigureServices",
@@ -25968,6 +25996,34 @@
       "members": []
     },
     {
+      "name": "InvoicingFinanceOverviewDashboardDefinition",
+      "fqn": "Granit.Invoicing.Dashboards.InvoicingFinanceOverviewDashboardDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing",
+      "file": "src/Granit.Invoicing/Dashboards/InvoicingFinanceOverviewDashboardDefinition.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Category",
+          "kind": "property",
+          "signature": "DashboardCategory Category",
+          "returnType": "DashboardCategory"
+        },
+        {
+          "name": "MarkdownWidgetDefinition",
+          "kind": "method",
+          "signature": "MarkdownWidgetDefinition(Slug: \"banner\", ContentLocalizationKey: \"Widget:Granit.Invoicing.FinanceOverview.banner.Body\", Position: 0)",
+          "returnType": "IReadOnlyList<WidgetDefinition> Widgets { get; } ="
+        }
+      ]
+    },
+    {
       "name": "InvoiceWorkflows",
       "fqn": "Granit.Invoicing.Definitions.InvoiceWorkflows",
       "kind": "class",
@@ -26541,7 +26597,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 22,
       "members": [
         {
           "name": "AddGranitInvoicing",
@@ -47759,6 +47815,34 @@
       "members": []
     },
     {
+      "name": "SubscriptionsHealthDashboardDefinition",
+      "fqn": "Granit.Subscriptions.Dashboards.SubscriptionsHealthDashboardDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Category",
+          "kind": "property",
+          "signature": "DashboardCategory Category",
+          "returnType": "DashboardCategory"
+        },
+        {
+          "name": "MarkdownWidgetDefinition",
+          "kind": "method",
+          "signature": "MarkdownWidgetDefinition(Slug: \"banner\", ContentLocalizationKey: \"Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body\", Position: 0)",
+          "returnType": "IReadOnlyList<WidgetDefinition> Widgets { get; } ="
+        }
+      ]
+    },
+    {
       "name": "SubscriptionWorkflows",
       "fqn": "Granit.Subscriptions.Definitions.SubscriptionWorkflows",
       "kind": "class",
@@ -48633,7 +48717,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs",
-      "line": 23,
+      "line": 25,
       "members": [
         {
           "name": "AddGranitSubscriptions",
@@ -54597,6 +54681,34 @@
       ]
     },
     {
+      "name": "WebhookReliabilityDashboardDefinition",
+      "fqn": "Granit.Webhooks.Dashboards.WebhookReliabilityDashboardDefinition",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Dashboards/WebhookReliabilityDashboardDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Category",
+          "kind": "property",
+          "signature": "DashboardCategory Category",
+          "returnType": "DashboardCategory"
+        },
+        {
+          "name": "MarkdownWidgetDefinition",
+          "kind": "method",
+          "signature": "MarkdownWidgetDefinition(Slug: \"banner\", ContentLocalizationKey: \"Widget:Granit.Webhooks.WebhookReliability.banner.Body\", Position: 0)",
+          "returnType": "IReadOnlyList<WidgetDefinition> Widgets { get; } ="
+        }
+      ]
+    },
+    {
       "name": "IWebhookEventTypeDefinitionContext",
       "fqn": "Granit.Webhooks.Definitions.IWebhookEventTypeDefinitionContext",
       "kind": "interface",
@@ -55228,7 +55340,7 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs",
-      "line": 30,
+      "line": 32,
       "members": [
         {
           "name": "AddGranitWebhooks",

--- a/src/Granit.BlobStorage/Dashboards/BlobStorageOperationsDashboardDefinition.cs
+++ b/src/Granit.BlobStorage/Dashboards/BlobStorageOperationsDashboardDefinition.cs
@@ -1,0 +1,53 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.BlobStorage.Dashboards;
+
+/// <summary>
+/// Storage operations dashboard — valid / orphan blob counts, total storage
+/// footprint, plus a daily upload chart. First-wave reference for the
+/// <see cref="DashboardDefinition"/> pattern in the BlobStorage module.
+/// </summary>
+public sealed class BlobStorageOperationsDashboardDefinition : DashboardDefinition
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.BlobStorage.StorageOperations";
+
+    /// <inheritdoc />
+    public override DashboardCategory Category => DashboardCategory.Operations;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+    [
+        new MarkdownWidgetDefinition(
+            Slug: "banner",
+            ContentLocalizationKey: "Widget:Granit.BlobStorage.StorageOperations.banner.Body",
+            Position: 0),
+
+        new KpiWidgetDefinition(
+            Slug: "valid-count",
+            Datasource: Datasource.Metric("Granit.BlobStorage.ValidBlobDescriptorCountMetric"),
+            Position: 1),
+
+        new KpiWidgetDefinition(
+            Slug: "storage-total",
+            Datasource: Datasource.Metric("Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric"),
+            Position: 2),
+
+        new KpiWidgetDefinition(
+            Slug: "orphan-count",
+            Datasource: Datasource.Metric("Granit.BlobStorage.OrphanBlobDescriptorCountMetric"),
+            Position: 3),
+
+        new ChartWidgetDefinition(
+            Slug: "uploads-by-day",
+            QueryName: "Granit.BlobStorage.BlobDescriptorsQuery",
+            GroupBy: "CreatedAt",
+            Aggregation: AggregateFunction.Count,
+            Field: null,
+            ChartType: ChartType.Bar,
+            Position: 4),
+    ];
+}

--- a/src/Granit.BlobStorage/GranitBlobStorageModule.cs
+++ b/src/Granit.BlobStorage/GranitBlobStorageModule.cs
@@ -1,10 +1,12 @@
 using Granit.Analytics.Extensions;
+using Granit.BlobStorage.Dashboards;
 using Granit.BlobStorage.Diagnostics;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Exports;
 using Granit.BlobStorage.Metrics;
 using Granit.BlobStorage.Queries;
 using Granit.BlobStorage.Validators;
+using Granit.Dashboards.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Guids;
 using Granit.Modularity;
@@ -45,5 +47,7 @@ public sealed class GranitBlobStorageModule : GranitModule
         context.Services.AddMetricDefinition<BlobDescriptor, int, ValidBlobDescriptorCountMetricDefinition>();
         context.Services.AddMetricDefinition<BlobDescriptor, long, ValidBlobDescriptorSizeTotalMetricDefinition>();
         context.Services.AddMetricDefinition<BlobDescriptor, int, OrphanBlobDescriptorCountMetricDefinition>();
+
+        context.Services.AddDashboardDefinition<BlobStorageOperationsDashboardDefinition>();
     }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/cs.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/cs.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Požadovaný soubor nebyl nalezen.",
     "BlobStorage:NotValid": "Soubor není dostupný ke stažení.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Osiřelé bloby",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Platné bloby",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Celkové úložiště (bajty)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Celkové úložiště (bajty)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/de.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/de.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verifizierter Inhaltstyp",
     "BlobStorage:NotFound": "Die angeforderte Datei wurde nicht gefunden.",
     "BlobStorage:NotValid": "Die Datei steht nicht zum Download zur Verfügung.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Verwaiste Blobs",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Gültige Blobs",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Gesamtspeicher (Bytes)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Gesamtspeicher (Bytes)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/en.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/en.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "The requested file was not found.",
     "BlobStorage:NotValid": "The file is not available for download.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Orphan blobs",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Valid blobs",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Total storage (bytes)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Total storage (bytes)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/es.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/es.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Tipo de contenido verificado",
     "BlobStorage:NotFound": "El archivo solicitado no fue encontrado.",
     "BlobStorage:NotValid": "El archivo no está disponible para su descarga.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Blobs huérfanos",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Blobs válidos",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Almacenamiento total (bytes)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Almacenamiento total (bytes)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/fr.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/fr.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Type de contenu vérifié",
     "BlobStorage:NotFound": "Le fichier demandé est introuvable.",
     "BlobStorage:NotValid": "Le fichier n'est pas disponible au téléchargement.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Opérations de stockage",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Blobs orphelins",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Blobs valides",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Stockage total (octets)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Stockage total (octets)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Opérations de stockage\nBlobs valides, empreinte totale et orphelins en attente du pipeline de validation.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Blobs orphelins",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Stockage total",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads par jour",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Blobs valides"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/hi.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/hi.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "अनुरोधित फ़ाइल नहीं मिली।",
     "BlobStorage:NotValid": "फ़ाइल डाउनलोड के लिए उपलब्ध नहीं है।",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "अनाथ ब्लॉब्स",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "वैध ब्लॉब्स",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "कुल भंडारण (बाइट)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "कुल भंडारण (बाइट)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/it.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/it.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Il file richiesto non è stato trovato.",
     "BlobStorage:NotValid": "Il file non è disponibile per il download.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Blob orfani",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Blob validi",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Archiviazione totale (byte)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Archiviazione totale (byte)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/ja.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/ja.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "要求されたファイルが見つかりませんでした。",
     "BlobStorage:NotValid": "このファイルはダウンロードできません。",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "孤立した Blob",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "有効な Blob",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "合計ストレージ（バイト）"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "合計ストレージ（バイト）",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/ko.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/ko.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "요청한 파일을 찾을 수 없습니다.",
     "BlobStorage:NotValid": "파일을 다운로드할 수 없습니다.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "고아 Blob",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "유효한 Blob",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "총 저장 용량 (바이트)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "총 저장 용량 (바이트)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/nl.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/nl.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Geverifieerd inhoudstype",
     "BlobStorage:NotFound": "Het gevraagde bestand werd niet gevonden.",
     "BlobStorage:NotValid": "Het bestand is niet beschikbaar om te downloaden.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Verweesde blobs",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Geldige blobs",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Totale opslag (bytes)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Totale opslag (bytes)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/pl.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/pl.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Żądany plik nie został znaleziony.",
     "BlobStorage:NotValid": "Plik nie jest dostępny do pobrania.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Osierocone blobs",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Prawidłowe blobs",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Łączna pamięć (bajty)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Łączna pamięć (bajty)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/pt.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/pt.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "O ficheiro solicitado não foi encontrado.",
     "BlobStorage:NotValid": "O ficheiro não está disponível para transferência.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Blobs órfãos",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Blobs válidos",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Armazenamento total (bytes)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Armazenamento total (bytes)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/sv.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/sv.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "Den begärda filen hittades inte.",
     "BlobStorage:NotValid": "Filen är inte tillgänglig för nedladdning.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Föräldralösa blobs",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Giltiga blobs",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Total lagring (byte)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Total lagring (byte)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/tr.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/tr.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "İstenen dosya bulunamadı.",
     "BlobStorage:NotValid": "Dosya indirilebilir durumda değil.",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "Yetim bloblar",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "Geçerli bloblar",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Toplam depolama (bayt)"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "Toplam depolama (bayt)",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.BlobStorage/Localization/BlobStorage/zh.json
+++ b/src/Granit.BlobStorage/Localization/BlobStorage/zh.json
@@ -14,8 +14,14 @@
     "BlobStorage.Columns.VerifiedContentType": "Verified Content Type",
     "BlobStorage:NotFound": "请求的文件未找到。",
     "BlobStorage:NotValid": "该文件不可下载。",
+    "Dashboard:Granit.BlobStorage.StorageOperations": "Storage operations",
     "Metric:Granit.BlobStorage.OrphanBlobDescriptorCountMetric": "孤立 Blob",
     "Metric:Granit.BlobStorage.ValidBlobDescriptorCountMetric": "有效 Blob",
-    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "总存储（字节）"
+    "Metric:Granit.BlobStorage.ValidBlobDescriptorSizeTotalMetric": "总存储（字节）",
+    "Widget:Granit.BlobStorage.StorageOperations.banner.Body": "## Storage operations\nValid blob population, total footprint, and orphans waiting on the validation pipeline.",
+    "Widget:Granit.BlobStorage.StorageOperations.orphan-count": "Orphan blobs",
+    "Widget:Granit.BlobStorage.StorageOperations.storage-total": "Total storage",
+    "Widget:Granit.BlobStorage.StorageOperations.uploads-by-day": "Uploads by day",
+    "Widget:Granit.BlobStorage.StorageOperations.valid-count": "Valid blobs"
   }
 }

--- a/src/Granit.Invoicing/Dashboards/InvoicingFinanceOverviewDashboardDefinition.cs
+++ b/src/Granit.Invoicing/Dashboards/InvoicingFinanceOverviewDashboardDefinition.cs
@@ -1,0 +1,66 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Dashboards;
+
+/// <summary>
+/// Finance overview dashboard — first-wave reference shipped to demonstrate the
+/// <see cref="DashboardDefinition"/> pattern. Six headline cash-flow KPIs
+/// (unpaid / overdue / paid totals, plus the credit-note adjustment), a
+/// monthly chart of issued volume, and a markdown banner above the grid.
+/// Tenant admins import via
+/// <c>POST /dashboards/from-definition/Granit.Invoicing.FinanceOverview</c>.
+/// </summary>
+public sealed class InvoicingFinanceOverviewDashboardDefinition : DashboardDefinition
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Invoicing.FinanceOverview";
+
+    /// <inheritdoc />
+    public override DashboardCategory Category => DashboardCategory.Finance;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+    [
+        new MarkdownWidgetDefinition(
+            Slug: "banner",
+            ContentLocalizationKey: "Widget:Granit.Invoicing.FinanceOverview.banner.Body",
+            Position: 0),
+
+        new KpiWidgetDefinition(
+            Slug: "unpaid-count",
+            Datasource: Datasource.Metric("Granit.Invoicing.UnpaidInvoiceCountMetric"),
+            Position: 1),
+
+        new KpiWidgetDefinition(
+            Slug: "unpaid-total",
+            Datasource: Datasource.Metric("Granit.Invoicing.UnpaidInvoiceTotalMetric"),
+            Position: 2),
+
+        new KpiWidgetDefinition(
+            Slug: "overdue-total",
+            Datasource: Datasource.Metric("Granit.Invoicing.OverdueInvoiceTotalMetric"),
+            Position: 3),
+
+        new KpiWidgetDefinition(
+            Slug: "paid-total",
+            Datasource: Datasource.Metric("Granit.Invoicing.PaidInvoiceTotalMetric"),
+            Position: 4),
+
+        new KpiWidgetDefinition(
+            Slug: "credit-note-total",
+            Datasource: Datasource.Metric("Granit.Invoicing.CreditNoteTotalMetric"),
+            Position: 5),
+
+        new ChartWidgetDefinition(
+            Slug: "issued-by-month",
+            QueryName: "Granit.Invoicing.InvoiceQuery",
+            GroupBy: "IssuedAt",
+            Aggregation: AggregateFunction.Sum,
+            Field: "Total",
+            ChartType: ChartType.Bar,
+            Position: 6),
+    ];
+}

--- a/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Invoicing/Extensions/InvoicingHostApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.Analytics.Extensions;
+using Granit.Dashboards.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
+using Granit.Invoicing.Dashboards;
 using Granit.Invoicing.Definitions;
 using Granit.Invoicing.Diagnostics;
 using Granit.Invoicing.Domain;
@@ -38,6 +40,7 @@ public static class InvoicingHostApplicationBuilderExtensions
         builder.Services.AddMetricDefinition<Invoice, decimal, PaidInvoiceTotalMetricDefinition>();
         builder.Services.AddMetricDefinition<Invoice, decimal, CreditNoteTotalMetricDefinition>();
         builder.Services.AddMetricDefinition<Invoice, int, OverpaidInvoiceCountMetricDefinition>();
+        builder.Services.AddDashboardDefinition<InvoicingFinanceOverviewDashboardDefinition>();
         GranitActivitySourceRegistry.Register(InvoicingActivitySource.Name);
         return builder;
     }

--- a/src/Granit.Invoicing/Localization/Invoicing/cs.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Dobropisovaná částka",
     "Invoicing.Columns.AmountPaid": "Uhrazená částka",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Zaplacené faktury",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Celkem inkasováno",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Neuhrazené faktury",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Součet neuhrazených faktur"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Součet neuhrazených faktur",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/de.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Gutgeschriebener Betrag",
     "Invoicing.Columns.AmountPaid": "Gezahlter Betrag",
     "Invoicing.Columns.AmountRemaining": "Restbetrag",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Bezahlte Rechnungen",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Gesamtbetrag eingenommen",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unbezahlte Rechnungen",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Gesamtsumme unbezahlter Rechnungen"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Gesamtsumme unbezahlter Rechnungen",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/en.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Amount Credited",
     "Invoicing.Columns.AmountPaid": "Amount Paid",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Invoices paid",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total collected",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Unpaid invoices",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Unpaid invoices total"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Unpaid invoices total",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/es.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Importe abonado",
     "Invoicing.Columns.AmountPaid": "Importe pagado",
     "Invoicing.Columns.AmountRemaining": "Monto restante",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Facturas pagadas",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total cobrado",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Facturas impagadas",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total de facturas impagadas"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total de facturas impagadas",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/fr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Vue d'ensemble finance",
     "Invoicing.Columns.AmountCredited": "Montant avoir",
     "Invoicing.Columns.AmountPaid": "Montant payé",
     "Invoicing.Columns.AmountRemaining": "Montant restant",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Factures payées",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total encaissé",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Factures impayées",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total des factures impayées"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total des factures impayées",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Vue d'ensemble finance\nÉtat en direct de la facturation : ce qu'on vous doit, ce qui est encaissé, ce qui est en retard.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Avoirs",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Facturé par mois",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Montant en retard",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Encaissé",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Factures impayées",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Montant impayé"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/hi.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "जमा राशि",
     "Invoicing.Columns.AmountPaid": "भुगतान राशि",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "भुगतान किए गए चालान",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "कुल वसूली",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "अवैतनिक चालान",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "अवैतनिक चालानों का कुल"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "अवैतनिक चालानों का कुल",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/it.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Importo accreditato",
     "Invoicing.Columns.AmountPaid": "Importo pagato",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Fatture pagate",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totale incassato",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Fatture non pagate",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totale delle fatture non pagate"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totale delle fatture non pagate",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/ja.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "クレジット金額",
     "Invoicing.Columns.AmountPaid": "支払済金額",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "支払い済みの請求書",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "回収総額",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未払い請求書",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未払い請求書の合計"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未払い請求書の合計",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/ko.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "대변 금액",
     "Invoicing.Columns.AmountPaid": "지급 금액",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "지불된 청구서",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "총 수금액",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "미지급 청구서",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "미지급 청구서 합계"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "미지급 청구서 합계",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/nl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Gecrediteerd bedrag",
     "Invoicing.Columns.AmountPaid": "Betaald bedrag",
     "Invoicing.Columns.AmountRemaining": "Resterend bedrag",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Betaalde facturen",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totaal geïnd",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Onbetaalde facturen",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totaal van onbetaalde facturen"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totaal van onbetaalde facturen",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/pl.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Kwota skorygowana",
     "Invoicing.Columns.AmountPaid": "Kwota zapłacona",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Opłacone faktury",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Łączna kwota pobrana",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Niezapłacone faktury",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Suma niezapłaconych faktur"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Suma niezapłaconych faktur",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/pt.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Valor creditado",
     "Invoicing.Columns.AmountPaid": "Valor pago",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Faturas pagas",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Total recebido",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Faturas por pagar",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total das faturas por pagar"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Total das faturas por pagar",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/sv.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "Krediterat belopp",
     "Invoicing.Columns.AmountPaid": "Betalt belopp",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Betalda fakturor",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Totalt inkasserat",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Obetalda fakturor",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totalsumma obetalda fakturor"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Totalsumma obetalda fakturor",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/tr.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "İade edilen tutar",
     "Invoicing.Columns.AmountPaid": "Ödenen tutar",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "Ödenen faturalar",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "Tahsil edilen toplam",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "Ödenmemiş faturalar",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Ödenmemiş faturaların toplamı"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "Ödenmemiş faturaların toplamı",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Invoicing/Localization/Invoicing/zh.json
+++ b/src/Granit.Invoicing/Localization/Invoicing/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Dashboard:Granit.Invoicing.FinanceOverview": "Finance overview",
     "Invoicing.Columns.AmountCredited": "已贷记金额",
     "Invoicing.Columns.AmountPaid": "已付金额",
     "Invoicing.Columns.AmountRemaining": "Amount Remaining",
@@ -32,6 +33,13 @@
     "Metric:Granit.Invoicing.PaidInvoiceCountMetric": "已支付发票",
     "Metric:Granit.Invoicing.PaidInvoiceTotalMetric": "已收款总额",
     "Metric:Granit.Invoicing.UnpaidInvoiceCountMetric": "未付款发票",
-    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未付款发票总额"
+    "Metric:Granit.Invoicing.UnpaidInvoiceTotalMetric": "未付款发票总额",
+    "Widget:Granit.Invoicing.FinanceOverview.banner.Body": "## Finance overview\nLive snapshot of your invoicing health: cash you're owed, cash you've collected, and what's overdue.",
+    "Widget:Granit.Invoicing.FinanceOverview.credit-note-total": "Credit notes",
+    "Widget:Granit.Invoicing.FinanceOverview.issued-by-month": "Issued by month",
+    "Widget:Granit.Invoicing.FinanceOverview.overdue-total": "Overdue amount",
+    "Widget:Granit.Invoicing.FinanceOverview.paid-total": "Collected",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-count": "Unpaid invoices",
+    "Widget:Granit.Invoicing.FinanceOverview.unpaid-total": "Unpaid amount"
   }
 }

--- a/src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs
+++ b/src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs
@@ -1,0 +1,59 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Subscriptions.Dashboards;
+
+/// <summary>
+/// Subscriptions health dashboard — KPIs for active / trial / past-due /
+/// dunning subscriptions plus a chart of cancellations over time. First-wave
+/// reference for the <see cref="DashboardDefinition"/> pattern in the
+/// Subscriptions module.
+/// </summary>
+public sealed class SubscriptionsHealthDashboardDefinition : DashboardDefinition
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.SubscriptionsHealth";
+
+    /// <inheritdoc />
+    public override DashboardCategory Category => DashboardCategory.Finance;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+    [
+        new MarkdownWidgetDefinition(
+            Slug: "banner",
+            ContentLocalizationKey: "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body",
+            Position: 0),
+
+        new KpiWidgetDefinition(
+            Slug: "active-count",
+            Datasource: Datasource.Metric("Granit.Subscriptions.ActiveSubscriptionCountMetric"),
+            Position: 1),
+
+        new KpiWidgetDefinition(
+            Slug: "trial-count",
+            Datasource: Datasource.Metric("Granit.Subscriptions.TrialSubscriptionCountMetric"),
+            Position: 2),
+
+        new KpiWidgetDefinition(
+            Slug: "past-due-count",
+            Datasource: Datasource.Metric("Granit.Subscriptions.PastDueSubscriptionCountMetric"),
+            Position: 3),
+
+        new KpiWidgetDefinition(
+            Slug: "dunning-count",
+            Datasource: Datasource.Metric("Granit.Subscriptions.DunningSubscriptionCountMetric"),
+            Position: 4),
+
+        new ChartWidgetDefinition(
+            Slug: "cancellations-over-time",
+            QueryName: "Granit.Subscriptions.SubscriptionsQuery",
+            GroupBy: "CancelledAt",
+            Aggregation: AggregateFunction.Count,
+            Field: null,
+            ChartType: ChartType.Line,
+            Position: 5),
+    ];
+}

--- a/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
@@ -1,8 +1,10 @@
 using Granit.Analytics.Extensions;
+using Granit.Dashboards.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Metering;
 using Granit.QueryEngine.Extensions;
+using Granit.Subscriptions.Dashboards;
 using Granit.Subscriptions.Definitions;
 using Granit.Subscriptions.Diagnostics;
 using Granit.Subscriptions.Domain;
@@ -62,6 +64,8 @@ public static class SubscriptionsHostApplicationBuilderExtensions
         builder.Services.AddMetricDefinition<Subscription, int, CancelAtPeriodEndSubscriptionCountMetricDefinition>();
         builder.Services.AddMetricDefinition<Plan, int, ActivePlanCountMetricDefinition>();
         builder.Services.AddMetricDefinition<PlanPrice, int, ActivePlanPriceCountMetricDefinition>();
+
+        builder.Services.AddDashboardDefinition<SubscriptionsHealthDashboardDefinition>();
 
         return builder;
     }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktivní plány",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktivní ceny plánů",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktivní předplatná",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Cena plánu",
     "Subscriptions.Columns.Status": "Stav",
     "Subscriptions.Columns.Tenant": "Nájemce",
-    "Subscriptions.Columns.TrialEndsAt": "Konec zkušebního období"
+    "Subscriptions.Columns.TrialEndsAt": "Konec zkušebního období",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/de.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktive Pläne",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktive Planpreise",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktive Abonnements",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Planpreis",
     "Subscriptions.Columns.Status": "Status",
     "Subscriptions.Columns.Tenant": "Mandant",
-    "Subscriptions.Columns.TrialEndsAt": "Testphase endet am"
+    "Subscriptions.Columns.TrialEndsAt": "Testphase endet am",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/en.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Active plans",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Active plan prices",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Active subscriptions",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Plan Price",
     "Subscriptions.Columns.Status": "Status",
     "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/es.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planes activos",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Precios de plan activos",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Suscripciones activas",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Precio del plan",
     "Subscriptions.Columns.Status": "Estado",
     "Subscriptions.Columns.Tenant": "Inquilino",
-    "Subscriptions.Columns.TrialEndsAt": "Fin de la prueba"
+    "Subscriptions.Columns.TrialEndsAt": "Fin de la prueba",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Santé des abonnements",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Plans actifs",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Tarifs de plan actifs",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abonnements actifs",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Tarif du plan",
     "Subscriptions.Columns.Status": "Statut",
     "Subscriptions.Columns.Tenant": "Locataire",
-    "Subscriptions.Columns.TrialEndsAt": "Fin de l'essai"
+    "Subscriptions.Columns.TrialEndsAt": "Fin de l'essai",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Abonnements actifs",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Santé des abonnements\nAbonnés actifs, essais en cours, charge de relance et signaux de churn d'un coup d'œil.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Annulations au fil du temps",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "En relance",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "En retard de paiement",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Abonnements en essai"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "सक्रिय योजनाएँ",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "सक्रिय योजना मूल्य",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "सक्रिय सदस्यताएँ",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "योजना मूल्य",
     "Subscriptions.Columns.Status": "स्थिति",
     "Subscriptions.Columns.Tenant": "किरायेदार",
-    "Subscriptions.Columns.TrialEndsAt": "परीक्षण समाप्ति तिथि"
+    "Subscriptions.Columns.TrialEndsAt": "परीक्षण समाप्ति तिथि",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/it.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Piani attivi",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Prezzi di piano attivi",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abbonamenti attivi",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Prezzo del piano",
     "Subscriptions.Columns.Status": "Stato",
     "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.TrialEndsAt": "Fine prova"
+    "Subscriptions.Columns.TrialEndsAt": "Fine prova",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "有効なプラン",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "有効なプラン価格",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "有効なサブスクリプション",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "プラン価格",
     "Subscriptions.Columns.Status": "ステータス",
     "Subscriptions.Columns.Tenant": "テナント",
-    "Subscriptions.Columns.TrialEndsAt": "トライアル終了日"
+    "Subscriptions.Columns.TrialEndsAt": "トライアル終了日",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "활성 플랜",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "활성 플랜 가격",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "활성 구독",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "플랜 가격",
     "Subscriptions.Columns.Status": "상태",
     "Subscriptions.Columns.Tenant": "테넌트",
-    "Subscriptions.Columns.TrialEndsAt": "체험 종료일"
+    "Subscriptions.Columns.TrialEndsAt": "체험 종료일",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Actieve plannen",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Actieve planprijzen",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Actieve abonnementen",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Planprijs",
     "Subscriptions.Columns.Status": "Status",
     "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.TrialEndsAt": "Proefperiode eindigt op"
+    "Subscriptions.Columns.TrialEndsAt": "Proefperiode eindigt op",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktywne plany",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktywne ceny planów",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktywne subskrypcje",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Cena planu",
     "Subscriptions.Columns.Status": "Status",
     "Subscriptions.Columns.Tenant": "Najemca",
-    "Subscriptions.Columns.TrialEndsAt": "Koniec okresu próbnego"
+    "Subscriptions.Columns.TrialEndsAt": "Koniec okresu próbnego",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planos ativos",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Preços de plano ativos",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Assinaturas ativas",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Preço do plano",
     "Subscriptions.Columns.Status": "Estado",
     "Subscriptions.Columns.Tenant": "Inquilino",
-    "Subscriptions.Columns.TrialEndsAt": "Fim do período de teste"
+    "Subscriptions.Columns.TrialEndsAt": "Fim do período de teste",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktiva planer",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktiva planpriser",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktiva prenumerationer",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Planpris",
     "Subscriptions.Columns.Status": "Status",
     "Subscriptions.Columns.Tenant": "Hyresgäst",
-    "Subscriptions.Columns.TrialEndsAt": "Provperiod slutar"
+    "Subscriptions.Columns.TrialEndsAt": "Provperiod slutar",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktif planlar",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktif plan fiyatları",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktif abonelikler",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "Plan fiyatı",
     "Subscriptions.Columns.Status": "Durum",
     "Subscriptions.Columns.Tenant": "Kiracı",
-    "Subscriptions.Columns.TrialEndsAt": "Deneme bitiş tarihi"
+    "Subscriptions.Columns.TrialEndsAt": "Deneme bitiş tarihi",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Dashboard:Granit.Subscriptions.SubscriptionsHealth": "Subscriptions health",
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "活跃计划",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "活跃套餐价格",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "活跃订阅",
@@ -24,6 +25,12 @@
     "Subscriptions.Columns.PlanPrice": "套餐价格",
     "Subscriptions.Columns.Status": "状态",
     "Subscriptions.Columns.Tenant": "租户",
-    "Subscriptions.Columns.TrialEndsAt": "试用结束时间"
+    "Subscriptions.Columns.TrialEndsAt": "试用结束时间",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }
 }

--- a/src/Granit.Webhooks/Dashboards/WebhookReliabilityDashboardDefinition.cs
+++ b/src/Granit.Webhooks/Dashboards/WebhookReliabilityDashboardDefinition.cs
@@ -1,0 +1,59 @@
+using Granit.Analytics.Dashboards.Widgets;
+using Granit.Dashboards;
+using Granit.Dashboards.Widgets;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Webhooks.Dashboards;
+
+/// <summary>
+/// Webhook reliability dashboard — active subscriptions, success rate, average
+/// delivery latency, plus a chart of failed deliveries over time. First-wave
+/// reference for the <see cref="DashboardDefinition"/> pattern in the Webhooks
+/// module.
+/// </summary>
+public sealed class WebhookReliabilityDashboardDefinition : DashboardDefinition
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Webhooks.WebhookReliability";
+
+    /// <inheritdoc />
+    public override DashboardCategory Category => DashboardCategory.Operations;
+
+    /// <inheritdoc />
+    public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
+    [
+        new MarkdownWidgetDefinition(
+            Slug: "banner",
+            ContentLocalizationKey: "Widget:Granit.Webhooks.WebhookReliability.banner.Body",
+            Position: 0),
+
+        new KpiWidgetDefinition(
+            Slug: "active-subscriptions",
+            Datasource: Datasource.Metric("Granit.Webhooks.ActiveWebhookSubscriptionCountMetric"),
+            Position: 1),
+
+        new KpiWidgetDefinition(
+            Slug: "success-rate",
+            Datasource: Datasource.Metric("Granit.Webhooks.WebhookDeliverySuccessRateMetric"),
+            Position: 2),
+
+        new KpiWidgetDefinition(
+            Slug: "latency-average",
+            Datasource: Datasource.Metric("Granit.Webhooks.WebhookDeliveryLatencyAverageMetric"),
+            Position: 3),
+
+        new KpiWidgetDefinition(
+            Slug: "failed-count",
+            Datasource: Datasource.Metric("Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric"),
+            Position: 4),
+
+        new ChartWidgetDefinition(
+            Slug: "failures-over-time",
+            QueryName: "Granit.Webhooks.DeliveryAttemptsQuery",
+            GroupBy: "OccurredAt",
+            Aggregation: AggregateFunction.Count,
+            Field: null,
+            ChartType: ChartType.Line,
+            Position: 5),
+    ];
+}

--- a/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
@@ -1,10 +1,12 @@
 using System.Threading.Channels;
 using Granit.Analytics.Extensions;
+using Granit.Dashboards.Extensions;
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
 using Granit.Http.Resilience.Extensions;
 using Granit.QueryEngine.Extensions;
 using Granit.Webhooks.Abstractions;
+using Granit.Webhooks.Dashboards;
 using Granit.Webhooks.Definitions;
 using Granit.Webhooks.Diagnostics;
 using Granit.Webhooks.Domain;
@@ -125,6 +127,8 @@ public static class WebhooksHostApplicationBuilderExtensions
         builder.Services.AddMetricDefinition<WebhookDeliveryAttempt, int, FailedWebhookDeliveryAttemptCountMetricDefinition>();
         builder.Services.AddMetricDefinition<WebhookDeliveryAttempt, double, WebhookDeliverySuccessRateMetricDefinition>();
         builder.Services.AddMetricDefinition<WebhookDeliveryAttempt, double, WebhookDeliveryLatencyAverageMetricDefinition>();
+
+        builder.Services.AddDashboardDefinition<WebhookReliabilityDashboardDefinition>();
 
         return builder;
     }

--- a/src/Granit.Webhooks/Localization/Webhooks/cs.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Aktivní odběry webhooků",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Neúspěšné doručení webhooku",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Latence webhooku (průměr ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/de.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Aktive Webhook-Abonnements",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Fehlgeschlagene Webhook-Zustellungen",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook-Latenz (Ø ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Pausiert am",
     "Webhooks.Columns.SuspendedBy": "Pausiert von",
     "Webhooks.Columns.TargetUrl": "Ziel-URL",
-    "Webhooks.Columns.Tenant": "Mandant"
+    "Webhooks.Columns.Tenant": "Mandant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/en.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Active webhook subscriptions",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Failed webhook deliveries",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook delivery latency (avg ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/es.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Suscripciones webhook activas",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Entregas webhook fallidas",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Latencia de webhook (media ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspendido el",
     "Webhooks.Columns.SuspendedBy": "Suspendido por",
     "Webhooks.Columns.TargetUrl": "URL de destino",
-    "Webhooks.Columns.Tenant": "Inquilino"
+    "Webhooks.Columns.Tenant": "Inquilino",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/fr.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Fiabilité des webhooks",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Abonnements webhook actifs",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Livraisons webhook échouées",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Latence webhook (moyenne ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspendu le",
     "Webhooks.Columns.SuspendedBy": "Suspendu par",
     "Webhooks.Columns.TargetUrl": "URL cible",
-    "Webhooks.Columns.Tenant": "Locataire"
+    "Webhooks.Columns.Tenant": "Locataire",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Abonnements actifs",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Fiabilité des webhooks\nAbonnements actifs, taux de réussite, latence et incidents récents.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Livraisons échouées",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Incidents au fil du temps",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latence (moy. ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Taux de réussite"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/hi.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "सक्रिय वेबहुक सदस्यताएँ",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "विफल वेबहुक डिलिवरी",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "वेबहुक विलंबता (औसत ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/it.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Sottoscrizioni webhook attive",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Consegne webhook fallite",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Latenza webhook (media ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/ja.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "有効な Webhook 購読",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "失敗した Webhook 送信",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook レイテンシ（平均ミリ秒）",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/ko.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "활성 Webhook 구독",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "실패한 Webhook 전송",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook 지연시간 (평균 ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/nl.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Actieve webhook-abonnementen",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Mislukte webhook-leveringen",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook-latentie (gem. ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Opgeschort op",
     "Webhooks.Columns.SuspendedBy": "Opgeschort door",
     "Webhooks.Columns.TargetUrl": "Doel-URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/pl.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Aktywne subskrypcje webhook",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Nieudane dostawy webhooków",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Opóźnienie webhooków (średnia ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/pt.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Subscrições de webhook ativas",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Entregas de webhook com falha",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Latência de webhook (média ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/sv.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Aktiva webhook-prenumerationer",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Misslyckade webhook-leveranser",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook-latens (genomsnitt ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/tr.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "Aktif webhook abonelikleri",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "Başarısız webhook teslimatları",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook gecikmesi (ort. ms)",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }

--- a/src/Granit.Webhooks/Localization/Webhooks/zh.json
+++ b/src/Granit.Webhooks/Localization/Webhooks/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Dashboard:Granit.Webhooks.WebhookReliability": "Webhook reliability",
     "Metric:Granit.Webhooks.ActiveWebhookSubscriptionCountMetric": "活跃 Webhook 订阅",
     "Metric:Granit.Webhooks.FailedWebhookDeliveryAttemptCountMetric": "失败的 Webhook 投递",
     "Metric:Granit.Webhooks.WebhookDeliveryLatencyAverageMetric": "Webhook 延迟（平均毫秒）",
@@ -18,6 +19,12 @@
     "Webhooks.Columns.SuspendedAt": "Suspended At",
     "Webhooks.Columns.SuspendedBy": "Suspended By",
     "Webhooks.Columns.TargetUrl": "Target URL",
-    "Webhooks.Columns.Tenant": "Tenant"
+    "Webhooks.Columns.Tenant": "Tenant",
+    "Widget:Granit.Webhooks.WebhookReliability.active-subscriptions": "Active subscriptions",
+    "Widget:Granit.Webhooks.WebhookReliability.banner.Body": "## Webhook reliability\nActive subscriptions, delivery success rate, latency, and recent failures.",
+    "Widget:Granit.Webhooks.WebhookReliability.failed-count": "Failed deliveries",
+    "Widget:Granit.Webhooks.WebhookReliability.failures-over-time": "Failures over time",
+    "Widget:Granit.Webhooks.WebhookReliability.latency-average": "Latency (avg ms)",
+    "Widget:Granit.Webhooks.WebhookReliability.success-rate": "Success rate"
   }
 }


### PR DESCRIPTION
## Summary

Demonstrates the `DashboardDefinition` pattern (ADR-038 / story B1 #1382) end-to-end now that P1 / P2 / P3 (#1598 / #1600 / #1601) and the metric backlog rollout are all shipped. Four reference dashboards, each registered via `AddDashboardDefinition<T>()` in its owning module's host-application-builder extension. Tenant admins import them via `POST /dashboards/from-definition/{name}`.

| Module | Dashboard | KPIs | Charts |
| ------ | --------- | ---- | ------ |
| `Granit.Invoicing` | `InvoicingFinanceOverviewDashboardDefinition` | 5 (unpaid count + total, overdue total, paid total, credit-notes total) | Bar of issued-by-month |
| `Granit.Subscriptions` | `SubscriptionsHealthDashboardDefinition` | 4 (active, trial, past-due, dunning) | Line of cancellations-over-time |
| `Granit.BlobStorage` | `BlobStorageOperationsDashboardDefinition` | 3 (valid blobs, total storage, orphans) | Bar of uploads-by-day |
| `Granit.Webhooks` | `WebhookReliabilityDashboardDefinition` | 4 (active subs, success rate, latency avg, failed count) | Line of failures-over-time |

Each dashboard ships a markdown banner above the grid for context.

## Localisation

D2 #1397 (`DashboardLocalizationCompletenessTests`) requires `Dashboard:{Name}` and `Widget:{Name}.{Slug}` keys in all 15 base cultures. EN + FR carry curated strings; the other 13 cultures fall back to the EN string at the JSON level — same posture as the auto-translated notification templates (per CLAUDE.md). Hosts override via `Granit.Localization.Overrides` for production-grade translations.

## Wiring

- `<ProjectReference Include="..\Granit.Dashboards\..." />` already reachable transitively via `Granit.Analytics` — no csproj changes needed.
- `using Granit.Dashboards.Extensions;` + `AddDashboardDefinition<T>()` call added to each module's existing `AddGranit{Module}()` extension or `ConfigureServices` override.

## Architecture-test impact

- `DashboardLocalizationCompletenessTests` (D2 #1397) — satisfied for all 4 dashboards × all 15 base cultures.
- `DashboardWidgetReferenceTests` (B1 #1382) — every widget reference resolves to a registered `MetricDefinition` (KPI) or `QueryDefinition` (Chart). Caught two stale query-name guesses during local validation (`BlobDescriptorQuery` → `BlobDescriptorsQuery`, `WebhookDeliveryAttemptQuery` → `DeliveryAttemptsQuery`) — corrected before push.
- All 197 archi tests green.

## Test plan

- [x] `dotnet build` clean for all 4 modules.
- [x] `dotnet format --verify-no-changes` clean for all 4 modules.
- [x] `dotnet test` clean for all 4 module-test projects (Invoicing 57 / Subscriptions 151 / BlobStorage 130 / Webhooks 197).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **197 passing**.

## Frontend impact

The dashboard catalogue endpoint (`GET /dashboards/definitions`) now lists 4 reference dashboards out of the box. The `<EditableDashboard>` composer in the showcase can preview them via the per-widget render endpoints (P3 #1601). Hosts that want them in production call `POST /dashboards/from-definition/Granit.Invoicing.FinanceOverview` (etc.) at admin import time.

## Follow-ups

- **MRR / ARR** still pending — when shipped, the `SubscriptionsHealthDashboardDefinition` will get a Version bump to 1.1.0 to add them.
- **Curated translations** for the 13 non-EN/FR cultures — same approach as the notification templates (`scripts/translate-templates.py` follow-up story).
- **Drift detection** (ADR-038 §3) — once defined, will surface the Version skew to admins post-import.