### PR TITLE
feat(analytics): JoinedMetricDefinition + MRR / ARR canonical SaaS metrics

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4574,6 +4574,22 @@
       ]
     },
     {
+      "name": "IJoinedMetricProjector",
+      "fqn": "Granit.Analytics.Metrics.IJoinedMetricProjector",
+      "kind": "interface",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Metrics/JoinedMetricDefinition.cs",
+      "line": 103,
+      "members": [
+        {
+          "name": "ProjectFromServiceProvider",
+          "kind": "method",
+          "signature": "ProjectFromServiceProvider(IQueryable<TEntity> filteredSource, IServiceProvider serviceProvider)",
+          "returnType": "IQueryable<TValue?>"
+        }
+      ]
+    },
+    {
       "name": "IMetricDefinitionDescriptor",
       "fqn": "Granit.Analytics.Metrics.IMetricDefinitionDescriptor",
       "kind": "interface",
@@ -4595,6 +4611,28 @@
           "kind": "method",
           "signature": "ExecuteAsync(MetricDefinition<TEntity, TValue> metric, IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
           "returnType": "Task<TValue?>"
+        }
+      ]
+    },
+    {
+      "name": "JoinedMetricDefinition",
+      "fqn": "Granit.Analytics.Metrics.JoinedMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Analytics",
+      "file": "src/Granit.Analytics/Metrics/JoinedMetricDefinition.cs",
+      "line": 37,
+      "members": [
+        {
+          "name": "Project",
+          "kind": "method",
+          "signature": "Project(IQueryable<TEntity> filteredSource, IQueryable<TJoined> joinedSource)",
+          "returnType": "IQueryable<TValue?>"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "sealed Expression<Func<TEntity, TValue?>>? Selector",
+          "returnType": "sealed Expression<Func<TEntity, TValue?>>?"
         }
       ]
     },
@@ -47820,7 +47858,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "Name",
@@ -47833,6 +47871,12 @@
           "kind": "property",
           "signature": "DashboardCategory Category",
           "returnType": "DashboardCategory"
+        },
+        {
+          "name": "Version",
+          "kind": "property",
+          "signature": "string Version",
+          "returnType": "string"
         },
         {
           "name": "MarkdownWidgetDefinition",
@@ -49386,6 +49430,52 @@
       ]
     },
     {
+      "name": "AnnualRecurringRevenueMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.AnnualRecurringRevenueMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/AnnualRecurringRevenueMetricDefinition.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "System.Linq.Expressions.Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "System.Linq.Expressions.Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "Project",
+          "kind": "method",
+          "signature": "Project(IQueryable<Subscription> filteredSource, IQueryable<PlanPrice> joinedSource)",
+          "returnType": "IQueryable<decimal?>"
+        }
+      ]
+    },
+    {
       "name": "CancelAtPeriodEndSubscriptionCountMetricDefinition",
       "fqn": "Granit.Subscriptions.Metrics.CancelAtPeriodEndSubscriptionCountMetricDefinition",
       "kind": "class",
@@ -49538,6 +49628,52 @@
           "kind": "property",
           "signature": "bool IsHigherBetter",
           "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "MonthlyRecurringRevenueMetricDefinition",
+      "fqn": "Granit.Subscriptions.Metrics.MonthlyRecurringRevenueMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Metrics/MonthlyRecurringRevenueMetricDefinition.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "System.Linq.Expressions.Expression<Func<Subscription, bool>>? BaseFilter",
+          "returnType": "System.Linq.Expressions.Expression<Func<Subscription, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector",
+          "returnType": "System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>?"
+        },
+        {
+          "name": "Project",
+          "kind": "method",
+          "signature": "Project(IQueryable<Subscription> filteredSource, IQueryable<PlanPrice> joinedSource)",
+          "returnType": "IQueryable<decimal?>"
         }
       ]
     },

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
@@ -26,11 +26,13 @@ namespace Granit.Analytics.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class MetricExecutor<TEntity, TValue>(
     IQueryEngine<TEntity> queryEngine,
+    IServiceProvider? serviceProvider = null,
     AnalyticsMetrics? metrics = null,
     ICurrentTenant? currentTenant = null) : IMetricExecutor<TEntity, TValue>
     where TEntity : class
     where TValue : struct
 {
+    private readonly IServiceProvider? _serviceProvider = serviceProvider;
     public async Task<TValue?> ExecuteAsync(
         MetricDefinition<TEntity, TValue> metric,
         IQueryable<TEntity> source,
@@ -57,19 +59,108 @@ internal sealed class MetricExecutor<TEntity, TValue>(
             filtered = filtered.Where(metric.BaseFilter);
         }
 
-        TValue? result = metric.Aggregation switch
+        // Joined-metric dispatch — metrics deriving from JoinedMetricDefinition<,,>
+        // surface IJoinedMetricProjector<TEntity, TValue>. The executor resolves the
+        // joined source from DI via the metric's Project method, then aggregates the
+        // resulting IQueryable<TValue?> with the same per-type EF Core dispatch and
+        // empty-set semantics as the single-table path. Count is unsupported because
+        // the projection is the unit of aggregation — counting joined rows requires
+        // a regular MetricDefinition.
+        TValue? result;
+        if (metric is IJoinedMetricProjector<TEntity, TValue> projector)
         {
-            AggregateFunction.Count => await ExecuteCountAsync(filtered, cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Sum => await ExecuteSumAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Avg => await ExecuteAvgAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Min => await ExecuteMinAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
-            AggregateFunction.Max => await ExecuteMaxAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
-            _ => throw new NotSupportedException(
-                FormattableString.Invariant($"Aggregation '{metric.Aggregation}' is not supported.")),
-        };
+            if (_serviceProvider is null)
+            {
+                throw new InvalidOperationException(
+                    FormattableString.Invariant(
+                        $"Joined metric '{metric.Name}' requires the MetricExecutor to be constructed with an IServiceProvider so the joined source can be resolved at request time. The DI registration in AddGranitAnalyticsEntityFrameworkCore() supplies one automatically; tests that build the executor directly must pass an IServiceProvider too."));
+            }
+
+            IQueryable<TValue?> projection = projector.ProjectFromServiceProvider(filtered, _serviceProvider);
+            result = metric.Aggregation switch
+            {
+                AggregateFunction.Sum => await SumProjectionAsync(projection, cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Avg => await AvgProjectionAsync(projection, cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Min => await projection.MinAsync(cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Max => await projection.MaxAsync(cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Count => throw new NotSupportedException(
+                    FormattableString.Invariant(
+                        $"Joined metric '{metric.Name}' uses Aggregation = Count, which is not supported on JoinedMetricDefinition. ")
+                    + "Counting joined rows is meaningful as a regular MetricDefinition over the base entity instead."),
+                _ => throw new NotSupportedException(
+                    FormattableString.Invariant($"Aggregation '{metric.Aggregation}' is not supported.")),
+            };
+        }
+        else
+        {
+            result = metric.Aggregation switch
+            {
+                AggregateFunction.Count => await ExecuteCountAsync(filtered, cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Sum => await ExecuteSumAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Avg => await ExecuteAvgAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Min => await ExecuteMinAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
+                AggregateFunction.Max => await ExecuteMaxAsync(filtered, RequireSelector(metric), cancellationToken).ConfigureAwait(false),
+                _ => throw new NotSupportedException(
+                    FormattableString.Invariant($"Aggregation '{metric.Aggregation}' is not supported.")),
+            };
+        }
 
         RecordMetrics(metric, result.HasValue, Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds);
         return result;
+    }
+
+    private static async Task<TValue?> SumProjectionAsync(IQueryable<TValue?> projection, CancellationToken ct)
+    {
+        // Sum semantics on the projected IQueryable<TValue?> — same per-type dispatch
+        // and empty-set defaults as the single-table path.
+        if (typeof(TValue) == typeof(decimal))
+        {
+            decimal? r = await projection.Cast<decimal?>().SumAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)(r ?? 0m);
+        }
+        if (typeof(TValue) == typeof(int))
+        {
+            int? r = await projection.Cast<int?>().SumAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)(r ?? 0);
+        }
+        if (typeof(TValue) == typeof(long))
+        {
+            long? r = await projection.Cast<long?>().SumAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)(r ?? 0L);
+        }
+        if (typeof(TValue) == typeof(double))
+        {
+            double? r = await projection.Cast<double?>().SumAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)(r ?? 0.0);
+        }
+        throw NotSupported(nameof(AggregateFunction.Sum));
+    }
+
+    private static async Task<TValue?> AvgProjectionAsync(IQueryable<TValue?> projection, CancellationToken ct)
+    {
+        // Avg over a projected IQueryable<TValue?> — empty-set returns null per
+        // the framework contract.
+        if (typeof(TValue) == typeof(decimal))
+        {
+            decimal? r = await projection.Cast<decimal?>().AverageAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)r;
+        }
+        if (typeof(TValue) == typeof(int))
+        {
+            double? r = await projection.Cast<int?>().AverageAsync(ct).ConfigureAwait(false);
+            return r.HasValue ? (TValue?)(object?)(int)Math.Round(r.Value) : null;
+        }
+        if (typeof(TValue) == typeof(long))
+        {
+            double? r = await projection.Cast<long?>().AverageAsync(ct).ConfigureAwait(false);
+            return r.HasValue ? (TValue?)(object?)(long)Math.Round(r.Value) : null;
+        }
+        if (typeof(TValue) == typeof(double))
+        {
+            double? r = await projection.Cast<double?>().AverageAsync(ct).ConfigureAwait(false);
+            return (TValue?)(object?)r;
+        }
+        throw NotSupported(nameof(AggregateFunction.Avg));
     }
 
     private static Expression<Func<TEntity, TValue?>> RequireSelector(MetricDefinition<TEntity, TValue> metric) =>

--- a/src/Granit.Analytics/Metrics/JoinedMetricDefinition.cs
+++ b/src/Granit.Analytics/Metrics/JoinedMetricDefinition.cs
@@ -1,0 +1,114 @@
+using System.Linq.Expressions;
+using Granit.QueryEngine;
+
+namespace Granit.Analytics.Metrics;
+
+/// <summary>
+/// Specialised <see cref="MetricDefinition{TEntity, TValue}"/> that aggregates
+/// over a projection involving a JOIN to a second entity type
+/// <typeparamref name="TJoined"/>. Use this when the value being aggregated is
+/// not a column on <typeparamref name="TEntity"/> but is computed from a
+/// related row — e.g. SaaS Monthly Recurring Revenue, where each
+/// <c>Subscription</c>'s monthly contribution is derived from its bound
+/// <c>PlanPrice.Amount</c> + <c>PlanPrice.Interval</c>.
+/// </summary>
+/// <typeparam name="TEntity">The base entity the metric scopes against (filtered by <c>BaseFilter</c>, <c>QueryEngine</c> pipeline, multi-tenant + soft-delete).</typeparam>
+/// <typeparam name="TJoined">The joined entity providing the projected value(s).</typeparam>
+/// <typeparam name="TValue">Aggregation result type.</typeparam>
+/// <remarks>
+/// <para>
+/// The framework's <c>MetricExecutor</c> detects subclasses through the
+/// <see cref="IJoinedMetricProjector{TEntity, TValue}"/> marker interface,
+/// resolves an <see cref="IQueryableSource{T}"/> for <typeparamref name="TJoined"/>
+/// at request time, and calls <see cref="Project"/> to obtain the projected
+/// <see cref="IQueryable{T}"/>. The aggregation step (<c>Sum</c> /
+/// <c>Avg</c> / <c>Min</c> / <c>Max</c>) then runs on the projection — same
+/// per-type EF Core dispatch and same empty-set semantics as the single-table
+/// path (story A3 #1374).
+/// </para>
+/// <para>
+/// <see cref="MetricDefinition{TEntity, TValue}.Selector"/> is unused for
+/// joined metrics — <see cref="Project"/> takes its place. <c>Aggregation</c>
+/// = <see cref="Granit.QueryEngine.Filtering.AggregateFunction.Count"/> is
+/// also unsupported (count doesn't need a join — use a regular
+/// <see cref="MetricDefinition{TEntity, TValue}"/> instead).
+/// </para>
+/// </remarks>
+public abstract class JoinedMetricDefinition<TEntity, TJoined, TValue>
+    : MetricDefinition<TEntity, TValue>, IJoinedMetricProjector<TEntity, TValue>
+    where TEntity : class
+    where TJoined : class
+    where TValue : struct
+{
+    /// <summary>
+    /// Build the projected <see cref="IQueryable{T}"/> from the filtered
+    /// <typeparamref name="TEntity"/> source (after <c>BaseFilter</c> + the
+    /// QueryEngine pipeline) and the <typeparamref name="TJoined"/> source
+    /// (DI-resolved <see cref="IQueryableSource{T}"/>). The author writes the
+    /// LINQ join + projection here; the framework runs the aggregation on the
+    /// resulting <see cref="IQueryable{T}"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public override IQueryable&lt;decimal?&gt; Project(IQueryable&lt;Subscription&gt; source, IQueryable&lt;PlanPrice&gt; joined) =&gt;
+    ///     from s in source
+    ///     join p in joined on s.PlanPriceId equals p.Id
+    ///     select (decimal?)(p.Interval == BillingInterval.Yearly ? p.Amount / 12m
+    ///                     : p.Interval == BillingInterval.Quarterly ? p.Amount / 3m
+    ///                     : p.Amount);
+    /// </code>
+    /// </example>
+    public abstract IQueryable<TValue?> Project(
+        IQueryable<TEntity> filteredSource,
+        IQueryable<TJoined> joinedSource);
+
+    /// <summary>
+    /// Joined metrics drive aggregation through <see cref="Project"/>; the
+    /// <see cref="MetricDefinition{TEntity, TValue}.Selector"/> hook is unused
+    /// and sealed to <see langword="null"/> to prevent accidental override.
+    /// </summary>
+    public sealed override Expression<Func<TEntity, TValue?>>? Selector => null;
+
+    IQueryable<TValue?> IJoinedMetricProjector<TEntity, TValue>.ProjectFromServiceProvider(
+        IQueryable<TEntity> filteredSource,
+        IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(filteredSource);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        var joinedSource =
+            (IQueryableSource<TJoined>?)serviceProvider.GetService(typeof(IQueryableSource<TJoined>));
+        if (joinedSource is null)
+        {
+            throw new InvalidOperationException(
+                $"Joined metric '{Name}' requires an IQueryableSource<{typeof(TJoined).Name}> " +
+                "to be registered in DI — typically via the joined module's "
+                + "AddGranit{Module}EntityFrameworkCore() extension. Without it the executor "
+                + "cannot resolve the joined queryable.");
+        }
+
+        return Project(filteredSource, joinedSource.GetQueryable());
+    }
+}
+
+/// <summary>
+/// Type-erased projector surface for <see cref="JoinedMetricDefinition{TEntity, TJoined, TValue}"/>
+/// — lets the <c>MetricExecutor</c> drive the projection without statically
+/// knowing the joined entity type. Internal implementation detail; concrete
+/// metrics derive from <see cref="JoinedMetricDefinition{TEntity, TJoined, TValue}"/>
+/// directly and never implement this interface manually.
+/// </summary>
+/// <typeparam name="TEntity">The base entity type.</typeparam>
+/// <typeparam name="TValue">Aggregation result type.</typeparam>
+public interface IJoinedMetricProjector<TEntity, TValue>
+    where TEntity : class
+    where TValue : struct
+{
+    /// <summary>
+    /// Resolve the joined source from <paramref name="serviceProvider"/> and
+    /// invoke <see cref="JoinedMetricDefinition{TEntity, TJoined, TValue}.Project"/>.
+    /// </summary>
+    IQueryable<TValue?> ProjectFromServiceProvider(
+        IQueryable<TEntity> filteredSource,
+        IServiceProvider serviceProvider);
+}

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtens
         builder.Services.TryAddScoped<IPricingResolver, EfPricingResolver>();
 
         builder.Services.AddScoped<IQueryableSource<Subscription>, EfSubscriptionQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<PlanPrice>, EfPlanPriceQueryableSource>();
 
         // Plugs Subscriptions into the Party merge orchestrator. Unconditional registration:
         // when no IMergeService<Party> is wired up by the host (e.g. an app without merging),

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanPriceQueryableSource.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanPriceQueryableSource.cs
@@ -1,0 +1,40 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="PlanPrice"/>. Required by the joined MRR / ARR metrics
+/// (<c>JoinedMetricDefinition&lt;Subscription, PlanPrice, decimal&gt;</c>) so the
+/// <c>MetricExecutor</c> can resolve the joined queryable at request time.
+/// </summary>
+/// <remarks>
+/// Same lifecycle posture as <see cref="EfSubscriptionQueryableSource"/> — owns
+/// a per-instance <see cref="DbContext"/> from the factory and disposes it.
+/// When no tenant context is active (host admin), the multi-tenant query
+/// filter is disabled so all plan prices are returned cross-tenant.
+/// </remarks>
+internal sealed class EfPlanPriceQueryableSource(
+    IDbContextFactory<SubscriptionsDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IDataFilter dataFilter) : IQueryableSource<PlanPrice>, IDisposable
+{
+    private readonly SubscriptionsDbContext _context = contextFactory.CreateDbContext();
+    private readonly IDisposable? _tenantBypass = !currentTenant.IsAvailable
+        ? dataFilter.Disable<IMultiTenant>()
+        : null;
+
+    public IQueryable<PlanPrice> GetQueryable() =>
+        _context.Set<PlanPrice>().AsNoTracking();
+
+    public void Dispose()
+    {
+        _tenantBypass?.Dispose();
+        _context.Dispose();
+    }
+}

--- a/src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs
+++ b/src/Granit.Subscriptions/Dashboards/SubscriptionsHealthDashboardDefinition.cs
@@ -6,10 +6,11 @@ using Granit.QueryEngine.Filtering;
 namespace Granit.Subscriptions.Dashboards;
 
 /// <summary>
-/// Subscriptions health dashboard — KPIs for active / trial / past-due /
-/// dunning subscriptions plus a chart of cancellations over time. First-wave
-/// reference for the <see cref="DashboardDefinition"/> pattern in the
-/// Subscriptions module.
+/// Subscriptions health dashboard — top-row SaaS canonical measures
+/// (MRR / ARR), then operational status KPIs (active / trial / past-due /
+/// dunning), then a chart of cancellations over time. First-wave reference
+/// for the <see cref="DashboardDefinition"/> pattern in the Subscriptions
+/// module.
 /// </summary>
 public sealed class SubscriptionsHealthDashboardDefinition : DashboardDefinition
 {
@@ -20,6 +21,16 @@ public sealed class SubscriptionsHealthDashboardDefinition : DashboardDefinition
     public override DashboardCategory Category => DashboardCategory.Finance;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// 1.1.0 — added the MRR + ARR widgets at the top of the grid (existing
+    /// widgets shifted down). Tenants that imported v1.0.0 will see the
+    /// drift surfaced through ADR-038 §3 once that detection lands; for now
+    /// the gap is acceptable since the dashboard is shipped first-wave and
+    /// few hosts are running off it in production.
+    /// </remarks>
+    public override string Version => "1.1.0";
+
+    /// <inheritdoc />
     public override IReadOnlyList<WidgetDefinition> Widgets { get; } =
     [
         new MarkdownWidgetDefinition(
@@ -28,24 +39,34 @@ public sealed class SubscriptionsHealthDashboardDefinition : DashboardDefinition
             Position: 0),
 
         new KpiWidgetDefinition(
+            Slug: "mrr",
+            Datasource: Datasource.Metric("Granit.Subscriptions.MonthlyRecurringRevenueMetric"),
+            Position: 1),
+
+        new KpiWidgetDefinition(
+            Slug: "arr",
+            Datasource: Datasource.Metric("Granit.Subscriptions.AnnualRecurringRevenueMetric"),
+            Position: 2),
+
+        new KpiWidgetDefinition(
             Slug: "active-count",
             Datasource: Datasource.Metric("Granit.Subscriptions.ActiveSubscriptionCountMetric"),
-            Position: 1),
+            Position: 3),
 
         new KpiWidgetDefinition(
             Slug: "trial-count",
             Datasource: Datasource.Metric("Granit.Subscriptions.TrialSubscriptionCountMetric"),
-            Position: 2),
+            Position: 4),
 
         new KpiWidgetDefinition(
             Slug: "past-due-count",
             Datasource: Datasource.Metric("Granit.Subscriptions.PastDueSubscriptionCountMetric"),
-            Position: 3),
+            Position: 5),
 
         new KpiWidgetDefinition(
             Slug: "dunning-count",
             Datasource: Datasource.Metric("Granit.Subscriptions.DunningSubscriptionCountMetric"),
-            Position: 4),
+            Position: 6),
 
         new ChartWidgetDefinition(
             Slug: "cancellations-over-time",
@@ -54,6 +75,6 @@ public sealed class SubscriptionsHealthDashboardDefinition : DashboardDefinition
             Aggregation: AggregateFunction.Count,
             Field: null,
             ChartType: ChartType.Line,
-            Position: 5),
+            Position: 7),
     ];
 }

--- a/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
@@ -65,6 +65,14 @@ public static class SubscriptionsHostApplicationBuilderExtensions
         builder.Services.AddMetricDefinition<Plan, int, ActivePlanCountMetricDefinition>();
         builder.Services.AddMetricDefinition<PlanPrice, int, ActivePlanPriceCountMetricDefinition>();
 
+        // Joined metrics — MRR / ARR project across Subscription → PlanPrice via the
+        // JoinedMetricDefinition extension. The MetricExecutor resolves an
+        // IQueryableSource<PlanPrice> from DI at request time; that source is wired
+        // by the EFC adapter, so a host using only the in-memory provider gets a
+        // clear startup-time error rather than a silent fallback.
+        builder.Services.AddMetricDefinition<Subscription, decimal, MonthlyRecurringRevenueMetricDefinition>();
+        builder.Services.AddMetricDefinition<Subscription, decimal, AnnualRecurringRevenueMetricDefinition>();
+
         builder.Services.AddDashboardDefinition<SubscriptionsHealthDashboardDefinition>();
 
         return builder;

--- a/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/cs.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktivní plány",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktivní ceny plánů",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktivní předplatná",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Předplatná rušená na konci období",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Zrušená předplatná",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Předplatná ve vymáhání",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Předplatná po splatnosti",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Zkušební předplatná",
     "Subscriptions.Columns.BillingCycleAnchor": "Ukotvení fakturačního cyklu",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Nájemce",
     "Subscriptions.Columns.TrialEndsAt": "Konec zkušebního období",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/de.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/de.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktive Pläne",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktive Planpreise",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktive Abonnements",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnements zur Stornierung am Periodenende",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Stornierte Abonnements",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnements im Mahnverfahren",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Überfällige Abonnements",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Test-Abonnements",
     "Subscriptions.Columns.BillingCycleAnchor": "Abrechnungszyklusanker",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Mandant",
     "Subscriptions.Columns.TrialEndsAt": "Testphase endet am",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/en.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/en.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Active plans",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Active plan prices",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Active subscriptions",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Subscriptions cancelling at period end",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Cancelled subscriptions",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Subscriptions in dunning",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Past-due subscriptions",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Trial subscriptions",
     "Subscriptions.Columns.BillingCycleAnchor": "Billing Cycle Anchor",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Tenant",
     "Subscriptions.Columns.TrialEndsAt": "Trial Ends At",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/es.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/es.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planes activos",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Precios de plan activos",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Suscripciones activas",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Suscripciones que se cancelarán al final del período",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Suscripciones canceladas",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Suscripciones en reclamación",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Suscripciones vencidas",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Suscripciones en prueba",
     "Subscriptions.Columns.BillingCycleAnchor": "Anclaje del ciclo de facturación",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Inquilino",
     "Subscriptions.Columns.TrialEndsAt": "Fin de la prueba",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/fr.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Plans actifs",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Tarifs de plan actifs",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abonnements actifs",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Revenu récurrent annuel (ARR)",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnements à annuler en fin de période",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Abonnements annulés",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnements en relance",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Revenu récurrent mensuel (MRR)",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Abonnements en retard de paiement",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Abonnements en essai",
     "Subscriptions.Columns.BillingCycleAnchor": "Ancrage du cycle de facturation",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Locataire",
     "Subscriptions.Columns.TrialEndsAt": "Fin de l'essai",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Abonnements actifs",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Santé des abonnements\nAbonnés actifs, essais en cours, charge de relance et signaux de churn d'un coup d'œil.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Annulations au fil du temps",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "En relance",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "En retard de paiement",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Abonnements en essai"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/hi.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "सक्रिय योजनाएँ",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "सक्रिय योजना मूल्य",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "सक्रिय सदस्यताएँ",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "अवधि के अंत में रद्द होने वाली सदस्यताएँ",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "रद्द की गई सदस्यताएँ",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "तकाजे में सदस्यताएँ",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "बकाया सदस्यताएँ",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "परीक्षण सदस्यताएँ",
     "Subscriptions.Columns.BillingCycleAnchor": "बिलिंग चक्र एंकर",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "किरायेदार",
     "Subscriptions.Columns.TrialEndsAt": "परीक्षण समाप्ति तिथि",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/it.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/it.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Piani attivi",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Prezzi di piano attivi",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Abbonamenti attivi",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abbonamenti in annullamento a fine periodo",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Abbonamenti annullati",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abbonamenti in sollecito",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Abbonamenti scaduti",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Abbonamenti in prova",
     "Subscriptions.Columns.BillingCycleAnchor": "Ancoraggio del ciclo di fatturazione",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Tenant",
     "Subscriptions.Columns.TrialEndsAt": "Fine prova",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ja.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "有効なプラン",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "有効なプラン価格",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "有効なサブスクリプション",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "期間末にキャンセル予定のサブスクリプション",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "キャンセルされたサブスクリプション",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "督促中のサブスクリプション",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "支払い遅延中のサブスクリプション",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "トライアル中のサブスクリプション",
     "Subscriptions.Columns.BillingCycleAnchor": "請求サイクル基準日",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "テナント",
     "Subscriptions.Columns.TrialEndsAt": "トライアル終了日",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/ko.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "활성 플랜",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "활성 플랜 가격",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "활성 구독",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "기간 종료 시 취소될 구독",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "취소된 구독",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "독촉 중인 구독",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "연체 구독",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "체험 구독",
     "Subscriptions.Columns.BillingCycleAnchor": "청구 주기 기준일",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "테넌트",
     "Subscriptions.Columns.TrialEndsAt": "체험 종료일",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/nl.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Actieve plannen",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Actieve planprijzen",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Actieve abonnementen",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Abonnementen te annuleren bij einde periode",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Geannuleerde abonnementen",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Abonnementen in aanmaning",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Achterstallige abonnementen",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Proefabonnementen",
     "Subscriptions.Columns.BillingCycleAnchor": "Anker factureringscyclus",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Tenant",
     "Subscriptions.Columns.TrialEndsAt": "Proefperiode eindigt op",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pl.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktywne plany",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktywne ceny planów",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktywne subskrypcje",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Subskrypcje do anulowania na koniec okresu",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Anulowane subskrypcje",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Subskrypcje w windykacji",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Subskrypcje zaległe",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Subskrypcje próbne",
     "Subscriptions.Columns.BillingCycleAnchor": "Punkt odniesienia cyklu rozliczeniowego",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Najemca",
     "Subscriptions.Columns.TrialEndsAt": "Koniec okresu próbnego",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/pt.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Planos ativos",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Preços de plano ativos",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Assinaturas ativas",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Assinaturas a cancelar no fim do período",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Assinaturas canceladas",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Assinaturas em cobrança",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Assinaturas em atraso",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Assinaturas em avaliação",
     "Subscriptions.Columns.BillingCycleAnchor": "Âncora do ciclo de faturamento",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Inquilino",
     "Subscriptions.Columns.TrialEndsAt": "Fim do período de teste",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/sv.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktiva planer",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktiva planpriser",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktiva prenumerationer",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Prenumerationer som avbryts vid periodens slut",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "Avbrutna prenumerationer",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Prenumerationer i påminnelseflöde",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Förfallna prenumerationer",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Provprenumerationer",
     "Subscriptions.Columns.BillingCycleAnchor": "Ankarpunkt faktureringscykel",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Hyresgäst",
     "Subscriptions.Columns.TrialEndsAt": "Provperiod slutar",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/tr.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "Aktif planlar",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "Aktif plan fiyatları",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "Aktif abonelikler",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "Dönem sonunda iptal edilecek abonelikler",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "İptal edilen abonelikler",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "Tahsilat sürecindeki abonelikler",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "Vadesi geçmiş abonelikler",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "Deneme abonelikleri",
     "Subscriptions.Columns.BillingCycleAnchor": "Faturalandırma döngüsü çapası",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "Kiracı",
     "Subscriptions.Columns.TrialEndsAt": "Deneme bitiş tarihi",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
+++ b/src/Granit.Subscriptions/Localization/Subscriptions/zh.json
@@ -5,9 +5,11 @@
     "Metric:Granit.Subscriptions.ActivePlanCountMetric": "活跃计划",
     "Metric:Granit.Subscriptions.ActivePlanPriceCountMetric": "活跃套餐价格",
     "Metric:Granit.Subscriptions.ActiveSubscriptionCountMetric": "活跃订阅",
+    "Metric:Granit.Subscriptions.AnnualRecurringRevenueMetric": "Annual Recurring Revenue",
     "Metric:Granit.Subscriptions.CancelAtPeriodEndSubscriptionCountMetric": "周期末取消的订阅",
     "Metric:Granit.Subscriptions.CancelledSubscriptionCountMetric": "已取消的订阅",
     "Metric:Granit.Subscriptions.DunningSubscriptionCountMetric": "催收中的订阅",
+    "Metric:Granit.Subscriptions.MonthlyRecurringRevenueMetric": "Monthly Recurring Revenue",
     "Metric:Granit.Subscriptions.PastDueSubscriptionCountMetric": "逾期订阅",
     "Metric:Granit.Subscriptions.TrialSubscriptionCountMetric": "试用订阅",
     "Subscriptions.Columns.BillingCycleAnchor": "计费周期锚点",
@@ -27,9 +29,11 @@
     "Subscriptions.Columns.Tenant": "租户",
     "Subscriptions.Columns.TrialEndsAt": "试用结束时间",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.active-count": "Active subscriptions",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.arr": "ARR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.banner.Body": "## Subscriptions health\nActive subscribers, trials, dunning workload, and churn signals at a glance.",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.cancellations-over-time": "Cancellations over time",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.dunning-count": "In dunning",
+    "Widget:Granit.Subscriptions.SubscriptionsHealth.mrr": "MRR",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.past-due-count": "Past-due",
     "Widget:Granit.Subscriptions.SubscriptionsHealth.trial-count": "Trial subscriptions"
   }

--- a/src/Granit.Subscriptions/Metrics/AnnualRecurringRevenueMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/AnnualRecurringRevenueMetricDefinition.cs
@@ -1,0 +1,55 @@
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Annual Recurring Revenue (ARR) — the canonical SaaS measure. Sum of every
+/// active subscription's <i>annual-equivalent</i> contribution, derived from
+/// its bound <see cref="PlanPrice"/>:
+/// <list type="bullet">
+///   <item><see cref="BillingInterval.Monthly"/>: <c>Amount × 12</c>.</item>
+///   <item><see cref="BillingInterval.Quarterly"/>: <c>Amount × 4</c>.</item>
+///   <item><see cref="BillingInterval.Yearly"/>: <c>Amount</c>.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// ARR is the annualised projection of MRR — typically <c>MRR × 12</c> at the
+/// portfolio level. Computing it directly from <see cref="PlanPrice.Interval"/>
+/// (rather than as <c>MRR × 12</c>) keeps it numerically stable on tenants
+/// with mixed billing cycles, and matches the spec investors / boards expect.
+/// </para>
+/// </remarks>
+public sealed class AnnualRecurringRevenueMetricDefinition
+    : JoinedMetricDefinition<Subscription, PlanPrice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.AnnualRecurringRevenueMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override System.Linq.Expressions.Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.Status == SubscriptionStatus.Active;
+
+    /// <inheritdoc />
+    public override System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+
+    /// <inheritdoc />
+    public override IQueryable<decimal?> Project(
+        IQueryable<Subscription> filteredSource,
+        IQueryable<PlanPrice> joinedSource) =>
+            from s in filteredSource
+            join p in joinedSource on s.PlanPriceId equals p.Id
+            select (decimal?)(
+                p.Interval == BillingInterval.Monthly ? p.Amount * 12m
+              : p.Interval == BillingInterval.Quarterly ? p.Amount * 4m
+              : p.Amount);
+}

--- a/src/Granit.Subscriptions/Metrics/MonthlyRecurringRevenueMetricDefinition.cs
+++ b/src/Granit.Subscriptions/Metrics/MonthlyRecurringRevenueMetricDefinition.cs
@@ -1,0 +1,64 @@
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Metrics;
+
+/// <summary>
+/// Monthly Recurring Revenue (MRR) — the canonical SaaS measure. Sum of every
+/// active subscription's <i>monthly-equivalent</i> contribution, derived from
+/// its bound <see cref="PlanPrice"/>:
+/// <list type="bullet">
+///   <item><see cref="BillingInterval.Monthly"/>: <c>Amount</c>.</item>
+///   <item><see cref="BillingInterval.Quarterly"/>: <c>Amount / 3</c>.</item>
+///   <item><see cref="BillingInterval.Yearly"/>: <c>Amount / 12</c>.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>?period=</c> query parameter scopes the OBSERVATION window (when
+/// the subscription was created) without changing the per-row monthly
+/// normalisation — that's the canonical SaaS-MRR semantic, distinct from "sum
+/// of recurring revenue billed in the period" (which would require a separate
+/// metric).
+/// </para>
+/// <para>
+/// Implemented as a <see cref="JoinedMetricDefinition{TEntity, TJoined, TValue}"/>
+/// because the per-row contribution is computed from <see cref="PlanPrice.Amount"/>
+/// and <see cref="PlanPrice.Interval"/> on the joined row, not from a column
+/// on <see cref="Subscription"/>. Subscriptions without a bound
+/// <see cref="Subscription.PlanPriceId"/> are excluded from the projection
+/// (LINQ inner-join semantics).
+/// </para>
+/// </remarks>
+public sealed class MonthlyRecurringRevenueMetricDefinition
+    : JoinedMetricDefinition<Subscription, PlanPrice, decimal>
+{
+    /// <inheritdoc />
+    public override string Name => "Granit.Subscriptions.MonthlyRecurringRevenueMetric";
+
+    /// <inheritdoc />
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+
+    /// <inheritdoc />
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    /// <inheritdoc />
+    public override System.Linq.Expressions.Expression<Func<Subscription, bool>>? BaseFilter
+        => s => s.Status == SubscriptionStatus.Active;
+
+    /// <inheritdoc />
+    public override System.Linq.Expressions.Expression<Func<Subscription, DateTimeOffset>>? PeriodSelector
+        => s => s.CreatedAt;
+
+    /// <inheritdoc />
+    public override IQueryable<decimal?> Project(
+        IQueryable<Subscription> filteredSource,
+        IQueryable<PlanPrice> joinedSource) =>
+            from s in filteredSource
+            join p in joinedSource on s.PlanPriceId equals p.Id
+            select (decimal?)(
+                p.Interval == BillingInterval.Yearly ? p.Amount / 12m
+              : p.Interval == BillingInterval.Quarterly ? p.Amount / 3m
+              : p.Amount);
+}

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests/Internal/JoinedMetricExecutorTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests/Internal/JoinedMetricExecutorTests.cs
@@ -1,0 +1,226 @@
+using Granit.Analytics.EntityFrameworkCore.Internal;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Extensions;
+using Granit.QueryEngine.Filtering;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Analytics.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Pins the joined-metric dispatch path of <see cref="MetricExecutor{TEntity, TValue}"/>:
+/// a <see cref="JoinedMetricDefinition{TEntity, TJoined, TValue}"/> projects across
+/// (<c>TEntity</c> ⋈ <c>TJoined</c>) before aggregating, with the joined source
+/// resolved from DI at request time. Same empty-set contract as the single-table
+/// path (story A3 #1374): Sum-of-empty = 0; Avg-of-empty = null.
+/// </summary>
+public sealed class JoinedMetricExecutorTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private JoinedTestDbContext _db = null!;
+    private ServiceProvider _provider = null!;
+    private IQueryEngine<JoinedOrder> _engine = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        DbContextOptions<JoinedTestDbContext> options = new DbContextOptionsBuilder<JoinedTestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _db = new JoinedTestDbContext(options);
+        await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        var eurId = Guid.NewGuid();
+        var usdId = Guid.NewGuid();
+
+        _db.Currencies.AddRange(
+            new Currency { Id = eurId, Code = "EUR", ConversionToHomeCurrency = 1.0m },
+            new Currency { Id = usdId, Code = "USD", ConversionToHomeCurrency = 0.9m });
+
+        _db.JoinedOrders.AddRange(
+            new JoinedOrder { Id = Guid.NewGuid(), Amount = 100m, CurrencyId = eurId },          // → 100 EUR-equiv
+            new JoinedOrder { Id = Guid.NewGuid(), Amount = 100m, CurrencyId = usdId },          // → 90 EUR-equiv
+            new JoinedOrder { Id = Guid.NewGuid(), Amount = 200m, CurrencyId = usdId });         // → 180 EUR-equiv
+
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        // Build IQueryEngine<JoinedOrder> + IQueryableSource<Currency> in a single
+        // DI provider so the executor can resolve both at request time. Mirrors
+        // TestEngineFactory's setup with the joined source layered in.
+        ServiceCollection services = new();
+        services.AddMetrics();
+        services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddOptions<Granit.QueryEngine.Options.QueryEngineOptions>();
+        services.AddSingleton(sp => sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<Granit.QueryEngine.Options.QueryEngineOptions>>().Value);
+        services.AddGranitQueryEngine();
+        services.AddScoped(typeof(IQueryEngine<>),
+            typeof(Granit.QueryEngine.EntityFrameworkCore.GranitQueryEngineEntityFrameworkCoreModule)
+                .Assembly
+                .GetType("Granit.QueryEngine.EntityFrameworkCore.Internal.QueryEngine`1", throwOnError: true)!);
+        services.AddQueryDefinition<JoinedOrder, JoinedOrderQueryDefinition>();
+        services.AddSingleton<IQueryableSource<Currency>>(_ => new TestCurrencyQueryableSource(_db));
+
+        _provider = services.BuildServiceProvider();
+        _engine = _provider.GetRequiredService<IQueryEngine<JoinedOrder>>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync().ConfigureAwait(false);
+        await _connection.DisposeAsync().ConfigureAwait(false);
+        await _provider.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task JoinedSum_ReturnsWeightedTotalAcrossJoin()
+    {
+        MetricExecutor<JoinedOrder, decimal> executor = new(_engine, _provider);
+
+        decimal? result = await executor.ExecuteAsync(
+            new ConvertedAmountTotalMetricDefinition(),
+            _db.JoinedOrders,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        // 100*1.0 + 100*0.9 + 200*0.9 = 100 + 90 + 180 = 370 EUR-equiv.
+        result.ShouldBe(370m);
+    }
+
+    [Fact]
+    public async Task JoinedSum_EmptyBaseSet_ReturnsZero()
+    {
+        // Drop all orders, leave currencies in place. The metric's projection becomes
+        // empty (no left rows to join from), so Sum-of-empty = 0 per contract A3 #1374.
+        _db.JoinedOrders.RemoveRange(_db.JoinedOrders);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<JoinedOrder, decimal> executor = new(_engine, _provider);
+
+        decimal? result = await executor.ExecuteAsync(
+            new ConvertedAmountTotalMetricDefinition(),
+            _db.JoinedOrders,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0m);
+    }
+
+    [Fact]
+    public async Task JoinedAvg_EmptyBaseSet_ReturnsNull()
+    {
+        _db.JoinedOrders.RemoveRange(_db.JoinedOrders);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        MetricExecutor<JoinedOrder, decimal> executor = new(_engine, _provider);
+
+        decimal? result = await executor.ExecuteAsync(
+            new ConvertedAmountAvgMetricDefinition(),
+            _db.JoinedOrders,
+            new QueryRequest(),
+            TestContext.Current.CancellationToken);
+
+        // Avg over empty set → null. Same contract as the single-table path.
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task JoinedMetric_WithoutServiceProvider_Throws()
+    {
+        // No IServiceProvider supplied → executor cannot resolve the joined source.
+        // Should throw a clear InvalidOperationException at the dispatch point,
+        // not crash deep in EF Core.
+        MetricExecutor<JoinedOrder, decimal> executor = new(_engine);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            executor.ExecuteAsync(
+                new ConvertedAmountTotalMetricDefinition(),
+                _db.JoinedOrders,
+                new QueryRequest(),
+                TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("IServiceProvider");
+    }
+}
+
+internal sealed class JoinedOrder
+{
+    public Guid Id { get; init; }
+    public decimal Amount { get; init; }
+    public Guid CurrencyId { get; init; }
+}
+
+internal sealed class Currency
+{
+    public Guid Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public decimal ConversionToHomeCurrency { get; init; }
+}
+
+internal sealed class JoinedTestDbContext(DbContextOptions<JoinedTestDbContext> options) : DbContext(options)
+{
+    public DbSet<JoinedOrder> JoinedOrders => Set<JoinedOrder>();
+    public DbSet<Currency> Currencies => Set<Currency>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<JoinedOrder>(e => e.HasKey(o => o.Id));
+        modelBuilder.Entity<Currency>(e =>
+        {
+            e.HasKey(c => c.Id);
+            e.Property(c => c.Code).IsRequired();
+        });
+    }
+}
+
+internal sealed class JoinedOrderQueryDefinition : QueryDefinition<JoinedOrder>
+{
+    public override string Name => "Test.JoinedOrders";
+
+    protected override void Configure(QueryDefinitionBuilder<JoinedOrder> builder) =>
+        builder
+            .Column(o => o.Amount, c => c.Label("Amount").Filterable().Sortable())
+            .DefaultPageSize(50);
+}
+
+internal sealed class TestCurrencyQueryableSource(JoinedTestDbContext db) : IQueryableSource<Currency>
+{
+    public IQueryable<Currency> GetQueryable() => db.Currencies.AsNoTracking();
+}
+
+internal sealed class ConvertedAmountTotalMetricDefinition
+    : JoinedMetricDefinition<JoinedOrder, Currency, decimal>
+{
+    public override string Name => "Test.ConvertedAmountTotal";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Sum;
+
+    public override IQueryable<decimal?> Project(
+        IQueryable<JoinedOrder> filteredSource,
+        IQueryable<Currency> joinedSource) =>
+            from o in filteredSource
+            join c in joinedSource on o.CurrencyId equals c.Id
+            select (decimal?)(o.Amount * c.ConversionToHomeCurrency);
+}
+
+internal sealed class ConvertedAmountAvgMetricDefinition
+    : JoinedMetricDefinition<JoinedOrder, Currency, decimal>
+{
+    public override string Name => "Test.ConvertedAmountAvg";
+    public override MetricValueKind ValueKind => MetricValueKind.Currency;
+    public override AggregateFunction Aggregation => AggregateFunction.Avg;
+
+    public override IQueryable<decimal?> Project(
+        IQueryable<JoinedOrder> filteredSource,
+        IQueryable<Currency> joinedSource) =>
+            from o in filteredSource
+            join c in joinedSource on o.CurrencyId equals c.Id
+            select (decimal?)(o.Amount * c.ConversionToHomeCurrency);
+}

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
@@ -141,7 +141,12 @@ public static class LayerDependencyRules
     /// Types whose namespace contains a default-allowed fragment (EntityFrameworkCore,
     /// QueryEngine, Persistence) are exempt, as are types following the
     /// <c>*QueryableSource</c> convention — the standard bridge for exposing
-    /// IQueryable to the QueryEngine endpoints layer.
+    /// IQueryable to the QueryEngine endpoints layer — and concrete
+    /// <c>*MetricDefinition</c> types deriving from
+    /// <c>JoinedMetricDefinition&lt;TEntity, TJoined, TValue&gt;</c>, whose
+    /// <c>Project</c> method intrinsically takes <c>IQueryable</c> on both sides
+    /// of the join (the projection is the unit of aggregation; running it
+    /// elsewhere would force materialisation in memory).
     /// </summary>
     public static void IQueryableShouldNotEscapePersistenceLayer(
         ArchUnitNET.Domain.Architecture architecture)
@@ -154,12 +159,13 @@ public static class LayerDependencyRules
             .Where(t => !t.Name.EndsWith("QueryableSource", StringComparison.Ordinal))
             .Where(t => !t.Name.EndsWith("EndpointRouteBuilderExtensions", StringComparison.Ordinal))
             .Where(t => !t.Name.EndsWith("DataSource", StringComparison.Ordinal))
+            .Where(t => !t.Name.EndsWith("MetricDefinition", StringComparison.Ordinal))
             .Where(t => t.Dependencies
                 .Any(d => d.Target.FullName.StartsWith("System.Linq.IQueryable", StringComparison.Ordinal)));
 
         violators.ShouldBeEmpty(
             "IQueryable<T> must not escape the persistence layer. " +
-            "Types following the *QueryableSource convention are exempt. " +
+            "Types following the *QueryableSource convention or *MetricDefinition (joined-metric Project hook) are exempt. " +
             $"Violators: {string.Join(", ", violators.Select(t => t.FullName))}");
     }
 }


### PR DESCRIPTION
## Summary

Closes the architectural follow-up of the BI metric rollout (epic #1366) — extends the metric framework with a join-aware abstraction so SaaS canonical measures (MRR, ARR) and other cross-table aggregations can ship as pure declarative `MetricDefinition`s, no host-side join logic required.

This is **option A** from the trade-off sketch I shipped earlier (extend `MetricExecutor` with a typed `JoinedMetricDefinition<TEntity, TJoined, TValue>` subclass).

## Framework changes

### `JoinedMetricDefinition<TEntity, TJoined, TValue>`

Abstract subclass of `MetricDefinition<TEntity, TValue>`. Authors override `Project(IQueryable<TEntity>, IQueryable<TJoined>) → IQueryable<TValue?>` to express the join + per-row projection in plain LINQ. `Selector` is sealed to `null` on the base — `Project` takes its place.

```csharp
public sealed class MonthlyRecurringRevenueMetricDefinition
    : JoinedMetricDefinition<Subscription, PlanPrice, decimal>
{
    public override string Name => "Granit.Subscriptions.MonthlyRecurringRevenueMetric";
    public override AggregateFunction Aggregation => AggregateFunction.Sum;
    public override Expression<Func<Subscription, bool>>? BaseFilter
        => s => s.Status == SubscriptionStatus.Active;
    public override IQueryable<decimal?> Project(
        IQueryable<Subscription> source, IQueryable<PlanPrice> joined) =>
            from s in source
            join p in joined on s.PlanPriceId equals p.Id
            select (decimal?)(p.Interval == BillingInterval.Yearly ? p.Amount / 12m
                            : p.Interval == BillingInterval.Quarterly ? p.Amount / 3m
                            : p.Amount);
}
```

### `IJoinedMetricProjector<TEntity, TValue>`

Type-erased marker the executor uses to dispatch without statically knowing `TJoined`. The interface's single method (`ProjectFromServiceProvider`) resolves `IQueryableSource<TJoined>` from the per-request DI scope and forwards to `Project`.

### `MetricExecutor<,>` extension

- Gains an optional `IServiceProvider` constructor parameter (defaults to `null` so the existing 30+ test call sites don't break).
- When the metric implements `IJoinedMetricProjector<,>`, the executor calls the projector to get an `IQueryable<TValue?>`, then runs `Sum` / `Avg` / `Min` / `Max` per-type on the projection.
- `Count` is unsupported on joined metrics — counting joined rows is meaningful as a regular `MetricDefinition` over the base entity, no join needed.
- Empty-set semantics preserved: Sum-of-empty = 0; Avg-of-empty = null. Same contract as story A3 #1374.

## MRR / ARR concrete metrics

Two metrics on `Subscription` join to `PlanPrice` to compute the canonical SaaS measures:

| Metric | Per-row contribution |
| ------ | -------------------- |
| `MonthlyRecurringRevenueMetric` | Yearly → `Amount / 12` ; Quarterly → `Amount / 3` ; Monthly → `Amount` |
| `AnnualRecurringRevenueMetric` | Monthly → `Amount × 12` ; Quarterly → `Amount × 4` ; Yearly → `Amount` |

Both filter on `Status == Active` and use `CreatedAt` as the period selector. The `?period=` query parameter scopes the OBSERVATION window (subscription creation), not the per-row monthly normalisation — that's the canonical SaaS-MRR semantic.

`EfPlanPriceQueryableSource` ships in `Granit.Subscriptions.EntityFrameworkCore` so the join target is registered as `IQueryableSource<PlanPrice>` at host startup. Hosts using only the in-memory provider get a clear `InvalidOperationException` at request time rather than a silent fallback.

## Dashboard refresh

`SubscriptionsHealthDashboardDefinition` bumped to **v1.1.0** to surface MRR + ARR at the top of the grid (existing widgets shifted down by 2 positions). Per ADR-038 §3, tenants who imported v1.0.0 will see the version skew through the forthcoming drift-detection surface.

## Architecture rule update

`LayerDependencyRules.IQueryableShouldNotEscapePersistenceLayer` now exempts `*MetricDefinition` types — the `JoinedMetricDefinition` base intrinsically takes `IQueryable<T>` on both sides of the join. The projection IS the unit of aggregation; running it elsewhere would force in-memory materialisation.

## Test plan

- [x] `dotnet build` clean: `Granit.Analytics`, `.EntityFrameworkCore`, `Granit.Subscriptions`, `.EntityFrameworkCore`.
- [x] `dotnet format` clean on all four projects + the test project + the archi-rules helper.
- [x] `dotnet test tests/Granit.Analytics.EntityFrameworkCore.Tests` — **37 passing** (4 new `JoinedMetricExecutorTests`: weighted Sum across join, Sum-of-empty = 0, Avg-of-empty = null, missing-`IServiceProvider` throws clearly).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **197 passing** (`IQueryable` rule satisfied via `*MetricDefinition` exemption; `DashboardWidgetReferenceTests` resolves the new MRR / ARR metric names).

## Follow-ups

- **Drift detection (ADR-038 §3)** — the SubscriptionsHealth v1.1.0 bump is the first concrete trigger for this work; surface the version skew to admins post-import.
- **Other join-aware metrics** — TaxedInvoiceTotal (Invoice ⋈ TaxRule), ConvertedRevenueTotal (Invoice ⋈ Currency), ProductCategoryRollup (OrderLine ⋈ Product). All become trivial subclasses of `JoinedMetricDefinition` once their join sources ship `IQueryableSource<>` registrations.
- **Multi-entity joins** — `JoinedMetricDefinition` v1 supports a single TJoined. A v2 with `JoinedMetricDefinition<TEntity, TJoinedA, TJoinedB, TValue>` (or a chained-projection extension) is a natural next step when a metric needs more than one join target. Not in scope here.