### PR TITLE
fix(test): add missing using Granit.Analytics.Metrics import in PostgresParityTests

### DIFF
--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
@@ -1,4 +1,5 @@
 using Granit.Analytics.EntityFrameworkCore;
+using Granit.Analytics.Metrics;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary

One-line fix for a latent CS0246 introduced by #1588 (Analytics layer purity refactor) that's now surfacing on CI builds:

\`\`\`
error CS0246: The type or namespace name 'IMetricExecutor<,>' could not be found
\`\`\`

#1588 moved \`IMetricExecutor<TEntity, TValue>\` from \`Granit.Analytics.EntityFrameworkCore\` to the new \`Granit.Analytics.Metrics\` namespace but missed updating the \`using\` directive in this integration-test file. The error went unnoticed because the project is excluded from the unit-test CI shards (\`SkipIntegrationTests=true\`); it surfaces only on the build phase of the integration job.

## Test plan

- [x] \`dotnet build tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration\` clean.
- [ ] CI green on the integration shard.