### PR TITLE
feat(dashboards-render): ADR-038 §3 drift detection on bundle render response

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13853,6 +13853,15 @@
       "members": []
     },
     {
+      "name": "DashboardDriftStatus",
+      "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardDriftStatus",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Endpoints",
+      "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "DashboardImportResponse",
       "fqn": "Granit.Dashboards.Endpoints.Dtos.DashboardImportResponse",
       "kind": "record",
@@ -13876,7 +13885,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 42,
+      "line": 61,
       "members": []
     },
     {
@@ -13894,7 +13903,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 27,
+      "line": 43,
       "members": []
     },
     {
@@ -13903,7 +13912,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 69,
+      "line": 88,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs
@@ -1,0 +1,41 @@
+namespace Granit.Dashboards.Endpoints.Dtos;
+
+/// <summary>
+/// Drift state of a persisted <c>Dashboard</c> against its source
+/// <c>DashboardDefinition</c> at render time. ADR-038 §3 — surfaced on
+/// <see cref="DashboardRenderResponse.DriftStatus"/> so the frontend can
+/// warn admins or offer a resync action without round-tripping to a
+/// dedicated drift-check endpoint.
+/// </summary>
+public enum DashboardDriftStatus
+{
+    /// <summary>
+    /// The dashboard was custom-built — no source definition to drift against.
+    /// Frontend hides drift UI entirely for these dashboards.
+    /// </summary>
+    NotApplicable = 0,
+
+    /// <summary>
+    /// Persisted <c>SourceDefinitionVersion</c> matches the currently-registered
+    /// descriptor's <c>Version</c>. No action required.
+    /// </summary>
+    InSync = 1,
+
+    /// <summary>
+    /// Persisted <c>SourceDefinitionVersion</c> differs from the currently-registered
+    /// descriptor's <c>Version</c> — the source module shipped a newer (or older)
+    /// version than what was imported. Frontend should surface a "Dashboard outdated,
+    /// click to resync" affordance; resync re-imports from the descriptor and best-effort
+    /// preserves per-instance overrides via slug-matching.
+    /// </summary>
+    Drift = 2,
+
+    /// <summary>
+    /// Source definition is no longer registered in the host (module unloaded,
+    /// renamed, or removed). Resync is impossible until the source is re-shipped
+    /// or the host wires up the missing module. Frontend should surface a
+    /// terminal warning — the dashboard renders from persisted widgets only;
+    /// view switches and per-widget Actions can no longer resolve.
+    /// </summary>
+    SourceUnregistered = 3,
+}

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -23,12 +23,31 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// registered source definition. The frontend's TanStack cache partitions per
 /// <c>(dashboardId, ActiveViewName)</c> tuple so view switches invalidate cleanly.
 /// </param>
+/// <param name="DriftStatus">
+/// ADR-038 §3 drift detection. Reports whether the persisted dashboard's
+/// <c>SourceDefinitionVersion</c> still matches the currently-registered
+/// descriptor's <see cref="DashboardDefinition.Version"/>. Frontend uses this to
+/// surface a "Dashboard outdated, click to resync" banner without an extra
+/// round-trip.
+/// </param>
+/// <param name="SourceDefinitionVersion">
+/// Persisted version captured at import time. <see langword="null"/> when the
+/// dashboard was custom-built (no source definition).
+/// </param>
+/// <param name="RegisteredVersion">
+/// Currently-registered descriptor version. <see langword="null"/> when the source
+/// definition is no longer registered (<c>DriftStatus</c> = <c>SourceUnregistered</c>)
+/// or the dashboard has no source (<c>DriftStatus</c> = <c>NotApplicable</c>).
+/// </param>
 /// <param name="Widgets">One flat record per widget, in <c>WidgetInstance.Position</c> order. Reflects the active view only.</param>
 public sealed record DashboardRenderResponse(
     Guid DashboardId,
     DateTimeOffset RenderedAt,
     DashboardRenderPeriodResponse? Period,
     string? ActiveViewName,
+    DashboardDriftStatus DriftStatus,
+    string? SourceDefinitionVersion,
+    string? RegisteredVersion,
     IReadOnlyList<DashboardRenderedWidgetResponse> Widgets);
 
 /// <summary>

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -82,12 +82,55 @@ internal static class DashboardRenderProjection
                 ReasonLocalizationKey: rw.Envelope.ReasonLocalizationKey);
         })];
 
+        (DashboardDriftStatus drift, string? registeredVersion) =
+            ResolveDriftStatus(dashboard, definitionRegistry);
+
         return new DashboardRenderResponse(
             DashboardId: result.DashboardId,
             RenderedAt: result.RenderedAt,
             Period: period,
             ActiveViewName: target.ActiveViewName,
+            DriftStatus: drift,
+            SourceDefinitionVersion: dashboard.SourceDefinitionVersion,
+            RegisteredVersion: registeredVersion,
             Widgets: widgets);
+    }
+
+    /// <summary>
+    /// ADR-038 §3 drift detection. Compares the persisted dashboard's
+    /// <see cref="Dashboard.SourceDefinitionVersion"/> against the currently-registered
+    /// descriptor's <see cref="IDashboardDefinitionDescriptor.Version"/>.
+    /// </summary>
+    /// <remarks>
+    /// Pure string equality on the Version field (semver values are not parsed
+    /// — the framework treats <c>"1.0.0"</c> and <c>"1.0.0.0"</c> as different,
+    /// which is the cautious default; module authors should keep the version
+    /// format stable across releases). A semver-aware variant can land in a
+    /// follow-up if the cautious string compare proves too noisy in practice.
+    /// </remarks>
+    private static (DashboardDriftStatus Status, string? RegisteredVersion) ResolveDriftStatus(
+        Dashboard dashboard,
+        IDashboardDefinitionRegistry registry)
+    {
+        if (dashboard.SourceDefinitionName is not { Length: > 0 } sourceName)
+        {
+            return (DashboardDriftStatus.NotApplicable, null);
+        }
+
+        IDashboardDefinitionDescriptor? descriptor = registry.Find(sourceName);
+        if (descriptor is null)
+        {
+            return (DashboardDriftStatus.SourceUnregistered, null);
+        }
+
+        DashboardDriftStatus status = string.Equals(
+            dashboard.SourceDefinitionVersion,
+            descriptor.Version,
+            StringComparison.Ordinal)
+                ? DashboardDriftStatus.InSync
+                : DashboardDriftStatus.Drift;
+
+        return (status, descriptor.Version);
     }
 
     public static ResolvedPeriod? TryBuildResolvedPeriod(DashboardRenderRequest request)

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -269,6 +269,106 @@ public sealed class DashboardRenderProjectionTests
         sourceDefinitionName: SourceDefinitionName,
         sourceDefinitionVersion: "1.0.0");
 
+    [Fact]
+    public void ToResponse_DriftStatus_NotApplicable_WhenNoSourceDefinition()
+    {
+        // Custom-built dashboard — no SourceDefinitionName.
+        var dashboard = Dashboard.Create(
+            id: Guid.NewGuid(),
+            name: "Adhoc",
+            category: DashboardCategory.General);
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id, RenderedAt: RenderedAt, Period: null, Widgets: []);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard,
+            new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null),
+            EmptyRegistry(),
+            periodToken: null);
+
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.NotApplicable);
+        response.SourceDefinitionVersion.ShouldBeNull();
+        response.RegisteredVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_DriftStatus_SourceUnregistered_WhenDescriptorMissing()
+    {
+        // Imported dashboard whose source module is no longer loaded.
+        Dashboard dashboard = NewDashboard();
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id, RenderedAt: RenderedAt, Period: null, Widgets: []);
+
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(SourceDefinitionName).Returns((IDashboardDefinitionDescriptor?)null);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard,
+            new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null),
+            registry,
+            periodToken: null);
+
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.SourceUnregistered);
+        response.SourceDefinitionVersion.ShouldBe("1.0.0");
+        response.RegisteredVersion.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_DriftStatus_InSync_WhenVersionsMatch()
+    {
+        Dashboard dashboard = NewDashboard();
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id, RenderedAt: RenderedAt, Period: null, Widgets: []);
+
+        IDashboardDefinitionDescriptor descriptor = Substitute.For<IDashboardDefinitionDescriptor>();
+        descriptor.Name.Returns(SourceDefinitionName);
+        descriptor.Version.Returns("1.0.0");
+        descriptor.Widgets.Returns(Array.Empty<WidgetDefinition>());
+
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(SourceDefinitionName).Returns(descriptor);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard,
+            new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null),
+            registry,
+            periodToken: null);
+
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.InSync);
+        response.SourceDefinitionVersion.ShouldBe("1.0.0");
+        response.RegisteredVersion.ShouldBe("1.0.0");
+    }
+
+    [Fact]
+    public void ToResponse_DriftStatus_Drift_WhenVersionsDiffer()
+    {
+        Dashboard dashboard = NewDashboard();                        // imported at v1.0.0
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id, RenderedAt: RenderedAt, Period: null, Widgets: []);
+
+        IDashboardDefinitionDescriptor descriptor = Substitute.For<IDashboardDefinitionDescriptor>();
+        descriptor.Name.Returns(SourceDefinitionName);
+        descriptor.Version.Returns("1.1.0");                         // module shipped a newer version
+        descriptor.Widgets.Returns(Array.Empty<WidgetDefinition>());
+
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(SourceDefinitionName).Returns(descriptor);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard,
+            new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null),
+            registry,
+            periodToken: null);
+
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.Drift);
+        response.SourceDefinitionVersion.ShouldBe("1.0.0");
+        response.RegisteredVersion.ShouldBe("1.1.0");
+    }
+
     private static IDashboardDefinitionRegistry EmptyRegistry()
     {
         IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();


### PR DESCRIPTION
## Summary

Surfaces per-dashboard drift state on `POST /dashboards/{id}/render` so the frontend can warn admins or offer a resync action without round-tripping to a dedicated drift-check endpoint.

**Concrete trigger**: PR #1612 just bumped `SubscriptionsHealthDashboardDefinition` from `1.0.0` to `1.1.0` to add MRR / ARR widgets. Tenants who imported v1.0.0 should see this drift the next time they hit `/render`.

## Wire shape additions

Strictly additive on `DashboardRenderResponse`:

```diff
 public sealed record DashboardRenderResponse(
     Guid DashboardId,
     DateTimeOffset RenderedAt,
     DashboardRenderPeriodResponse? Period,
     string? ActiveViewName,
+    DashboardDriftStatus DriftStatus,
+    string? SourceDefinitionVersion,   // persisted at-import version
+    string? RegisteredVersion,         // current at-runtime version
     IReadOnlyList<DashboardRenderedWidgetResponse> Widgets);
```

### `DashboardDriftStatus` enum

| Value | Meaning |
| ----- | ------- |
| `NotApplicable` | Dashboard was custom-built (no `SourceDefinitionName`). Frontend hides drift UI. |
| `InSync` | Persisted version matches the registered descriptor's version. |
| `Drift` | Persisted version differs from the registered descriptor — module shipped a newer (or older) build. Frontend surfaces "Dashboard outdated, click to resync". |
| `SourceUnregistered` | Source module no longer loaded. Resync impossible until the module is re-shipped. Frontend surfaces a terminal warning. |

## Implementation

`DashboardRenderProjection.ResolveDriftStatus(dashboard, registry)` does pure string equality on `Dashboard.SourceDefinitionVersion` vs `descriptor.Version`. Cautious default — `"1.0.0"` and `"1.0.0.0"` register as different. A semver-aware variant can land in a follow-up if the cautious compare proves too noisy in practice; module authors should keep the version format stable across releases.

## Tests

4 new `DashboardRenderProjectionTests` cover the four `DriftStatus` branches:
- `NotApplicable` when dashboard has no `SourceDefinitionName`.
- `SourceUnregistered` when registry returns `null` for the source name.
- `InSync` when versions match.
- `Drift` when versions differ.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` clean.
- [x] `dotnet format src/Granit.Dashboards.Endpoints --verify-no-changes` clean.
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — **120 passing** (4 new drift tests).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **197 passing**.
- [ ] CI green on full shard pipeline.

## Frontend follow-up

- Surface a banner ("Dashboard outdated, click to resync") on `Drift`.
- Surface a greyed-out warning ("Source module unavailable") on `SourceUnregistered`.
- No UI change on `InSync` / `NotApplicable`.

## Resync endpoint (deferred)

A dedicated `POST /dashboards/{id}/resync` that re-imports from the descriptor while best-effort preserving per-instance overrides via slug-matching is the natural follow-up. For now, admins can trigger resync by deleting the existing dashboard and re-running `POST /dashboards/from-definition/{name}` — coarser but workable.