### PR TITLE
feat(dashboards-render): align drift status with frontend semver semantics

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13858,7 +13858,7 @@
       "kind": "enum",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs",
-      "line": 10,
+      "line": 19,
       "members": []
     },
     {
@@ -13885,7 +13885,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 61,
+      "line": 65,
       "members": []
     },
     {
@@ -13903,7 +13903,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 43,
+      "line": 47,
       "members": []
     },
     {
@@ -13912,7 +13912,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 88,
+      "line": 92,
       "members": []
     },
     {

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardDriftStatus.cs
@@ -7,6 +7,15 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// warn admins or offer a resync action without round-tripping to a
 /// dedicated drift-check endpoint.
 /// </summary>
+/// <remarks>
+/// Comparison is semver-aware: persisted and registered <c>Version</c> strings
+/// are parsed as <c>MAJOR.MINOR.PATCH</c> with an optional pre-release / build
+/// suffix (<c>"1.2.3-alpha"</c>, <c>"1.2.3+build.7"</c>). The numeric tuple
+/// drives <see cref="Behind"/> vs <see cref="Ahead"/>; mismatched suffixes or
+/// unparseable strings collapse to <see cref="Unknown"/> (cautious default —
+/// the frontend treats <see cref="Unknown"/> like <see cref="Aligned"/> for
+/// resync prompts but surfaces a tooltip).
+/// </remarks>
 public enum DashboardDriftStatus
 {
     /// <summary>
@@ -17,18 +26,36 @@ public enum DashboardDriftStatus
 
     /// <summary>
     /// Persisted <c>SourceDefinitionVersion</c> matches the currently-registered
-    /// descriptor's <c>Version</c>. No action required.
+    /// descriptor's <c>Version</c> on every semver component (MAJOR.MINOR.PATCH +
+    /// pre-release / build suffix). No action required.
     /// </summary>
-    InSync = 1,
+    Aligned = 1,
 
     /// <summary>
-    /// Persisted <c>SourceDefinitionVersion</c> differs from the currently-registered
-    /// descriptor's <c>Version</c> — the source module shipped a newer (or older)
-    /// version than what was imported. Frontend should surface a "Dashboard outdated,
-    /// click to resync" affordance; resync re-imports from the descriptor and best-effort
-    /// preserves per-instance overrides via slug-matching.
+    /// Persisted <c>SourceDefinitionVersion</c> is older than the currently-registered
+    /// descriptor — the source module shipped a newer version since import. Frontend
+    /// should surface a "Dashboard outdated, click to resync" affordance; resync
+    /// re-imports from the descriptor and best-effort preserves per-instance overrides
+    /// via slug-matching.
     /// </summary>
-    Drift = 2,
+    Behind = 2,
+
+    /// <summary>
+    /// Persisted <c>SourceDefinitionVersion</c> is newer than the currently-registered
+    /// descriptor — the host loaded an older module than the one originally imported.
+    /// Frontend should warn admins; resync would downgrade the dashboard, so offer
+    /// it as an explicit "force-resync" rather than a one-click action.
+    /// </summary>
+    Ahead = 3,
+
+    /// <summary>
+    /// Versions cannot be ordered: either string fails the semver regex, or the
+    /// numeric components match but pre-release / build suffixes differ
+    /// (<c>"1.0.0-alpha"</c> vs <c>"1.0.0-beta"</c>). Frontend treats this like
+    /// <see cref="Aligned"/> for the main banner but exposes a tooltip with both
+    /// raw version strings so admins can reconcile manually.
+    /// </summary>
+    Unknown = 4,
 
     /// <summary>
     /// Source definition is no longer registered in the host (module unloaded,
@@ -37,5 +64,5 @@ public enum DashboardDriftStatus
     /// terminal warning — the dashboard renders from persisted widgets only;
     /// view switches and per-widget Actions can no longer resolve.
     /// </summary>
-    SourceUnregistered = 3,
+    SourceUnregistered = 5,
 }

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -24,11 +24,15 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// <c>(dashboardId, ActiveViewName)</c> tuple so view switches invalidate cleanly.
 /// </param>
 /// <param name="DriftStatus">
-/// ADR-038 §3 drift detection. Reports whether the persisted dashboard's
-/// <c>SourceDefinitionVersion</c> still matches the currently-registered
-/// descriptor's <see cref="DashboardDefinition.Version"/>. Frontend uses this to
-/// surface a "Dashboard outdated, click to resync" banner without an extra
-/// round-trip.
+/// ADR-038 §3 drift detection. Reports the semver-aware ordering between the
+/// persisted dashboard's <c>SourceDefinitionVersion</c> and the currently-registered
+/// descriptor's <see cref="DashboardDefinition.Version"/>:
+/// <see cref="DashboardDriftStatus.Aligned"/> (equal),
+/// <see cref="DashboardDriftStatus.Behind"/> (module shipped a newer version since import),
+/// <see cref="DashboardDriftStatus.Ahead"/> (host loaded an older module than at import),
+/// <see cref="DashboardDriftStatus.Unknown"/> (unparseable / mismatched pre-release suffixes).
+/// Frontend uses this to surface a "Dashboard outdated, click to resync" banner without
+/// an extra round-trip.
 /// </param>
 /// <param name="SourceDefinitionVersion">
 /// Persisted version captured at import time. <see langword="null"/> when the
@@ -36,8 +40,8 @@ namespace Granit.Dashboards.Endpoints.Dtos;
 /// </param>
 /// <param name="RegisteredVersion">
 /// Currently-registered descriptor version. <see langword="null"/> when the source
-/// definition is no longer registered (<c>DriftStatus</c> = <c>SourceUnregistered</c>)
-/// or the dashboard has no source (<c>DriftStatus</c> = <c>NotApplicable</c>).
+/// definition is no longer registered (<c>DriftStatus</c> = <see cref="DashboardDriftStatus.SourceUnregistered"/>)
+/// or the dashboard has no source (<c>DriftStatus</c> = <see cref="DashboardDriftStatus.NotApplicable"/>).
 /// </param>
 /// <param name="Widgets">One flat record per widget, in <c>WidgetInstance.Position</c> order. Reflects the active view only.</param>
 public sealed record DashboardRenderResponse(

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Granit.Analytics;
 using Granit.Dashboards;
 using Granit.Dashboards.Domain;
@@ -12,8 +13,17 @@ namespace Granit.Dashboards.Endpoints.Internal;
 /// other projection helpers so the endpoint handler stays reflection-free and
 /// the wire shape can be unit-tested without an HTTP harness.
 /// </summary>
-internal static class DashboardRenderProjection
+internal static partial class DashboardRenderProjection
 {
+    /// <summary>
+    /// Semver shape accepted by drift detection: <c>MAJOR.MINOR.PATCH</c> with an
+    /// optional pre-release (<c>-alpha.1</c>) or build-metadata (<c>+build.7</c>)
+    /// suffix. Strings outside this shape collapse to
+    /// <see cref="DashboardDriftStatus.Unknown"/> (cautious default).
+    /// </summary>
+    [GeneratedRegex(@"^(\d+)\.(\d+)\.(\d+)([-+].*)?$", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 200)]
+    private static partial Regex SemverRegex();
+
     /// <summary>
     /// Composes the wire response from the renderer's pipeline result, the
     /// persisted <see cref="Dashboard"/> aggregate (source of structural metadata
@@ -99,14 +109,19 @@ internal static class DashboardRenderProjection
     /// <summary>
     /// ADR-038 §3 drift detection. Compares the persisted dashboard's
     /// <see cref="Dashboard.SourceDefinitionVersion"/> against the currently-registered
-    /// descriptor's <see cref="IDashboardDefinitionDescriptor.Version"/>.
+    /// descriptor's <see cref="IDashboardDefinitionDescriptor.Version"/> using a
+    /// semver-aware ordering (MAJOR.MINOR.PATCH numeric tuple, suffix string-equal).
     /// </summary>
     /// <remarks>
-    /// Pure string equality on the Version field (semver values are not parsed
-    /// — the framework treats <c>"1.0.0"</c> and <c>"1.0.0.0"</c> as different,
-    /// which is the cautious default; module authors should keep the version
-    /// format stable across releases). A semver-aware variant can land in a
-    /// follow-up if the cautious string compare proves too noisy in practice.
+    /// Mirrors the frontend's <c>compareVersions</c> helper in
+    /// <c>granit-front/@granit/dashboards</c>: numeric tuple drives
+    /// <see cref="DashboardDriftStatus.Behind"/> / <see cref="DashboardDriftStatus.Ahead"/>;
+    /// matching tuples with identical suffixes report
+    /// <see cref="DashboardDriftStatus.Aligned"/>; matching tuples with mismatched
+    /// suffixes (or strings outside the semver shape) report
+    /// <see cref="DashboardDriftStatus.Unknown"/>. Keeping both ends in lock-step
+    /// avoids a UI banner that disagrees with the wire response on what "drift"
+    /// means.
     /// </remarks>
     private static (DashboardDriftStatus Status, string? RegisteredVersion) ResolveDriftStatus(
         Dashboard dashboard,
@@ -123,14 +138,66 @@ internal static class DashboardRenderProjection
             return (DashboardDriftStatus.SourceUnregistered, null);
         }
 
-        DashboardDriftStatus status = string.Equals(
-            dashboard.SourceDefinitionVersion,
-            descriptor.Version,
-            StringComparison.Ordinal)
-                ? DashboardDriftStatus.InSync
-                : DashboardDriftStatus.Drift;
-
+        DashboardDriftStatus status = CompareSemver(dashboard.SourceDefinitionVersion, descriptor.Version);
         return (status, descriptor.Version);
+    }
+
+    /// <summary>
+    /// Pure semver compare; returns one of <see cref="DashboardDriftStatus.Aligned"/>
+    /// / <see cref="DashboardDriftStatus.Behind"/> / <see cref="DashboardDriftStatus.Ahead"/>
+    /// / <see cref="DashboardDriftStatus.Unknown"/>. Marked <see langword="internal"/>
+    /// so the projection unit tests can pin every branch of the matrix without
+    /// reaching for a full <c>Dashboard</c> aggregate.
+    /// </summary>
+    internal static DashboardDriftStatus CompareSemver(string? persisted, string? registered)
+    {
+        if (persisted is not { Length: > 0 } || registered is not { Length: > 0 })
+        {
+            return DashboardDriftStatus.Unknown;
+        }
+
+        Match persistedMatch = SemverRegex().Match(persisted);
+        Match registeredMatch = SemverRegex().Match(registered);
+        if (!persistedMatch.Success || !registeredMatch.Success)
+        {
+            return DashboardDriftStatus.Unknown;
+        }
+
+        int persistedMajor = int.Parse(persistedMatch.Groups[1].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        int persistedMinor = int.Parse(persistedMatch.Groups[2].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        int persistedPatch = int.Parse(persistedMatch.Groups[3].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        string persistedSuffix = persistedMatch.Groups[4].Value;
+
+        int registeredMajor = int.Parse(registeredMatch.Groups[1].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        int registeredMinor = int.Parse(registeredMatch.Groups[2].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        int registeredPatch = int.Parse(registeredMatch.Groups[3].ValueSpan, System.Globalization.CultureInfo.InvariantCulture);
+        string registeredSuffix = registeredMatch.Groups[4].Value;
+
+        int majorCmp = persistedMajor.CompareTo(registeredMajor);
+        if (majorCmp != 0)
+        {
+            return majorCmp < 0 ? DashboardDriftStatus.Behind : DashboardDriftStatus.Ahead;
+        }
+
+        int minorCmp = persistedMinor.CompareTo(registeredMinor);
+        if (minorCmp != 0)
+        {
+            return minorCmp < 0 ? DashboardDriftStatus.Behind : DashboardDriftStatus.Ahead;
+        }
+
+        int patchCmp = persistedPatch.CompareTo(registeredPatch);
+        if (patchCmp != 0)
+        {
+            return patchCmp < 0 ? DashboardDriftStatus.Behind : DashboardDriftStatus.Ahead;
+        }
+
+        // Numeric tuple matches — suffix must agree byte-for-byte to claim alignment.
+        // Pre-release ordering per semver §11 is intentionally not implemented: cautious
+        // default of Unknown lets the frontend show both raw strings instead of guessing
+        // whether "1.0.0-rc.1" precedes or follows "1.0.0-beta.2".
+        return string.Equals(persistedSuffix, registeredSuffix, StringComparison.Ordinal)
+            ? DashboardDriftStatus.Aligned
+            : DashboardDriftStatus.Unknown;
     }
 
     public static ResolvedPeriod? TryBuildResolvedPeriod(DashboardRenderRequest request)

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -316,7 +316,7 @@ public sealed class DashboardRenderProjectionTests
     }
 
     [Fact]
-    public void ToResponse_DriftStatus_InSync_WhenVersionsMatch()
+    public void ToResponse_DriftStatus_Aligned_WhenVersionsMatch()
     {
         Dashboard dashboard = NewDashboard();
 
@@ -337,13 +337,13 @@ public sealed class DashboardRenderProjectionTests
             registry,
             periodToken: null);
 
-        response.DriftStatus.ShouldBe(DashboardDriftStatus.InSync);
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.Aligned);
         response.SourceDefinitionVersion.ShouldBe("1.0.0");
         response.RegisteredVersion.ShouldBe("1.0.0");
     }
 
     [Fact]
-    public void ToResponse_DriftStatus_Drift_WhenVersionsDiffer()
+    public void ToResponse_DriftStatus_Behind_WhenRegisteredVersionIsNewer()
     {
         Dashboard dashboard = NewDashboard();                        // imported at v1.0.0
 
@@ -364,9 +364,55 @@ public sealed class DashboardRenderProjectionTests
             registry,
             periodToken: null);
 
-        response.DriftStatus.ShouldBe(DashboardDriftStatus.Drift);
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.Behind);
         response.SourceDefinitionVersion.ShouldBe("1.0.0");
         response.RegisteredVersion.ShouldBe("1.1.0");
+    }
+
+    [Fact]
+    public void ToResponse_DriftStatus_Ahead_WhenRegisteredVersionIsOlder()
+    {
+        Dashboard dashboard = NewDashboard();                        // imported at v1.0.0
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id, RenderedAt: RenderedAt, Period: null, Widgets: []);
+
+        IDashboardDefinitionDescriptor descriptor = Substitute.For<IDashboardDefinitionDescriptor>();
+        descriptor.Name.Returns(SourceDefinitionName);
+        descriptor.Version.Returns("0.9.0");                         // host loaded an older module
+        descriptor.Widgets.Returns(Array.Empty<WidgetDefinition>());
+
+        IDashboardDefinitionRegistry registry = Substitute.For<IDashboardDefinitionRegistry>();
+        registry.Find(SourceDefinitionName).Returns(descriptor);
+
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard,
+            new ResolvedRenderTarget(dashboard.Widgets, ActiveViewName: null),
+            registry,
+            periodToken: null);
+
+        response.DriftStatus.ShouldBe(DashboardDriftStatus.Ahead);
+        response.SourceDefinitionVersion.ShouldBe("1.0.0");
+        response.RegisteredVersion.ShouldBe("0.9.0");
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "1.0.0", DashboardDriftStatus.Aligned)]
+    [InlineData("1.0.0", "1.0.1", DashboardDriftStatus.Behind)]                  // patch bump
+    [InlineData("1.0.0", "1.1.0", DashboardDriftStatus.Behind)]                  // minor bump
+    [InlineData("1.0.0", "2.0.0", DashboardDriftStatus.Behind)]                  // major bump
+    [InlineData("1.10.0", "1.9.0", DashboardDriftStatus.Ahead)]                  // numeric (not lexicographic) compare
+    [InlineData("2.0.0", "1.99.99", DashboardDriftStatus.Ahead)]                 // major dominates
+    [InlineData("1.0.0-alpha", "1.0.0-alpha", DashboardDriftStatus.Aligned)]     // identical pre-release suffix
+    [InlineData("1.0.0-alpha", "1.0.0-beta", DashboardDriftStatus.Unknown)]      // mismatched pre-release suffix
+    [InlineData("1.0.0", "1.0.0-rc.1", DashboardDriftStatus.Unknown)]            // suffix vs no suffix on equal tuple
+    [InlineData("1.0.0+build.7", "1.0.0+build.8", DashboardDriftStatus.Unknown)] // build metadata differs
+    [InlineData("not-a-version", "1.0.0", DashboardDriftStatus.Unknown)]         // unparseable persisted
+    [InlineData("1.0.0", "v1.0.0", DashboardDriftStatus.Unknown)]                // 'v' prefix not part of semver shape
+    [InlineData("", "1.0.0", DashboardDriftStatus.Unknown)]                      // empty persisted
+    public void CompareSemver_PinsTheMatrix(string persisted, string registered, DashboardDriftStatus expected)
+    {
+        DashboardRenderProjection.CompareSemver(persisted, registered).ShouldBe(expected);
     }
 
     private static IDashboardDefinitionRegistry EmptyRegistry()


### PR DESCRIPTION
## Summary

- Aligns the backend's ADR-038 §3 drift detection with the frontend's existing semver-aware ordering — backend was emitting `Drift` for `1.0.0` → `1.10.0` while the frontend (which compares numeric tuples) was already showing `behind` for `1.10.0` ahead of `1.9.0`.
- Replaces the 4-state enum (`NotApplicable` / `InSync` / `Drift` / `SourceUnregistered`) with the 6-state model the frontend already speaks: `NotApplicable`, `Aligned`, `Behind`, `Ahead`, `Unknown`, `SourceUnregistered`.
- Introduces a `[GeneratedRegex]`-backed semver parse (`MAJOR.MINOR.PATCH(-prerelease|+build)?`) and exposes `CompareSemver` as `internal` so the matrix can be pinned by a single Theory (numeric bumps, `1.10.0 > 1.9.0`, mismatched / missing pre-release suffixes, build metadata, unparseable strings).
- Closes the `// A semver-aware variant can land in a follow-up if the cautious string compare proves too noisy in practice` follow-up the original code comment in `DashboardRenderProjection` left open.

Pre-release ordering per semver §11 is intentionally not implemented — mismatched suffixes report `Unknown` (cautious default; the frontend then shows both raw strings via tooltip rather than guessing whether `1.0.0-rc.1` precedes `1.0.0-beta.2`).

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Endpoints` — green
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 134 passed (4 existing drift tests renamed/updated, 1 new theory with 13 rows + 1 new Ahead fact)
- [x] `dotnet format src/Granit.Dashboards.Endpoints --verify-no-changes` — clean
- [x] `dotnet format tests/Granit.Dashboards.Endpoints.Tests --verify-no-changes` — clean
- [x] No remaining `DashboardDriftStatus.InSync` / `DashboardDriftStatus.Drift` references in repo (`grep -rn` clean)

Refs ADR-038 §3, follow-up to #1615.
