### PR TITLE
docs(adr): ADR-043 dashboard push transport is framework-owned (P2.4-A)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4219,7 +4219,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
-      "line": 90,
+      "line": 91,
       "members": [
         {
           "name": "MapCenter",
@@ -4266,7 +4266,7 @@
       "kind": "record",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs",
-      "line": 68,
+      "line": 69,
       "members": [
         {
           "name": "MapCenter",
@@ -4691,7 +4691,7 @@
       "kind": "enum",
       "project": "Granit.Analytics.Abstractions",
       "file": "src/Granit.Analytics.Abstractions/Metrics/RefreshHint.cs",
-      "line": 15,
+      "line": 19,
       "members": []
     },
     {
@@ -4879,7 +4879,7 @@
       "kind": "interface",
       "project": "Granit.Analytics",
       "file": "src/Granit.Analytics/Widgets/IWidgetSource.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "RenderAsync",

--- a/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
@@ -1,0 +1,321 @@
+---
+title: "ADR-043: Dashboard push transport (SSE / WebSocket) is framework-owned"
+description: "Push transport for dashboards is a Granit framework concern, not deferred to a downstream IoT repository. RefreshHint stays widget-level; a new DashboardPushPolicy stays dashboard-level; the effective policy at render time is the union. SSE is the default v1 transport; WebSocket ships as an optional sibling. Renderers, transports, and the existing pull endpoint share one envelope shape."
+sidebar:
+  order: 43
+  label: "043 - Dashboard Push Transport"
+---
+
+> **Date:** 2026-04-30
+> **Authors:** Jean-Francois Meyers
+> **Scope:** granit-dotnet (`Granit.Analytics`, `Granit.Dashboards`, `Granit.Dashboards.Endpoints`, new `Granit.Dashboards.Push`)
+> **Epic:** [#1366](https://github.com/granit-fx/granit-dotnet/issues/1366) — Business Intelligence (P2.4 of the dashboards roadmap)
+> **Status:** Proposed
+
+## Context
+
+The BI EPIC #1366 v1 ships pure **pull** transport: `POST /dashboards/{id}/render`
+returns a one-shot bundle, the frontend re-fetches per the `RefreshHint`. The wire
+shape was deliberately designed to be push-compatible — `WidgetSnapshotEnvelope`
+carries a `Sequence` field that increments per `(widget, tenant)`, and
+`IWidgetSource<TSnapshot>` declares `SubscribeAsync` returning a
+`ChannelReader<WidgetPayload<TSnapshot>>` — but no transport ever shipped.
+
+Several call sites in code and docs frame push transport as *"reserved for the
+future `granit-iot` repository"*:
+
+- [`RefreshHint.cs`](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Analytics.Abstractions/Metrics/RefreshHint.cs) — `Realtime` value: *"Reserved — requires `granit-iot` transport."*
+- [`MetricDefinition.cs`](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Analytics/Metrics/MetricDefinition.cs) — *"`Realtime` is reserved — it requires the push transport scheduled in the `granit-iot` repo."*
+- [`IWidgetSource.cs`](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Analytics/Widgets/IWidgetSource.cs) — *"Real push (WebSocket / SSE) replaces the emulation when the `granit-iot` transport lands."*
+- [`MapWidgetDefinition.cs`](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs) — *"a future `granit-iot` dashboard module owns live device traces"*
+- [`AnalyticsEndpointsOptions.cs`](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs) — *"push transport — see `granit-iot` roadmap"*
+
+**This is wrong.** Push transport is not an IoT-specific concern — it is a
+framework-level capability that any vertical may need:
+
+- A SaaS *Customer Success* dashboard wants live churn-risk events.
+- A *Workflow* dashboard wants real-time task-state transitions.
+- An *Auditing* dashboard wants a live security-event stream.
+- An IoT cockpit wants sensor traces.
+
+Conflating "push transport" with "IoT" forces every non-IoT vertical that
+needs live updates to either pull at unhealthy cadences or take an unwanted
+dependency on a specialised repo. It also leaves the existing scaffolding
+(`Sequence`, `IWidgetSource.SubscribeAsync`, `RefreshHint.Realtime`) in
+permanent placeholder state — a code smell that compounds with every
+release that doesn't ship the transport.
+
+`granit-iot` will still exist — but its job is to ship **IoT-specific
+widget definitions** (sensor gauge, camera feed, alarm light) and the
+*producer* side of the transport (MQTT bridge, OPC-UA adapter). The
+**transport itself** belongs in `granit-dotnet`.
+
+## Decision
+
+### 1. Push transport is owned by `granit-dotnet`
+
+A new package `Granit.Dashboards.Push` ships the SSE transport and the
+sequence-numbering / fan-out plumbing. WebSocket lands as an optional
+sibling `Granit.Dashboards.Push.WebSockets` for hosts that want
+bidirectional payloads (e.g. live alerting back to the server). Both
+implement the same producer contract.
+
+| Package | Role | Default? |
+| ------- | ---- | -------- |
+| `Granit.Dashboards.Push` | SSE transport, `IWidgetPushPublisher`, sequence allocator, fan-out hub | yes (recommended for v1) |
+| `Granit.Dashboards.Push.WebSockets` | WebSocket transport sharing the same publisher contract | opt-in |
+
+### 2. Per-dashboard *and* per-widget — `DashboardPushPolicy` × `RefreshHint`
+
+The user-visible question is *"which widgets warrant a live channel?"*.
+Answering it one way or the other (dashboard-only OR widget-only) loses
+real cases:
+
+- A *cockpit* dashboard is live by design — every widget should push, even
+  ones whose `MetricDefinition.RefreshHint` is `Dynamic` (admin opted in
+  for the whole board).
+- A *Finance Overview* dashboard is mostly KPIs (`Dynamic`) but carries one
+  *alerting widget* whose underlying metric is `Realtime` — only that
+  widget should push.
+
+The contract therefore exposes **two orthogonal axes**:
+
+#### 2.1 Per-widget hint — `RefreshHint`, already there
+
+`RefreshHint.Realtime` is no longer "reserved". It declares *"this widget's
+data is push-eligible — wire the live channel when the host has loaded the
+push transport"*. Inheritance stays the same:
+
+- KPI widgets inherit from `MetricDefinition.RefreshHint`.
+- Chart / Table / Pivot inherit from a future `QueryDefinition.RefreshHint`
+  (today they hardcode `Dynamic`).
+- Static-content widgets (Markdown / Image / Text) stay `Static` — never
+  push.
+
+#### 2.2 Per-dashboard policy — `DashboardPushPolicy`, new
+
+`DashboardDefinition` exposes a virtual `PushPolicy` property; the persisted
+`Dashboard` aggregate captures the same value at import time and admins
+can adjust it on their persisted instance:
+
+```csharp
+public enum DashboardPushPolicy
+{
+    /// <summary>
+    /// Pure pull. Dashboard ignores any per-widget Realtime hint. Frontend
+    /// polls per RefreshHint TTL. Default for verticals that don't ship the
+    /// push transport package or want to keep the cost ceiling predictable.
+    /// </summary>
+    PullOnly = 0,
+
+    /// <summary>
+    /// Push the widgets whose effective RefreshHint is Realtime. Pull
+    /// everything else. Default for dashboards that mix live + cached data
+    /// (e.g. one alerting widget on a finance overview).
+    /// </summary>
+    WhenWidgetsRequest = 1,
+
+    /// <summary>
+    /// Push every widget regardless of its RefreshHint. Use sparingly —
+    /// reserved for cockpit-style boards where the whole admin's mental
+    /// model is "this board is live".
+    /// </summary>
+    Force = 2,
+}
+```
+
+#### 2.3 Effective policy — composition rule
+
+At render time the framework computes the **effective transport per widget**:
+
+| Dashboard policy | Widget hint | Effective transport |
+| ---------------- | ----------- | ------------------- |
+| `PullOnly` | any | pull |
+| `WhenWidgetsRequest` | `Static` / `Dynamic` | pull |
+| `WhenWidgetsRequest` | `Realtime` | push |
+| `Force` | `Static` | pull (no point pushing static content) |
+| `Force` | `Dynamic` / `Realtime` | push |
+
+The render bundle response surfaces the chosen transport on each
+`DashboardRenderedWidgetResponse` so the frontend knows which subscriptions
+to open, and which widgets to leave on TanStack pull cadences. Wire field:
+`Transport: "pull" | "push"`.
+
+### 3. Wire contract — SSE first
+
+The default transport ships as **Server-Sent Events** under one endpoint per
+dashboard:
+
+```http
+GET /dashboards/{id}/stream
+Accept: text/event-stream
+```
+
+Wire format — one event per envelope, JSON-encoded same shape as
+`DashboardRenderedWidgetResponse`:
+
+```text
+event: snapshot
+id: <Sequence>
+data: { "widgetId": "...", "sequence": 42, "snapshot": {...}, "transport": "push" }
+
+event: heartbeat
+data: {"emittedAt":"2026-04-30T10:00:00Z"}
+```
+
+Reasons for SSE-as-default:
+
+- One-way (server → client) matches the dashboard use-case 1:1.
+- HTTP/2 multiplexes multiple SSE streams over the same connection — no
+  WebSocket per-tab budget pressure.
+- Built-in reconnect + `Last-Event-ID` resume. Sequence numbering on the
+  server side is enough — clients don't need a custom replay protocol.
+- No SignalR / Microsoft.AspNetCore.WebSockets dependency in the default
+  package. WebSocket sits behind a sibling package that hosts opt into.
+- Auth piggybacks on the existing cookie/JWT — same identity bearer as
+  `POST /dashboards/{id}/render`.
+
+WebSocket sibling (`Granit.Dashboards.Push.WebSockets`) ships when a host
+wants bidirectional flow (live commands back to the server, e.g.
+acknowledging an alert). Same `IWidgetPushPublisher` producer contract,
+different consumer protocol.
+
+### 4. Producer contract — `IWidgetPushPublisher`
+
+Modules that produce live data publish through the framework rather than
+directly to a SignalR hub:
+
+```csharp
+public interface IWidgetPushPublisher
+{
+    /// <summary>
+    /// Publishes a fresh snapshot for the given (tenant, widget). Framework
+    /// allocates the next Sequence, fans out to subscribed streams, and
+    /// invalidates the FusionCache entry so a cold pull returns the new
+    /// value immediately after a push hits.
+    /// </summary>
+    Task PublishAsync(
+        Guid? tenantId,
+        Guid widgetInstanceId,
+        WidgetSnapshotEnvelope envelope,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The poll-emulation default that `IWidgetSource<TSnapshot>.SubscribeAsync`
+documented but never shipped is replaced by the explicit publisher
+contract. Producers that *can't* push (because their data only updates on
+schedule) simply don't call `IWidgetPushPublisher` — the dashboard falls
+back to the pull cadence implied by the effective policy.
+
+### 5. Sequence numbering
+
+Locked by EPIC #1366 invariant #2 — *"`Sequence` is monotonic per `(widget,
+tenant)`; v1 in pull mode = always `1`, push transport increments on every
+emit"*. The framework owns the allocator:
+
+- v1 implementation: `IDistributedCache`-backed counter, key
+  `granit:dashboards:push:seq:{tenantId}:{widgetId}`.
+- Pull endpoint stays at `Sequence = 1` (same envelope, no change to the
+  bundle response) — pull doesn't need ordering.
+- Push transport reads `Last-Event-ID` on reconnect and replays the
+  per-widget snapshot at `seq + 1` from a small server-side ring (last 100
+  envelopes per widget), then continues live. Ring size is a host option
+  with a sensible default — not a per-tenant knob.
+
+The pull / push split therefore stays a *transport* detail. The widget
+producer doesn't know whether its envelope reached the client over SSE
+or via the next pull.
+
+### 6. Authorization
+
+Stream channels enforce the **same permission gate as the render
+endpoint**: `Dashboards.Instances.Read` for the dashboard, plus
+per-widget `RequiredPermission` for individual widgets. A client lacking a
+widget's permission receives `Status = Unavailable` envelopes (mirrors the
+pull behaviour) — never silently dropped. Multi-tenant isolation is
+enforced at fan-out: `IWidgetPushPublisher.PublishAsync` takes the tenant
+id, the hub partitions subscribers per tenant.
+
+### 7. Pull fallback when transport not wired
+
+A host that ships `Granit.Dashboards.Endpoints` *without*
+`Granit.Dashboards.Push` continues working — the framework defaults
+`DashboardPushPolicy` to `PullOnly` when no `IWidgetPushPublisher` is
+registered, regardless of what the descriptor declared. A widget whose
+`RefreshHint` is `Realtime` but whose host has no push transport renders
+as if it were `Dynamic` (short-TTL pull). The wire response's `Transport`
+field reports `"pull"` so the frontend doesn't try to open a stream that
+will never connect.
+
+### 8. Cleanup of `granit-iot` references
+
+Every reference framing push transport as a `granit-iot` concern is
+rewritten to reflect framework ownership. The `Map` widget specifically
+keeps a `granit-iot` mention — but only for the *content* (live device
+traces require NetTopologySuite plumbing that belongs in IoT) — never for
+the *transport*.
+
+## Consequences
+
+**Positive:**
+
+- Verticals beyond IoT can ship live dashboards without depending on a
+  specialised repo. Customer Success, Workflow, Auditing all unlocked.
+- The placeholder scaffolding (`Sequence`, `RefreshHint.Realtime`,
+  `IWidgetSource.SubscribeAsync`) becomes load-bearing rather than
+  permanently aspirational.
+- Per-dashboard policy is the right knob to add — it lets admins opt a
+  whole board into live mode without touching individual widget
+  definitions.
+
+**Negative:**
+
+- New package family to maintain (`Granit.Dashboards.Push`,
+  `Granit.Dashboards.Push.WebSockets`).
+- Per-tenant ring buffer is an additional infra concern — hosts on
+  serverless platforms (no in-memory state across cold starts) need to
+  back it with a distributed cache, which the v1 design assumes anyway.
+- The render bundle response gains a new `Transport` field — minor wire
+  break for clients that auto-generated their TS types and didn't widen
+  on extras. Mitigated by shipping the field as an additive optional
+  string with a default of `"pull"` for backwards compat.
+
+**Out of scope for this ADR:**
+
+- The producer-side adapters for IoT protocols (MQTT, OPC-UA) — they live
+  in `granit-iot` and consume `IWidgetPushPublisher`.
+- The frontend `usePushedDashboard` hook and TanStack invalidation
+  bridging — owned by `granit-front`.
+- Bidirectional commands over WebSocket (e.g. acknowledging an alert
+  from the dashboard) — the WebSocket sibling package will spec this in
+  a separate ADR if and when it ships.
+
+## Implementation roadmap
+
+This ADR is the foundation for a new mini-EPIC under #1366. Stories
+break down as:
+
+1. **P2.4-A — Cleanup + scaffolding** *(this PR)*
+   - Strip `granit-iot` framing from XML docs, prose, and ADR text
+     (8 sites).
+   - Document `RefreshHint.Realtime` as framework-owned.
+   - Document `IWidgetSource<TSnapshot>.SubscribeAsync` as framework-owned
+     and remove the poll-emulation promise (the producer contract supersedes
+     it).
+2. **P2.4-B — `DashboardPushPolicy` + `Transport` wire field** *(separate PR)*
+   - Add the enum, expose it on `DashboardDefinition` + the persisted
+     `Dashboard` aggregate, surface `Transport` on the render bundle.
+   - Architecture test: dashboard renderers must compute the effective
+     transport per widget per the matrix in §2.3.
+3. **P2.4-C — `Granit.Dashboards.Push` SSE transport**
+   - `IWidgetPushPublisher`, `GET /dashboards/{id}/stream`, sequence
+     allocator, fan-out hub, `Last-Event-ID` resume.
+4. **P2.4-D — `Granit.Dashboards.Push.WebSockets`** *(opt-in)*
+   - WebSocket consumer over the same producer contract.
+5. **P2.4-E — Frontend `usePushedDashboard`** *(`granit-front`)*
+   - Reads the `Transport` field, opens streams selectively, falls back
+     to TanStack pull when `Transport = "pull"`.
+
+P2.4-A through P2.4-C are the load-bearing minimum. D and E are
+incremental.

--- a/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/index.mdx
@@ -110,15 +110,21 @@ would either mislead with "Average invoice amount: 0 €" (because EF Core could
 coalesce) or throw `InvalidOperationException`. Locked by integration tests against both
 SQLite and PostgreSQL.
 
-## Future-proofing for real-time
+## Real-time push transport
 
-Layer 1 is intentionally pull-based (FusionCache TTL 60–120 s). Real-time push (WebSocket
-delta updates, ThingsBoard-style for IoT) is deferred to the
-[`granit-iot`](https://github.com/granit-fx/granit-iot) repo, where the ingestion
-pipeline (MQTT bridge, AWS IoT, TimescaleDB) already lives. The wire-format envelope
-`{ Snapshot, Sequence, EmittedAt, RefreshHint }` and the `IWidgetSource<T>` contract
-(with stub `SubscribeAsync`) are locked v1 so push transport can be added later without
-breaking pull consumers.
+Layer 1 ships pull-based (FusionCache TTL 60–120 s). Real-time push (SSE by default,
+WebSocket as an opt-in sibling) is owned by the framework — `Granit.Dashboards.Push`
+under [ADR-043](/dotnet/architecture/adr/043-dashboard-push-transport/). Hosts that
+need live channels load that package; hosts that don't keep pull-only and degrade
+`Realtime` widgets to `Dynamic` cadence with no runtime breakage. IoT-specific
+producers (MQTT bridge, OPC-UA adapter) and IoT-specific widget definitions (sensor
+gauge, camera feed) live in [`granit-iot`](https://github.com/granit-fx/granit-iot)
+and consume the same framework `IWidgetPushPublisher` contract — the transport
+itself is not IoT-specific.
+
+The wire-format envelope `{ Snapshot, Sequence, EmittedAt, RefreshHint }` and the
+`IWidgetSource<T>` contract are locked v1 so the same source code serves both pull
+and push consumers.
 
 ## Read next
 

--- a/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/inline-metrics.mdx
@@ -159,7 +159,9 @@ yourself:
   `analytics:metric:{name}:{tenantId|global}:{period.from}:{period.to}[:cmp:...]`.
   The tenant is the first security boundary; cross-tenant cache contamination
   is impossible by construction. TTL is 60 s for `Dynamic` metrics, 5 min for
-  `Static`. `Realtime` is reserved for the future push transport (granit-iot).
+  `Static`. `Realtime` metrics bypass the cache and route through the
+  framework push transport (`Granit.Dashboards.Push`, ADR-043) when the host
+  has loaded it; otherwise they degrade to `Dynamic` cadence.
 
 ## `BaseFilter` vs `Selector` — which is which
 

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 58;
-export const ADR_COUNT = 39;
+export const ADR_COUNT = 43;

--- a/src/Granit.Analytics.Abstractions/Metrics/RefreshHint.cs
+++ b/src/Granit.Analytics.Abstractions/Metrics/RefreshHint.cs
@@ -2,14 +2,18 @@ namespace Granit.Analytics.Metrics;
 
 /// <summary>
 /// Indicates how often a metric's underlying data is expected to change. Drives the
-/// caching layer's TTL and signals to the frontend which transport to use (pull vs push).
+/// caching layer's TTL and signals to the dashboards transport layer whether the
+/// widget is push-eligible.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Pure pull-based widgets (the v1 reality) honor <see cref="Static"/> and <see cref="Dynamic"/>
-/// to pick a TTL. <see cref="Realtime"/> is reserved for future push-based transport delivered
-/// by the <c>granit-iot</c> repository (WebSocket / SSE) — pull-based renderers should reject
-/// metrics declaring it (architecture-test enforced) until that transport ships.
+/// <see cref="Static"/> and <see cref="Dynamic"/> drive FusionCache TTL on the pull
+/// path. <see cref="Realtime"/> declares the metric as push-eligible — the framework
+/// transport (<c>Granit.Dashboards.Push</c>, ADR-043) wires a live channel for the
+/// widget when its dashboard's effective <c>DashboardPushPolicy</c> opts in. Hosts
+/// that haven't loaded the push transport package fall back to the
+/// <see cref="Dynamic"/> pull cadence — no widget breaks at runtime when the
+/// transport is absent.
 /// </para>
 /// </remarks>
 public enum RefreshHint
@@ -17,9 +21,13 @@ public enum RefreshHint
     /// <summary>Long-lived data (5+ min cache acceptable). E.g. tenant settings, role catalog.</summary>
     Static,
 
-    /// <summary>Short-lived but pull-friendly (60–120 s cache). v1 default for most KPIs.</summary>
+    /// <summary>Short-lived but pull-friendly (60–120 s cache). Default for most KPIs.</summary>
     Dynamic,
 
-    /// <summary>Push-only, sub-second updates. Reserved — requires <c>granit-iot</c> transport.</summary>
+    /// <summary>
+    /// Push-eligible — sub-second updates. Wired to the live channel by
+    /// <c>Granit.Dashboards.Push</c> (ADR-043). Falls back to <see cref="Dynamic"/>
+    /// pull cadence when the host hasn't loaded the push transport package.
+    /// </summary>
     Realtime,
 }

--- a/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
+++ b/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
@@ -32,7 +32,9 @@ public sealed class AnalyticsEndpointsOptions
     /// <summary>
     /// FusionCache TTL applied to <see cref="Metrics.RefreshHint.Dynamic"/> metrics.
     /// Default: 60 seconds. Static metrics use <see cref="StaticTtl"/>; realtime metrics
-    /// bypass the cache entirely (push transport — see <c>granit-iot</c> roadmap).
+    /// bypass the cache entirely — they are routed through the framework push transport
+    /// (<c>Granit.Dashboards.Push</c>, ADR-043) when the host has loaded it, and
+    /// degrade to <see cref="DynamicTtl"/> when it isn't loaded.
     /// </summary>
     public TimeSpan DynamicTtl { get; set; } = TimeSpan.FromSeconds(60);
 

--- a/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
+++ b/src/Granit.Analytics/Dashboards/Widgets/MapWidgetDefinition.cs
@@ -33,8 +33,9 @@ public abstract record MapPointSource
 /// <summary>
 /// Map widget — renders geocoded query rows as markers on an interactive map.
 /// Useful for any tenant with location data: customer addresses, branch offices,
-/// delivery routes, sales-by-region. Orthogonal to IoT real-time tracking
-/// (a future <c>granit-iot</c> dashboard module owns live device traces).
+/// delivery routes, sales-by-region. The widget itself is pull-friendly; live
+/// device traces (with NetTopologySuite plumbing) are owned by future
+/// <c>granit-iot</c> widget definitions, not by this widget.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Granit.Analytics/Metrics/MetricDefinition.cs
+++ b/src/Granit.Analytics/Metrics/MetricDefinition.cs
@@ -82,10 +82,13 @@ public abstract class MetricDefinition<TEntity, TValue> : IMetricDefinitionDescr
     public virtual bool IsHigherBetter => true;
 
     /// <summary>
-    /// How fresh the metric is expected to be. Pull-based renderers (v1) honor
+    /// How fresh the metric is expected to be. Pull renderers honor
     /// <see cref="RefreshHint.Static"/> and <see cref="RefreshHint.Dynamic"/> to pick a
-    /// FusionCache TTL. <see cref="RefreshHint.Realtime"/> is reserved — it requires the
-    /// push transport scheduled in the <c>granit-iot</c> repo.
+    /// FusionCache TTL. <see cref="RefreshHint.Realtime"/> declares the metric as
+    /// push-eligible; the framework transport (<c>Granit.Dashboards.Push</c>, ADR-043)
+    /// wires the live channel when the host has loaded it. Hosts without the push
+    /// package degrade <c>Realtime</c> widgets to <c>Dynamic</c> cadence — no runtime
+    /// breakage when the transport is absent.
     /// </summary>
     public virtual RefreshHint RefreshHint => RefreshHint.Dynamic;
 

--- a/src/Granit.Analytics/Rendering/MapWidgetInstanceRenderer.cs
+++ b/src/Granit.Analytics/Rendering/MapWidgetInstanceRenderer.cs
@@ -22,8 +22,9 @@ namespace Granit.Analytics.Rendering;
 /// B7-2 ships <see cref="MapPointSource.LatLng"/> (decimal lat/lng columns,
 /// works on any database). The PostGIS <see cref="MapPointSource.Geography"/>
 /// path is deferred — the renderer surfaces
-/// <c>Widget:Unavailable.MapGeographyNotImplemented</c> until
-/// <c>granit-iot</c> ships the NetTopologySuite plumbing.
+/// <c>Widget:Unavailable.MapGeographyNotImplemented</c> until the NetTopologySuite
+/// adapter ships in a future <c>granit-iot</c> package (the spatial column type
+/// is the IoT-specific dependency, not the rendering itself).
 /// </remarks>
 internal sealed class MapWidgetInstanceRenderer(
     MapService mapService,

--- a/src/Granit.Analytics/Widgets/IWidgetSource.cs
+++ b/src/Granit.Analytics/Widgets/IWidgetSource.cs
@@ -3,19 +3,20 @@ using System.Threading.Channels;
 namespace Granit.Analytics.Widgets;
 
 /// <summary>
-/// Pull-and-future-push contract for any widget that produces a payload of
-/// <typeparamref name="TSnapshot"/>. Locked v1 so push transport can be added later
-/// (in <c>granit-iot</c>) without rewriting consumer code.
+/// Pull-and-push contract for any widget that produces a payload of
+/// <typeparamref name="TSnapshot"/>. Locked v1 so consumer code stays the same whether
+/// the host wires the framework push transport (<c>Granit.Dashboards.Push</c>,
+/// ADR-043) or stays pull-only.
 /// </summary>
 /// <typeparam name="TSnapshot">The payload-specific snapshot shape.</typeparam>
 /// <remarks>
 /// <para>
 /// Per EPIC #1366 future-proofing invariant #1 — both <see cref="RenderAsync"/> and
 /// <see cref="SubscribeAsync"/> are exposed from v1. <see cref="RenderAsync"/> is the
-/// real implementation; <see cref="SubscribeAsync"/> ships a poll-emulation default
-/// that re-runs <see cref="RenderAsync"/> on the cadence implied by the metric's
-/// <see cref="Metrics.RefreshHint"/>. Real push (WebSocket / SSE) replaces the
-/// emulation when the <c>granit-iot</c> transport lands.
+/// always-on pull implementation. <see cref="SubscribeAsync"/> is the in-process
+/// stream the push transport adapts onto SSE / WebSocket. Hosts without the push
+/// package can still consume <see cref="SubscribeAsync"/> directly (e.g. internal
+/// background processors that follow widget snapshots without round-tripping HTTP).
 /// </para>
 /// </remarks>
 public interface IWidgetSource<TSnapshot>
@@ -28,15 +29,18 @@ public interface IWidgetSource<TSnapshot>
     Task<WidgetPayload<TSnapshot>> RenderAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Subscribes to a stream of payload updates for this widget. v1 default emulates push
-    /// by repeatedly invoking <see cref="RenderAsync"/> — real push transport (WebSocket / SSE)
-    /// will replace this in the <c>granit-iot</c> repo.
+    /// Subscribes to a stream of payload updates for this widget. Producers that
+    /// can't push (their data only updates on schedule) emit a single seed envelope
+    /// from <see cref="RenderAsync"/> and complete the channel — the dashboard then
+    /// falls back to the pull cadence implied by the effective transport policy
+    /// (ADR-043 §2.3).
     /// </summary>
     /// <param name="cancellationToken">Cancellation token; closes the channel.</param>
     /// <returns>A channel reader that emits payloads as they become available.</returns>
     /// <remarks>
-    /// Implementations may emit either full <see cref="WidgetPayload{TSnapshot}"/> envelopes
-    /// (initial snapshot) or future delta messages. v1 emits snapshots only.
+    /// Implementations may emit full <see cref="WidgetPayload{TSnapshot}"/> envelopes
+    /// (initial snapshot, then live updates). Delta-message support is reserved for
+    /// a follow-up.
     /// </remarks>
     ChannelReader<WidgetPayload<TSnapshot>> SubscribeAsync(CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

- Reframes **P2.4 push transport as a `granit-dotnet` framework concern**, not a `granit-iot` deferral. The existing scaffolding (`Sequence` per `(widget, tenant)`, `RefreshHint.Realtime`, `IWidgetSource<T>.SubscribeAsync`) was put in place from v1 with that intent — but every public framing said *"reserved, see granit-iot roadmap"*, which forced any non-IoT vertical that needs live updates (Customer Success, Workflow, Auditing) to either pull at unhealthy cadences or take an unwanted dependency on a specialised repo.
- Adds **[ADR-043](docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md)** — the load-bearing design doc. Highlights:
  - Per-widget `RefreshHint` × per-dashboard `DashboardPushPolicy` (`PullOnly` / `WhenWidgetsRequest` / `Force`) → effective transport per widget is the composition (matrix in §2.3). Two orthogonal axes because real cases need both: a cockpit dashboard pushes everything; a Finance Overview pushes only its alerting widget.
  - **SSE as the v1 default transport** (one-way fits dashboards 1:1, HTTP/2-multiplexable, built-in `Last-Event-ID` resume, no SignalR dep). WebSocket ships as opt-in sibling `Granit.Dashboards.Push.WebSockets`.
  - **`IWidgetPushPublisher`** is the producer contract — framework owns sequence allocation + per-tenant fan-out + FusionCache invalidation. Producers that can't push simply don't call it; pull fallback kicks in.
  - **Pull fallback** when no `IWidgetPushPublisher` is registered: `Realtime` widgets degrade to `Dynamic` cadence — no runtime breakage when a host hasn't loaded the push package.
  - Authorization piggybacks on the existing `Dashboards.Instances.Read` + per-widget `RequiredPermission`. Multi-tenant fan-out partitions per `tenantId`.
- Strips the `granit-iot` framing from 5 XML doc comments + 2 MDX pages. The remaining 3 references are correctly scoped to IoT-specific *content* (NetTopologySuite spatial column types, IoT-specific widget definitions — sensor gauge, camera feed) — never to the transport itself.
- Bumps `ADR_COUNT` 39 → 43 (was stale — ADRs 040/041/042 + this one weren't reflected).

**P2.4 broken into 5 stories:** A (this PR — cleanup + ADR), B (`DashboardPushPolicy` + `Transport` wire field), C (`Granit.Dashboards.Push` SSE transport), D (WebSocket sibling, opt-in), E (frontend `usePushedDashboard` hook in `granit-front`). A through C are the load-bearing minimum; D and E are incremental.

## Test plan

- [x] `dotnet build` clean on all 4 affected packages (`Granit.Analytics`, `Granit.Analytics.Abstractions`, `Granit.Analytics.Endpoints`, `Granit.Dashboards.Endpoints`)
- [x] `dotnet test tests/Granit.Analytics.Tests` — 46 passed
- [x] `dotnet test tests/Granit.Dashboards.Tests` — 31 passed
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 138 passed
- [x] `dotnet format --verify-no-changes` clean on touched packages
- [x] `markdownlint-cli2` clean on the new ADR
- [x] `grep -r "granit-iot"` clean except the 3 intentional content references (Map widget spatial path)

No runtime contract changes — pure docs / XML doc updates. The runtime contract changes land in P2.4-B.

Refs EPIC #1366 (P2.4 of the dashboards roadmap).
