### PR TITLE
feat(dashboards-render): DashboardPushPolicy + Transport wire field (P2.4-B)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13451,6 +13451,12 @@
           "returnType": "DashboardLayout"
         },
         {
+          "name": "PushPolicy",
+          "kind": "property",
+          "signature": "DashboardPushPolicy PushPolicy",
+          "returnType": "DashboardPushPolicy"
+        },
+        {
           "name": "DefaultTimeWindow",
           "kind": "property",
           "signature": "DashboardTimeWindow? DefaultTimeWindow",
@@ -13542,6 +13548,31 @@
       "file": "src/Granit.Dashboards.Abstractions/DashboardLayout.cs",
       "line": 71,
       "members": []
+    },
+    {
+      "name": "DashboardPushPolicy",
+      "fqn": "Granit.Dashboards.DashboardPushPolicy",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardPushPolicy.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "DashboardPushPolicyComposer",
+      "fqn": "Granit.Dashboards.DashboardPushPolicyComposer",
+      "kind": "class",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/DashboardPushPolicyComposer.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Compose",
+          "kind": "method",
+          "signature": "Compose(DashboardPushPolicy dashboardPolicy, RefreshHint widgetHint)",
+          "returnType": "WidgetTransport"
+        }
+      ]
     },
     {
       "name": "DashboardTimeWindow",
@@ -13662,9 +13693,15 @@
           "returnType": "DashboardCategory"
         },
         {
+          "name": "Widgets",
+          "kind": "property",
+          "signature": "IReadOnlyList<WidgetInstance> Widgets",
+          "returnType": "IReadOnlyList<WidgetInstance>"
+        },
+        {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, string name, DashboardCategory category, int layoutColumns = 12, int layoutRowHeight = 80, Guid? tenantId = null, string? sourceDefinitionName = null, string? sourceDefinitionVersion = null, bool isSystem = false)",
+          "signature": "Create(Guid id, string name, DashboardCategory category, int layoutColumns = 12, int layoutRowHeight = 80, Guid? tenantId = null, string? sourceDefinitionName = null, string? sourceDefinitionVersion = null, bool isSystem = false, DashboardPushPolicy pushPolicy = DashboardPushPolicy.WhenWidgetsRequest)",
           "returnType": "Dashboard"
         }
       ]
@@ -13939,7 +13976,7 @@
       "kind": "record",
       "project": "Granit.Dashboards.Endpoints",
       "file": "src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs",
-      "line": 92,
+      "line": 98,
       "members": []
     },
     {
@@ -14574,6 +14611,15 @@
           "returnType": "WidgetSize MediaTile =>"
         }
       ]
+    },
+    {
+      "name": "WidgetTransport",
+      "fqn": "Granit.Dashboards.WidgetTransport",
+      "kind": "enum",
+      "project": "Granit.Dashboards.Abstractions",
+      "file": "src/Granit.Dashboards.Abstractions/WidgetTransport.cs",
+      "line": 15,
+      "members": []
     },
     {
       "name": "ImageFit",

--- a/src/Granit.Analytics.Endpoints/Internal/WidgetRenderHelper.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/WidgetRenderHelper.cs
@@ -116,6 +116,12 @@ internal static class WidgetRenderHelper
             Sequence: rendered.Envelope.Sequence,
             EmittedAt: rendered.Envelope.EmittedAt,
             RefreshHint: rendered.Envelope.RefreshHint,
+            // Single-widget render path has no parent dashboard policy — fall back to
+            // the default WhenWidgetsRequest semantics so a Realtime widget rendered
+            // standalone still reports Transport=Push to the caller (ADR-043 §2.3).
+            Transport: DashboardPushPolicyComposer.Compose(
+                DashboardPushPolicy.WhenWidgetsRequest,
+                rendered.Envelope.RefreshHint),
             Snapshot: rendered.Envelope.Snapshot,
             ReasonLocalizationKey: rendered.Envelope.ReasonLocalizationKey));
     }

--- a/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardDefinition.cs
@@ -63,6 +63,16 @@ public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
     public virtual DashboardLayout Layout => DashboardLayout.Default;
 
     /// <summary>
+    /// Per-dashboard transport switch — ADR-043 §2. Defaults to
+    /// <see cref="DashboardPushPolicy.WhenWidgetsRequest"/> so the framework opens a
+    /// live channel only for widgets that explicitly declare
+    /// <c>RefreshHint.Realtime</c>. Cockpit-style boards override to
+    /// <see cref="DashboardPushPolicy.Force"/>; verticals that prefer a predictable
+    /// cost ceiling override to <see cref="DashboardPushPolicy.PullOnly"/>.
+    /// </summary>
+    public virtual DashboardPushPolicy PushPolicy => DashboardPushPolicy.WhenWidgetsRequest;
+
+    /// <summary>
     /// Default time window applied to every data-bound widget that does not carry
     /// its own <see cref="WidgetDefinition.TimeWindowOverride"/>. <c>null</c> means
     /// "let the frontend pick its global default" — typical for a dashboard whose

--- a/src/Granit.Dashboards.Abstractions/DashboardPushPolicy.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardPushPolicy.cs
@@ -1,0 +1,46 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Per-dashboard switch that decides which widgets warrant a live push channel.
+/// ADR-043 §2 — composed at render time with each widget's
+/// <c>RefreshHint</c> to produce the effective transport.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework evaluates the composition matrix per widget; the render bundle
+/// response surfaces the chosen transport on
+/// <c>DashboardRenderedWidgetResponse.Transport</c> so the frontend opens streams
+/// selectively. See <see cref="DashboardPushPolicyComposer.Compose"/> for the
+/// canonical resolution.
+/// </para>
+/// <para>
+/// Pull fallback is automatic — a host that hasn't loaded the framework push
+/// transport package emits <see cref="WidgetTransport.Pull"/> for every widget
+/// regardless of declared policy, so dashboards keep rendering.
+/// </para>
+/// </remarks>
+public enum DashboardPushPolicy
+{
+    /// <summary>
+    /// Pure pull. Dashboard ignores any per-widget <c>Realtime</c> hint — every
+    /// widget renders over the pull endpoint and the frontend polls per
+    /// <c>RefreshHint</c> TTL. Default for verticals that prefer a predictable
+    /// cost ceiling or haven't loaded the push transport package.
+    /// </summary>
+    PullOnly = 0,
+
+    /// <summary>
+    /// Push the widgets whose effective <c>RefreshHint</c> is <c>Realtime</c>.
+    /// Pull everything else. Default for dashboards that mix live + cached data
+    /// (e.g. one alerting widget on a finance overview).
+    /// </summary>
+    WhenWidgetsRequest = 1,
+
+    /// <summary>
+    /// Push every widget regardless of its <c>RefreshHint</c> (with the exception
+    /// of static-content widgets — there's no point pushing a Markdown banner).
+    /// Use sparingly — reserved for cockpit-style boards where the whole admin's
+    /// mental model is "this board is live".
+    /// </summary>
+    Force = 2,
+}

--- a/src/Granit.Dashboards.Abstractions/DashboardPushPolicyComposer.cs
+++ b/src/Granit.Dashboards.Abstractions/DashboardPushPolicyComposer.cs
@@ -1,0 +1,41 @@
+using Granit.Analytics.Metrics;
+
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Pure composition of <see cref="DashboardPushPolicy"/> and
+/// <see cref="RefreshHint"/> into the effective <see cref="WidgetTransport"/> for
+/// one widget. Locked by ADR-043 §2.3 — the same matrix is shipped to the front
+/// in the public docs page.
+/// </summary>
+/// <remarks>
+/// Lives in <c>Granit.Dashboards.Abstractions</c> so both the render-time projector
+/// (<c>Granit.Dashboards.Endpoints</c>) and the future push transport hub
+/// (<c>Granit.Dashboards.Push</c>) consume the exact same function — no chance for
+/// the two ends to disagree on which widget is live.
+/// </remarks>
+public static class DashboardPushPolicyComposer
+{
+    /// <summary>
+    /// Composes a single widget's effective transport from its dashboard's policy
+    /// and its own <see cref="RefreshHint"/>. Pure — same input, same output.
+    /// </summary>
+    /// <param name="dashboardPolicy">Policy declared by the dashboard descriptor (or persisted on the aggregate after import).</param>
+    /// <param name="widgetHint">Refresh hint surfaced by the widget renderer (typically inherited from the underlying metric / query, or hardcoded for static-content widgets).</param>
+    /// <returns>
+    /// <see cref="WidgetTransport.Push"/> when the widget warrants a live channel
+    /// per the matrix; <see cref="WidgetTransport.Pull"/> otherwise. Static-content
+    /// widgets always pull, even under <see cref="DashboardPushPolicy.Force"/> —
+    /// pushing a Markdown banner has no value.
+    /// </returns>
+    public static WidgetTransport Compose(DashboardPushPolicy dashboardPolicy, RefreshHint widgetHint)
+        => (dashboardPolicy, widgetHint) switch
+        {
+            (DashboardPushPolicy.PullOnly, _) => WidgetTransport.Pull,
+            (DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Realtime) => WidgetTransport.Push,
+            (DashboardPushPolicy.WhenWidgetsRequest, _) => WidgetTransport.Pull,
+            (DashboardPushPolicy.Force, RefreshHint.Static) => WidgetTransport.Pull,
+            (DashboardPushPolicy.Force, _) => WidgetTransport.Push,
+            _ => WidgetTransport.Pull,
+        };
+}

--- a/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
+++ b/src/Granit.Dashboards.Abstractions/IDashboardDefinitionDescriptor.cs
@@ -38,6 +38,13 @@ public interface IDashboardDefinitionDescriptor
     DashboardLayout Layout { get; }
 
     /// <summary>
+    /// Per-dashboard transport switch. Composed at render time with each widget's
+    /// <c>RefreshHint</c> via <see cref="DashboardPushPolicyComposer.Compose"/> to
+    /// produce the effective <see cref="WidgetTransport"/>. ADR-043 §2.
+    /// </summary>
+    DashboardPushPolicy PushPolicy { get; }
+
+    /// <summary>
     /// Default time window applied to every data-bound widget that does not carry its
     /// own <see cref="WidgetDefinition.TimeWindowOverride"/>. <c>null</c> means the
     /// frontend falls back to its global default (typically <c>last_30d</c>) — useful

--- a/src/Granit.Dashboards.Abstractions/WidgetTransport.cs
+++ b/src/Granit.Dashboards.Abstractions/WidgetTransport.cs
@@ -1,0 +1,30 @@
+namespace Granit.Dashboards;
+
+/// <summary>
+/// Effective transport selected for a widget at render time. Output of
+/// <see cref="DashboardPushPolicyComposer.Compose"/> — the composition of
+/// the dashboard's <see cref="DashboardPushPolicy"/> and the widget's
+/// <c>RefreshHint</c>.
+/// </summary>
+/// <remarks>
+/// Surfaced on the wire under <c>DashboardRenderedWidgetResponse.Transport</c> so
+/// the frontend opens push subscriptions only for widgets that actually receive
+/// live updates. Pull-only widgets continue to drive their TanStack cache cadence
+/// from <c>RefreshHint</c>. ADR-043 §2.3.
+/// </remarks>
+public enum WidgetTransport
+{
+    /// <summary>
+    /// The widget renders over the pull endpoint. Frontend polls per
+    /// <c>RefreshHint</c> TTL — never opens a stream for it.
+    /// </summary>
+    Pull = 0,
+
+    /// <summary>
+    /// The widget is live — frontend should open a push subscription
+    /// (<c>GET /dashboards/{id}/stream</c>) and stop pulling. The pull endpoint
+    /// still returns the seed envelope so the dashboard renders before the
+    /// stream connects.
+    /// </summary>
+    Push = 1,
+}

--- a/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
+++ b/src/Granit.Dashboards.Endpoints/Dtos/DashboardRenderResponse.cs
@@ -87,6 +87,12 @@ public sealed record DashboardRenderPeriodResponse(DateTimeOffset From, DateTime
 /// <param name="Sequence">Always <c>1</c> in pull mode; future push transport increments per (widget, tenant). EPIC #1366 invariant #2.</param>
 /// <param name="EmittedAt">Server-side timestamp of the widget's computation.</param>
 /// <param name="RefreshHint">Pull / push transport hint — drives the frontend's per-widget cache TTL.</param>
+/// <param name="Transport">
+/// Effective transport selected for this widget — composition of the dashboard's
+/// <c>PushPolicy</c> and the widget's <see cref="RefreshHint"/> per ADR-043 §2.3.
+/// <see cref="WidgetTransport.Push"/> tells the frontend to subscribe to the live channel and stop pulling;
+/// <see cref="WidgetTransport.Pull"/> means the widget honors <see cref="RefreshHint"/> on the pull endpoint.
+/// </param>
 /// <param name="Snapshot">Pre-serialised typed payload. <see langword="null"/> when <see cref="Status"/> is not <see cref="WidgetSnapshotStatus.Snapshot"/>.</param>
 /// <param name="ReasonLocalizationKey">Localization key for the user-facing reason — set on <see cref="WidgetSnapshotStatus.Unavailable"/> and <see cref="WidgetSnapshotStatus.Error"/>; <see langword="null"/> on <see cref="WidgetSnapshotStatus.Snapshot"/>. Resolved client-side so the same envelope can be cached across user locales.</param>
 public sealed record DashboardRenderedWidgetResponse(
@@ -103,5 +109,6 @@ public sealed record DashboardRenderedWidgetResponse(
     long Sequence,
     DateTimeOffset EmittedAt,
     RefreshHint RefreshHint,
+    WidgetTransport Transport,
     JsonElement? Snapshot,
     string? ReasonLocalizationKey = null);

--- a/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
+++ b/src/Granit.Dashboards.Endpoints/Internal/DashboardRenderProjection.cs
@@ -74,6 +74,14 @@ internal static partial class DashboardRenderProjection
             string slug = ExtractSlug(instance.TitleLocalizationKey, dashboard.SourceDefinitionName);
             actionsBySlug.TryGetValue(slug, out IReadOnlyList<WidgetAction>? actions);
 
+            // ADR-043 §2.3 — effective transport is the composition of the
+            // dashboard's policy and this widget's RefreshHint. Composer is
+            // shared with the future push hub so both ends agree on which
+            // widgets are live.
+            WidgetTransport transport = DashboardPushPolicyComposer.Compose(
+                dashboard.PushPolicy,
+                rw.Envelope.RefreshHint);
+
             return new DashboardRenderedWidgetResponse(
                 Id: rw.WidgetId,
                 WidgetType: rw.Envelope.WidgetType,
@@ -88,6 +96,7 @@ internal static partial class DashboardRenderProjection
                 Sequence: rw.Envelope.Sequence,
                 EmittedAt: rw.Envelope.EmittedAt,
                 RefreshHint: rw.Envelope.RefreshHint,
+                Transport: transport,
                 Snapshot: rw.Envelope.Snapshot,
                 ReasonLocalizationKey: rw.Envelope.ReasonLocalizationKey);
         })];

--- a/src/Granit.Dashboards.EntityFrameworkCore/Configurations/DashboardConfiguration.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Configurations/DashboardConfiguration.cs
@@ -39,6 +39,9 @@ internal sealed class DashboardConfiguration : IEntityTypeConfiguration<Dashboar
         builder.Property(d => d.IsSystem).IsRequired();
         builder.Property(d => d.LayoutColumns).IsRequired();
         builder.Property(d => d.LayoutRowHeight).IsRequired();
+        builder.Property(d => d.PushPolicy)
+            .HasConversion<int>()
+            .IsRequired();
         builder.Property(d => d.TenantId);
 
         // Aggregate child collection — cascade delete keeps widgets tied to their dashboard.

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardImporter.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardImporter.cs
@@ -44,7 +44,8 @@ internal sealed class DashboardImporter(
             tenantId: currentTenant?.Id,
             sourceDefinitionName: def.Name,
             sourceDefinitionVersion: def.Version,
-            isSystem: def.IsSystem);
+            isSystem: def.IsSystem,
+            pushPolicy: def.PushPolicy);
 
         foreach (WidgetDefinition widget in widgets)
         {

--- a/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardResyncer.cs
+++ b/src/Granit.Dashboards.EntityFrameworkCore/Internal/DashboardResyncer.cs
@@ -73,6 +73,7 @@ internal sealed class DashboardResyncer(
             newLayoutColumns: descriptor.Layout.Columns,
             newLayoutRowHeight: descriptor.Layout.RowHeight,
             newIsSystem: descriptor.IsSystem,
+            newPushPolicy: descriptor.PushPolicy,
             incomingWidgets: inputs);
 
         // EF Core's change tracker classifies a new entity added to a tracked

--- a/src/Granit.Dashboards/Domain/Dashboard.cs
+++ b/src/Granit.Dashboards/Domain/Dashboard.cs
@@ -72,6 +72,14 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
     /// <summary>Grid row height in CSS pixels — typically 80.</summary>
     public int LayoutRowHeight { get; private set; }
 
+    /// <summary>
+    /// Per-dashboard transport switch — captured from the source definition at
+    /// import time and refreshed on resync. Composed at render time with each
+    /// widget's <c>RefreshHint</c> via <see cref="DashboardPushPolicyComposer.Compose"/>
+    /// to produce the effective <see cref="WidgetTransport"/>. ADR-043 §2.
+    /// </summary>
+    public DashboardPushPolicy PushPolicy { get; private set; } = DashboardPushPolicy.WhenWidgetsRequest;
+
     /// <summary>Widgets pinned on the dashboard, in declared <see cref="WidgetInstance.Position"/> order.</summary>
     public IReadOnlyList<WidgetInstance> Widgets => _widgets;
 
@@ -87,7 +95,8 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
         Guid? tenantId = null,
         string? sourceDefinitionName = null,
         string? sourceDefinitionVersion = null,
-        bool isSystem = false)
+        bool isSystem = false,
+        DashboardPushPolicy pushPolicy = DashboardPushPolicy.WhenWidgetsRequest)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
@@ -113,6 +122,7 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
             IsSystem = isSystem,
             LayoutColumns = layoutColumns,
             LayoutRowHeight = layoutRowHeight,
+            PushPolicy = pushPolicy,
         };
 
         dashboard.AddDomainEvent(new DashboardCreatedEvent(id, tenantId, name, sourceDefinitionName));
@@ -296,6 +306,7 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
         int newLayoutColumns,
         int newLayoutRowHeight,
         bool newIsSystem,
+        DashboardPushPolicy newPushPolicy,
         IReadOnlyList<ResyncWidgetInput> incomingWidgets)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(newSourceDefinitionVersion);
@@ -373,6 +384,7 @@ public sealed class Dashboard : FullAuditedAggregateRoot, IMultiTenant
         LayoutColumns = newLayoutColumns;
         LayoutRowHeight = newLayoutRowHeight;
         IsSystem = newIsSystem;
+        PushPolicy = newPushPolicy;
 
         DashboardResyncSummary summary = new(
             PreviousSourceDefinitionVersion: previousVersion,

--- a/tests/Granit.Dashboards.Abstractions.Tests/DashboardPushPolicyComposerTests.cs
+++ b/tests/Granit.Dashboards.Abstractions.Tests/DashboardPushPolicyComposerTests.cs
@@ -1,0 +1,43 @@
+using Granit.Analytics.Metrics;
+using Granit.Dashboards;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Abstractions.Tests;
+
+/// <summary>
+/// Pins the composition matrix from ADR-043 §2.3. The same function feeds the
+/// render-time projector and the future push hub — every widget in the system
+/// answers a single boolean question through this helper, so the matrix MUST
+/// stay byte-stable. A behavior change here is a wire break.
+/// </summary>
+public sealed class DashboardPushPolicyComposerTests
+{
+    [Theory]
+    // PullOnly — every hint pulls, no push channel ever.
+    [InlineData(DashboardPushPolicy.PullOnly, RefreshHint.Static, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.PullOnly, RefreshHint.Dynamic, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.PullOnly, RefreshHint.Realtime, WidgetTransport.Pull)]
+    // WhenWidgetsRequest — only Realtime widgets push.
+    [InlineData(DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Static, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Dynamic, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Realtime, WidgetTransport.Push)]
+    // Force — Dynamic / Realtime push; Static stays pull (no value pushing a Markdown banner).
+    [InlineData(DashboardPushPolicy.Force, RefreshHint.Static, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.Force, RefreshHint.Dynamic, WidgetTransport.Push)]
+    [InlineData(DashboardPushPolicy.Force, RefreshHint.Realtime, WidgetTransport.Push)]
+    public void Compose_PinsMatrix(DashboardPushPolicy policy, RefreshHint hint, WidgetTransport expected)
+    {
+        DashboardPushPolicyComposer.Compose(policy, hint).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Compose_DefaultEnumValues_ProducePullOnly()
+    {
+        // Defensive: the default value of every enum (0) is what NSubstitute returns
+        // for unconfigured mocks, what new Dashboard descriptors produce before any
+        // override, and what a freshly-defaulted DTO carries on the wire. Compose
+        // MUST stay safe under those defaults.
+        DashboardPushPolicyComposer.Compose(default, default).ShouldBe(WidgetTransport.Pull);
+    }
+}

--- a/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
+++ b/tests/Granit.Dashboards.Endpoints.Tests/Internal/DashboardRenderProjectionTests.cs
@@ -82,6 +82,7 @@ public sealed class DashboardRenderProjectionTests
         w.Status.ShouldBe(WidgetSnapshotStatus.Snapshot);
         w.Sequence.ShouldBe(1);
         w.RefreshHint.ShouldBe(RefreshHint.Dynamic);
+        w.Transport.ShouldBe(WidgetTransport.Pull);                          // default push policy + Dynamic hint = pull
         w.Snapshot.ShouldNotBeNull();
         w.Snapshot!.Value.GetProperty("value").GetInt32().ShouldBe(42);
         w.ReasonLocalizationKey.ShouldBeNull();
@@ -262,12 +263,56 @@ public sealed class DashboardRenderProjectionTests
         }
     }
 
-    private static Dashboard NewDashboard() => Dashboard.Create(
+    private static Dashboard NewDashboard(
+        DashboardPushPolicy pushPolicy = DashboardPushPolicy.WhenWidgetsRequest) => Dashboard.Create(
         id: Guid.NewGuid(),
         name: "SampleDashboard",
         category: DashboardCategory.Finance,
         sourceDefinitionName: SourceDefinitionName,
-        sourceDefinitionVersion: "1.0.0");
+        sourceDefinitionVersion: "1.0.0",
+        pushPolicy: pushPolicy);
+
+    [Theory]
+    [InlineData(DashboardPushPolicy.PullOnly, RefreshHint.Realtime, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Dynamic, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.WhenWidgetsRequest, RefreshHint.Realtime, WidgetTransport.Push)]
+    [InlineData(DashboardPushPolicy.Force, RefreshHint.Static, WidgetTransport.Pull)]
+    [InlineData(DashboardPushPolicy.Force, RefreshHint.Dynamic, WidgetTransport.Push)]
+    public void ToResponse_ComputesEffectiveTransportPerWidget(
+        DashboardPushPolicy policy,
+        RefreshHint hint,
+        WidgetTransport expected)
+    {
+        Dashboard dashboard = NewDashboard(policy);
+        WidgetInstance widget = dashboard.AddWidget(
+            widgetId: Guid.NewGuid(),
+            widgetType: "Kpi",
+            position: 0,
+            width: 4,
+            height: 2,
+            titleLocalizationKey: $"Widget:{SourceDefinitionName}.live",
+            configJson: "{}");
+
+        DashboardRenderResult result = new(
+            DashboardId: dashboard.Id,
+            RenderedAt: RenderedAt,
+            Period: null,
+            Widgets:
+            [
+                new RenderedWidget(widget.Id, WidgetSnapshotEnvelope.ForSnapshot(
+                    widgetType: "Kpi",
+                    snapshot: JsonSerializer.SerializeToElement(new { value = 1 }),
+                    sequence: 1,
+                    emittedAt: RenderedAt,
+                    refreshHint: hint)),
+            ]);
+
+        ResolvedRenderTarget target = new(dashboard.Widgets, ActiveViewName: null);
+        DashboardRenderResponse response = DashboardRenderProjection.ToResponse(
+            result, dashboard, target, EmptyRegistry(), periodToken: null);
+
+        response.Widgets[0].Transport.ShouldBe(expected);
+    }
 
     [Fact]
     public void ToResponse_DriftStatus_NotApplicable_WhenNoSourceDefinition()

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardResyncTests.cs
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardResyncTests.cs
@@ -55,6 +55,7 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 12,
             newLayoutRowHeight: 80,
             newIsSystem: false,
+            newPushPolicy: DashboardPushPolicy.WhenWidgetsRequest,
             incomingWidgets: inputs);
 
         summary.PreviousSourceDefinitionVersion.ShouldBe("1.0.0");
@@ -89,6 +90,7 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 12,
             newLayoutRowHeight: 80,
             newIsSystem: false,
+            newPushPolicy: DashboardPushPolicy.WhenWidgetsRequest,
             incomingWidgets:
             [
                 new ResyncWidgetInput(
@@ -109,12 +111,14 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 24,
             newLayoutRowHeight: 60,
             newIsSystem: true,
+            newPushPolicy: DashboardPushPolicy.Force,
             incomingWidgets: []);
 
         dashboard.SourceDefinitionVersion.ShouldBe("1.5.0");
         dashboard.LayoutColumns.ShouldBe(24);
         dashboard.LayoutRowHeight.ShouldBe(60);
         dashboard.IsSystem.ShouldBeTrue();
+        dashboard.PushPolicy.ShouldBe(DashboardPushPolicy.Force);            // refreshed from descriptor
     }
 
     [Fact]
@@ -131,6 +135,7 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 12,
             newLayoutRowHeight: 80,
             newIsSystem: false,
+            newPushPolicy: DashboardPushPolicy.WhenWidgetsRequest,
             incomingWidgets:
             [
                 new ResyncWidgetInput(
@@ -159,6 +164,7 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 12,
             newLayoutRowHeight: 80,
             newIsSystem: false,
+            newPushPolicy: DashboardPushPolicy.WhenWidgetsRequest,
             incomingWidgets: []));
     }
 
@@ -174,6 +180,7 @@ public sealed class DashboardResyncTests
             newLayoutColumns: 12,
             newLayoutRowHeight: 80,
             newIsSystem: false,
+            newPushPolicy: DashboardPushPolicy.WhenWidgetsRequest,
             incomingWidgets: []));
     }
 

--- a/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardStateMachineTests.cs
+++ b/tests/Granit.Dashboards.EntityFrameworkCore.Tests/Domain/DashboardStateMachineTests.cs
@@ -30,9 +30,27 @@ public sealed class DashboardStateMachineTests
         dashboard.TenantId.ShouldBe(tenantId);
         dashboard.SourceDefinitionName.ShouldBe("Granit.Invoicing.FinanceOverview");
 
+        // Default push policy — admin opts widgets in via RefreshHint, never the
+        // whole board (ADR-043 §2). Verticals override on the descriptor.
+        dashboard.PushPolicy.ShouldBe(DashboardPushPolicy.WhenWidgetsRequest);
+
         DashboardCreatedEvent created = dashboard.DomainEvents.OfType<DashboardCreatedEvent>().Single();
         created.DashboardId.ShouldBe(id);
         created.TenantId.ShouldBe(tenantId);
+    }
+
+    [Fact]
+    public void Create_CapturesPushPolicy_FromCallerOverride()
+    {
+        var dashboard = Dashboard.Create(
+            id: Guid.NewGuid(),
+            name: "Cockpit",
+            category: DashboardCategory.Operations,
+            sourceDefinitionName: "Sample.Cockpit",
+            sourceDefinitionVersion: "1.0.0",
+            pushPolicy: DashboardPushPolicy.Force);
+
+        dashboard.PushPolicy.ShouldBe(DashboardPushPolicy.Force);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Lands the runtime contract from [ADR-043](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md) §2 — per-widget `RefreshHint` and per-dashboard `DashboardPushPolicy` compose into a per-widget `Transport` that rides the existing render bundle. **No transport package yet** (that ships in P2.4-C); this PR is the **wire shape + composer + persistence hook** so frontend consumers can already start coding against the contract.

## What's added

**In `Granit.Dashboards.Abstractions`:**

- [DashboardPushPolicy](src/Granit.Dashboards.Abstractions/DashboardPushPolicy.cs) enum: `PullOnly` / `WhenWidgetsRequest` / `Force`.
- [WidgetTransport](src/Granit.Dashboards.Abstractions/WidgetTransport.cs) enum: `Pull` / `Push` (effective transport per widget).
- [DashboardPushPolicyComposer.Compose(policy, hint)](src/Granit.Dashboards.Abstractions/DashboardPushPolicyComposer.cs) — pure function pinning the ADR-043 §2.3 matrix. Lives in the Abstractions package so the render-time projector AND the future push hub (`Granit.Dashboards.Push`) consume the same function — no chance of the two ends disagreeing on which widget is live.
- `DashboardDefinition.PushPolicy` (virtual, default `WhenWidgetsRequest`) + matching getter on `IDashboardDefinitionDescriptor`.

**On the persisted aggregate + runtime:**

- `Dashboard.PushPolicy` (private set, captured via `Dashboard.Create`'s new `pushPolicy` parameter; default `WhenWidgetsRequest`).
- `DashboardConfiguration.PushPolicy` column (int conversion, required).
- `DashboardImporter` reads the descriptor's `PushPolicy` and seeds the aggregate.
- `Dashboard.Resync` accepts `newPushPolicy` and refreshes it from the descriptor on every resync; `DashboardResyncer` orchestrator wires it.
- `DashboardRenderedWidgetResponse.Transport` wire field added.
- `DashboardRenderProjection` composes `Dashboard.PushPolicy` × widget's `RefreshHint` and surfaces the result on each widget.
- `WidgetRenderHelper` (single-widget render path under `Granit.Analytics.Endpoints`) defaults to `WhenWidgetsRequest` since it has no parent dashboard — a `Realtime` widget rendered standalone still reports `Transport=Push`.

## Composition matrix (pinned by tests)

| Dashboard policy | Widget hint | Effective transport |
| ---------------- | ----------- | ------------------- |
| `PullOnly` | any | `Pull` |
| `WhenWidgetsRequest` | `Static` / `Dynamic` | `Pull` |
| `WhenWidgetsRequest` | `Realtime` | `Push` |
| `Force` | `Static` | `Pull` *(no value pushing a Markdown banner)* |
| `Force` | `Dynamic` / `Realtime` | `Push` |

## EF Core migration

**Not included** — per Granit framework rule, migrations live in the consuming app. Apps that have already run the dashboards migration generate a fresh one with `dotnet ef migrations add` after this PR ships.

## Test plan

- [x] `dotnet build` clean on all 5 affected packages
- [x] `dotnet test tests/Granit.Dashboards.Abstractions.Tests` — 71 passed (9-row composer Theory pinning the entire matrix + default-values guard)
- [x] `dotnet test tests/Granit.Dashboards.Tests` — 31 passed
- [x] `dotnet test tests/Granit.Dashboards.EntityFrameworkCore.Tests` — 34 passed (`Create_CapturesPushPolicy_FromCallerOverride` pinning the factory; `Resync_RefreshesStructuralMetadata` extended to assert `PushPolicy` refresh; 5 existing Resync tests updated to pass `newPushPolicy`)
- [x] `dotnet test tests/Granit.Dashboards.Endpoints.Tests` — 143 passed (`ToResponse_ComputesEffectiveTransportPerWidget` Theory verifies the projection actually consumes the composer output instead of hardcoding)
- [x] `dotnet test tests/Granit.Analytics.Endpoints.Tests` — 198 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 197 passed
- [x] `dotnet format --verify-no-changes` clean on all 8 touched projects

Refs [ADR-043](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md) §2 — P2.4-B of the dashboards roadmap, follow-up to P2.4-A in #1618. P2.4-C (`Granit.Dashboards.Push` SSE transport with `IWidgetPushPublisher` + `GET /dashboards/{id}/stream`) is next.
