### PR TITLE
feat(dashboards-push): per-widget RequiredPermission gate on SSE (P2.4-C-Auth)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14407,13 +14407,13 @@
         {
           "name": "PublishSnapshotAsync",
           "kind": "method",
-          "signature": "PublishSnapshotAsync(Guid? tenantId, Guid dashboardId, Guid widgetInstanceId, string widgetType, JsonElement snapshot, DateTimeOffset emittedAt, RefreshHint refreshHint, CancellationToken cancellationToken = default)",
+          "signature": "PublishSnapshotAsync(Guid? tenantId, Guid dashboardId, Guid widgetInstanceId, string widgetType, string? requiredPermission, JsonElement snapshot, DateTimeOffset emittedAt, RefreshHint refreshHint, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {
           "name": "PublishUnavailableAsync",
           "kind": "method",
-          "signature": "PublishUnavailableAsync(Guid? tenantId, Guid dashboardId, Guid widgetInstanceId, string widgetType, DateTimeOffset emittedAt, RefreshHint refreshHint, string reasonLocalizationKey, CancellationToken cancellationToken = default)",
+          "signature": "PublishUnavailableAsync(Guid? tenantId, Guid dashboardId, Guid widgetInstanceId, string widgetType, string? requiredPermission, DateTimeOffset emittedAt, RefreshHint refreshHint, string reasonLocalizationKey, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]

--- a/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
@@ -308,14 +308,25 @@ break down as:
      `Dashboard` aggregate, surface `Transport` on the render bundle.
    - Architecture test: dashboard renderers must compute the effective
      transport per widget per the matrix in §2.3.
-3. **P2.4-C — `Granit.Dashboards.Push` SSE transport**
+3. **P2.4-C — `Granit.Dashboards.Push` SSE transport** *(happy path)*
    - `IWidgetPushPublisher`, `GET /dashboards/{id}/stream`, sequence
-     allocator, fan-out hub, `Last-Event-ID` resume.
-4. **P2.4-D — `Granit.Dashboards.Push.WebSockets`** *(opt-in)*
+     allocator, fan-out hub.
+4. **P2.4-C-Auth — Per-widget permission filter on push**
+   - `IWidgetPushPublisher` carries the widget's `RequiredPermission`;
+     the SSE handler downgrades envelopes to `Unavailable` for
+     subscribers that lack the grant (mirrors the render-time gate in
+     `DashboardRenderer`). Per-stream permission cache.
+5. **P2.4-C2 — `Last-Event-ID` resume + ring buffer** *(reliability)*
+   - Per-`(tenantId, dashboardId)` ring buffer of recent envelopes
+     (default 100) + stream-level monotonic cursor on the SSE `id:`
+     field. Reconnects with `Last-Event-ID` get the missed envelopes
+     replayed before going live.
+6. **P2.4-D — `Granit.Dashboards.Push.WebSockets`** *(opt-in)*
    - WebSocket consumer over the same producer contract.
-5. **P2.4-E — Frontend `usePushedDashboard`** *(`granit-front`)*
+7. **P2.4-E — Frontend `usePushedDashboard`** *(`granit-front`)*
    - Reads the `Transport` field, opens streams selectively, falls back
      to TanStack pull when `Transport = "pull"`.
 
-P2.4-A through P2.4-C are the load-bearing minimum. D and E are
-incremental.
+P2.4-A through P2.4-C-Auth are the load-bearing minimum. C2, D, E are
+incremental — C2 closes the reconnect-resume reliability gap, D ships
+an alternate transport, E lights the front up.

--- a/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
+++ b/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
@@ -1,7 +1,10 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Threading.Channels;
+using Granit.Authorization;
 using Granit.Dashboards.Push.Internal;
 using Granit.Dashboards.Push.Options;
+using Granit.Dashboards.Rendering;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.AspNetCore.Authorization;
@@ -53,6 +56,7 @@ internal static class DashboardStreamEndpoint
         IWidgetPushHub hub = context.RequestServices.GetRequiredService<IWidgetPushHub>();
         IOptions<DashboardsPushOptions> options = context.RequestServices.GetRequiredService<IOptions<DashboardsPushOptions>>();
         IClock clock = context.RequestServices.GetRequiredService<IClock>();
+        IPermissionChecker permissionChecker = context.RequestServices.GetRequiredService<IPermissionChecker>();
         ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
 
         Guid? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null;
@@ -79,6 +83,12 @@ internal static class DashboardStreamEndpoint
             });
 
         using IDisposable subscription = hub.Subscribe(tenantId, id, channel.Writer);
+
+        // Per-stream permission cache — populated lazily on the first envelope
+        // that declares a RequiredPermission. Stays scoped to this connection
+        // (permission changes mid-stream only take effect on reconnect, matching
+        // the pull endpoint's snapshot-at-render-time semantics).
+        ConcurrentDictionary<string, bool> permissionCache = new(StringComparer.Ordinal);
 
         TimeSpan heartbeat = options.Value.HeartbeatInterval;
         DateTimeOffset nextHeartbeat = clock.Now + heartbeat;
@@ -115,20 +125,28 @@ internal static class DashboardStreamEndpoint
                     continue;
                 }
 
+                // Per-widget permission gate — mirrors the render-time check in
+                // DashboardRenderer. Snapshots for widgets the subscriber lacks
+                // permission to read get rewritten to Unavailable before they
+                // touch the wire.
+                WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter
+                    .ResolveEffectiveAsync(message, permissionChecker, permissionCache, cancellationToken)
+                    .ConfigureAwait(false);
+
                 string payload = JsonSerializer.Serialize(new
                 {
                     widgetId = message.WidgetInstanceId,
-                    widgetType = message.Envelope.WidgetType,
-                    status = message.Envelope.Status,
-                    sequence = message.Envelope.Sequence,
-                    emittedAt = message.Envelope.EmittedAt,
-                    refreshHint = message.Envelope.RefreshHint,
-                    snapshot = message.Envelope.Snapshot,
-                    reasonLocalizationKey = message.Envelope.ReasonLocalizationKey,
+                    widgetType = effective.WidgetType,
+                    status = effective.Status,
+                    sequence = effective.Sequence,
+                    emittedAt = effective.EmittedAt,
+                    refreshHint = effective.RefreshHint,
+                    snapshot = effective.Snapshot,
+                    reasonLocalizationKey = effective.ReasonLocalizationKey,
                 });
 
                 await context.Response.WriteAsync(
-                    $"event: snapshot\nid: {message.Envelope.Sequence}\ndata: {payload}\n\n",
+                    $"event: snapshot\nid: {effective.Sequence}\ndata: {payload}\n\n",
                     cancellationToken).ConfigureAwait(false);
                 await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Dashboards.Push/IWidgetPushPublisher.cs
+++ b/src/Granit.Dashboards.Push/IWidgetPushPublisher.cs
@@ -35,6 +35,15 @@ public interface IWidgetPushPublisher
     /// <param name="dashboardId">Persisted dashboard identifier the widget belongs to. Streams partition by this id.</param>
     /// <param name="widgetInstanceId">Persisted <c>WidgetInstance.Id</c>.</param>
     /// <param name="widgetType">Widget kind discriminator — mirrors <c>WidgetSnapshotEnvelope.WidgetType</c>.</param>
+    /// <param name="requiredPermission">
+    /// Per-widget permission gate (mirrors <c>WidgetInstance.RequiredPermission</c>).
+    /// When non-null, the SSE handler downgrades envelopes to <c>Unavailable</c> for
+    /// subscribers that lack the permission — matches the render-time gating in
+    /// <c>DashboardRenderer</c> so the push and pull paths surface the same envelope
+    /// shape to clients without the right grant. Pass <see langword="null"/> for widgets
+    /// whose data is broadly readable across the dashboard (the framework still gates
+    /// the stream itself with <c>Dashboards.Instances.Read</c>).
+    /// </param>
     /// <param name="snapshot">Pre-serialized typed payload. Same shape consumers see on the pull endpoint.</param>
     /// <param name="emittedAt">Server-side timestamp of the snapshot.</param>
     /// <param name="refreshHint">Refresh hint surfaced on the wire envelope (typically inherited from the metric / query).</param>
@@ -44,6 +53,7 @@ public interface IWidgetPushPublisher
         Guid dashboardId,
         Guid widgetInstanceId,
         string widgetType,
+        string? requiredPermission,
         JsonElement snapshot,
         DateTimeOffset emittedAt,
         RefreshHint refreshHint,
@@ -56,11 +66,25 @@ public interface IWidgetPushPublisher
     /// shape as a snapshot envelope with <c>Status = Unavailable</c> and the
     /// reason key populated.
     /// </summary>
+    /// <param name="tenantId">See <see cref="PublishSnapshotAsync"/>.</param>
+    /// <param name="dashboardId">See <see cref="PublishSnapshotAsync"/>.</param>
+    /// <param name="widgetInstanceId">See <see cref="PublishSnapshotAsync"/>.</param>
+    /// <param name="widgetType">See <see cref="PublishSnapshotAsync"/>.</param>
+    /// <param name="requiredPermission">
+    /// See <see cref="PublishSnapshotAsync"/>. When non-null and the subscriber lacks
+    /// it, the framework rewrites the reason key to the generic <c>Widget:Unavailable</c>
+    /// — never leaks the producer's specific reason to a non-entitled subscriber.
+    /// </param>
+    /// <param name="emittedAt">Server-side timestamp of the unavailable signal.</param>
+    /// <param name="refreshHint">Refresh hint surfaced on the wire envelope.</param>
+    /// <param name="reasonLocalizationKey">Localization key explaining why the widget is unavailable to entitled subscribers (rewritten to the generic <c>Widget:Unavailable</c> for unentitled subscribers — see <paramref name="requiredPermission"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task PublishUnavailableAsync(
         Guid? tenantId,
         Guid dashboardId,
         Guid widgetInstanceId,
         string widgetType,
+        string? requiredPermission,
         DateTimeOffset emittedAt,
         RefreshHint refreshHint,
         string reasonLocalizationKey,

--- a/src/Granit.Dashboards.Push/Internal/InMemoryWidgetPushHub.cs
+++ b/src/Granit.Dashboards.Push/Internal/InMemoryWidgetPushHub.cs
@@ -41,6 +41,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         Guid dashboardId,
         Guid widgetInstanceId,
         string widgetType,
+        string? requiredPermission,
         JsonElement snapshot,
         DateTimeOffset emittedAt,
         RefreshHint refreshHint,
@@ -50,7 +51,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         var envelope = WidgetSnapshotEnvelope.ForSnapshot(
             widgetType, snapshot, sequence, emittedAt, refreshHint);
 
-        Dispatch(tenantId, dashboardId, widgetInstanceId, envelope);
+        Dispatch(tenantId, dashboardId, widgetInstanceId, requiredPermission, envelope);
         return Task.CompletedTask;
     }
 
@@ -60,6 +61,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         Guid dashboardId,
         Guid widgetInstanceId,
         string widgetType,
+        string? requiredPermission,
         DateTimeOffset emittedAt,
         RefreshHint refreshHint,
         string reasonLocalizationKey,
@@ -71,7 +73,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         var envelope = WidgetSnapshotEnvelope.Unavailable(
             widgetType, sequence, emittedAt, refreshHint, reasonLocalizationKey);
 
-        Dispatch(tenantId, dashboardId, widgetInstanceId, envelope);
+        Dispatch(tenantId, dashboardId, widgetInstanceId, requiredPermission, envelope);
         return Task.CompletedTask;
     }
 
@@ -99,6 +101,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         Guid? tenantId,
         Guid dashboardId,
         Guid widgetInstanceId,
+        string? requiredPermission,
         WidgetSnapshotEnvelope envelope)
     {
         StreamKey key = new(tenantId, dashboardId);
@@ -107,7 +110,7 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
             return;
         }
 
-        WidgetPushMessage message = new(tenantId, dashboardId, widgetInstanceId, envelope);
+        WidgetPushMessage message = new(tenantId, dashboardId, widgetInstanceId, requiredPermission, envelope);
         foreach (ChannelWriter<WidgetPushMessage> writer in subs.Values)
         {
             // TryWrite is non-blocking. Slow / closed subscribers silently drop —

--- a/src/Granit.Dashboards.Push/Internal/WidgetPushMessage.cs
+++ b/src/Granit.Dashboards.Push/Internal/WidgetPushMessage.cs
@@ -14,4 +14,5 @@ internal sealed record WidgetPushMessage(
     Guid? TenantId,
     Guid DashboardId,
     Guid WidgetInstanceId,
+    string? RequiredPermission,
     WidgetSnapshotEnvelope Envelope);

--- a/src/Granit.Dashboards.Push/Internal/WidgetPushPermissionFilter.cs
+++ b/src/Granit.Dashboards.Push/Internal/WidgetPushPermissionFilter.cs
@@ -1,0 +1,78 @@
+using System.Collections.Concurrent;
+using Granit.Authorization;
+using Granit.Dashboards.Rendering;
+
+namespace Granit.Dashboards.Push.Internal;
+
+/// <summary>
+/// Pure helper that mirrors the render-time permission gate
+/// (<c>DashboardRenderer</c>'s 3.a step) on the push path: when a widget
+/// declares a <see cref="WidgetPushMessage.RequiredPermission"/> the current
+/// user lacks, the framework rewrites the envelope to
+/// <see cref="WidgetSnapshotStatus.Unavailable"/> before forwarding to the
+/// stream — never leaks a snapshot to a non-entitled subscriber, never leaks
+/// a producer's specific reason key either.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lives separate from the SSE handler so it stays unit-testable without
+/// spinning up a TestServer. The handler calls
+/// <see cref="ResolveEffectiveAsync"/> on every inbound envelope and forwards
+/// the result.
+/// </para>
+/// <para>
+/// Per-permission lookups are cached for the lifetime of the stream connection
+/// in the <paramref name="permissionCache"/> the caller owns — the same SSE
+/// connection sees the same set of permissions throughout. Permission changes
+/// mid-stream are intentionally not picked up; clients reconnect to refresh
+/// their entitlements (matches the pull endpoint's snapshot-at-render-time
+/// gate).
+/// </para>
+/// </remarks>
+internal static class WidgetPushPermissionFilter
+{
+    /// <summary>
+    /// Returns the envelope the subscriber actually receives — the original
+    /// envelope when the user holds the required permission (or none is
+    /// declared), an <c>Unavailable</c> envelope otherwise.
+    /// </summary>
+    public static async ValueTask<WidgetSnapshotEnvelope> ResolveEffectiveAsync(
+        WidgetPushMessage message,
+        IPermissionChecker permissionChecker,
+        ConcurrentDictionary<string, bool> permissionCache,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(permissionChecker);
+        ArgumentNullException.ThrowIfNull(permissionCache);
+
+        if (message.RequiredPermission is not { Length: > 0 } permission)
+        {
+            return message.Envelope;
+        }
+
+        if (!permissionCache.TryGetValue(permission, out bool granted))
+        {
+            granted = await permissionChecker
+                .IsGrantedAsync(permission, cancellationToken)
+                .ConfigureAwait(false);
+            permissionCache[permission] = granted;
+        }
+
+        if (granted)
+        {
+            return message.Envelope;
+        }
+
+        // Replace with Unavailable, preserving sequence + emittedAt + refreshHint
+        // so the wire shape stays identical to the render-time gating path. The
+        // generic "Widget:Unavailable" reason key is intentional — never echoes
+        // the producer's specific reason to a subscriber who isn't entitled to
+        // see it.
+        return WidgetSnapshotEnvelope.Unavailable(
+            widgetType: message.Envelope.WidgetType,
+            sequence: message.Envelope.Sequence,
+            emittedAt: message.Envelope.EmittedAt,
+            refreshHint: message.Envelope.RefreshHint);
+    }
+}

--- a/tests/Granit.Dashboards.Push.Tests/Internal/InMemoryWidgetPushHubTests.cs
+++ b/tests/Granit.Dashboards.Push.Tests/Internal/InMemoryWidgetPushHubTests.cs
@@ -33,6 +33,7 @@ public sealed class InMemoryWidgetPushHubTests
         await hub.PublishSnapshotAsync(
             tenant, dashboard, widget,
             widgetType: "Kpi",
+            requiredPermission: null,
             snapshot: SamplePayload,
             emittedAt: EmittedAt,
             refreshHint: RefreshHint.Realtime,
@@ -64,7 +65,7 @@ public sealed class InMemoryWidgetPushHubTests
 
         await hub.PublishSnapshotAsync(
             tenant, dashboard, Guid.NewGuid(),
-            "Kpi", SamplePayload, EmittedAt, RefreshHint.Realtime,
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
             cancellationToken: TestContext.Current.CancellationToken);
 
         a.Reader.TryRead(out WidgetPushMessage? _).ShouldBeTrue();
@@ -84,7 +85,7 @@ public sealed class InMemoryWidgetPushHubTests
 
         await hub.PublishSnapshotAsync(
             tenant, dashboardB, Guid.NewGuid(),
-            "Kpi", SamplePayload, EmittedAt, RefreshHint.Realtime,
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
             cancellationToken: TestContext.Current.CancellationToken);
 
         subscribedToA.Reader.TryRead(out WidgetPushMessage? _).ShouldBeFalse(); // wrong dashboard
@@ -105,7 +106,7 @@ public sealed class InMemoryWidgetPushHubTests
         // is enforced at the stream-key level, ADR-043 §6.
         await hub.PublishSnapshotAsync(
             tenantB, dashboard, Guid.NewGuid(),
-            "Kpi", SamplePayload, EmittedAt, RefreshHint.Realtime,
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
             cancellationToken: TestContext.Current.CancellationToken);
 
         subscribedToA.Reader.TryRead(out WidgetPushMessage? _).ShouldBeFalse();
@@ -125,7 +126,7 @@ public sealed class InMemoryWidgetPushHubTests
 
         await hub.PublishSnapshotAsync(
             tenant, dashboard, Guid.NewGuid(),
-            "Kpi", SamplePayload, EmittedAt, RefreshHint.Realtime,
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
             cancellationToken: TestContext.Current.CancellationToken);
 
         channel.Reader.TryRead(out WidgetPushMessage? _).ShouldBeFalse();
@@ -143,7 +144,7 @@ public sealed class InMemoryWidgetPushHubTests
 
         await hub.PublishUnavailableAsync(
             tenant, dashboard, Guid.NewGuid(),
-            "Kpi", EmittedAt, RefreshHint.Realtime,
+            "Kpi", requiredPermission: null, EmittedAt, RefreshHint.Realtime,
             reasonLocalizationKey: "Widget:Unavailable.MetricNotFound",
             cancellationToken: TestContext.Current.CancellationToken);
 
@@ -168,7 +169,7 @@ public sealed class InMemoryWidgetPushHubTests
         {
             await hub.PublishSnapshotAsync(
                 tenant, dashboard, widget,
-                "Kpi", SamplePayload, EmittedAt, RefreshHint.Realtime,
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
             cancellationToken: TestContext.Current.CancellationToken);
         }
 

--- a/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushPermissionFilterTests.cs
+++ b/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushPermissionFilterTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Granit.Analytics.Metrics;
+using Granit.Authorization;
+using Granit.Dashboards.Push.Internal;
+using Granit.Dashboards.Rendering;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Push.Tests.Internal;
+
+/// <summary>
+/// Pins the per-widget permission gate on the SSE push path: envelopes whose
+/// <see cref="WidgetPushMessage.RequiredPermission"/> the current user lacks
+/// get rewritten to <see cref="WidgetSnapshotStatus.Unavailable"/> with the
+/// generic reason key — the producer's specific reason never leaks to a
+/// non-entitled subscriber. Mirrors the render-time gating in
+/// <c>DashboardRenderer</c>.
+/// </summary>
+public sealed class WidgetPushPermissionFilterTests
+{
+    private static readonly JsonElement SamplePayload = JsonSerializer.SerializeToElement(new { value = 42 });
+    private static readonly DateTimeOffset EmittedAt = new(2026, 4, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ResolveEffective_NoRequiredPermission_PassesEnvelopeThrough()
+    {
+        WidgetPushMessage message = NewSnapshotMessage(requiredPermission: null);
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        ConcurrentDictionary<string, bool> cache = new(StringComparer.Ordinal);
+
+        WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter.ResolveEffectiveAsync(
+            message, checker, cache, TestContext.Current.CancellationToken);
+
+        effective.ShouldBeSameAs(message.Envelope);
+        await checker.DidNotReceive().IsGrantedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveEffective_PermissionGranted_PassesEnvelopeThrough()
+    {
+        WidgetPushMessage message = NewSnapshotMessage(requiredPermission: "Invoicing.Invoices.Read");
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync("Invoicing.Invoices.Read", Arg.Any<CancellationToken>()).Returns(true);
+        ConcurrentDictionary<string, bool> cache = new(StringComparer.Ordinal);
+
+        WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter.ResolveEffectiveAsync(
+            message, checker, cache, TestContext.Current.CancellationToken);
+
+        effective.ShouldBeSameAs(message.Envelope);
+    }
+
+    [Fact]
+    public async Task ResolveEffective_PermissionDenied_RewritesToUnavailable()
+    {
+        WidgetPushMessage message = NewSnapshotMessage(requiredPermission: "Invoicing.Invoices.Read");
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync("Invoicing.Invoices.Read", Arg.Any<CancellationToken>()).Returns(false);
+        ConcurrentDictionary<string, bool> cache = new(StringComparer.Ordinal);
+
+        WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter.ResolveEffectiveAsync(
+            message, checker, cache, TestContext.Current.CancellationToken);
+
+        effective.Status.ShouldBe(WidgetSnapshotStatus.Unavailable);
+        effective.WidgetType.ShouldBe("Kpi");
+        effective.Sequence.ShouldBe(message.Envelope.Sequence);              // sequence preserved
+        effective.EmittedAt.ShouldBe(message.Envelope.EmittedAt);            // timing preserved
+        effective.RefreshHint.ShouldBe(message.Envelope.RefreshHint);
+        effective.Snapshot.ShouldBeNull();                                   // snapshot scrubbed
+        effective.ReasonLocalizationKey.ShouldBe("Widget:Unavailable");      // generic reason — no leak
+    }
+
+    [Fact]
+    public async Task ResolveEffective_PermissionDeniedOnUnavailableEnvelope_RewritesGenericReason()
+    {
+        // Producer published an Unavailable with a specific reason ("Widget:Unavailable.MetricNotFound").
+        // A subscriber lacking the permission must NOT see that reason — the framework rewrites to
+        // the generic "Widget:Unavailable" so the producer's diagnostic stays internal.
+        var unavailableEnvelope = WidgetSnapshotEnvelope.Unavailable(
+            widgetType: "Kpi",
+            sequence: 7,
+            emittedAt: EmittedAt,
+            refreshHint: RefreshHint.Realtime,
+            reasonLocalizationKey: "Widget:Unavailable.MetricNotFound");
+
+        WidgetPushMessage message = new(
+            TenantId: Guid.NewGuid(),
+            DashboardId: Guid.NewGuid(),
+            WidgetInstanceId: Guid.NewGuid(),
+            RequiredPermission: "Invoicing.Invoices.Read",
+            Envelope: unavailableEnvelope);
+
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync("Invoicing.Invoices.Read", Arg.Any<CancellationToken>()).Returns(false);
+        ConcurrentDictionary<string, bool> cache = new(StringComparer.Ordinal);
+
+        WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter.ResolveEffectiveAsync(
+            message, checker, cache, TestContext.Current.CancellationToken);
+
+        effective.ReasonLocalizationKey.ShouldBe("Widget:Unavailable");      // never leaks "MetricNotFound"
+    }
+
+    [Fact]
+    public async Task ResolveEffective_CachesPermissionLookup_WithinAStream()
+    {
+        WidgetPushMessage first = NewSnapshotMessage(requiredPermission: "Invoicing.Invoices.Read");
+        WidgetPushMessage second = NewSnapshotMessage(requiredPermission: "Invoicing.Invoices.Read");
+        IPermissionChecker checker = Substitute.For<IPermissionChecker>();
+        checker.IsGrantedAsync("Invoicing.Invoices.Read", Arg.Any<CancellationToken>()).Returns(true);
+        ConcurrentDictionary<string, bool> cache = new(StringComparer.Ordinal);
+
+        await WidgetPushPermissionFilter.ResolveEffectiveAsync(first, checker, cache, TestContext.Current.CancellationToken);
+        await WidgetPushPermissionFilter.ResolveEffectiveAsync(second, checker, cache, TestContext.Current.CancellationToken);
+
+        // Two messages, same permission, single store query — cache hit on the second envelope.
+        await checker.Received(1).IsGrantedAsync("Invoicing.Invoices.Read", Arg.Any<CancellationToken>());
+    }
+
+    private static WidgetPushMessage NewSnapshotMessage(string? requiredPermission)
+    {
+        var envelope = WidgetSnapshotEnvelope.ForSnapshot(
+            widgetType: "Kpi",
+            snapshot: SamplePayload,
+            sequence: 1,
+            emittedAt: EmittedAt,
+            refreshHint: RefreshHint.Realtime);
+
+        return new WidgetPushMessage(
+            TenantId: Guid.NewGuid(),
+            DashboardId: Guid.NewGuid(),
+            WidgetInstanceId: Guid.NewGuid(),
+            RequiredPermission: requiredPermission,
+            Envelope: envelope);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the v1 limitation called out in [#1620](https://github.com/granit-fx/granit-dotnet/pull/1620)'s PR description: **per-widget `RequiredPermission` is now enforced server-side on the SSE push path**, mirroring the render-time gate in `DashboardRenderer` (step 3.a). A subscriber lacking a widget's permission no longer receives the snapshot — the framework rewrites the envelope to `Status=Unavailable` with the generic `Widget:Unavailable` reason key before it touches the wire.

## Wire / contract changes

Additive — **no v1 producers shipped yet, so no migration needed**.

- `IWidgetPushPublisher.PublishSnapshotAsync` / `PublishUnavailableAsync` gain a `string? requiredPermission` parameter mirroring `WidgetInstance.RequiredPermission`. Producers that hold the persisted aggregate already have this value; passing `null` means *"broadly readable across the dashboard"* (the stream itself is still gated by `Dashboards.Instances.Read`).
- `WidgetPushMessage` (internal) carries `RequiredPermission` alongside the envelope; `InMemoryWidgetPushHub` propagates it on dispatch.
- `DashboardStreamEndpoint` resolves `IPermissionChecker` from the request scope, builds a per-stream `ConcurrentDictionary<string, bool>` permission cache, and runs every envelope through `WidgetPushPermissionFilter.ResolveEffectiveAsync` before serializing.

## Permission semantics

| Producer declared | User entitled? | Wire result |
| ----------------- | -------------- | ----------- |
| `RequiredPermission = null` | n/a | envelope passes through unchanged |
| `RequiredPermission = "X"` | granted | envelope passes through unchanged |
| `RequiredPermission = "X"` | denied | envelope rewritten to `Unavailable` |

When rewritten:
- **Sequence / EmittedAt / RefreshHint preserved** — wire shape stays identical to the render-time gating path so frontend can't tell push-rewrites from pull-gates.
- **Snapshot scrubbed**.
- **Reason key forced to the generic `Widget:Unavailable`** — never echoes the producer's specific reason (`Widget:Unavailable.MetricNotFound`, etc.) to a non-entitled subscriber.

Per-permission lookups are cached for the lifetime of the SSE connection. Permission changes mid-stream are intentionally not picked up — clients reconnect to refresh entitlements (matches the pull endpoint's snapshot-at-render-time semantics).

## ADR-043 roadmap update

- P2.4-C now scoped explicitly as *"happy path"* (what shipped in #1620).
- **P2.4-C-Auth (this PR)** explicitly tracked as the auth-gate story.
- P2.4-C2 (reconnect resume + ring buffer) renumbered.
- D and E unchanged.

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Push` — green
- [x] `dotnet test tests/Granit.Dashboards.Push.Tests` — **20 passed** (15 existing + 5 new)
  - `WidgetPushPermissionFilterTests` (5 cases):
    - no-permission pass-through — checker is never called
    - granted pass-through — same envelope reference returned
    - denied → `Unavailable` rewrite preserving sequence / emittedAt / refreshHint, scrubbing snapshot, generic reason key
    - **denied on a producer-emitted `Unavailable` rewrites the specific reason to the generic one** (no leak)
    - per-permission cache: two envelopes, same permission → single store query
  - Hub call sites updated for the new `requiredPermission` parameter; existing 15 tests still green.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 197 passed
- [x] `dotnet format --verify-no-changes` clean on src + test projects
- [x] `markdownlint` clean on the updated ADR

Refs [ADR-043](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md) §6, follow-up to #1620 (P2.4-C). Next remaining: **P2.4-C2** (`Last-Event-ID` resume + ring buffer for reconnect reliability), **P2.4-D** (WebSocket sibling), **P2.4-E** (frontend hook in `granit-front` — cross-repo).
