### PR TITLE
feat(dashboards-push): Last-Event-ID resume + ring buffer (P2.4-C2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14459,6 +14459,12 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "RingBufferCapacity",
+          "kind": "property",
+          "signature": "int RingBufferCapacity",
+          "returnType": "int"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md
@@ -316,11 +316,13 @@ break down as:
      the SSE handler downgrades envelopes to `Unavailable` for
      subscribers that lack the grant (mirrors the render-time gate in
      `DashboardRenderer`). Per-stream permission cache.
-5. **P2.4-C2 — `Last-Event-ID` resume + ring buffer** *(reliability)*
+5. **P2.4-C2 — `Last-Event-ID` resume + ring buffer** *(shipped)*
    - Per-`(tenantId, dashboardId)` ring buffer of recent envelopes
      (default 100) + stream-level monotonic cursor on the SSE `id:`
      field. Reconnects with `Last-Event-ID` get the missed envelopes
-     replayed before going live.
+     replayed before going live; clients behind the ring's oldest entry
+     receive an `event: resume-failed` frame and re-fetch the seed via
+     the pull endpoint.
 6. **P2.4-D — `Granit.Dashboards.Push.WebSockets`** *(opt-in)*
    - WebSocket consumer over the same producer contract.
 7. **P2.4-E — Frontend `usePushedDashboard`** *(`granit-front`)*

--- a/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
+++ b/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
@@ -82,7 +82,25 @@ internal static class DashboardStreamEndpoint
                 SingleWriter = false,
             });
 
-        using IDisposable subscription = hub.Subscribe(tenantId, id, channel.Writer);
+        // Parse the SSE Last-Event-ID header — sent by the EventSource client on
+        // automatic reconnect (HTML5 spec) — to drive the per-stream replay
+        // window. Bad / missing headers gracefully fall back to a fresh
+        // subscription with no replay.
+        long? lastEventId = TryParseLastEventId(context.Request.Headers["Last-Event-ID"]);
+
+        SubscriptionResult subscriptionResult = hub.Subscribe(tenantId, id, lastEventId, channel.Writer);
+        using IDisposable subscription = subscriptionResult.Handle;
+
+        // Resume failed — the client is behind the oldest ring entry. Tell it
+        // to fall back to the pull endpoint for a fresh seed before proceeding.
+        // The frontend hook recognises `event: resume-failed` and re-fetches.
+        if (subscriptionResult.ResumeFailed)
+        {
+            await context.Response.WriteAsync(
+                "event: resume-failed\ndata: {}\n\n",
+                cancellationToken).ConfigureAwait(false);
+            await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
 
         // Per-stream permission cache — populated lazily on the first envelope
         // that declares a RequiredPermission. Stays scoped to this connection
@@ -95,6 +113,17 @@ internal static class DashboardStreamEndpoint
 
         try
         {
+            // Replay phase — flush any buffered envelopes the client missed
+            // during its disconnect window. The hub returned them under the
+            // same lock that registered the subscription, so live envelopes
+            // arriving in the channel are always strictly newer than the last
+            // replay item.
+            foreach (WidgetPushMessage replay in subscriptionResult.Replay)
+            {
+                await WriteEnvelopeAsync(replay).ConfigureAwait(false);
+                nextHeartbeat = clock.Now + heartbeat;
+            }
+
             while (!cancellationToken.IsCancellationRequested)
             {
                 using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -125,30 +154,7 @@ internal static class DashboardStreamEndpoint
                     continue;
                 }
 
-                // Per-widget permission gate — mirrors the render-time check in
-                // DashboardRenderer. Snapshots for widgets the subscriber lacks
-                // permission to read get rewritten to Unavailable before they
-                // touch the wire.
-                WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter
-                    .ResolveEffectiveAsync(message, permissionChecker, permissionCache, cancellationToken)
-                    .ConfigureAwait(false);
-
-                string payload = JsonSerializer.Serialize(new
-                {
-                    widgetId = message.WidgetInstanceId,
-                    widgetType = effective.WidgetType,
-                    status = effective.Status,
-                    sequence = effective.Sequence,
-                    emittedAt = effective.EmittedAt,
-                    refreshHint = effective.RefreshHint,
-                    snapshot = effective.Snapshot,
-                    reasonLocalizationKey = effective.ReasonLocalizationKey,
-                });
-
-                await context.Response.WriteAsync(
-                    $"event: snapshot\nid: {effective.Sequence}\ndata: {payload}\n\n",
-                    cancellationToken).ConfigureAwait(false);
-                await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await WriteEnvelopeAsync(message).ConfigureAwait(false);
 
                 // Reset the heartbeat deadline — we just wrote a real message.
                 nextHeartbeat = clock.Now + heartbeat;
@@ -158,5 +164,55 @@ internal static class DashboardStreamEndpoint
         {
             // Client disconnected — graceful exit. Subscription disposes via the using block.
         }
+
+        async Task WriteEnvelopeAsync(WidgetPushMessage message)
+        {
+            // Per-widget permission gate — mirrors the render-time check in
+            // DashboardRenderer. Snapshots for widgets the subscriber lacks
+            // permission to read get rewritten to Unavailable before they
+            // touch the wire.
+            WidgetSnapshotEnvelope effective = await WidgetPushPermissionFilter
+                .ResolveEffectiveAsync(message, permissionChecker, permissionCache, cancellationToken)
+                .ConfigureAwait(false);
+
+            string payload = JsonSerializer.Serialize(new
+            {
+                widgetId = message.WidgetInstanceId,
+                widgetType = effective.WidgetType,
+                status = effective.Status,
+                sequence = effective.Sequence,
+                emittedAt = effective.EmittedAt,
+                refreshHint = effective.RefreshHint,
+                snapshot = effective.Snapshot,
+                reasonLocalizationKey = effective.ReasonLocalizationKey,
+            });
+
+            // SSE `id:` carries the per-stream cursor (used by the client's
+            // EventSource for Last-Event-ID resume). The per-widget envelope
+            // sequence stays inside the payload — distinct ordering, distinct
+            // purpose (ADR-043 §5).
+            await context.Response.WriteAsync(
+                $"event: snapshot\nid: {message.StreamCursor}\ndata: {payload}\n\n",
+                cancellationToken).ConfigureAwait(false);
+            await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Parses the SSE <c>Last-Event-ID</c> header. Returns <see langword="null"/>
+    /// for missing, blank, or non-numeric headers — bad headers fall back to a
+    /// fresh subscription so a malformed reconnect never breaks the stream.
+    /// </summary>
+    private static long? TryParseLastEventId(Microsoft.Extensions.Primitives.StringValues headerValue)
+    {
+        string? raw = headerValue.ToString();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        return long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out long parsed)
+            ? parsed
+            : null;
     }
 }

--- a/src/Granit.Dashboards.Push/Internal/IWidgetPushHub.cs
+++ b/src/Granit.Dashboards.Push/Internal/IWidgetPushHub.cs
@@ -17,13 +17,22 @@ internal interface IWidgetPushHub : IWidgetPushPublisher
 {
     /// <summary>
     /// Registers <paramref name="writer"/> as a subscriber for the given
-    /// <c>(tenantId, dashboardId)</c> stream. Returns an
-    /// <see cref="IDisposable"/> that unregisters and (optionally) completes
-    /// the writer on disposal — the caller (SSE endpoint) disposes when the
-    /// HTTP connection closes or cancellation fires.
+    /// <c>(tenantId, dashboardId)</c> stream. Atomic with the ring snapshot so
+    /// no envelope is lost between the replay and the live drain. ADR-043 §5.
     /// </summary>
-    IDisposable Subscribe(
+    /// <param name="tenantId">Tenant scope (matches the publisher's tenantId on the same stream).</param>
+    /// <param name="dashboardId">Dashboard the subscriber is following.</param>
+    /// <param name="lastEventId">
+    /// SSE <c>Last-Event-ID</c> sent by reconnecting clients. <see langword="null"/> for
+    /// fresh subscribers — they get no replay. When non-null, the hub returns the
+    /// buffered messages with <c>StreamCursor &gt; lastEventId</c>; if the client is
+    /// behind the oldest ring entry, <see cref="SubscriptionResult.ResumeFailed"/>
+    /// is set and replay is empty.
+    /// </param>
+    /// <param name="writer">Channel writer that receives live envelopes after the replay.</param>
+    SubscriptionResult Subscribe(
         Guid? tenantId,
         Guid dashboardId,
+        long? lastEventId,
         ChannelWriter<WidgetPushMessage> writer);
 }

--- a/src/Granit.Dashboards.Push/Internal/InMemoryWidgetPushHub.cs
+++ b/src/Granit.Dashboards.Push/Internal/InMemoryWidgetPushHub.cs
@@ -2,7 +2,9 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Threading.Channels;
 using Granit.Analytics.Metrics;
+using Granit.Dashboards.Push.Options;
 using Granit.Dashboards.Rendering;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Dashboards.Push.Internal;
 
@@ -10,7 +12,8 @@ namespace Granit.Dashboards.Push.Internal;
 /// In-process implementation of <see cref="IWidgetPushHub"/>. Producers call
 /// <see cref="PublishSnapshotAsync"/> / <see cref="PublishUnavailableAsync"/>;
 /// the SSE endpoint subscribes via <see cref="Subscribe"/>; the hub fans out
-/// inside the same process.
+/// inside the same process and keeps a per-stream ring buffer for
+/// <c>Last-Event-ID</c> resume (ADR-043 §5).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -21,19 +24,25 @@ namespace Granit.Dashboards.Push.Internal;
 /// <para>
 /// Slow subscribers are dropped silently (<c>TryWrite</c>) instead of
 /// backpressuring the publisher. A subscriber whose channel is bounded and full
-/// loses the in-flight message; the SSE endpoint shapes its channel as
-/// unbounded with <see cref="BoundedChannelFullMode.DropOldest"/> on the
-/// rendering side, so practical loss only happens when the client has
-/// disconnected and is about to be unregistered.
+/// loses the in-flight message; the SSE handler shapes its channel as bounded
+/// with <see cref="BoundedChannelFullMode.DropOldest"/> on the rendering side,
+/// so practical loss only happens when the client has disconnected and is
+/// about to be unregistered.
+/// </para>
+/// <para>
+/// Per-stream state (cursor + ring + subscriber set) is guarded by a
+/// <see cref="System.Threading.Lock"/> so dispatch (cursor allocation +
+/// ring append + fan-out) and subscribe-with-replay are mutually atomic —
+/// no envelope can land in both the replay snapshot and the live channel.
 /// </para>
 /// </remarks>
-internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequenceAllocator) : IWidgetPushHub
+internal sealed class InMemoryWidgetPushHub(
+    WidgetPushSequenceAllocator sequenceAllocator,
+    IOptions<DashboardsPushOptions> options) : IWidgetPushHub
 {
     private readonly WidgetPushSequenceAllocator _sequenceAllocator = sequenceAllocator;
-
-    // ConcurrentDictionary<StreamKey, ConcurrentDictionary<SubscriptionId, ChannelWriter>>.
-    // Outer key partitions per (tenant, dashboard); inner per active subscription.
-    private readonly ConcurrentDictionary<StreamKey, ConcurrentDictionary<Guid, ChannelWriter<WidgetPushMessage>>> _streams = new();
+    private readonly int _ringCapacity = options.Value.RingBufferCapacity;
+    private readonly ConcurrentDictionary<StreamKey, StreamState> _streams = new();
 
     /// <inheritdoc/>
     public Task PublishSnapshotAsync(
@@ -78,23 +87,57 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
     }
 
     /// <inheritdoc/>
-    public IDisposable Subscribe(
+    public SubscriptionResult Subscribe(
         Guid? tenantId,
         Guid dashboardId,
+        long? lastEventId,
         ChannelWriter<WidgetPushMessage> writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
 
         var key = new StreamKey(tenantId, dashboardId);
-        ConcurrentDictionary<Guid, ChannelWriter<WidgetPushMessage>> subs = _streams.GetOrAdd(
-            key, _ => new ConcurrentDictionary<Guid, ChannelWriter<WidgetPushMessage>>());
+        StreamState state = _streams.GetOrAdd(key, _ => new StreamState(_ringCapacity));
 
 #pragma warning disable GRSEC002 // In-process subscription id, opaque, never persisted — sequential UUID would buy nothing.
         var subscriptionId = Guid.NewGuid();
 #pragma warning restore GRSEC002
-        subs[subscriptionId] = writer;
 
-        return new SubscriptionHandle(this, key, subscriptionId);
+        lock (state.Mutex)
+        {
+            state.Subscribers[subscriptionId] = writer;
+
+            if (lastEventId is null)
+            {
+                return new SubscriptionResult(
+                    ResumeFailed: false,
+                    ServerCursor: state.Cursor,
+                    Replay: [],
+                    Handle: new SubscriptionHandle(this, key, subscriptionId));
+            }
+
+            long requestedFrom = lastEventId.Value + 1;
+
+            // Resume failed when the client is behind the oldest ring entry —
+            // we can't replay envelopes that have aged out.
+            if (state.Ring.Count > 0 && state.Ring.Peek().StreamCursor > requestedFrom)
+            {
+                return new SubscriptionResult(
+                    ResumeFailed: true,
+                    ServerCursor: state.Cursor,
+                    Replay: [],
+                    Handle: new SubscriptionHandle(this, key, subscriptionId));
+            }
+
+            // Caught up or in-range — collect everything strictly newer than the
+            // client's last seen cursor. Empty list when fully caught up.
+            WidgetPushMessage[] replay = [.. state.Ring.Where(m => m.StreamCursor >= requestedFrom)];
+
+            return new SubscriptionResult(
+                ResumeFailed: false,
+                ServerCursor: state.Cursor,
+                Replay: replay,
+                Handle: new SubscriptionHandle(this, key, subscriptionId));
+        }
     }
 
     private void Dispatch(
@@ -104,14 +147,33 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
         string? requiredPermission,
         WidgetSnapshotEnvelope envelope)
     {
-        StreamKey key = new(tenantId, dashboardId);
-        if (!_streams.TryGetValue(key, out ConcurrentDictionary<Guid, ChannelWriter<WidgetPushMessage>>? subs))
+        var key = new StreamKey(tenantId, dashboardId);
+        StreamState state = _streams.GetOrAdd(key, _ => new StreamState(_ringCapacity));
+
+        WidgetPushMessage message;
+        ChannelWriter<WidgetPushMessage>[] writers;
+
+        lock (state.Mutex)
         {
-            return;
+            long cursor = ++state.Cursor;
+            message = new WidgetPushMessage(
+                tenantId, dashboardId, widgetInstanceId, requiredPermission, cursor, envelope);
+
+            // Append to ring + evict oldest when over capacity. Bounded under
+            // the same lock as Subscribe so no race between an envelope landing
+            // in the ring and a new subscriber's replay snapshot.
+            state.Ring.Enqueue(message);
+            while (state.Ring.Count > _ringCapacity)
+            {
+                state.Ring.Dequeue();
+            }
+
+            // Snapshot the writer list under the lock; TryWrite outside to keep
+            // the critical section as short as possible.
+            writers = [.. state.Subscribers.Values];
         }
 
-        WidgetPushMessage message = new(tenantId, dashboardId, widgetInstanceId, requiredPermission, envelope);
-        foreach (ChannelWriter<WidgetPushMessage> writer in subs.Values)
+        foreach (ChannelWriter<WidgetPushMessage> writer in writers)
         {
             // TryWrite is non-blocking. Slow / closed subscribers silently drop —
             // the SSE handler unregisters on disconnect via the SubscriptionHandle.
@@ -121,13 +183,32 @@ internal sealed class InMemoryWidgetPushHub(WidgetPushSequenceAllocator sequence
 
     private void Unregister(StreamKey key, Guid subscriptionId)
     {
-        if (_streams.TryGetValue(key, out ConcurrentDictionary<Guid, ChannelWriter<WidgetPushMessage>>? subs))
+        if (!_streams.TryGetValue(key, out StreamState? state))
         {
-            subs.TryRemove(subscriptionId, out _);
+            return;
+        }
+
+        lock (state.Mutex)
+        {
+            state.Subscribers.Remove(subscriptionId, out _);
         }
     }
 
     private readonly record struct StreamKey(Guid? TenantId, Guid DashboardId);
+
+    /// <summary>
+    /// Per-stream state guarded by <see cref="Mutex"/>. <see cref="Cursor"/>
+    /// is the monotonic per-<c>(tenant, dashboard)</c> stream counter;
+    /// <see cref="Ring"/> is the bounded replay buffer; <see cref="Subscribers"/>
+    /// is the active fan-out set.
+    /// </summary>
+    private sealed class StreamState(int ringCapacity)
+    {
+        public long Cursor;
+        public Queue<WidgetPushMessage> Ring { get; } = new(ringCapacity);
+        public Dictionary<Guid, ChannelWriter<WidgetPushMessage>> Subscribers { get; } = [];
+        public Lock Mutex { get; } = new();
+    }
 
     private sealed class SubscriptionHandle(
         InMemoryWidgetPushHub hub,

--- a/src/Granit.Dashboards.Push/Internal/SubscriptionResult.cs
+++ b/src/Granit.Dashboards.Push/Internal/SubscriptionResult.cs
@@ -1,0 +1,33 @@
+namespace Granit.Dashboards.Push.Internal;
+
+/// <summary>
+/// Outcome of <see cref="IWidgetPushHub.Subscribe"/>: the (possibly empty)
+/// replay snapshot, the current server cursor, and the disposable handle the
+/// caller releases on disconnect. ADR-043 §5.
+/// </summary>
+/// <param name="ResumeFailed">
+/// <see langword="true"/> when the caller passed a <c>Last-Event-ID</c> that is
+/// older than the oldest entry still in the ring buffer — the client missed
+/// envelopes that have since aged out and must re-pull the seed via
+/// <c>POST /dashboards/{id}/render</c>. The SSE handler emits a dedicated
+/// <c>event: resume-failed</c> frame so the frontend hook knows to fall back.
+/// </param>
+/// <param name="ServerCursor">
+/// Current server-side stream cursor at subscribe time. Informational —
+/// surfaced so test harnesses can pin behaviour without reflecting on the
+/// hub's internal state.
+/// </param>
+/// <param name="Replay">
+/// Buffered messages with <c>StreamCursor &gt; lastEventId</c>, in cursor order.
+/// Empty when no resume was requested or when the client is fully caught up.
+/// </param>
+/// <param name="Handle">
+/// Subscription handle. Disposing unregisters the writer from the stream's
+/// fan-out list. Once disposed, the hub will not call <c>TryWrite</c> on the
+/// associated channel again.
+/// </param>
+internal sealed record SubscriptionResult(
+    bool ResumeFailed,
+    long ServerCursor,
+    IReadOnlyList<WidgetPushMessage> Replay,
+    IDisposable Handle);

--- a/src/Granit.Dashboards.Push/Internal/WidgetPushMessage.cs
+++ b/src/Granit.Dashboards.Push/Internal/WidgetPushMessage.cs
@@ -10,9 +10,21 @@ namespace Granit.Dashboards.Push.Internal;
 /// already partitions by <c>(tenantId, dashboardId)</c>, the receiver gets the
 /// full identity for free.
 /// </summary>
+/// <param name="TenantId">Owning tenant (matches the publisher's tenant scope).</param>
+/// <param name="DashboardId">Dashboard the widget belongs to — partitions streams.</param>
+/// <param name="WidgetInstanceId">Persisted <c>WidgetInstance.Id</c>.</param>
+/// <param name="RequiredPermission">Per-widget permission gate; <see langword="null"/> when broadly readable. Filtered server-side by the SSE handler so non-entitled subscribers receive an <c>Unavailable</c> envelope instead of the live snapshot.</param>
+/// <param name="StreamCursor">
+/// Per-<c>(tenantId, dashboardId)</c> monotonic stream-level counter (distinct from
+/// <see cref="WidgetSnapshotEnvelope.Sequence"/> which is per-widget). Surfaced on the
+/// SSE <c>id:</c> field so reconnecting clients can resume via the standard
+/// <c>Last-Event-ID</c> header. ADR-043 §5.
+/// </param>
+/// <param name="Envelope">The pull-shape envelope produced by the renderer or producer.</param>
 internal sealed record WidgetPushMessage(
     Guid? TenantId,
     Guid DashboardId,
     Guid WidgetInstanceId,
     string? RequiredPermission,
+    long StreamCursor,
     WidgetSnapshotEnvelope Envelope);

--- a/src/Granit.Dashboards.Push/Options/DashboardsPushOptions.cs
+++ b/src/Granit.Dashboards.Push/Options/DashboardsPushOptions.cs
@@ -36,4 +36,15 @@ public sealed class DashboardsPushOptions
     [Required]
     [MinLength(1)]
     public string TagName { get; set; } = "Dashboards - Stream";
+
+    /// <summary>
+    /// Per-stream ring-buffer capacity used by the in-memory hub for
+    /// <c>Last-Event-ID</c> resume (ADR-043 §5). When a reconnecting client
+    /// requests envelopes older than the ring's oldest entry, the SSE handler
+    /// emits <c>event: resume-failed</c> and the frontend hook re-fetches the
+    /// seed via the pull endpoint. Default: 100 — sized so a 30 s reconnect
+    /// gap on a busy 3-Hz dashboard still resumes cleanly.
+    /// </summary>
+    [Range(1, 100_000)]
+    public int RingBufferCapacity { get; set; } = 100;
 }

--- a/tests/Granit.Dashboards.Push.Tests/Internal/InMemoryWidgetPushHubTests.cs
+++ b/tests/Granit.Dashboards.Push.Tests/Internal/InMemoryWidgetPushHubTests.cs
@@ -2,7 +2,9 @@ using System.Text.Json;
 using System.Threading.Channels;
 using Granit.Analytics.Metrics;
 using Granit.Dashboards.Push.Internal;
+using Granit.Dashboards.Push.Options;
 using Granit.Dashboards.Rendering;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -28,7 +30,7 @@ public sealed class InMemoryWidgetPushHubTests
         var widget = Guid.NewGuid();
 
         var channel = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenant, dashboard, channel.Writer);
+        using IDisposable _ = hub.Subscribe(tenant, dashboard, lastEventId: null, channel.Writer).Handle;
 
         await hub.PublishSnapshotAsync(
             tenant, dashboard, widget,
@@ -60,8 +62,8 @@ public sealed class InMemoryWidgetPushHubTests
 
         var a = Channel.CreateUnbounded<WidgetPushMessage>();
         var b = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenant, dashboard, a.Writer);
-        using IDisposable __ = hub.Subscribe(tenant, dashboard, b.Writer);
+        using IDisposable _ = hub.Subscribe(tenant, dashboard, lastEventId: null, a.Writer).Handle;
+        using IDisposable __ = hub.Subscribe(tenant, dashboard, lastEventId: null, b.Writer).Handle;
 
         await hub.PublishSnapshotAsync(
             tenant, dashboard, Guid.NewGuid(),
@@ -81,7 +83,7 @@ public sealed class InMemoryWidgetPushHubTests
         var dashboardB = Guid.NewGuid();
 
         var subscribedToA = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenant, dashboardA, subscribedToA.Writer);
+        using IDisposable _ = hub.Subscribe(tenant, dashboardA, lastEventId: null, subscribedToA.Writer).Handle;
 
         await hub.PublishSnapshotAsync(
             tenant, dashboardB, Guid.NewGuid(),
@@ -100,7 +102,7 @@ public sealed class InMemoryWidgetPushHubTests
         var tenantB = Guid.NewGuid();
 
         var subscribedToA = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenantA, dashboard, subscribedToA.Writer);
+        using IDisposable _ = hub.Subscribe(tenantA, dashboard, lastEventId: null, subscribedToA.Writer).Handle;
 
         // Same dashboard id, different tenant — must not leak. Multi-tenant isolation
         // is enforced at the stream-key level, ADR-043 §6.
@@ -120,7 +122,7 @@ public sealed class InMemoryWidgetPushHubTests
         var dashboard = Guid.NewGuid();
 
         var channel = Channel.CreateUnbounded<WidgetPushMessage>();
-        IDisposable handle = hub.Subscribe(tenant, dashboard, channel.Writer);
+        IDisposable handle = hub.Subscribe(tenant, dashboard, lastEventId: null, channel.Writer).Handle;
 
         handle.Dispose();
 
@@ -140,7 +142,7 @@ public sealed class InMemoryWidgetPushHubTests
         var dashboard = Guid.NewGuid();
 
         var channel = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenant, dashboard, channel.Writer);
+        using IDisposable _ = hub.Subscribe(tenant, dashboard, lastEventId: null, channel.Writer).Handle;
 
         await hub.PublishUnavailableAsync(
             tenant, dashboard, Guid.NewGuid(),
@@ -163,7 +165,7 @@ public sealed class InMemoryWidgetPushHubTests
         var widget = Guid.NewGuid();
 
         var channel = Channel.CreateUnbounded<WidgetPushMessage>();
-        using IDisposable _ = hub.Subscribe(tenant, dashboard, channel.Writer);
+        using IDisposable _ = hub.Subscribe(tenant, dashboard, lastEventId: null, channel.Writer).Handle;
 
         for (int i = 0; i < 3; i++)
         {
@@ -189,5 +191,12 @@ public sealed class InMemoryWidgetPushHubTests
         return message!;
     }
 
-    private static InMemoryWidgetPushHub NewHub() => new(new WidgetPushSequenceAllocator());
+    private static InMemoryWidgetPushHub NewHub(int ringCapacity = 100)
+    {
+        IOptions<DashboardsPushOptions> options = Microsoft.Extensions.Options.Options.Create(new DashboardsPushOptions
+        {
+            RingBufferCapacity = ringCapacity,
+        });
+        return new InMemoryWidgetPushHub(new WidgetPushSequenceAllocator(), options);
+    }
 }

--- a/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushHubResumeTests.cs
+++ b/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushHubResumeTests.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Granit.Analytics.Metrics;
+using Granit.Dashboards.Push.Internal;
+using Granit.Dashboards.Push.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Dashboards.Push.Tests.Internal;
+
+/// <summary>
+/// Pins the <c>Last-Event-ID</c> resume contract from ADR-043 §5: ring buffer
+/// drops oldest on overflow, fresh subscribers get no replay, reconnecting
+/// subscribers within the ring window get the missed envelopes back, and a
+/// client behind the oldest ring entry surfaces <see cref="SubscriptionResult.ResumeFailed"/>
+/// = <see langword="true"/> so the SSE handler can emit
+/// <c>event: resume-failed</c> and the frontend re-pulls the seed.
+/// </summary>
+public sealed class WidgetPushHubResumeTests
+{
+    private static readonly JsonElement SamplePayload = JsonSerializer.SerializeToElement(new { value = 42 });
+    private static readonly DateTimeOffset EmittedAt = new(2026, 4, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Subscribe_FreshClient_NoLastEventId_NoReplay()
+    {
+        InMemoryWidgetPushHub hub = NewHub(ringCapacity: 100);
+
+        var channel = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(
+            tenantId: Guid.NewGuid(),
+            dashboardId: Guid.NewGuid(),
+            lastEventId: null,
+            writer: channel.Writer);
+        using IDisposable _ = result.Handle;
+
+        result.ResumeFailed.ShouldBeFalse();
+        result.Replay.ShouldBeEmpty();
+        result.ServerCursor.ShouldBe(0L);                                    // no envelopes yet
+    }
+
+    [Fact]
+    public async Task PublishSnapshot_AssignsMonotonicStreamCursor_PerStream()
+    {
+        InMemoryWidgetPushHub hub = NewHub();
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        var channel = Channel.CreateUnbounded<WidgetPushMessage>();
+        using IDisposable _ = hub.Subscribe(tenant, dashboard, lastEventId: null, channel.Writer).Handle;
+
+        // Three different widget instances on the same dashboard — stream cursor
+        // increments per-(tenant, dashboard), not per-widget.
+        for (int i = 0; i < 3; i++)
+        {
+            await hub.PublishSnapshotAsync(
+                tenant, dashboard, Guid.NewGuid(),
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        long[] cursors =
+        [
+            ReadOne(channel).StreamCursor,
+            ReadOne(channel).StreamCursor,
+            ReadOne(channel).StreamCursor,
+        ];
+
+        cursors.ShouldBe([1L, 2L, 3L]);
+    }
+
+    [Fact]
+    public async Task Subscribe_WithLastEventId_InRange_ReplaysMissedEnvelopes()
+    {
+        InMemoryWidgetPushHub hub = NewHub();
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        // Phase 1: a first client publishes, then disconnects after cursor=2.
+        var live = Channel.CreateUnbounded<WidgetPushMessage>();
+        IDisposable initial = hub.Subscribe(tenant, dashboard, lastEventId: null, live.Writer).Handle;
+        for (int i = 0; i < 5; i++)
+        {
+            await hub.PublishSnapshotAsync(
+                tenant, dashboard, Guid.NewGuid(),
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        initial.Dispose();
+
+        // Phase 2: client reconnects with Last-Event-ID=2 — expects cursors 3, 4, 5.
+        var resumed = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(tenant, dashboard, lastEventId: 2, resumed.Writer);
+        using IDisposable _ = result.Handle;
+
+        result.ResumeFailed.ShouldBeFalse();
+        result.Replay.Select(m => m.StreamCursor).ShouldBe([3L, 4L, 5L]);
+    }
+
+    [Fact]
+    public async Task Subscribe_WithLastEventId_FullyCaughtUp_NoReplay()
+    {
+        InMemoryWidgetPushHub hub = NewHub();
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        var live = Channel.CreateUnbounded<WidgetPushMessage>();
+        IDisposable initial = hub.Subscribe(tenant, dashboard, lastEventId: null, live.Writer).Handle;
+        for (int i = 0; i < 3; i++)
+        {
+            await hub.PublishSnapshotAsync(
+                tenant, dashboard, Guid.NewGuid(),
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        initial.Dispose();
+
+        // Client reconnects already up to cursor=3 — nothing to replay.
+        var resumed = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(tenant, dashboard, lastEventId: 3, resumed.Writer);
+        using IDisposable _ = result.Handle;
+
+        result.ResumeFailed.ShouldBeFalse();
+        result.Replay.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Subscribe_WithLastEventId_BehindRingOldest_ReportsResumeFailed()
+    {
+        // Tiny ring (capacity 3) so we can overflow it deterministically.
+        InMemoryWidgetPushHub hub = NewHub(ringCapacity: 3);
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        var live = Channel.CreateUnbounded<WidgetPushMessage>();
+        IDisposable initial = hub.Subscribe(tenant, dashboard, lastEventId: null, live.Writer).Handle;
+
+        // Publish 10 envelopes — ring keeps cursors 8, 9, 10 only.
+        for (int i = 0; i < 10; i++)
+        {
+            await hub.PublishSnapshotAsync(
+                tenant, dashboard, Guid.NewGuid(),
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        initial.Dispose();
+
+        // Client reconnects with Last-Event-ID=2 — far behind the ring's oldest
+        // (cursor 8). Resume must fail so the SSE handler can emit
+        // `event: resume-failed` and the frontend re-fetches the seed.
+        var resumed = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(tenant, dashboard, lastEventId: 2, resumed.Writer);
+        using IDisposable _ = result.Handle;
+
+        result.ResumeFailed.ShouldBeTrue();
+        result.Replay.ShouldBeEmpty();
+        result.ServerCursor.ShouldBe(10L);
+    }
+
+    [Fact]
+    public async Task Ring_DropsOldest_OnOverflow()
+    {
+        InMemoryWidgetPushHub hub = NewHub(ringCapacity: 3);
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        // Drive the cursor past the ring's capacity.
+        var warmup = Channel.CreateUnbounded<WidgetPushMessage>();
+        IDisposable initial = hub.Subscribe(tenant, dashboard, lastEventId: null, warmup.Writer).Handle;
+        for (int i = 0; i < 7; i++)
+        {
+            await hub.PublishSnapshotAsync(
+                tenant, dashboard, Guid.NewGuid(),
+                "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        initial.Dispose();
+
+        // The ring holds the last 3 cursors only — replay from id 4 returns 5, 6, 7.
+        var probe = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(tenant, dashboard, lastEventId: 4, probe.Writer);
+        using IDisposable _ = result.Handle;
+
+        result.ResumeFailed.ShouldBeFalse();
+        result.Replay.Select(m => m.StreamCursor).ShouldBe([5L, 6L, 7L]);
+    }
+
+    [Fact]
+    public async Task Subscribe_AfterDispatchStarts_ReceivesLiveEnvelopesAfterReplay()
+    {
+        // Atomic guarantee: the hub locks ring + subscriber registration together,
+        // so a publish that races with a Subscribe call lands EITHER in the replay
+        // snapshot OR on the live channel — never both, never neither. This test
+        // exercises the happy path where the publisher fires before subscribe (so
+        // the message is in the replay) and again after (so the message is on the
+        // channel) and verifies no duplicate.
+        InMemoryWidgetPushHub hub = NewHub();
+        var tenant = Guid.NewGuid();
+        var dashboard = Guid.NewGuid();
+
+        // Pre-publish one envelope without any subscriber — only the ring buffers it.
+        await hub.PublishSnapshotAsync(
+            tenant, dashboard, Guid.NewGuid(),
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var channel = Channel.CreateUnbounded<WidgetPushMessage>();
+        SubscriptionResult result = hub.Subscribe(tenant, dashboard, lastEventId: 0, channel.Writer);
+        using IDisposable _ = result.Handle;
+
+        // Replay carries cursor=1.
+        result.Replay.Select(m => m.StreamCursor).ShouldBe([1L]);
+
+        // Now publish a second envelope — lands on the live channel only.
+        await hub.PublishSnapshotAsync(
+            tenant, dashboard, Guid.NewGuid(),
+            "Kpi", requiredPermission: null, SamplePayload, EmittedAt, RefreshHint.Realtime,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        WidgetPushMessage live = ReadOne(channel);
+        live.StreamCursor.ShouldBe(2L);
+        channel.Reader.TryRead(out WidgetPushMessage? extra).ShouldBeFalse(); // no second item — no duplicate
+        extra.ShouldBeNull();
+    }
+
+    private static WidgetPushMessage ReadOne(Channel<WidgetPushMessage> channel)
+    {
+        channel.Reader.TryRead(out WidgetPushMessage? message).ShouldBeTrue();
+        return message!;
+    }
+
+    private static InMemoryWidgetPushHub NewHub(int ringCapacity = 100)
+    {
+        IOptions<DashboardsPushOptions> options = Microsoft.Extensions.Options.Options.Create(new DashboardsPushOptions
+        {
+            RingBufferCapacity = ringCapacity,
+        });
+        return new InMemoryWidgetPushHub(new WidgetPushSequenceAllocator(), options);
+    }
+}

--- a/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushPermissionFilterTests.cs
+++ b/tests/Granit.Dashboards.Push.Tests/Internal/WidgetPushPermissionFilterTests.cs
@@ -89,6 +89,7 @@ public sealed class WidgetPushPermissionFilterTests
             DashboardId: Guid.NewGuid(),
             WidgetInstanceId: Guid.NewGuid(),
             RequiredPermission: "Invoicing.Invoices.Read",
+            StreamCursor: 1,
             Envelope: unavailableEnvelope);
 
         IPermissionChecker checker = Substitute.For<IPermissionChecker>();
@@ -131,6 +132,7 @@ public sealed class WidgetPushPermissionFilterTests
             DashboardId: Guid.NewGuid(),
             WidgetInstanceId: Guid.NewGuid(),
             RequiredPermission: requiredPermission,
+            StreamCursor: 1,
             Envelope: envelope);
     }
 }


### PR DESCRIPTION
## Summary

Closes the reliability gap deferred in [#1620](https://github.com/granit-fx/granit-dotnet/pull/1620): SSE clients reconnecting after a network blip now resume from the last cursor they saw without losing in-flight envelopes — the framework holds a per-stream ring buffer (default 100) and replays everything strictly newer than the client's `Last-Event-ID` before going live.

## Wire / contract changes

- **`WidgetPushMessage` (internal)** gains `StreamCursor` — a per-`(tenantId, dashboardId)` monotonic counter distinct from the per-widget envelope `Sequence`. The SSE `id:` field carries `StreamCursor` so the standard HTML5 EventSource reconnect protocol Just Works; the per-widget `Sequence` stays inside the JSON payload (locked by EPIC #1366 invariant #2 — ordering per `(widget, tenant)`).
- **`IWidgetPushHub.Subscribe`** now takes `long? lastEventId` and returns a `SubscriptionResult` (`ResumeFailed`, `ServerCursor`, `Replay`, `Handle`). **Atomic with the ring snapshot**: dispatch (cursor allocation + ring append + fan-out) and subscribe-with-replay are mutually exclusive under a per-stream `System.Threading.Lock`, so no envelope can land in both the replay snapshot and the live channel.
- **`DashboardsPushOptions.RingBufferCapacity`** (default 100, range [1, 100_000]) — sized so a 30 s reconnect gap on a busy 3-Hz dashboard still resumes cleanly.

## SSE handler

- Parses the `Last-Event-ID` request header (HTML5 standard sent by `EventSource` on auto-reconnect). Bad / missing headers fall back to a fresh subscription so a malformed reconnect never breaks the stream.
- When the hub returns `ResumeFailed=true` (client behind the ring's oldest entry), emits a dedicated `event: resume-failed\ndata: {}\n\n` frame so the frontend hook recognises the case and re-fetches the seed via `POST /dashboards/{id}/render`.
- **Replays** the buffered envelopes BEFORE entering the live read loop — same `WriteEnvelopeAsync` local function for both phases so the per-widget permission filter (P2.4-C-Auth) applies identically.
- SSE `id:` switches from per-widget `Sequence` to the new `StreamCursor`.

## Hub implementation

- `InMemoryWidgetPushHub` refactored to a per-stream `StreamState` (Cursor + Ring + Subscribers + Mutex). Single `ConcurrentDictionary` keyed by `(TenantId, DashboardId)`; per-stream lock keeps the critical section tight (cursor allocate + ring enqueue/dequeue + writer-list snapshot, then `TryWrite` outside the lock).
- Ring uses a plain `Queue<WidgetPushMessage>` with manual `Enqueue+Dequeue` eviction.

## Test plan

**27 push tests passing (15 hub + 5 filter + 7 new resume).**

The 7 new `WidgetPushHubResumeTests` pin:

- Fresh subscriber with no `Last-Event-ID` gets empty `Replay` + `ServerCursor=0`.
- `StreamCursor` increments monotonically per `(tenant, dashboard)` across different widgets — distinct from per-widget `Sequence`.
- Reconnect with `Last-Event-ID` in-range replays envelopes 3..N in order.
- Reconnect when fully caught up (`Last-Event-ID == ServerCursor`) replays nothing.
- **Reconnect behind ring's oldest entry**: capacity=3 with 10 publishes, request resume from 2 → `ResumeFailed=true`, `Replay` empty, `ServerCursor=10`.
- **Ring drop-oldest**: capacity=3 with 7 publishes, request resume from 4 → `Replay = [5, 6, 7]` (cursors 1..4 evicted).
- **Atomicity**: pre-publish then subscribe with `lastEventId=0` puts the pre-published envelope in `Replay`; a subsequent publish lands on the live channel only — **no duplicate, no skip**.

- [x] `dotnet build src/Granit.Dashboards.Push` — green
- [x] `dotnet test tests/Granit.Dashboards.Push.Tests` — 27 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 197 passed
- [x] `dotnet format --verify-no-changes` clean on src + test projects

ADR-043 implementation roadmap updated: P2.4-C2 marked shipped. Remaining: **P2.4-D** (WebSocket sibling, opt-in) and **P2.4-E** (frontend `usePushedDashboard` hook in `granit-front`, cross-repo).

Refs [ADR-043](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md) §5, follow-up to #1620 / #1623.
