### PR TITLE
fix(archi): include Granit.Dashboards.Push{,.WebSockets} in archi tests scope

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -69,6 +69,8 @@
       "src/Granit.Dashboards.Abstractions/Granit.Dashboards.Abstractions.csproj",
       "src/Granit.Dashboards.Endpoints/Granit.Dashboards.Endpoints.csproj",
       "src/Granit.Dashboards.EntityFrameworkCore/Granit.Dashboards.EntityFrameworkCore.csproj",
+      "src/Granit.Dashboards.Push.WebSockets/Granit.Dashboards.Push.WebSockets.csproj",
+      "src/Granit.Dashboards.Push/Granit.Dashboards.Push.csproj",
       "src/Granit.Dashboards/Granit.Dashboards.csproj",
       "src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14434,22 +14434,6 @@
       ]
     },
     {
-      "name": "WidgetPushSequenceAllocator",
-      "fqn": "Granit.Dashboards.Push.Internal.WidgetPushSequenceAllocator",
-      "kind": "class",
-      "project": "Granit.Dashboards.Push",
-      "file": "src/Granit.Dashboards.Push/Internal/WidgetPushSequenceAllocator.cs",
-      "line": 24,
-      "members": [
-        {
-          "name": "Next",
-          "kind": "method",
-          "signature": "Next(Guid? tenantId, Guid widgetInstanceId)",
-          "returnType": "long"
-        }
-      ]
-    },
-    {
       "name": "DashboardsPushOptions",
       "fqn": "Granit.Dashboards.Push.Options.DashboardsPushOptions",
       "kind": "class",

--- a/src/Granit.Dashboards.Push/Internal/WidgetPushSequenceAllocator.cs
+++ b/src/Granit.Dashboards.Push/Internal/WidgetPushSequenceAllocator.cs
@@ -21,7 +21,7 @@ namespace Granit.Dashboards.Push.Internal;
 /// the same so the SSE endpoint never sees the difference.
 /// </para>
 /// </remarks>
-public sealed class WidgetPushSequenceAllocator
+internal sealed class WidgetPushSequenceAllocator
 {
     private readonly ConcurrentDictionary<SequenceKey, Counter> _counters = new();
 

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -49,6 +49,8 @@
     <ProjectReference Include="..\..\src\Granit.Dashboards.Abstractions\Granit.Dashboards.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards.Endpoints\Granit.Dashboards.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Dashboards.EntityFrameworkCore\Granit.Dashboards.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Push\Granit.Dashboards.Push.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Dashboards.Push.WebSockets\Granit.Dashboards.Push.WebSockets.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.ConfigurationChanges\Granit.Auditing.ConfigurationChanges.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.EntityFrameworkCore\Granit.Auditing.EntityFrameworkCore.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1999,6 +1999,33 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
+      "granit.dashboards.push": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.push.websockets": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Push": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange": {
         "type": "Project",
         "dependencies": {


### PR DESCRIPTION
## Summary

The two new packages shipped with **P2.4-C** (#1620) and **P2.4-D** (#1629) landed in `Granit.slnx`, the `business` test shard, and CI's `business.slnf` correctly — but the **architecture-tests scope had not been updated**, so the rules in `Granit.ArchitectureTests` (class design, layer purity, naming conventions, abstractions purity, …) silently skipped them.

Effect was real: scanning the new assemblies surfaces one violation that had been hiding in plain sight —

- **`Granit.Dashboards.Push.Internal.WidgetPushSequenceAllocator`** was declared `public sealed class` while sitting in a `*.Internal.*` namespace. The class is genuinely an implementation detail of `InMemoryWidgetPushHub` (the hub takes it in its constructor and uses it directly; nothing outside the assembly resolves it). Hosts that want a different sequence backing replace the whole `IWidgetPushHub` registration via DI, not the allocator individually.

## Fix

- Add `Granit.Dashboards.Push` + `Granit.Dashboards.Push.WebSockets` to [Granit.ArchitectureTests.csproj](tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj)'s `ProjectReference` list (the hand-maintained *"reference ALL src assemblies"* block).
- Make `WidgetPushSequenceAllocator` `internal` to align with the archi rule. The `InternalsVisibleTo` on `Granit.Dashboards.Push` already grants the test project access, so `WidgetPushSequenceAllocatorTests` (the 5-case Theory + the 8000-call concurrency stress test) keep working unchanged.
- Regenerate `.github/shard-filters/architecture.slnf` (298 → 300 projects) via `python3 scripts/generate-shard-filters.py`.

`business.slnf` and `src-only.slnf` already carried the two packages — they were generated correctly when P2.4-C / P2.4-D landed; only `architecture.slnf` was undercovered because its scope is driven by the `Granit.ArchitectureTests` `ProjectReference`s (not by the slnx contents).

## Test plan

- [x] `dotnet build src/Granit.Dashboards.Push` — green after the visibility change
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "ClassDesignTests.Public_types_should_not_reside_in_Internal_namespaces"` — green (was failing before the visibility fix once the new assemblies entered scope)
- [x] `dotnet format src/Granit.Dashboards.Push --verify-no-changes` — clean
- [x] `architecture.slnf` regenerated (298 → 300 projects)

Refs [ADR-043](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/043-dashboard-push-transport.md), follow-up to #1620 / #1629.
