### PR TITLE
fix(analytics): security audit fixes (lifetime, whitelist, bounds, overflow)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4506,7 +4506,7 @@
       "kind": "class",
       "project": "Granit.Analytics.Endpoints",
       "file": "src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "RoutePrefix",
@@ -4531,6 +4531,18 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan StaticTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(365 * 5)",
+          "returnType": "TimeSpan MaxPeriodLength { get; set; } = TimeSpan."
+        },
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(ValidationContext validationContext)",
+          "returnType": "IEnumerable<ValidationResult>"
         }
       ]
     },

--- a/src/Granit.Analytics.Endpoints/Internal/MetricEndpointService.cs
+++ b/src/Granit.Analytics.Endpoints/Internal/MetricEndpointService.cs
@@ -51,6 +51,11 @@ internal sealed class MetricEndpointService(
             ? _periodResolver.Resolve(request.Period)
             : null;
 
+        if (mainPeriod is { } main)
+        {
+            EnforceMaxPeriodLength(main);
+        }
+
         ResolvedPeriod? comparePeriod = null;
         if (request.CompareTo is not null)
         {
@@ -62,6 +67,7 @@ internal sealed class MetricEndpointService(
             }
 
             comparePeriod = _periodResolver.ResolveComparison(request.CompareTo, mainPeriod!.Value);
+            EnforceMaxPeriodLength(comparePeriod.Value);
         }
 
         string tenantId = _currentTenant is { IsAvailable: true, Id: { } id } ? id.ToString() : "global";
@@ -131,5 +137,22 @@ internal sealed class MetricEndpointService(
         _ = Stopwatch.GetElapsedTime(startTimestamp); // observed via metrics in a future story
 
         return value;
+    }
+
+    /// <summary>
+    /// Caps the resolved <c>[from, to)</c> window at <see cref="AnalyticsEndpointsOptions.MaxPeriodLength"/>.
+    /// Without this guard, an authenticated caller could submit
+    /// <c>{ from: 0001-01-01, to: 9999-12-31 }</c> and force a full-table aggregate scan
+    /// per request — a cheap-input/expensive-DB amplification.
+    /// </summary>
+    private void EnforceMaxPeriodLength(ResolvedPeriod period)
+    {
+        TimeSpan length = period.To - period.From;
+        if (length > _options.MaxPeriodLength)
+        {
+            throw new BusinessRuleViolationException(
+                "Granit.Analytics:PeriodSpecOutOfRange",
+                $"Period length {length} exceeds the configured maximum {_options.MaxPeriodLength}.");
+        }
     }
 }

--- a/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
+++ b/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
@@ -6,12 +6,26 @@ namespace Granit.Analytics.Endpoints.Options;
 /// Configuration options for the Granit.Analytics endpoint surface. Bound from the
 /// <c>AnalyticsEndpoints</c> section of <c>appsettings.json</c> by
 /// <c>AddGranitAnalyticsEndpoints</c>; data-annotation constraints are validated on
-/// startup via <c>ValidateDataAnnotations</c> + <c>ValidateOnStart</c>.
+/// startup via <c>ValidateDataAnnotations</c> + <c>ValidateOnStart</c> AND through
+/// <see cref="IValidatableObject"/> for the <see cref="TimeSpan"/> ranges that
+/// <c>RangeAttribute</c> cannot express.
 /// </summary>
-public sealed class AnalyticsEndpointsOptions
+public sealed class AnalyticsEndpointsOptions : IValidatableObject
 {
     /// <summary>Configuration section name.</summary>
     public const string SectionName = "AnalyticsEndpoints";
+
+    /// <summary>Lower bound (inclusive) for the cache TTL options — values below this disable caching entirely instead.</summary>
+    private static readonly TimeSpan MinTtl = TimeSpan.FromSeconds(1);
+
+    /// <summary>Upper bound (inclusive) for <see cref="DynamicTtl"/>: 1 day. A dynamic metric stale for longer is no longer dynamic.</summary>
+    private static readonly TimeSpan MaxDynamicTtl = TimeSpan.FromDays(1);
+
+    /// <summary>Upper bound (inclusive) for <see cref="StaticTtl"/>: 7 days. Beyond a week, restart the host and re-warm.</summary>
+    private static readonly TimeSpan MaxStaticTtl = TimeSpan.FromDays(7);
+
+    /// <summary>Upper bound (inclusive) for <see cref="MaxPeriodLength"/>: 50 years.</summary>
+    private static readonly TimeSpan MaxPeriodLengthCeiling = TimeSpan.FromDays(365 * 50);
 
     /// <summary>
     /// Route prefix for analytics endpoints. Default: <c>"analytics"</c>
@@ -43,4 +57,37 @@ public sealed class AnalyticsEndpointsOptions
     /// Default: 5 minutes.
     /// </summary>
     public TimeSpan StaticTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Maximum length accepted for an absolute <c>{from, to}</c> period and for the
+    /// implicit comparison window resolved from <c>previous_period</c>. Default: 5 years.
+    /// Caps unbounded aggregate scans an authenticated caller could otherwise force by
+    /// submitting <c>{ from: 0001-01-01, to: 9999-12-31 }</c>.
+    /// </summary>
+    public TimeSpan MaxPeriodLength { get; set; } = TimeSpan.FromDays(365 * 5);
+
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (DynamicTtl < MinTtl || DynamicTtl > MaxDynamicTtl)
+        {
+            yield return new ValidationResult(
+                $"{nameof(DynamicTtl)} must be between {MinTtl} and {MaxDynamicTtl} (current: {DynamicTtl}).",
+                [nameof(DynamicTtl)]);
+        }
+
+        if (StaticTtl < MinTtl || StaticTtl > MaxStaticTtl)
+        {
+            yield return new ValidationResult(
+                $"{nameof(StaticTtl)} must be between {MinTtl} and {MaxStaticTtl} (current: {StaticTtl}).",
+                [nameof(StaticTtl)]);
+        }
+
+        if (MaxPeriodLength <= TimeSpan.Zero || MaxPeriodLength > MaxPeriodLengthCeiling)
+        {
+            yield return new ValidationResult(
+                $"{nameof(MaxPeriodLength)} must be strictly positive and at most {MaxPeriodLengthCeiling} (current: {MaxPeriodLength}).",
+                [nameof(MaxPeriodLength)]);
+        }
+    }
 }

--- a/src/Granit.Analytics.EntityFrameworkCore/Extensions/AnalyticsEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Extensions/AnalyticsEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -62,11 +62,17 @@ public static class AnalyticsEntityFrameworkCoreServiceCollectionExtensions
         // One closed-generic MetricRunner<TEntity, TValue> per registered metric definition.
         // The runner wraps IMetricExecutor<,> (this package) so request-time dispatch from
         // MetricEndpointService stays reflection-free.
+        //
+        // Lifetime MUST be Scoped: the runner transitively depends on IQueryableSource<TEntity>
+        // (DbContext-bound) and IMetricExecutor<,> (Scoped), both of which capture the request's
+        // ICurrentTenant. A singleton would resolve those dependencies once from the root scope
+        // and freeze the first request's tenant context, producing a cross-tenant data leak on
+        // every subsequent call.
         foreach (ServiceDescriptor metricDescriptor in services
             .Where(d => d.ServiceType == typeof(IMetricDefinitionDescriptor))
             .ToList())
         {
-            services.AddSingleton<IMetricRunner>(sp =>
+            services.AddScoped<IMetricRunner>(sp =>
             {
                 var d = (IMetricDefinitionDescriptor)
                     (metricDescriptor.ImplementationFactory?.Invoke(sp)
@@ -158,6 +164,8 @@ public static class AnalyticsEntityFrameworkCoreServiceCollectionExtensions
                     typeof(IQueryableSource<>).MakeGenericType(d.EntityType));
                 object engine = sp.GetRequiredService(
                     typeof(IQueryEngine<>).MakeGenericType(d.EntityType));
+                object definition = sp.GetRequiredService(
+                    typeof(QueryDefinition<>).MakeGenericType(d.EntityType));
                 AnalyticsRuntimeMetrics metrics = sp.GetRequiredService<AnalyticsRuntimeMetrics>();
                 ICurrentTenant? currentTenant = sp.GetService<ICurrentTenant>();
                 // Optional Geography projector — registered by Granit.Analytics.PostGIS
@@ -167,7 +175,7 @@ public static class AnalyticsEntityFrameworkCoreServiceCollectionExtensions
                 object? geographyProjector = sp.GetService(projectorType);
 
                 return (IMapRunner)Activator.CreateInstance(
-                    runnerType, d.Name, queryableSource, engine, metrics, currentTenant, geographyProjector)!;
+                    runnerType, d.Name, queryableSource, engine, definition, metrics, currentTenant, geographyProjector)!;
             });
         }
 

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/AnalyticsColumnWhitelist.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/AnalyticsColumnWhitelist.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using Granit.QueryEngine;
+
+namespace Granit.Analytics.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Whitelist-aware property resolver shared by Map / Chart / Pivot /
+/// QueryAggregate runners. Validates that a caller-supplied field name is
+/// declared on the <see cref="QueryDefinition{TEntity}"/> (the same column
+/// whitelist the admin grid honours) BEFORE reflecting on the entity. Without
+/// this gate, dashboard authors could aggregate, group-by, or popup-render
+/// arbitrary public properties of the target entity — including columns the
+/// QueryDefinition deliberately keeps off the grid (audit notes, internal
+/// flags, per-row scores).
+/// </summary>
+internal static class AnalyticsColumnWhitelist
+{
+    /// <summary>
+    /// Resolves <paramref name="fieldName"/> to its declared
+    /// <see cref="ColumnDescriptor"/> on <paramref name="definition"/>, then
+    /// to the matching <see cref="PropertyInfo"/> on
+    /// <typeparamref name="TEntity"/>. Throws <see cref="ArgumentException"/>
+    /// when the field is not declared, or when the declared column has no
+    /// public instance property (e.g. shadow columns — those are not
+    /// reachable from runtime reflection).
+    /// </summary>
+    public static (PropertyInfo Property, ColumnDescriptor Column) ResolveProperty<TEntity>(
+        QueryDefinition<TEntity> definition,
+        string queryName,
+        string fieldName,
+        string paramName)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
+
+        ColumnDescriptor? declared = null;
+        foreach (ColumnDescriptor candidate in definition.GetColumns())
+        {
+            if (string.Equals(candidate.PropertyName, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                declared = candidate;
+                break;
+            }
+        }
+
+        if (declared is null)
+        {
+            throw new ArgumentException(
+                $"Field '{fieldName}' is not declared by query '{queryName}'.",
+                paramName);
+        }
+
+        if (declared.IsShadowProperty)
+        {
+            throw new ArgumentException(
+                $"Field '{declared.PropertyName}' on query '{queryName}' is a shadow property and is not supported by analytics runners.",
+                paramName);
+        }
+
+        // Resolve via the declared (canonical) property name — case-insensitive
+        // declared lookup tolerates frontend casing variations without exposing
+        // undeclared columns.
+        PropertyInfo? prop = typeof(TEntity).GetProperty(
+            declared.PropertyName,
+            BindingFlags.Public | BindingFlags.Instance);
+
+        if (prop is null)
+        {
+            throw new ArgumentException(
+                $"Declared column '{declared.PropertyName}' on query '{queryName}' has no public instance property.",
+                paramName);
+        }
+
+        return (prop, declared);
+    }
+}

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/ChartRunner.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/ChartRunner.cs
@@ -87,8 +87,15 @@ internal sealed class ChartRunner<TEntity>(
         string groupBy, AggregateFunction aggregation, string field,
         IReadOnlyDictionary<string, string>? dashboardFilters, CancellationToken ct)
     {
-        PropertyInfo groupProp = ResolveProperty(groupBy, nameof(groupBy));
-        PropertyInfo valueProp = ResolveProperty(field, nameof(field));
+        // Whitelist enforcement — both the group-by axis and the aggregated
+        // value field must be declared on the QueryDefinition. Without this
+        // gate, dashboard authors could pivot any aggregate by an undeclared
+        // categorical column (leaking distribution statistics) or aggregate
+        // an undeclared numeric (binary-search inference attack with Min/Max).
+        (PropertyInfo groupProp, _) = AnalyticsColumnWhitelist.ResolveProperty(
+            _definition, Name, groupBy, nameof(groupBy));
+        (PropertyInfo valueProp, _) = AnalyticsColumnWhitelist.ResolveProperty(
+            _definition, Name, field, nameof(field));
 
         Type valueUnderlying = Nullable.GetUnderlyingType(valueProp.PropertyType) ?? valueProp.PropertyType;
 
@@ -127,17 +134,6 @@ internal sealed class ChartRunner<TEntity>(
         ColumnDescriptor? match = columns.FirstOrDefault(c =>
             string.Equals(c.PropertyName, prop.Name, StringComparison.Ordinal));
         return match?.CurrencyCode;
-    }
-
-    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
-    {
-        PropertyInfo? prop = typeof(TEntity).GetProperty(
-            fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-        return prop ?? throw new ArgumentException(
-            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
-            paramName);
     }
 
     private static string LabelOf(object? key) =>

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/MapRunner.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/MapRunner.cs
@@ -29,6 +29,7 @@ internal sealed class MapRunner<TEntity>(
     string name,
     IQueryableSource<TEntity> source,
     IQueryEngine<TEntity> engine,
+    QueryDefinition<TEntity> definition,
     AnalyticsRuntimeMetrics metrics,
     ICurrentTenant? currentTenant = null,
     IGeographyPointProjector<TEntity>? geographyProjector = null) : IMapRunner
@@ -51,6 +52,7 @@ internal sealed class MapRunner<TEntity>(
 
     private readonly IQueryableSource<TEntity> _source = source;
     private readonly IQueryEngine<TEntity> _engine = engine;
+    private readonly QueryDefinition<TEntity> _definition = definition;
     private readonly AnalyticsRuntimeMetrics _metrics = metrics;
     private readonly ICurrentTenant? _currentTenant = currentTenant;
     private readonly IGeographyPointProjector<TEntity>? _geographyProjector = geographyProjector;
@@ -78,7 +80,7 @@ internal sealed class MapRunner<TEntity>(
             MapPointSource.LatLng latLng => BuildLatLngExtractor(latLng),
             MapPointSource.Geography geography => BuildGeographyExtractor(geography),
             _ => throw new NotSupportedException(
-                $"MapPointSource '{pointSource.GetType().Name}' is not supported by MapRunner<{typeof(TEntity).Name}>."),
+                $"MapPointSource '{pointSource.GetType().Name}' is not supported on map widget for query '{Name}'."),
         };
 
         PropertyInfo? idProp = typeof(TEntity).GetProperty(
@@ -137,7 +139,7 @@ internal sealed class MapRunner<TEntity>(
     }
 
     /// <summary>Builds the LatLng-path coordinate extractor — reflects two double/decimal columns and converts via invariant culture.</summary>
-    private static Func<TEntity, (double Latitude, double Longitude)?> BuildLatLngExtractor(MapPointSource.LatLng latLng)
+    private Func<TEntity, (double Latitude, double Longitude)?> BuildLatLngExtractor(MapPointSource.LatLng latLng)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(latLng.LatitudeColumn);
         ArgumentException.ThrowIfNullOrWhiteSpace(latLng.LongitudeColumn);
@@ -169,48 +171,54 @@ internal sealed class MapRunner<TEntity>(
         if (_geographyProjector is null)
         {
             throw new NotSupportedException(
-                $"MapRunner<{typeof(TEntity).Name}> received a Geography PointSource but no IGeographyPointProjector<{typeof(TEntity).Name}> is registered. " +
+                $"Map widget for query '{Name}' received a Geography PointSource but no IGeographyPointProjector is registered. " +
                 "Renderers should pre-check IMapRunner.SupportsGeography and surface 'Widget:Unavailable.MapGeographyNotImplemented' instead.");
         }
 
+        // Whitelist enforcement on the geography column — the projector
+        // internally reflects on TEntity to read the column, so the same gate
+        // that guards the LatLng path must apply here. Use the declared
+        // PropertyName so we hand the projector the canonical name regardless
+        // of the dashboard config's casing.
+        (PropertyInfo prop, _) = AnalyticsColumnWhitelist.ResolveProperty(
+            _definition, Name, geography.GeographyColumn, nameof(geography.GeographyColumn));
+
         IGeographyPointProjector<TEntity> projector = _geographyProjector;
-        string column = geography.GeographyColumn;
+        string column = prop.Name;
         return entity => projector.TryProject(entity, column);
     }
 
-    private static PropertyInfo ResolveCoordinateProperty(string fieldName, string paramName)
+    private PropertyInfo ResolveCoordinateProperty(string fieldName, string paramName)
     {
-        PropertyInfo prop = ResolveProperty(fieldName, paramName);
+        // Whitelist enforcement — coordinate columns must be declared on the
+        // QueryDefinition (the same set the admin grid honours). This blocks
+        // map widgets from reading undeclared properties of TEntity.
+        (PropertyInfo prop, _) = AnalyticsColumnWhitelist.ResolveProperty(
+            _definition, Name, fieldName, paramName);
+
         Type underlying = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
         if (underlying != typeof(double) && underlying != typeof(decimal))
         {
             throw new ArgumentException(
                 FormattableString.Invariant(
-                    $"Coordinate column '{prop.Name}' on entity '{typeof(TEntity).Name}' is of type '{underlying.Name}'. Map widgets require double or decimal latitude/longitude columns."),
+                    $"Coordinate column '{prop.Name}' on query '{Name}' is of type '{underlying.Name}'. Map widgets require double or decimal latitude/longitude columns."),
                 paramName);
         }
         return prop;
     }
 
-    private static PropertyInfo[] ResolvePopupProperties(IReadOnlyList<string> popupColumns)
+    private PropertyInfo[] ResolvePopupProperties(IReadOnlyList<string> popupColumns)
     {
+        // Whitelist enforcement — popup columns must be declared on the
+        // QueryDefinition. Without this gate, dashboard authors could leak
+        // raw values of any public property of TEntity through the popup.
         var resolved = new PropertyInfo[popupColumns.Count];
         for (int i = 0; i < popupColumns.Count; i++)
         {
-            resolved[i] = ResolveProperty(popupColumns[i], nameof(popupColumns));
+            (resolved[i], _) = AnalyticsColumnWhitelist.ResolveProperty(
+                _definition, Name, popupColumns[i], nameof(popupColumns));
         }
         return resolved;
-    }
-
-    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
-    {
-        PropertyInfo? prop = typeof(TEntity).GetProperty(
-            fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-        return prop ?? throw new ArgumentException(
-            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
-            paramName);
     }
 
     /// <summary>

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq.Expressions;
 using Granit.Analytics.Diagnostics;
 using Granit.Analytics.Metrics;
@@ -170,9 +169,32 @@ internal sealed class MetricExecutor<TEntity, TValue>(
 
     private static async Task<TValue?> ExecuteCountAsync(IQueryable<TEntity> filtered, CancellationToken ct)
     {
-        int count = await filtered.CountAsync(ct).ConfigureAwait(false);
-        // TValue is a value type that can hold an int (caller declared MetricDefinition<TEntity, int|long|decimal|double>).
-        return (TValue)Convert.ChangeType(count, typeof(TValue), CultureInfo.InvariantCulture);
+        // Use LongCountAsync — CountAsync returns int and overflows past
+        // int.MaxValue (≈ 2.1B rows). On event-stream-scale tables (audit log,
+        // telemetry, webhook delivery attempts) this is reachable by an
+        // authenticated caller widening the filter, which would surface as a
+        // 500. Long handles it; the per-TValue dispatch then uses a `checked`
+        // cast so a metric typed MetricDefinition<TEntity, int> fails fast on
+        // overflow instead of silently truncating.
+        long count = await filtered.LongCountAsync(ct).ConfigureAwait(false);
+
+        if (typeof(TValue) == typeof(int))
+        {
+            return (TValue?)(object?)checked((int)count);
+        }
+        if (typeof(TValue) == typeof(long))
+        {
+            return (TValue?)(object?)count;
+        }
+        if (typeof(TValue) == typeof(decimal))
+        {
+            return (TValue?)(object?)(decimal)count;
+        }
+        if (typeof(TValue) == typeof(double))
+        {
+            return (TValue?)(object?)(double)count;
+        }
+        throw NotSupported(nameof(AggregateFunction.Count));
     }
 
     private static async Task<TValue?> ExecuteSumAsync(

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/PivotRunner.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/PivotRunner.cs
@@ -51,8 +51,12 @@ internal sealed class PivotRunner<TEntity>(
                 nameof(rowFields));
         }
 
-        PropertyInfo[] rowProps = ResolveProperties(rowFields, nameof(rowFields));
-        PropertyInfo[] colProps = ResolveProperties(columnFields, nameof(columnFields));
+        // Whitelist enforcement — every row, column, and value field must be
+        // declared on the QueryDefinition (the same set the admin grid honours).
+        // Without this gate, a dashboard author could pivot any aggregate by
+        // an undeclared categorical column or aggregate undeclared numerics.
+        PropertyInfo[] rowProps = ResolveWhitelistedProperties(rowFields, nameof(rowFields));
+        PropertyInfo[] colProps = ResolveWhitelistedProperties(columnFields, nameof(columnFields));
 
         PropertyInfo? valueProp = null;
         Type? valueUnderlying = null;
@@ -65,7 +69,8 @@ internal sealed class PivotRunner<TEntity>(
                     nameof(valueField));
             }
 
-            valueProp = ResolveProperty(valueField, nameof(valueField));
+            (valueProp, _) = AnalyticsColumnWhitelist.ResolveProperty(
+                _definition, Name, valueField, nameof(valueField));
             valueUnderlying = Nullable.GetUnderlyingType(valueProp.PropertyType) ?? valueProp.PropertyType;
 
             if (!IsSupportedNumericType(valueUnderlying))
@@ -137,25 +142,15 @@ internal sealed class PivotRunner<TEntity>(
         return match?.CurrencyCode;
     }
 
-    private static PropertyInfo[] ResolveProperties(IReadOnlyList<string> fieldNames, string paramName)
+    private PropertyInfo[] ResolveWhitelistedProperties(IReadOnlyList<string> fieldNames, string paramName)
     {
         var resolved = new PropertyInfo[fieldNames.Count];
         for (int i = 0; i < fieldNames.Count; i++)
         {
-            resolved[i] = ResolveProperty(fieldNames[i], paramName);
+            (resolved[i], _) = AnalyticsColumnWhitelist.ResolveProperty(
+                _definition, Name, fieldNames[i], paramName);
         }
         return resolved;
-    }
-
-    private static PropertyInfo ResolveProperty(string fieldName, string paramName)
-    {
-        PropertyInfo? prop = typeof(TEntity).GetProperty(
-            fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-
-        return prop ?? throw new ArgumentException(
-            $"Field '{fieldName}' not found on entity '{typeof(TEntity).Name}'.",
-            paramName);
     }
 
     private static bool IsSupportedNumericType(Type underlying) =>

--- a/src/Granit.Analytics.EntityFrameworkCore/Internal/QueryAggregateRunner.cs
+++ b/src/Granit.Analytics.EntityFrameworkCore/Internal/QueryAggregateRunner.cs
@@ -71,12 +71,12 @@ internal sealed class QueryAggregateRunner<TEntity>(
                 nameof(field));
         }
 
-        PropertyInfo prop = typeof(TEntity).GetProperty(
-            field,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
-            ?? throw new ArgumentException(
-                $"Field '{field}' not found on entity '{typeof(TEntity).Name}' for query '{Name}'.",
-                nameof(field));
+        // Whitelist enforcement — only columns declared on the QueryDefinition
+        // are aggregatable (same set the admin grid exposes). Without this
+        // gate, dashboard authors could aggregate undeclared fields such as
+        // audit notes, internal scores, or password timestamps.
+        (PropertyInfo prop, _) = AnalyticsColumnWhitelist.ResolveProperty(
+            _definition, Name, field, nameof(field));
 
         Type underlying = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
 

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/ChartRunnerTests.cs
@@ -448,6 +448,10 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             builder
                 .Column(x => x.Status, c => c.Label("Status").Filterable())
                 .Column(x => x.Amount, c => c.Label("Amount").Filterable())
+                .Column(x => x.Quantity, c => c.Label("Quantity"))
+                .Column(x => x.BigQuantity, c => c.Label("BigQuantity"))
+                .Column(x => x.Score, c => c.Label("Score"))
+                .Column(x => x.Bonus, c => c.Label("Bonus"))
                 .AllowGroupBy(x => x.Status);
         }
     }
@@ -461,6 +465,10 @@ public sealed class ChartRunnerTests : IAsyncLifetime
             builder
                 .Column(x => x.Status, c => c.Label("Status").Filterable())
                 .Column(x => x.Amount, c => c.Label("Amount").Filterable().Currency("EUR"))
+                .Column(x => x.Quantity, c => c.Label("Quantity"))
+                .Column(x => x.BigQuantity, c => c.Label("BigQuantity"))
+                .Column(x => x.Score, c => c.Label("Score"))
+                .Column(x => x.Bonus, c => c.Label("Bonus"))
                 .AllowGroupBy(x => x.Status);
         }
     }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests.cs
@@ -36,7 +36,7 @@ public sealed class MapRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -63,7 +63,7 @@ public sealed class MapRunnerTests
         ];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("LatitudeNullable", "LongitudeNullable"),
@@ -84,7 +84,7 @@ public sealed class MapRunnerTests
         TestItem[] items = [new() { Id = id, Latitude = 48.85, Longitude = 2.35 }];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -108,7 +108,7 @@ public sealed class MapRunnerTests
         }];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -128,7 +128,7 @@ public sealed class MapRunnerTests
         TestItem[] items = [new() { Id = Guid.NewGuid(), Latitude = 0d, Longitude = 0d }];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -152,7 +152,7 @@ public sealed class MapRunnerTests
         }];
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics());
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("LatitudeDecimal", "LongitudeDecimal"),
@@ -168,7 +168,7 @@ public sealed class MapRunnerTests
     public async Task ExecuteAsync_NonNumericCoordinateColumn_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
 
         await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -182,7 +182,7 @@ public sealed class MapRunnerTests
     public async Task ExecuteAsync_UnknownLatitudeColumn_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -198,7 +198,7 @@ public sealed class MapRunnerTests
     public async Task ExecuteAsync_UnknownPopupColumn_Throws()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
 
         ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
             await runner.ExecuteAsync(
@@ -211,10 +211,53 @@ public sealed class MapRunnerTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_PopupColumn_NotDeclaredOnQueryDefinition_Throws()
+    {
+        // Whitelist enforcement: InternalNote is a public property of TestItem
+        // but is intentionally NOT declared on TestQueryDefinition. The runner
+        // must reject popup references to it instead of leaking its raw value.
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
+
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+            await runner.ExecuteAsync(
+                pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
+                popupColumns: ["InternalNote"],
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("InternalNote");
+        ex.Message.ShouldContain("Test.Items");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CoordinateColumn_NotDeclaredOnQueryDefinition_Throws()
+    {
+        // Whitelist enforcement applies to coordinate columns too — even
+        // numeric columns must be declared on the QueryDefinition before the
+        // map widget can read them.
+        IQueryEngine<TestItem> engine = ConfigureStream([]);
+
+        // Build a QueryDefinition that declares Longitude but NOT Latitude.
+        ArgumentException ex = await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            MapRunner<TestItem> runner = new(
+                "Test.Items", new TestItemSource([]), engine, new LongitudeOnlyQueryDefinition(), BuildMetrics());
+            await runner.ExecuteAsync(
+                pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
+                popupColumns: null,
+                dashboardFilters: null,
+                TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain("Latitude");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_DashboardFilter_PassedAsQueryRequestFilter()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
 
         await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -232,7 +275,7 @@ public sealed class MapRunnerTests
     public void Name_IsSetFromConstructor()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Granit.Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
         runner.Name.ShouldBe("Granit.Test.Items");
     }
 
@@ -257,7 +300,7 @@ public sealed class MapRunnerTests
             scope.MeterFactory, AnalyticsRuntimeMetrics.MeterName, "granit.analytics.map.invalid_coordinates");
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), scope.Metrics);
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -292,7 +335,7 @@ public sealed class MapRunnerTests
             scope.MeterFactory, AnalyticsRuntimeMetrics.MeterName, "granit.analytics.map.invalid_coordinates");
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), scope.Metrics);
 
         MapRunnerResult result = await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -308,12 +351,12 @@ public sealed class MapRunnerTests
     public async Task SupportsGeography_FalseWhenNoProjector_TrueWhenInjected()
     {
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runnerLatLngOnly = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runnerLatLngOnly = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
         runnerLatLngOnly.SupportsGeography.ShouldBeFalse();
 
         IGeographyPointProjector<TestItem> projector = Substitute.For<IGeographyPointProjector<TestItem>>();
         MapRunner<TestItem> runnerWithGeography = new(
-            "Test.Items", new TestItemSource([]), engine, BuildMetrics(),
+            "Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics(),
             currentTenant: null, geographyProjector: projector);
         runnerWithGeography.SupportsGeography.ShouldBeTrue();
 
@@ -335,7 +378,7 @@ public sealed class MapRunnerTests
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
         MapRunner<TestItem> runner = new(
-            "Test.Items", new TestItemSource(items), engine, BuildMetrics(),
+            "Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), BuildMetrics(),
             currentTenant: null, geographyProjector: projector);
 
         MapRunnerResult result = await runner.ExecuteAsync(
@@ -356,7 +399,7 @@ public sealed class MapRunnerTests
         // Renderer is supposed to pre-check SupportsGeography — this throw is
         // a safety net for misconfigured callers, not the user-facing path.
         IQueryEngine<TestItem> engine = ConfigureStream([]);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, BuildMetrics());
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource([]), engine, new TestQueryDefinition(), BuildMetrics());
 
         await Should.ThrowAsync<NotSupportedException>(async () =>
             await runner.ExecuteAsync(
@@ -384,7 +427,7 @@ public sealed class MapRunnerTests
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
         MapRunner<TestItem> runner = new(
-            "Test.Items", new TestItemSource(items), engine, scope.Metrics,
+            "Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), scope.Metrics,
             currentTenant: null, geographyProjector: projector);
 
         MapRunnerResult result = await runner.ExecuteAsync(
@@ -414,7 +457,7 @@ public sealed class MapRunnerTests
         currentTenant.Id.Returns(tenantId);
 
         IQueryEngine<TestItem> engine = ConfigureStream(items);
-        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, scope.Metrics, currentTenant);
+        MapRunner<TestItem> runner = new("Test.Items", new TestItemSource(items), engine, new TestQueryDefinition(), scope.Metrics, currentTenant);
 
         await runner.ExecuteAsync(
             pointSource: new MapPointSource.LatLng("Latitude", "Longitude"),
@@ -498,10 +541,58 @@ public sealed class MapRunnerTests
         public double? LongitudeNullable { get; set; }
         public decimal LatitudeDecimal { get; set; }
         public decimal LongitudeDecimal { get; set; }
+
+        // Deliberately undeclared on TestQueryDefinition — the whitelist must
+        // reject popup / coordinate references to this column.
+        public string InternalNote { get; set; } = string.Empty;
+
+        // Custom geography column name — exercised by the geography path tests.
+        public string Position { get; set; } = string.Empty;
     }
 
     public sealed class TestItemSource(IReadOnlyList<TestItem> items) : IQueryableSource<TestItem>
     {
         public IQueryable<TestItem> GetQueryable() => items.AsQueryable();
+    }
+
+    /// <summary>
+    /// Negative-control definition that declares only the longitude column.
+    /// Used by the whitelist test that pins coordinate-column rejection — the
+    /// runner must refuse to read <c>Latitude</c> even though it exists as a
+    /// public property on <see cref="TestItem"/>.
+    /// </summary>
+    public sealed class LongitudeOnlyQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder.Column(x => x.Longitude, c => c.Label("Longitude"));
+        }
+    }
+
+    /// <summary>
+    /// Whitelist for <see cref="TestItem"/> — declares every field the runner
+    /// is allowed to read (coordinate columns + popup columns + geography
+    /// column). Any property not listed here is rejected by the runner per
+    /// the <c>AnalyticsColumnWhitelist</c> rule.
+    /// </summary>
+    public sealed class TestQueryDefinition : QueryDefinition<TestItem>
+    {
+        public override string Name => "Test.Items";
+
+        protected override void Configure(QueryDefinitionBuilder<TestItem> builder)
+        {
+            builder
+                .Column(x => x.Name, c => c.Label("Name"))
+                .Column(x => x.Country, c => c.Label("Country"))
+                .Column(x => x.Latitude, c => c.Label("Latitude"))
+                .Column(x => x.Longitude, c => c.Label("Longitude"))
+                .Column(x => x.LatitudeNullable, c => c.Label("LatitudeNullable"))
+                .Column(x => x.LongitudeNullable, c => c.Label("LongitudeNullable"))
+                .Column(x => x.LatitudeDecimal, c => c.Label("LatitudeDecimal"))
+                .Column(x => x.LongitudeDecimal, c => c.Label("LongitudeDecimal"))
+                .Column(x => x.Position, c => c.Label("Position"));
+        }
     }
 }

--- a/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
+++ b/tests/Granit.Analytics.Endpoints.Tests/Internal/QueryAggregateRunnerTests.cs
@@ -204,7 +204,7 @@ public sealed class QueryAggregateRunnerTests : IAsyncLifetime
                 AggregateFunction.Sum, field: "NotAColumn", dashboardFilters: null, TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("NotAColumn");
-        ex.Message.ShouldContain(nameof(TestItem));
+        ex.Message.ShouldContain("Test.Items");
     }
 
     [Fact]

--- a/tests/Granit.ArchitectureTests/AnalyticsRunnerLifetimeTests.cs
+++ b/tests/Granit.ArchitectureTests/AnalyticsRunnerLifetimeTests.cs
@@ -1,0 +1,89 @@
+using System.Linq.Expressions;
+using Granit.Analytics.EntityFrameworkCore.Extensions;
+using Granit.Analytics.Extensions;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Pins the DI lifetime of <c>I*Runner</c> registrations emitted by
+/// <c>AddGranitAnalyticsRunners</c>. Every runner transitively depends on
+/// <c>IQueryableSource&lt;TEntity&gt;</c> (DbContext-bound) and on the per-request
+/// <c>ICurrentTenant</c>, so a Singleton lifetime would freeze the first
+/// request's tenant context and leak data across tenants on every subsequent
+/// call. This test fails the build the moment a runner is registered as
+/// Singleton again.
+/// </summary>
+public sealed class AnalyticsRunnerLifetimeTests
+{
+    [Fact]
+    public void AddGranitAnalyticsRunners_RegistersAllRunnerInterfacesAsScoped()
+    {
+        ServiceCollection services = [];
+        // One descriptor of each kind so the foreach loops in
+        // AddGranitAnalyticsRunners produce at least one registration.
+        services.AddMetricDefinition<TestEntity, int, TestMetricDefinition>();
+        services.AddSingleton<QueryDefinition<TestEntity>, TestQueryDefinition>();
+        services.AddSingleton<IQueryDefinitionDescriptor>(
+            sp => sp.GetRequiredService<QueryDefinition<TestEntity>>());
+
+        services.AddGranitAnalyticsRunners();
+
+        // The runner interface names emitted by AddGranitAnalyticsRunners.
+        // Every entry must be Scoped — never Singleton, never Transient
+        // (Transient would also re-resolve scoped deps from root).
+        string[] runnerInterfaceNames =
+        [
+            "IMetricRunner",
+            "IQueryAggregateRunner",
+            "ITableRunner",
+            "IChartRunner",
+            "IPivotRunner",
+            "IMapRunner",
+        ];
+
+        foreach (string ifaceName in runnerInterfaceNames)
+        {
+            ServiceDescriptor[] matches = [.. services.Where(d =>
+                d.ServiceType.Name == ifaceName)];
+
+            matches.ShouldNotBeEmpty(
+                $"AddGranitAnalyticsRunners should register at least one '{ifaceName}'.");
+
+            foreach (ServiceDescriptor descriptor in matches)
+            {
+                descriptor.Lifetime.ShouldBe(
+                    ServiceLifetime.Scoped,
+                    $"'{ifaceName}' must be Scoped — Singleton/Transient captures the request's DbContext + ICurrentTenant " +
+                    $"and leaks tenant data across requests under .NET's production default (ValidateScopes=false). " +
+                    $"Current lifetime: {descriptor.Lifetime}.");
+            }
+        }
+    }
+
+    private sealed class TestEntity
+    {
+        public int Id { get; set; }
+    }
+
+    private sealed class TestMetricDefinition : MetricDefinition<TestEntity, int>
+    {
+        public override string Name => "Test.Metric";
+        public override MetricValueKind ValueKind => MetricValueKind.Count;
+        public override AggregateFunction Aggregation => AggregateFunction.Count;
+        public override Expression<Func<TestEntity, int?>>? Selector => null;
+    }
+
+    private sealed class TestQueryDefinition : QueryDefinition<TestEntity>
+    {
+        public override string Name => "Test.Entities";
+
+        protected override void Configure(QueryDefinitionBuilder<TestEntity> builder) =>
+            builder.Column(x => x.Id, c => c.Label("Id"));
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2011,7 +2011,8 @@
           "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.push.websockets": {
@@ -2025,7 +2026,8 @@
           "Granit.Dashboards.Push": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange": {


### PR DESCRIPTION
## Summary

Six security fixes from a `/security` audit on `Granit.Analytics.*`. VULN-100 (per-entity permission inheritance) is intentionally deferred to `Granit.Entities`.

| Severity | Finding | Fix |
|----------|---------|-----|
| **CRITICAL** | VULN-001 | `IMetricRunner` was `AddSingleton` with scoped deps — captured first request's tenant context, leaking data across tenants. Switched to `AddScoped`. |
| **HIGH** | VULN-101 | `Map`/`Chart`/`Pivot`/`QueryAggregate` runners reflected on any public CLR property, ignoring `QueryDefinition.GetColumns()`. New `AnalyticsColumnWhitelist` helper gates every reflective lookup. `MapRunner` now also takes a `QueryDefinition<TEntity>`. |
| **MEDIUM** | VULN-200 | Unbounded `PeriodSpec.From/To` allowed `{ from: 0001-01-01, to: 9999-12-31 }`. Added `MaxPeriodLength` option (default 5y) enforced in `MetricEndpointService`. |
| **MEDIUM** | VULN-201 | `AnalyticsEndpointsOptions` TTLs accepted any `TimeSpan`. Added `IValidatableObject`: DynamicTtl ∈ [1s, 1d], StaticTtl ∈ [1s, 7d]. |
| **MEDIUM** | VULN-202 | `MetricExecutor.ExecuteCountAsync` used `int CountAsync` — overflows past 2.1B rows. Switched to `LongCountAsync` with `checked` cast per `TValue`. |
| **INFO** | VULN-401 | Reflective error messages echoed `typeof(TEntity).Name`. Now use the QueryDefinition's `Name` (already public). |

### Architecture test

`AnalyticsRunnerLifetimeTests` pins `Scoped` lifetime for the six `I*Runner` interfaces emitted by `AddGranitAnalyticsRunners`. Build fails the moment anyone re-introduces `AddSingleton` — the regression that produced VULN-001.

### Second commit — CI lockfile refresh

`fix(archi)` refreshes `tests/Granit.ArchitectureTests/packages.lock.json` after `Granit.Validation` became a transitive dep of `Granit.Dashboards.Push{,.WebSockets}` (NU1004 was failing CI on develop). Independent of the security fixes but bundled to unblock CI on this PR.

## Test plan

- [x] `dotnet build` clean on `Granit.Analytics.{,Endpoints,EntityFrameworkCore}`
- [x] Granit.Analytics.Tests — 46/46
- [x] Granit.Analytics.Endpoints.Tests — 200/200 (incl. 2 new whitelist regression tests)
- [x] Granit.Analytics.EntityFrameworkCore.Tests — 37/37
- [x] Granit.Analytics.PostGIS.Tests — 10/10
- [x] Granit.ArchitectureTests — 198/198 (incl. new `AnalyticsRunnerLifetimeTests`)
- [x] `dotnet format --verify-no-changes` clean on every touched project
- [ ] CI green on the PR
