### PR TITLE
fix(test): add missing definition arg to MapRunner integration test

### DIFF
--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
@@ -61,6 +61,7 @@ public sealed class MapPostGisIntegrationTests(PostGisFixture postgis)
             name: "Test.Branches",
             source: new BranchSource(_db),
             engine: engine,
+            definition: new BranchQueryDefinition(),
             metrics: metrics,
             currentTenant: null,
             geographyProjector: new NtsGeographyPointProjector<Branch>());


### PR DESCRIPTION
## Summary

CI build failure on `develop`:

```
error CS7036: There is no argument given that corresponds to the required parameter 'definition'
of 'MapRunner<Branch>.MapRunner(string, IQueryableSource<Branch>, IQueryEngine<Branch>,
                                  QueryDefinition<Branch>, AnalyticsRuntimeMetrics,
                                  ICurrentTenant?, IGeographyPointProjector<Branch>?)'
   at MapPostGisIntegrationTests.cs(60,23)
```

`MapRunner<TEntity>` gained a required `QueryDefinition<TEntity> definition` constructor parameter on `develop` (post the `QueryAggregateRunner` / `ChartRunner` refactor in the analytics layer). The **unit-test** sites in `Granit.Analytics.Endpoints.Tests/Internal/MapRunnerTests` were updated in that same PR, but the **integration test** `MapPostGisIntegrationTests.cs` was missed because the integration shard runs in a separate CI job and its build wasn't gated by the unit-test build.

## Fix

Pass `new BranchQueryDefinition()` (already declared in [`TestEntities.cs:86`](tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs#L86)) through the new `definition` constructor arg.

## Test plan

- [x] `dotnet build tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration` — green
- [x] `dotnet format --verify-no-changes` — clean
- [ ] CI integration shard (Testcontainers + Postgres) will validate the runtime path on this PR.

One-line fix.
