### PR TITLE
fix(analytics): enable NetTopologySuite plugin in Postgres parity test fixtures

### DIFF
--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
@@ -24,7 +24,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async ValueTask InitializeAsync()
     {
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseNpgsql(_postgres.ConnectionString)
+            .UseNpgsql(_postgres.ConnectionString, o => o.UseNetTopologySuite())
             .Options;
 
         _db = new TestDbContext(options);

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PivotPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PivotPostgresParityTests.cs
@@ -30,7 +30,7 @@ public sealed class PivotPostgresParityTests(PostgresFixture postgres)
     public async ValueTask InitializeAsync()
     {
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseNpgsql(_postgres.ConnectionString)
+            .UseNpgsql(_postgres.ConnectionString, o => o.UseNetTopologySuite())
             .Options;
 
         _db = new TestDbContext(options);


### PR DESCRIPTION
## Summary

CI is failing on `Granit.Analytics.EntityFrameworkCore.Tests.Integration` Postgres parity tests with:

```
The property 'Point.UserData' could not be mapped because it is of type 'object'
```

The shared `TestDbContext` declares `Branch.Location` of type `NetTopologySuite.Geometries.Point?` (used by `MapPostGisIntegrationTests`). Postgres-side this requires the Npgsql NetTopologySuite plugin to be enabled — otherwise EF Core fails model validation at `EnsureCreatedAsync`.

`MapPostGisIntegrationTests` wires it correctly (`UseNpgsql(..., o => o.UseNetTopologySuite())`), but the two parity fixtures (`EmptySetSemanticsPostgresParityTests`, `PivotPostgresParityTests`) call only `UseNpgsql(...)` — failing every test in those classes at fixture initialisation.

## Fix

Two-line change: add `o => o.UseNetTopologySuite()` to the `UseNpgsql(...)` call in both fixtures, matching the working pattern in `MapPostGisIntegrationTests`. No behavior change for the test logic; the package already references `Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite`.

## Test plan

- [x] `dotnet build tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration` — clean
- [ ] CI Postgres parity tests green (validated on this PR's CI run — cannot be reproduced locally without Docker / Testcontainers)