### PR TITLE
fix(analytics): isolate PostGIS entity into its own DbContext

### DIFF
--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/EmptySetSemanticsPostgresParityTests.cs
@@ -24,7 +24,7 @@ public sealed class EmptySetSemanticsPostgresParityTests(PostgresFixture postgre
     public async ValueTask InitializeAsync()
     {
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseNpgsql(_postgres.ConnectionString, o => o.UseNetTopologySuite())
+            .UseNpgsql(_postgres.ConnectionString)
             .Options;
 
         _db = new TestDbContext(options);

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/MapPostGisIntegrationTests.cs
@@ -24,17 +24,17 @@ public sealed class MapPostGisIntegrationTests(PostGisFixture postgis)
     : IClassFixture<PostGisFixture>, IAsyncLifetime
 {
     private readonly PostGisFixture _postgis = postgis;
-    private TestDbContext _db = null!;
+    private BranchDbContext _db = null!;
     private ServiceProvider _provider = null!;
     private MapRunner<Branch> _runner = null!;
 
     public async ValueTask InitializeAsync()
     {
-        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+        DbContextOptions<BranchDbContext> options = new DbContextOptionsBuilder<BranchDbContext>()
             .UseNpgsql(_postgis.ConnectionString, o => o.UseNetTopologySuite())
             .Options;
 
-        _db = new TestDbContext(options);
+        _db = new BranchDbContext(options);
         await _db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
         await _db.Branches.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PivotPostgresParityTests.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/PivotPostgresParityTests.cs
@@ -30,7 +30,7 @@ public sealed class PivotPostgresParityTests(PostgresFixture postgres)
     public async ValueTask InitializeAsync()
     {
         DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseNpgsql(_postgres.ConnectionString, o => o.UseNetTopologySuite())
+            .UseNpgsql(_postgres.ConnectionString)
             .Options;
 
         _db = new TestDbContext(options);

--- a/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs
@@ -32,7 +32,6 @@ internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : D
 {
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<Customer> Customers => Set<Customer>();
-    public DbSet<Branch> Branches => Set<Branch>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -43,13 +42,25 @@ internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : D
             e.Property(c => c.Country).HasMaxLength(64).IsRequired();
             e.Property(c => c.Status).HasMaxLength(64).IsRequired();
         });
+    }
+}
+
+// Branch lives in its own context: its geography(Point) column requires the
+// PostGIS extension at the server level. Keeping it apart lets the empty-set
+// and pivot parity fixtures run on plain Postgres images, without paying the
+// PostGIS image weight or hitting "extension postgis is not available".
+internal sealed class BranchDbContext(DbContextOptions<BranchDbContext> options) : DbContext(options)
+{
+    public DbSet<Branch> Branches => Set<Branch>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
         modelBuilder.Entity<Branch>(e =>
         {
             e.HasKey(b => b.Id);
             e.Property(b => b.Name).HasMaxLength(128).IsRequired();
             // Location uses Npgsql's NetTopologySuite plugin (UseNetTopologySuite()) —
             // when the plugin is wired the column is mapped to geography(Point) by default.
-            // Property-level config beyond that is the host's responsibility.
         });
     }
 }
@@ -90,12 +101,16 @@ internal sealed class BranchQueryDefinition : QueryDefinition<Branch>
     protected override void Configure(QueryDefinitionBuilder<Branch> builder) =>
         builder
             .Column(b => b.Name, c => c.Filterable())
+            // Declared so the analytics column whitelist accepts it as a
+            // geography source on the Map widget. Not filterable / not sortable —
+            // a Point column is not meaningful in either role.
+            .Column(b => b.Location)
             .DefaultPageSize(50);
 }
 
-internal sealed class BranchSource(TestDbContext db) : IQueryableSource<Branch>
+internal sealed class BranchSource(BranchDbContext db) : IQueryableSource<Branch>
 {
-    private readonly TestDbContext _db = db;
+    private readonly BranchDbContext _db = db;
     public IQueryable<Branch> GetQueryable() => _db.Branches.AsNoTracking();
 }
 


### PR DESCRIPTION
## Summary

Hotfix for two bugs that broke the **Analytics integration shard** on develop
after the recent stack of analytics fixes / Phase 1.B work.

### Bug 1 — `extension "postgis" is not available`

Every test in `EmptySetSemanticsPostgresParityTests` + `PivotPostgresParityTests`
failed during `EnsureCreatedAsync`. Root cause:

- `PostgresFixture` boots `postgres:17-alpine` (no PostGIS extension).
- The shared `TestDbContext` declared `Branch.Location` (`Point`).
- Hotfix #1636 added `o.UseNetTopologySuite()` to the test wiring; EF Core
  then translates `Location` → `geography(Point, 4326)` server-side, which
  requires the postgis extension to be installed.

The hotfix fixed the client-side type mapper but introduced a server-side
dependency the parity tests don't actually need — they only query `Order` /
`Customer`, never `Branch`.

### Bug 2 — `Field 'Location' is not declared by query 'Test.Branches'`

`MapPostGisIntegrationTests` failed in `MapRunner.BuildGeographyExtractor`.
Root cause: the analytics security fix #1633 tightened
`AnalyticsColumnWhitelist` to require every Geography column be declared on
the `QueryDefinition`. `BranchQueryDefinition` only declared `Name`, so
`Location` was rejected before the projector ran.

## Fix

- **`Branch` moves to its own [`BranchDbContext`](tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration/TestEntities.cs)** — used solely by `MapPostGisIntegrationTests`
  with `PostGisFixture`. `TestDbContext` is back to `Order` + `Customer`, no
  PostGIS dependency, so the parity fixtures drop `UseNetTopologySuite()`.
- **`BranchQueryDefinition`** now declares `Column(b => b.Location)` (not
  filterable / not sortable — neither role makes sense for a Point) so the
  analytics column whitelist accepts it as a Geography source.

## Test plan

- [x] `dotnet test tests/Granit.Analytics.EntityFrameworkCore.Tests.Integration` — **13/13 pass locally** (was 0/13 on develop)
- [x] `dotnet format` clean
- [ ] CI green on the integration shard

Refs #1633, #1636.