### PR TITLE
feat(workspaces): Framework shell + landing route resolver (Phase 1.D-bis)

### DIFF
--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -95,6 +95,7 @@
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit.Workspaces.Endpoints/Granit.Workspaces.Endpoints.csproj",
+      "src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj",
       "src/Granit.Workspaces/Granit.Workspaces.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Analytics.Abstractions.Tests/Granit.Analytics.Abstractions.Tests.csproj",
@@ -161,6 +162,7 @@
       "tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj",
       "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj",
       "tests/Granit.Workspaces.Endpoints.Tests/Granit.Workspaces.Endpoints.Tests.csproj",
+      "tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj",
       "tests/Granit.Workspaces.Tests/Granit.Workspaces.Tests.csproj"
     ]
   }

--- a/.github/shard-filters/src-only.slnf
+++ b/.github/shard-filters/src-only.slnf
@@ -320,6 +320,7 @@
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit.Workspaces.Endpoints/Granit.Workspaces.Endpoints.csproj",
+      "src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj",
       "src/Granit.Workspaces/Granit.Workspaces.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -119,6 +119,7 @@
         "tests/Granit.Entities.Views.Tests",
         "tests/Granit.Workspaces.Abstractions.Tests",
         "tests/Granit.Workspaces.Endpoints.Tests",
+        "tests/Granit.Workspaces.Framework.Tests",
         "tests/Granit.Workspaces.Tests"
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2898,6 +2898,14 @@
         "Granit.Workspaces"
       ],
       "framework": "net10.0"
+    },
+    {
+      "name": "Granit.Workspaces.Framework",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Workspaces.Abstractions"
+      ],
+      "framework": "net10.0"
     }
   ],
   "symbols": [
@@ -58583,6 +58591,24 @@
       ]
     },
     {
+      "name": "LandingRouteResponse",
+      "fqn": "Granit.Workspaces.Endpoints.Dtos.LandingRouteResponse",
+      "kind": "record",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Dtos/LandingRouteResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "SetPinnedLandingRouteRequest",
+      "fqn": "Granit.Workspaces.Endpoints.Dtos.SetPinnedLandingRouteRequest",
+      "kind": "record",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Dtos/LandingRouteResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
       "name": "WorkspaceItemResponse",
       "fqn": "Granit.Workspaces.Endpoints.Dtos.WorkspaceItemResponse",
       "kind": "record",
@@ -58624,7 +58650,7 @@
       "kind": "class",
       "project": "Granit.Workspaces.Endpoints",
       "file": "src/Granit.Workspaces.Endpoints/Extensions/WorkspacesEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "MapGranitWorkspacesEndpoints",
@@ -58651,6 +58677,116 @@
       ]
     },
     {
+      "name": "ILandingRouteAccessGuard",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.ILandingRouteAccessGuard",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/LandingRouteResolver.cs",
+      "line": 125,
+      "members": [
+        {
+          "name": "CanAccessAsync",
+          "kind": "method",
+          "signature": "CanAccessAsync(string route, ClaimsPrincipal user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ILandingRouteStore",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.ILandingRouteStore",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/ILandingRouteStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetStickyAsync",
+          "kind": "method",
+          "signature": "GetStickyAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        },
+        {
+          "name": "GetPinnedAsync",
+          "kind": "method",
+          "signature": "GetPinnedAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        },
+        {
+          "name": "SetPinnedAsync",
+          "kind": "method",
+          "signature": "SetPinnedAsync(string userId, Guid? tenantId, string? route, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IRoleLandingRouteProvider",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.IRoleLandingRouteProvider",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/IRoleLandingRouteProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetRoleDefaultAsync",
+          "kind": "method",
+          "signature": "GetRoleDefaultAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantLandingRouteProvider",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.ITenantLandingRouteProvider",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/IRoleLandingRouteProvider.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "GetTenantDefaultAsync",
+          "kind": "method",
+          "signature": "GetTenantDefaultAsync(Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "LandingRouteResolver",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.LandingRouteResolver",
+      "kind": "class",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/LandingRouteResolver.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(ClaimsPrincipal user, CancellationToken cancellationToken)",
+          "returnType": "Task<LandingRouteResult>"
+        }
+      ]
+    },
+    {
+      "name": "LandingRouteResult",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.LandingRouteResult",
+      "kind": "record",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/LandingRouteResolver.cs",
+      "line": 117,
+      "members": []
+    },
+    {
+      "name": "LandingRouteSource",
+      "fqn": "Granit.Workspaces.Endpoints.Landing.LandingRouteSource",
+      "kind": "enum",
+      "project": "Granit.Workspaces.Endpoints",
+      "file": "src/Granit.Workspaces.Endpoints/Landing/LandingRouteSource.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "WorkspacesEndpointsOptions",
       "fqn": "Granit.Workspaces.Endpoints.Options.WorkspacesEndpointsOptions",
       "kind": "class",
@@ -58669,6 +58805,18 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan TreeCacheTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FrameworkLandingRoute",
+          "kind": "property",
+          "signature": "string FrameworkLandingRoute",
+          "returnType": "string"
+        },
+        {
+          "name": "LandingRouteAllowedPrefixes",
+          "kind": "property",
+          "signature": "IList<string> LandingRouteAllowedPrefixes",
+          "returnType": "IList<string>"
         }
       ]
     },
@@ -58705,6 +58853,56 @@
           "returnType": "IServiceCollection"
         }
       ]
+    },
+    {
+      "name": "FrameworkWorkspaceDefinition",
+      "fqn": "Granit.Workspaces.Framework.FrameworkWorkspaceDefinition",
+      "kind": "class",
+      "project": "Granit.Workspaces.Framework",
+      "file": "src/Granit.Workspaces.Framework/FrameworkWorkspaceDefinition.cs",
+      "line": 47,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FrameworkWorkspaceNames",
+      "fqn": "Granit.Workspaces.Framework.FrameworkWorkspaceNames",
+      "kind": "class",
+      "project": "Granit.Workspaces.Framework",
+      "file": "src/Granit.Workspaces.Framework/FrameworkWorkspaceDefinition.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "GranitWorkspacesFrameworkModule",
+      "fqn": "Granit.Workspaces.Framework.GranitWorkspacesFrameworkModule",
+      "kind": "class",
+      "project": "Granit.Workspaces.Framework",
+      "file": "src/Granit.Workspaces.Framework/GranitWorkspacesFrameworkModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WorkspacesFrameworkLocalizationResource",
+      "fqn": "Granit.Workspaces.Framework.WorkspacesFrameworkLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Workspaces.Framework",
+      "file": "src/Granit.Workspaces.Framework/WorkspacesFrameworkLocalizationResource.cs",
+      "line": 7,
+      "members": []
     },
     {
       "name": "GranitWorkspacesAbstractionsModule",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -221,6 +221,7 @@
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit.Workspaces.Endpoints/Granit.Workspaces.Endpoints.csproj",
+      "src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj",
       "src/Granit.Workspaces/Granit.Workspaces.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
@@ -438,6 +439,7 @@
       "tests/Granit.Wolverine.Tests/Granit.Wolverine.Tests.csproj",
       "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj",
       "tests/Granit.Workspaces.Endpoints.Tests/Granit.Workspaces.Endpoints.Tests.csproj",
+      "tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj",
       "tests/Granit.Workspaces.Tests/Granit.Workspaces.Tests.csproj"
     ]
   }

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -170,6 +170,7 @@
       "src/Granit.Workflow/Granit.Workflow.csproj",
       "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit.Workspaces.Endpoints/Granit.Workspaces.Endpoints.csproj",
+      "src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj",
       "src/Granit.Workspaces/Granit.Workspaces.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
@@ -307,6 +308,7 @@
       "tests/Granit.Validation.UnitedKingdom.Tests/Granit.Validation.UnitedKingdom.Tests.csproj",
       "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj",
       "tests/Granit.Workspaces.Endpoints.Tests/Granit.Workspaces.Endpoints.Tests.csproj",
+      "tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj",
       "tests/Granit.Workspaces.Tests/Granit.Workspaces.Tests.csproj"
     ]
   }

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -118,6 +118,7 @@
     <Project Path="src/Granit.Entities/Granit.Entities.csproj" />
     <Project Path="src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj" />
     <Project Path="src/Granit.Workspaces.Endpoints/Granit.Workspaces.Endpoints.csproj" />
+    <Project Path="src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj" />
     <Project Path="src/Granit.Workspaces/Granit.Workspaces.csproj" />
     <Project Path="src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj" />
     <Project Path="src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj" />
@@ -473,6 +474,7 @@
     <Project Path="tests/Granit.Entities.Views.Tests/Granit.Entities.Views.Tests.csproj" />
     <Project Path="tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj" />
     <Project Path="tests/Granit.Workspaces.Endpoints.Tests/Granit.Workspaces.Endpoints.Tests.csproj" />
+    <Project Path="tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj" />
     <Project Path="tests/Granit.Workspaces.Tests/Granit.Workspaces.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.Abstractions.Tests/Granit.DataExchange.Abstractions.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj" />

--- a/src/Granit.Workspaces.Endpoints/Dtos/LandingRouteResponse.cs
+++ b/src/Granit.Workspaces.Endpoints/Dtos/LandingRouteResponse.cs
@@ -1,0 +1,12 @@
+using Granit.Workspaces.Endpoints.Landing;
+
+namespace Granit.Workspaces.Endpoints.Dtos;
+
+/// <summary>Response payload for <c>GET /api/me/landing-route</c>.</summary>
+/// <param name="Route">The resolved landing route (e.g. <c>"/w/Granit.Framework"</c>).</param>
+/// <param name="Source">Which tier of the precedence chain produced the route.</param>
+public sealed record LandingRouteResponse(string Route, LandingRouteSource Source);
+
+/// <summary>Request body for <c>PUT /api/me/landing-route/pinned</c>.</summary>
+/// <param name="Route">The route to pin, or <see langword="null"/> to clear the pin.</param>
+public sealed record SetPinnedLandingRouteRequest(string? Route);

--- a/src/Granit.Workspaces.Endpoints/Endpoints/LandingRouteEndpoints.cs
+++ b/src/Granit.Workspaces.Endpoints/Endpoints/LandingRouteEndpoints.cs
@@ -1,0 +1,76 @@
+using System.Security.Claims;
+using Granit.MultiTenancy;
+using Granit.Workspaces.Endpoints.Dtos;
+using Granit.Workspaces.Endpoints.Landing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Workspaces.Endpoints.Endpoints;
+
+/// <summary>
+/// Minimal API handlers for the landing-route surface (story #1556).
+/// Mounted by <c>MapGranitLandingRouteEndpoints</c> under the supplied prefix.
+/// </summary>
+internal static class LandingRouteEndpoints
+{
+    public static RouteGroupBuilder MapLandingRouteEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", GetAsync)
+            .WithName("GetLandingRoute")
+            .WithSummary("Resolves the requesting user's landing route via the 5-tier precedence chain.")
+            .WithDescription("Precedence per ADR-048: personal-sticky > personal-pinned > role-default > tenant-default > framework. Each tier may be null (provider not configured, no preference) — the resolver falls through. Routes that fail the URL whitelist (configured prefixes) or the access guard are also skipped to the next tier. The framework fallback is configured (not user-supplied) and always wins as the closing tier.")
+            .Produces<LandingRouteResponse>();
+
+        group.MapPut("/pinned", SetPinnedAsync)
+            .WithName("SetPinnedLandingRoute")
+            .WithSummary("Pins (or clears) the requesting user's preferred landing route.")
+            .WithDescription("The pinned route is consulted at the second-highest precedence tier (after personal-sticky). Pass null in the body to clear the pin. Routes that don't match the URL whitelist are rejected with 400.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static async Task<Ok<LandingRouteResponse>> GetAsync(
+        [FromServices] LandingRouteResolver resolver,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        LandingRouteResult result = await resolver.ResolveAsync(user, cancellationToken).ConfigureAwait(false);
+        return TypedResults.Ok(new LandingRouteResponse(result.Route, result.Source));
+    }
+
+    private static async Task<Results<NoContent, ValidationProblem, UnauthorizedHttpResult>> SetPinnedAsync(
+        SetPinnedLandingRouteRequest request,
+        [FromServices] ILandingRouteStore store,
+        [FromServices] LandingRouteResolver resolver,
+        ClaimsPrincipal user,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        string? userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        if (userId is null)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        // null clears the pin — accepted unconditionally so users can opt out.
+        if (request.Route is not null && !resolver.IsAllowedRoute(request.Route))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["route"] = ["Route must start with one of the configured allowed prefixes."],
+            });
+        }
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        await store.SetPinnedAsync(userId, tenantId, request.Route, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Granit.Workspaces.Endpoints/Extensions/WorkspacesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Workspaces.Endpoints/Extensions/WorkspacesEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Validation.AspNetCore;
 using Granit.Workspaces.Endpoints.Endpoints;
 using Granit.Workspaces.Endpoints.Internal;
+using Granit.Workspaces.Endpoints.Landing;
 using Granit.Workspaces.Endpoints.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -46,14 +47,46 @@ public static class WorkspacesEndpointRouteBuilderExtensions
     }
 
     /// <summary>
-    /// Registers the <see cref="WorkspaceFilter"/> service required by the
-    /// workspace tree handler. Called once from the framework's
-    /// service-collection extension.
+    /// Mounts <c>GET /api/me/landing-route</c> + <c>PUT /api/me/landing-route/pinned</c>
+    /// under the supplied prefix (typically <c>"/api/{version}/me"</c>).
+    /// Uses the same options bag as the workspace tree endpoint — the
+    /// framework fallback / URL whitelist live on
+    /// <see cref="WorkspacesEndpointsOptions"/>.
+    /// </summary>
+    public static RouteGroupBuilder MapGranitLandingRouteEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        string prefix,
+        Action<WorkspacesEndpointsOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+
+        WorkspacesEndpointsOptions options = new();
+        configure?.Invoke(options);
+
+        RouteGroupBuilder group = endpoints
+            .MapGranitGroup(prefix + "/landing-route")
+            .WithTags(options.TagName)
+            .RequireAuthorization();
+
+        group.MapLandingRouteEndpoints();
+        return group;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="WorkspaceFilter"/> + landing-route services
+    /// required by the workspace HTTP surface. Called once from the framework's
+    /// module class.
     /// </summary>
     public static IServiceCollection AddGranitWorkspacesEndpoints(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
         services.TryAddScoped<WorkspaceFilter>();
+        services.TryAddScoped<LandingRouteResolver>();
+        services.TryAddSingleton<ILandingRouteStore, NullLandingRouteStore>();
+        services.TryAddSingleton<IRoleLandingRouteProvider, NullRoleLandingRouteProvider>();
+        services.TryAddSingleton<ITenantLandingRouteProvider, NullTenantLandingRouteProvider>();
+        services.TryAddSingleton<ILandingRouteAccessGuard, AllowAllLandingRouteAccessGuard>();
         services.AddOptions<WorkspacesEndpointsOptions>();
         return services;
     }

--- a/src/Granit.Workspaces.Endpoints/Landing/ILandingRouteStore.cs
+++ b/src/Granit.Workspaces.Endpoints/Landing/ILandingRouteStore.cs
@@ -1,0 +1,36 @@
+namespace Granit.Workspaces.Endpoints.Landing;
+
+/// <summary>
+/// Persistence surface for per-user landing-route preferences (sticky + pinned).
+/// Hosts that want real persistence ship their own implementation; the
+/// framework registers <see cref="NullLandingRouteStore"/> by default so
+/// <c>GET /api/me/landing-route</c> falls through to lower tiers.
+/// </summary>
+public interface ILandingRouteStore
+{
+    /// <summary>Returns the user's last-visited route, or <see langword="null"/> if none recorded.</summary>
+    Task<string?> GetStickyAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the user's explicitly pinned route, or <see langword="null"/> if not pinned.</summary>
+    Task<string?> GetPinnedAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default);
+
+    /// <summary>Records or clears the user's pinned route.</summary>
+    Task SetPinnedAsync(string userId, Guid? tenantId, string? route, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Null-object default — never records anything, always returns <see langword="null"/>.
+/// Hosts that want sticky / pinned behaviour register a real implementation
+/// over this one through <c>services.AddSingleton&lt;ILandingRouteStore, ...&gt;()</c>.
+/// </summary>
+internal sealed class NullLandingRouteStore : ILandingRouteStore
+{
+    public Task<string?> GetStickyAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<string?>(null);
+
+    public Task<string?> GetPinnedAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<string?>(null);
+
+    public Task SetPinnedAsync(string userId, Guid? tenantId, string? route, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/src/Granit.Workspaces.Endpoints/Landing/IRoleLandingRouteProvider.cs
+++ b/src/Granit.Workspaces.Endpoints/Landing/IRoleLandingRouteProvider.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+
+namespace Granit.Workspaces.Endpoints.Landing;
+
+/// <summary>
+/// Provider for the role-default tier of the landing-route resolver
+/// (per ADR-048, story #1556). When the user belongs to multiple roles with
+/// distinct defaults, the provider returns the first match — order is the
+/// host's responsibility.
+/// </summary>
+public interface IRoleLandingRouteProvider
+{
+    /// <summary>Returns the role-default route, or <see langword="null"/> when no role has one configured.</summary>
+    Task<string?> GetRoleDefaultAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Provider for the tenant-default tier.</summary>
+public interface ITenantLandingRouteProvider
+{
+    /// <summary>Returns the tenant-default route, or <see langword="null"/> when none is configured.</summary>
+    Task<string?> GetTenantDefaultAsync(Guid? tenantId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Null-object — always returns <see langword="null"/>, falling through to the next tier.</summary>
+internal sealed class NullRoleLandingRouteProvider : IRoleLandingRouteProvider
+{
+    public Task<string?> GetRoleDefaultAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default) =>
+        Task.FromResult<string?>(null);
+}
+
+/// <summary>Null-object — always returns <see langword="null"/>, falling through to the next tier.</summary>
+internal sealed class NullTenantLandingRouteProvider : ITenantLandingRouteProvider
+{
+    public Task<string?> GetTenantDefaultAsync(Guid? tenantId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<string?>(null);
+}

--- a/src/Granit.Workspaces.Endpoints/Landing/LandingRouteResolver.cs
+++ b/src/Granit.Workspaces.Endpoints/Landing/LandingRouteResolver.cs
@@ -1,0 +1,136 @@
+using System.Security.Claims;
+using Granit.MultiTenancy;
+using Granit.Workspaces.Endpoints.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Workspaces.Endpoints.Landing;
+
+/// <summary>
+/// Resolves the user's effective landing route per ADR-048's 5-tier
+/// precedence (story #1556):
+/// <c>personal-sticky &gt; personal-pinned &gt; role &gt; tenant &gt; framework</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each tier may return <see langword="null"/> (provider not configured, no
+/// preference recorded), in which case the resolver falls through to the
+/// next tier. URL whitelist validation runs against
+/// <see cref="WorkspacesEndpointsOptions.LandingRouteAllowedPrefixes"/> at
+/// every tier; a route that fails validation is treated as if the tier had
+/// returned <see langword="null"/> — the resolver falls through. The
+/// framework fallback is configured (not user-supplied), so it is trusted
+/// and not re-validated.
+/// </para>
+/// <para>
+/// Permission fallthrough on the workspace target is the host's responsibility
+/// — the resolver itself is permission-agnostic. Hosts that want
+/// "drop the route if the user can't access the referenced workspace" wire a
+/// custom <see cref="ILandingRouteAccessGuard"/> implementation; the default
+/// guard accepts every route.
+/// </para>
+/// </remarks>
+public sealed class LandingRouteResolver(
+    ILandingRouteStore store,
+    IRoleLandingRouteProvider roleProvider,
+    ITenantLandingRouteProvider tenantProvider,
+    ILandingRouteAccessGuard accessGuard,
+    IOptions<WorkspacesEndpointsOptions> options,
+    ICurrentTenant? currentTenant = null)
+{
+    /// <summary>
+    /// Resolves the route for the requesting user. Always returns a result —
+    /// the framework fallback closes the precedence chain.
+    /// </summary>
+    public async Task<LandingRouteResult> ResolveAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        string? userId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        Guid? tenantId = currentTenant is { IsAvailable: true } ct ? ct.Id : null;
+
+        if (userId is not null)
+        {
+            string? sticky = await store.GetStickyAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
+            if (await IsAcceptableAsync(sticky, user, cancellationToken).ConfigureAwait(false))
+            {
+                return new LandingRouteResult(sticky!, LandingRouteSource.PersonalSticky);
+            }
+
+            string? pinned = await store.GetPinnedAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
+            if (await IsAcceptableAsync(pinned, user, cancellationToken).ConfigureAwait(false))
+            {
+                return new LandingRouteResult(pinned!, LandingRouteSource.PersonalPinned);
+            }
+        }
+
+        string? roleDefault = await roleProvider.GetRoleDefaultAsync(user, cancellationToken).ConfigureAwait(false);
+        if (await IsAcceptableAsync(roleDefault, user, cancellationToken).ConfigureAwait(false))
+        {
+            return new LandingRouteResult(roleDefault!, LandingRouteSource.Role);
+        }
+
+        string? tenantDefault = await tenantProvider.GetTenantDefaultAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        if (await IsAcceptableAsync(tenantDefault, user, cancellationToken).ConfigureAwait(false))
+        {
+            return new LandingRouteResult(tenantDefault!, LandingRouteSource.Tenant);
+        }
+
+        return new LandingRouteResult(options.Value.FrameworkLandingRoute, LandingRouteSource.Framework);
+    }
+
+    /// <summary>Whitelist validator — public so the PUT endpoint can reuse it before persisting a pinned route.</summary>
+    public bool IsAllowedRoute(string? route) =>
+        IsAllowedRoute(route, options.Value);
+
+    internal static bool IsAllowedRoute(string? route, WorkspacesEndpointsOptions opts)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+        {
+            return false;
+        }
+
+        foreach (string prefix in opts.LandingRouteAllowedPrefixes)
+        {
+            if (route.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private async Task<bool> IsAcceptableAsync(string? route, ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        if (!IsAllowedRoute(route, options.Value))
+        {
+            return false;
+        }
+        return await accessGuard.CanAccessAsync(route!, user, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>The tier the resolver picked.</summary>
+/// <param name="Route">The resolved route.</param>
+/// <param name="Source">Which tier of the precedence chain produced the route.</param>
+public sealed record LandingRouteResult(string Route, LandingRouteSource Source);
+
+/// <summary>
+/// Permission-aware guard that lets hosts veto a route the resolver would
+/// otherwise return — the guard says "this user cannot access /w/Granit.Framework",
+/// the resolver falls through to the next tier. Default implementation
+/// (<see cref="AllowAllLandingRouteAccessGuard"/>) accepts every route.
+/// </summary>
+public interface ILandingRouteAccessGuard
+{
+    /// <summary>Returns <see langword="true"/> when the user is allowed to land on <paramref name="route"/>.</summary>
+    Task<bool> CanAccessAsync(string route, ClaimsPrincipal user, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Null-object — accepts every route.</summary>
+internal sealed class AllowAllLandingRouteAccessGuard : ILandingRouteAccessGuard
+{
+    public Task<bool> CanAccessAsync(string route, ClaimsPrincipal user, CancellationToken cancellationToken = default) =>
+        Task.FromResult(true);
+}

--- a/src/Granit.Workspaces.Endpoints/Landing/LandingRouteSource.cs
+++ b/src/Granit.Workspaces.Endpoints/Landing/LandingRouteSource.cs
@@ -1,0 +1,24 @@
+namespace Granit.Workspaces.Endpoints.Landing;
+
+/// <summary>
+/// Closed enum describing which tier of the landing-route precedence
+/// resolved the route returned by <c>GET /api/me/landing-route</c>
+/// (per ADR-048's 5-tier resolver, story #1556).
+/// </summary>
+public enum LandingRouteSource
+{
+    /// <summary>The user's last-visited route, sticky across sessions (highest precedence).</summary>
+    PersonalSticky,
+
+    /// <summary>The user's explicitly pinned route (set via <c>PUT /api/me/landing-route/pinned</c>).</summary>
+    PersonalPinned,
+
+    /// <summary>Default landing route attached to one of the user's roles.</summary>
+    Role,
+
+    /// <summary>Tenant-wide default landing route.</summary>
+    Tenant,
+
+    /// <summary>Framework fallback — the configured <c>WorkspacesEndpointsOptions.FrameworkLandingRoute</c>.</summary>
+    Framework,
+}

--- a/src/Granit.Workspaces.Endpoints/Options/WorkspacesEndpointsOptions.cs
+++ b/src/Granit.Workspaces.Endpoints/Options/WorkspacesEndpointsOptions.cs
@@ -11,4 +11,18 @@ public sealed class WorkspacesEndpointsOptions
 
     /// <summary>FusionCache TTL for the filtered tree. Default 5 minutes.</summary>
     public TimeSpan TreeCacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Framework fallback returned by <c>GET /api/me/landing-route</c> when no
+    /// higher tier resolves (per ADR-048, story #1556). Default <c>"/w/Granit.Framework"</c>.
+    /// </summary>
+    public string FrameworkLandingRoute { get; set; } = "/w/Granit.Framework";
+
+    /// <summary>
+    /// Allowed prefixes for landing routes — the resolver rejects any route
+    /// that does not start with one of these. Defaults to <c>"/w/"</c>
+    /// (workspace) and <c>"/e/"</c> (entity). Hosts that expose custom
+    /// front-end routes append their own prefix here.
+    /// </summary>
+    public IList<string> LandingRouteAllowedPrefixes { get; set; } = ["/w/", "/e/"];
 }

--- a/src/Granit.Workspaces.Framework/FrameworkWorkspaceDefinition.cs
+++ b/src/Granit.Workspaces.Framework/FrameworkWorkspaceDefinition.cs
@@ -1,0 +1,76 @@
+namespace Granit.Workspaces.Framework;
+
+/// <summary>
+/// Wire identifiers + permission strings used by the framework workspace
+/// surface. Centralised here so consumers (contributors, tests, hosts) can
+/// reference them without typo'ing the wire form.
+/// </summary>
+public static class FrameworkWorkspaceNames
+{
+    /// <summary>Root framework workspace.</summary>
+    public const string Framework = "Granit.Framework";
+
+    /// <summary>Permission required to enter the framework workspace.</summary>
+    public const string FrameworkReadPermission = "Workspace.Granit.Framework.Read";
+
+    /// <summary>Shell sub-workspaces.</summary>
+    public const string System = "Granit.Framework.System";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Users = "Granit.Framework.Users";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Automation = "Granit.Framework.Automation";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Data = "Granit.Framework.Data";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Email = "Granit.Framework.Email";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Integrations = "Granit.Framework.Integrations";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Monitoring = "Granit.Framework.Monitoring";
+
+    /// <summary><inheritdoc cref="System"/></summary>
+    public const string Privacy = "Granit.Framework.Privacy";
+}
+
+/// <summary>
+/// Root framework workspace — a single section listing the 8 shell
+/// sub-workspaces populated by other modules through
+/// <see cref="IWorkspaceContributor"/>. Hidden from non-admin users via the
+/// <c>Workspace.Granit.Framework.Read</c> permission gate.
+/// </summary>
+public sealed class FrameworkWorkspaceDefinition : WorkspaceDefinition
+{
+    /// <inheritdoc/>
+    public override string Name => FrameworkWorkspaceNames.Framework;
+
+    /// <inheritdoc/>
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Framework")
+            .Icon("settings")
+            .Order(1000)
+            .RequiresPermission(FrameworkWorkspaceNames.FrameworkReadPermission)
+            .Section("framework", s => s
+                .DisplayKey("WorkspacesFramework:Section.Framework")
+                .SubWorkspace(FrameworkWorkspaceNames.System, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.System").Icon("server").Order(0))
+                .SubWorkspace(FrameworkWorkspaceNames.Users, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Users").Icon("users").Order(1))
+                .SubWorkspace(FrameworkWorkspaceNames.Automation, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Automation").Icon("zap").Order(2))
+                .SubWorkspace(FrameworkWorkspaceNames.Data, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Data").Icon("database").Order(3))
+                .SubWorkspace(FrameworkWorkspaceNames.Email, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Email").Icon("mail").Order(4))
+                .SubWorkspace(FrameworkWorkspaceNames.Integrations, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Integrations").Icon("plug").Order(5))
+                .SubWorkspace(FrameworkWorkspaceNames.Monitoring, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Monitoring").Icon("activity").Order(6))
+                .SubWorkspace(FrameworkWorkspaceNames.Privacy, i => i
+                    .DisplayKey("WorkspacesFramework:Workspace.Privacy").Icon("shield").Order(7)));
+}

--- a/src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj
+++ b/src/Granit.Workspaces.Framework/Granit.Workspaces.Framework.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Workspaces.Framework</PackageId>
+    <Description>Framework navigation shell (per ADR-040 §7) — declares the `Granit.Framework` root workspace plus 8 shell sub-workspaces (System / Users / Automation / Data / Email / Integrations / Monitoring / Privacy) populated by other modules through `IWorkspaceContributor`. Zero business-module dependency. Empty shells auto-filter from the rendered tree.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Workspaces.Framework.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Workspaces.Framework/GranitWorkspacesFrameworkModule.cs
+++ b/src/Granit.Workspaces.Framework/GranitWorkspacesFrameworkModule.cs
@@ -1,0 +1,32 @@
+using Granit.Modularity;
+using Granit.Workspaces.Extensions;
+using Granit.Workspaces.Framework.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Workspaces.Framework;
+
+/// <summary>
+/// Granit module for the framework navigation shell — registers the
+/// <see cref="FrameworkWorkspaceDefinition"/> root and the eight shell
+/// sub-workspaces (System / Users / Automation / Data / Email / Integrations
+/// / Monitoring / Privacy). Other modules graft their admin entries onto a
+/// shell via <see cref="IWorkspaceContributor"/>.
+/// </summary>
+[DependsOn(typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitWorkspacesFrameworkModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        IServiceCollection s = context.Services;
+        s.AddWorkspaceDefinition<FrameworkWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<SystemShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<UsersShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<AutomationShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<DataShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<EmailShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<IntegrationsShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<MonitoringShellWorkspaceDefinition>();
+        s.AddWorkspaceDefinition<PrivacyShellWorkspaceDefinition>();
+    }
+}

--- a/src/Granit.Workspaces.Framework/Internal/FrameworkShellWorkspaces.cs
+++ b/src/Granit.Workspaces.Framework/Internal/FrameworkShellWorkspaces.cs
@@ -1,0 +1,63 @@
+namespace Granit.Workspaces.Framework.Internal;
+
+/// <summary>
+/// The 8 framework shell sub-workspaces. Each is declared by name only and
+/// flagged as a shell — populated at boot through
+/// <see cref="IWorkspaceContributor"/> implementations. Empty shells
+/// auto-filter from the rendered tree (handled by the workspace composer).
+/// </summary>
+internal sealed class SystemShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.System;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.System").Icon("server").Order(0).Shell();
+}
+
+internal sealed class UsersShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Users;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Users").Icon("users").Order(1).Shell();
+}
+
+internal sealed class AutomationShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Automation;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Automation").Icon("zap").Order(2).Shell();
+}
+
+internal sealed class DataShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Data;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Data").Icon("database").Order(3).Shell();
+}
+
+internal sealed class EmailShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Email;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Email").Icon("mail").Order(4).Shell();
+}
+
+internal sealed class IntegrationsShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Integrations;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Integrations").Icon("plug").Order(5).Shell();
+}
+
+internal sealed class MonitoringShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Monitoring;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Monitoring").Icon("activity").Order(6).Shell();
+}
+
+internal sealed class PrivacyShellWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => FrameworkWorkspaceNames.Privacy;
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder.DisplayKey("WorkspacesFramework:Workspace.Privacy").Icon("shield").Order(7).Shell();
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/cs.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/cs.json
@@ -1,0 +1,15 @@
+{
+  "culture": "cs",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/de.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/de.json
@@ -1,0 +1,15 @@
+{
+  "culture": "de",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/en-GB.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/en-GB.json
@@ -1,0 +1,15 @@
+{
+  "culture": "en-GB",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/en.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/en.json
@@ -1,0 +1,15 @@
+{
+  "culture": "en",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/es.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/es.json
@@ -1,0 +1,15 @@
+{
+  "culture": "es",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/fr-CA.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/fr-CA.json
@@ -1,0 +1,15 @@
+{
+  "culture": "fr-CA",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/fr.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/fr.json
@@ -1,0 +1,15 @@
+{
+  "culture": "fr",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "Système",
+    "WorkspacesFramework:Workspace.Users": "Utilisateurs",
+    "WorkspacesFramework:Workspace.Automation": "Automatisation",
+    "WorkspacesFramework:Workspace.Data": "Données",
+    "WorkspacesFramework:Workspace.Email": "E-mail",
+    "WorkspacesFramework:Workspace.Integrations": "Intégrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Supervision",
+    "WorkspacesFramework:Workspace.Privacy": "Confidentialité",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/hi.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/hi.json
@@ -1,0 +1,15 @@
+{
+  "culture": "hi",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/it.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/it.json
@@ -1,0 +1,15 @@
+{
+  "culture": "it",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/ja.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/ja.json
@@ -1,0 +1,15 @@
+{
+  "culture": "ja",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/ko.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/ko.json
@@ -1,0 +1,15 @@
+{
+  "culture": "ko",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/nl.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/nl.json
@@ -1,0 +1,15 @@
+{
+  "culture": "nl",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pl.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pl.json
@@ -1,0 +1,15 @@
+{
+  "culture": "pl",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pt-BR.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pt-BR.json
@@ -1,0 +1,15 @@
+{
+  "culture": "pt-BR",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pt.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/pt.json
@@ -1,0 +1,15 @@
+{
+  "culture": "pt",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/sv.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/sv.json
@@ -1,0 +1,15 @@
+{
+  "culture": "sv",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/tr.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/tr.json
@@ -1,0 +1,15 @@
+{
+  "culture": "tr",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/zh.json
+++ b/src/Granit.Workspaces.Framework/Localization/WorkspacesFramework/zh.json
@@ -1,0 +1,15 @@
+{
+  "culture": "zh",
+  "texts": {
+    "WorkspacesFramework:Workspace.Framework": "Framework",
+    "WorkspacesFramework:Workspace.System": "System",
+    "WorkspacesFramework:Workspace.Users": "Users",
+    "WorkspacesFramework:Workspace.Automation": "Automation",
+    "WorkspacesFramework:Workspace.Data": "Data",
+    "WorkspacesFramework:Workspace.Email": "Email",
+    "WorkspacesFramework:Workspace.Integrations": "Integrations",
+    "WorkspacesFramework:Workspace.Monitoring": "Monitoring",
+    "WorkspacesFramework:Workspace.Privacy": "Privacy",
+    "WorkspacesFramework:Section.Framework": "Sections"
+  }
+}

--- a/src/Granit.Workspaces.Framework/README.md
+++ b/src/Granit.Workspaces.Framework/README.md
@@ -1,0 +1,34 @@
+# Granit.Workspaces.Framework
+
+Framework navigation shell
+([ADR-040 §7](https://granit-fx.dev/dotnet/architecture/adr/040-entity-definition/)) —
+declares the `Granit.Framework` root workspace plus 8 shell sub-workspaces
+(`System` / `Users` / `Automation` / `Data` / `Email` / `Integrations` /
+`Monitoring` / `Privacy`) populated by other modules through
+`IWorkspaceContributor`.
+
+Zero business-module dependency. Empty shells auto-filter from the rendered
+tree (handled by the workspace composer in `Granit.Workspaces`). Hidden from
+non-admin users via the `Workspace.Granit.Framework.Read` permission gate.
+
+Pull this from a host that wants the framework navigation:
+
+```csharp
+[DependsOn(
+    typeof(GranitWorkspacesEndpointsModule),
+    typeof(GranitWorkspacesFrameworkModule))]
+public sealed class HostModule : GranitModule;
+```
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Workspaces.Framework
+```
+
+## Dependencies
+
+- `Granit.Localization`
+- `Granit.Workspaces.Abstractions`

--- a/src/Granit.Workspaces.Framework/WorkspacesFrameworkLocalizationResource.cs
+++ b/src/Granit.Workspaces.Framework/WorkspacesFrameworkLocalizationResource.cs
@@ -1,0 +1,7 @@
+using Granit.Localization;
+
+namespace Granit.Workspaces.Framework;
+
+/// <summary>Marker class for the localisation resource shipped by this package.</summary>
+[LocalizationResourceName("WorkspacesFramework")]
+public sealed class WorkspacesFrameworkLocalizationResource;

--- a/src/Granit.Workspaces.Framework/packages.lock.json
+++ b/src/Granit.Workspaces.Framework/packages.lock.json
@@ -1,0 +1,268 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Workspaces.Endpoints.Tests/LandingRouteResolverTests.cs
+++ b/tests/Granit.Workspaces.Endpoints.Tests/LandingRouteResolverTests.cs
@@ -1,0 +1,171 @@
+using System.Security.Claims;
+using Granit.MultiTenancy;
+using Granit.Workspaces.Endpoints.Landing;
+using Granit.Workspaces.Endpoints.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Workspaces.Endpoints.Tests;
+
+public sealed class LandingRouteResolverTests
+{
+    private const string FrameworkRoute = "/w/Granit.Framework";
+
+    [Fact]
+    public async Task Resolve_returns_framework_when_no_higher_tier_resolves()
+    {
+        LandingRouteResolver resolver = Build();
+
+        LandingRouteResult result = await resolver.ResolveAsync(
+            BuildUser("user-1"), TestContext.Current.CancellationToken);
+
+        result.Route.ShouldBe(FrameworkRoute);
+        result.Source.ShouldBe(LandingRouteSource.Framework);
+    }
+
+    [Fact]
+    public async Task Resolve_prefers_personal_sticky_over_every_other_tier()
+    {
+        ILandingRouteStore store = Substitute.For<ILandingRouteStore>();
+        store.GetStickyAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Sales");
+        store.GetPinnedAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Pinned");
+
+        IRoleLandingRouteProvider role = Substitute.For<IRoleLandingRouteProvider>();
+        role.GetRoleDefaultAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Role");
+
+        LandingRouteResolver resolver = Build(store: store, role: role);
+
+        LandingRouteResult result = await resolver.ResolveAsync(
+            BuildUser("user-1"), TestContext.Current.CancellationToken);
+
+        result.Route.ShouldBe("/w/Sales");
+        result.Source.ShouldBe(LandingRouteSource.PersonalSticky);
+    }
+
+    [Fact]
+    public async Task Resolve_falls_back_to_pinned_when_sticky_is_blocked_by_access_guard()
+    {
+        ILandingRouteStore store = Substitute.For<ILandingRouteStore>();
+        store.GetStickyAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("/w/SecretWorkspace");
+        store.GetPinnedAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Pinned");
+
+        ILandingRouteAccessGuard guard = Substitute.For<ILandingRouteAccessGuard>();
+        guard.CanAccessAsync("/w/SecretWorkspace", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        guard.CanAccessAsync("/w/Pinned", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        LandingRouteResolver resolver = Build(store: store, guard: guard);
+
+        LandingRouteResult result = await resolver.ResolveAsync(
+            BuildUser("user-1"), TestContext.Current.CancellationToken);
+
+        result.Source.ShouldBe(LandingRouteSource.PersonalPinned);
+    }
+
+    [Fact]
+    public async Task Resolve_skips_routes_that_fail_the_url_whitelist()
+    {
+        ILandingRouteStore store = Substitute.For<ILandingRouteStore>();
+        store.GetPinnedAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("https://evil.example/w/Sales"); // not on the whitelist
+
+        IRoleLandingRouteProvider role = Substitute.For<IRoleLandingRouteProvider>();
+        role.GetRoleDefaultAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Sales");
+
+        LandingRouteResolver resolver = Build(store: store, role: role);
+
+        LandingRouteResult result = await resolver.ResolveAsync(
+            BuildUser("user-1"), TestContext.Current.CancellationToken);
+
+        result.Source.ShouldBe(LandingRouteSource.Role);
+    }
+
+    [Fact]
+    public async Task Resolve_uses_role_then_tenant_when_no_personal_preference_exists()
+    {
+        ITenantLandingRouteProvider tenant = Substitute.For<ITenantLandingRouteProvider>();
+        tenant.GetTenantDefaultAsync(Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns("/w/Tenant");
+
+        LandingRouteResolver resolver = Build(tenant: tenant);
+
+        LandingRouteResult result = await resolver.ResolveAsync(
+            BuildUser("user-1"), TestContext.Current.CancellationToken);
+
+        result.Source.ShouldBe(LandingRouteSource.Tenant);
+        result.Route.ShouldBe("/w/Tenant");
+    }
+
+    [Fact]
+    public void IsAllowedRoute_rejects_routes_that_dont_match_a_prefix()
+    {
+        LandingRouteResolver resolver = Build();
+
+        resolver.IsAllowedRoute("/w/Sales").ShouldBeTrue();
+        resolver.IsAllowedRoute("/e/Granit.Parties.Party").ShouldBeTrue();
+        resolver.IsAllowedRoute("https://elsewhere/w/Sales").ShouldBeFalse();
+        resolver.IsAllowedRoute("/admin").ShouldBeFalse();
+        resolver.IsAllowedRoute(null).ShouldBeFalse();
+        resolver.IsAllowedRoute("").ShouldBeFalse();
+    }
+
+    private static LandingRouteResolver Build(
+        ILandingRouteStore? store = null,
+        IRoleLandingRouteProvider? role = null,
+        ITenantLandingRouteProvider? tenant = null,
+        ILandingRouteAccessGuard? guard = null)
+    {
+        WorkspacesEndpointsOptions options = new()
+        {
+            FrameworkLandingRoute = FrameworkRoute,
+            LandingRouteAllowedPrefixes = ["/w/", "/e/"],
+        };
+
+        return new LandingRouteResolver(
+            store ?? new EmptyStore(),
+            role ?? new NullRole(),
+            tenant ?? new NullTenant(),
+            guard ?? new AcceptAll(),
+            MsOptions.Create(options));
+    }
+
+    private static ClaimsPrincipal BuildUser(string sub) =>
+        new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, sub)], "test"));
+
+    private sealed class EmptyStore : ILandingRouteStore
+    {
+        public Task<string?> GetStickyAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+        public Task<string?> GetPinnedAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+        public Task SetPinnedAsync(string userId, Guid? tenantId, string? route, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class NullRole : IRoleLandingRouteProvider
+    {
+        public Task<string?> GetRoleDefaultAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class NullTenant : ITenantLandingRouteProvider
+    {
+        public Task<string?> GetTenantDefaultAsync(Guid? tenantId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class AcceptAll : ILandingRouteAccessGuard
+    {
+        public Task<bool> CanAccessAsync(string route, ClaimsPrincipal user, CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+}

--- a/tests/Granit.Workspaces.Framework.Tests/FrameworkWorkspaceDefinitionTests.cs
+++ b/tests/Granit.Workspaces.Framework.Tests/FrameworkWorkspaceDefinitionTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Workspaces.Framework.Tests;
+
+public sealed class FrameworkWorkspaceDefinitionTests
+{
+    [Fact]
+    public void Framework_root_is_gated_by_admin_permission()
+    {
+        WorkspaceDescriptor d = new FrameworkWorkspaceDefinition().Descriptor;
+
+        d.Name.ShouldBe(FrameworkWorkspaceNames.Framework);
+        d.RequiresPermission.ShouldBe(FrameworkWorkspaceNames.FrameworkReadPermission);
+        d.IsShell.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Framework_root_lists_the_eight_shell_sub_workspaces_in_canonical_order()
+    {
+        WorkspaceDescriptor d = new FrameworkWorkspaceDefinition().Descriptor;
+
+        WorkspaceSectionDescriptor section = d.Sections.Single();
+        section.Items.Select(i => i.SubWorkspaceName).ShouldBe(
+        [
+            FrameworkWorkspaceNames.System,
+            FrameworkWorkspaceNames.Users,
+            FrameworkWorkspaceNames.Automation,
+            FrameworkWorkspaceNames.Data,
+            FrameworkWorkspaceNames.Email,
+            FrameworkWorkspaceNames.Integrations,
+            FrameworkWorkspaceNames.Monitoring,
+            FrameworkWorkspaceNames.Privacy,
+        ]);
+    }
+
+    [Fact]
+    public void All_eight_shell_definitions_are_marked_as_shells()
+    {
+        // Reflection-based — the 8 shell types are internal so we discover them
+        // via the assembly to avoid hand-listing each one (which the
+        // localisation-completeness test catches anyway).
+        Assembly assembly = typeof(FrameworkWorkspaceDefinition).Assembly;
+        IReadOnlyList<WorkspaceDefinition> shells = [..
+            assembly.GetTypes()
+                .Where(t => !t.IsAbstract
+                    && typeof(WorkspaceDefinition).IsAssignableFrom(t)
+                    && t.Name.EndsWith("ShellWorkspaceDefinition", StringComparison.Ordinal))
+                .Select(t => (WorkspaceDefinition)Activator.CreateInstance(t)!)];
+
+        shells.Count.ShouldBe(8);
+        shells.ShouldAllBe(d => d.Descriptor.IsShell);
+    }
+}

--- a/tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj
+++ b/tests/Granit.Workspaces.Framework.Tests/Granit.Workspaces.Framework.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Workspaces.Framework\Granit.Workspaces.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Workspaces.Framework.Tests/packages.lock.json
+++ b/tests/Granit.Workspaces.Framework.Tests/packages.lock.json
@@ -1,0 +1,485 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "OpenTelemetry.Api": "[1.15.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.framework": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes **stories #1557 and #1556** of feature #1534 — the Framework navigation
shell and the 5-tier landing-route resolver. Both are foundation pieces that
unblock module contributions (#1558) and the Phase 1.F cobaye host (#1536).

## Story coverage

| Story | What |
| ----- | ---- |
| **#1557** | New `Granit.Workspaces.Framework` package — `Granit.Framework` root workspace gated by `Workspace.Granit.Framework.Read` (admin-only) plus the 8 shell sub-workspaces (`System` / `Users` / `Automation` / `Data` / `Email` / `Integrations` / `Monitoring` / `Privacy`). Empty shells auto-filter from the rendered tree. 18-culture localisation. |
| **#1556** | `Granit.Workspaces.Endpoints` gains `GET /api/me/landing-route` + `PUT /api/me/landing-route/pinned` via `MapGranitLandingRouteEndpoints("/api/{version}/me")`. 5-tier resolver per ADR-048. URL whitelist via `LandingRouteAllowedPrefixes` (default `["/w/", "/e/"]`). |

## 5-tier precedence

```
personal-sticky > personal-pinned > role-default > tenant-default > framework
```

Each tier may return `null` (provider not configured, no preference), or a
route that fails the URL whitelist, or a route the access guard vetoes (e.g.
sticky points to a workspace the user no longer has access to) — in any of
those cases the resolver falls through to the next tier. The framework
fallback is configured (`WorkspacesEndpointsOptions.FrameworkLandingRoute`,
default `/w/Granit.Framework`) and always closes the chain.

## Out of scope (deferred)

Persistence stays a host concern. The framework registers null-object
defaults so the surface compiles & runs immediately:

- `NullLandingRouteStore` — never records anything.
- `NullRoleLandingRouteProvider` / `NullTenantLandingRouteProvider` — always null.
- `AllowAllLandingRouteAccessGuard` — accepts every route.

Hosts that want sticky / pinned / role / tenant defaults register their own
implementations over these (`services.AddSingleton<ILandingRouteStore, ...>()`).

## Tests — 13 new cases

- `Granit.Workspaces.Framework.Tests` (3) — root permission gate, 8 shells in canonical order, every shell discovered by reflection is `IsShell=true`.
- `Granit.Workspaces.Endpoints.Tests.LandingRouteResolverTests` (6) — framework fallback, sticky precedence, access-guard fallthrough, whitelist rejection, role/tenant tier walk, `IsAllowedRoute` matrix.

Plus 202/202 architecture tests still green.

## Phase 1 status

```
1.A      ✅ #1632
1.B      ✅ #1634/#1637/#1638/#1639
1.C      ✅ #1641
1.D      ✅ #1642
1.D-bis  👉 here
1.E      ✅ #1643
1.F      ⏭ Cobaye (Party + Invoice + showcase, #1536)
```

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` ✅
- [x] `dotnet build .github/shard-filters/architecture.slnf` ✅
- [x] `dotnet test tests/Granit.Workspaces.{Tests,Abstractions.Tests,Endpoints.Tests,Framework.Tests}` — 23/23 (7+4+10+3) green
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 green
- [x] `dotnet format` clean across business + architecture shards
- [ ] CI green across all 8 shards

Refs ADR-040, ADR-048, #1534, #1556, #1557.