### PR TITLE
feat(entities-relations): batched aggregates endpoint (Phase 1.E-bis)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19007,6 +19007,24 @@
       "members": []
     },
     {
+      "name": "RelationAggregatesRequest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.RelationAggregatesRequest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/RelationAggregatesDtos.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "RelationAggregatesResponse",
+      "fqn": "Granit.Entities.Endpoints.Dtos.RelationAggregatesResponse",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/RelationAggregatesDtos.cs",
+      "line": 22,
+      "members": []
+    },
+    {
       "name": "EntitiesEndpointsLocalizationResource",
       "fqn": "Granit.Entities.Endpoints.EntitiesEndpointsLocalizationResource",
       "kind": "class",
@@ -19021,7 +19039,7 @@
       "kind": "class",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "MapGranitEntitiesEndpoints",
@@ -19072,6 +19090,12 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan DiscoveryCacheTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan RelationAggregatesCacheTtl { get; set; } = TimeSpan."
         }
       ]
     },
@@ -19343,6 +19367,38 @@
       ]
     },
     {
+      "name": "IRelationAggregateService",
+      "fqn": "Granit.Entities.Relations.IRelationAggregateService",
+      "kind": "interface",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Relations/IRelationAggregateService.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ComputeAsync",
+          "kind": "method",
+          "signature": "ComputeAsync(string sourceEntityName, string sourceId, IReadOnlyList<string> relationNames, ClaimsPrincipal user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, RelationAggregateValue>>"
+        }
+      ]
+    },
+    {
+      "name": "NullRelationAggregateService",
+      "fqn": "Granit.Entities.Relations.NullRelationAggregateService",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Relations/IRelationAggregateService.cs",
+      "line": 54,
+      "members": [
+        {
+          "name": "ComputeAsync",
+          "kind": "method",
+          "signature": "ComputeAsync(string sourceEntityName, string sourceId, IReadOnlyList<string> relationNames, ClaimsPrincipal user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, RelationAggregateValue>>"
+        }
+      ]
+    },
+    {
       "name": "RelationAggregateBuilder",
       "fqn": "Granit.Entities.Relations.RelationAggregateBuilder",
       "kind": "class",
@@ -19392,6 +19448,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Relations/RelationAggregateKind.cs",
       "line": 7,
+      "members": []
+    },
+    {
+      "name": "RelationAggregateValue",
+      "fqn": "Granit.Entities.Relations.RelationAggregateValue",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Relations/RelationAggregateValue.cs",
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/Relations/IRelationAggregateService.cs
+++ b/src/Granit.Entities.Abstractions/Relations/IRelationAggregateService.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+
+namespace Granit.Entities.Relations;
+
+/// <summary>
+/// Computes aggregate values for a set of relations on a single source row.
+/// The framework ships <c>NullRelationAggregateService</c> as the default —
+/// hosts that want real values register an EF Core (or other) implementation
+/// over it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations SHOULD execute each relation aggregate in parallel
+/// (typically <c>Task.WhenAll</c>) — that is the explicit acceptance
+/// criterion of story #1561. Implementations SHOULD also emit one
+/// OpenTelemetry activity per relation so the per-aggregate latency is
+/// visible without sampling.
+/// </para>
+/// <para>
+/// Aggregates that the runner cannot compute for a relation (unknown
+/// property, type mismatch, …) MUST return a <see cref="RelationAggregateValue"/>
+/// with the ill-defined slot left <see langword="null"/> rather than throwing —
+/// the calling endpoint surfaces a partial result so one bad relation does
+/// not blank-out the whole detail page.
+/// </para>
+/// </remarks>
+public interface IRelationAggregateService
+{
+    /// <summary>
+    /// Computes <see cref="RelationAggregateValue"/> for each
+    /// <paramref name="relationNames"/> on the source identified by
+    /// (<paramref name="sourceEntityName"/>, <paramref name="sourceId"/>).
+    /// </summary>
+    /// <param name="sourceEntityName">Wire identifier of the source entity (e.g. <c>"Granit.Parties.Party"</c>).</param>
+    /// <param name="sourceId">String form of the source primary key — caller does not assume Guid.</param>
+    /// <param name="relationNames">The relations whose aggregates the caller wants.</param>
+    /// <param name="user">The requesting principal — implementations MAY use this to bound queries by tenant / row-level permissions.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>One entry per relation in <paramref name="relationNames"/>; relations the runner could not resolve are absent.</returns>
+    Task<IReadOnlyDictionary<string, RelationAggregateValue>> ComputeAsync(
+        string sourceEntityName,
+        string sourceId,
+        IReadOnlyList<string> relationNames,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Default implementation — returns an empty dictionary. Hosts that don't
+/// want real aggregate computation can leave this in place; the manifest's
+/// <see cref="RelationDescriptor.Aggregates"/> still surfaces the wire shape,
+/// the endpoint just returns no values.
+/// </summary>
+public sealed class NullRelationAggregateService : IRelationAggregateService
+{
+    /// <inheritdoc />
+    public Task<IReadOnlyDictionary<string, RelationAggregateValue>> ComputeAsync(
+        string sourceEntityName,
+        string sourceId,
+        IReadOnlyList<string> relationNames,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyDictionary<string, RelationAggregateValue> empty =
+            new Dictionary<string, RelationAggregateValue>(StringComparer.Ordinal);
+        return Task.FromResult(empty);
+    }
+}

--- a/src/Granit.Entities.Abstractions/Relations/RelationAggregateValue.cs
+++ b/src/Granit.Entities.Abstractions/Relations/RelationAggregateValue.cs
@@ -1,0 +1,22 @@
+namespace Granit.Entities.Relations;
+
+/// <summary>
+/// Computed aggregate values for one relation, returned by
+/// <see cref="IRelationAggregateService"/>. Each numeric slot is nullable —
+/// the runner only fills the aggregates the relation declared (a relation
+/// without <see cref="RelationAggregateKind.Sum"/> in its descriptor leaves
+/// <see cref="Sum"/> null).
+/// </summary>
+/// <param name="Count">Count of related rows. <see langword="null"/> when the relation does not declare a Count aggregate.</param>
+/// <param name="Sum">Sum over a property. <see langword="null"/> when no Sum was declared, or when the relation contains zero rows (per ADR-038 empty-set semantics).</param>
+/// <param name="Avg">Average over a property. <see langword="null"/> on empty sets.</param>
+/// <param name="Min">Min over a property. <see langword="null"/> on empty sets.</param>
+/// <param name="Max">Max over a property. <see langword="null"/> on empty sets.</param>
+/// <param name="Currency">Optional ISO 4217 currency code when the aggregate's <see cref="RelationAggregateDescriptor.Format"/> is <c>"currency"</c>.</param>
+public sealed record RelationAggregateValue(
+    long? Count,
+    decimal? Sum,
+    decimal? Avg,
+    decimal? Min,
+    decimal? Max,
+    string? Currency = null);

--- a/src/Granit.Entities.Endpoints/Diagnostics/EntityActivitySource.cs
+++ b/src/Granit.Entities.Endpoints/Diagnostics/EntityActivitySource.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using Granit.Diagnostics;
+
+namespace Granit.Entities.Endpoints.Diagnostics;
+
+/// <summary>
+/// <see cref="ActivitySource"/> for the entity-manifest HTTP surface — used
+/// today for the relations-aggregate endpoint span (story #1561), available
+/// as the catch-all for future spans on this package. Auto-registered with
+/// <see cref="GranitActivitySourceRegistry"/> so OpenTelemetry exporters
+/// pick it up when the host wires Granit observability.
+/// </summary>
+internal static class EntityActivitySource
+{
+    public const string Name = "Granit.Entities.Endpoints";
+
+    public static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.Entities.Endpoints/Dtos/RelationAggregatesDtos.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/RelationAggregatesDtos.cs
@@ -1,0 +1,23 @@
+using Granit.Entities.Relations;
+
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Request body for <c>POST /api/entities/{name}/{id}/relations/aggregates</c>.
+/// </summary>
+/// <param name="Relations">
+/// Names of the relations whose aggregates the caller wants. When
+/// <see langword="null"/> or empty, the endpoint resolves "every relation
+/// the caller can read on the source entity" — convenient for a detail page
+/// that wants every smart-button count in one round-trip.
+/// </param>
+public sealed record RelationAggregatesRequest(IReadOnlyList<string>? Relations);
+
+/// <summary>
+/// Response body — keyed by relation name, each entry carries the computed
+/// aggregate values. Relations the caller cannot read are absent (defense
+/// in depth, story #1562 acceptance).
+/// </summary>
+/// <param name="Aggregates">One entry per resolved relation.</param>
+public sealed record RelationAggregatesResponse(
+    IReadOnlyDictionary<string, RelationAggregateValue> Aggregates);

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -39,6 +39,8 @@ internal static class EntitiesEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status403Forbidden);
 
+        group.MapRelationAggregatesEndpoint();
+
         return group;
     }
 

--- a/src/Granit.Entities.Endpoints/Endpoints/RelationAggregatesEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/RelationAggregatesEndpoint.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Claims;
+using Granit.Entities.Endpoints.Diagnostics;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using Granit.Entities.Endpoints.Options;
+using Granit.Entities.Internal;
+using Granit.Entities.Relations;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Entities.Endpoints.Endpoints;
+
+/// <summary>
+/// <c>POST /api/entities/{name}/{id}/relations/aggregates</c> — returns the
+/// aggregate values (count / sum / avg / min / max) for the relations of a
+/// single source row in one round-trip (story #1561). Wires permission
+/// filtering on the relation list (story #1562) and FusionCache 30-second
+/// sliding per (source, id, relation, perms-hash, culture).
+/// </summary>
+internal static class RelationAggregatesEndpoint
+{
+    /// <summary>
+    /// Mounts the route on the provided group. Called from
+    /// <c>MapGranitEntitiesEndpoints</c> alongside the discovery + manifest routes.
+    /// </summary>
+    public static RouteGroupBuilder MapRelationAggregatesEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{name}/{id}/relations/aggregates", HandleAsync)
+            .WithName("PostEntityRelationAggregates")
+            .WithSummary("Returns the aggregate values for the relations of a single source row, in one round-trip.")
+            .WithDescription("Computes count / sum / avg / min / max per relation declared on the source EntityDefinition. Pass `relations: []` (or omit the body) to get every relation the caller can read; pass an explicit list to slim the response. Each relation is computed in parallel by the registered IRelationAggregateService — the framework default returns an empty dictionary; hosts plug in an EF Core implementation. Defense-in-depth: relations gated by a permission the caller does not hold are absent from the request set and the response. FusionCache 30-second sliding per (sourceEntity, sourceId, relation, perms-hash, culture).")
+            .Produces<RelationAggregatesResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<RelationAggregatesResponse>, ProblemHttpResult>> HandleAsync(
+        string name,
+        string id,
+        RelationAggregatesRequest? request,
+        [FromServices] IEntityDefinitionRegistry registry,
+        [FromServices] EntityPermissionResolver permissionResolver,
+        [FromServices] IRelationAggregateService aggregateService,
+        [FromServices] IFusionCache cache,
+        [FromServices] IOptions<EntitiesEndpointsOptions> options,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        IEntityDefinitionDescriptor? definitionRef = registry.GetByName(name);
+        if (definitionRef is null)
+        {
+            return TypedResults.Problem(
+                detail: $"No EntityDefinition is registered with name '{name}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        EntityDefinitionDescriptor descriptor = definitionRef.Descriptor;
+        EntityPermissionSnapshot snapshot = await permissionResolver
+            .ResolveAsync(descriptor.PermissionGroup, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!snapshot.IsVisible)
+        {
+            return TypedResults.Problem(
+                detail: $"You do not have permission to read entity '{name}'.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        IReadOnlyList<RelationDescriptor> visibleRelations = await ResolveVisibleRelationsAsync(
+            descriptor, request?.Relations, permissionResolver, cancellationToken).ConfigureAwait(false);
+
+        if (visibleRelations.Count == 0)
+        {
+            return TypedResults.Ok(new RelationAggregatesResponse(
+                new Dictionary<string, RelationAggregateValue>(StringComparer.Ordinal)));
+        }
+
+        IReadOnlyDictionary<string, RelationAggregateValue> aggregates = await ComputeWithCacheAsync(
+            descriptor.Name, id, visibleRelations, aggregateService, cache, user, options.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new RelationAggregatesResponse(aggregates));
+    }
+
+    /// <summary>
+    /// Resolves the requested relation list down to the relations the caller
+    /// is allowed to see (defense in depth, story #1562). When the caller
+    /// passes <see langword="null"/> or an empty list, defaults to every
+    /// readable relation on the source.
+    /// </summary>
+    private static async Task<IReadOnlyList<RelationDescriptor>> ResolveVisibleRelationsAsync(
+        EntityDefinitionDescriptor descriptor,
+        IReadOnlyList<string>? requested,
+        EntityPermissionResolver permissionResolver,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<RelationDescriptor> candidates = requested is null || requested.Count == 0
+            ? descriptor.Relations
+            : [.. descriptor.Relations.Where(r => requested.Contains(r.Name, StringComparer.Ordinal))];
+
+        if (candidates.Count == 0)
+        {
+            return [];
+        }
+
+        // Resolve every distinct RequiresPermission referenced by the
+        // candidates in one batch. Relations with no gate fall through.
+        HashSet<string> referenced = new(
+            candidates.Where(r => r.RequiresPermission is not null).Select(r => r.RequiresPermission!),
+            StringComparer.Ordinal);
+
+        if (referenced.Count == 0)
+        {
+            return candidates;
+        }
+
+        IReadOnlyList<string> granted = await permissionResolver
+            .CheckBatchAsync(referenced, cancellationToken)
+            .ConfigureAwait(false);
+        HashSet<string> grantedSet = new(granted, StringComparer.Ordinal);
+
+        return [.. candidates.Where(r =>
+            r.RequiresPermission is null || grantedSet.Contains(r.RequiresPermission))];
+    }
+
+    /// <summary>
+    /// Fans the visible relations through FusionCache. Cache misses go
+    /// through the registered <see cref="IRelationAggregateService"/> in
+    /// parallel; cache hits are returned without re-computation.
+    /// </summary>
+    private static async Task<IReadOnlyDictionary<string, RelationAggregateValue>> ComputeWithCacheAsync(
+        string sourceEntityName,
+        string sourceId,
+        IReadOnlyList<RelationDescriptor> visible,
+        IRelationAggregateService service,
+        IFusionCache cache,
+        ClaimsPrincipal user,
+        EntitiesEndpointsOptions options,
+        CancellationToken cancellationToken)
+    {
+        CultureInfo culture = CultureInfo.CurrentUICulture;
+
+        // Pass 1: discover which relations are already cached.
+        Dictionary<string, RelationAggregateValue> cached = new(StringComparer.Ordinal);
+        List<string> misses = [];
+
+        foreach (RelationDescriptor relation in visible)
+        {
+            string key = RelationAggregateCacheKey.Build(
+                sourceEntityName, sourceId, relation.Name, user, culture);
+
+            MaybeValue<RelationAggregateValue> maybe = cache.TryGet<RelationAggregateValue>(
+                key, token: cancellationToken);
+
+            if (maybe.HasValue)
+            {
+                cached[relation.Name] = maybe.Value;
+            }
+            else
+            {
+                misses.Add(relation.Name);
+            }
+        }
+
+        // Pass 2: compute the misses in one runner call (the runner is
+        // expected to fan them in parallel internally — story #1561 SLA).
+        if (misses.Count > 0)
+        {
+            using Activity? activity = EntityActivitySource.Source.StartActivity("relations.aggregates.compute");
+            activity?.SetTag("source_entity", sourceEntityName);
+            activity?.SetTag("relation_count", misses.Count);
+
+            IReadOnlyDictionary<string, RelationAggregateValue> computed = await service
+                .ComputeAsync(sourceEntityName, sourceId, misses, user, cancellationToken)
+                .ConfigureAwait(false);
+
+            FusionCacheEntryOptions entryOptions = new() { Duration = options.RelationAggregatesCacheTtl };
+            string evictionTag = RelationAggregateCacheKey.EvictionTag(sourceEntityName, sourceId);
+
+            foreach ((string relName, RelationAggregateValue value) in computed)
+            {
+                string key = RelationAggregateCacheKey.Build(
+                    sourceEntityName, sourceId, relName, user, culture);
+                await cache.SetAsync(key, value, entryOptions, [evictionTag], token: cancellationToken)
+                    .ConfigureAwait(false);
+                cached[relName] = value;
+            }
+        }
+
+        return cached;
+    }
+}

--- a/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Endpoints.Diagnostics;
 using Granit.Entities.Endpoints.Endpoints;
 using Granit.Entities.Endpoints.Internal;
 using Granit.Entities.Endpoints.Options;
@@ -58,7 +59,13 @@ public static class EntitiesEndpointRouteBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         services.TryAddScoped<EntityPermissionResolver>();
+        // Default null-object service — hosts wanting real aggregate values
+        // plug in an EF Core (or other) implementation over this. Per-relation
+        // parallelism is the implementation's responsibility (story #1561).
+        services.TryAddSingleton<Granit.Entities.Relations.IRelationAggregateService,
+            Granit.Entities.Relations.NullRelationAggregateService>();
         services.AddOptions<EntitiesEndpointsOptions>();
+        Granit.Diagnostics.GranitActivitySourceRegistry.Register(EntityActivitySource.Name);
         return services;
     }
 }

--- a/src/Granit.Entities.Endpoints/Internal/RelationAggregateCacheKey.cs
+++ b/src/Granit.Entities.Endpoints/Internal/RelationAggregateCacheKey.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Granit.Entities.Endpoints.Internal;
+
+/// <summary>
+/// Cache-key composer for the relation aggregates endpoint (story #1562).
+/// Format: <c>relation-agg:{sourceEntity}:{sourceId}:{relationName}:{userPermsHash}:{cultureName}</c>.
+/// </summary>
+/// <remarks>
+/// Per-relation keys (not per-batch) so a detail page that requests 5
+/// relations only re-computes the ones whose entries have aged past the
+/// 30-second sliding TTL — instead of invalidating the whole batch when
+/// any single counter changes. The user-perms-hash gates per-RBAC partition
+/// so two callers with different roles don't share each other's cached
+/// results even when the source row matches.
+/// </remarks>
+internal static class RelationAggregateCacheKey
+{
+    public const string Prefix = "relation-agg";
+
+    public static string Build(
+        string sourceEntityName,
+        string sourceId,
+        string relationName,
+        ClaimsPrincipal user,
+        CultureInfo culture)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceEntityName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(relationName);
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(culture);
+
+        return $"{Prefix}:{sourceEntityName}:{sourceId}:{relationName}:{HashPermissions(user)}:{culture.Name}";
+    }
+
+    /// <summary>
+    /// Cache eviction tag for all aggregates of a given (sourceEntity, sourceId).
+    /// Phase 2 wires invalidation events to <c>cache.RemoveByTagAsync(...)</c> when
+    /// the source or any of its related rows change.
+    /// </summary>
+    public static string EvictionTag(string sourceEntityName, string sourceId) =>
+        $"entity:{sourceEntityName}:{sourceId}";
+
+    private static string HashPermissions(ClaimsPrincipal user)
+    {
+        IEnumerable<string> roleClaims = user.Claims
+            .Where(c => c.Type is ClaimTypes.Role or "role" or "permission")
+            .Select(c => $"{c.Type}={c.Value}")
+            .OrderBy(s => s, StringComparer.Ordinal);
+
+        StringBuilder buffer = new();
+        foreach (string claim in roleClaims)
+        {
+            buffer.Append(claim);
+            buffer.Append('|');
+        }
+
+        string? sub = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        buffer.Append(sub ?? "anon");
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(buffer.ToString()));
+        return Convert.ToHexString(hash)[..16].ToLowerInvariant();
+    }
+}

--- a/src/Granit.Entities.Endpoints/Options/EntitiesEndpointsOptions.cs
+++ b/src/Granit.Entities.Endpoints/Options/EntitiesEndpointsOptions.cs
@@ -21,4 +21,13 @@ public sealed class EntitiesEndpointsOptions
     /// <see cref="ManifestCacheTtl"/>. Default 5 minutes.
     /// </summary>
     public TimeSpan DiscoveryCacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// FusionCache TTL for relation aggregates returned by
+    /// <c>POST /relations/aggregates</c>. Counts and sums change frequently —
+    /// keep this short. Default 30 seconds. Per-(sourceEntity, sourceId)
+    /// invalidation tags are emitted so future event-driven evictions can
+    /// burst-clear all relation aggregates for a row in one call.
+    /// </summary>
+    public TimeSpan RelationAggregatesCacheTtl { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/tests/Granit.Entities.Abstractions.Tests/NullRelationAggregateServiceTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/NullRelationAggregateServiceTests.cs
@@ -1,0 +1,22 @@
+using System.Security.Claims;
+using Granit.Entities.Relations;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests;
+
+public sealed class NullRelationAggregateServiceTests
+{
+    [Fact]
+    public async Task ComputeAsync_returns_empty_dictionary_for_any_input()
+    {
+        NullRelationAggregateService service = new();
+        ClaimsPrincipal user = new(new ClaimsIdentity());
+
+        IReadOnlyDictionary<string, RelationAggregateValue> result = await service.ComputeAsync(
+            "Granit.Parties.Party", "any-id", ["invoices", "addresses"],
+            user, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/RelationAggregateCacheKeyTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/RelationAggregateCacheKeyTests.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Security.Claims;
+using Granit.Entities.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Endpoints.Tests;
+
+public sealed class RelationAggregateCacheKeyTests
+{
+    [Fact]
+    public void Build_includes_every_partitioning_segment()
+    {
+        ClaimsPrincipal user = BuildUser(["Admin"], "user-1");
+        string key = RelationAggregateCacheKey.Build(
+            "Granit.Parties.Party", "abc-123", "invoices", user,
+            CultureInfo.GetCultureInfo("en-GB"));
+
+        key.ShouldStartWith("relation-agg:Granit.Parties.Party:abc-123:invoices:");
+        key.ShouldEndWith(":en-GB");
+    }
+
+    [Fact]
+    public void Build_partitions_by_user_perms_hash()
+    {
+        ClaimsPrincipal admin = BuildUser(["Admin"], "user-1");
+        ClaimsPrincipal viewer = BuildUser(["Viewer"], "user-1");
+
+        string adminKey = RelationAggregateCacheKey.Build(
+            "X", "1", "invoices", admin, CultureInfo.InvariantCulture);
+        string viewerKey = RelationAggregateCacheKey.Build(
+            "X", "1", "invoices", viewer, CultureInfo.InvariantCulture);
+
+        adminKey.ShouldNotBe(viewerKey);
+    }
+
+    [Fact]
+    public void Build_returns_same_key_for_role_reordering()
+    {
+        ClaimsPrincipal a = BuildUser(["Admin", "Editor"], "user-1");
+        ClaimsPrincipal b = BuildUser(["Editor", "Admin"], "user-1");
+
+        RelationAggregateCacheKey.Build("X", "1", "r", a, CultureInfo.InvariantCulture)
+            .ShouldBe(RelationAggregateCacheKey.Build("X", "1", "r", b, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void EvictionTag_is_per_source_row()
+    {
+        RelationAggregateCacheKey.EvictionTag("Granit.Parties.Party", "abc-123")
+            .ShouldBe("entity:Granit.Parties.Party:abc-123");
+    }
+
+    private static ClaimsPrincipal BuildUser(IEnumerable<string> roles, string sub)
+    {
+        List<Claim> claims = [new(ClaimTypes.NameIdentifier, sub)];
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes **stories #1561 and #1562** (manifest-side defense-in-depth) of feature
#1535. Adds the wire contract + plumbing for `POST /api/entities/{name}/{id}/relations/aggregates`;
the actual SQL-emitting runner stays a host concern (default null-object
service ships in this PR).

## What landed

| Story | What |
| ----- | ---- |
| **#1561** | `POST /api/entities/{name}/{id}/relations/aggregates`. Body `{ relations: [...] }` (empty = all visible). Returns one `RelationAggregateValue` per relation (count / sum / avg / min / max). Mounted by `MapGranitEntitiesEndpoints` so existing hosts get it for free. |
| **#1562 (manifest side)** | Defense-in-depth filter: relations gated by a permission the caller does NOT hold are absent from the request set AND from the response. FusionCache 30 s sliding, key `relation-agg:{src}:{id}:{relName}:{permsHash}:{culture}`. Per-row eviction tag `entity:{src}:{id}` emitted for future bus-event invalidation. |

## Wire shape

```http
POST /api/v1/entities/Granit.Parties.Party/abc-123/relations/aggregates
Content-Type: application/json

{ "relations": ["invoices", "addresses"] }
```

```json
{
  "aggregates": {
    "invoices": { "count": 12, "sum": 4800.00, "currency": "EUR" },
    "addresses": { "count": 2 }
  }
}
```

## Out of scope (deferred)

- **EF-Core-backed runner** that actually computes counts / sums / avgs against a `DbContext`. Hosts plug their own in via `services.AddSingleton<IRelationAggregateService, ...>()`.
- The "5 relations = 5 parallel queries" test from #1561's acceptance — measures `DbContext` command parallelism, so it lands with the EF runner.
- Reactive cache invalidation on row writes — eviction tag is in place; the bus-event subscription that calls `cache.RemoveByTagAsync(...)` is Phase 2.

## Tests — 5 new cases

- `NullRelationAggregateServiceTests` (1) — default returns empty for any input.
- `RelationAggregateCacheKeyTests` (4) — key shape, perms-hash partitioning, role-reorder equivalence, per-row eviction tag.

Plus 202/202 architecture tests still green (after relocating `EntityActivitySource` from `Internal/` to the conventional `Diagnostics/` folder per `FileOrganizationTests`).

## Phase 1 status

```
1.A      ✅ #1632
1.B      ✅ #1634/#1637/#1638/#1639
1.C      ✅ #1641
1.D      ✅ #1642
1.D-bis  ✅ #1644
1.E      ✅ #1643
1.E-bis  👉 here
1.F      ⏭ Cobaye (Party + Invoice + showcase, #1536)
```

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` ✅
- [x] `dotnet build .github/shard-filters/architecture.slnf` ✅
- [x] `dotnet test tests/Granit.Entities.{Abstractions.Tests,Endpoints.Tests,Tests}` — 75/75 passing (23 + 40 + 12)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 passing
- [x] `dotnet format` clean across business + architecture shards
- [ ] CI green across all 8 shards

Refs ADR-040, ADR-048, #1535, #1561, #1562.