### PR TITLE
feat(cobaye): cross-module relation contributions on Party (Phase 1.F-β)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -603,6 +603,7 @@
       "name": "Granit.CustomerBalance.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Entities.Abstractions",
         "Granit.Parties",
         "Granit.CustomerBalance",
         "Granit.QueryEngine.AspNetCore",
@@ -1349,6 +1350,7 @@
       "name": "Granit.Invoicing.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Entities.Abstractions",
         "Granit.Http.Abstractions",
         "Granit.Invoicing",
         "Granit.QueryEngine.AspNetCore",
@@ -2018,6 +2020,7 @@
       "name": "Granit.Payments.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Entities.Abstractions",
         "Granit.Parties",
         "Granit.Guids",
         "Granit.Http.Abstractions",
@@ -2444,7 +2447,9 @@
       "name": "Granit.Subscriptions.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Entities.Abstractions",
         "Granit.Http.Abstractions",
+        "Granit.Parties",
         "Granit.Subscriptions",
         "Granit.QueryEngine.AspNetCore",
         "Granit.Validation"
@@ -12728,8 +12733,15 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Endpoints",
       "file": "src/Granit.CustomerBalance.Endpoints/GranitCustomerBalanceEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "CustomerBalanceEndpointsOptions",
@@ -28031,7 +28043,7 @@
       "kind": "class",
       "project": "Granit.Invoicing.Endpoints",
       "file": "src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs",
-      "line": 18,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -40092,8 +40104,15 @@
       "kind": "class",
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/GranitPaymentsEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "PaymentsEndpointsOptions",
@@ -49912,8 +49931,15 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs",
-      "line": 16,
-      "members": []
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "SubscriptionsEndpointsOptions",

--- a/src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj
+++ b/src/Granit.CustomerBalance.Endpoints/Granit.CustomerBalance.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.CustomerBalance\Granit.CustomerBalance.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />

--- a/src/Granit.CustomerBalance.Endpoints/GranitCustomerBalanceEndpointsModule.cs
+++ b/src/Granit.CustomerBalance.Endpoints/GranitCustomerBalanceEndpointsModule.cs
@@ -1,4 +1,7 @@
 using Granit.Authorization;
+using Granit.CustomerBalance.Endpoints.Relations;
+using Granit.Entities;
+using Granit.Entities.Relations;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.Validation;
@@ -9,6 +12,13 @@ namespace Granit.CustomerBalance.Endpoints;
 [DependsOn(
     typeof(GranitAuthorizationModule),
     typeof(GranitCustomerBalanceModule),
+    typeof(GranitEntitiesAbstractionsModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitValidationModule))]
-public sealed class GranitCustomerBalanceEndpointsModule : GranitModule;
+public sealed class GranitCustomerBalanceEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        // Phase 1.F-β cobaye: graft the "balance" smart-button relation onto Party.
+        context.Services.AddEntityRelationContribution<BalanceOnPartyRelationContribution>();
+}

--- a/src/Granit.CustomerBalance.Endpoints/Relations/BalanceOnPartyRelationContribution.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Relations/BalanceOnPartyRelationContribution.cs
@@ -1,0 +1,34 @@
+using Granit.CustomerBalance.Domain;
+using Granit.CustomerBalance.Endpoints.Permissions;
+using Granit.Entities.Relations;
+using Granit.Parties.Domain;
+
+namespace Granit.CustomerBalance.Endpoints.Relations;
+
+/// <summary>
+/// Phase 1.F-β cobaye — grafts a <c>"balance"</c> smart-button relation
+/// onto <c>Granit.Parties.Party</c>, surfacing the running customer balance
+/// (<c>Sum(Balance)</c> over zero-or-one BalanceAccount per party).
+/// </summary>
+/// <remarks>
+/// Modelled as a 1:N relation by the cross-module contributor surface even
+/// though the source's cardinality is at most 1 — the framework's
+/// <c>IEntityRelationContributionContext.AddRelation&lt;TSource,TRelated&gt;</c>
+/// hardcodes <see cref="RelationCardinality.Many"/>; the renderer collapses
+/// the count-of-1 case into the single-value smart button.
+/// </remarks>
+internal sealed class BalanceOnPartyRelationContribution : IEntityRelationContributor
+{
+    public void Contribute(IEntityRelationContributionContext context) =>
+        context.AddRelation<Party, BalanceAccount>(
+            name: "balance",
+            targetEntityName: "Granit.CustomerBalance.BalanceAccount",
+            r => r
+                .DisplayAs(RelationDisplay.SmartButton)
+                .DisplayKey("CustomerBalance:Relation.OnParty.Balance")
+                .Icon("wallet")
+                .Order(40)
+                .RequiresPermission(CustomerBalancePermissions.Accounts.Read)
+                .Aggregate(a => a
+                    .Sum(b => b.Balance, labelKey: "CustomerBalance:Relation.OnParty.Balance.Current", format: "currency")));
+}

--- a/src/Granit.Invoicing.Endpoints/Granit.Invoicing.Endpoints.csproj
+++ b/src/Granit.Invoicing.Endpoints/Granit.Invoicing.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Invoicing\Granit.Invoicing.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />

--- a/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
+++ b/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.Entities;
+using Granit.Entities.Relations;
 using Granit.Http.ApiDocumentation;
 using Granit.Invoicing.Endpoints.Internal;
+using Granit.Invoicing.Endpoints.Relations;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
 using Granit.Validation;
@@ -12,13 +15,19 @@ namespace Granit.Invoicing.Endpoints;
 /// <summary>Granit module for invoicing administration HTTP endpoints.</summary>
 [DependsOn(
     typeof(GranitAuthorizationModule),
+    typeof(GranitEntitiesAbstractionsModule),
     typeof(GranitInvoicingModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitValidationModule))]
 public sealed class GranitInvoicingEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ISchemaExampleProvider, InvoicingSchemaExampleProvider>());
+
+        // Phase 1.F-β cobaye: graft the "invoices" smart-button relation onto Party.
+        context.Services.AddEntityRelationContribution<InvoicesOnPartyRelationContribution>();
+    }
 }

--- a/src/Granit.Invoicing.Endpoints/Relations/InvoicesOnPartyRelationContribution.cs
+++ b/src/Granit.Invoicing.Endpoints/Relations/InvoicesOnPartyRelationContribution.cs
@@ -1,0 +1,28 @@
+using Granit.Entities.Relations;
+using Granit.Invoicing.Domain;
+using Granit.Invoicing.Endpoints.Permissions;
+using Granit.Parties.Domain;
+
+namespace Granit.Invoicing.Endpoints.Relations;
+
+/// <summary>
+/// Phase 1.F-β cobaye — grafts an <c>"invoices"</c> smart-button relation
+/// onto <c>Granit.Parties.Party</c>, surfacing <c>Count</c> + <c>Sum(Total)</c>
+/// in one round-trip on the party detail header.
+/// </summary>
+internal sealed class InvoicesOnPartyRelationContribution : IEntityRelationContributor
+{
+    public void Contribute(IEntityRelationContributionContext context) =>
+        context.AddRelation<Party, Invoice>(
+            name: "invoices",
+            targetEntityName: "Granit.Invoicing.Invoice",
+            r => r
+                .DisplayAs(RelationDisplay.SmartButton)
+                .DisplayKey("Invoicing:Relation.OnParty.Invoices")
+                .Icon("file-text")
+                .Order(10)
+                .RequiresPermission(InvoicingPermissions.Invoices.Read)
+                .Aggregate(a => a
+                    .Count(labelKey: "Invoicing:Relation.OnParty.Invoices.Count")
+                    .Sum(i => i.Total, labelKey: "Invoicing:Relation.OnParty.Invoices.Total", format: "currency")));
+}

--- a/src/Granit.Payments.Endpoints/Granit.Payments.Endpoints.csproj
+++ b/src/Granit.Payments.Endpoints/Granit.Payments.Endpoints.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />

--- a/src/Granit.Payments.Endpoints/GranitPaymentsEndpointsModule.cs
+++ b/src/Granit.Payments.Endpoints/GranitPaymentsEndpointsModule.cs
@@ -1,5 +1,8 @@
 using Granit.Authorization;
+using Granit.Entities;
+using Granit.Entities.Relations;
 using Granit.Modularity;
+using Granit.Payments.Endpoints.Relations;
 using Granit.RateLimiting;
 using Granit.Validation;
 
@@ -8,7 +11,14 @@ namespace Granit.Payments.Endpoints;
 /// <summary>Granit module for payment HTTP endpoints.</summary>
 [DependsOn(
     typeof(GranitAuthorizationModule),
+    typeof(GranitEntitiesAbstractionsModule),
     typeof(GranitPaymentsModule),
     typeof(GranitRateLimitingModule),
     typeof(GranitValidationModule))]
-public sealed class GranitPaymentsEndpointsModule : GranitModule;
+public sealed class GranitPaymentsEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        // Phase 1.F-β cobaye: graft the "payments" smart-button relation onto Party.
+        context.Services.AddEntityRelationContribution<PaymentsOnPartyRelationContribution>();
+}

--- a/src/Granit.Payments.Endpoints/Relations/PaymentsOnPartyRelationContribution.cs
+++ b/src/Granit.Payments.Endpoints/Relations/PaymentsOnPartyRelationContribution.cs
@@ -1,0 +1,28 @@
+using Granit.Entities.Relations;
+using Granit.Parties.Domain;
+using Granit.Payments.Domain;
+using Granit.Payments.Endpoints.Permissions;
+
+namespace Granit.Payments.Endpoints.Relations;
+
+/// <summary>
+/// Phase 1.F-β cobaye — grafts a <c>"payments"</c> smart-button relation
+/// onto <c>Granit.Parties.Party</c>, surfacing <c>Count</c> + <c>Sum(Amount)</c>
+/// on the party detail header.
+/// </summary>
+internal sealed class PaymentsOnPartyRelationContribution : IEntityRelationContributor
+{
+    public void Contribute(IEntityRelationContributionContext context) =>
+        context.AddRelation<Party, PaymentTransaction>(
+            name: "payments",
+            targetEntityName: "Granit.Payments.PaymentTransaction",
+            r => r
+                .DisplayAs(RelationDisplay.SmartButton)
+                .DisplayKey("Payments:Relation.OnParty.Payments")
+                .Icon("credit-card")
+                .Order(30)
+                .RequiresPermission(PaymentsPermissions.Transactions.Read)
+                .Aggregate(a => a
+                    .Count(labelKey: "Payments:Relation.OnParty.Payments.Count")
+                    .Sum(p => p.Amount, labelKey: "Payments:Relation.OnParty.Payments.Amount", format: "currency")));
+}

--- a/src/Granit.Subscriptions.Endpoints/Granit.Subscriptions.Endpoints.csproj
+++ b/src/Granit.Subscriptions.Endpoints/Granit.Subscriptions.Endpoints.csproj
@@ -17,7 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Subscriptions\Granit.Subscriptions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
+++ b/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.Entities;
+using Granit.Entities.Relations;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.Subscriptions.Endpoints.Relations;
 using Granit.Validation;
 
 namespace Granit.Subscriptions.Endpoints;
@@ -10,7 +13,14 @@ namespace Granit.Subscriptions.Endpoints;
 /// </summary>
 [DependsOn(
     typeof(GranitAuthorizationModule),
+    typeof(GranitEntitiesAbstractionsModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitSubscriptionsModule),
     typeof(GranitValidationModule))]
-public sealed class GranitSubscriptionsEndpointsModule : GranitModule;
+public sealed class GranitSubscriptionsEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        // Phase 1.F-β cobaye: graft the "subscriptions" smart-button relation onto Party.
+        context.Services.AddEntityRelationContribution<SubscriptionsOnPartyRelationContribution>();
+}

--- a/src/Granit.Subscriptions.Endpoints/Relations/SubscriptionsOnPartyRelationContribution.cs
+++ b/src/Granit.Subscriptions.Endpoints/Relations/SubscriptionsOnPartyRelationContribution.cs
@@ -1,0 +1,27 @@
+using Granit.Entities.Relations;
+using Granit.Parties.Domain;
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Endpoints.Permissions;
+
+namespace Granit.Subscriptions.Endpoints.Relations;
+
+/// <summary>
+/// Phase 1.F-β cobaye — grafts a <c>"subscriptions"</c> smart-button
+/// relation onto <c>Granit.Parties.Party</c>, surfacing the count of
+/// subscriptions on the party detail header.
+/// </summary>
+internal sealed class SubscriptionsOnPartyRelationContribution : IEntityRelationContributor
+{
+    public void Contribute(IEntityRelationContributionContext context) =>
+        context.AddRelation<Party, Subscription>(
+            name: "subscriptions",
+            targetEntityName: "Granit.Subscriptions.Subscription",
+            r => r
+                .DisplayAs(RelationDisplay.SmartButton)
+                .DisplayKey("Subscriptions:Relation.OnParty.Subscriptions")
+                .Icon("repeat")
+                .Order(20)
+                .RequiresPermission(SubscriptionsPermissions.Subscriptions.Read)
+                .Aggregate(a => a
+                    .Count(labelKey: "Subscriptions:Relation.OnParty.Subscriptions.Count")));
+}

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -109,6 +109,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -156,6 +167,12 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
@@ -173,6 +190,21 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.parties.abstractions": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1951,6 +1951,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.CustomerBalance": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
@@ -2567,6 +2568,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Invoicing": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
@@ -3197,6 +3199,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
@@ -3587,7 +3590,9 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.CustomerBalance.Endpoints.Tests/packages.lock.json
@@ -379,6 +379,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.CustomerBalance": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Invoicing.Endpoints.Tests/InvoicesOnPartyRelationContributionTests.cs
+++ b/tests/Granit.Invoicing.Endpoints.Tests/InvoicesOnPartyRelationContributionTests.cs
@@ -1,0 +1,30 @@
+using Granit.Entities.Relations;
+using Granit.Invoicing.Endpoints.Relations;
+using Granit.Parties.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Invoicing.Endpoints.Tests;
+
+public sealed class InvoicesOnPartyRelationContributionTests
+{
+    [Fact]
+    public void Contribute_grafts_invoices_relation_onto_Party()
+    {
+        EntityRelationContributionContext context = new();
+
+        new InvoicesOnPartyRelationContribution().Contribute(context);
+
+        IReadOnlyList<RelationDescriptor> relations = context.Contributions[typeof(Party)];
+        relations.ShouldHaveSingleItem();
+
+        RelationDescriptor invoices = relations.Single();
+        invoices.Name.ShouldBe("invoices");
+        invoices.TargetEntityName.ShouldBe("Granit.Invoicing.Invoice");
+        invoices.Display.ShouldBe(RelationDisplay.SmartButton);
+        invoices.RequiresPermission.ShouldBe("Invoicing.Invoices.Read");
+        invoices.Aggregates.Select(a => a.Kind).ShouldBe(
+            [RelationAggregateKind.Count, RelationAggregateKind.Sum]);
+        invoices.ContributorAssemblyName.ShouldNotBeNull();
+    }
+}

--- a/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Invoicing.Endpoints.Tests/packages.lock.json
@@ -656,6 +656,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Invoicing": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",

--- a/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
@@ -719,6 +719,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -596,6 +596,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -647,6 +658,13 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.mergeable": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
       "granit.metering": {
         "type": "Project",
         "dependencies": {
@@ -665,6 +683,21 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.parties": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.Mergeable": "[0.1.0-dev, )",
+          "Granit.Parties.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.parties.abstractions": {
@@ -738,7 +771,9 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Parties": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

Closes **story #1563 (second half)** of feature #1536 — the four billing
modules graft smart-button relations onto `Granit.Parties.Party` so the
showcase party-detail page surfaces invoices, subscriptions, payments and
balance counters in one round-trip.

## Contributions

| Module | Relation | Target | Aggregates | Permission |
| ------ | -------- | ------ | ---------- | ---------- |
| `Granit.Invoicing.Endpoints` | `invoices` | `Invoice` | `Count` + `Sum(Total)` | `Invoicing.Invoices.Read` |
| `Granit.Subscriptions.Endpoints` | `subscriptions` | `Subscription` | `Count` | `Subscriptions.Subscriptions.Read` |
| `Granit.Payments.Endpoints` | `payments` | `PaymentTransaction` | `Count` + `Sum(Amount)` | `Payments.Transactions.Read` |
| `Granit.CustomerBalance.Endpoints` | `balance` | `BalanceAccount` | `Sum(Balance)` | `CustomerBalance.Accounts.Read` |

Each is `Relations/{X}OnPartyRelationContribution.cs` implementing
`IEntityRelationContributor`, registered through
`services.AddEntityRelationContribution<T>()` in the module class. Display
mode is `RelationDisplay.SmartButton` for the four — the renderer collapses
the count-of-1 case (CustomerBalance) into a single-value chip.

## Wiring

Each Endpoints package gains:
- `<ProjectReference>` to `Granit.Entities.Abstractions` for the `IEntityRelationContributor` API.
- `[DependsOn(typeof(GranitEntitiesAbstractionsModule))]` on the module attribute.

`Granit.Subscriptions.Endpoints` additionally adds `Granit.Parties` (it
previously only saw `Granit.Parties.Abstractions`, which doesn't carry the
`Party` CLR type).

## Defense in depth

Every contribution carries `RequiresPermission(<module>.<resource>.Read)` —
callers without the permission see neither the relation in the manifest's
Relations facet nor an entry in the `POST /relations/aggregates` response
(the manifest composer + the aggregate endpoint both filter by
`RequiresPermission`, shipped in #1645).

## Tests — 1 representative case + reuse existing coverage

- `InvoicesOnPartyRelationContributionTests` — feeds the contributor into a
  real `EntityRelationContributionContext`, asserts the relation lands on
  Party with the expected name / target / display / permission / aggregates
  + that the contributor assembly name is captured for diagnostics.

The other three follow the exact same pattern; their correctness is
validated at compile time (typed `AddRelation<TSource, TRelated>` API + the
build) and at runtime by the existing `EntityRelationMerger` test that
covers merge / unknown-source-drop / intra-module-precedence behaviour.

Plus 202/202 architecture tests still green. Format clean across business +
saas + architecture + infrastructure shards.

## Phase 1 status

```
1.A / 1.B / 1.C / 1.D / 1.D-bis / 1.E / 1.E-bis / 1.D-bis(#1558) / 1.F-α  ✅
1.F-β (this PR)                                                            👉 here
Showcase repo (CRM + Accounting workspaces, #1566)                        ⏭ (separate repo)
```

After merge, the Phase 1 framework-side scope is **closed**. The remaining
piece (showcase declarations) lives in `granit-showcase-dotnet` and ships
separately.

Refs ADR-040, ADR-048, #1536, #1563.