### PR TITLE
fix(query-engine, api-documentation): $ref paged/grouped schemas + drop int32 string fallback

### DIFF
--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ public static class ApiDocumentationServiceCollectionExtensions
         services.AddTransient<ParameterDescriptionOperationTransformer>();
         services.AddTransient<SchemaExampleSchemaTransformer>();
         services.AddTransient<JsonElementSchemaTransformer>();
+        services.AddTransient<Int32SchemaTransformer>();
 
         DiscoverSchemaExampleProviders(services);
 
@@ -120,6 +121,7 @@ public static class ApiDocumentationServiceCollectionExtensions
                 openApiOptions.AddOperationTransformer<ParameterDescriptionOperationTransformer>();
                 openApiOptions.AddSchemaTransformer<SchemaExampleSchemaTransformer>();
                 openApiOptions.AddSchemaTransformer<JsonElementSchemaTransformer>();
+                openApiOptions.AddSchemaTransformer<Int32SchemaTransformer>();
             });
         }
     }

--- a/src/Granit.Http.ApiDocumentation/Transformers/Int32SchemaTransformer.cs
+++ b/src/Granit.Http.ApiDocumentation/Transformers/Int32SchemaTransformer.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Granit.Http.ApiDocumentation.Transformers;
+
+/// <summary>
+/// Normalizes <c>int</c> properties on response/request schemas. ASP.NET Core's OpenAPI
+/// generator emits them as <c>type: ["integer", "string"]</c> with a numeric pattern
+/// because System.Text.Json accepts both representations on read. The string fallback is
+/// only meaningful for <c>long</c> (JavaScript's <c>Number</c> precision tops out at 2^53);
+/// for <c>int32</c> it just adds noise and confuses code generators.
+/// </summary>
+internal sealed class Int32SchemaTransformer : IOpenApiSchemaTransformer
+{
+    /// <inheritdoc/>
+    public Task TransformAsync(
+        OpenApiSchema schema,
+        OpenApiSchemaTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        Normalize(schema);
+
+        if (schema.Properties is { } props)
+        {
+            foreach (IOpenApiSchema property in props.Values)
+            {
+                if (property is OpenApiSchema concrete)
+                {
+                    Normalize(concrete);
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void Normalize(OpenApiSchema schema)
+    {
+        if (schema.Format != "int32")
+        {
+            return;
+        }
+
+        if (schema.Type == (JsonSchemaType.Integer | JsonSchemaType.String))
+        {
+            schema.Type = JsonSchemaType.Integer;
+            schema.Pattern = null;
+        }
+        else if (schema.Type == (JsonSchemaType.Null | JsonSchemaType.Integer | JsonSchemaType.String))
+        {
+            schema.Type = JsonSchemaType.Null | JsonSchemaType.Integer;
+            schema.Pattern = null;
+        }
+    }
+}

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -278,15 +278,41 @@ public static class QueryEndpointRouteBuilderExtensions
             && concrete.Content is not null
             && concrete.Content.TryGetValue("application/json", out OpenApiMediaType? media))
         {
-            IOpenApiSchema pagedSchema = await context.GetOrCreateSchemaAsync(pagedResultType, null, cancellationToken).ConfigureAwait(false);
-            IOpenApiSchema groupedSchema = await context.GetOrCreateSchemaAsync(groupedResultType, null, cancellationToken).ConfigureAwait(false);
+            // Trigger registration in components.schemas. The returned IOpenApiSchema is the
+            // concrete schema (not a reference) — for OneOf to serialize as $ref we must
+            // construct OpenApiSchemaReference explicitly. Without this, both PagedResult and
+            // GroupedResult are inlined in the response, duplicating ~5KB per query endpoint
+            // and leaving 16 orphan *Of* schemas in components.
+            await context.GetOrCreateSchemaAsync(pagedResultType, null, cancellationToken).ConfigureAwait(false);
+            await context.GetOrCreateSchemaAsync(groupedResultType, null, cancellationToken).ConfigureAwait(false);
 
             media.Schema = new OpenApiSchema
             {
-                OneOf = [pagedSchema, groupedSchema],
+                OneOf =
+                [
+                    new OpenApiSchemaReference(GetSchemaReferenceId(pagedResultType), null),
+                    new OpenApiSchemaReference(GetSchemaReferenceId(groupedResultType), null),
+                ],
                 Description = "PagedResult when groupBy is absent; GroupedResult otherwise.",
             };
         }
+    }
+
+    /// <summary>
+    /// Mirrors the default schema reference id convention used by ASP.NET Core's OpenAPI
+    /// generator for closed generic types: <c>{TypeName}Of{Arg1}And{Arg2}...</c>.
+    /// E.g. <c>PagedResult&lt;AuditEntryResponse&gt;</c> → <c>PagedResultOfAuditEntryResponse</c>.
+    /// </summary>
+    private static string GetSchemaReferenceId(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        string name = type.Name[..type.Name.IndexOf('`')];
+        string args = string.Join("And", type.GetGenericArguments().Select(GetSchemaReferenceId));
+        return $"{name}Of{args}";
     }
 
     private static void AddParam(


### PR DESCRIPTION
## Summary

- **`MapGranitQuery`**: the operation transformer was inlining `PagedResult` and `GroupedResult` schemas inside the 200 response `oneOf` instead of `$ref`-ing the schemas already registered in `components.schemas`. Constructs `OpenApiSchemaReference` explicitly so `OneOf` serializes as `$ref`.
- **`Int32SchemaTransformer`**: new schema transformer that strips the spurious string fallback ASP.NET Core emits on `int32` properties (`type: ["integer", "string"]` with a numeric pattern). Limited to `int32` — `int64` keeps the string fallback for JS `Number` precision reasons.

## Impact (showcase OpenAPI)

Before:
- 16 query endpoints inline the `oneOf` (~4–10 KB each, ~150 KB total bloat).
- 16 `GroupedResultOf*` schemas defined in `components.schemas` but **never referenced** (orphan).
- Every `int32` field carries a regex pattern + string union type.

After:
- `oneOf` branches are `{"$ref": "#/components/schemas/PagedResultOfX"}` / `{"$ref": ".../GroupedResultOfY"}`.
- Orphan schemas become live references — no more dead components.
- `int32` fields are clean integers (or `[integer, null]` for nullable).

Resolves audit findings #1, #17, #18 from `/audit --scope openapi`.

## Out of scope (follow-up PRs)

- **#2 — entity leak in `GroupedResult.Items[]`**: requires an `IQueryEngine.ExecuteGroupedAsync<TProjection>` overload to apply the declared projection to the grouped branch. Engine API change — separate PR.
- **#3 — tag drift `/products` and `/multi-tenancy/tenants/meta`**: showcase wiring issue (different `MapGroup` calls with different `WithTags`). Showcase-side PR.

## Test plan

- [x] `dotnet build src/Granit.QueryEngine.AspNetCore` — green
- [x] `dotnet build src/Granit.Http.ApiDocumentation` — green
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests` — 48/48 pass
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests.Integration` — 7/7 pass
- [x] `dotnet test tests/Granit.Http.ApiDocumentation.Tests` — 114/114 pass
- [x] `dotnet format --verify-no-changes` on touched packages
- [ ] Visual check on showcase OpenAPI after CI/deploy: `/api/v1/auditing/audit-entries` 200 schema is `{oneOf: [{$ref}, {$ref}]}`, `entityChangeCount` is plain integer