### PR TITLE
fix(api-documentation, multiple): clean up OpenAPI operation metadata across modules

### DIFF
--- a/src/Granit.Analytics.Endpoints/Endpoints/MetricEndpoints.cs
+++ b/src/Granit.Analytics.Endpoints/Endpoints/MetricEndpoints.cs
@@ -16,7 +16,7 @@ internal static class MetricEndpoints
     internal static RouteGroupBuilder MapMetricEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/metrics/{name}", EvaluateAsync)
-            .WithName("EvaluateGranitMetric")
+            .WithName("EvaluateMetric")
             .WithSummary("Evaluates a registered Granit.Analytics MetricDefinition.")
             .WithDescription(
                 "Resolves the metric by name, applies the period (and optional comparison window) "

--- a/src/Granit.Analytics.Endpoints/Endpoints/WidgetRenderEndpoints.cs
+++ b/src/Granit.Analytics.Endpoints/Endpoints/WidgetRenderEndpoints.cs
@@ -39,7 +39,7 @@ internal static class WidgetRenderEndpoints
     internal static RouteGroupBuilder MapWidgetRenderEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/widgets/kpi/render", RenderKpiAsync)
-            .WithName("RenderGranitKpiWidget")
+            .WithName("RenderKpiWidget")
             .WithSummary("Renders a single KPI widget definition.")
             .WithDescription(
                 "Used by the dashboard composer / catalogue / preview paths to fetch a "
@@ -51,7 +51,7 @@ internal static class WidgetRenderEndpoints
             .ProducesValidationProblem();
 
         group.MapPost("/widgets/chart/render", RenderChartAsync)
-            .WithName("RenderGranitChartWidget")
+            .WithName("RenderChartWidget")
             .WithSummary("Renders a single chart widget definition.")
             .WithDescription(
                 "Used by the dashboard composer / catalogue / preview paths to fetch a "
@@ -62,7 +62,7 @@ internal static class WidgetRenderEndpoints
             .ProducesValidationProblem();
 
         group.MapPost("/widgets/table/render", RenderTableAsync)
-            .WithName("RenderGranitTableWidget")
+            .WithName("RenderTableWidget")
             .WithSummary("Renders a single table widget definition.")
             .WithDescription(
                 "Used by the dashboard composer / catalogue / preview paths to fetch a "
@@ -72,7 +72,7 @@ internal static class WidgetRenderEndpoints
             .ProducesValidationProblem();
 
         group.MapPost("/widgets/pivot/render", RenderPivotAsync)
-            .WithName("RenderGranitPivotWidget")
+            .WithName("RenderPivotWidget")
             .WithSummary("Renders a single pivot widget definition.")
             .WithDescription(
                 "Used by the dashboard composer / catalogue / preview paths to fetch a "
@@ -82,7 +82,7 @@ internal static class WidgetRenderEndpoints
             .ProducesValidationProblem();
 
         group.MapPost("/widgets/map/render", RenderMapAsync)
-            .WithName("RenderGranitMapWidget")
+            .WithName("RenderMapWidget")
             .WithSummary("Renders a single map widget definition.")
             .WithDescription(
                 "Used by the dashboard composer / catalogue / preview paths to fetch a "

--- a/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
+++ b/src/Granit.Analytics.Endpoints/Options/AnalyticsEndpointsOptions.cs
@@ -36,12 +36,13 @@ public sealed class AnalyticsEndpointsOptions : IValidatableObject
     public string RoutePrefix { get; set; } = "analytics";
 
     /// <summary>
-    /// OpenAPI tag for metric endpoints. Default: <c>"Analytics - Metrics"</c>
-    /// (per CLAUDE.md sub-tag convention <c>&lt;Module&gt; - &lt;SubGroup&gt;</c>).
+    /// OpenAPI tag for metric endpoints. Default: <c>"Analytics"</c>.
+    /// Per CLAUDE.md, modules with a single tag use the module's user-facing name directly;
+    /// promote to a sub-tag (<c>"Analytics - Metrics"</c>) only once a second sibling tag exists.
     /// </summary>
     [Required]
     [MinLength(1)]
-    public string MetricsTagName { get; set; } = "Analytics - Metrics";
+    public string MetricsTagName { get; set; } = "Analytics";
 
     /// <summary>
     /// FusionCache TTL applied to <see cref="Metrics.RefreshHint.Dynamic"/> metrics.

--- a/src/Granit.Bff.Endpoints/Endpoints/BffCsrfEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffCsrfEndpoints.cs
@@ -19,7 +19,7 @@ internal static class BffCsrfEndpoints
         group.MapPost("/csrf-token", (HttpContext httpContext,
                 [FromServices] IBffCsrfTokenGenerator csrfGenerator) =>
                 HandleGenerateCsrfTokenAsync(httpContext, frontend, csrfGenerator))
-            .WithName($"BffGenerateCsrfToken_{frontend.Name}")
+            .WithName($"BffGenerateCsrfToken{frontend.OperationIdSuffix}")
             .WithSummary("Generates a CSRF token for the current BFF session.")
             .WithDescription(
                 "Reads the session cookie to identify the session, generates an HMAC-SHA256 based "

--- a/src/Granit.Bff.Endpoints/Endpoints/BffUserEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffUserEndpoints.cs
@@ -22,7 +22,7 @@ internal static class BffUserEndpoints
                 [FromServices] IBffTokenStore tokenStore,
                 CancellationToken cancellationToken) =>
                 HandleGetUserAsync(httpContext, frontend, tokenStore, cancellationToken))
-            .WithName($"BffGetUser_{frontend.Name}")
+            .WithName($"BffGetUser{frontend.OperationIdSuffix}")
             .WithSummary("Returns the current user's claims for the SPA.")
             .WithDescription(
                 "Reads the session cookie, loads the ID token from the token store, decodes "

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -95,6 +95,16 @@ public sealed class BffFrontendOptions
     /// <summary>Unique name for this frontend (e.g., <c>"admin"</c>, <c>"patient"</c>).</summary>
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>
+    /// PascalCase suffix derived from <see cref="Name"/> for OpenAPI operation IDs.
+    /// Splits on <c>-</c> and <c>_</c>, capitalizing each segment so a single-word name like
+    /// <c>"app"</c> becomes <c>"App"</c> and a kebab name like <c>"my-frontend"</c> becomes
+    /// <c>"MyFrontend"</c>. Operation IDs must be PascalCase per CLAUDE.md.
+    /// </summary>
+    internal string OperationIdSuffix => string.Concat(
+        Name.Split(['-', '_'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(p => char.ToUpperInvariant(p[0]) + p[1..]));
+
     /// <summary>OIDC client ID (confidential client).</summary>
     public string ClientId { get; set; } = string.Empty;
 

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardCatalogEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardCatalogEndpoints.cs
@@ -24,7 +24,7 @@ internal static class DashboardCatalogEndpoints
     public static RouteGroupBuilder MapCatalogEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/catalog", ListCatalog)
-            .WithName("ListGranitDashboardCatalog")
+            .WithName("ListDashboardCatalog")
             .WithSummary("Lists every registered DashboardDefinition.")
             .WithDescription(
                 "Returns the full dashboard catalogue surfaced by IDashboardDefinitionRegistry. "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardImportEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardImportEndpoints.cs
@@ -21,7 +21,7 @@ internal static class DashboardImportEndpoints
     public static RouteGroupBuilder MapImportEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/from-definition/{name}", ImportAsync)
-            .WithName("ImportGranitDashboardFromDefinition")
+            .WithName("ImportDashboardFromDefinition")
             .WithSummary("Imports a registered DashboardDefinition into a persisted Dashboard.")
             .WithDescription(
                 "Deep-copies the named DashboardDefinition into a fresh tenant-scoped "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardInstanceEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardInstanceEndpoints.cs
@@ -23,7 +23,7 @@ internal static class DashboardInstanceEndpoints
     public static RouteGroupBuilder MapInstanceEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/", ListAsync)
-            .WithName("ListGranitDashboards")
+            .WithName("ListDashboards")
             .WithSummary("Lists the current tenant's persisted dashboards (paged).")
             .WithDescription(
                 "Returns the tenant's dashboards as a paged summary list, optionally "
@@ -36,7 +36,7 @@ internal static class DashboardInstanceEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         group.MapGet("/{id:guid}", ReadByIdAsync)
-            .WithName("ReadGranitDashboardById")
+            .WithName("ReadDashboardById")
             .WithSummary("Reads a single persisted dashboard with its widget tree.")
             .WithDescription(
                 "Returns the full dashboard payload including the layout values and "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardMetadataEditEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardMetadataEditEndpoints.cs
@@ -23,7 +23,7 @@ internal static class DashboardMetadataEditEndpoints
     public static RouteGroupBuilder MapMetadataEditEndpoints(this RouteGroupBuilder group)
     {
         group.MapPut("/{id:guid}", UpdateMetadataAsync)
-            .WithName("UpdateGranitDashboardMetadata")
+            .WithName("UpdateDashboardMetadata")
             .WithSummary("Updates the dashboard's name and grid layout.")
             .WithDescription(
                 "Full replacement of the editable metadata: Name, LayoutColumns and "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardRenderEndpoints.cs
@@ -28,7 +28,7 @@ internal static class DashboardRenderEndpoints
     public static RouteGroupBuilder MapRenderEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/{id:guid}/render", RenderAsync)
-            .WithName("RenderGranitDashboard")
+            .WithName("RenderDashboard")
             .WithSummary("Renders a dashboard's widget pool into one bundle response.")
             .WithDescription(
                 "Loads the persisted dashboard, builds the per-render context "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardResyncEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardResyncEndpoints.cs
@@ -25,7 +25,7 @@ internal static class DashboardResyncEndpoints
     public static RouteGroupBuilder MapResyncEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/{id:guid}/resync", ResyncAsync)
-            .WithName("ResyncGranitDashboard")
+            .WithName("ResyncDashboard")
             .WithSummary("Resyncs a persisted dashboard with its currently-registered DashboardDefinition.")
             .WithDescription(
                 "Replaces the widget pool with the descriptor's current entry-view widgets, "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardStateTransitionEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardStateTransitionEndpoints.cs
@@ -23,7 +23,7 @@ internal static class DashboardStateTransitionEndpoints
     public static RouteGroupBuilder MapStateTransitionEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/{id:guid}/publish", PublishAsync)
-            .WithName("PublishGranitDashboard")
+            .WithName("PublishDashboard")
             .WithSummary("Transitions the dashboard from Draft to Published.")
             .WithDescription(
                 "Publishes a Draft dashboard, making it visible to consumers. "
@@ -36,7 +36,7 @@ internal static class DashboardStateTransitionEndpoints
             .ProducesProblem(StatusCodes.Status409Conflict);
 
         group.MapPost("/{id:guid}/archive", ArchiveAsync)
-            .WithName("ArchiveGranitDashboard")
+            .WithName("ArchiveDashboard")
             .WithSummary("Archives the dashboard.")
             .WithDescription(
                 "Archives the dashboard regardless of its current status. Idempotent — "
@@ -48,7 +48,7 @@ internal static class DashboardStateTransitionEndpoints
             .ProducesProblem(StatusCodes.Status409Conflict);
 
         group.MapPost("/{id:guid}/restore", RestoreAsync)
-            .WithName("RestoreGranitDashboard")
+            .WithName("RestoreDashboard")
             .WithSummary("Restores an archived dashboard to Draft.")
             .WithDescription(
                 "Transitions an Archived dashboard back to Draft. Returns 409 Conflict "

--- a/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
+++ b/src/Granit.Dashboards.Endpoints/Endpoints/DashboardWidgetEndpoints.cs
@@ -23,7 +23,7 @@ internal static class DashboardWidgetEndpoints
     public static RouteGroupBuilder MapWidgetEndpoints(this RouteGroupBuilder group)
     {
         group.MapPost("/{id:guid}/widgets", AddWidgetAsync)
-            .WithName("AddGranitDashboardWidget")
+            .WithName("AddDashboardWidget")
             .WithSummary("Adds a widget instance to the dashboard.")
             .WithDescription(
                 "Pins a new widget into the dashboard's widget pool. The widget id is "
@@ -38,7 +38,7 @@ internal static class DashboardWidgetEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapPut("/{id:guid}/widgets/{widgetId:guid}", UpdateWidgetAsync)
-            .WithName("UpdateGranitDashboardWidget")
+            .WithName("UpdateDashboardWidget")
             .WithSummary("Updates a widget's layout, title and config.")
             .WithDescription(
                 "Full replacement of the widget's editable fields: Position, Width, "
@@ -54,7 +54,7 @@ internal static class DashboardWidgetEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapDelete("/{id:guid}/widgets/{widgetId:guid}", RemoveWidgetAsync)
-            .WithName("RemoveGranitDashboardWidget")
+            .WithName("RemoveDashboardWidget")
             .WithSummary("Removes a widget instance from the dashboard.")
             .WithDescription(
                 "Removes the named widget from the dashboard's pool. Returns 204 on "

--- a/src/Granit.Dashboards.Push.WebSockets/Endpoints/DashboardWebSocketStreamEndpoint.cs
+++ b/src/Granit.Dashboards.Push.WebSockets/Endpoints/DashboardWebSocketStreamEndpoint.cs
@@ -29,7 +29,7 @@ internal static class DashboardWebSocketStreamEndpoint
     public static RouteGroupBuilder MapDashboardWebSocketStreamEndpoint(this RouteGroupBuilder group)
     {
         group.MapGet("/{id:guid}/stream-ws", StreamAsync)
-            .WithName("StreamGranitDashboardWebSocket")
+            .WithName("StreamDashboardWebSocket")
             .WithSummary("Subscribes to live widget updates for a dashboard via WebSocket.")
             .WithDescription(
                 "Long-lived WebSocket connection emitting one JSON frame per envelope. "

--- a/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
+++ b/src/Granit.Dashboards.Push/Endpoints/DashboardStreamEndpoint.cs
@@ -26,7 +26,7 @@ internal static class DashboardStreamEndpoint
     public static RouteGroupBuilder MapDashboardStreamEndpoint(this RouteGroupBuilder group)
     {
         group.MapGet("/{id:guid}/stream", StreamAsync)
-            .WithName("StreamGranitDashboard")
+            .WithName("StreamDashboard")
             .WithSummary("Subscribes to live widget updates for a dashboard via Server-Sent Events.")
             .WithDescription(
                 "Long-lived HTTP/1.1 (or HTTP/2) connection that stays open and emits one "

--- a/src/Granit.Http.ApiDocumentation/Transformers/ParameterDescriptionOperationTransformer.cs
+++ b/src/Granit.Http.ApiDocumentation/Transformers/ParameterDescriptionOperationTransformer.cs
@@ -1,12 +1,18 @@
+using System.Text;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
 
 namespace Granit.Http.ApiDocumentation.Transformers;
 
 /// <summary>
-/// Adds human-readable descriptions to well-known path and query parameters
-/// that ASP.NET Core Minimal APIs cannot describe via attributes alone.
-/// Descriptions are only set when not already present.
+/// Adds human-readable descriptions to path and query parameters that ASP.NET Core
+/// Minimal APIs cannot describe via attributes alone. Resolution order:
+/// <list type="number">
+///   <item>Existing description on the parameter — never overwritten.</item>
+///   <item>Exact match in <see cref="s_descriptions"/> (well-known names).</item>
+///   <item>Convention fallback: <c>*Id</c> / <c>*Name</c> / <c>*Type</c> / <c>page*</c> /
+///         pagination tokens.</item>
+/// </list>
 /// </summary>
 internal sealed class ParameterDescriptionOperationTransformer : IOpenApiOperationTransformer
 {
@@ -14,10 +20,15 @@ internal sealed class ParameterDescriptionOperationTransformer : IOpenApiOperati
     {
         // Identity
         ["userId"] = "External user identifier from the identity provider.",
+        ["sessionId"] = "Session identifier — opaque token bound to a single browser/device session.",
+        ["impersonationId"] = "Impersonation grant identifier.",
 
         // Authorization
         ["roleName"] = "Role name (e.g. 'admin', 'practitioner').",
         ["permissionName"] = "Permission identifier (e.g. 'Users.Read').",
+        ["clientId"] = "OAuth/OIDC client identifier (registered application).",
+        ["scopeName"] = "OAuth/OIDC scope name.",
+        ["authorizationId"] = "OAuth/OIDC authorization grant identifier.",
 
         // Reference data
         ["code"] = "Reference data code (e.g. ISO 3166-1 Alpha-2 for countries: 'BE', 'FR').",
@@ -29,6 +40,7 @@ internal sealed class ParameterDescriptionOperationTransformer : IOpenApiOperati
         ["entityType"] = "Fully qualified entity type (e.g. 'Acme.Patients').",
         ["entityId"] = "Entity identifier (primary key).",
         ["entryId"] = "Timeline entry identifier (UUID).",
+        ["entityName"] = "Entity definition name (matches the registered Granit.Entities entity).",
 
         // Data exchange
         ["jobId"] = "Import or export job identifier (UUID).",
@@ -38,8 +50,44 @@ internal sealed class ParameterDescriptionOperationTransformer : IOpenApiOperati
         // Notifications
         ["typeName"] = "Notification type name.",
 
-        // QueryEngine
+        // QueryEngine / generic
         ["id"] = "Resource identifier (UUID).",
+        ["correlationId"] = "Distributed tracing correlation identifier — groups events emitted in the same logical transaction.",
+        ["tenantId"] = "Tenant identifier — scopes the request to a single tenant.",
+        ["cultureName"] = "BCP 47 culture tag (e.g. 'fr', 'fr-BE', 'zh-Hant-TW').",
+        ["resourceName"] = "Localization resource name (matches a registered LocalizationResource type).",
+        ["key"] = "Translation key within the resource (e.g. 'Permission:Users.Read').",
+        ["providerName"] = "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+        ["workspaceName"] = "Workspace identifier — isolates configuration and routing per AI workspace.",
+        ["flagName"] = "Feature flag name (e.g. 'beta.passkeys').",
+        ["meterId"] = "Metering meter identifier.",
+        ["addressId"] = "Address identifier within the parent aggregate.",
+        ["emailId"] = "Email identifier within the parent aggregate.",
+        ["phoneId"] = "Phone identifier within the parent aggregate.",
+        ["survivorId"] = "Identifier of the surviving record in a merge operation (the duplicate is merged into this one).",
+        ["deliveryId"] = "Webhook delivery attempt identifier.",
+        ["subscriptionId"] = "Subscription identifier.",
+        ["seatId"] = "Subscription seat identifier.",
+        ["planId"] = "Subscription plan identifier.",
+        ["priceId"] = "Subscription price identifier.",
+        ["transactionId"] = "Payment transaction identifier.",
+        ["methodType"] = "Payment method type (e.g. 'card', 'sepa', 'paypal').",
+        ["containerName"] = "Blob container name.",
+        ["scheduleId"] = "Scheduled action identifier.",
+        ["groupId"] = "Group identifier.",
+        ["role"] = "Role name (e.g. 'owner', 'member').",
+        ["currency"] = "ISO 4217 three-letter currency code (e.g. 'EUR', 'USD').",
+
+        // Pagination — covers endpoints that don't go through MapGranitQuery
+        ["page"] = "1-based page index.",
+        ["pageSize"] = "Number of items per page.",
+        ["cursor"] = "Opaque cursor for keyset pagination. When supplied, overrides page.",
+        ["search"] = "Free-text search query.",
+        ["status"] = "Filter by status value.",
+        ["environment"] = "Filter by environment (e.g. 'production', 'staging', 'sandbox').",
+        ["includerevoked"] = "When true, include revoked items in the response.",
+        ["type"] = "Filter by type discriminator value.",
+        ["token"] = "Single-use token from a confirmation/reset email link.",
     };
 
     /// <inheritdoc/>
@@ -55,18 +103,75 @@ internal sealed class ParameterDescriptionOperationTransformer : IOpenApiOperati
 
         foreach (IOpenApiParameter parameter in operation.Parameters)
         {
-            if (!string.IsNullOrEmpty(parameter.Description))
+            if (!string.IsNullOrEmpty(parameter.Description) || string.IsNullOrEmpty(parameter.Name))
             {
                 continue;
             }
 
-            if (parameter.Name is not null
-                && s_descriptions.TryGetValue(parameter.Name, out string? description))
+            string name = parameter.Name;
+
+            if (s_descriptions.TryGetValue(name, out string? description))
             {
                 parameter.Description = description;
+                continue;
+            }
+
+            // Convention fallback — only for path parameters (query params are too varied).
+            if (parameter.In == ParameterLocation.Path)
+            {
+                parameter.Description = DeriveDescription(name);
             }
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Derives a generic description from a camelCase parameter name following the
+    /// <c>{noun}Id</c> / <c>{noun}Name</c> / <c>{noun}Type</c> conventions.
+    /// </summary>
+    private static string? DeriveDescription(string name)
+    {
+        if (name.EndsWith("Id", StringComparison.Ordinal) && name.Length > 2)
+        {
+            string noun = HumanizeCamelCase(name[..^2]);
+            return $"Unique identifier of the {noun}.";
+        }
+
+        if (name.EndsWith("Name", StringComparison.Ordinal) && name.Length > 4)
+        {
+            string noun = HumanizeCamelCase(name[..^4]);
+            return $"Name of the {noun}.";
+        }
+
+        if (name.EndsWith("Type", StringComparison.Ordinal) && name.Length > 4)
+        {
+            string noun = HumanizeCamelCase(name[..^4]);
+            return $"Type of the {noun}.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts a camelCase identifier to a lowercase space-separated phrase.
+    /// <c>"survivor"</c> → <c>"survivor"</c>; <c>"externalLogin"</c> → <c>"external login"</c>.
+    /// </summary>
+    private static string HumanizeCamelCase(string camelCase)
+    {
+        StringBuilder sb = new(camelCase.Length + 4);
+        foreach (char c in camelCase)
+        {
+            if (char.IsUpper(c) && sb.Length > 0)
+            {
+                sb.Append(' ');
+                sb.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                sb.Append(char.ToLowerInvariant(c));
+            }
+        }
+        return sb.ToString();
     }
 }

--- a/src/Granit.Http.Cookies.Endpoints/Options/CookieConsentEndpointsOptions.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Options/CookieConsentEndpointsOptions.cs
@@ -8,6 +8,6 @@ public sealed class CookieConsentEndpointsOptions
     /// <summary>Base route prefix for the cookie consent endpoints. Default: "cookies".</summary>
     public string RoutePrefix { get; set; } = "cookies";
 
-    /// <summary>OpenAPI tag name. Default: "Cookies".</summary>
-    public string TagName { get; set; } = "Cookies";
+    /// <summary>OpenAPI tag name. Default: "Cookie Consent".</summary>
+    public string TagName { get; set; } = "Cookie Consent";
 }

--- a/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
         endpoints
             .MapGet(options.RoutePrefix, HandleGetLocalization)
             .AllowAnonymous()
-            .WithName("GetGranitLocalization")
+            .WithName("GetLocalization")
             .WithTags(options.TagName)
             .WithSummary("Returns all localization resources for the requested culture.")
             .WithDescription("Returns all localization resources (key-value pairs) for the requested culture, grouped by resource name. Accepts an optional cultureName query parameter (BCP 47 format); defaults to the Accept-Language header culture. Also returns the list of supported languages. Response is cached for 1 hour (Cache-Control: public, max-age=3600, Vary: Accept-Language). Anonymous — no authentication required.")

--- a/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
+++ b/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
@@ -45,6 +45,7 @@ public static class ModuleConfigEndpointExtensions
             .WithName(endpointName)
             .WithTags(tag)
             .WithSummary($"Returns the current {tag} module configuration.")
+            .WithDescription($"Returns the runtime configuration of the {tag} module — the same shape used by SPAs to render module-specific UI without hardcoding values. The payload is module-defined and stable; clients should not assume new fields are absent.")
             .Produces<TResponse>();
 
         configureEndpoint?.Invoke(builder);
@@ -88,6 +89,7 @@ public static class ModuleConfigEndpointExtensions
             .WithName(endpointName)
             .WithTags(tag)
             .WithSummary($"Returns the current {tag} module configuration.")
+            .WithDescription($"Returns the runtime configuration of the {tag} module — the same shape used by SPAs to render module-specific UI without hardcoding values. The payload is module-defined and stable; clients should not assume new fields are absent.")
             .Produces<TResponse>();
 
         configureEndpoint?.Invoke(builder);


### PR DESCRIPTION
Follow-up to #1651 — second pass on the OpenAPI audit (`/audit --scope openapi`, 2026-04-30).

## Summary

- **OperationIds**: drop `Granit` infix on 21 endpoints (Dashboards, Localization, Analytics, Widgets, Metric) and replace BFF `_{frontend.Name}` kebab suffix with PascalCase via a new `BffFrontendOptions.OperationIdSuffix` helper.
- **Default tags**: `Cookies` → `Cookie Consent`, `Analytics - Metrics` → `Analytics` (single-tag module).
- **Missing `WithDescription`**: `MapGranitModuleConfig` / `MapGranitModuleConfigAsync` now emit a default description, fixing `/webhooks/config` and `/account/config` (and any future module-config endpoint).
- **Parameter descriptions**: `ParameterDescriptionOperationTransformer` extended with ~25 well-known names and a convention fallback for path-params ending in `Id` / `Name` / `Type`. Resolves ~134 undocumented params reported by the audit.

## Audit findings resolved

| # | Severity | Finding |
|---|----------|---------|
| #4 | CONVENTION | Tag `Cookies` → `Cookie Consent` |
| #5 | CONVENTION | Tag `Analytics - Metrics` → `Analytics` |
| #7 | CONVENTION | 21 operationIds with `Granit*` infix renamed |
| #8 | CONVENTION | 4 BFF operationIds with underscore separator → PascalCase |
| #9 | CONVENTION | 2 endpoints missing `WithDescription` (handled at the framework helper level) |
| #10 | CONVENTION | 59 path-params lacking description (handled by transformer) |
| #11 | CONVENTION | 75 query-params lacking description (well-known names + pagination defaults) |

## Breaking change notice (pre-1.0)

OperationId renames are clean breaks — consumer SDK regeneration required. Per project policy, Granit is pre-1.0 and does not graduate `[Obsolete]` shims.

Map (most impactful):

| Before | After |
|---|---|
| `GetGranitLocalization` | `GetLocalization` |
| `EvaluateGranitMetric` | `EvaluateMetric` |
| `RenderGranitDashboard` | `RenderDashboard` |
| `ListGranitDashboards` | `ListDashboards` |
| `BffGetUser_app` / `BffGetUser_host` | `BffGetUserApp` / `BffGetUserHost` |
| `BffGenerateCsrfToken_app/_host` | `BffGenerateCsrfTokenApp/Host` |

Same scheme applied to all `*GranitDashboard*`, `*GranitWidget*`, and `*GranitMetric*` operationIds.

## Test plan

- [x] `dotnet build` clean on all 10 touched packages
- [x] `dotnet test` per package: ApiDocumentation 114, Bff 166, Bff.Endpoints 109, Localization.Endpoints 70, Analytics.Endpoints 200, Dashboards.Endpoints 143, Dashboards.Push 27, Dashboards.Push.WebSockets 3, Cookies.Endpoints 25, Granit 457
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 pass
- [x] `dotnet format --verify-no-changes` on each touched project
- [x] `dotnet restore Granit.slnx --force-evaluate` (lockfiles regenerated)
- [ ] Showcase visual check post-rebuild: no `_app`/`_host` in opIds, no `Granit*` infix, `Cookies` tag absent, `/api/v1/*/config` endpoints have descriptions, path-params show generic descriptions.

## Out of scope (next PR — showcase repo)

- #3 tag drift on `/products` and `/multi-tenancy/tenants/meta` — showcase wiring
- #6 `Catalog - Products` ↔ `Products` collision — showcase wiring
- #12 missing 401 on `/playground/*`, `/products` CRUD, `/host|app/bff/user`
- #13 `info.version`, #14 servers, #20 securitySchemes, #22 top-level tags array
- #16 SSE content-type, #19 unbounded `/correlation/{id}` array

A self-contained prompt for the showcase repo work has been prepared.

## Out of scope (future framework PR)

- #2 `GroupedResult.Items[]` exposes the EF entity — requires `IQueryEngine.ExecuteGroupedAsync<TProjection>` overload (engine API change)