### PR TITLE
feat(query-engine): project grouped result items so OpenAPI exposes the DTO

### DIFF
--- a/src/Granit.QueryEngine.Abstractions/IQueryEngine.cs
+++ b/src/Granit.QueryEngine.Abstractions/IQueryEngine.cs
@@ -55,6 +55,28 @@ public interface IQueryEngine<TEntity> where TEntity : class
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Executes a grouped query and projects each materialized item to <typeparamref name="TProjection"/>
+    /// before assembling the <see cref="GroupedResult{T}"/>. The grouping is computed on the entity
+    /// columns (the <see cref="QueryRequest.GroupBy"/> property must exist on <typeparamref name="TEntity"/>),
+    /// then items inside each group are projected so the response contract exposes the projected shape
+    /// instead of the raw entity.
+    /// </summary>
+    /// <typeparam name="TProjection">The projected item type returned in <c>GroupedResult&lt;TProjection&gt;.Groups[].Items</c>.</typeparam>
+    /// <param name="source">The base queryable.</param>
+    /// <param name="request">The query parameters (must include <see cref="QueryRequest.GroupBy"/>).</param>
+    /// <param name="projection">
+    /// A projection expression applied to each materialized entity. Compiled and applied in-memory
+    /// after materialization (the group-by property must remain on the entity for key extraction).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A grouped result whose items are projected.</returns>
+    Task<GroupedResult<TProjection>> ExecuteGroupedAsync<TProjection>(
+        IQueryable<TEntity> source,
+        QueryRequest request,
+        Expression<Func<TEntity, TProjection>> projection,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Executes a query and streams all matching entities without pagination.
     /// Applies filtering and sorting from the <paramref name="request"/> but returns
     /// every matching row as an async stream — used by the export pipeline.

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -188,9 +188,9 @@ public static class QueryEndpointRouteBuilderExtensions
         var projection = (Expression<Func<TEntity, TDto>>)projectionLambda;
         string dtoName = typeof(TDto).Name;
 
-        // groupBy is incompatible with per-row projection: grouping operates on entity columns
-        // and returns aggregated rows, not entity rows — the declarative projection is ignored
-        // for the grouped branch and GroupedResult<TEntity> is returned unchanged.
+        // The projection applies to BOTH branches: paged uses SQL-level projection (typed
+        // ExecuteAsync<TDto>); grouped applies the same projection in-memory after entity
+        // materialization so GroupedResult.Items[] surfaces TDto, never the raw entity.
 #pragma warning disable GRAPI001 // Results.Ok is needed here for polymorphic return
         group.MapGet("/", async (
             [FromServices] IQueryEngine<TEntity> engine,
@@ -202,8 +202,8 @@ public static class QueryEndpointRouteBuilderExtensions
 
             if (!string.IsNullOrWhiteSpace(request.Value.GroupBy))
             {
-                GroupedResult<TEntity> grouped = await engine
-                    .ExecuteGroupedAsync(source, request.Value, cancellationToken)
+                GroupedResult<TDto> grouped = await engine
+                    .ExecuteGroupedAsync(source, request.Value, projection, cancellationToken)
                     .ConfigureAwait(false);
                 return Results.Ok(grouped);
             }
@@ -216,12 +216,12 @@ public static class QueryEndpointRouteBuilderExtensions
 #pragma warning restore GRAPI001
         .WithName($"Query{entityName}")
         .WithSummary($"Returns a filtered, sorted, and paginated list of {dtoName} entries projected from {entityName}.")
-        .WithDescription($"Executes a dynamic query against {entityName} using the Granit query engine and projects each row to {dtoName}. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<{dtoName}> by default. When the groupBy query parameter is specified, returns a GroupedResult<{entityName}> instead (projection is not applied to grouped queries).")
+        .WithDescription($"Executes a dynamic query against {entityName} using the Granit query engine and projects each row to {dtoName}. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<{dtoName}> by default. When the groupBy query parameter is specified, returns a GroupedResult<{dtoName}> with the same projection applied to the items inside each group.")
         .Produces<PagedResult<TDto>>()
-        .Produces<GroupedResult<TEntity>>(StatusCodes.Status200OK)
+        .Produces<GroupedResult<TDto>>(StatusCodes.Status200OK)
         .ProducesValidationProblem()
         .AddOpenApiOperationTransformer((op, ctx, ct) =>
-            DescribeQueryEndpointAsync(op, ctx, typeof(PagedResult<TDto>), typeof(GroupedResult<TEntity>), ct));
+            DescribeQueryEndpointAsync(op, ctx, typeof(PagedResult<TDto>), typeof(GroupedResult<TDto>), ct));
     }
 
     /// <summary>

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -165,10 +165,35 @@ internal sealed class QueryEngine<TEntity>(
     }
 
     /// <inheritdoc/>
-    public async Task<GroupedResult<TEntity>> ExecuteGroupedAsync(
+    public Task<GroupedResult<TEntity>> ExecuteGroupedAsync(
         IQueryable<TEntity> source,
         QueryRequest request,
+        CancellationToken cancellationToken = default) =>
+        ExecuteGroupedCoreAsync<TEntity>(source, request, projector: null, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<GroupedResult<TProjection>> ExecuteGroupedAsync<TProjection>(
+        IQueryable<TEntity> source,
+        QueryRequest request,
+        Expression<Func<TEntity, TProjection>> projection,
         CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        Func<TEntity, TProjection> projector = projection.Compile();
+        return ExecuteGroupedCoreAsync(source, request, projector, cancellationToken);
+    }
+
+    /// <summary>
+    /// Common grouped execution. When <paramref name="projector"/> is <see langword="null"/>,
+    /// the items inside each group are returned as <typeparamref name="TItem"/> = <typeparamref name="TEntity"/>.
+    /// When supplied, the projector is applied in-memory after materialization so the result
+    /// surfaces the projected shape (matches the contract exposed by <c>MapGranitQuery</c>).
+    /// </summary>
+    private async Task<GroupedResult<TItem>> ExecuteGroupedCoreAsync<TItem>(
+        IQueryable<TEntity> source,
+        QueryRequest request,
+        Func<TEntity, TItem>? projector,
+        CancellationToken cancellationToken)
     {
         using Activity? activity = QueryEngineEfCoreActivitySource.Source.StartActivity(QueryEngineEfCoreActivitySource.ExecuteGrouped);
         activity?.SetTag("entity_type", EntityTypeName);
@@ -176,21 +201,22 @@ internal sealed class QueryEngine<TEntity>(
 
         if (string.IsNullOrWhiteSpace(request.GroupBy))
         {
-            return new GroupedResult<TEntity>([], 0);
+            return new GroupedResult<TItem>([], 0);
         }
 
         IQueryable<TEntity> query = ApplyCommonFilters(source.AsNoTracking(), request);
 
-        GroupedResult<TEntity> result = await query.ApplyGroupByAsync(
+        GroupedResult<TEntity> entityResult = await query.ApplyGroupByAsync(
             request.GroupBy, _builder, engineOptions.Value.MaxGroupCount, cancellationToken)
             .ConfigureAwait(false);
 
-        // Populate items per group: sort the filtered set, materialize, then distribute by group key
-        if (result.Groups.Count > 0)
+        List<GroupEntry<TItem>> groups = new(entityResult.Groups.Count);
+
+        if (entityResult.Groups.Count > 0)
         {
             IQueryable<TEntity> sorted = query.ApplySort(request.Sort, _builder);
             List<TEntity> allItems = await sorted
-                .Take(_builder.MaxPageSizeValue * result.Groups.Count)
+                .Take(_builder.MaxPageSizeValue * entityResult.Groups.Count)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
@@ -198,21 +224,32 @@ internal sealed class QueryEngine<TEntity>(
                 request.GroupBy,
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
 
-            if (groupProp is not null)
+            ILookup<string, TItem>? itemsByKey = groupProp is null
+                ? null
+                : allItems.ToLookup(
+                    e => groupProp.GetValue(e)?.ToString() ?? "(null)",
+                    e => projector is null ? (TItem)(object)e : projector(e));
+
+            foreach (GroupEntry<TEntity> group in entityResult.Groups)
             {
-                ILookup<string, TEntity> itemsByKey = allItems
-                    .ToLookup(e => groupProp.GetValue(e)?.ToString() ?? "(null)");
+                IReadOnlyList<TItem>? items = itemsByKey is null
+                    ? null
+                    : itemsByKey[group.Value?.ToString() ?? "(null)"].ToList();
 
-                var populated = result.Groups
-                    .Select(g => g with { Items = itemsByKey[g.Value?.ToString() ?? "(null)"].ToList() })
-                    .ToList();
-
-                result = new GroupedResult<TEntity>(populated, result.TotalCount);
+                groups.Add(new GroupEntry<TItem>
+                {
+                    Field = group.Field,
+                    Value = group.Value,
+                    Label = group.Label,
+                    Count = group.Count,
+                    Aggregates = group.Aggregates,
+                    Items = items,
+                });
             }
         }
 
         RecordMetrics("grouped", startTimestamp);
-        return result;
+        return new GroupedResult<TItem>(groups, entityResult.TotalCount);
     }
 
     /// <inheritdoc/>

--- a/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
@@ -800,6 +800,12 @@ public sealed class ExportOrchestratorTests
             IQueryable<TestEntity> source, QueryRequest request, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
 
+        public Task<GroupedResult<TProjection>> ExecuteGroupedAsync<TProjection>(
+            IQueryable<TestEntity> source, QueryRequest request,
+            System.Linq.Expressions.Expression<Func<TestEntity, TProjection>> projection,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
         public QueryMetadata GetMetadata() =>
             throw new NotSupportedException();
 

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointProjectionTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointProjectionTests.cs
@@ -89,10 +89,10 @@ public sealed class QueryEndpointProjectionTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task Query_with_projection_and_groupBy_returns_entity_grouped_result()
+    public async Task Query_with_projection_and_groupBy_returns_projected_grouped_result()
     {
-        GroupedResult<TestProduct> expected = new(
-            [new GroupEntry<TestProduct>
+        GroupedResult<TestProductDto> expected = new(
+            [new GroupEntry<TestProductDto>
             {
                 Field = "Category",
                 Value = "Electronics",
@@ -104,6 +104,7 @@ public sealed class QueryEndpointProjectionTests : IAsyncDisposable
         _engine.ExecuteGroupedAsync(
             Arg.Any<IQueryable<TestProduct>>(),
             Arg.Any<QueryRequest>(),
+            Arg.Any<System.Linq.Expressions.Expression<Func<TestProduct, TestProductDto>>>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
 
@@ -115,6 +116,13 @@ public sealed class QueryEndpointProjectionTests : IAsyncDisposable
         await _engine.Received(1).ExecuteGroupedAsync(
             Arg.Any<IQueryable<TestProduct>>(),
             Arg.Is<QueryRequest>(r => r.GroupBy == "Category"),
+            Arg.Any<System.Linq.Expressions.Expression<Func<TestProduct, TestProductDto>>>(),
+            Arg.Any<CancellationToken>());
+
+        // Entity-typed grouped overload must NOT be called when a projection is declared.
+        await _engine.DidNotReceive().ExecuteGroupedAsync(
+            Arg.Any<IQueryable<TestProduct>>(),
+            Arg.Any<QueryRequest>(),
             Arg.Any<CancellationToken>());
 
         await _engine.DidNotReceive().ExecuteAsync(

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableGroupByExtensionsTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableGroupByExtensionsTests.cs
@@ -124,4 +124,43 @@ public sealed class QueryableGroupByExtensionsTests : IAsyncLifetime
         result.Groups.ShouldBeEmpty();
         result.TotalCount.ShouldBe(0);
     }
+
+    [Fact]
+    public async Task GroupBy_with_projection_returns_projected_items()
+    {
+        QueryEngine<TestProduct> engine = new(new GroupByDefinition(), NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        GroupedResult<ProductSummary> result = await engine.ExecuteGroupedAsync(
+            _db.Products.AsQueryable(),
+            new QueryRequest { GroupBy = "Category" },
+            p => new ProductSummary(p.Name, p.Price),
+            TestContext.Current.CancellationToken);
+
+        result.Groups.Count.ShouldBe(3);
+        result.TotalCount.ShouldBe(5);
+
+        GroupEntry<ProductSummary> electronics = result.Groups.First(g => g.Label == "Electronics");
+        electronics.Count.ShouldBe(3);
+        electronics.Items.ShouldNotBeNull();
+        electronics.Items!.Count.ShouldBe(3);
+        electronics.Items.ShouldAllBe(item => item is ProductSummary);
+        electronics.Items.Select(i => i.Name).ShouldContain("Laptop");
+    }
+
+    [Fact]
+    public async Task GroupBy_with_projection_and_empty_groupBy_returns_empty()
+    {
+        QueryEngine<TestProduct> engine = new(new GroupByDefinition(), NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        GroupedResult<ProductSummary> result = await engine.ExecuteGroupedAsync(
+            _db.Products.AsQueryable(),
+            new QueryRequest { GroupBy = null },
+            p => new ProductSummary(p.Name, p.Price),
+            TestContext.Current.CancellationToken);
+
+        result.Groups.ShouldBeEmpty();
+        result.TotalCount.ShouldBe(0);
+    }
+
+    private sealed record ProductSummary(string Name, decimal Price);
 }


### PR DESCRIPTION
Follow-up to #1651 / #1652 — last open framework finding from the OpenAPI audit (`/audit --scope openapi`, 2026-04-30).

## Summary

`MapGranitQuery<TEntity>` with a declared projection used to return `GroupedResult<TEntity>` when `?groupBy=` was supplied — leaking the raw EF entity (audit metadata, owned collections, navigation properties) through `groups[].items[]`. This PR adds an `IQueryEngine<TEntity>.ExecuteGroupedAsync<TProjection>` overload and threads it through the projected endpoint so the grouped branch surfaces the same DTO as the paged branch.

## Audit finding resolved

**#2 ARCHITECTURE — `GroupedResult.Items[]` exposes the EF entity in `MapGranitQuery` projected endpoints.**

After this PR, the `oneOf[1]` branch on every `MapGranitQuery` projected endpoint references `GroupedResultOf{TDto}` instead of `GroupedResultOf{TEntity}` — the contract is now consistent with `Produces<PagedResult<TDto>>`.

## Design choices

- **Engine API**: new method `ExecuteGroupedAsync<TProjection>(source, request, projection, ct) → Task<GroupedResult<TProjection>>`. The existing entity-typed `ExecuteGroupedAsync` is preserved for callers that explicitly want the raw entity (e.g. analytics chart runners).
- **Implementation**: refactored `QueryEngine.cs` to share a private `ExecuteGroupedCoreAsync<TItem>` between both overloads. The projector is compiled and applied **in-memory after entity materialization** because the group-by property must remain readable on the entity for key extraction. SQL load is unchanged versus the previous behavior — the goal is contract correctness, not I/O reduction.
- **Endpoint**: `MapProjectedGetEndpoint` now calls the projected overload for the grouped branch and emits `Produces<GroupedResult<TDto>>` instead of `Produces<GroupedResult<TEntity>>`.

## Test plan

- [x] Unit: 2 new tests in `QueryableGroupByExtensionsTests` cover the projected overload (returns projected items + early-exit on empty groupBy).
- [x] Integration: `QueryEndpointProjectionTests.Query_with_projection_and_groupBy_returns_projected_grouped_result` verifies the projected overload is called and the entity-typed overload is not.
- [x] `dotnet build` clean (Granit.QueryEngine.Abstractions, EntityFrameworkCore, AspNetCore).
- [x] `dotnet test` per package — QueryEngine.EFC 176, QueryEngine.AspNetCore 48, QueryEngine.AspNetCore.Tests.Integration 7, DataExchange 353, ArchitectureTests 202.
- [x] `dotnet format --verify-no-changes` clean on each touched project.
- [x] `dotnet restore Granit.slnx --force-evaluate` (lockfiles regenerated; abstractions surface change ripples through the dep tree).

## Stacking note

Independent of #1651 (merged) and #1652 (in CI). No file overlaps with either. Mergeable as soon as develop is green.

## Backward compatibility

- **Engine implementers**: must add the new overload (interface gained a method). Test stubs in `Granit.DataExchange.Tests` and `Granit.QueryEngine.AspNetCore.Tests.Integration` updated.
- **Endpoint consumers**: a projected `MapGranitQuery` now returns `GroupedResult<TDto>` from the grouped branch instead of `GroupedResult<TEntity>`. SDK regen required for clients that materialized the previous shape. Pre-1.0 — clean break.
- **Non-projected consumers**: unchanged. The entity-typed `ExecuteGroupedAsync` and the non-projected endpoint shape (`GroupedResult<TEntity>`) are preserved.