### PR TITLE
fix(cookies-endpoints): align TagName test with the new "Cookie Consent" default

### DIFF
--- a/tests/Granit.Http.Cookies.Endpoints.Tests/CookieConsentEndpointsOptionsTests.cs
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/CookieConsentEndpointsOptionsTests.cs
@@ -11,6 +11,6 @@ public sealed class CookieConsentEndpointsOptionsTests
         new CookieConsentEndpointsOptions().RoutePrefix.ShouldBe("cookies");
 
     [Fact]
-    public void TagName_Default_ShouldBeCookies() =>
-        new CookieConsentEndpointsOptions().TagName.ShouldBe("Cookies");
+    public void TagName_Default_ShouldBeCookieConsent() =>
+        new CookieConsentEndpointsOptions().TagName.ShouldBe("Cookie Consent");
 }


### PR DESCRIPTION
Hotfix — develop is broken since #1652 merged.

## Root cause

PR #1652 changed the default `CookieConsentEndpointsOptions.TagName` from `"Cookies"` to `"Cookie Consent"` but missed updating `CookieConsentEndpointsOptionsTests.TagName_Default_ShouldBeCookies` which still asserts the old value. The failure was visible on the api-data shard but the PR landed before I could fix it.

## Fix

Renames the test to `TagName_Default_ShouldBeCookieConsent` and updates the assertion to `"Cookie Consent"`.

## Test plan

- [x] `dotnet test tests/Granit.Http.Cookies.Endpoints.Tests` — 25/25 pass
- [ ] CI green on api-data shard