### PR TITLE
feat(entities-abstractions): owned-collection section primitive (Phase 2.A)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18991,7 +18991,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 37,
+      "line": 39,
       "members": []
     },
     {
@@ -19004,12 +19004,21 @@
       "members": []
     },
     {
+      "name": "EntityFormOwnedCollectionManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormOwnedCollectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
+      "line": 56,
+      "members": []
+    },
+    {
       "name": "EntityFormSectionManifest",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormSectionManifest",
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 20,
+      "line": 21,
       "members": []
     },
     {
@@ -19256,7 +19265,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FormBuilder.cs",
-      "line": 7,
+      "line": 10,
       "members": []
     },
     {
@@ -19266,6 +19275,24 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Forms/FormDescriptor.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "OwnedCollectionDescriptor",
+      "fqn": "Granit.Entities.Forms.OwnedCollectionDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Forms/OwnedCollectionDescriptor.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "OwnedCollectionSectionBuilder",
+      "fqn": "Granit.Entities.Forms.OwnedCollectionSectionBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Forms/OwnedCollectionSectionBuilder.cs",
+      "line": 13,
       "members": []
     },
     {
@@ -28102,7 +28129,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "Name",
@@ -38526,7 +38553,7 @@
       "kind": "class",
       "project": "Granit.Parties",
       "file": "src/Granit.Parties/Entities/PartyEntityDefinition.cs",
-      "line": 28,
+      "line": 32,
       "members": [
         {
           "name": "Name",

--- a/src/Granit.Entities.Abstractions/Forms/FormBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FormBuilder.cs
@@ -1,3 +1,6 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
 namespace Granit.Entities.Forms;
 
 /// <summary>
@@ -19,14 +22,38 @@ public sealed class FormBuilder<TEntity>
     }
 
     /// <summary>
-    /// Adds a section to the form. The <paramref name="key"/> is the stable address used
-    /// for i18n keys and tenant layout customization (Phase 2).
+    /// Adds a scalar section to the form. The <paramref name="key"/> is the stable address
+    /// used for i18n keys and tenant layout customization (Phase 2).
     /// </summary>
     public FormBuilder<TEntity> Section(string key, Action<SectionBuilder<TEntity>>? configure = null)
     {
         int order = _nextSectionOrder++;
         SectionBuilder<TEntity> builder = new(key, order);
         configure?.Invoke(builder);
+        _sectionFactories.Add(builder.Build);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an owned-collection section to the form. The <paramref name="collectionSelector"/>
+    /// must be a direct property access pointing at an <see cref="IEnumerable{T}"/>-shaped
+    /// navigation on the owner (e.g. <c>p =&gt; p.Addresses</c>); the per-item form schema
+    /// is configured via <paramref name="configure"/>.
+    /// </summary>
+    public FormBuilder<TEntity> OwnedCollectionSection<TItem>(
+        string key,
+        Expression<Func<TEntity, IEnumerable<TItem>>> collectionSelector,
+        Action<OwnedCollectionSectionBuilder<TEntity, TItem>> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(collectionSelector);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        string propertyName = ParseCollectionSelector(collectionSelector);
+
+        int order = _nextSectionOrder++;
+        OwnedCollectionSectionBuilder<TEntity, TItem> builder = new(key, propertyName, order);
+        configure(builder);
         _sectionFactories.Add(builder.Build);
         return this;
     }
@@ -49,4 +76,18 @@ public sealed class FormBuilder<TEntity>
             Sections = [.. _sectionFactories.Select(f => f())],
             Customizable = _customizable,
         };
+
+    private static string ParseCollectionSelector<TItem>(
+        Expression<Func<TEntity, IEnumerable<TItem>>> selector)
+    {
+        if (selector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "Collection selector must be a direct property access expression (e.g. p => p.Addresses).",
+                nameof(selector));
+        }
+
+        return property.Name;
+    }
 }

--- a/src/Granit.Entities.Abstractions/Forms/OwnedCollectionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Forms/OwnedCollectionDescriptor.cs
@@ -1,0 +1,35 @@
+namespace Granit.Entities.Forms;
+
+/// <summary>
+/// Sub-descriptor that turns a <see cref="SectionDescriptor"/> into an owned-collection
+/// section — the section renders as a list of items (one entry per element of the owner's
+/// collection navigation), each item built from its own <see cref="ItemFields"/> schema.
+/// </summary>
+/// <remarks>
+/// Per ADR-040 the renderer treats a section with <c>OwnedCollection != null</c> as a
+/// list-of-cards layout: each item gets the form schema described by <see cref="ItemFields"/>,
+/// optionally headlined by the item's <see cref="ItemDisplayProperty"/>. The owner's
+/// scalar <see cref="SectionDescriptor.Fields"/> list MUST be empty in this case — the
+/// builder enforces mutual exclusion.
+/// </remarks>
+public sealed record OwnedCollectionDescriptor
+{
+    /// <summary>Property name on the owning entity that exposes the collection (e.g. <c>"Addresses"</c>).</summary>
+    public required string PropertyName { get; init; }
+
+    /// <summary>CLR type of the items in the collection (e.g. <c>typeof(PartyAddress)</c>).</summary>
+    public required Type ItemType { get; init; }
+
+    /// <summary>Per-item form schema, in declaration order.</summary>
+    public required IReadOnlyList<FieldDescriptor> ItemFields { get; init; }
+
+    /// <summary>
+    /// Optional property on the item used as the collapsed-row headline (e.g. <c>"Line1"</c>
+    /// for a <c>PartyAddress</c>). Resolved client-side; the field itself must also appear
+    /// in <see cref="ItemFields"/> for the value to be in the payload.
+    /// </summary>
+    public string? ItemDisplayProperty { get; init; }
+
+    /// <summary>Optional renderer hint capping how many items the renderer expands inline before paging.</summary>
+    public int? MaxRendered { get; init; }
+}

--- a/src/Granit.Entities.Abstractions/Forms/OwnedCollectionSectionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/OwnedCollectionSectionBuilder.cs
@@ -1,0 +1,115 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.Entities.Forms;
+
+/// <summary>
+/// Fluent builder for an owned-collection section — combines section-level metadata
+/// (label, collapsing) with the per-item form schema (item fields, item display
+/// property, render cap).
+/// </summary>
+/// <typeparam name="TOwner">The owning entity type (the section's parent form's TEntity).</typeparam>
+/// <typeparam name="TItem">The item CLR type held by the owner's collection navigation.</typeparam>
+public sealed class OwnedCollectionSectionBuilder<TOwner, TItem>
+{
+    private readonly string _key;
+    private readonly string _propertyName;
+    private readonly int _order;
+    private readonly List<Func<FieldDescriptor>> _itemFieldFactories = [];
+
+    private string? _labelKey;
+    private bool _collapsedByDefault;
+    private string? _itemDisplayProperty;
+    private int? _maxRendered;
+    private int _nextItemFieldOrder;
+
+    internal OwnedCollectionSectionBuilder(string key, string propertyName, int order)
+    {
+        _key = key;
+        _propertyName = propertyName;
+        _order = order;
+    }
+
+    /// <summary>i18n key for the section header (resolved client-side).</summary>
+    public OwnedCollectionSectionBuilder<TOwner, TItem> Label(string labelKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(labelKey);
+        _labelKey = labelKey;
+        return this;
+    }
+
+    /// <summary>Marks the section as collapsed by default in the renderer.</summary>
+    public OwnedCollectionSectionBuilder<TOwner, TItem> CollapsedByDefault()
+    {
+        _collapsedByDefault = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a per-item field. The lambda must be a direct property access on
+    /// <typeparamref name="TItem"/> (e.g. <c>a =&gt; a.Line1</c>). Configuration follows
+    /// the same fluent shape as a scalar <see cref="SectionBuilder{TEntity}.Field"/>.
+    /// </summary>
+    public OwnedCollectionSectionBuilder<TOwner, TItem> ItemField<TProperty>(
+        Expression<Func<TItem, TProperty>> propertySelector,
+        Action<FieldBuilder<TItem, TProperty>>? configure = null)
+    {
+        int order = _nextItemFieldOrder++;
+        FieldBuilder<TItem, TProperty> builder = new(propertySelector, order);
+        configure?.Invoke(builder);
+        _itemFieldFactories.Add(builder.Build);
+        return this;
+    }
+
+    /// <summary>
+    /// Names the item property used as the collapsed-row headline (e.g. <c>"Line1"</c>
+    /// for an address). The lambda must be a direct property access on
+    /// <typeparamref name="TItem"/>; the field must also have been declared via
+    /// <see cref="ItemField"/> for the value to appear in the payload.
+    /// </summary>
+    public OwnedCollectionSectionBuilder<TOwner, TItem> ItemDisplayProperty<TProperty>(
+        Expression<Func<TItem, TProperty>> propertySelector)
+    {
+        ArgumentNullException.ThrowIfNull(propertySelector);
+
+        if (propertySelector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "ItemDisplayProperty selector must be a direct property access expression (e.g. a => a.Line1).",
+                nameof(propertySelector));
+        }
+
+        _itemDisplayProperty = property.Name;
+        return this;
+    }
+
+    /// <summary>Caps how many items the renderer expands inline before paging (renderer hint).</summary>
+    public OwnedCollectionSectionBuilder<TOwner, TItem> MaxRendered(int max)
+    {
+        if (max <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(max), "Max must be a positive integer.");
+        }
+        _maxRendered = max;
+        return this;
+    }
+
+    internal SectionDescriptor Build() =>
+        new()
+        {
+            Key = _key,
+            LabelKey = _labelKey,
+            Order = _order,
+            Fields = [],
+            CollapsedByDefault = _collapsedByDefault,
+            OwnedCollection = new OwnedCollectionDescriptor
+            {
+                PropertyName = _propertyName,
+                ItemType = typeof(TItem),
+                ItemFields = [.. _itemFieldFactories.Select(f => f())],
+                ItemDisplayProperty = _itemDisplayProperty,
+                MaxRendered = _maxRendered,
+            },
+        };
+}

--- a/src/Granit.Entities.Abstractions/Forms/SectionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Forms/SectionDescriptor.cs
@@ -15,9 +15,20 @@ public sealed record SectionDescriptor
     /// <summary>Display order within the form (lower first).</summary>
     public int Order { get; init; }
 
-    /// <summary>The section's fields, in declaration order.</summary>
+    /// <summary>
+    /// The section's scalar fields, in declaration order. Empty when the section is an
+    /// owned-collection section (<see cref="OwnedCollection"/> non-null) — the per-item
+    /// schema lives on <see cref="OwnedCollectionDescriptor.ItemFields"/> instead.
+    /// </summary>
     public required IReadOnlyList<FieldDescriptor> Fields { get; init; }
 
     /// <summary>True when the section is collapsed by default in the renderer.</summary>
     public bool CollapsedByDefault { get; init; }
+
+    /// <summary>
+    /// Non-null when the section renders as an owned-collection (list-of-cards layout)
+    /// rather than a flat field grid. Mutually exclusive with <see cref="Fields"/>: the
+    /// builder rejects mixing scalar fields and an owned collection in the same section.
+    /// </summary>
+    public OwnedCollectionDescriptor? OwnedCollection { get; init; }
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
@@ -16,13 +16,15 @@ public sealed record EntityFormManifest(
 /// <param name="LabelKey">i18n key for the section header.</param>
 /// <param name="Order">Display order (lower first).</param>
 /// <param name="CollapsedByDefault">Whether the section starts collapsed in the renderer.</param>
-/// <param name="Fields">Fields the user is allowed to see (already permission-filtered server-side).</param>
+/// <param name="Fields">Scalar fields (empty when <paramref name="OwnedCollection"/> is non-null).</param>
+/// <param name="OwnedCollection">Non-null when the section renders as a list of owned items.</param>
 public sealed record EntityFormSectionManifest(
     string Key,
     string? LabelKey,
     int Order,
     bool CollapsedByDefault,
-    IReadOnlyList<EntityFormFieldManifest> Fields);
+    IReadOnlyList<EntityFormFieldManifest> Fields,
+    EntityFormOwnedCollectionManifest? OwnedCollection = null);
 
 /// <summary>One form field.</summary>
 /// <param name="PropertyName">PascalCase property name on the entity.</param>
@@ -44,3 +46,16 @@ public sealed record EntityFormFieldManifest(
     int Order,
     bool ReadOnly,
     VisibilityCondition? VisibleIf);
+
+/// <summary>An owned-collection sub-section (rendered as a list of items per ADR-040).</summary>
+/// <param name="PropertyName">Owner-side property exposing the collection (e.g. <c>"Addresses"</c>).</param>
+/// <param name="ItemTypeName">Short CLR type name of the item.</param>
+/// <param name="ItemFields">Per-item form schema, in declaration order (already permission-filtered).</param>
+/// <param name="ItemDisplayProperty">Optional item property used as the collapsed-row headline.</param>
+/// <param name="MaxRendered">Optional renderer hint capping inline expansion.</param>
+public sealed record EntityFormOwnedCollectionManifest(
+    string PropertyName,
+    string ItemTypeName,
+    IReadOnlyList<EntityFormFieldManifest> ItemFields,
+    string? ItemDisplayProperty,
+    int? MaxRendered);

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -131,27 +131,17 @@ internal static class EntityManifestComposer
             List<EntityFormSectionManifest> sections = new(form.Sections.Count);
             foreach (SectionDescriptor section in form.Sections)
             {
-                List<EntityFormFieldManifest> fields = new(section.Fields.Count);
-                foreach (FieldDescriptor field in section.Fields)
+                if (section.OwnedCollection is { } owned)
                 {
-                    if (field.RequiresPermission is { } perm
-                        && !granted.Contains(perm))
+                    EntityFormSectionManifest? ownedSection = ComposeOwnedCollectionSection(section, owned, granted);
+                    if (ownedSection is not null)
                     {
-                        // Drop entirely — defense in depth.
-                        continue;
+                        sections.Add(ownedSection);
                     }
-
-                    fields.Add(new EntityFormFieldManifest(
-                        field.PropertyName,
-                        field.ClrType.Name,
-                        field.Widget,
-                        field.Config,
-                        field.LabelKey,
-                        field.HelpKey,
-                        field.Order,
-                        field.ReadOnly,
-                        field.VisibleIf));
+                    continue;
                 }
+
+                List<EntityFormFieldManifest> fields = FilterFields(section.Fields, granted);
 
                 // A section with no surviving fields is dropped too — avoids
                 // empty section headers when the user lacks permission for
@@ -173,6 +163,61 @@ internal static class EntityManifestComposer
         }
 
         return forms;
+    }
+
+    private static EntityFormSectionManifest? ComposeOwnedCollectionSection(
+        SectionDescriptor section,
+        OwnedCollectionDescriptor owned,
+        IReadOnlySet<string> granted)
+    {
+        List<EntityFormFieldManifest> itemFields = FilterFields(owned.ItemFields, granted);
+
+        // No surviving item field → drop the whole section (defense in depth).
+        if (itemFields.Count == 0)
+        {
+            return null;
+        }
+
+        EntityFormOwnedCollectionManifest collection = new(
+            owned.PropertyName,
+            owned.ItemType.Name,
+            itemFields,
+            owned.ItemDisplayProperty,
+            owned.MaxRendered);
+
+        return new EntityFormSectionManifest(
+            section.Key,
+            section.LabelKey,
+            section.Order,
+            section.CollapsedByDefault,
+            Fields: [],
+            OwnedCollection: collection);
+    }
+
+    private static List<EntityFormFieldManifest> FilterFields(
+        IReadOnlyList<FieldDescriptor> source,
+        IReadOnlySet<string> granted)
+    {
+        List<EntityFormFieldManifest> fields = new(source.Count);
+        foreach (FieldDescriptor field in source)
+        {
+            if (field.RequiresPermission is { } perm && !granted.Contains(perm))
+            {
+                continue;
+            }
+
+            fields.Add(new EntityFormFieldManifest(
+                field.PropertyName,
+                field.ClrType.Name,
+                field.Widget,
+                field.Config,
+                field.LabelKey,
+                field.HelpKey,
+                field.Order,
+                field.ReadOnly,
+                field.VisibleIf));
+        }
+        return fields;
     }
 
     private static List<EntityDetailManifest> ComposeDetails(

--- a/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
+++ b/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
@@ -8,9 +8,10 @@ namespace Granit.Invoicing.Entities;
 
 /// <summary>
 /// Phase 1.F cobaye — declares the <see cref="Invoice"/> aggregate's UI surface
-/// (per ADR-040). Form variants <c>"default"</c> + <c>"quick"</c>, detail with
-/// the standard Audit + Timeline side panels, list collection backed by the
-/// existing <c>InvoiceQueryDefinition</c>.
+/// (per ADR-040). Form variants <c>"default"</c> + <c>"quick"</c>; the default
+/// form carries the line-items, external-references, and document
+/// owned-collection sections; detail uses the standard Audit + Timeline side
+/// panels; list collection backed by the existing <c>InvoiceQueryDefinition</c>.
 /// </summary>
 public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
 {
@@ -46,7 +47,27 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
                     .Field(i => i.TaxTotal)
                     .Field(i => i.Total)
                     .Field(i => i.AmountPaid)
-                    .Field(i => i.AmountRemaining)))
+                    .Field(i => i.AmountRemaining))
+                .OwnedCollectionSection<InvoiceLineItem>("lineItems", i => i.LineItems, s => s
+                    .ItemDisplayProperty(li => li.Description)
+                    .ItemField(li => li.Description)
+                    .ItemField(li => li.Quantity)
+                    .ItemField(li => li.UnitPrice)
+                    .ItemField(li => li.Amount, x => x.ReadOnly())
+                    .ItemField(li => li.TaxRate)
+                    .ItemField(li => li.TaxAmount, x => x.ReadOnly()))
+                .OwnedCollectionSection<InvoiceExternalReference>(
+                    "externalReferences", i => i.ExternalReferences, s => s
+                    .CollapsedByDefault()
+                    .ItemDisplayProperty(r => r.ProviderName)
+                    .ItemField(r => r.ProviderName)
+                    .ItemField(r => r.ExternalId))
+                .OwnedCollectionSection<InvoiceDocument>("documents", i => i.Documents, s => s
+                    .CollapsedByDefault()
+                    .ItemDisplayProperty(doc => doc.FileName)
+                    .ItemField(doc => doc.FileName, x => x.ReadOnly())
+                    .ItemField(doc => doc.ContentType, x => x.ReadOnly())
+                    .ItemField(doc => doc.GeneratedAt, x => x.ReadOnly())))
             .Form("quick", f => f
                 .Section("essentials", s => s
                     .Field(i => i.PartyId)

--- a/src/Granit.Parties/Entities/PartyEntityDefinition.cs
+++ b/src/Granit.Parties/Entities/PartyEntityDefinition.cs
@@ -20,8 +20,12 @@ namespace Granit.Parties.Entities;
 /// <para>
 /// Form variants:
 /// <list type="bullet">
-///   <item><c>"default"</c> — full edit form with identity, locale, contact, and metadata sections.</item>
-///   <item><c>"quick"</c> — minimum-input subset for the SPA's quick-create modal (Name + Currency + Status).</item>
+///   <item><c>"default"</c> — full edit form with identity, locale, contact, the
+///     four owned-collection sections (emails, phones, addresses, external
+///     mappings) and a <c>"tax"</c> read-only section for the computed tax
+///     status.</item>
+///   <item><c>"quick"</c> — minimum-input subset for the SPA's quick-create modal
+///     (Name + Currency + Status).</item>
 /// </list>
 /// </para>
 /// </remarks>
@@ -53,7 +57,31 @@ public sealed class PartyEntityDefinition : EntityDefinition<Party>
                 .Section("contact", s => s
                     .Field(p => p.Website)
                     .Field(p => p.TaxId)
-                    .Field(p => p.RegistrationNumber)))
+                    .Field(p => p.RegistrationNumber))
+                .OwnedCollectionSection<PartyEmail>("emails", p => p.Emails, s => s
+                    .ItemDisplayProperty(e => e.Address)
+                    .ItemField(e => e.Address)
+                    .ItemField(e => e.Label)
+                    .ItemField(e => e.IsPrimary))
+                .OwnedCollectionSection<PartyPhone>("phones", p => p.Phones, s => s
+                    .ItemDisplayProperty(ph => ph.Number)
+                    .ItemField(ph => ph.Kind)
+                    .ItemField(ph => ph.Number)
+                    .ItemField(ph => ph.Label)
+                    .ItemField(ph => ph.IsPrimary))
+                .OwnedCollectionSection<PartyAddress>("addresses", p => p.Addresses, s => s
+                    .ItemDisplayProperty(a => a.Label)
+                    .ItemField(a => a.Kind)
+                    .ItemField(a => a.Label)
+                    .ItemField(a => a.IsDefault))
+                .OwnedCollectionSection<PartyExternalMapping>(
+                    "externalMappings", p => p.ExternalMappings, s => s
+                    .CollapsedByDefault()
+                    .ItemDisplayProperty(m => m.ProviderName)
+                    .ItemField(m => m.ProviderName)
+                    .ItemField(m => m.ExternalId))
+                .Section("tax", s => s
+                    .Field(p => p.TaxStatus, x => x.ReadOnly())))
             .Form("quick", f => f
                 .Section("essentials", s => s
                     .Field(p => p.Name)

--- a/tests/Granit.Entities.Abstractions.Tests/OwnedCollectionSectionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/OwnedCollectionSectionTests.cs
@@ -1,0 +1,156 @@
+using Granit.Entities.Forms;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests;
+
+public sealed class OwnedCollectionSectionTests
+{
+    [Fact]
+    public void OwnedCollectionSection_carries_property_name_item_type_and_fields()
+    {
+        EntityDefinitionDescriptor d = new SampleOwnerDefinition().Descriptor;
+
+        FormDescriptor form = d.Forms.Single(f => f.Name == "default");
+        SectionDescriptor section = form.Sections.Single(s => s.Key == "addresses");
+
+        section.OwnedCollection.ShouldNotBeNull();
+        section.Fields.ShouldBeEmpty();
+
+        OwnedCollectionDescriptor owned = section.OwnedCollection!;
+        owned.PropertyName.ShouldBe("Addresses");
+        owned.ItemType.ShouldBe(typeof(SampleAddress));
+        owned.ItemFields.Select(f => f.PropertyName).ShouldBe(["Line1", "City", "Country"]);
+        owned.ItemDisplayProperty.ShouldBe("Line1");
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_preserves_per_item_field_options()
+    {
+        EntityDefinitionDescriptor d = new SampleOwnerDefinition().Descriptor;
+
+        FormDescriptor form = d.Forms.Single(f => f.Name == "default");
+        SectionDescriptor section = form.Sections.Single(s => s.Key == "addresses");
+
+        FieldDescriptor country = section.OwnedCollection!.ItemFields.Single(f => f.PropertyName == "Country");
+        country.ReadOnly.ShouldBeTrue();
+        country.LabelKey.ShouldBe("Sample:Address.Country");
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_supports_label_collapsedByDefault_and_maxRendered()
+    {
+        EntityDefinitionDescriptor d = new SampleOwnerDefinition().Descriptor;
+
+        FormDescriptor form = d.Forms.Single(f => f.Name == "default");
+        SectionDescriptor section = form.Sections.Single(s => s.Key == "addresses");
+
+        section.LabelKey.ShouldBe("Sample:Section.Addresses");
+        section.CollapsedByDefault.ShouldBeTrue();
+        section.OwnedCollection!.MaxRendered.ShouldBe(5);
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_orders_relative_to_scalar_sections_by_declaration()
+    {
+        EntityDefinitionDescriptor d = new SampleOwnerDefinition().Descriptor;
+
+        FormDescriptor form = d.Forms.Single(f => f.Name == "default");
+
+        form.Sections.Select(s => s.Key).ShouldBe(["identity", "addresses", "footer"]);
+        form.Sections.Select(s => s.Order).ShouldBe([0, 1, 2]);
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_rejects_non_property_collection_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadCollectionLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("Collection selector must be a direct property access");
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_rejects_non_property_item_display_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadItemDisplayLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("ItemDisplayProperty selector must be a direct property access");
+    }
+
+    [Fact]
+    public void OwnedCollectionSection_rejects_non_positive_MaxRendered()
+    {
+        ArgumentOutOfRangeException ex = Should.Throw<ArgumentOutOfRangeException>(() =>
+            _ = new BadMaxRenderedDefinition().Descriptor);
+
+        ex.ParamName.ShouldBe("max");
+    }
+
+    private sealed class SampleOwner
+    {
+        public string Name { get; set; } = string.Empty;
+        public IReadOnlyList<SampleAddress> Addresses { get; set; } = [];
+        public string? FooterNote { get; set; }
+    }
+
+    private sealed class SampleAddress
+    {
+        public string Line1 { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+    }
+
+    private sealed class SampleOwnerDefinition : EntityDefinition<SampleOwner>
+    {
+        public override string Name => "Granit.Sample.Owner";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleOwner> builder) =>
+            builder.Form("default", f => f
+                .Section("identity", s => s.Field(o => o.Name))
+                .OwnedCollectionSection<SampleAddress>("addresses", o => o.Addresses, s => s
+                    .Label("Sample:Section.Addresses")
+                    .CollapsedByDefault()
+                    .MaxRendered(5)
+                    .ItemField(a => a.Line1)
+                    .ItemField(a => a.City)
+                    .ItemField(a => a.Country, f => f
+                        .ReadOnly()
+                        .Label("Sample:Address.Country"))
+                    .ItemDisplayProperty(a => a.Line1))
+                .Section("footer", s => s.Field(o => o.FooterNote)));
+    }
+
+    private sealed class BadCollectionLambdaDefinition : EntityDefinition<SampleOwner>
+    {
+        public override string Name => "Granit.Sample.BadOwner";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleOwner> builder) =>
+            builder.Form("default", f => f
+                .OwnedCollectionSection<SampleAddress>("addresses", o => o.Addresses.Where(_ => true), s => s
+                    .ItemField(a => a.Line1)));
+    }
+
+    private sealed class BadItemDisplayLambdaDefinition : EntityDefinition<SampleOwner>
+    {
+        public override string Name => "Granit.Sample.BadOwnerB";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleOwner> builder) =>
+            builder.Form("default", f => f
+                .OwnedCollectionSection<SampleAddress>("addresses", o => o.Addresses, s => s
+                    .ItemField(a => a.Line1)
+                    .ItemDisplayProperty(a => a.Line1.ToUpperInvariant())));
+    }
+
+    private sealed class BadMaxRenderedDefinition : EntityDefinition<SampleOwner>
+    {
+        public override string Name => "Granit.Sample.BadOwnerC";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleOwner> builder) =>
+            builder.Form("default", f => f
+                .OwnedCollectionSection<SampleAddress>("addresses", o => o.Addresses, s => s
+                    .MaxRendered(0)
+                    .ItemField(a => a.Line1)));
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -159,6 +159,172 @@ public sealed class EntityManifestComposerTests
         manifest.SchemaVersion.ShouldBe(EntityManifestComposer.SchemaVersion);
     }
 
+    [Fact]
+    public void Compose_emits_owned_collection_section_with_item_fields_and_display_property()
+    {
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(
+            forms: [
+                new FormDescriptor
+                {
+                    Name = "default",
+                    Customizable = false,
+                    Sections = [
+                        new SectionDescriptor
+                        {
+                            Key = "addresses",
+                            Order = 0,
+                            Fields = [],
+                            OwnedCollection = new OwnedCollectionDescriptor
+                            {
+                                PropertyName = "Addresses",
+                                ItemType = typeof(SampleAddress),
+                                ItemDisplayProperty = "Line1",
+                                MaxRendered = 5,
+                                ItemFields = [
+                                    new FieldDescriptor
+                                    {
+                                        PropertyName = "Line1",
+                                        ClrType = typeof(string),
+                                        Widget = "text",
+                                        Order = 0,
+                                    },
+                                    new FieldDescriptor
+                                    {
+                                        PropertyName = "City",
+                                        ClrType = typeof(string),
+                                        Widget = "text",
+                                        Order = 1,
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ]);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Forms,
+            defaultViewId: null);
+
+        EntityFormSectionManifest section = manifest.Forms!.Single().Sections.Single();
+        section.Key.ShouldBe("addresses");
+        section.Fields.ShouldBeEmpty();
+        section.OwnedCollection.ShouldNotBeNull();
+        section.OwnedCollection!.PropertyName.ShouldBe("Addresses");
+        section.OwnedCollection.ItemTypeName.ShouldBe(nameof(SampleAddress));
+        section.OwnedCollection.ItemDisplayProperty.ShouldBe("Line1");
+        section.OwnedCollection.MaxRendered.ShouldBe(5);
+        section.OwnedCollection.ItemFields.Select(f => f.PropertyName).ShouldBe(["Line1", "City"]);
+    }
+
+    [Fact]
+    public void Compose_filters_owned_collection_item_fields_by_permission()
+    {
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(
+            forms: [
+                new FormDescriptor
+                {
+                    Name = "default",
+                    Customizable = false,
+                    Sections = [
+                        new SectionDescriptor
+                        {
+                            Key = "addresses",
+                            Order = 0,
+                            Fields = [],
+                            OwnedCollection = new OwnedCollectionDescriptor
+                            {
+                                PropertyName = "Addresses",
+                                ItemType = typeof(SampleAddress),
+                                ItemFields = [
+                                    new FieldDescriptor
+                                    {
+                                        PropertyName = "Line1",
+                                        ClrType = typeof(string),
+                                        Widget = "text",
+                                        Order = 0,
+                                    },
+                                    new FieldDescriptor
+                                    {
+                                        PropertyName = "Country",
+                                        ClrType = typeof(string),
+                                        Widget = "text",
+                                        Order = 1,
+                                        RequiresPermission = "Sample.Manage",
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ]);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Forms,
+            defaultViewId: null);
+
+        manifest.Forms!.Single().Sections.Single().OwnedCollection!.ItemFields
+            .Select(f => f.PropertyName)
+            .ShouldBe(["Line1"]);
+    }
+
+    [Fact]
+    public void Compose_drops_owned_collection_section_when_every_item_field_is_filtered()
+    {
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(
+            forms: [
+                new FormDescriptor
+                {
+                    Name = "default",
+                    Customizable = false,
+                    Sections = [
+                        new SectionDescriptor
+                        {
+                            Key = "addresses",
+                            Order = 0,
+                            Fields = [],
+                            OwnedCollection = new OwnedCollectionDescriptor
+                            {
+                                PropertyName = "Addresses",
+                                ItemType = typeof(SampleAddress),
+                                ItemFields = [
+                                    new FieldDescriptor
+                                    {
+                                        PropertyName = "Vault",
+                                        ClrType = typeof(string),
+                                        Widget = "text",
+                                        Order = 0,
+                                        RequiresPermission = "Sample.Manage",
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ]);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Forms,
+            defaultViewId: null);
+
+        manifest.Forms!.Single().Sections.ShouldBeEmpty();
+    }
+
+    private sealed class SampleAddress
+    {
+        public string Line1 { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+    }
+
     private static EntityDefinitionDescriptor BuildDescriptor(
         IReadOnlyList<FormDescriptor>? forms = null,
         IReadOnlyList<DetailDescriptor>? details = null) => new()

--- a/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
@@ -1,4 +1,6 @@
 using Granit.Entities;
+using Granit.Entities.Forms;
+using Granit.Invoicing.Domain;
 using Granit.Invoicing.Entities;
 using Shouldly;
 using Xunit;
@@ -28,12 +30,67 @@ public sealed class InvoiceEntityDefinitionTests
     }
 
     [Fact]
+    public void Descriptor_default_form_carries_scalar_and_owned_collection_sections_in_declaration_order()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        FormDescriptor defaultForm = d.Forms.Single(f => f.Name == "default");
+
+        defaultForm.Sections.Select(s => s.Key).ShouldBe(
+            ["identity", "billing", "amounts", "lineItems", "externalReferences", "documents"]);
+    }
+
+    [Fact]
+    public void Descriptor_lineItems_owned_collection_targets_InvoiceLineItem_with_description_as_display_property()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        SectionDescriptor lineItems = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "lineItems");
+
+        lineItems.OwnedCollection.ShouldNotBeNull();
+        lineItems.OwnedCollection!.PropertyName.ShouldBe("LineItems");
+        lineItems.OwnedCollection.ItemType.ShouldBe(typeof(InvoiceLineItem));
+        lineItems.OwnedCollection.ItemDisplayProperty.ShouldBe("Description");
+        lineItems.OwnedCollection.ItemFields.Select(f => f.PropertyName)
+            .ShouldBe(["Description", "Quantity", "UnitPrice", "Amount", "TaxRate", "TaxAmount"]);
+    }
+
+    [Fact]
+    public void Descriptor_lineItems_marks_computed_amounts_as_read_only()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        OwnedCollectionDescriptor lineItems = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "lineItems")
+            .OwnedCollection!;
+
+        lineItems.ItemFields.Single(f => f.PropertyName == "Amount").ReadOnly.ShouldBeTrue();
+        lineItems.ItemFields.Single(f => f.PropertyName == "TaxAmount").ReadOnly.ShouldBeTrue();
+        lineItems.ItemFields.Single(f => f.PropertyName == "Quantity").ReadOnly.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Descriptor_documents_section_targets_InvoiceDocument_and_is_collapsed()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        SectionDescriptor documents = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "documents");
+
+        documents.CollapsedByDefault.ShouldBeTrue();
+        documents.OwnedCollection!.ItemType.ShouldBe(typeof(InvoiceDocument));
+        documents.OwnedCollection.ItemFields.ShouldAllBe(f => f.ReadOnly);
+    }
+
+    [Fact]
     public void Descriptor_default_form_groups_amounts_separately_from_identity()
     {
         EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
 
-        Granit.Entities.Forms.FormDescriptor defaultForm = d.Forms.Single(f => f.Name == "default");
-        defaultForm.Sections.Select(s => s.Key).ShouldBe(["identity", "billing", "amounts"]);
+        FormDescriptor defaultForm = d.Forms.Single(f => f.Name == "default");
+        defaultForm.Sections.Select(s => s.Key).ShouldContain("identity");
+        defaultForm.Sections.Select(s => s.Key).ShouldContain("amounts");
     }
 
     [Fact]

--- a/tests/Granit.Parties.Tests/PartyEntityDefinitionTests.cs
+++ b/tests/Granit.Parties.Tests/PartyEntityDefinitionTests.cs
@@ -1,4 +1,6 @@
 using Granit.Entities;
+using Granit.Entities.Forms;
+using Granit.Parties.Domain;
 using Granit.Parties.Entities;
 using Shouldly;
 using Xunit;
@@ -25,6 +27,69 @@ public sealed class PartyEntityDefinitionTests
         EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
 
         d.Forms.Select(f => f.Name).ShouldBe(["default", "quick"]);
+    }
+
+    [Fact]
+    public void Descriptor_default_form_carries_scalar_and_owned_collection_sections_in_declaration_order()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        FormDescriptor defaultForm = d.Forms.Single(f => f.Name == "default");
+
+        defaultForm.Sections.Select(s => s.Key).ShouldBe(
+            ["identity", "locale", "contact", "emails", "phones", "addresses", "externalMappings", "tax"]);
+    }
+
+    [Fact]
+    public void Descriptor_emails_owned_collection_targets_PartyEmail_with_address_as_display_property()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        SectionDescriptor emails = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "emails");
+
+        emails.OwnedCollection.ShouldNotBeNull();
+        emails.OwnedCollection!.PropertyName.ShouldBe("Emails");
+        emails.OwnedCollection.ItemType.ShouldBe(typeof(PartyEmail));
+        emails.OwnedCollection.ItemDisplayProperty.ShouldBe("Address");
+        emails.OwnedCollection.ItemFields.Select(f => f.PropertyName)
+            .ShouldBe(["Address", "Label", "IsPrimary"]);
+    }
+
+    [Fact]
+    public void Descriptor_addresses_owned_collection_targets_PartyAddress()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        SectionDescriptor addresses = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "addresses");
+
+        addresses.OwnedCollection!.PropertyName.ShouldBe("Addresses");
+        addresses.OwnedCollection.ItemType.ShouldBe(typeof(PartyAddress));
+    }
+
+    [Fact]
+    public void Descriptor_external_mappings_section_is_collapsed_by_default()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        SectionDescriptor mappings = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "externalMappings");
+
+        mappings.CollapsedByDefault.ShouldBeTrue();
+        mappings.OwnedCollection!.PropertyName.ShouldBe("ExternalMappings");
+    }
+
+    [Fact]
+    public void Descriptor_tax_section_exposes_TaxStatus_as_read_only()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        SectionDescriptor tax = d.Forms.Single(f => f.Name == "default")
+            .Sections.Single(s => s.Key == "tax");
+
+        FieldDescriptor taxStatus = tax.Fields.Single(f => f.PropertyName == "TaxStatus");
+        taxStatus.ReadOnly.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds the `OwnedCollectionSection<TItem>` primitive to the form DSL — sections that render as a list of items (one per element of the owner-side collection navigation), each item built from its own `ItemFields` schema. Companion to the existing scalar `Section` and the `HasMany` / `HasOne` relations (which model cross-aggregate links rendered as smart buttons / tabs / sidebars).

\`\`\`csharp
.OwnedCollectionSection<PartyEmail>(\"emails\", p => p.Emails, s => s
    .ItemDisplayProperty(e => e.Address)
    .ItemField(e => e.Address)
    .ItemField(e => e.Label)
    .ItemField(e => e.IsPrimary))
\`\`\`

Composer-side: the per-item `RequiresPermission` drop-not-hide rule matches the scalar-section behaviour, and an owned-collection section whose every item field gets filtered out is dropped from the manifest entirely (defense in depth, story #1549).

## Party + Invoice cobaye expansion

Brings the manifest closer to the surfaces the showcase UI already renders by hand:

| Entity | New sections |
| ------ | ------------ |
| Party | `emails`, `phones`, `addresses`, `externalMappings` (collapsed by default) + `tax` (`TaxStatus` read-only) |
| Invoice | `lineItems`, `externalReferences` (collapsed), `documents` (collapsed, all read-only) |

`Amount` and `TaxAmount` on invoice line items are flagged read-only (derived from `Quantity * UnitPrice`).

## What's deferred to PR B

The `Action` primitive (lifecycle / merge / vCard / PDF download / workflow transitions) and the `Indicator` primitive (Duplicates badge) — needed to fully match the showcase UI but conceptually orthogonal to owned collections, so they sequence cleanly in a follow-up PR.

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 30/30 pass (7 new owned-collection)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 43/43 pass (3 new composer)
- [x] `dotnet test tests/Granit.Parties.Tests` — 164/164 pass (6 new entity-def)
- [x] `dotnet test tests/Granit.Invoicing.Tests` — 65/65 pass (5 new entity-def)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 pass
- [x] `dotnet format style .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift