### PR TITLE
feat(entities-abstractions): kanban list-view layout primitive (Phase 2.A.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18910,7 +18910,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 27,
+      "line": 31,
       "members": []
     },
     {
@@ -18919,7 +18919,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 14,
+      "line": 17,
       "members": []
     },
     {
@@ -19028,6 +19028,42 @@
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 66,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanColumnManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanColumnManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 74,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanLayoutManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "EntityListLayoutManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityListLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 43,
       "members": []
     },
     {
@@ -19190,7 +19226,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "DisplayKey",
@@ -19206,13 +19242,19 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "Name",
           "kind": "property",
           "signature": "required string Name",
           "returnType": "required string"
+        },
+        {
+          "name": "ListLayouts",
+          "kind": "property",
+          "signature": "IReadOnlyList<EntityListLayoutDescriptor> ListLayouts",
+          "returnType": "IReadOnlyList<EntityListLayoutDescriptor>"
         }
       ]
     },
@@ -19368,6 +19410,117 @@
           "returnType": "IEntityDefinitionDescriptor?"
         }
       ]
+    },
+    {
+      "name": "EntityListLayoutDescriptor",
+      "fqn": "Granit.Entities.Layouts.EntityListLayoutDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/EntityListLayoutDescriptor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "EntityListLayoutKind",
+      "fqn": "Granit.Entities.Layouts.EntityListLayoutKind",
+      "kind": "enum",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "KanbanCardBuilder",
+      "fqn": "Granit.Entities.Layouts.KanbanCardBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanCardBuilder.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "KanbanCardDescriptor",
+      "fqn": "Granit.Entities.Layouts.KanbanCardDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanCardDescriptor.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "KanbanColor",
+      "fqn": "Granit.Entities.Layouts.KanbanColor",
+      "kind": "enum",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanColor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "KanbanColumnBuilder",
+      "fqn": "Granit.Entities.Layouts.KanbanColumnBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanColumnBuilder.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Color",
+          "kind": "method",
+          "signature": "Color(KanbanColor color)",
+          "returnType": "KanbanColumnBuilder"
+        }
+      ]
+    },
+    {
+      "name": "KanbanColumnDescriptor",
+      "fqn": "Granit.Entities.Layouts.KanbanColumnDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanColumnDescriptor.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Value",
+          "kind": "property",
+          "signature": "required string Value",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "KanbanColumnState",
+      "fqn": "Granit.Entities.Layouts.KanbanColumnState",
+      "kind": "enum",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanColumnState.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "KanbanLayoutBuilder",
+      "fqn": "Granit.Entities.Layouts.KanbanLayoutBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanLayoutBuilder.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GroupBy",
+          "kind": "method",
+          "signature": "GroupBy(Expression<Func<TEntity, TGroupBy>> propertySelector)",
+          "returnType": "KanbanLayoutBuilder<TEntity, TGroupBy>"
+        }
+      ]
+    },
+    {
+      "name": "KanbanLayoutDescriptor",
+      "fqn": "Granit.Entities.Layouts.KanbanLayoutDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/KanbanLayoutDescriptor.cs",
+      "line": 8,
+      "members": []
     },
     {
       "name": "EntitiesOptions",
@@ -28129,7 +28282,7 @@
       "kind": "class",
       "project": "Granit.Invoicing",
       "file": "src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "Name",

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
+using Granit.Entities.Layouts;
 using Granit.Entities.Relations;
 
 namespace Granit.Entities;
@@ -27,6 +28,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     private readonly List<Func<FormDescriptor>> _formFactories = [];
     private readonly List<Func<DetailDescriptor>> _detailFactories = [];
     private readonly List<RelationDescriptor> _relations = [];
+    private readonly List<Func<EntityListLayoutDescriptor>> _layoutFactories = [];
 
     /// <summary>Sets the i18n key for the entity's display name (singular).</summary>
     public EntityDefinitionBuilder<TEntity> DisplayKey(string displayKey)
@@ -196,6 +198,26 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         return this;
     }
 
+    /// <summary>
+    /// Declares a kanban list-view layout for this entity. The
+    /// <typeparamref name="TGroupBy"/> generic argument types the
+    /// <c>GroupBy</c> property and the per-column values so the DSL refuses
+    /// invalid enum members at compile time. The list layout is always
+    /// available implicitly — adding kanban exposes the
+    /// <c>EntityListViewSwitcher</c> with a second tab.
+    /// </summary>
+    public EntityDefinitionBuilder<TEntity> KanbanView<TGroupBy>(
+        Action<KanbanLayoutBuilder<TEntity, TGroupBy>> configure)
+        where TGroupBy : notnull
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        KanbanLayoutBuilder<TEntity, TGroupBy> builder = new();
+        configure(builder);
+        _layoutFactories.Add(builder.Build);
+        return this;
+    }
+
     internal EntityDefinitionDescriptor Build(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -210,6 +232,10 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         IReadOnlyList<RelationDescriptor> relations = [.. _relations
             .OrderBy(r => r.Order)
             .ThenBy(r => r.Name, StringComparer.Ordinal)];
+
+        IReadOnlyList<EntityListLayoutDescriptor> layouts = [.. _layoutFactories.Select(f => f())];
+        AssertAtMostOneDefaultLayout(layouts);
+        AssertUniqueLayoutKinds(layouts);
 
         return new EntityDefinitionDescriptor
         {
@@ -227,7 +253,31 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
             Forms = forms,
             Details = details,
             Relations = relations,
+            ListLayouts = layouts,
         };
+    }
+
+    private static void AssertAtMostOneDefaultLayout(IReadOnlyList<EntityListLayoutDescriptor> layouts)
+    {
+        int defaults = layouts.Count(l => l.IsDefault);
+        if (defaults > 1)
+        {
+            throw new InvalidOperationException(
+                $"At most one list-view layout may be marked IsDefault on entity '{typeof(TEntity).FullName}' — found {defaults}.");
+        }
+    }
+
+    private static void AssertUniqueLayoutKinds(IReadOnlyList<EntityListLayoutDescriptor> layouts)
+    {
+        IGrouping<EntityListLayoutKind, EntityListLayoutDescriptor>? duplicate = layouts
+            .GroupBy(l => l.Kind)
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate is not null)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate list-view layout kind '{duplicate.Key}' on entity '{typeof(TEntity).FullName}'. Declare at most one layout per kind.");
+        }
     }
 
     private static void AssertUniqueRelationNames(IReadOnlyList<RelationDescriptor> relations)

--- a/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
@@ -1,5 +1,6 @@
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
+using Granit.Entities.Layouts;
 using Granit.Entities.Relations;
 
 namespace Granit.Entities;
@@ -91,4 +92,12 @@ public sealed record EntityDefinitionDescriptor
     /// precedence on conflicts (same <see cref="RelationDescriptor.Name"/>).
     /// </summary>
     public IReadOnlyList<RelationDescriptor> Relations { get; init; } = [];
+
+    /// <summary>
+    /// Alternative list-view layouts the entity supports (kanban, calendar,
+    /// map, …). The default <see cref="EntityListLayoutKind.List"/> is always
+    /// available implicitly; this collection only carries the additional
+    /// layouts declared via <c>b.KanbanView&lt;TGroupBy&gt;(...)</c> and friends.
+    /// </summary>
+    public IReadOnlyList<EntityListLayoutDescriptor> ListLayouts { get; init; } = [];
 }

--- a/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutDescriptor.cs
@@ -1,0 +1,26 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Base record for an entity-list layout declaration. Concrete shapes (kanban,
+/// future calendar / map / gallery) carry the kind-specific configuration
+/// alongside this base.
+/// </summary>
+public abstract record EntityListLayoutDescriptor
+{
+    /// <summary>Layout kind — drives front-end component selection.</summary>
+    public required EntityListLayoutKind Kind { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, this layout is the one the
+    /// <c>EntityListViewSwitcher</c> picks on first render. At most one layout
+    /// per entity may set it; framework default falls back to
+    /// <see cref="EntityListLayoutKind.List"/> when no layout opts in.
+    /// </summary>
+    public bool IsDefault { get; init; }
+
+    /// <summary>
+    /// When set, the layout is dropped from the manifest payload entirely if
+    /// the user lacks this permission — defense in depth (per ADR-040 §6).
+    /// </summary>
+    public string? RequiresPermission { get; init; }
+}

--- a/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
@@ -1,0 +1,16 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Closed enumeration of the list-view layouts an entity may declare via the
+/// manifest (per ADR-040). The renderer's <c>EntityListViewSwitcher</c> picks
+/// the active layout from this list — single-layout entities skip the switcher
+/// entirely.
+/// </summary>
+public enum EntityListLayoutKind
+{
+    /// <summary>Default tabular layout — driven by the entity's <c>QueryDefinition</c> columns.</summary>
+    List = 0,
+
+    /// <summary>Card-board layout grouped by a discrete property (typically an enum or lookup).</summary>
+    Kanban = 1,
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanCardBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanCardBuilder.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Granit.Entities.Forms;
+
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Fluent sub-builder for the kanban-tile card schema. Reuses the form
+/// <see cref="FieldBuilder{TEntity, TProperty}"/> for body fields so widget
+/// overrides, permission gating and visibility rules apply consistently.
+/// </summary>
+/// <typeparam name="TEntity">The entity type rendered in the card.</typeparam>
+public sealed class KanbanCardBuilder<TEntity>
+{
+    private readonly List<Func<FieldDescriptor>> _fieldFactories = [];
+
+    private string? _titleProperty;
+    private int _nextFieldOrder;
+
+    internal KanbanCardBuilder() { }
+
+    /// <summary>
+    /// Names the property used as the tile headline. The lambda must be a
+    /// direct property access (e.g. <c>i =&gt; i.InvoiceNumber</c>); when omitted
+    /// the renderer falls back to the entity's <c>DisplayProperty</c>.
+    /// </summary>
+    public KanbanCardBuilder<TEntity> Title<TProperty>(Expression<Func<TEntity, TProperty>> propertySelector)
+    {
+        ArgumentNullException.ThrowIfNull(propertySelector);
+
+        if (propertySelector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "Title selector must be a direct property access expression (e.g. i => i.InvoiceNumber).",
+                nameof(propertySelector));
+        }
+
+        _titleProperty = property.Name;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a body field rendered inside the card. Same lambda + configuration
+    /// shape as form <see cref="SectionBuilder{TEntity}.Field"/>.
+    /// </summary>
+    public KanbanCardBuilder<TEntity> Field<TProperty>(
+        Expression<Func<TEntity, TProperty>> propertySelector,
+        Action<FieldBuilder<TEntity, TProperty>>? configure = null)
+    {
+        int order = _nextFieldOrder++;
+        FieldBuilder<TEntity, TProperty> builder = new(propertySelector, order);
+        configure?.Invoke(builder);
+        _fieldFactories.Add(builder.Build);
+        return this;
+    }
+
+    internal KanbanCardDescriptor Build() =>
+        new()
+        {
+            TitleProperty = _titleProperty,
+            Fields = [.. _fieldFactories.Select(f => f())],
+        };
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanCardDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanCardDescriptor.cs
@@ -1,0 +1,27 @@
+using Granit.Entities.Forms;
+
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Card-content schema for a kanban tile. Frappe-style three-slot layout:
+/// title (large headline), then ordered body fields. The renderer caps the
+/// number of body fields visually — the descriptor is descriptive, not
+/// prescriptive, so per-card density is a theme decision.
+/// </summary>
+/// <remarks>
+/// Fields reference entity properties that MUST also appear in the entity's
+/// <c>QueryDefinition</c> column whitelist. Otherwise the projection cannot
+/// emit the value and the card renders blank — pairing enforced by the
+/// architecture tests.
+/// </remarks>
+public sealed record KanbanCardDescriptor
+{
+    /// <summary>
+    /// Property used as the tile headline. <see langword="null"/> means the
+    /// renderer falls back to the entity's <see cref="EntityDefinitionDescriptor.DisplayProperty"/>.
+    /// </summary>
+    public string? TitleProperty { get; init; }
+
+    /// <summary>Body fields, in declaration order.</summary>
+    public required IReadOnlyList<FieldDescriptor> Fields { get; init; }
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColor.cs
@@ -1,0 +1,36 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Closed catalog of column colours for the kanban layout. Each value maps to a
+/// design-token in the renderer's theme — the wire never carries a hex code, so
+/// tenant theming and dark-mode swaps stay declarative.
+/// </summary>
+public enum KanbanColor
+{
+    /// <summary>Theme-neutral grey — for archived / terminal states.</summary>
+    Neutral = 0,
+
+    /// <summary>Cool grey — for draft / pending states.</summary>
+    Gray = 1,
+
+    /// <summary>Blue — for in-progress / active states.</summary>
+    Blue = 2,
+
+    /// <summary>Green — for completed / success states.</summary>
+    Green = 3,
+
+    /// <summary>Orange — for waiting / attention states.</summary>
+    Orange = 4,
+
+    /// <summary>Red — for blocked / error states.</summary>
+    Red = 5,
+
+    /// <summary>Yellow — for warning / soft-attention states.</summary>
+    Yellow = 6,
+
+    /// <summary>Purple — for special / categorical highlights.</summary>
+    Purple = 7,
+
+    /// <summary>Cyan — for informational / secondary highlights.</summary>
+    Cyan = 8,
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColumnBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColumnBuilder.cs
@@ -1,0 +1,46 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Fluent sub-builder for one kanban column — sets the column's color and the
+/// default render state (Open / Collapsed / Hidden).
+/// </summary>
+public sealed class KanbanColumnBuilder
+{
+    private KanbanColor? _color;
+    private KanbanColumnState _state = KanbanColumnState.Open;
+
+    internal KanbanColumnBuilder() { }
+
+    /// <summary>Sets the column's colour from the closed catalog.</summary>
+    public KanbanColumnBuilder Color(KanbanColor color)
+    {
+        _color = color;
+        return this;
+    }
+
+    /// <summary>Marks the column as collapsed by default (header + count only).</summary>
+    public KanbanColumnBuilder Collapsed()
+    {
+        _state = KanbanColumnState.Collapsed;
+        return this;
+    }
+
+    /// <summary>
+    /// Marks the column as hidden by default — the user can opt back in via the
+    /// column manager. Use for archived / wind-down states the renderer should
+    /// not surface unless explicitly requested.
+    /// </summary>
+    public KanbanColumnBuilder Hidden()
+    {
+        _state = KanbanColumnState.Hidden;
+        return this;
+    }
+
+    internal KanbanColumnDescriptor Build(string value) =>
+        new()
+        {
+            Value = value,
+            Color = _color,
+            DefaultState = _state,
+        };
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColumnDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColumnDescriptor.cs
@@ -1,0 +1,22 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Per-value column declaration for a kanban layout — pairs a discrete value
+/// of the <c>GroupBy</c> property with optional rendering metadata (colour,
+/// default visibility state). The framework declares server-known defaults;
+/// per-user overlays (saved <c>EntityView</c>) may override them.
+/// </summary>
+public sealed record KanbanColumnDescriptor
+{
+    /// <summary>
+    /// The discrete value of the <c>GroupBy</c> property this column matches.
+    /// Stored as the value's wire form (e.g. enum member name, string literal).
+    /// </summary>
+    public required string Value { get; init; }
+
+    /// <summary>Optional column colour from the closed catalog.</summary>
+    public KanbanColor? Color { get; init; }
+
+    /// <summary>Default render state — Open, Collapsed, or Hidden.</summary>
+    public KanbanColumnState DefaultState { get; init; } = KanbanColumnState.Open;
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanColumnState.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanColumnState.cs
@@ -1,0 +1,17 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Default render state of a kanban column. The framework declares the value;
+/// per-user overlays (saved <c>EntityView</c>) may override it.
+/// </summary>
+public enum KanbanColumnState
+{
+    /// <summary>Expanded — header + cards visible.</summary>
+    Open = 0,
+
+    /// <summary>Collapsed — header + count only.</summary>
+    Collapsed = 1,
+
+    /// <summary>Hidden — column is not rendered (toggleable from the column manager).</summary>
+    Hidden = 2,
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanLayoutBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanLayoutBuilder.cs
@@ -1,0 +1,120 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Fluent builder for a kanban layout declaration. Mirrors Frappe's three
+/// kanban settings: column field (group-by), title field (tile headline),
+/// and body fields — plus per-column metadata (colour, default state) and
+/// the framework-wide <see cref="EntityListLayoutDescriptor.IsDefault"/> /
+/// <see cref="EntityListLayoutDescriptor.RequiresPermission"/> opt-ins.
+/// </summary>
+/// <typeparam name="TEntity">The entity rendered on the board.</typeparam>
+/// <typeparam name="TGroupBy">CLR type of the group-by property — typed so per-column values can't collide.</typeparam>
+public sealed class KanbanLayoutBuilder<TEntity, TGroupBy>
+    where TGroupBy : notnull
+{
+    private readonly List<Func<KanbanColumnDescriptor>> _columnFactories = [];
+
+    private string? _groupByPropertyName;
+    private KanbanCardBuilder<TEntity>? _cardBuilder;
+    private bool _isDefault;
+    private string? _requiresPermission;
+
+    internal KanbanLayoutBuilder() { }
+
+    /// <summary>
+    /// Names the property used to bucket rows into columns. The lambda must be
+    /// a direct property access (e.g. <c>i =&gt; i.Status</c>); only enums and
+    /// lookup-table values (finite discrete sets) are supported in v1.
+    /// </summary>
+    public KanbanLayoutBuilder<TEntity, TGroupBy> GroupBy(Expression<Func<TEntity, TGroupBy>> propertySelector)
+    {
+        ArgumentNullException.ThrowIfNull(propertySelector);
+
+        if (propertySelector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "GroupBy selector must be a direct property access expression (e.g. i => i.Status).",
+                nameof(propertySelector));
+        }
+
+        _groupByPropertyName = property.Name;
+        return this;
+    }
+
+    /// <summary>Configures the card-content schema rendered inside each tile.</summary>
+    public KanbanLayoutBuilder<TEntity, TGroupBy> Card(Action<KanbanCardBuilder<TEntity>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        KanbanCardBuilder<TEntity> builder = new();
+        configure(builder);
+        _cardBuilder = builder;
+        return this;
+    }
+
+    /// <summary>
+    /// Declares one column with optional colour and default state. Values are
+    /// strongly typed by <typeparamref name="TGroupBy"/>; serialised via
+    /// <c>ToString()</c> (enum members keep their member name).
+    /// </summary>
+    public KanbanLayoutBuilder<TEntity, TGroupBy> Column(
+        TGroupBy value,
+        Action<KanbanColumnBuilder>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        KanbanColumnBuilder builder = new();
+        configure?.Invoke(builder);
+        string serialised = value.ToString() ?? throw new InvalidOperationException(
+            $"Kanban column value of type '{typeof(TGroupBy).FullName}' returned a null ToString().");
+        _columnFactories.Add(() => builder.Build(serialised));
+        return this;
+    }
+
+    /// <summary>
+    /// Marks this layout as the one the renderer picks on first load. At most
+    /// one layout per entity may opt in.
+    /// </summary>
+    public KanbanLayoutBuilder<TEntity, TGroupBy> IsDefault()
+    {
+        _isDefault = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Drops the layout from the manifest payload entirely when the user lacks
+    /// this permission — defense in depth, never just hidden.
+    /// </summary>
+    public KanbanLayoutBuilder<TEntity, TGroupBy> RequiresPermission(string permissionName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permissionName);
+        _requiresPermission = permissionName;
+        return this;
+    }
+
+    internal KanbanLayoutDescriptor Build()
+    {
+        if (_groupByPropertyName is null)
+        {
+            throw new InvalidOperationException(
+                "KanbanView requires GroupBy(...) — declare which property buckets rows into columns.");
+        }
+
+        KanbanCardDescriptor card = _cardBuilder?.Build() ?? new KanbanCardDescriptor { Fields = [] };
+
+        return new KanbanLayoutDescriptor
+        {
+            Kind = EntityListLayoutKind.Kanban,
+            IsDefault = _isDefault,
+            RequiresPermission = _requiresPermission,
+            GroupByPropertyName = _groupByPropertyName,
+            GroupByClrType = typeof(TGroupBy),
+            Card = card,
+            Columns = [.. _columnFactories.Select(f => f())],
+        };
+    }
+}

--- a/src/Granit.Entities.Abstractions/Layouts/KanbanLayoutDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/KanbanLayoutDescriptor.cs
@@ -1,0 +1,21 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Kanban layout — board grouped by a discrete property (typically an enum or
+/// lookup-table value). Combines the group-by axis, the per-tile card schema,
+/// and per-value column metadata.
+/// </summary>
+public sealed record KanbanLayoutDescriptor : EntityListLayoutDescriptor
+{
+    /// <summary>Property on the entity used to bucket rows into columns.</summary>
+    public required string GroupByPropertyName { get; init; }
+
+    /// <summary>CLR type of the group-by property — drives wire serialisation of column values.</summary>
+    public required Type GroupByClrType { get; init; }
+
+    /// <summary>Card-content schema rendered inside each tile.</summary>
+    public required KanbanCardDescriptor Card { get; init; }
+
+    /// <summary>Per-value column metadata, in declaration order.</summary>
+    public required IReadOnlyList<KanbanColumnDescriptor> Columns { get; init; }
+}

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -1,3 +1,5 @@
+using Granit.Entities.Layouts;
+
 namespace Granit.Entities.Endpoints.Dtos;
 
 /// <summary>
@@ -11,12 +13,14 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="Metrics">Metric KPIs surfaced on the detail header.</param>
 /// <param name="Dashboards">Dashboards embedded on the detail header.</param>
 /// <param name="DefaultViewId">Resolved default <c>EntityView</c> id per ADR-049's 5-tier resolver, or <see langword="null"/> when none applies.</param>
+/// <param name="ListLayouts">Alternative list-view layouts (kanban, …) the entity exposes — drives the EntityListViewSwitcher tabs.</param>
 public sealed record EntityCollectionsSection(
     EntityCollectionReference? Query,
     EntityCollectionReference? Export,
     IReadOnlyList<EntityCollectionReference> Metrics,
     IReadOnlyList<EntityCollectionReference> Dashboards,
-    Guid? DefaultViewId);
+    Guid? DefaultViewId,
+    IReadOnlyList<EntityListLayoutManifest> ListLayouts);
 
 /// <summary>
 /// Reference to one external declarative primitive (Query / Export / Metric / Dashboard
@@ -27,3 +31,47 @@ public sealed record EntityCollectionsSection(
 public sealed record EntityCollectionReference(
     string Name,
     string ClrTypeName);
+
+/// <summary>
+/// One alternative list-view layout exposed in the manifest. The kind drives
+/// front-end component selection; per-kind config lives in <see cref="Kanban"/>
+/// (and future <c>Calendar</c> / <c>Map</c> / <c>Gallery</c> sub-records).
+/// </summary>
+/// <param name="Kind">Layout kind from the closed catalog.</param>
+/// <param name="IsDefault">Whether this layout is the default tab on first render.</param>
+/// <param name="Kanban">Kanban-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Kanban"/>.</param>
+public sealed record EntityListLayoutManifest(
+    EntityListLayoutKind Kind,
+    bool IsDefault,
+    EntityKanbanLayoutManifest? Kanban);
+
+/// <summary>Kanban-specific layout configuration carried in the manifest.</summary>
+/// <param name="GroupByPropertyName">Entity property used to bucket rows into columns.</param>
+/// <param name="GroupByClrTypeName">Short CLR type name of the group-by property — drives front-end value-parsing.</param>
+/// <param name="Card">Card-content schema for each tile.</param>
+/// <param name="Columns">Per-value column metadata (colour + default state).</param>
+public sealed record EntityKanbanLayoutManifest(
+    string GroupByPropertyName,
+    string GroupByClrTypeName,
+    EntityKanbanCardManifest Card,
+    IReadOnlyList<EntityKanbanColumnManifest> Columns);
+
+/// <summary>
+/// Card-content schema rendered inside a kanban tile. Frappe-style: optional
+/// title (falls back to the entity's <c>DisplayProperty</c> when absent) plus
+/// an ordered list of body fields.
+/// </summary>
+/// <param name="TitleProperty">Entity property used as the tile headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
+/// <param name="Fields">Body fields, in declaration order — already permission-filtered server-side.</param>
+public sealed record EntityKanbanCardManifest(
+    string? TitleProperty,
+    IReadOnlyList<EntityFormFieldManifest> Fields);
+
+/// <summary>One per-value kanban column declaration.</summary>
+/// <param name="Value">Wire form of the discrete <c>GroupBy</c> value (enum member name, string literal, …).</param>
+/// <param name="Color">Optional column colour from the closed catalog, or <see langword="null"/> for theme default.</param>
+/// <param name="DefaultState">Open / Collapsed / Hidden — initial render state per ADR-040.</param>
+public sealed record EntityKanbanColumnManifest(
+    string Value,
+    KanbanColor? Color,
+    KanbanColumnState DefaultState);

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -1,6 +1,7 @@
 using Granit.Entities.Details;
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Forms;
+using Granit.Entities.Layouts;
 using Granit.Entities.Relations;
 
 namespace Granit.Entities.Endpoints.Internal;
@@ -48,7 +49,7 @@ internal static class EntityManifestComposer
             facets.HasFlag(EntityFacets.Collections)
             || facets.HasFlag(EntityFacets.Exports)
             || facets.HasFlag(EntityFacets.Dashboards)
-                ? ComposeCollections(definition, defaultViewId)
+                ? ComposeCollections(definition, grantedPermissions, defaultViewId)
                 : null;
 
         IReadOnlyList<EntityRelationManifest>? relations = facets.HasFlag(EntityFacets.Relations)
@@ -261,7 +262,9 @@ internal static class EntityManifestComposer
     }
 
     private static EntityCollectionsSection ComposeCollections(
-        EntityDefinitionDescriptor d, Guid? defaultViewId)
+        EntityDefinitionDescriptor d,
+        IReadOnlySet<string> granted,
+        Guid? defaultViewId)
     {
         EntityCollectionReference? query = d.QueryDefinitionType is { } q
             ? new EntityCollectionReference(InferDefinitionName(q), q.Name)
@@ -279,7 +282,67 @@ internal static class EntityManifestComposer
             .Select(t => new EntityCollectionReference(InferDefinitionName(t), t.Name))
             .ToList();
 
-        return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId);
+        IReadOnlyList<EntityListLayoutManifest> layouts = ComposeListLayouts(d.ListLayouts, granted);
+
+        return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId, layouts);
+    }
+
+    private static List<EntityListLayoutManifest> ComposeListLayouts(
+        IReadOnlyList<EntityListLayoutDescriptor> source,
+        IReadOnlySet<string> granted)
+    {
+        List<EntityListLayoutManifest> layouts = new(source.Count);
+        foreach (EntityListLayoutDescriptor layout in source)
+        {
+            if (layout.RequiresPermission is { } perm && !granted.Contains(perm))
+            {
+                // Drop entirely — defense in depth.
+                continue;
+            }
+
+            EntityKanbanLayoutManifest? kanban = layout switch
+            {
+                KanbanLayoutDescriptor k => ComposeKanban(k, granted),
+                _ => null,
+            };
+
+            // Layout produced no usable shape (e.g. kanban whose card lost every
+            // field to permission filtering). Drop the layout — empty switcher
+            // tabs would be UX clutter.
+            if (kanban is null && layout.Kind == EntityListLayoutKind.Kanban)
+            {
+                continue;
+            }
+
+            layouts.Add(new EntityListLayoutManifest(
+                layout.Kind,
+                layout.IsDefault,
+                kanban));
+        }
+        return layouts;
+    }
+
+    private static EntityKanbanLayoutManifest? ComposeKanban(
+        KanbanLayoutDescriptor descriptor,
+        IReadOnlySet<string> granted)
+    {
+        List<EntityFormFieldManifest> cardFields = FilterFields(descriptor.Card.Fields, granted);
+
+        // A kanban with no surviving body field is still useful when the title
+        // fallback (entity DisplayProperty) carries the headline; only drop if
+        // the explicit Title got filtered AND no body field survives.
+        // (Title filtering is symmetric with form field permissions.)
+
+        EntityKanbanCardManifest card = new(descriptor.Card.TitleProperty, cardFields);
+
+        IReadOnlyList<EntityKanbanColumnManifest> columns = [.. descriptor.Columns
+            .Select(c => new EntityKanbanColumnManifest(c.Value, c.Color, c.DefaultState))];
+
+        return new EntityKanbanLayoutManifest(
+            descriptor.GroupByPropertyName,
+            descriptor.GroupByClrType.Name,
+            card,
+            columns);
     }
 
     /// <summary>

--- a/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
+++ b/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
@@ -1,4 +1,5 @@
 using Granit.Entities;
+using Granit.Entities.Layouts;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Exports;
 using Granit.Invoicing.Metrics;
@@ -77,5 +78,22 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
             {
                 d.Section("overview", s => s.InheritsFromForm("default"));
                 d.SidePanel.Audit().Timeline();
-            });
+            })
+            // Phase 2.A — kanban grouped by InvoiceStatus. Tile shows the
+            // invoice number as headline + party + due date + total in the
+            // body. Terminal states (Void / Uncollectible) are hidden by
+            // default — workflow keeps them addressable but they shouldn't
+            // clutter the daily board.
+            .KanbanView<InvoiceStatus>(k => k
+                .GroupBy(i => i.Status)
+                .Card(c => c
+                    .Title(i => i.InvoiceNumber)
+                    .Field(i => i.PartyId)
+                    .Field(i => i.DueAt)
+                    .Field(i => i.Total))
+                .Column(InvoiceStatus.Draft, c => c.Color(KanbanColor.Gray))
+                .Column(InvoiceStatus.Open, c => c.Color(KanbanColor.Orange))
+                .Column(InvoiceStatus.Paid, c => c.Color(KanbanColor.Green))
+                .Column(InvoiceStatus.Void, c => c.Color(KanbanColor.Neutral).Hidden())
+                .Column(InvoiceStatus.Uncollectible, c => c.Color(KanbanColor.Red).Collapsed()));
 }

--- a/tests/Granit.Entities.Abstractions.Tests/Layouts/KanbanLayoutTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Layouts/KanbanLayoutTests.cs
@@ -1,0 +1,180 @@
+using Granit.Entities.Layouts;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Layouts;
+
+public sealed class KanbanLayoutTests
+{
+    [Fact]
+    public void Descriptor_carries_groupby_card_and_columns()
+    {
+        EntityDefinitionDescriptor d = new SampleTaskDefinition().Descriptor;
+
+        d.ListLayouts.ShouldHaveSingleItem();
+        KanbanLayoutDescriptor kanban = d.ListLayouts.Single().ShouldBeOfType<KanbanLayoutDescriptor>();
+
+        kanban.Kind.ShouldBe(EntityListLayoutKind.Kanban);
+        kanban.GroupByPropertyName.ShouldBe("Status");
+        kanban.GroupByClrType.ShouldBe(typeof(SampleTaskStatus));
+        kanban.Card.TitleProperty.ShouldBe("Title");
+        kanban.Card.Fields.Select(f => f.PropertyName).ShouldBe(["AssignedTo", "DueDate"]);
+        kanban.Columns.Select(c => c.Value).ShouldBe(["Todo", "InProgress", "Done", "Archived"]);
+    }
+
+    [Fact]
+    public void Column_color_and_default_state_are_preserved()
+    {
+        EntityDefinitionDescriptor d = new SampleTaskDefinition().Descriptor;
+        var kanban = (KanbanLayoutDescriptor)d.ListLayouts.Single();
+
+        KanbanColumnDescriptor todo = kanban.Columns.Single(c => c.Value == "Todo");
+        todo.Color.ShouldBe(KanbanColor.Gray);
+        todo.DefaultState.ShouldBe(KanbanColumnState.Open);
+
+        KanbanColumnDescriptor inProgress = kanban.Columns.Single(c => c.Value == "InProgress");
+        inProgress.Color.ShouldBe(KanbanColor.Orange);
+
+        KanbanColumnDescriptor done = kanban.Columns.Single(c => c.Value == "Done");
+        done.Color.ShouldBe(KanbanColor.Green);
+
+        KanbanColumnDescriptor archived = kanban.Columns.Single(c => c.Value == "Archived");
+        archived.DefaultState.ShouldBe(KanbanColumnState.Hidden);
+    }
+
+    [Fact]
+    public void IsDefault_and_RequiresPermission_round_trip()
+    {
+        EntityDefinitionDescriptor d = new SampleTaskDefinition().Descriptor;
+        EntityListLayoutDescriptor kanban = d.ListLayouts.Single();
+
+        kanban.IsDefault.ShouldBeTrue();
+        kanban.RequiresPermission.ShouldBe("Tasks.Tasks.Kanban");
+    }
+
+    [Fact]
+    public void Build_rejects_missing_groupby()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new MissingGroupByDefinition().Descriptor);
+
+        ex.Message.ShouldContain("GroupBy");
+    }
+
+    [Fact]
+    public void Build_rejects_non_property_groupby_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadGroupByLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("GroupBy selector must be a direct property access");
+    }
+
+    [Fact]
+    public void Build_rejects_non_property_title_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadTitleLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("Title selector must be a direct property access");
+    }
+
+    [Fact]
+    public void Build_rejects_two_default_layouts()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new TwoDefaultsDefinition().Descriptor);
+
+        ex.Message.ShouldContain("At most one list-view layout may be marked IsDefault");
+    }
+
+    [Fact]
+    public void Build_rejects_duplicate_layout_kinds()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new DuplicateKindsDefinition().Descriptor);
+
+        ex.Message.ShouldContain("Duplicate list-view layout kind 'Kanban'");
+    }
+
+    [Fact]
+    public void Card_field_options_round_trip()
+    {
+        EntityDefinitionDescriptor d = new SampleTaskDefinition().Descriptor;
+        var kanban = (KanbanLayoutDescriptor)d.ListLayouts.Single();
+
+        Forms.FieldDescriptor due = kanban.Card.Fields.Single(f => f.PropertyName == "DueDate");
+        due.ReadOnly.ShouldBeTrue();
+        due.LabelKey.ShouldBe("Tasks:Field.DueDate");
+    }
+
+    private enum SampleTaskStatus { Todo, InProgress, Done, Archived }
+
+    private sealed class SampleTask
+    {
+        public string Title { get; set; } = string.Empty;
+        public SampleTaskStatus Status { get; set; }
+        public string AssignedTo { get; set; } = string.Empty;
+        public DateOnly DueDate { get; set; }
+    }
+
+    private sealed class SampleTaskDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.Task";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder.KanbanView<SampleTaskStatus>(k => k
+                .IsDefault()
+                .RequiresPermission("Tasks.Tasks.Kanban")
+                .GroupBy(t => t.Status)
+                .Card(c => c
+                    .Title(t => t.Title)
+                    .Field(t => t.AssignedTo)
+                    .Field(t => t.DueDate, f => f.ReadOnly().Label("Tasks:Field.DueDate")))
+                .Column(SampleTaskStatus.Todo, c => c.Color(KanbanColor.Gray))
+                .Column(SampleTaskStatus.InProgress, c => c.Color(KanbanColor.Orange))
+                .Column(SampleTaskStatus.Done, c => c.Color(KanbanColor.Green))
+                .Column(SampleTaskStatus.Archived, c => c.Color(KanbanColor.Neutral).Hidden()));
+    }
+
+    private sealed class MissingGroupByDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.MissingGroupBy";
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder.KanbanView<SampleTaskStatus>(k => k.Card(c => c.Field(t => t.Title)));
+    }
+
+    private sealed class BadGroupByLambdaDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.BadGroupBy";
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder.KanbanView<string>(k => k.GroupBy(t => t.Title.ToUpperInvariant()));
+    }
+
+    private sealed class BadTitleLambdaDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.BadTitle";
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder.KanbanView<SampleTaskStatus>(k => k
+                .GroupBy(t => t.Status)
+                .Card(c => c.Title(t => t.Title.ToUpperInvariant())));
+    }
+
+    private sealed class TwoDefaultsDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.TwoDefaults";
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder
+                .KanbanView<SampleTaskStatus>(k => k.IsDefault().GroupBy(t => t.Status))
+                .KanbanView<string>(k => k.IsDefault().GroupBy(t => t.AssignedTo));
+    }
+
+    private sealed class DuplicateKindsDefinition : EntityDefinition<SampleTask>
+    {
+        public override string Name => "Granit.Sample.DuplicateKinds";
+        protected override void Configure(EntityDefinitionBuilder<SampleTask> builder) =>
+            builder
+                .KanbanView<SampleTaskStatus>(k => k.GroupBy(t => t.Status))
+                .KanbanView<string>(k => k.GroupBy(t => t.AssignedTo));
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -327,7 +327,8 @@ public sealed class EntityManifestComposerTests
 
     private static EntityDefinitionDescriptor BuildDescriptor(
         IReadOnlyList<FormDescriptor>? forms = null,
-        IReadOnlyList<DetailDescriptor>? details = null) => new()
+        IReadOnlyList<DetailDescriptor>? details = null,
+        IReadOnlyList<Granit.Entities.Layouts.EntityListLayoutDescriptor>? listLayouts = null) => new()
         {
             Name = "Test.Sample",
             EntityType = typeof(SampleEntity),
@@ -342,5 +343,113 @@ public sealed class EntityManifestComposerTests
             WorkflowDefinitionType = null,
             Forms = forms ?? [],
             Details = details ?? [],
+            ListLayouts = listLayouts ?? [],
         };
+
+    [Fact]
+    public void Compose_emits_kanban_layout_with_card_and_columns()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            IsDefault = true,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                TitleProperty = "Title",
+                Fields = [
+                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 },
+                ],
+            },
+            Columns = [
+                new Granit.Entities.Layouts.KanbanColumnDescriptor
+                {
+                    Value = "Open",
+                    Color = Granit.Entities.Layouts.KanbanColor.Orange,
+                    DefaultState = Granit.Entities.Layouts.KanbanColumnState.Open,
+                },
+                new Granit.Entities.Layouts.KanbanColumnDescriptor
+                {
+                    Value = "Done",
+                    Color = Granit.Entities.Layouts.KanbanColor.Green,
+                    DefaultState = Granit.Entities.Layouts.KanbanColumnState.Collapsed,
+                },
+            ],
+        };
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(listLayouts: [kanban]);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityListLayoutManifest layout = manifest.Collections!.ListLayouts.ShouldHaveSingleItem();
+        layout.Kind.ShouldBe(Granit.Entities.Layouts.EntityListLayoutKind.Kanban);
+        layout.IsDefault.ShouldBeTrue();
+        layout.Kanban.ShouldNotBeNull();
+        layout.Kanban!.GroupByPropertyName.ShouldBe("Status");
+        layout.Kanban.Card.TitleProperty.ShouldBe("Title");
+        layout.Kanban.Card.Fields.Select(f => f.PropertyName).ShouldBe(["Owner"]);
+        layout.Kanban.Columns.Select(c => c.Value).ShouldBe(["Open", "Done"]);
+        layout.Kanban.Columns.Single(c => c.Value == "Done").DefaultState
+            .ShouldBe(Granit.Entities.Layouts.KanbanColumnState.Collapsed);
+    }
+
+    [Fact]
+    public void Compose_drops_layout_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            RequiresPermission = "Tasks.Tasks.Kanban",
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor { Fields = [] },
+            Columns = [],
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [kanban]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.ListLayouts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Compose_filters_kanban_card_fields_by_permission()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                Fields = [
+                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 },
+                    new FieldDescriptor { PropertyName = "Salary", ClrType = typeof(decimal), Widget = "money", Order = 1, RequiresPermission = "Tasks.Sensitive.Read" },
+                ],
+            },
+            Columns = [],
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [kanban]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.ListLayouts.ShouldHaveSingleItem()
+            .Kanban!.Card.Fields.Select(f => f.PropertyName).ShouldBe(["Owner"]);
+    }
+
+    private enum SampleStatus { Open, Done }
 }

--- a/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
@@ -1,5 +1,6 @@
 using Granit.Entities;
 using Granit.Entities.Forms;
+using Granit.Entities.Layouts;
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Entities;
 using Shouldly;
@@ -101,5 +102,38 @@ public sealed class InvoiceEntityDefinitionTests
         d.QueryDefinitionType.ShouldNotBeNull();
         d.ExportDefinitionType.ShouldNotBeNull();
         d.MetricDefinitionTypes.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Descriptor_exposes_kanban_layout_grouped_by_status()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        KanbanLayoutDescriptor kanban = d.ListLayouts.OfType<KanbanLayoutDescriptor>().ShouldHaveSingleItem();
+        kanban.GroupByPropertyName.ShouldBe("Status");
+        kanban.GroupByClrType.ShouldBe(typeof(InvoiceStatus));
+    }
+
+    [Fact]
+    public void Descriptor_kanban_card_uses_invoice_number_as_title_and_lists_party_due_total()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+        var kanban = (KanbanLayoutDescriptor)d.ListLayouts.Single(l => l.Kind == EntityListLayoutKind.Kanban);
+
+        kanban.Card.TitleProperty.ShouldBe("InvoiceNumber");
+        kanban.Card.Fields.Select(f => f.PropertyName).ShouldBe(["PartyId", "DueAt", "Total"]);
+    }
+
+    [Fact]
+    public void Descriptor_kanban_columns_carry_status_specific_color_and_state()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+        var kanban = (KanbanLayoutDescriptor)d.ListLayouts.Single(l => l.Kind == EntityListLayoutKind.Kanban);
+
+        kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Draft)).Color.ShouldBe(KanbanColor.Gray);
+        kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Open)).Color.ShouldBe(KanbanColor.Orange);
+        kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Paid)).Color.ShouldBe(KanbanColor.Green);
+        kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Void)).DefaultState.ShouldBe(KanbanColumnState.Hidden);
+        kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Uncollectible)).DefaultState.ShouldBe(KanbanColumnState.Collapsed);
     }
 }


### PR DESCRIPTION
## Summary

Adds the closed-DSL kanban layout to the form manifest — entities declare which list-view layouts the `EntityListViewSwitcher` should expose, with typed group-by, Frappe-style card schema (title + ordered body fields), and per-column metadata (colour from a closed catalog, default open / collapsed / hidden state).

\`\`\`csharp
.KanbanView<InvoiceStatus>(k => k
    .GroupBy(i => i.Status)
    .Card(c => c
        .Title(i => i.InvoiceNumber)
        .Field(i => i.PartyId)
        .Field(i => i.DueAt)
        .Field(i => i.Total))
    .Column(InvoiceStatus.Draft, c => c.Color(KanbanColor.Gray))
    .Column(InvoiceStatus.Open, c => c.Color(KanbanColor.Orange))
    .Column(InvoiceStatus.Paid, c => c.Color(KanbanColor.Green))
    .Column(InvoiceStatus.Void, c => c.Color(KanbanColor.Neutral).Hidden())
    .Column(InvoiceStatus.Uncollectible, c => c.Color(KanbanColor.Red).Collapsed()))
\`\`\`

Closed enums (`KanbanColor`, `KanbanColumnState`) keep theming declarative — no hex codes on the wire, no free-form state strings; the front-end maps to design tokens. List layout is implicit; entities only declare the extra layouts they support.

## Composer behaviour

- Layout-level `RequiresPermission` drops the entire layout from the manifest payload when ungranted (defense in depth, ADR-040 §6).
- Per-card-field `RequiresPermission` drops fields individually (same drop-not-hide rule as scalar form fields).
- Empty cards (every body field filtered out, no Title) still render via the entity's `DisplayProperty` fallback — kanban survives partial permission grants.

## Builder validation

- `GroupBy(...)` is required — `Build()` throws if missing.
- At most one layout may be `IsDefault`; duplicate layout kinds rejected.
- `GroupBy` / `Title` selectors must be direct property access (no computations).

## Cobaye

`Invoice` ships a kanban view grouped by `Status` with colour / state defaults that match the workflow's terminal states (`Void` hidden, `Uncollectible` collapsed). `Party` stays on the implicit list-only layout for now — a future PR will add a kanban grouped by Status (Active / Suspended / Archived).

## Deferred

- **PR C2** — per-user overlay (extends `EntityView` with `LayoutKind` + `LayoutConfigJson`) so a user can save "my kanban grouped by Priority".
- **PR C3** — Calendar / Map / Gallery layouts (same `EntityListLayoutKind` enum, separate descriptors).
- **Architecture test** pairing `Card.Title` / `Card.Field` properties with the entity's `QueryDefinition.Columns` whitelist — needed before any host ships a kanban with non-whitelisted card fields.

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 39/39 pass (9 new kanban DSL)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 46/46 pass (3 new composer projection)
- [x] `dotnet test tests/Granit.Invoicing.Tests` — 68/68 pass (3 new entity-def kanban)
- [x] `dotnet test tests/Granit.Parties.Tests` — 164/164 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 pass
- [x] `dotnet format style .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift