### PR TITLE
chore(ci): drop legacy integration-test job, unify on Testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,67 +147,6 @@ jobs:
           retention-days: 7
 
   # ---------------------------------------------------------------------------
-  # INTEGRATION TESTS (needs Docker service container)
-  # ---------------------------------------------------------------------------
-  integration-test:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    services:
-      postgres:
-        image: postgres:18
-        env:
-          POSTGRES_DB: granit_test
-          POSTGRES_USER: granit_test
-          POSTGRES_PASSWORD: test_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U granit_test"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-    env:
-      POSTGRES_HOST: localhost
-      POSTGRES_PORT: "5432"
-      POSTGRES_DB: granit_test
-      POSTGRES_USER: granit_test
-      POSTGRES_PASSWORD: test_password
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: NuGet cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
-          restore-keys: nuget-${{ runner.os }}-
-
-      - name: Build
-        run: dotnet build -c $CONFIGURATION -p:RunAnalyzers=false -p:EnforceCodeStyleInBuild=false
-
-      - name: Run integration tests
-        run: |
-          for proj in tests/*.Tests.Integration/*.Tests.Integration.csproj; do
-            [ -f "$proj" ] && dotnet test "$proj" -c $CONFIGURATION --no-build \
-              --logger "trx;LogFilePath=TestResults/results.trx" \
-              --collect:"XPlat Code Coverage" \
-              -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover,cobertura
-          done
-
-      - name: Upload integration test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: integration-test-results
-          path: "**/TestResults/"
-          retention-days: 7
-
-  # ---------------------------------------------------------------------------
   # SECURITY (parallel, no build needed except CodeQL)
   # ---------------------------------------------------------------------------
   secret-detection:

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/PerTenantRoutingTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/PerTenantRoutingTests.cs
@@ -16,7 +16,6 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Npgsql;
 using NSubstitute;
 using Shouldly;
 using Testcontainers.PostgreSql;
@@ -49,54 +48,27 @@ internal sealed class TenantIntegrationDbContext(
 
 public sealed class TwoPostgresContainersFixture : IAsyncLifetime
 {
-    private PostgreSqlContainer? _containerA;
-    private PostgreSqlContainer? _containerB;
+    private readonly PostgreSqlContainer _containerA = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase("tenant_a")
+        .WithUsername("granit")
+        .WithPassword("granit_test")
+        .Build();
+
+    private readonly PostgreSqlContainer _containerB = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase("tenant_b")
+        .WithUsername("granit")
+        .WithPassword("granit_test")
+        .Build();
 
     public string ConnectionStringA { get; private set; } = string.Empty;
     public string ConnectionStringB { get; private set; } = string.Empty;
 
     public async ValueTask InitializeAsync()
     {
-        string? ciHost = Environment.GetEnvironmentVariable("POSTGRES_HOST");
+        await Task.WhenAll(_containerA.StartAsync(), _containerB.StartAsync());
 
-        if (!string.IsNullOrEmpty(ciHost))
-        {
-            // CI mode: use the PostgreSQL service container provided by CI.
-            // Create two separate databases on the same server.
-            string port = Environment.GetEnvironmentVariable("POSTGRES_PORT") ?? "5432";
-            string user = Environment.GetEnvironmentVariable("POSTGRES_USER") ?? "granit_test";
-            string password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? "test_password";
-            string mainDb = Environment.GetEnvironmentVariable("POSTGRES_DB") ?? "granit_test";
-
-            string adminConnectionString =
-                $"Host={ciHost};Port={port};Database={mainDb};Username={user};Password={password}";
-
-            await CreateDatabaseAsync(adminConnectionString, "tenant_a");
-            await CreateDatabaseAsync(adminConnectionString, "tenant_b");
-
-            ConnectionStringA = $"Host={ciHost};Port={port};Database=tenant_a;Username={user};Password={password}";
-            ConnectionStringB = $"Host={ciHost};Port={port};Database=tenant_b;Username={user};Password={password}";
-        }
-        else
-        {
-            // Local mode: use Testcontainers (requires Docker).
-            _containerA = new PostgreSqlBuilder("postgres:16-alpine")
-                .WithDatabase("tenant_a")
-                .WithUsername("granit")
-                .WithPassword("granit_test")
-                .Build();
-
-            _containerB = new PostgreSqlBuilder("postgres:16-alpine")
-                .WithDatabase("tenant_b")
-                .WithUsername("granit")
-                .WithPassword("granit_test")
-                .Build();
-
-            await Task.WhenAll(_containerA.StartAsync(), _containerB.StartAsync());
-
-            ConnectionStringA = _containerA.GetConnectionString();
-            ConnectionStringB = _containerB.GetConnectionString();
-        }
+        ConnectionStringA = _containerA.GetConnectionString();
+        ConnectionStringB = _containerB.GetConnectionString();
 
         await MigrateAsync(ConnectionStringA);
         await MigrateAsync(ConnectionStringB);
@@ -104,47 +76,8 @@ public sealed class TwoPostgresContainersFixture : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        if (_containerA is not null)
-        {
-            await _containerA.DisposeAsync();
-        }
-
-        if (_containerB is not null)
-        {
-            await _containerB.DisposeAsync();
-        }
-    }
-
-    private static async Task CreateDatabaseAsync(string adminConnectionString, string dbName)
-    {
-        // Retry to handle transient DNS/networking delays when the CI PostgreSQL service is starting.
-        const int maxAttempts = 5;
-        for (int attempt = 1; ; attempt++)
-        {
-            try
-            {
-                await using NpgsqlConnection conn = new(adminConnectionString);
-                await conn.OpenAsync().ConfigureAwait(false);
-
-                // Check if the database already exists before creating.
-                await using NpgsqlCommand checkCmd = conn.CreateCommand();
-                checkCmd.CommandText = $"SELECT 1 FROM pg_database WHERE datname = '{dbName}'";
-                object? exists = await checkCmd.ExecuteScalarAsync().ConfigureAwait(false);
-
-                if (exists is null)
-                {
-                    await using NpgsqlCommand createCmd = conn.CreateCommand();
-                    createCmd.CommandText = $"CREATE DATABASE {dbName}";
-                    await createCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-                }
-
-                return;
-            }
-            catch when (attempt < maxAttempts)
-            {
-                await Task.Delay(attempt * 1_000).ConfigureAwait(false);
-            }
-        }
+        await _containerA.DisposeAsync();
+        await _containerB.DisposeAsync();
     }
 
     private static async Task MigrateAsync(string connectionString)
@@ -154,21 +87,8 @@ public sealed class TwoPostgresContainersFixture : IAsyncLifetime
                 .UseNpgsql(connectionString)
                 .Options;
 
-        // Retry to handle transient networking delays after service startup.
-        const int maxAttempts = 5;
-        for (int attempt = 1; ; attempt++)
-        {
-            try
-            {
-                await using TenantIntegrationDbContext ctx = new(opts);
-                await ctx.Database.EnsureCreatedAsync().ConfigureAwait(false);
-                return;
-            }
-            catch when (attempt < maxAttempts)
-            {
-                await Task.Delay(attempt * 1_000).ConfigureAwait(false);
-            }
-        }
+        await using TenantIntegrationDbContext ctx = new(opts);
+        await ctx.Database.EnsureCreatedAsync().ConfigureAwait(false);
     }
 }
 


### PR DESCRIPTION
## Summary

Since #1655 added the \`integration\` shard to the matrix \`test\` job, every \`*.Tests.Integration\` project ran **twice** per push:

| Job | Source | Failures gating? |
|-----|--------|------------------|
| \`test (Integration Tests)\` (matrix shard) | \`dotnet test .github/shard-filters/integration.slnf\` — Testcontainers | **Yes** |
| \`integration-test\` (standalone) | \`for proj in tests/*.Tests.Integration/...; do dotnet test\` — service Postgres | No (\`continue-on-error: true\`) |

17 of the 18 projects were already on Testcontainers, so the standalone job was 100% duplicate work for them — the same Docker-in-Docker spin-up fired twice per push, ignoring the GitHub-provided service Postgres entirely.

Only \`Granit.Wolverine.Postgresql.Tests.Integration.PerTenantRoutingTests\` had a \`POSTGRES_HOST\` fallback that used the service container. Strip that branch — the fixture already had the Testcontainers path; we just remove the env-var lookup, the \`CreateDatabaseAsync\` helper that bootstrapped the per-tenant DBs on the shared service, and the migration retry loop that compensated for service-startup races (Testcontainers handles all of that natively).

## Effect

- **~10 min CI saved per push** (the duplicated Testcontainer spin-ups).
- **One source of truth** for integration-test failures (the matrix shard, which is already gating).
- **One less silent failure path** — no more \`continue-on-error\` job hiding regressions.

## Test plan

- [x] \`dotnet build tests/Granit.Wolverine.Postgresql.Tests.Integration\` — clean
- [x] \`dotnet test tests/Granit.Wolverine.Postgresql.Tests.Integration\` — 5/5 pass with simplified Testcontainers-only fixture
- [x] \`dotnet format style tests/Granit.Wolverine.Postgresql.Tests.Integration --verify-no-changes\` — clean