### PR TITLE
feat(entities-abstractions): Action<TEntity> primitive (Phase 2.B)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18811,6 +18811,83 @@
       "members": []
     },
     {
+      "name": "EntityActionBuilder",
+      "fqn": "Granit.Entities.Actions.EntityActionBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "EntityActionContributionContext",
+      "fqn": "Granit.Entities.Actions.EntityActionContributionContext",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/EntityActionContributionContext.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Contributions",
+          "kind": "property",
+          "signature": "IReadOnlyDictionary<Type, IReadOnlyList<EntityActionDescriptor>> Contributions",
+          "returnType": "IReadOnlyDictionary<Type, IReadOnlyList<EntityActionDescriptor>>"
+        }
+      ]
+    },
+    {
+      "name": "EntityActionDescriptor",
+      "fqn": "Granit.Entities.Actions.EntityActionDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "EntityActionKind",
+      "fqn": "Granit.Entities.Actions.EntityActionKind",
+      "kind": "enum",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/EntityActionKind.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "EntityActionServiceCollectionExtensions",
+      "fqn": "Granit.Entities.Actions.EntityActionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/EntityActionServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IEntityActionContributionContext",
+      "fqn": "Granit.Entities.Actions.IEntityActionContributionContext",
+      "kind": "interface",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/IEntityActionContributor.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "IEntityActionContributor",
+      "fqn": "Granit.Entities.Actions.IEntityActionContributor",
+      "kind": "interface",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/IEntityActionContributor.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Contribute",
+          "kind": "method",
+          "signature": "Contribute(IEntityActionContributionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "DetailBuilder",
       "fqn": "Granit.Entities.Details.DetailBuilder",
       "kind": "class",
@@ -18902,6 +18979,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Details/SidePanelKind.cs",
       "line": 13,
+      "members": []
+    },
+    {
+      "name": "EntityActionManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs",
+      "line": 21,
       "members": []
     },
     {
@@ -19072,7 +19158,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -19226,7 +19312,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "DisplayKey",
@@ -19242,7 +19328,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "Name",
@@ -19255,6 +19341,12 @@
           "kind": "property",
           "signature": "IReadOnlyList<EntityListLayoutDescriptor> ListLayouts",
           "returnType": "IReadOnlyList<EntityListLayoutDescriptor>"
+        },
+        {
+          "name": "Actions",
+          "kind": "property",
+          "signature": "IReadOnlyList<EntityActionDescriptor> Actions",
+          "returnType": "IReadOnlyList<EntityActionDescriptor>"
         }
       ]
     },

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
@@ -1,0 +1,166 @@
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Fluent builder for one entity action. Each kind-shortcut (<see cref="ApiCall"/>,
+/// <see cref="Download"/>, <see cref="Navigate"/>, <see cref="WorkflowTransition"/>)
+/// sets the discriminator and the kind-specific fields atomically — there is no way
+/// to build an inconsistent descriptor (e.g. ApiCall without a URL).
+/// </summary>
+/// <typeparam name="TEntity">The entity the action is attached to. Reserved for future
+/// type-safe shortcuts (e.g. expression-based URL building); currently unused but
+/// kept for symmetry with <c>RelationBuilder&lt;TSource, TRelated&gt;</c>.</typeparam>
+public sealed class EntityActionBuilder<TEntity>
+    where TEntity : class
+{
+    private readonly string _name;
+    private readonly string? _contributorAssemblyName;
+
+    private EntityActionKind _kind = EntityActionKind.ApiCall;
+    private string? _displayKey;
+    private string? _icon;
+    private int _order;
+    private string? _requiresPermission;
+    private string? _urlTemplate;
+    private string? _httpMethod;
+    private string? _confirmationKey;
+    private string? _workflowTransitionName;
+
+    internal EntityActionBuilder(string name, string? contributorAssemblyName = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _name = name;
+        _contributorAssemblyName = contributorAssemblyName;
+    }
+
+    /// <summary>
+    /// Configures the action as an HTTP write call (POST / PUT / DELETE) against
+    /// <paramref name="urlTemplate"/>. The template can reference <c>{id}</c> for
+    /// the entity primary key; the renderer resolves it at click time.
+    /// </summary>
+    public EntityActionBuilder<TEntity> ApiCall(string method, string urlTemplate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(method);
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlTemplate);
+
+        _kind = EntityActionKind.ApiCall;
+        _httpMethod = method.ToUpperInvariant();
+        _urlTemplate = urlTemplate;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the action as a binary download (HTTP GET) against
+    /// <paramref name="urlTemplate"/>. The renderer triggers a browser download.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Download(string urlTemplate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlTemplate);
+
+        _kind = EntityActionKind.Download;
+        _httpMethod = null;
+        _urlTemplate = urlTemplate;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the action as a client-side navigation (route or external URL).
+    /// </summary>
+    public EntityActionBuilder<TEntity> Navigate(string urlTemplate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlTemplate);
+
+        _kind = EntityActionKind.Navigate;
+        _httpMethod = null;
+        _urlTemplate = urlTemplate;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the action as a workflow transition. The renderer consults the
+    /// entity's <c>WorkflowDefinitionType</c> to know whether the transition is
+    /// allowed for the current row state — actions whose target state isn't
+    /// reachable are rendered disabled.
+    /// </summary>
+    public EntityActionBuilder<TEntity> WorkflowTransition(string targetStateName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetStateName);
+
+        _kind = EntityActionKind.WorkflowTransition;
+        _httpMethod = null;
+        _urlTemplate = null;
+        _workflowTransitionName = targetStateName;
+        return this;
+    }
+
+    /// <summary>i18n key for the user-facing label.</summary>
+    public EntityActionBuilder<TEntity> DisplayKey(string displayKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayKey);
+        _displayKey = displayKey;
+        return this;
+    }
+
+    /// <summary>Icon name from the framework's icon catalog.</summary>
+    public EntityActionBuilder<TEntity> Icon(string icon)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(icon);
+        _icon = icon;
+        return this;
+    }
+
+    /// <summary>Display order among the entity's actions (lower first).</summary>
+    public EntityActionBuilder<TEntity> Order(int order)
+    {
+        _order = order;
+        return this;
+    }
+
+    /// <summary>
+    /// Drops the action from the manifest payload when the user lacks this
+    /// permission — defense in depth, never just hidden.
+    /// </summary>
+    public EntityActionBuilder<TEntity> RequiresPermission(string permissionName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permissionName);
+        _requiresPermission = permissionName;
+        return this;
+    }
+
+    /// <summary>
+    /// i18n key for a confirmation modal shown before invoking the action.
+    /// Only meaningful for <see cref="EntityActionKind.ApiCall"/> and
+    /// <see cref="EntityActionKind.WorkflowTransition"/>.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Confirmation(string confirmationKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(confirmationKey);
+        _confirmationKey = confirmationKey;
+        return this;
+    }
+
+    internal EntityActionDescriptor Build()
+    {
+        // Kind-specific guards: invariants the fluent shortcuts can't catch on
+        // their own (e.g. someone configures DisplayKey + Order without ever
+        // calling ApiCall/Download/Navigate/WorkflowTransition).
+        if (_kind != EntityActionKind.WorkflowTransition && _urlTemplate is null)
+        {
+            throw new InvalidOperationException(
+                $"Action '{_name}' must declare a URL via ApiCall(...) / Download(...) / Navigate(...) "
+                + "or be a WorkflowTransition. Bare actions are not allowed.");
+        }
+
+        return new EntityActionDescriptor(
+            Name: _name,
+            Kind: _kind,
+            DisplayKey: _displayKey,
+            Icon: _icon,
+            Order: _order,
+            RequiresPermission: _requiresPermission,
+            UrlTemplate: _urlTemplate,
+            HttpMethod: _httpMethod,
+            ConfirmationKey: _confirmationKey,
+            WorkflowTransitionName: _workflowTransitionName,
+            ContributorAssemblyName: _contributorAssemblyName);
+    }
+}

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionContributionContext.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionContributionContext.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Default <see cref="IEntityActionContributionContext"/> — accumulates per-source
+/// contributions in memory; the <c>Granit.Entities</c> runtime composer later
+/// merges them into the canonical <see cref="EntityDefinitionDescriptor.Actions"/>
+/// list. Sealed: the surface is not extensible — contributors interact through
+/// the interface.
+/// </summary>
+public sealed class EntityActionContributionContext : IEntityActionContributionContext
+{
+    private readonly Dictionary<Type, List<EntityActionDescriptor>> _bySource = [];
+
+    /// <summary>The accumulated contributions, indexed by source CLR type.</summary>
+    public IReadOnlyDictionary<Type, IReadOnlyList<EntityActionDescriptor>> Contributions =>
+        _bySource.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlyList<EntityActionDescriptor>)kv.Value);
+
+    /// <inheritdoc />
+    public IEntityActionContributionContext AddAction<TSource>(
+        string name,
+        Action<EntityActionBuilder<TSource>> configure)
+        where TSource : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        Assembly contributorAssembly = configure.Method.DeclaringType?.Assembly
+            ?? Assembly.GetCallingAssembly();
+        string assemblyName = contributorAssembly.GetName().Name ?? "unknown";
+
+        EntityActionBuilder<TSource> builder = new(name, assemblyName);
+        configure(builder);
+
+        if (!_bySource.TryGetValue(typeof(TSource), out List<EntityActionDescriptor>? bag))
+        {
+            bag = [];
+            _bySource[typeof(TSource)] = bag;
+        }
+        bag.Add(builder.Build());
+
+        return this;
+    }
+}

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
@@ -1,0 +1,31 @@
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Immutable descriptor for one action declared on an entity — covers both
+/// intra-module declarations (<c>Action(...)</c> on
+/// <see cref="EntityDefinitionBuilder{TEntity}"/>) and cross-module grafts
+/// (<see cref="IEntityActionContributor"/>).
+/// </summary>
+/// <param name="Name">Stable action name, unique per source entity (e.g. <c>"finalize"</c>).</param>
+/// <param name="Kind">Renderer dispatch — drives which payload fields the frontend reads.</param>
+/// <param name="DisplayKey">i18n key for the user-facing label.</param>
+/// <param name="Icon">Icon name from the icon catalog.</param>
+/// <param name="Order">Display order among the entity's actions.</param>
+/// <param name="RequiresPermission">Optional permission gate — drops the action from the manifest payload when the user does not hold it (defense in depth, never just hidden).</param>
+/// <param name="UrlTemplate">URL template with <c>{id}</c> placeholder. Required for ApiCall, Download and Navigate; <see langword="null"/> for WorkflowTransition.</param>
+/// <param name="HttpMethod">HTTP verb for ApiCall (POST / PUT / DELETE). <see langword="null"/> otherwise.</param>
+/// <param name="ConfirmationKey">Optional i18n key for the confirmation modal shown before invoking the action.</param>
+/// <param name="WorkflowTransitionName">Name of the target workflow state for <see cref="EntityActionKind.WorkflowTransition"/>.</param>
+/// <param name="ContributorAssemblyName">Name of the contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+public sealed record EntityActionDescriptor(
+    string Name,
+    EntityActionKind Kind,
+    string? DisplayKey,
+    string? Icon,
+    int Order,
+    string? RequiresPermission,
+    string? UrlTemplate,
+    string? HttpMethod,
+    string? ConfirmationKey,
+    string? WorkflowTransitionName,
+    string? ContributorAssemblyName);

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionKind.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionKind.cs
@@ -1,0 +1,26 @@
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Closed catalog of action kinds the renderer knows how to surface (per ADR-040).
+/// Each kind binds to a specific frontend behaviour and a specific descriptor field
+/// shape; the renderer dispatches on this enum and never on a free-form string.
+/// </summary>
+public enum EntityActionKind
+{
+    /// <summary>HTTP write call (POST / PUT / DELETE) to <c>UrlTemplate</c>; optional confirmation modal.</summary>
+    ApiCall = 0,
+
+    /// <summary>HTTP GET against <c>UrlTemplate</c> returning a binary payload — opens the browser's download dialog.</summary>
+    Download = 1,
+
+    /// <summary>Client-side navigation to <c>UrlTemplate</c> (route or external URL).</summary>
+    Navigate = 2,
+
+    /// <summary>
+    /// Workflow state transition resolved through the entity's
+    /// <c>WorkflowDefinitionType</c>; the renderer consults the workflow runtime
+    /// to know whether the transition is currently allowed for the row.
+    /// <c>WorkflowTransitionName</c> carries the target state name.
+    /// </summary>
+    WorkflowTransition = 3,
+}

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionServiceCollectionExtensions.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Service-collection extensions for registering cross-module entity action
+/// contributors.
+/// </summary>
+public static class EntityActionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <typeparamref name="TContributor"/> as a singleton implementing
+    /// <see cref="IEntityActionContributor"/>. Multiple contributors per host
+    /// are expected — invocation order at boot is registration order.
+    /// </summary>
+    public static IServiceCollection AddEntityActionContribution<TContributor>(this IServiceCollection services)
+        where TContributor : class, IEntityActionContributor
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<IEntityActionContributor, TContributor>();
+        return services;
+    }
+}

--- a/src/Granit.Entities.Abstractions/Actions/IEntityActionContributor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/IEntityActionContributor.cs
@@ -1,0 +1,37 @@
+namespace Granit.Entities.Actions;
+
+/// <summary>
+/// Cross-module hook for grafting an action onto an entity owned by another
+/// module. Same IoC contributor pattern as <see cref="Relations.IEntityRelationContributor"/>
+/// (per ADR-040) — used so that, for example, <c>Granit.Tasks</c> can graft an
+/// <c>"add-task"</c> quick-action onto <c>Granit.Parties.Party</c> without either
+/// side taking a runtime dependency on the other.
+/// </summary>
+public interface IEntityActionContributor
+{
+    /// <summary>
+    /// Apply this module's action contributions. The runtime resolves them
+    /// after every <see cref="EntityDefinition{TEntity}"/> is registered, so
+    /// contributions targeting an unknown source entity are dropped with a
+    /// debug log (module load order is non-deterministic, can't be strict).
+    /// </summary>
+    void Contribute(IEntityActionContributionContext context);
+}
+
+/// <summary>
+/// Surface a contributor uses to graft actions onto a source entity.
+/// </summary>
+public interface IEntityActionContributionContext
+{
+    /// <summary>
+    /// Adds an action to the source entity. The action appears alongside the
+    /// source entity's intra-module actions in the manifest, ordered by
+    /// <see cref="EntityActionBuilder{TEntity}.Order"/>.
+    /// </summary>
+    /// <param name="name">Stable action name, unique per source entity.</param>
+    /// <param name="configure">Builder configuration delegate.</param>
+    IEntityActionContributionContext AddAction<TSource>(
+        string name,
+        Action<EntityActionBuilder<TSource>> configure)
+        where TSource : class;
+}

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using Granit.Entities.Actions;
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
@@ -29,6 +30,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     private readonly List<Func<DetailDescriptor>> _detailFactories = [];
     private readonly List<RelationDescriptor> _relations = [];
     private readonly List<Func<EntityListLayoutDescriptor>> _layoutFactories = [];
+    private readonly List<EntityActionDescriptor> _actions = [];
 
     /// <summary>Sets the i18n key for the entity's display name (singular).</summary>
     public EntityDefinitionBuilder<TEntity> DisplayKey(string displayKey)
@@ -218,6 +220,29 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         return this;
     }
 
+    /// <summary>
+    /// Declares an action exposed on this entity (button on the detail header,
+    /// row action, kanban tile quick-action — surface decided by the renderer).
+    /// One of <see cref="EntityActionBuilder{TEntity}.ApiCall"/>,
+    /// <see cref="EntityActionBuilder{TEntity}.Download"/>,
+    /// <see cref="EntityActionBuilder{TEntity}.Navigate"/> or
+    /// <see cref="EntityActionBuilder{TEntity}.WorkflowTransition"/> must be called
+    /// inside <paramref name="configure"/>; otherwise <c>Build()</c> rejects the
+    /// definition.
+    /// </summary>
+    public EntityDefinitionBuilder<TEntity> Action(
+        string name,
+        Action<EntityActionBuilder<TEntity>> configure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        EntityActionBuilder<TEntity> builder = new(name);
+        configure(builder);
+        _actions.Add(builder.Build());
+        return this;
+    }
+
     internal EntityDefinitionDescriptor Build(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -237,6 +262,11 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         AssertAtMostOneDefaultLayout(layouts);
         AssertUniqueLayoutKinds(layouts);
 
+        AssertUniqueActionNames(_actions);
+        IReadOnlyList<EntityActionDescriptor> actions = [.. _actions
+            .OrderBy(a => a.Order)
+            .ThenBy(a => a.Name, StringComparer.Ordinal)];
+
         return new EntityDefinitionDescriptor
         {
             Name = name,
@@ -254,7 +284,21 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
             Details = details,
             Relations = relations,
             ListLayouts = layouts,
+            Actions = actions,
         };
+    }
+
+    private static void AssertUniqueActionNames(IReadOnlyList<EntityActionDescriptor> actions)
+    {
+        IGrouping<string, EntityActionDescriptor>? duplicate = actions
+            .GroupBy(a => a.Name, StringComparer.Ordinal)
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate is not null)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate action name '{duplicate.Key}' on entity '{typeof(TEntity).FullName}'. Names must be unique per entity.");
+        }
     }
 
     private static void AssertAtMostOneDefaultLayout(IReadOnlyList<EntityListLayoutDescriptor> layouts)

--- a/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Actions;
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
@@ -100,4 +101,13 @@ public sealed record EntityDefinitionDescriptor
     /// layouts declared via <c>b.KanbanView&lt;TGroupBy&gt;(...)</c> and friends.
     /// </summary>
     public IReadOnlyList<EntityListLayoutDescriptor> ListLayouts { get; init; } = [];
+
+    /// <summary>
+    /// Actions exposed on this entity — both intra-module via <c>Action(...)</c> on
+    /// the builder and cross-module via <see cref="IEntityActionContributor"/>
+    /// grafts. Sorted by <see cref="EntityActionDescriptor.Order"/> then
+    /// <see cref="EntityActionDescriptor.Name"/>; intra-module declarations take
+    /// precedence on conflicts (same <see cref="EntityActionDescriptor.Name"/>).
+    /// </summary>
+    public IReadOnlyList<EntityActionDescriptor> Actions { get; init; } = [];
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs
@@ -1,0 +1,31 @@
+using Granit.Entities.Actions;
+
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Wire shape for one action exposed on an entity manifest. Mirrors
+/// <see cref="EntityActionDescriptor"/> with the contributor-assembly
+/// attribution carried over so the SPA can render an "Added by {Module}"
+/// affordance.
+/// </summary>
+/// <param name="Name">Stable action name, unique per entity.</param>
+/// <param name="Kind">Renderer dispatch — drives which payload fields the frontend reads.</param>
+/// <param name="DisplayKey">i18n key for the user-facing label.</param>
+/// <param name="Icon">Icon name from the catalog.</param>
+/// <param name="Order">Display order among the entity's actions.</param>
+/// <param name="UrlTemplate">URL template with <c>{id}</c> placeholder. <see langword="null"/> for WorkflowTransition.</param>
+/// <param name="HttpMethod">HTTP verb for ApiCall (POST / PUT / DELETE). <see langword="null"/> otherwise.</param>
+/// <param name="ConfirmationKey">Optional i18n key for the confirmation modal.</param>
+/// <param name="WorkflowTransitionName">Name of the target workflow state for WorkflowTransition.</param>
+/// <param name="ContributorAssemblyName">Contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+public sealed record EntityActionManifest(
+    string Name,
+    EntityActionKind Kind,
+    string? DisplayKey,
+    string? Icon,
+    int Order,
+    string? UrlTemplate,
+    string? HttpMethod,
+    string? ConfirmationKey,
+    string? WorkflowTransitionName,
+    string? ContributorAssemblyName);

--- a/src/Granit.Entities.Endpoints/Dtos/EntityFacets.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityFacets.cs
@@ -38,6 +38,9 @@ public enum EntityFacets
     /// <summary>Relations declared on the entity (intra-module + cross-module contributions per ADR-048).</summary>
     Relations = 1 << 8,
 
+    /// <summary>Actions exposed on the entity (intra-module + cross-module contributions per ADR-040).</summary>
+    Actions = 1 << 9,
+
     /// <summary>All facets — the default when <c>?facets=</c> is absent.</summary>
-    All = Identity | Permissions | Forms | Details | Collections | Dashboards | Exports | Views | Relations,
+    All = Identity | Permissions | Forms | Details | Collections | Dashboards | Exports | Views | Relations | Actions,
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs
@@ -12,6 +12,7 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="Details">Detail-view variants the user is allowed to see (already permission-filtered).</param>
 /// <param name="Collections">Query / Export / Metric / Dashboard references + resolved default view.</param>
 /// <param name="Relations">Relations surfaced on the source entity (Tab / SmartButton / Sidebar / InlineChips per ADR-048). Already permission-filtered server-side.</param>
+/// <param name="Actions">Actions exposed on the entity (intra-module + cross-module contributions). Already permission-filtered server-side.</param>
 public sealed record EntityManifestResponse(
     int SchemaVersion,
     EntityIdentitySection? Identity,
@@ -19,4 +20,5 @@ public sealed record EntityManifestResponse(
     IReadOnlyList<EntityFormManifest>? Forms,
     IReadOnlyList<EntityDetailManifest>? Details,
     EntityCollectionsSection? Collections,
-    IReadOnlyList<EntityRelationManifest>? Relations);
+    IReadOnlyList<EntityRelationManifest>? Relations,
+    IReadOnlyList<EntityActionManifest>? Actions = null);

--- a/src/Granit.Entities.Endpoints/Internal/EntityFacetParser.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityFacetParser.cs
@@ -30,6 +30,7 @@ internal static class EntityFacetParser
                 "export" or "exports" => EntityFacets.Exports,
                 "view" or "views" or "saved-views" => EntityFacets.Views,
                 "relation" or "relations" => EntityFacets.Relations,
+                "action" or "actions" => EntityFacets.Actions,
                 _ => EntityFacets.None,
             };
         }

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Actions;
 using Granit.Entities.Details;
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Forms;
@@ -56,6 +57,10 @@ internal static class EntityManifestComposer
             ? ComposeRelations(definition, grantedPermissions)
             : null;
 
+        IReadOnlyList<EntityActionManifest>? actions = facets.HasFlag(EntityFacets.Actions)
+            ? ComposeActions(definition, grantedPermissions)
+            : null;
+
         return new EntityManifestResponse(
             SchemaVersion,
             identity,
@@ -63,7 +68,40 @@ internal static class EntityManifestComposer
             forms,
             details,
             collections,
-            relations);
+            relations,
+            actions);
+    }
+
+    private static List<EntityActionManifest> ComposeActions(
+        EntityDefinitionDescriptor d, IReadOnlySet<string> granted)
+    {
+        if (d.Actions.Count == 0)
+        {
+            return [];
+        }
+
+        List<EntityActionManifest> actions = new(d.Actions.Count);
+        foreach (EntityActionDescriptor action in d.Actions)
+        {
+            if (action.RequiresPermission is { } perm && !granted.Contains(perm))
+            {
+                // Drop entirely — defense in depth (per ADR-040 §6).
+                continue;
+            }
+
+            actions.Add(new EntityActionManifest(
+                action.Name,
+                action.Kind,
+                action.DisplayKey,
+                action.Icon,
+                action.Order,
+                action.UrlTemplate,
+                action.HttpMethod,
+                action.ConfirmationKey,
+                action.WorkflowTransitionName,
+                action.ContributorAssemblyName));
+        }
+        return actions;
     }
 
     private static List<EntityRelationManifest> ComposeRelations(

--- a/src/Granit.Entities/Internal/EntityActionMerger.cs
+++ b/src/Granit.Entities/Internal/EntityActionMerger.cs
@@ -1,0 +1,103 @@
+using Granit.Entities.Actions;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Entities.Internal;
+
+/// <summary>
+/// Boot-time merger that runs every registered <see cref="IEntityActionContributor"/>
+/// and folds the contributed actions into the matching
+/// <see cref="EntityDefinitionDescriptor"/>. Mirrors
+/// <see cref="EntityRelationMerger"/>; same merge rules:
+/// <list type="bullet">
+///   <item>Contributions targeting an unknown source entity are dropped with a debug log.</item>
+///   <item>When a contributor declares an action whose name matches an existing intra-module
+///         action on the source, the intra-module declaration takes precedence — the
+///         contribution is dropped with a debug log.</item>
+///   <item>Final action list is sorted by <c>Order</c> then <c>Name</c>.</item>
+/// </list>
+/// </summary>
+internal static class EntityActionMerger
+{
+    public static IReadOnlyList<IEntityDefinitionDescriptor> Merge(
+        IEnumerable<IEntityDefinitionDescriptor> definitions,
+        IEnumerable<IEntityActionContributor> contributors,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        ArgumentNullException.ThrowIfNull(contributors);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        IEntityDefinitionDescriptor[] frozen = [.. definitions];
+
+        EntityActionContributionContext context = new();
+        foreach (IEntityActionContributor contributor in contributors)
+        {
+            contributor.Contribute(context);
+        }
+
+        if (context.Contributions.Count == 0)
+        {
+            return frozen;
+        }
+
+        Dictionary<Type, IEntityDefinitionDescriptor> byType = frozen.ToDictionary(d => d.EntityType);
+
+        foreach ((Type sourceType, IReadOnlyList<EntityActionDescriptor> contributed) in context.Contributions)
+        {
+            if (!byType.TryGetValue(sourceType, out IEntityDefinitionDescriptor? hostDescriptor))
+            {
+                logger.LogDebug(
+                    "Entity action contribution targeted unknown source CLR type '{SourceType}' — dropped.",
+                    sourceType.FullName);
+                continue;
+            }
+
+            EntityDefinitionDescriptor merged = MergeActions(hostDescriptor.Descriptor, contributed, logger);
+            byType[sourceType] = new MergedActionsEntityDefinitionDescriptor(hostDescriptor, merged);
+        }
+
+        return [.. byType.Values];
+    }
+
+    private static EntityDefinitionDescriptor MergeActions(
+        EntityDefinitionDescriptor host,
+        IReadOnlyList<EntityActionDescriptor> contributed,
+        ILogger logger)
+    {
+        var intraModuleNames = host.Actions
+            .Where(a => a.ContributorAssemblyName is null)
+            .Select(a => a.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<EntityActionDescriptor> merged = [.. host.Actions];
+
+        foreach (EntityActionDescriptor c in contributed)
+        {
+            if (intraModuleNames.Contains(c.Name))
+            {
+                logger.LogDebug(
+                    "Cross-module action contribution '{Name}' on entity '{Entity}' was dropped because the source entity already declares an action with the same name.",
+                    c.Name, host.Name);
+                continue;
+            }
+            merged.Add(c);
+        }
+
+        merged.Sort(static (a, b) =>
+        {
+            int byOrder = a.Order.CompareTo(b.Order);
+            return byOrder != 0 ? byOrder : string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+        });
+
+        return host with { Actions = merged };
+    }
+
+    private sealed class MergedActionsEntityDefinitionDescriptor(
+        IEntityDefinitionDescriptor inner,
+        EntityDefinitionDescriptor merged) : IEntityDefinitionDescriptor
+    {
+        public string Name => inner.Name;
+        public Type EntityType => inner.EntityType;
+        public EntityDefinitionDescriptor Descriptor { get; } = merged;
+    }
+}

--- a/src/Granit.Entities/Internal/EntityDefinitionRegistry.cs
+++ b/src/Granit.Entities/Internal/EntityDefinitionRegistry.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Actions;
 using Granit.Entities.Relations;
 using Microsoft.Extensions.Logging;
 
@@ -8,7 +9,8 @@ namespace Granit.Entities.Internal;
 /// enumerable of <see cref="IEntityDefinitionDescriptor"/>. Detects duplicate
 /// names + duplicate entity types at construction (fails fast). Folds
 /// cross-module relation contributions into the matching descriptors via
-/// <see cref="EntityRelationMerger"/> before indexing.
+/// <see cref="EntityRelationMerger"/>, then folds action contributions via
+/// <see cref="EntityActionMerger"/>, before indexing.
 /// </summary>
 internal sealed class EntityDefinitionRegistry : IEntityDefinitionRegistry
 {
@@ -18,14 +20,18 @@ internal sealed class EntityDefinitionRegistry : IEntityDefinitionRegistry
     public EntityDefinitionRegistry(
         IEnumerable<IEntityDefinitionDescriptor> definitions,
         IEnumerable<IEntityRelationContributor> relationContributors,
+        IEnumerable<IEntityActionContributor> actionContributors,
         ILogger<EntityDefinitionRegistry> logger)
     {
         ArgumentNullException.ThrowIfNull(definitions);
         ArgumentNullException.ThrowIfNull(relationContributors);
+        ArgumentNullException.ThrowIfNull(actionContributors);
         ArgumentNullException.ThrowIfNull(logger);
 
-        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+        IReadOnlyList<IEntityDefinitionDescriptor> withRelations =
             EntityRelationMerger.Merge(definitions, relationContributors, logger);
+        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+            EntityActionMerger.Merge(withRelations, actionContributors, logger);
 
         _byName = new Dictionary<string, IEntityDefinitionDescriptor>(StringComparer.Ordinal);
         _byEntityType = [];

--- a/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
+++ b/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
@@ -95,5 +95,38 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
                 .Column(InvoiceStatus.Open, c => c.Color(KanbanColor.Orange))
                 .Column(InvoiceStatus.Paid, c => c.Color(KanbanColor.Green))
                 .Column(InvoiceStatus.Void, c => c.Color(KanbanColor.Neutral).Hidden())
-                .Column(InvoiceStatus.Uncollectible, c => c.Color(KanbanColor.Red).Collapsed()));
+                .Column(InvoiceStatus.Uncollectible, c => c.Color(KanbanColor.Red).Collapsed()))
+            // Phase 2.B — actions exposed on the invoice detail header. Lifecycle
+            // mutations route through the Granit.Invoicing endpoints (POST handlers
+            // already in place); the PDF download hits the existing document
+            // endpoint. WorkflowTransition and structured input forms are deferred
+            // to a follow-up — the four actions below cover the showcase parity gap
+            // identified by the front Claude.
+            .Action("finalize", a => a
+                .ApiCall("POST", "/api/v1/invoices/{id}/finalize")
+                .DisplayKey("Invoicing:Action.Finalize")
+                .Icon("check")
+                .Order(10)
+                .RequiresPermission("Invoicing.Invoices.Manage")
+                .Confirmation("Invoicing:Action.Finalize.Confirm"))
+            .Action("void", a => a
+                .ApiCall("POST", "/api/v1/invoices/{id}/void")
+                .DisplayKey("Invoicing:Action.Void")
+                .Icon("ban")
+                .Order(20)
+                .RequiresPermission("Invoicing.Invoices.Manage")
+                .Confirmation("Invoicing:Action.Void.Confirm"))
+            .Action("mark-uncollectible", a => a
+                .ApiCall("POST", "/api/v1/invoices/{id}/mark-uncollectible")
+                .DisplayKey("Invoicing:Action.MarkUncollectible")
+                .Icon("alert-triangle")
+                .Order(30)
+                .RequiresPermission("Invoicing.Invoices.Manage")
+                .Confirmation("Invoicing:Action.MarkUncollectible.Confirm"))
+            .Action("download-pdf", a => a
+                .Download("/api/v1/invoices/{id}/pdf")
+                .DisplayKey("Invoicing:Action.DownloadPdf")
+                .Icon("file-down")
+                .Order(40)
+                .RequiresPermission("Invoicing.Invoices.Read"));
 }

--- a/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
@@ -1,0 +1,143 @@
+using Granit.Entities.Actions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Actions;
+
+public sealed class EntityActionTests
+{
+    [Fact]
+    public void Action_apicall_records_method_url_and_kind()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        EntityActionDescriptor finalize = d.Actions.Single(a => a.Name == "finalize");
+        finalize.Kind.ShouldBe(EntityActionKind.ApiCall);
+        finalize.HttpMethod.ShouldBe("POST");
+        finalize.UrlTemplate.ShouldBe("/api/v1/orders/{id}/finalize");
+        finalize.RequiresPermission.ShouldBe("Orders.Manage");
+        finalize.ConfirmationKey.ShouldBe("Orders:Action.Finalize.Confirm");
+        finalize.Icon.ShouldBe("check");
+        finalize.Order.ShouldBe(10);
+    }
+
+    [Fact]
+    public void Action_download_records_url_only_no_method()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        EntityActionDescriptor pdf = d.Actions.Single(a => a.Name == "download-pdf");
+        pdf.Kind.ShouldBe(EntityActionKind.Download);
+        pdf.HttpMethod.ShouldBeNull();
+        pdf.UrlTemplate.ShouldBe("/api/v1/orders/{id}/pdf");
+    }
+
+    [Fact]
+    public void Action_navigate_records_url_with_navigate_kind()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        EntityActionDescriptor merge = d.Actions.Single(a => a.Name == "merge");
+        merge.Kind.ShouldBe(EntityActionKind.Navigate);
+        merge.HttpMethod.ShouldBeNull();
+        merge.UrlTemplate.ShouldBe("/w/orders/{id}/merge");
+    }
+
+    [Fact]
+    public void Action_workflowtransition_records_target_state_no_url()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        EntityActionDescriptor archive = d.Actions.Single(a => a.Name == "archive");
+        archive.Kind.ShouldBe(EntityActionKind.WorkflowTransition);
+        archive.UrlTemplate.ShouldBeNull();
+        archive.HttpMethod.ShouldBeNull();
+        archive.WorkflowTransitionName.ShouldBe("Archived");
+    }
+
+    [Fact]
+    public void Actions_sorted_by_order_then_name()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        d.Actions.Select(a => a.Name).ShouldBe(
+            ["finalize", "archive", "download-pdf", "merge"]);
+    }
+
+    [Fact]
+    public void Action_intramodule_has_no_contributor_assembly_name()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        d.Actions.ShouldAllBe(a => a.ContributorAssemblyName == null);
+    }
+
+    [Fact]
+    public void Build_rejects_action_without_kind_shortcut()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new BareActionDefinition().Descriptor);
+
+        ex.Message.ShouldContain("must declare a URL via ApiCall");
+    }
+
+    [Fact]
+    public void Build_rejects_duplicate_action_names()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new DuplicateActionNamesDefinition().Descriptor);
+
+        ex.Message.ShouldContain("Duplicate action name 'finalize'");
+    }
+
+    private sealed class SampleEntity;
+
+    private sealed class SampleDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.Order";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .Action("finalize", a => a
+                    .ApiCall("POST", "/api/v1/orders/{id}/finalize")
+                    .DisplayKey("Orders:Action.Finalize")
+                    .Icon("check")
+                    .Order(10)
+                    .RequiresPermission("Orders.Manage")
+                    .Confirmation("Orders:Action.Finalize.Confirm"))
+                .Action("download-pdf", a => a
+                    .Download("/api/v1/orders/{id}/pdf")
+                    .DisplayKey("Orders:Action.Pdf")
+                    .Icon("file-down")
+                    .Order(30))
+                .Action("merge", a => a
+                    .Navigate("/w/orders/{id}/merge")
+                    .DisplayKey("Orders:Action.Merge")
+                    .Icon("git-merge")
+                    .Order(40))
+                .Action("archive", a => a
+                    .WorkflowTransition("Archived")
+                    .DisplayKey("Orders:Action.Archive")
+                    .Icon("archive")
+                    .Order(20)
+                    .RequiresPermission("Orders.Manage"));
+    }
+
+    private sealed class BareActionDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.Bare";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.Action("naked", a => a.DisplayKey("X").Icon("y").Order(1));
+    }
+
+    private sealed class DuplicateActionNamesDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.Duplicates";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .Action("finalize", a => a.ApiCall("POST", "/x"))
+                .Action("finalize", a => a.ApiCall("POST", "/y"));
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -452,4 +452,74 @@ public sealed class EntityManifestComposerTests
     }
 
     private enum SampleStatus { Open, Done }
+
+    [Fact]
+    public void Compose_emits_actions_when_facet_requested()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor finalize = new(
+            Name: "finalize",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: "Test:Action.Finalize",
+            Icon: "check",
+            Order: 10,
+            RequiresPermission: null,
+            UrlTemplate: "/api/{id}/finalize",
+            HttpMethod: "POST",
+            ConfirmationKey: "Test:Action.Finalize.Confirm",
+            WorkflowTransitionName: null,
+            ContributorAssemblyName: null);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor() with { Actions = [finalize] },
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Actions,
+            defaultViewId: null);
+
+        EntityActionManifest only = manifest.Actions!.ShouldHaveSingleItem();
+        only.Name.ShouldBe("finalize");
+        only.Kind.ShouldBe(Granit.Entities.Actions.EntityActionKind.ApiCall);
+        only.HttpMethod.ShouldBe("POST");
+        only.UrlTemplate.ShouldBe("/api/{id}/finalize");
+        only.ConfirmationKey.ShouldBe("Test:Action.Finalize.Confirm");
+    }
+
+    [Fact]
+    public void Compose_drops_action_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor gated = new(
+            Name: "void",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: null, Icon: null, Order: 0,
+            RequiresPermission: "Invoicing.Invoices.Manage",
+            UrlTemplate: "/api/{id}/void", HttpMethod: "POST",
+            ConfirmationKey: null, WorkflowTransitionName: null,
+            ContributorAssemblyName: null);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor() with { Actions = [gated] },
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Actions,
+            defaultViewId: null);
+
+        manifest.Actions!.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Compose_omits_actions_when_facet_not_requested()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor finalize = new(
+            "finalize", Granit.Entities.Actions.EntityActionKind.ApiCall,
+            null, null, 0, null, "/x", "POST", null, null, null);
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor() with { Actions = [finalize] },
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Identity,
+            defaultViewId: null);
+
+        manifest.Actions.ShouldBeNull();
+    }
 }

--- a/tests/Granit.Entities.Tests/EntityActionMergerTests.cs
+++ b/tests/Granit.Entities.Tests/EntityActionMergerTests.cs
@@ -1,0 +1,124 @@
+using Granit.Entities.Actions;
+using Granit.Entities.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Tests;
+
+public sealed class EntityActionMergerTests
+{
+    private sealed class Party { }
+    private sealed class Address { }
+
+    [Fact]
+    public void Merge_grafts_contribution_into_matching_source()
+    {
+        FakeDescriptor party = new("Test.Party", typeof(Party));
+        FakeContributor tasks = new(c => c.AddAction<Party>("add-task", a => a
+            .ApiCall("POST", "/api/v1/parties/{id}/tasks")
+            .DisplayKey("Tasks:Action.Add")
+            .Order(0)));
+
+        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+            EntityActionMerger.Merge([party], [tasks], NullLogger.Instance);
+
+        merged.ShouldHaveSingleItem();
+        EntityActionDescriptor only = merged.Single().Descriptor.Actions.ShouldHaveSingleItem();
+        only.Name.ShouldBe("add-task");
+        only.ContributorAssemblyName.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Merge_drops_contribution_targeting_unknown_source()
+    {
+        FakeDescriptor party = new("Test.Party", typeof(Party));
+        FakeContributor stray = new(c => c.AddAction<Address>("add-task", a => a
+            .ApiCall("POST", "/api/v1/addresses/{id}/tasks")));
+
+        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+            EntityActionMerger.Merge([party], [stray], NullLogger.Instance);
+
+        merged.Single().Descriptor.Actions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Merge_intra_module_action_takes_precedence_over_contribution_with_same_name()
+    {
+        EntityDefinitionDescriptor partyDescriptor = new()
+        {
+            Name = "Test.Party",
+            EntityType = typeof(Party),
+            MetricDefinitionTypes = [],
+            DashboardDefinitionTypes = [],
+            Forms = [],
+            Details = [],
+            Actions =
+            [
+                new EntityActionDescriptor(
+                    Name: "merge",
+                    Kind: EntityActionKind.Navigate,
+                    DisplayKey: "Owned",
+                    Icon: "git-merge",
+                    Order: 5,
+                    RequiresPermission: null,
+                    UrlTemplate: "/parties/{id}/merge",
+                    HttpMethod: null,
+                    ConfirmationKey: null,
+                    WorkflowTransitionName: null,
+                    ContributorAssemblyName: null),
+            ],
+        };
+        FakeDescriptor party = new(partyDescriptor);
+        FakeContributor stray = new(c => c.AddAction<Party>("merge", a => a
+            .Navigate("/contrib/parties/{id}/merge")
+            .DisplayKey("Contributed")));
+
+        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+            EntityActionMerger.Merge([party], [stray], NullLogger.Instance);
+
+        EntityActionDescriptor only = merged.Single().Descriptor.Actions.ShouldHaveSingleItem();
+        only.DisplayKey.ShouldBe("Owned");
+        only.UrlTemplate.ShouldBe("/parties/{id}/merge");
+    }
+
+    [Fact]
+    public void Merge_sorts_by_order_then_name()
+    {
+        FakeDescriptor party = new("Test.Party", typeof(Party));
+        FakeContributor a = new(c => c
+            .AddAction<Party>("zebra", x => x.ApiCall("POST", "/x").Order(5))
+            .AddAction<Party>("alpha", x => x.ApiCall("POST", "/y").Order(5))
+            .AddAction<Party>("first", x => x.ApiCall("POST", "/z").Order(1)));
+
+        IReadOnlyList<IEntityDefinitionDescriptor> merged =
+            EntityActionMerger.Merge([party], [a], NullLogger.Instance);
+
+        merged.Single().Descriptor.Actions.Select(x => x.Name)
+            .ShouldBe(["first", "alpha", "zebra"]);
+    }
+
+    private sealed class FakeDescriptor(EntityDefinitionDescriptor descriptor) : IEntityDefinitionDescriptor
+    {
+        public FakeDescriptor(string name, Type entityType) : this(new EntityDefinitionDescriptor
+        {
+            Name = name,
+            EntityType = entityType,
+            MetricDefinitionTypes = [],
+            DashboardDefinitionTypes = [],
+            Forms = [],
+            Details = [],
+        })
+        { }
+
+        public string Name => descriptor.Name;
+        public Type EntityType => descriptor.EntityType;
+        public EntityDefinitionDescriptor Descriptor => descriptor;
+    }
+
+    private sealed class FakeContributor(Action<IEntityActionContributionContext> body)
+        : IEntityActionContributor
+    {
+        public void Contribute(IEntityActionContributionContext context) => body(context);
+    }
+}

--- a/tests/Granit.Entities.Tests/EntityDefinitionRegistryTests.cs
+++ b/tests/Granit.Entities.Tests/EntityDefinitionRegistryTests.cs
@@ -71,7 +71,7 @@ public sealed class EntityDefinitionRegistryTests
     }
 
     private static EntityDefinitionRegistry Build(IEnumerable<IEntityDefinitionDescriptor> definitions) =>
-        new(definitions, [], NullLogger<EntityDefinitionRegistry>.Instance);
+        new(definitions, [], [], NullLogger<EntityDefinitionRegistry>.Instance);
 
     private sealed record FakeDescriptor(string Name, Type EntityType) : IEntityDefinitionDescriptor
     {

--- a/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
@@ -136,4 +136,39 @@ public sealed class InvoiceEntityDefinitionTests
         kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Void)).DefaultState.ShouldBe(KanbanColumnState.Hidden);
         kanban.Columns.Single(c => c.Value == nameof(InvoiceStatus.Uncollectible)).DefaultState.ShouldBe(KanbanColumnState.Collapsed);
     }
+
+    [Fact]
+    public void Descriptor_exposes_lifecycle_actions_in_declaration_order()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        d.Actions.Select(a => a.Name).ShouldBe(
+            ["finalize", "void", "mark-uncollectible", "download-pdf"]);
+    }
+
+    [Fact]
+    public void Descriptor_finalize_action_is_apicall_post_with_confirmation_and_manage_perm()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+        Granit.Entities.Actions.EntityActionDescriptor finalize = d.Actions.Single(a => a.Name == "finalize");
+
+        finalize.Kind.ShouldBe(Granit.Entities.Actions.EntityActionKind.ApiCall);
+        finalize.HttpMethod.ShouldBe("POST");
+        finalize.UrlTemplate.ShouldBe("/api/v1/invoices/{id}/finalize");
+        finalize.RequiresPermission.ShouldBe("Invoicing.Invoices.Manage");
+        finalize.ConfirmationKey.ShouldBe("Invoicing:Action.Finalize.Confirm");
+    }
+
+    [Fact]
+    public void Descriptor_download_pdf_action_is_download_kind_no_method_no_confirmation()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+        Granit.Entities.Actions.EntityActionDescriptor pdf = d.Actions.Single(a => a.Name == "download-pdf");
+
+        pdf.Kind.ShouldBe(Granit.Entities.Actions.EntityActionKind.Download);
+        pdf.HttpMethod.ShouldBeNull();
+        pdf.UrlTemplate.ShouldBe("/api/v1/invoices/{id}/pdf");
+        pdf.ConfirmationKey.ShouldBeNull();
+        pdf.RequiresPermission.ShouldBe("Invoicing.Invoices.Read");
+    }
 }


### PR DESCRIPTION
## Summary

Adds the closed-DSL **Action** primitive to the form manifest — entities declare buttons exposed on the detail header (and later, kanban tile via Phase 2.C opt-in). Symmetrical with the existing relation primitive: intra-module declarations on the `EntityDefinitionBuilder` + cross-module `IEntityActionContributor` grafts (third application of the IoC contributor pattern, after `IWorkspaceContributor` and `IEntityRelationContributor`).

\`\`\`csharp
.Action(\"finalize\", a => a
    .ApiCall(\"POST\", \"/api/v1/invoices/{id}/finalize\")
    .DisplayKey(\"Invoicing:Action.Finalize\")
    .Icon(\"check\")
    .Order(10)
    .RequiresPermission(\"Invoicing.Invoices.Manage\")
    .Confirmation(\"Invoicing:Action.Finalize.Confirm\"))
\`\`\`

`EntityActionKind` closed enum dispatches the renderer:

| Kind | Behaviour | Key payload fields |
|------|-----------|--------------------|
| `ApiCall` | POST/PUT/DELETE to `UrlTemplate`, optional confirmation | `HttpMethod`, `UrlTemplate`, `ConfirmationKey` |
| `Download` | GET returning a binary, browser download dialog | `UrlTemplate` |
| `Navigate` | Client-side route or external URL | `UrlTemplate` |
| `WorkflowTransition` | Resolved against the entity's `WorkflowDefinitionType` | `WorkflowTransitionName` |

Builder kind-shortcuts (`.ApiCall` / `.Download` / `.Navigate` / `.WorkflowTransition`) set the discriminator and kind-specific fields atomically; `Build()` rejects an action that never declared its kind.

## Composer

Action-level `RequiresPermission` drops the entry from the manifest payload when the user lacks the permission (defense in depth, ADR-040 §6 — never just hidden). New `EntityFacets.Actions` flag (kebab `actions` alias on the wire) opts the action list into the response shape; omitted by default until callers ask for it explicitly.

## Cross-module IoC contributor

`IEntityActionContributor` + `EntityActionMerger` fold contributed actions into the matching `EntityDefinitionDescriptor` at boot. Intra-module declarations win on name conflicts (same merge rules as `EntityRelationMerger`). Contributor's assembly name is captured for diagnostics + future \"Added by {Module}\" affordance.

## Cobaye

`Invoice` ships **four lifecycle actions** matching the showcase UI parity gap:
- `finalize` (ApiCall POST + confirmation, Manage permission)
- `void` (ApiCall POST + confirmation, Manage permission)
- `mark-uncollectible` (ApiCall POST + confirmation, Manage permission)
- `download-pdf` (Download GET, Read permission)

WorkflowTransition runtime resolution (which transitions are currently allowed for a row) is deferred to a follow-up — needs IWorkflowDefinition lookup beyond the scope of this DSL extension.

## Deferred (separate PRs)

- **Phase 2.B.1** — `Action.OnKanbanCard()` opt-in to render compact buttons on the kanban tile (depends on Phase 2.A kanban primitive already shipped).
- **WorkflowTransition runtime resolution** against the entity's workflow.

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 47/47 (8 new action DSL)
- [x] `dotnet test tests/Granit.Entities.Tests` — 16/16 (4 new merger)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 49/49 (3 new composer)
- [x] `dotnet test tests/Granit.Invoicing.Tests` — 71/71 (3 new entity-def actions)
- [x] `dotnet test tests/Granit.Parties.Tests` — 164/164 (no regression)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 (no regression)
- [x] `dotnet format style .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift