### PR TITLE
feat(entities-relations): Relation.OnKanbanCard() cross-module pinning (Phase 2.B.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19122,7 +19122,16 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 66,
+      "line": 68,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardRelationManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardRelationManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 83,
       "members": []
     },
     {
@@ -19131,7 +19140,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 74,
+      "line": 93,
       "members": []
     },
     {
@@ -19815,7 +19824,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Relations/RelationDescriptor.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {
@@ -38798,7 +38807,7 @@
       "kind": "class",
       "project": "Granit.Parties",
       "file": "src/Granit.Parties/Entities/PartyEntityDefinition.cs",
-      "line": 32,
+      "line": 33,
       "members": [
         {
           "name": "Name",

--- a/src/Granit.Entities.Abstractions/Relations/RelationBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Relations/RelationBuilder.cs
@@ -23,6 +23,7 @@ public sealed class RelationBuilder<TSource, TRelated>
     private string? _requiresPermission;
     private string? _queryDefinitionName;
     private RelationAggregateBuilder<TRelated>? _aggregates;
+    private bool _showOnKanbanCard;
     private readonly string? _contributorAssemblyName;
 
     internal RelationBuilder(
@@ -93,6 +94,21 @@ public sealed class RelationBuilder<TSource, TRelated>
         return this;
     }
 
+    /// <summary>
+    /// Pins this relation as a compact smart-button on the source entity's kanban
+    /// tile (Phase 2.B.1). Use sparingly — kanban tiles have far less surface than
+    /// the detail header, so only opt in for the relations the user genuinely wants
+    /// to see at-a-glance (typical: counters of related notes / tasks / messages).
+    /// The relation must already be visible on the detail header (the kanban tile
+    /// reuses the same descriptor); calling this without the relation also
+    /// rendering on detail still works but is unusual.
+    /// </summary>
+    public RelationBuilder<TSource, TRelated> OnKanbanCard()
+    {
+        _showOnKanbanCard = true;
+        return this;
+    }
+
     internal RelationDescriptor Build(string targetEntityName) =>
         new(
             _name,
@@ -107,7 +123,8 @@ public sealed class RelationBuilder<TSource, TRelated>
             _foreignKeyExpression,
             _aggregates?.Build() ?? [],
             _queryDefinitionName,
-            _contributorAssemblyName);
+            _contributorAssemblyName,
+            _showOnKanbanCard);
 
     internal static string ResolveTargetEntityName(string? overrideName) =>
         overrideName ?? typeof(TRelated).FullName ?? typeof(TRelated).Name;

--- a/src/Granit.Entities.Abstractions/Relations/RelationDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Relations/RelationDescriptor.cs
@@ -19,6 +19,7 @@ namespace Granit.Entities.Relations;
 /// <param name="Aggregates">Aggregates surfaced by this relation, in declaration order.</param>
 /// <param name="QueryDefinitionName">Optional reference to a <c>QueryDefinition</c> on the target entity — when set, the renderer uses it for the drilldown collection instead of the target entity's default query.</param>
 /// <param name="ContributorAssemblyName">Name of the assembly that contributed this relation. <see langword="null"/> for intra-module declarations; populated by the contribution context for cross-module grafts.</param>
+/// <param name="ShowOnKanbanCard">When <see langword="true"/>, the relation also appears as a compact smart-button on the source entity's kanban tile (Phase 2.B.1). Off by default — only the relations the contributor explicitly opts into via <c>OnKanbanCard()</c> are pinned, since kanban tiles have far less surface than the detail header.</param>
 public sealed record RelationDescriptor(
     string Name,
     RelationCardinality Cardinality,
@@ -32,4 +33,5 @@ public sealed record RelationDescriptor(
     string? ForeignKeyExpression,
     IReadOnlyList<RelationAggregateDescriptor> Aggregates,
     string? QueryDefinitionName,
-    string? ContributorAssemblyName);
+    string? ContributorAssemblyName,
+    bool ShowOnKanbanCard = false);

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -59,13 +59,32 @@ public sealed record EntityKanbanLayoutManifest(
 /// <summary>
 /// Card-content schema rendered inside a kanban tile. Frappe-style: optional
 /// title (falls back to the entity's <c>DisplayProperty</c> when absent) plus
-/// an ordered list of body fields.
+/// an ordered list of body fields, plus pinned smart-buttons summarising the
+/// relations the contributors opted to surface on the tile.
 /// </summary>
 /// <param name="TitleProperty">Entity property used as the tile headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
 /// <param name="Fields">Body fields, in declaration order — already permission-filtered server-side.</param>
+/// <param name="Relations">Compact references to the entity's relations that opted into kanban via <c>OnKanbanCard()</c>. Already permission-filtered.</param>
 public sealed record EntityKanbanCardManifest(
     string? TitleProperty,
-    IReadOnlyList<EntityFormFieldManifest> Fields);
+    IReadOnlyList<EntityFormFieldManifest> Fields,
+    IReadOnlyList<EntityKanbanCardRelationManifest> Relations);
+
+/// <summary>
+/// Compact reference to one relation pinned on a kanban tile. Carries only the
+/// fields the renderer needs to draw a small smart-button (name, label, icon,
+/// permission-aware aggregate selection) — the full relation descriptor stays
+/// addressable via the entity's <c>Relations</c> facet.
+/// </summary>
+/// <param name="Name">Stable relation name — matches the entry in the entity's <c>Relations</c> facet.</param>
+/// <param name="DisplayKey">i18n key for the user-facing label.</param>
+/// <param name="Icon">Icon override on the smart-button.</param>
+/// <param name="ContributorAssemblyName">Contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+public sealed record EntityKanbanCardRelationManifest(
+    string Name,
+    string? DisplayKey,
+    string? Icon,
+    string? ContributorAssemblyName);
 
 /// <summary>One per-value kanban column declaration.</summary>
 /// <param name="Value">Wire form of the discrete <c>GroupBy</c> value (enum member name, string literal, …).</param>

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -320,13 +320,14 @@ internal static class EntityManifestComposer
             .Select(t => new EntityCollectionReference(InferDefinitionName(t), t.Name))
             .ToList();
 
-        IReadOnlyList<EntityListLayoutManifest> layouts = ComposeListLayouts(d.ListLayouts, granted);
+        IReadOnlyList<EntityListLayoutManifest> layouts = ComposeListLayouts(d.ListLayouts, d.Relations, granted);
 
         return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId, layouts);
     }
 
     private static List<EntityListLayoutManifest> ComposeListLayouts(
         IReadOnlyList<EntityListLayoutDescriptor> source,
+        IReadOnlyList<RelationDescriptor> relations,
         IReadOnlySet<string> granted)
     {
         List<EntityListLayoutManifest> layouts = new(source.Count);
@@ -340,7 +341,7 @@ internal static class EntityManifestComposer
 
             EntityKanbanLayoutManifest? kanban = layout switch
             {
-                KanbanLayoutDescriptor k => ComposeKanban(k, granted),
+                KanbanLayoutDescriptor k => ComposeKanban(k, relations, granted),
                 _ => null,
             };
 
@@ -362,6 +363,7 @@ internal static class EntityManifestComposer
 
     private static EntityKanbanLayoutManifest? ComposeKanban(
         KanbanLayoutDescriptor descriptor,
+        IReadOnlyList<RelationDescriptor> relations,
         IReadOnlySet<string> granted)
     {
         List<EntityFormFieldManifest> cardFields = FilterFields(descriptor.Card.Fields, granted);
@@ -371,7 +373,17 @@ internal static class EntityManifestComposer
         // the explicit Title got filtered AND no body field survives.
         // (Title filtering is symmetric with form field permissions.)
 
-        EntityKanbanCardManifest card = new(descriptor.Card.TitleProperty, cardFields);
+        // Pin only the relations the contributor opted into via OnKanbanCard()
+        // AND that survived the user's permission check (defense in depth —
+        // a relation hidden from the detail header MUST also be hidden from
+        // the kanban tile).
+        IReadOnlyList<EntityKanbanCardRelationManifest> pinnedRelations = [.. relations
+            .Where(r => r.ShowOnKanbanCard
+                && (r.RequiresPermission is null || granted.Contains(r.RequiresPermission)))
+            .Select(r => new EntityKanbanCardRelationManifest(
+                r.Name, r.DisplayKey, r.Icon, r.ContributorAssemblyName))];
+
+        EntityKanbanCardManifest card = new(descriptor.Card.TitleProperty, cardFields, pinnedRelations);
 
         IReadOnlyList<EntityKanbanColumnManifest> columns = [.. descriptor.Columns
             .Select(c => new EntityKanbanColumnManifest(c.Value, c.Color, c.DefaultState))];

--- a/src/Granit.Invoicing.Endpoints/Relations/InvoicesOnPartyRelationContribution.cs
+++ b/src/Granit.Invoicing.Endpoints/Relations/InvoicesOnPartyRelationContribution.cs
@@ -24,5 +24,9 @@ internal sealed class InvoicesOnPartyRelationContribution : IEntityRelationContr
                 .RequiresPermission(InvoicingPermissions.Invoices.Read)
                 .Aggregate(a => a
                     .Count(labelKey: "Invoicing:Relation.OnParty.Invoices.Count")
-                    .Sum(i => i.Total, labelKey: "Invoicing:Relation.OnParty.Invoices.Total", format: "currency")));
+                    .Sum(i => i.Total, labelKey: "Invoicing:Relation.OnParty.Invoices.Total", format: "currency"))
+                // Phase 2.B.1 — pin the invoice counter on the Party kanban tile so
+                // the daily-board view shows "N invoices" at a glance without opening
+                // each record.
+                .OnKanbanCard());
 }

--- a/src/Granit.Parties/Entities/PartyEntityDefinition.cs
+++ b/src/Granit.Parties/Entities/PartyEntityDefinition.cs
@@ -1,4 +1,5 @@
 using Granit.Entities;
+using Granit.Entities.Layouts;
 using Granit.Parties.Domain;
 using Granit.Parties.Exports;
 using Granit.Parties.Metrics;
@@ -91,5 +92,17 @@ public sealed class PartyEntityDefinition : EntityDefinition<Party>
             {
                 d.Section("overview", s => s.InheritsFromForm("default"));
                 d.SidePanel.Audit().Timeline();
-            });
+            })
+            // Phase 2.A — kanban grouped by PartyStatus. The Archived column is
+            // hidden by default (terminal state, ISO-27001 retention column —
+            // shouldn't clutter the daily board); Suspended is collapsed.
+            .KanbanView<PartyStatus>(k => k
+                .GroupBy(p => p.Status)
+                .Card(c => c
+                    .Title(p => p.Name)
+                    .Field(p => p.Kind)
+                    .Field(p => p.DefaultCurrency))
+                .Column(PartyStatus.Active, c => c.Color(KanbanColor.Green))
+                .Column(PartyStatus.Suspended, c => c.Color(KanbanColor.Orange).Collapsed())
+                .Column(PartyStatus.Archived, c => c.Color(KanbanColor.Neutral).Hidden()));
 }

--- a/tests/Granit.Entities.Abstractions.Tests/RelationBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/RelationBuilderTests.cs
@@ -112,4 +112,27 @@ public sealed class RelationBuilderTests
             b.HasMany<Address>(p => p.Addresses.Where(a => a.City == "Paris"));
     }
 
+    [Fact]
+    public void OnKanbanCard_defaults_false_and_opt_in_sets_flag()
+    {
+        EntityDefinitionDescriptor d = new KanbanPinnedDefinition().Descriptor;
+
+        RelationDescriptor pinned = d.Relations.Single(r => r.Name == "Addresses");
+        RelationDescriptor unpinned = d.Relations.Single(r => r.Name == "Primary");
+
+        pinned.ShowOnKanbanCard.ShouldBeTrue();
+        unpinned.ShowOnKanbanCard.ShouldBeFalse();
+    }
+
+    private sealed class KanbanPinnedDefinition : EntityDefinition<Party>
+    {
+        public override string Name => "Test.Party.KanbanPinned";
+        protected override void Configure(EntityDefinitionBuilder<Party> b) =>
+            b
+                .HasMany<Address>(p => p.Addresses, r => r
+                    .DisplayAs(RelationDisplay.SmartButton)
+                    .OnKanbanCard())
+                .HasOne<PrimaryContact>(p => p.Primary, r => r
+                    .DisplayAs(RelationDisplay.Sidebar));
+    }
 }

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -522,4 +522,98 @@ public sealed class EntityManifestComposerTests
 
         manifest.Actions.ShouldBeNull();
     }
+
+    [Fact]
+    public void Compose_kanban_card_pins_relations_that_opted_in()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+            },
+            Columns = [],
+        };
+
+        Granit.Entities.Relations.RelationDescriptor pinned = new(
+            Name: "tasks",
+            Cardinality: Granit.Entities.Relations.RelationCardinality.Many,
+            Display: Granit.Entities.Relations.RelationDisplay.SmartButton,
+            TargetEntityName: "Granit.Tasks.Task",
+            TargetEntityClrType: typeof(SampleEntity),
+            DisplayKey: "Tasks:Relation.Tasks",
+            Icon: "checklist",
+            Order: 10,
+            RequiresPermission: null,
+            ForeignKeyExpression: null,
+            Aggregates: [],
+            QueryDefinitionName: null,
+            ContributorAssemblyName: "Granit.Tasks",
+            ShowOnKanbanCard: true);
+
+        Granit.Entities.Relations.RelationDescriptor unpinned = pinned with { Name = "notes", ShowOnKanbanCard = false };
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(listLayouts: [kanban])
+            with
+        { Relations = [pinned, unpinned] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityKanbanCardRelationManifest only = manifest.Collections!
+            .ListLayouts.Single().Kanban!.Card.Relations.ShouldHaveSingleItem();
+        only.Name.ShouldBe("tasks");
+        only.Icon.ShouldBe("checklist");
+        only.ContributorAssemblyName.ShouldBe("Granit.Tasks");
+    }
+
+    [Fact]
+    public void Compose_kanban_card_drops_pinned_relation_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+            },
+            Columns = [],
+        };
+
+        Granit.Entities.Relations.RelationDescriptor gated = new(
+            Name: "tasks",
+            Cardinality: Granit.Entities.Relations.RelationCardinality.Many,
+            Display: Granit.Entities.Relations.RelationDisplay.SmartButton,
+            TargetEntityName: "Granit.Tasks.Task",
+            TargetEntityClrType: typeof(SampleEntity),
+            DisplayKey: null, Icon: null, Order: 10,
+            RequiresPermission: "Tasks.Tasks.Read",
+            ForeignKeyExpression: null,
+            Aggregates: [],
+            QueryDefinitionName: null,
+            ContributorAssemblyName: null,
+            ShowOnKanbanCard: true);
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(listLayouts: [kanban])
+            with
+        { Relations = [gated] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.ListLayouts.Single().Kanban!.Card.Relations.ShouldBeEmpty();
+    }
 }

--- a/tests/Granit.Invoicing.Endpoints.Tests/InvoicesOnPartyRelationContributionTests.cs
+++ b/tests/Granit.Invoicing.Endpoints.Tests/InvoicesOnPartyRelationContributionTests.cs
@@ -26,5 +26,6 @@ public sealed class InvoicesOnPartyRelationContributionTests
         invoices.Aggregates.Select(a => a.Kind).ShouldBe(
             [RelationAggregateKind.Count, RelationAggregateKind.Sum]);
         invoices.ContributorAssemblyName.ShouldNotBeNull();
+        invoices.ShowOnKanbanCard.ShouldBeTrue("the invoice counter is pinned on the Party kanban tile");
     }
 }

--- a/tests/Granit.Parties.Tests/PartyEntityDefinitionTests.cs
+++ b/tests/Granit.Parties.Tests/PartyEntityDefinitionTests.cs
@@ -112,4 +112,41 @@ public sealed class PartyEntityDefinitionTests
         d.ExportDefinitionType.ShouldNotBeNull();
         d.MetricDefinitionTypes.ShouldNotBeEmpty();
     }
+
+    [Fact]
+    public void Descriptor_exposes_kanban_layout_grouped_by_status()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban =
+            d.ListLayouts.OfType<Granit.Entities.Layouts.KanbanLayoutDescriptor>().ShouldHaveSingleItem();
+        kanban.GroupByPropertyName.ShouldBe("Status");
+        kanban.GroupByClrType.ShouldBe(typeof(PartyStatus));
+    }
+
+    [Fact]
+    public void Descriptor_kanban_card_uses_name_as_title_with_kind_and_currency()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+        var kanban = (Granit.Entities.Layouts.KanbanLayoutDescriptor)d.ListLayouts
+            .Single(l => l.Kind == Granit.Entities.Layouts.EntityListLayoutKind.Kanban);
+
+        kanban.Card.TitleProperty.ShouldBe("Name");
+        kanban.Card.Fields.Select(f => f.PropertyName).ShouldBe(["Kind", "DefaultCurrency"]);
+    }
+
+    [Fact]
+    public void Descriptor_kanban_columns_carry_status_specific_color_and_state()
+    {
+        EntityDefinitionDescriptor d = new PartyEntityDefinition().Descriptor;
+        var kanban = (Granit.Entities.Layouts.KanbanLayoutDescriptor)d.ListLayouts
+            .Single(l => l.Kind == Granit.Entities.Layouts.EntityListLayoutKind.Kanban);
+
+        kanban.Columns.Single(c => c.Value == nameof(PartyStatus.Active)).Color
+            .ShouldBe(Granit.Entities.Layouts.KanbanColor.Green);
+        kanban.Columns.Single(c => c.Value == nameof(PartyStatus.Suspended)).DefaultState
+            .ShouldBe(Granit.Entities.Layouts.KanbanColumnState.Collapsed);
+        kanban.Columns.Single(c => c.Value == nameof(PartyStatus.Archived)).DefaultState
+            .ShouldBe(Granit.Entities.Layouts.KanbanColumnState.Hidden);
+    }
 }


### PR DESCRIPTION
## Summary

Adds the relation-side opt-in for surfacing a smart-button as a compact pinned indicator on the source entity's kanban tile. Closes the third leg of the manifest-driven UI contract: where to render which information.

\`\`\`csharp
// Inside an IEntityRelationContributor (cross-module).
context.AddRelation<Party, Invoice>(
    name: \"invoices\",
    targetEntityName: \"Granit.Invoicing.Invoice\",
    r => r
        .DisplayAs(RelationDisplay.SmartButton)
        .DisplayKey(\"Invoicing:Relation.OnParty.Invoices\")
        .Icon(\"file-text\")
        .RequiresPermission(InvoicingPermissions.Invoices.Read)
        .Aggregate(a => a.Count())
        .OnKanbanCard());  // ← NEW
\`\`\`

## Why opt-in lives on the contributor

The opt-in lives on the contributor side (not on the source entity's kanban declaration) so the source entity stays oblivious to which modules contribute relations to it — same IoC pattern as the relation contribution itself. The source entity (here Party) doesn't need to enumerate \"tasks\", \"invoices\", \"notes\" by name; each owning module decides whether its own relation belongs on the kanban tile. Install Granit.Tasks → \"add-task\" appears on the Party kanban tile; uninstall it → it disappears. No coupling.

## Manifest shape

`EntityKanbanCardManifest` gains a `Relations` list carrying the compact wire shape (name + label + icon + contributor) for every relation that opted in AND survived the user's permission check. Defense in depth — a relation hidden from the detail header MUST also be hidden from the kanban tile.

## Cobaye

| Change | Effect |
|--------|--------|
| Party gains a `KanbanView<PartyStatus>` | Active green / Suspended collapsed / Archived hidden — daily-board view of the party list |
| `InvoicesOnPartyRelationContribution` opts the `\"invoices\"` smart-button into `OnKanbanCard()` | The Party kanban tile now shows the invoice counter at-a-glance, no extra round-trip |

## Deferred

`Action.OnKanbanCard()` — same pattern for entity actions (Phase 2.C). Symmetrical: the contributing module decides whether its action appears on the kanban tile of the source entity.

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 48/48 (1 new)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 51/51 (2 new composer)
- [x] `dotnet test tests/Granit.Parties.Tests` — 167/167 (3 new Party kanban)
- [x] `dotnet test tests/Granit.Invoicing.Endpoints.Tests` — 14/14 (1 updated assertion)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 (no regression)
- [x] `dotnet format style .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift