### PR TITLE
feat(entities-actions): Action.OnKanbanCard() cross-module pinning (Phase 2.B.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18841,7 +18841,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs",
-      "line": 20,
+      "line": 21,
       "members": []
     },
     {
@@ -19117,12 +19117,21 @@
       "members": []
     },
     {
+      "name": "EntityKanbanCardActionManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 101,
+      "members": []
+    },
+    {
       "name": "EntityKanbanCardManifest",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardManifest",
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 68,
+      "line": 69,
       "members": []
     },
     {
@@ -19131,7 +19140,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 83,
+      "line": 85,
       "members": []
     },
     {
@@ -19140,7 +19149,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 93,
+      "line": 111,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
@@ -24,6 +24,7 @@ public sealed class EntityActionBuilder<TEntity>
     private string? _httpMethod;
     private string? _confirmationKey;
     private string? _workflowTransitionName;
+    private bool _showOnKanbanCard;
 
     internal EntityActionBuilder(string name, string? contributorAssemblyName = null)
     {
@@ -138,6 +139,21 @@ public sealed class EntityActionBuilder<TEntity>
         return this;
     }
 
+    /// <summary>
+    /// Pins this action as a compact icon-button on the source entity's kanban
+    /// tile (Phase 2.B.2). Use sparingly — kanban tiles have far less surface
+    /// than the detail header, so only opt in for the actions the user genuinely
+    /// performs at-a-glance (typical: quick "+ Note" / "+ Task" buttons or the
+    /// most frequent lifecycle transition). The action is also rendered on the
+    /// detail header via the same descriptor; the kanban tile reuses the same
+    /// payload. Skip this for destructive or rare actions (Void, Archive).
+    /// </summary>
+    public EntityActionBuilder<TEntity> OnKanbanCard()
+    {
+        _showOnKanbanCard = true;
+        return this;
+    }
+
     internal EntityActionDescriptor Build()
     {
         // Kind-specific guards: invariants the fluent shortcuts can't catch on
@@ -161,6 +177,7 @@ public sealed class EntityActionBuilder<TEntity>
             HttpMethod: _httpMethod,
             ConfirmationKey: _confirmationKey,
             WorkflowTransitionName: _workflowTransitionName,
-            ContributorAssemblyName: _contributorAssemblyName);
+            ContributorAssemblyName: _contributorAssemblyName,
+            ShowOnKanbanCard: _showOnKanbanCard);
     }
 }

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
@@ -17,6 +17,7 @@ namespace Granit.Entities.Actions;
 /// <param name="ConfirmationKey">Optional i18n key for the confirmation modal shown before invoking the action.</param>
 /// <param name="WorkflowTransitionName">Name of the target workflow state for <see cref="EntityActionKind.WorkflowTransition"/>.</param>
 /// <param name="ContributorAssemblyName">Name of the contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+/// <param name="ShowOnKanbanCard">When <see langword="true"/>, the action also appears as a compact icon-button on the source entity's kanban tile (Phase 2.B.2). Off by default — only the actions the contributor explicitly opts into via <c>OnKanbanCard()</c> are pinned, since kanban tiles have far less surface than the detail header.</param>
 public sealed record EntityActionDescriptor(
     string Name,
     EntityActionKind Kind,
@@ -28,4 +29,5 @@ public sealed record EntityActionDescriptor(
     string? HttpMethod,
     string? ConfirmationKey,
     string? WorkflowTransitionName,
-    string? ContributorAssemblyName);
+    string? ContributorAssemblyName,
+    bool ShowOnKanbanCard = false);

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -59,16 +59,18 @@ public sealed record EntityKanbanLayoutManifest(
 /// <summary>
 /// Card-content schema rendered inside a kanban tile. Frappe-style: optional
 /// title (falls back to the entity's <c>DisplayProperty</c> when absent) plus
-/// an ordered list of body fields, plus pinned smart-buttons summarising the
-/// relations the contributors opted to surface on the tile.
+/// an ordered list of body fields, plus pinned smart-buttons (relations) and
+/// pinned icon-buttons (actions) the contributors opted to surface on the tile.
 /// </summary>
 /// <param name="TitleProperty">Entity property used as the tile headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
 /// <param name="Fields">Body fields, in declaration order — already permission-filtered server-side.</param>
-/// <param name="Relations">Compact references to the entity's relations that opted into kanban via <c>OnKanbanCard()</c>. Already permission-filtered.</param>
+/// <param name="Relations">Compact references to the entity's relations that opted into kanban via <c>Relation.OnKanbanCard()</c>. Already permission-filtered.</param>
+/// <param name="Actions">Compact references to the entity's actions that opted into kanban via <c>Action.OnKanbanCard()</c>. Already permission-filtered.</param>
 public sealed record EntityKanbanCardManifest(
     string? TitleProperty,
     IReadOnlyList<EntityFormFieldManifest> Fields,
-    IReadOnlyList<EntityKanbanCardRelationManifest> Relations);
+    IReadOnlyList<EntityKanbanCardRelationManifest> Relations,
+    IReadOnlyList<EntityKanbanCardActionManifest> Actions);
 
 /// <summary>
 /// Compact reference to one relation pinned on a kanban tile. Carries only the
@@ -81,6 +83,22 @@ public sealed record EntityKanbanCardManifest(
 /// <param name="Icon">Icon override on the smart-button.</param>
 /// <param name="ContributorAssemblyName">Contributing assembly. <see langword="null"/> for intra-module declarations.</param>
 public sealed record EntityKanbanCardRelationManifest(
+    string Name,
+    string? DisplayKey,
+    string? Icon,
+    string? ContributorAssemblyName);
+
+/// <summary>
+/// Compact reference to one action pinned on a kanban tile. Same wire shape
+/// philosophy as <see cref="EntityKanbanCardRelationManifest"/> — the renderer
+/// looks up the full descriptor (URL template, HTTP method, confirmation key)
+/// in the entity's <c>Actions</c> facet via <see cref="Name"/>.
+/// </summary>
+/// <param name="Name">Stable action name — matches the entry in the entity's <c>Actions</c> facet.</param>
+/// <param name="DisplayKey">i18n key for the user-facing label (rendered as tooltip on the icon-button).</param>
+/// <param name="Icon">Icon name from the catalog.</param>
+/// <param name="ContributorAssemblyName">Contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+public sealed record EntityKanbanCardActionManifest(
     string Name,
     string? DisplayKey,
     string? Icon,

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -320,7 +320,7 @@ internal static class EntityManifestComposer
             .Select(t => new EntityCollectionReference(InferDefinitionName(t), t.Name))
             .ToList();
 
-        IReadOnlyList<EntityListLayoutManifest> layouts = ComposeListLayouts(d.ListLayouts, d.Relations, granted);
+        IReadOnlyList<EntityListLayoutManifest> layouts = ComposeListLayouts(d.ListLayouts, d.Relations, d.Actions, granted);
 
         return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId, layouts);
     }
@@ -328,6 +328,7 @@ internal static class EntityManifestComposer
     private static List<EntityListLayoutManifest> ComposeListLayouts(
         IReadOnlyList<EntityListLayoutDescriptor> source,
         IReadOnlyList<RelationDescriptor> relations,
+        IReadOnlyList<EntityActionDescriptor> actions,
         IReadOnlySet<string> granted)
     {
         List<EntityListLayoutManifest> layouts = new(source.Count);
@@ -341,7 +342,7 @@ internal static class EntityManifestComposer
 
             EntityKanbanLayoutManifest? kanban = layout switch
             {
-                KanbanLayoutDescriptor k => ComposeKanban(k, relations, granted),
+                KanbanLayoutDescriptor k => ComposeKanban(k, relations, actions, granted),
                 _ => null,
             };
 
@@ -364,6 +365,7 @@ internal static class EntityManifestComposer
     private static EntityKanbanLayoutManifest? ComposeKanban(
         KanbanLayoutDescriptor descriptor,
         IReadOnlyList<RelationDescriptor> relations,
+        IReadOnlyList<EntityActionDescriptor> actions,
         IReadOnlySet<string> granted)
     {
         List<EntityFormFieldManifest> cardFields = FilterFields(descriptor.Card.Fields, granted);
@@ -373,17 +375,24 @@ internal static class EntityManifestComposer
         // the explicit Title got filtered AND no body field survives.
         // (Title filtering is symmetric with form field permissions.)
 
-        // Pin only the relations the contributor opted into via OnKanbanCard()
-        // AND that survived the user's permission check (defense in depth —
-        // a relation hidden from the detail header MUST also be hidden from
-        // the kanban tile).
+        // Pin only the relations / actions the contributor opted into via
+        // OnKanbanCard() AND that survived the user's permission check (defense
+        // in depth — anything hidden from the detail header MUST also be hidden
+        // from the kanban tile).
         IReadOnlyList<EntityKanbanCardRelationManifest> pinnedRelations = [.. relations
             .Where(r => r.ShowOnKanbanCard
                 && (r.RequiresPermission is null || granted.Contains(r.RequiresPermission)))
             .Select(r => new EntityKanbanCardRelationManifest(
                 r.Name, r.DisplayKey, r.Icon, r.ContributorAssemblyName))];
 
-        EntityKanbanCardManifest card = new(descriptor.Card.TitleProperty, cardFields, pinnedRelations);
+        IReadOnlyList<EntityKanbanCardActionManifest> pinnedActions = [.. actions
+            .Where(a => a.ShowOnKanbanCard
+                && (a.RequiresPermission is null || granted.Contains(a.RequiresPermission)))
+            .Select(a => new EntityKanbanCardActionManifest(
+                a.Name, a.DisplayKey, a.Icon, a.ContributorAssemblyName))];
+
+        EntityKanbanCardManifest card = new(
+            descriptor.Card.TitleProperty, cardFields, pinnedRelations, pinnedActions);
 
         IReadOnlyList<EntityKanbanColumnManifest> columns = [.. descriptor.Columns
             .Select(c => new EntityKanbanColumnManifest(c.Value, c.Color, c.DefaultState))];

--- a/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
+++ b/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
@@ -108,7 +108,12 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
                 .Icon("check")
                 .Order(10)
                 .RequiresPermission("Invoicing.Invoices.Manage")
-                .Confirmation("Invoicing:Action.Finalize.Confirm"))
+                .Confirmation("Invoicing:Action.Finalize.Confirm")
+                // Phase 2.B.2 — pin the finalize quick-action on the kanban tile
+                // so a clerk can move a Draft invoice to Open without opening the
+                // detail. The destructive actions (void, mark-uncollectible) stay
+                // off the tile to avoid mis-clicks.
+                .OnKanbanCard())
             .Action("void", a => a
                 .ApiCall("POST", "/api/v1/invoices/{id}/void")
                 .DisplayKey("Invoicing:Action.Void")
@@ -128,5 +133,8 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
                 .DisplayKey("Invoicing:Action.DownloadPdf")
                 .Icon("file-down")
                 .Order(40)
-                .RequiresPermission("Invoicing.Invoices.Read"));
+                .RequiresPermission("Invoicing.Invoices.Read")
+                // PDF download is non-destructive and frequently requested from
+                // the kanban view (clerk grabs a copy without leaving the board).
+                .OnKanbanCard());
 }

--- a/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
@@ -140,4 +140,31 @@ public sealed class EntityActionTests
                 .Action("finalize", a => a.ApiCall("POST", "/x"))
                 .Action("finalize", a => a.ApiCall("POST", "/y"));
     }
+
+    [Fact]
+    public void OnKanbanCard_defaults_false_and_opt_in_sets_flag()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        d.Actions.Single(a => a.Name == "finalize").ShowOnKanbanCard.ShouldBeFalse();
+
+        EntityDefinitionDescriptor pinned = new KanbanPinnedDefinition().Descriptor;
+        pinned.Actions.Single(a => a.Name == "quick-note").ShowOnKanbanCard.ShouldBeTrue();
+        pinned.Actions.Single(a => a.Name == "archive").ShowOnKanbanCard.ShouldBeFalse();
+    }
+
+    private sealed class KanbanPinnedDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.KanbanPinned";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .Action("quick-note", a => a
+                    .ApiCall("POST", "/api/v1/orders/{id}/notes")
+                    .Icon("note-plus")
+                    .OnKanbanCard())
+                .Action("archive", a => a
+                    .WorkflowTransition("Archived")
+                    .Icon("archive"));
+    }
 }

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -616,4 +616,92 @@ public sealed class EntityManifestComposerTests
 
         manifest.Collections!.ListLayouts.Single().Kanban!.Card.Relations.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void Compose_kanban_card_pins_actions_that_opted_in()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+            },
+            Columns = [],
+        };
+
+        Granit.Entities.Actions.EntityActionDescriptor pinned = new(
+            Name: "quick-note",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: "Notes:Action.Add",
+            Icon: "note-plus",
+            Order: 5,
+            RequiresPermission: null,
+            UrlTemplate: "/api/{id}/notes",
+            HttpMethod: "POST",
+            ConfirmationKey: null,
+            WorkflowTransitionName: null,
+            ContributorAssemblyName: "Granit.Notes",
+            ShowOnKanbanCard: true);
+
+        Granit.Entities.Actions.EntityActionDescriptor unpinned = pinned with { Name = "void", ShowOnKanbanCard = false };
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(listLayouts: [kanban])
+            with
+        { Actions = [pinned, unpinned] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityKanbanCardActionManifest only = manifest.Collections!
+            .ListLayouts.Single().Kanban!.Card.Actions.ShouldHaveSingleItem();
+        only.Name.ShouldBe("quick-note");
+        only.Icon.ShouldBe("note-plus");
+        only.ContributorAssemblyName.ShouldBe("Granit.Notes");
+    }
+
+    [Fact]
+    public void Compose_kanban_card_drops_pinned_action_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Layouts.KanbanLayoutDescriptor kanban = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Kanban,
+            GroupByPropertyName = "Status",
+            GroupByClrType = typeof(SampleStatus),
+            Card = new Granit.Entities.Layouts.KanbanCardDescriptor
+            {
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+            },
+            Columns = [],
+        };
+
+        Granit.Entities.Actions.EntityActionDescriptor gated = new(
+            Name: "void",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: null, Icon: "ban", Order: 0,
+            RequiresPermission: "Invoicing.Invoices.Manage",
+            UrlTemplate: "/api/{id}/void", HttpMethod: "POST",
+            ConfirmationKey: null, WorkflowTransitionName: null,
+            ContributorAssemblyName: null,
+            ShowOnKanbanCard: true);
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor(listLayouts: [kanban])
+            with
+        { Actions = [gated] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.ListLayouts.Single().Kanban!.Card.Actions.ShouldBeEmpty();
+    }
 }

--- a/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
+++ b/tests/Granit.Invoicing.Tests/InvoiceEntityDefinitionTests.cs
@@ -171,4 +171,15 @@ public sealed class InvoiceEntityDefinitionTests
         pdf.ConfirmationKey.ShouldBeNull();
         pdf.RequiresPermission.ShouldBe("Invoicing.Invoices.Read");
     }
+
+    [Fact]
+    public void Descriptor_pins_finalize_and_download_pdf_on_kanban_card_only()
+    {
+        EntityDefinitionDescriptor d = new InvoiceEntityDefinition().Descriptor;
+
+        d.Actions.Single(a => a.Name == "finalize").ShowOnKanbanCard.ShouldBeTrue();
+        d.Actions.Single(a => a.Name == "download-pdf").ShowOnKanbanCard.ShouldBeTrue();
+        d.Actions.Single(a => a.Name == "void").ShowOnKanbanCard.ShouldBeFalse();
+        d.Actions.Single(a => a.Name == "mark-uncollectible").ShowOnKanbanCard.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Symmetrical companion to `Relation.OnKanbanCard()` (Phase 2.B.1) for actions — the contributing module decides whether its action surfaces as a compact icon-button on the source entity's kanban tile. Same IoC contributor pattern: the source entity stays oblivious to which modules contribute actions; install `Granit.Tasks` → \"+ Task\" appears on the Party kanban tile, uninstall it → gone, no source-entity edit needed.

\`\`\`csharp
// Inside an IEntityActionContributor (cross-module), or directly on the
// entity's own EntityDefinitionBuilder for intra-module actions.
context.AddAction<Party>(\"add-task\", a => a
    .ApiCall(\"POST\", \"/api/v1/parties/{id}/tasks\")
    .DisplayKey(\"Tasks:Action.Add\")
    .Icon(\"plus\")
    .RequiresPermission(TasksPermissions.Tasks.Manage)
    .OnKanbanCard());  // ← NEW
\`\`\`

## Manifest shape

`EntityKanbanCardManifest` gains a sibling `Actions` list to its `Relations` list, carrying the compact wire shape (name + label + icon + contributor) for every action that opted in AND survived the user's permission check. Same defense in depth: an action hidden from the detail header is also hidden from the kanban tile.

## Cobaye

Invoice opts `finalize` and `download-pdf` into `OnKanbanCard()`. The destructive lifecycle actions (`void`, `mark-uncollectible`) stay on the detail header only — the kanban tile is for the daily quick-actions, not for mis-clickable terminal mutations.

## Phase 2 status after this PR

| Sub-phase | Scope | Status |
|-----------|-------|--------|
| 2.A | Owned-collection sections | ✅ |
| 2.A.2 | Kanban list-view layout | ✅ |
| 2.B | `Action<TEntity>` primitive | ✅ |
| 2.B.1 | `Relation.OnKanbanCard()` | ✅ |
| **2.B.2** | **`Action.OnKanbanCard()`** | **this PR** |

The kanban tile is now a complete manifest-driven UI surface: title + body fields + pinned smart-buttons (relations) + pinned icon-buttons (actions), all permission-filtered server-side.

## What still falls outside

- **WorkflowTransition runtime resolution** — which transitions are currently allowed for a given row state. Needs `IWorkflowDefinition` lookup at request time; deferred to a follow-up.
- **EntityView personal overlays for kanban** — the user reordering / hiding pinned actions in their own saved kanban view (Phase C2).
- **Calendar / Map / Gallery layouts** — same `EntityListLayoutKind` enum, separate descriptors (Phase C3, when first need arises).

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 49/49 (1 new builder)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 53/53 (2 new composer)
- [x] `dotnet test tests/Granit.Invoicing.Tests` — 72/72 (1 new cobaye)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 (no regression)
- [x] `dotnet format style .github/shard-filters/business.slnf --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — no lockfile drift