### PR TITLE
feat(privacy-endpoints): GPC public discovery resource at /.well-known/gpc.json

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44706,6 +44706,38 @@
       ]
     },
     {
+      "name": "GpcDiscoveryEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Privacy.Endpoints.Discovery.GpcDiscoveryEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryEndpointRouteBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "MapGranitGpcDiscovery",
+          "kind": "method",
+          "signature": "MapGranitGpcDiscovery(this IEndpointRouteBuilder endpoints)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GpcDiscoveryOptions",
+      "fqn": "Granit.Privacy.Endpoints.Discovery.GpcDiscoveryOptions",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryOptions.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
       "name": "LegalDocumentCreateRequest",
       "fqn": "Granit.Privacy.Endpoints.Dtos.LegalDocumentCreateRequest",
       "kind": "record",
@@ -44862,7 +44894,7 @@
       "kind": "class",
       "project": "Granit.Privacy.Endpoints",
       "file": "src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs",
-      "line": 41,
+      "line": 44,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/consent.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/consent.mdx
@@ -65,3 +65,92 @@ First-party `Analytics` cookies are preserved — GPC means "Do Not Sell", not
 | `NullConsentResolver` | Denies consent for all non-essential categories (default) |
 | `NullCookieConsentModelProvider` | Returns `null` — no GPC suppression (default) |
 | `GlobalPrivacyControlHeaderSignal` | Reads `Sec-GPC: 1` header (always registered) |
+
+## Publishing the GPC discovery document
+
+Honoring the `Sec-GPC` header is the *inbound* half of GPC support. The
+[GPC spec](https://w3c.github.io/gpc/#the-well-known-resource) also defines an
+*outbound* declaration: a public JSON document at `/.well-known/gpc.json`
+through which the operator publicly attests that the site honors GPC. Several
+US state privacy laws — CPRA (Cal. Civ. Code §1798.135(b)(1)), Colorado CPA,
+Connecticut CTDPA — recognize this as the canonical way to opt into honoring
+the signal.
+
+Granit ships an opt-in endpoint in `Granit.Privacy.Endpoints` that publishes
+the document at the host root.
+
+### Wiring
+
+```csharp
+// Program.cs
+app.MapGranitPrivacy();        // existing privacy endpoints
+app.MapGranitGpcDiscovery();   // /.well-known/gpc.json — no-op when disabled
+```
+
+```jsonc
+// appsettings.json
+{
+  "Privacy": {
+    "GpcDiscovery": {
+      "Enabled": true,
+      "LastUpdate": "2026-01-15"   // see below — this is a legal anchor
+    }
+  }
+}
+```
+
+When `Enabled` is `false` (the default), no route is mapped and the path
+returns 404 — which is the spec-prescribed behavior for non-publishers.
+
+### `LastUpdate` is a legal anchor, not a build timestamp
+
+Per the GPC spec, `lastUpdate` is *"the time at which the statement of support
+was made, such that later changes to the meaning of the GPC standard should
+not affect the interpretation of the resource for legal purposes."* It pins
+the interpretation of your declaration to the version of the GPC standard in
+force at that date.
+
+<Aside type="caution">
+**Do not auto-default `LastUpdate`** to today's date, the build date, or the
+deployment date. Doing so would silently move the legal anchor on every
+deploy and defeat its purpose. Set it deliberately and only bump it when
+materially restating the commitment — broadened scope, revised privacy
+policy, alignment with a new GPC version. The framework refuses to start if
+`Enabled = true` and `LastUpdate` is not set (`IValidateOptions` fail-fast).
+</Aside>
+
+### Host scoping — split-host deployments
+
+The `.well-known` URI scheme (RFC 8615) is host-rooted: the discovery
+document covers **the host that responds to the request**, not your
+organization. If your front-end is served from a host distinct from the BFF
+(e.g. `app.example.com` for a SPA, `api.example.com` for the .NET host), then
+this endpoint only declares GPC support for the BFF host. Browsers, crawlers,
+and regulators looking up `app.example.com/.well-known/gpc.json` will see a
+404 unless you also publish the document there.
+
+Two options for the front-end host:
+
+1. **Static publication** — drop a matching `public/.well-known/gpc.json` in
+   your Vite / Next / static-site build. Both `LastUpdate` values must stay
+   in lock-step with the BFF declaration.
+2. **Reverse-proxy routing** — configure your edge (Cloudflare, Azure Front
+   Door, Nginx) so that requests to `<front-host>/.well-known/*` are routed
+   to the BFF host. The single .NET endpoint then covers both hosts.
+
+### What opting in actually commits you to
+
+Publishing `gpc: true` is a public, opposable declaration that your operation
+honors GPC across the *entire processing surface* of the host — not only the
+cookie layer Granit enforces. Before flipping the switch, audit:
+
+- Third-party SDKs (analytics, marketing pixels, A/B testing, session replay)
+  loaded by the front-end — many do not respect `Sec-GPC` by default and need
+  configuration or replacement.
+- Server-side processing pipelines that share data with vendors (CDP,
+  affiliate networks, retargeting partners) — they must read your inbound
+  GPC state and adjust accordingly.
+- Privacy policy text — should explicitly reference your GPC commitment.
+
+If any of these don't currently honor the signal, fix them first. A
+declaration backed by non-conforming behavior is worse than no declaration.

--- a/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryDocument.cs
+++ b/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryDocument.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Granit.Privacy.Endpoints.Discovery;
+
+/// <summary>
+/// Wire shape of the GPC discovery document served at <c>/.well-known/gpc.json</c>
+/// per <see href="https://w3c.github.io/gpc/#the-well-known-resource"/>.
+/// </summary>
+/// <param name="Gpc">Always <see langword="true"/> when the document is published — the operator declares support for GPC.</param>
+/// <param name="LastUpdate">RFC 3339 full-date marking when the operator made the statement of support. Serialized as <c>YYYY-MM-DD</c>.</param>
+internal sealed record GpcDiscoveryDocument(
+    [property: JsonPropertyName("gpc")] bool Gpc,
+    [property: JsonPropertyName("lastUpdate")] DateOnly LastUpdate);

--- a/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.Endpoints.Discovery;
+
+/// <summary>
+/// Extension methods for the Global Privacy Control public discovery endpoint.
+/// </summary>
+public static class GpcDiscoveryEndpointRouteBuilderExtensions
+{
+    private const string DiscoveryPath = "/.well-known/gpc.json";
+
+    /// <summary>
+    /// Maps <c>GET /.well-known/gpc.json</c> at the host root, serving the GPC
+    /// discovery document. No-op when <see cref="GpcDiscoveryOptions.Enabled"/> is
+    /// <see langword="false"/> — the path then returns 404 naturally, which is the
+    /// behavior the GPC spec expects for non-publishers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The endpoint is anonymous, excluded from OpenAPI, and emits a
+    /// <c>Cache-Control: public, max-age=&lt;n&gt;</c> header per
+    /// <see cref="GpcDiscoveryOptions.CacheMaxAgeSeconds"/>.
+    /// </para>
+    /// <para>
+    /// Intentionally NOT mapped under the privacy route group — the
+    /// <c>.well-known</c> URI scheme (RFC 8615) requires host-root placement, and
+    /// the resource must be reachable without authentication and outside any API
+    /// versioning prefix.
+    /// </para>
+    /// </remarks>
+    public static IEndpointRouteBuilder MapGranitGpcDiscovery(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        GpcDiscoveryOptions options = endpoints.ServiceProvider
+            .GetRequiredService<IOptions<GpcDiscoveryOptions>>()
+            .Value;
+
+        if (!options.Enabled)
+        {
+            return endpoints;
+        }
+
+        // Validator guarantees LastUpdate is set when Enabled.
+        DateOnly lastUpdate = options.LastUpdate!.Value;
+        string cacheControl = $"public, max-age={options.CacheMaxAgeSeconds}";
+        GpcDiscoveryDocument document = new(Gpc: true, LastUpdate: lastUpdate);
+
+        endpoints.MapGet(DiscoveryPath, (HttpContext httpContext) =>
+            {
+                httpContext.Response.Headers.CacheControl = cacheControl;
+                return TypedResults.Json(document, contentType: "application/json");
+            })
+            .AllowAnonymous()
+            .ExcludeFromDescription()
+            .WithName("GetGpcDiscovery");
+
+        return endpoints;
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryOptions.cs
+++ b/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryOptions.cs
@@ -1,0 +1,65 @@
+namespace Granit.Privacy.Endpoints.Discovery;
+
+/// <summary>
+/// Configuration for the Global Privacy Control (GPC) public discovery resource
+/// served at <c>/.well-known/gpc.json</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Publishing this resource is a public, opposable declaration that the operator
+/// honors GPC signals. Recognized by US state privacy laws including CPRA
+/// (Cal. Civ. Code §1798.135(b)(1)), Colorado CPA, and Connecticut CTDPA.
+/// </para>
+/// <para>
+/// Opt-in only — disabled by default. When disabled, no route is mapped and the
+/// path returns 404 naturally. When enabled, <see cref="LastUpdate"/> MUST be set
+/// (validated at startup via <see cref="GpcDiscoveryOptionsValidator"/>).
+/// </para>
+/// <para>
+/// <b>Host scoping.</b> The <c>.well-known</c> URI scheme (RFC 8615) is host-rooted:
+/// publishing the document from this endpoint covers the host that responds to it
+/// (typically the BFF). When the front-end is served from a distinct host, that
+/// host MUST publish its own copy (e.g. a static <c>public/.well-known/gpc.json</c>
+/// in the React/Vite/Next app), or a reverse proxy must route both hosts'
+/// <c>.well-known/*</c> to this endpoint.
+/// </para>
+/// <para>
+/// Spec: <see href="https://w3c.github.io/gpc/#the-well-known-resource"/>.
+/// </para>
+/// </remarks>
+public sealed class GpcDiscoveryOptions
+{
+    /// <summary>
+    /// Configuration section name bound by <c>BindConfiguration</c>.
+    /// </summary>
+    public const string SectionName = "Privacy:GpcDiscovery";
+
+    /// <summary>
+    /// When <see langword="true"/>, maps <c>GET /.well-known/gpc.json</c> serving
+    /// the GPC discovery document. Default: <see langword="false"/>.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Date at which the operator made the statement of support for GPC, formatted
+    /// per RFC 3339 full-date (<c>YYYY-MM-DD</c>). Required when <see cref="Enabled"/>
+    /// is <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Per the GPC spec this value is a <b>legal anchor</b>: it pins the interpretation
+    /// of the declaration to the version of the GPC standard in force at this date,
+    /// so later changes to the standard do not retroactively alter what the operator
+    /// committed to. Set it deliberately and only bump it when materially restating
+    /// the commitment (broadened scope, revised privacy policy, alignment with a new
+    /// GPC version). Do <b>not</b> auto-default it to today's date or the build date —
+    /// that would silently move the legal anchor on every deploy and defeat its purpose.
+    /// </remarks>
+    public DateOnly? LastUpdate { get; set; }
+
+    /// <summary>
+    /// <c>Cache-Control max-age</c> (seconds) emitted with the discovery document.
+    /// Default: 86400 (1 day) — matches the day-level granularity of
+    /// <see cref="LastUpdate"/>. Must be &gt;= 0.
+    /// </summary>
+    public int CacheMaxAgeSeconds { get; set; } = 86_400;
+}

--- a/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
+++ b/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
@@ -3,25 +3,28 @@ using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Http.Cookies;
 using Granit.Modularity;
+using Granit.Privacy.Endpoints.Discovery;
+using Granit.Privacy.Endpoints.Internal;
 using Granit.Privacy.Endpoints.Workspaces;
 using Granit.Privacy.Regulations;
 using Granit.Validation;
 using Granit.Workspaces;
 using Granit.Workspaces.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Privacy.Endpoints;
 
 /// <summary>
 /// Granit module for privacy endpoints: personal data export, data deletion,
-/// legal agreement consent management, and regulation profile resolution.
+/// legal agreement consent management, regulation profile resolution, and the
+/// optional Global Privacy Control (GPC) public discovery resource.
 /// </summary>
 /// <remarks>
-/// <para>Exposes four endpoint groups via <see cref="Extensions.PrivacyEndpointRouteBuilderExtensions.MapGranitPrivacy"/>:</para>
+/// <para>Exposes the following endpoint groups:</para>
 /// <list type="bullet">
-/// <item>Regulation — returns the applicable regulation profile for the current tenant.</item>
-/// <item>Export — triggers the scatter-gather saga and reports export status.</item>
-/// <item>Deletion — publishes the distributed deletion event.</item>
-/// <item>Agreements — lists legal documents, records consent, checks user status.</item>
+/// <item><see cref="Extensions.PrivacyEndpointRouteBuilderExtensions.MapGranitPrivacy"/> — regulation, export, deletion, agreements (authenticated, under the privacy prefix).</item>
+/// <item><see cref="GpcDiscoveryEndpointRouteBuilderExtensions.MapGranitGpcDiscovery"/> — opt-in <c>/.well-known/gpc.json</c> at the host root (anonymous, excluded from OpenAPI).</item>
 /// </list>
 /// <para>
 /// <b>Reverse proxy note:</b> The consent acceptance endpoint reads the client IP address
@@ -41,6 +44,14 @@ namespace Granit.Privacy.Endpoints;
 public sealed class GranitPrivacyEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<PrivacyWorkspaceContribution>();
+
+        context.Services
+            .AddOptions<GpcDiscoveryOptions>()
+            .BindConfiguration(GpcDiscoveryOptions.SectionName)
+            .ValidateOnStart();
+        context.Services.AddSingleton<IValidateOptions<GpcDiscoveryOptions>, GpcDiscoveryOptionsValidator>();
+    }
 }

--- a/src/Granit.Privacy.Endpoints/Internal/GpcDiscoveryOptionsValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/GpcDiscoveryOptionsValidator.cs
@@ -1,0 +1,41 @@
+using Granit.Privacy.Endpoints.Discovery;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Privacy.Endpoints.Internal;
+
+/// <summary>
+/// Validates <see cref="GpcDiscoveryOptions"/> at startup. Refuses
+/// <c>Enabled = true</c> without a <see cref="GpcDiscoveryOptions.LastUpdate"/>
+/// value — the GPC spec requires the field, and auto-defaulting would silently
+/// move the legal anchor (see <see cref="GpcDiscoveryOptions.LastUpdate"/> remarks).
+/// </summary>
+internal sealed class GpcDiscoveryOptionsValidator : IValidateOptions<GpcDiscoveryOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GpcDiscoveryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Enabled)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        if (options.LastUpdate is null)
+        {
+            return ValidateOptionsResult.Fail(
+                "GPC discovery is enabled but GpcDiscoveryOptions.LastUpdate is not set. "
+                + "The GPC spec requires a stable lastUpdate date marking when the operator "
+                + "committed to honoring GPC. Set it deliberately in configuration "
+                + $"(section '{GpcDiscoveryOptions.SectionName}'); do not auto-default to "
+                + "today/build date — this value is a legal anchor and must be deliberate.");
+        }
+
+        if (options.CacheMaxAgeSeconds < 0)
+        {
+            return ValidateOptionsResult.Fail(
+                $"GpcDiscoveryOptions.CacheMaxAgeSeconds must be >= 0 (got {options.CacheMaxAgeSeconds}).");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryEndpointTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryEndpointTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Text.Json;
+using Granit.Privacy.Endpoints.Discovery;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Discovery;
+
+public sealed class GpcDiscoveryEndpointTests
+{
+    private const string DiscoveryPath = "/.well-known/gpc.json";
+
+    [Fact]
+    public async Task Disabled_ReturnsNotFound()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await using TestApp app = await TestApp.CreateAsync(
+            new GpcDiscoveryOptions { Enabled = false },
+            requireAuthFallback: false,
+            ct).ConfigureAwait(true);
+
+        HttpResponseMessage response = await app.Client.GetAsync(DiscoveryPath, ct).ConfigureAwait(true);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Enabled_ReturnsSpecCompliantDocument()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        DateOnly lastUpdate = new(2026, 5, 1);
+
+        await using TestApp app = await TestApp.CreateAsync(new GpcDiscoveryOptions
+        {
+            Enabled = true,
+            LastUpdate = lastUpdate,
+        }, requireAuthFallback: false, ct).ConfigureAwait(true);
+
+        HttpResponseMessage response = await app.Client.GetAsync(DiscoveryPath, ct).ConfigureAwait(true);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
+
+        // Use a JsonDocument so we assert the wire shape, not C# field naming.
+        Stream stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(true);
+        using JsonDocument doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(true);
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("gpc").GetBoolean().ShouldBeTrue();
+        root.GetProperty("lastUpdate").GetString().ShouldBe("2026-05-01");
+    }
+
+    [Fact]
+    public async Task Enabled_EmitsCacheControlPublicMaxAge()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        await using TestApp app = await TestApp.CreateAsync(new GpcDiscoveryOptions
+        {
+            Enabled = true,
+            LastUpdate = new DateOnly(2026, 5, 1),
+            CacheMaxAgeSeconds = 3_600,
+        }, requireAuthFallback: false, ct).ConfigureAwait(true);
+
+        HttpResponseMessage response = await app.Client.GetAsync(DiscoveryPath, ct).ConfigureAwait(true);
+
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl!.Public.ShouldBeTrue();
+        response.Headers.CacheControl.MaxAge.ShouldBe(TimeSpan.FromSeconds(3_600));
+    }
+
+    [Fact]
+    public async Task Enabled_AllowsAnonymous_DespiteAuthFallback()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        // Sets a global RequireAuthenticatedUser fallback so any endpoint
+        // without AllowAnonymous would be challenged — proves the discovery
+        // endpoint correctly opts out of auth.
+        await using TestApp app = await TestApp.CreateAsync(new GpcDiscoveryOptions
+        {
+            Enabled = true,
+            LastUpdate = new DateOnly(2026, 5, 1),
+        }, requireAuthFallback: true, ct).ConfigureAwait(true);
+
+        HttpResponseMessage response = await app.Client.GetAsync(DiscoveryPath, ct).ConfigureAwait(true);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    private sealed class TestApp : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+
+        public HttpClient Client { get; }
+
+        private TestApp(WebApplication app, HttpClient client)
+        {
+            _app = app;
+            Client = client;
+        }
+
+        public static async Task<TestApp> CreateAsync(
+            GpcDiscoveryOptions options,
+            bool requireAuthFallback,
+            CancellationToken cancellationToken)
+        {
+            WebApplicationBuilder builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Logging.ClearProviders();
+
+            builder.Services
+                .AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, AlwaysFailAuthHandler>("Test", _ => { });
+
+            AuthorizationBuilder authBuilder = builder.Services.AddAuthorizationBuilder();
+            if (requireAuthFallback)
+            {
+                authBuilder.SetFallbackPolicy(new AuthorizationPolicyBuilder("Test")
+                    .RequireAuthenticatedUser()
+                    .Build());
+            }
+
+            builder.Services.AddSingleton<IOptions<GpcDiscoveryOptions>>(
+                Microsoft.Extensions.Options.Options.Create(options));
+
+            WebApplication app = builder.Build();
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapGranitGpcDiscovery();
+            await app.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            return new TestApp(app, app.GetTestClient());
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await _app.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class AlwaysFailAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryOptionsValidatorTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryOptionsValidatorTests.cs
@@ -1,0 +1,68 @@
+using Granit.Privacy.Endpoints.Discovery;
+using Granit.Privacy.Endpoints.Internal;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Discovery;
+
+public sealed class GpcDiscoveryOptionsValidatorTests
+{
+    private readonly GpcDiscoveryOptionsValidator _validator = new();
+
+    [Fact]
+    public void Disabled_WithoutLastUpdate_IsValid()
+    {
+        GpcDiscoveryOptions options = new() { Enabled = false };
+
+        ValidateOptionsResult result = _validator.Validate(name: null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Enabled_WithLastUpdate_IsValid()
+    {
+        GpcDiscoveryOptions options = new()
+        {
+            Enabled = true,
+            LastUpdate = new DateOnly(2026, 5, 1),
+        };
+
+        ValidateOptionsResult result = _validator.Validate(name: null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Enabled_WithoutLastUpdate_FailsWithLegalAnchorMessage()
+    {
+        GpcDiscoveryOptions options = new() { Enabled = true, LastUpdate = null };
+
+        ValidateOptionsResult result = _validator.Validate(name: null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("LastUpdate");
+        result.FailureMessage.ShouldContain("legal anchor");
+    }
+
+    [Fact]
+    public void Enabled_WithNegativeCacheMaxAge_Fails()
+    {
+        GpcDiscoveryOptions options = new()
+        {
+            Enabled = true,
+            LastUpdate = new DateOnly(2026, 5, 1),
+            CacheMaxAgeSeconds = -1,
+        };
+
+        ValidateOptionsResult result = _validator.Validate(name: null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("CacheMaxAgeSeconds");
+    }
+
+    [Fact]
+    public void Validate_NullOptions_Throws() =>
+        Should.Throw<ArgumentNullException>(() => _validator.Validate(name: null, options: null!));
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in endpoint that publishes the [Global Privacy Control discovery document](https://w3c.github.io/gpc/#the-well-known-resource) at `/.well-known/gpc.json`, declaring publicly that the host honors GPC. Recognized by CPRA, Colorado CPA, and Connecticut CTDPA as the canonical opt-in.
- Endpoint is anonymous, excluded from OpenAPI, host-rooted (RFC 8615), and emits `Cache-Control: public, max-age=...` (default 1 day).
- Disabled by default — when `Enabled = false`, no route is mapped and the path returns 404 (the spec-prescribed behavior for non-publishers).
- `LastUpdate` treated as a legal anchor: `IValidateOptions` fails fast at startup when `Enabled = true` without an explicit value, so the date can never silently drift on a deploy.
- Doc page (Consent & GPC) gains a section spelling out the host-scoping caveat: in split-host deployments, the front host needs its own static `public/.well-known/gpc.json` or a reverse-proxy route to the BFF — a single .NET endpoint only covers the host that answers it.

## Wiring (consumer side)

```csharp
app.MapGranitPrivacy();
app.MapGranitGpcDiscovery();
```

```jsonc
"Privacy": {
  "GpcDiscovery": {
    "Enabled": true,
    "LastUpdate": "2026-05-01"
  }
}
```

## Out of scope (follow-ups)

- Wiring `MapGranitGpcDiscovery()` and `Privacy:GpcDiscovery:LastUpdate=2026-05-01` into `granit-showcase-dotnet`.
- Publishing a matching static `public/.well-known/gpc.json` in `granit-showcase-admin-react` / `granit-front` so the front-host origin also declares support (we are in the split-host case).

## Test plan

- [x] `dotnet test tests/Granit.Privacy.Endpoints.Tests --filter Discovery` — 9/9 green
- [x] `dotnet test tests/Granit.Privacy.Endpoints.Tests` — 116/116 green (no regression on existing suite)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 202/202 green
- [x] `dotnet test .github/shard-filters/security.slnf --no-build` — all suites green
- [x] `dotnet format style` — clean on both `Granit.Privacy.Endpoints` and `Granit.Privacy.Endpoints.Tests`
- [ ] Manual: hit `/.well-known/gpc.json` once wired into showcase, confirm spec-compliant payload + `application/json` + `Cache-Control: public, max-age=86400`