### PR TITLE
docs(entities, workspaces): module reference for EntityDefinition, EntityView, Workspace (#1567)

### DIFF
--- a/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
@@ -1,0 +1,122 @@
+---
+title: Entity Definition
+description: Declarative manifest for an entity's UI surface — identity, forms, detail view, list collection, kanban layout, relations, and actions. The frontend renders everything from the manifest with no per-entity React.
+sidebar:
+  label: Entity Definition
+  order: 5
+  badge:
+    text: New
+    variant: tip
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+`EntityDefinition<T>` declares the UI surface of one aggregate. The manifest aggregator
+serves it to the frontend, which renders forms, detail views, lists, kanban boards,
+smart-button relations, and action buttons — all from the same descriptor, with no
+per-entity React code. One source of truth for the structure of a CRUD-style admin
+screen.
+
+The primitive sits at the heart of the three-tier metadata architecture
+([ADR-040](/dotnet/architecture/adr/040-three-tier-metadata-architecture/)): the
+framework declares the compiled layer here, tenants overlay tier-B customizations
+(layout reordering), and users save tier-C personal views via [`EntityView`](/dotnet/data/entity-view/).
+
+## Quick example
+
+```csharp
+using Granit.Entities;
+using Granit.Entities.Layouts;
+using Granit.Parties.Domain;
+
+public sealed class PartyEntityDefinition : EntityDefinition<Party>
+{
+    public override string Name => "Granit.Parties.Party";
+
+    protected override void Configure(EntityDefinitionBuilder<Party> builder) =>
+        builder
+            .DisplayKey("Parties:Entity.Party")
+            .Icon("users")
+            .PermissionGroup("Parties.Parties")
+            .DisplayProperty(p => p.Name)
+            .Query<PartyQueryDefinition>()        // list/grid backing
+            .Export<PartyExportDefinition>()      // CSV/XLSX
+            .Metric<PartyCountMetricDefinition>() // KPI on detail header
+            .Form("default", f => f
+                .Section("identity", s => s
+                    .Field(p => p.Name)
+                    .Field(p => p.Status))
+                .OwnedCollectionSection<PartyEmail>("emails", p => p.Emails, s => s
+                    .ItemDisplayProperty(e => e.Address)
+                    .ItemField(e => e.Address)
+                    .ItemField(e => e.IsPrimary)))
+            .Detail("default", d =>
+            {
+                d.Section("overview", s => s.InheritsFromForm("default"));
+                d.SidePanel.Audit().Timeline();
+            })
+            .KanbanView<PartyStatus>(k => k
+                .GroupBy(p => p.Status)
+                .Card(c => c.Title(p => p.Name).Field(p => p.Kind))
+                .Column(PartyStatus.Active, c => c.Color(KanbanColor.Green))
+                .Column(PartyStatus.Archived, c => c.Color(KanbanColor.Neutral).Hidden()));
+}
+```
+
+Register via `services.AddEntityDefinition<Party, PartyEntityDefinition>()`. The boot-time
+integrity check (`IntegrityCheckRunner`) walks every `EntityDefinitionDescriptor` and
+asserts each cited `QueryDefinition` / `ExportDefinition` / `MetricDefinition` is
+resolvable through DI — host startup fails fast on a typo or missing registration.
+
+## Primitives
+
+| Primitive | Surfaces as | DSL |
+| --------- | ----------- | --- |
+| `Form("name", ...)` | Edit form variant (multiple per entity — `default`, `quick`, …) | `.Section(...).Field(...)`, `.OwnedCollectionSection<TItem>(...)` |
+| `Detail("name", ...)` | Read-only detail view (variants like Form) | `.Section(...).InheritsFromForm("default")`, `.SidePanel.Audit().Timeline()` |
+| `Query<T>` / `Export<T>` / `Metric<T>` / `Dashboard<T>` | Wire references to declarative collection primitives | `.Query<MyQueryDef>()`, `.Metric<MyMetricDef>()` |
+| `HasMany<TRelated>` / `HasOne<TRelated>` | Smart-button / tab / sidebar / inline-chips relation on detail | `.HasMany(p => p.Invoices, r => r.DisplayAs(RelationDisplay.SmartButton).Aggregate(a => a.Count()))` |
+| `KanbanView<TGroupBy>(...)` | Kanban board grouped by an enum | `.GroupBy(p => p.Status).Card(...).Column(...)` |
+| `Action("name", ...)` | Detail-header / row / kanban-tile button | `.ApiCall("POST", "/api/.../finalize").RequiresPermission("...")` |
+
+Per-field defense in depth: `RequiresPermission(...)` drops the field from the manifest
+payload when the user does not hold the permission ([ADR-040 §6](/dotnet/architecture/adr/040-three-tier-metadata-architecture/)
+and story #1549) — never just hidden, always absent. Same rule applies to sections,
+side panels, relations, and actions.
+
+## Cross-module contributions
+
+Other modules graft relations and actions onto an entity they don't own through the
+contributor pattern ([ADR-045](/dotnet/architecture/adr/045-contributor-pattern/),
+[ADR-048](/dotnet/architecture/adr/048-cross-module-entity-relations/)):
+
+```csharp
+// Granit.Invoicing.Endpoints/Relations/InvoicesOnPartyRelationContribution.cs
+internal sealed class InvoicesOnPartyRelationContribution : IEntityRelationContributor
+{
+    public void Contribute(IEntityRelationContributionContext context) =>
+        context.AddRelation<Party, Invoice>(
+            name: "invoices",
+            targetEntityName: "Granit.Invoicing.Invoice",
+            r => r.DisplayAs(RelationDisplay.SmartButton)
+                .RequiresPermission(InvoicingPermissions.Invoices.Read)
+                .Aggregate(a => a.Count().Sum(i => i.Total))
+                .OnKanbanCard());
+}
+```
+
+Register with `services.AddEntityRelationContribution<InvoicesOnPartyRelationContribution>()`.
+The merger (`EntityRelationMerger`) folds contributions into the matching descriptor at
+boot — name conflicts resolve in favour of the entity's intra-module declarations.
+
+`IEntityActionContributor` follows the symmetric pattern for cross-module action grafts.
+
+## Related
+
+- [Entity View](/dotnet/data/entity-view/) — user-saved view configurations (filters, sort, columns, kanban overlays)
+- [Workspace](/dotnet/data/workspace/) — navigation tree that hosts entities
+- [ADR-040](/dotnet/architecture/adr/040-three-tier-metadata-architecture/) — three-tier metadata architecture
+- [ADR-041](/dotnet/architecture/adr/041-widget-catalog/) — widget catalog
+- [ADR-042](/dotnet/architecture/adr/042-view-catalog/) — view catalog
+- [ADR-045](/dotnet/architecture/adr/045-contributor-pattern/) — IoC contributor pattern
+- [ADR-048](/dotnet/architecture/adr/048-cross-module-entity-relations/) — cross-module relations

--- a/docs-site/src/content/docs/dotnet/data/entity-view.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-view.mdx
@@ -1,0 +1,100 @@
+---
+title: Entity View
+description: User-saved view configurations — filters, sort, columns, kanban overlays — with Personal / Shared / Tenant visibility, pin / star / set-default behaviours, and audit trail. Supersedes Granit.QueryEngine.SavedViews.
+sidebar:
+  label: Entity View
+  order: 6
+  badge:
+    text: New
+    variant: tip
+---
+
+`EntityView` is the saved-view aggregate that lets a user pin a configured browse
+(filter set + sort + columns + per-layout overlay like the kanban groupBy) on top
+of a compiled `QueryDefinition`. It supersedes the legacy
+`Granit.QueryEngine.SavedViews` (clean-broken in PR #1639) per
+[ADR-047](/dotnet/architecture/adr/047-entity-view/).
+
+The aggregate enforces the three-visibility model at write time and exposes a
+sorted list at read time, with per-user permission filtering and audit trails on
+every mutation.
+
+## Visibility scopes
+
+Per [ADR-047 §4](/dotnet/architecture/adr/047-entity-view/):
+
+| Scope | Owner | Audience | Created via |
+| ----- | ----- | -------- | ----------- |
+| **Personal** | The current user | Owner only | `Create(...)` — only valid initial visibility |
+| **Shared** | The original creator | Roles + user IDs declared in `EntityViewSharedWith` | `ShareWith(...)` from a Personal view |
+| **Tenant** | Tenant admin | Every user in the tenant | `PromoteToTenant(...)` from a Shared view |
+
+Promotion is one-way (`Personal → Shared → Tenant`); a Tenant view can never demote
+back to Personal.
+
+## Wire shape
+
+```jsonc
+{
+  "id": "9c8f0d20-…",
+  "entityName": "Granit.Parties.Party",
+  "basedOn": "Granit.Parties.PartyQuery",
+  "kind": "list",                          // or "kanban", "calendar", … (per ADR-042)
+  "name": "Active customers — APAC",
+  "description": null,
+  "icon": "globe",
+  "state": {                               // JSONB delta over the base collection
+    "filters": [ { "field": "Region", "op": "eq", "value": "APAC" } ],
+    "sort": [ "-Revenue" ],
+    "columns": [ "Name", "Region", "Revenue", "Status" ]
+  },
+  "visibility": "Personal",
+  "ownerId": "…",
+  "isPersonalDefault": true,               // user's landing view
+  "sortOrder": 0
+}
+```
+
+The `state` field is intentionally opaque on the wire — its shape depends on
+`kind`. For `kind: "kanban"` it carries overlay fields like `groupBy` and
+per-column `state` (Open / Collapsed / Hidden) overrides on top of the framework
+defaults declared via [`KanbanView<TGroupBy>`](/dotnet/data/entity-definition/).
+
+## Endpoints
+
+`MapGranitEntityViewsEndpoints("/api/entities/{name}/views")` mounts the full
+CRUD surface on the host:
+
+| Method | Route | Permission | Notes |
+| ------ | ----- | ---------- | ----- |
+| `GET` | `/` | (any authenticated user) | Returns Personal owned by user + Shared targeted to user + Tenant |
+| `GET` | `/{id:guid}` | Same as list | 404 when inaccessible (no scope leak) |
+| `GET` | `/_default` | Same as list | Resolves the user's effective default per ADR-047 §4 |
+| `POST` | `/` | `Entities.Views.Create` | Returns 201 |
+| `PUT` | `/{id:guid}` | Owner-only for Personal/Shared, `Entities.Views.Manage` for Tenant | `BasedOn` and `Kind` immutable |
+| `DELETE` | `/{id:guid}` | Owner, or `Entities.Views.Delete.Any` | Returns 204 |
+| `POST` | `/{id:guid}/pin` | `Entities.Views.Manage` | Admin promotes a Tenant view to a workspace-tab pin |
+| `POST` | `/{id:guid}/set-default` | `Entities.Views.Manage` | Replaces the compiled default for the tenant |
+| `POST` | `/{id:guid}/star` | (any authenticated user) | Per-user — sets `IsPersonalDefault` |
+| `POST` | `/{id:guid}/share` | Owner | Personal → Shared promotion |
+
+Every write goes through `IEntityViewWriter`, which persists via the standard
+`AuditedEntityInterceptor` pipeline — `CreatedAt` / `CreatedBy` / `ModifiedAt` /
+`ModifiedBy` are recorded on every mutation, and the framework's audit
+infrastructure ([`Granit.Auditing`](/dotnet/security/identity/)) captures the
+before/after diff.
+
+## Validation
+
+`EntityViewCreateBodyRequest`, `EntityViewUpdateBodyRequest` and
+`EntityViewShareBodyRequest` ship FluentValidation validators discovered
+automatically by `GranitValidationModule`. Localized error codes resolve to the
+host's locale via `Granit:Validation:*` keys (auto-mapped from FluentValidation's
+`PropertyValidator` rule sets).
+
+## Related
+
+- [Entity Definition](/dotnet/data/entity-definition/) — the compiled layer that `EntityView` overlays
+- [ADR-042](/dotnet/architecture/adr/042-view-catalog/) — view kinds + state schema per kind
+- [ADR-047](/dotnet/architecture/adr/047-entity-view/) — supersedes legacy SavedViews
+- [ADR-049](/dotnet/architecture/adr/049-default-landing-route/) — 5-tier landing route resolver (uses `EntityView` defaults)

--- a/docs-site/src/content/docs/dotnet/data/workspace.mdx
+++ b/docs-site/src/content/docs/dotnet/data/workspace.mdx
@@ -1,0 +1,136 @@
+---
+title: Workspace
+description: Navigation tree exposed by GET /api/workspaces — hierarchical sub-workspaces (depth ≤ 4), per-item permission gating, cross-workspace entity sharing with additive preset overlays, framework shells (System / Users / Automation / Data / Email / Integrations / Monitoring / Privacy), and the 5-tier landing route resolver.
+sidebar:
+  label: Workspace
+  order: 7
+  badge:
+    text: New
+    variant: tip
+---
+
+A `WorkspaceDefinition` declares one branch of the navigation tree the SPA renders
+in its left rail. Workspaces nest up to four levels deep
+([ADR-044](/dotnet/architecture/adr/044-workspace-navigation/)) and host two kinds
+of items: links to entities (rendered through their
+[`EntityDefinition`](/dotnet/data/entity-definition/)) and links to dashboards.
+The composer filters the tree per-user using the same defense-in-depth rule as
+the entity manifest — items the user lacks permission for are dropped from the
+payload, never just hidden.
+
+## Quick example
+
+```csharp
+using Granit.Workspaces;
+
+public sealed class CrmWorkspaceDefinition : WorkspaceDefinition
+{
+    public override string Name => "Showcase.Crm";
+
+    protected override void Configure(WorkspaceBuilder builder) =>
+        builder
+            .DisplayKey("Showcase:Workspace.Crm")
+            .Icon("users")
+            .Order(10)
+            .RequiresPermission("Showcase.Crm.Read")
+            .Section("identities", section => section
+                .DisplayKey("Showcase:Workspace.Crm.Section.Identities")
+                .Entity<Party>(item => item
+                    .DisplayKey("Showcase:Workspace.Crm.Item.Customers")
+                    .Icon("user-circle")
+                    .Order(0))
+                .Entity<Lead>(item => item
+                    .DisplayKey("Showcase:Workspace.Crm.Item.Leads")
+                    .Order(10)));
+}
+```
+
+Register via `services.AddWorkspaceDefinition<CrmWorkspaceDefinition>()`. The host
+mounts the composed tree with
+`endpoints.MapGranitWorkspacesEndpoints("/api/workspaces")`. A
+`?includeShells=false` query parameter strips the framework shells from the
+response when the SPA already renders them separately.
+
+## Cross-workspace entity sharing
+
+The same entity may be referenced by multiple workspaces; each can carry an
+**additive preset overlay** that constrains the default list (extra filters,
+fixed sort, predefined columns). Two workspaces can both expose `Party` with
+different presets — the CRM workspace shows the full list, the Accounting
+workspace shows the same `Party` with an "outstanding balance > 0" preset.
+
+```csharp
+.Entity<Party>(item => item
+    .DisplayKey("Showcase:Workspace.Accounting.Item.OverdueParties")
+    .Preset(new Dictionary<string, object?>
+    {
+        ["filters"] = new[] { new { field = "OutstandingBalance", op = "gt", value = 0 } },
+        ["sort"] = new[] { "-OverdueAt" },
+    }))
+```
+
+The overlay must be **additive only** — the framework rejects presets that try
+to relax filters baked into the entity's `EntityDefinition` /
+`QueryDefinition`. The validation surface lives in
+[ADR-048 §4](/dotnet/architecture/adr/048-cross-module-entity-relations/).
+
+## IoC contributor pattern
+
+Other modules graft items onto a workspace they don't own through
+`IWorkspaceContributor` ([ADR-045](/dotnet/architecture/adr/045-contributor-pattern/)):
+
+```csharp
+internal sealed class FeatureFlagsOnFrameworkWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.System)
+            .Section("automation", section => section
+                .Link(item => item
+                    .DisplayKey("Features:Workspace.FeatureFlags")
+                    .Icon("flag")
+                    .Url("/admin/feature-flags")
+                    .RequiresPermission("Features.Flags.Read")));
+}
+```
+
+Register with `services.AddWorkspaceContribution<FeatureFlagsOnFrameworkWorkspaceContribution>()`.
+The composer folds contributions into the matching workspace at boot — empty
+shells (a sub-workspace nobody contributed items to) are auto-omitted from the
+rendered tree.
+
+## Framework shells
+
+`Granit.Workspaces.Framework` ships eight pre-declared shell sub-workspaces under
+the root `Granit.Framework` workspace:
+
+`System`, `Users`, `Automation`, `Data`, `Email`, `Integrations`, `Monitoring`,
+`Privacy`.
+
+Modules graft their admin pages onto the appropriate shell — `BlobStorage` and
+`BackgroundJobs` land in `Data` and `Automation` respectively, `Notifications`
+in `Email`, and so on. Hosts that don't load `Granit.Workspaces.Framework`
+simply don't see the shells.
+
+## Landing route resolver
+
+`MapGranitLandingRouteEndpoints` exposes `GET /api/me/landing-route` — a 5-tier
+precedence resolver that picks the user's effective landing URL on app start
+([ADR-049](/dotnet/architecture/adr/049-default-landing-route/)):
+
+1. **Personal sticky** — last-visited route persisted via `PUT /api/me/landing-route/pinned`.
+2. **Personal pinned** — explicit user choice.
+3. **Role default** — admin-configured per role.
+4. **Tenant default** — tenant-wide override.
+5. **Framework default** — `/w/{first-workspace}` from the composed tree.
+
+The route URL is gated by `LandingRouteAllowedPrefixes` (default `["/w/", "/e/"]`)
+to prevent open-redirect attacks via a poisoned saved-route value.
+
+## Related
+
+- [Entity Definition](/dotnet/data/entity-definition/) — the entities a workspace links to
+- [Entity View](/dotnet/data/entity-view/) — saved views the workspace tab strip pins
+- [ADR-040](/dotnet/architecture/adr/040-three-tier-metadata-architecture/) — three-tier metadata
+- [ADR-044](/dotnet/architecture/adr/044-workspace-navigation/) — workspace navigation
+- [ADR-045](/dotnet/architecture/adr/045-contributor-pattern/) — IoC contributor pattern
+- [ADR-049](/dotnet/architecture/adr/049-default-landing-route/) — landing route resolver

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,8 +1,8 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 308;
+export const PACKAGE_COUNT = 322;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 58;
-export const ADR_COUNT = 43;
+export const ADR_COUNT = 49;


### PR DESCRIPTION
## Summary

Closes story #1567 — module reference docs for the Phase 1 manifest-driven UI primitives. Three new pages under `/dotnet/data/`:

- **[Entity Definition](docs-site/src/content/docs/dotnet/data/entity-definition.mdx)** — declarative manifest (`EntityDefinition<T>`): forms, detail, list, kanban, relations, actions; cross-module contributor pattern (`IEntityRelationContributor` / `IEntityActionContributor`); per-field defense-in-depth.
- **[Entity View](docs-site/src/content/docs/dotnet/data/entity-view.mdx)** — user-saved views aggregate: Personal / Shared / Tenant scopes, full CRUD + pin / star / share / set-default endpoints, audit trail, FluentValidation surface. Supersedes legacy `Granit.QueryEngine.SavedViews`.
- **[Workspace](docs-site/src/content/docs/dotnet/data/workspace.mdx)** — `WorkspaceDefinition` navigation tree: nesting (≤4 levels), cross-workspace entity sharing with **additive preset overlays**, IoC contributor pattern, framework shells (System / Users / Automation / Data / Email / Integrations / Monitoring / Privacy), 5-tier landing route resolver.

Counters refreshed in [`docs-site/src/data/constants.ts`](docs-site/src/data/constants.ts):
- `PACKAGE_COUNT`: 308 → 322
- `ADR_COUNT`: 43 → 49

## Test plan

- [x] `npx markdownlint-cli2` — 0 errors
- [x] `npx astro build` — 458 pages built, "All internal links are valid", 489 HTML files indexed
- [x] All ADR cross-links resolve (ADR-040 / 042 / 044 / 045 / 047 / 048 / 049)
- [x] No code changes — docs-only PR, no CI shard impact