### PR TITLE
fix(entities-views-endpoints): wrap localization JSON in culture envelope + archi test

### DIFF
--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/cs.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/cs.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "cs",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Pohledy na entity",
+    "Permission:Entities.Views.Read": "Zobrazit pohledy na entity",
+    "Permission:Entities.Views.Create": "Vytvářet osobní pohledy na entity",
+    "Permission:Entities.Views.Share": "Sdílet pohledy na entity s rolemi nebo uživateli",
+    "Permission:Entities.Views.Manage": "Spravovat pohledy na entity (připnout / nastavit výchozí pro tenant / povýšit)",
+    "Permission:Entities.Views.Delete.Any": "Smazat libovolný pohled na entitu (moderace)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/de.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/de.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "de",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Entitätsansichten",
+    "Permission:Entities.Views.Read": "Entitätsansichten anzeigen",
+    "Permission:Entities.Views.Create": "Persönliche Entitätsansichten erstellen",
+    "Permission:Entities.Views.Share": "Entitätsansichten mit Rollen oder Benutzern teilen",
+    "Permission:Entities.Views.Manage": "Entitätsansichten verwalten (anheften / Mandanten-Standard festlegen / hochstufen)",
+    "Permission:Entities.Views.Delete.Any": "Beliebige Entitätsansicht löschen (Moderation)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/en-GB.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/en-GB.json
@@ -1,8 +1,4 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "en-GB",
+  "texts": {}
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/en.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/en.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "en",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Entity views",
+    "Permission:Entities.Views.Read": "Read entity views",
+    "Permission:Entities.Views.Create": "Create personal entity views",
+    "Permission:Entities.Views.Share": "Share entity views with roles or users",
+    "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
+    "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/es.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/es.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "es",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Vistas de entidades",
+    "Permission:Entities.Views.Read": "Ver vistas de entidades",
+    "Permission:Entities.Views.Create": "Crear vistas de entidades personales",
+    "Permission:Entities.Views.Share": "Compartir vistas de entidades con roles o usuarios",
+    "Permission:Entities.Views.Manage": "Gestionar vistas de entidades (fijar / establecer predeterminada del tenant / promover)",
+    "Permission:Entities.Views.Delete.Any": "Eliminar cualquier vista de entidad (moderación)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/fr-CA.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/fr-CA.json
@@ -1,8 +1,4 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "fr-CA",
+  "texts": {}
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/fr.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/fr.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Vues d'entités",
-  "Permission:Entities.Views.Read": "Lire les vues d'entités",
-  "Permission:Entities.Views.Create": "Créer une vue personnelle",
-  "Permission:Entities.Views.Share": "Partager une vue avec des rôles ou des utilisateurs",
-  "Permission:Entities.Views.Manage": "Gérer les vues (épingler / définir le défaut tenant / promouvoir)",
-  "Permission:Entities.Views.Delete.Any": "Supprimer toute vue (modération)"
+  "culture": "fr",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Vues d'entités",
+    "Permission:Entities.Views.Read": "Lire les vues d'entités",
+    "Permission:Entities.Views.Create": "Créer une vue personnelle",
+    "Permission:Entities.Views.Share": "Partager une vue avec des rôles ou des utilisateurs",
+    "Permission:Entities.Views.Manage": "Gérer les vues (épingler / définir le défaut tenant / promouvoir)",
+    "Permission:Entities.Views.Delete.Any": "Supprimer toute vue (modération)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/hi.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/hi.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "hi",
+  "texts": {
+    "PermissionGroup:Entities.Views": "एंटिटी व्यू",
+    "Permission:Entities.Views.Read": "एंटिटी व्यू देखें",
+    "Permission:Entities.Views.Create": "व्यक्तिगत एंटिटी व्यू बनाएँ",
+    "Permission:Entities.Views.Share": "एंटिटी व्यू को भूमिकाओं या उपयोगकर्ताओं के साथ साझा करें",
+    "Permission:Entities.Views.Manage": "एंटिटी व्यू प्रबंधित करें (पिन करें / टेनेंट डिफ़ॉल्ट सेट करें / प्रमोट करें)",
+    "Permission:Entities.Views.Delete.Any": "कोई भी एंटिटी व्यू हटाएँ (मॉडरेशन)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/it.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/it.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "it",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Viste delle entità",
+    "Permission:Entities.Views.Read": "Visualizzare le viste delle entità",
+    "Permission:Entities.Views.Create": "Creare viste personali delle entità",
+    "Permission:Entities.Views.Share": "Condividere le viste delle entità con ruoli o utenti",
+    "Permission:Entities.Views.Manage": "Gestire le viste delle entità (fissare / impostare predefinita del tenant / promuovere)",
+    "Permission:Entities.Views.Delete.Any": "Eliminare qualsiasi vista di entità (moderazione)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/ja.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/ja.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "ja",
+  "texts": {
+    "PermissionGroup:Entities.Views": "エンティティビュー",
+    "Permission:Entities.Views.Read": "エンティティビューを表示",
+    "Permission:Entities.Views.Create": "個人用エンティティビューを作成",
+    "Permission:Entities.Views.Share": "エンティティビューをロールまたはユーザーと共有",
+    "Permission:Entities.Views.Manage": "エンティティビューを管理（ピン留め / テナントの既定を設定 / 昇格）",
+    "Permission:Entities.Views.Delete.Any": "任意のエンティティビューを削除（モデレーション）"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/ko.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/ko.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "ko",
+  "texts": {
+    "PermissionGroup:Entities.Views": "엔터티 뷰",
+    "Permission:Entities.Views.Read": "엔터티 뷰 보기",
+    "Permission:Entities.Views.Create": "개인 엔터티 뷰 생성",
+    "Permission:Entities.Views.Share": "역할 또는 사용자와 엔터티 뷰 공유",
+    "Permission:Entities.Views.Manage": "엔터티 뷰 관리 (고정 / 테넌트 기본값 설정 / 승격)",
+    "Permission:Entities.Views.Delete.Any": "모든 엔터티 뷰 삭제 (모더레이션)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/nl.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/nl.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "nl",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Entiteitsweergaven",
+    "Permission:Entities.Views.Read": "Entiteitsweergaven bekijken",
+    "Permission:Entities.Views.Create": "Persoonlijke entiteitsweergaven maken",
+    "Permission:Entities.Views.Share": "Entiteitsweergaven delen met rollen of gebruikers",
+    "Permission:Entities.Views.Manage": "Entiteitsweergaven beheren (vastmaken / tenant-standaard instellen / promoveren)",
+    "Permission:Entities.Views.Delete.Any": "Elke entiteitsweergave verwijderen (moderatie)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pl.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pl.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "pl",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Widoki encji",
+    "Permission:Entities.Views.Read": "Wyświetlanie widoków encji",
+    "Permission:Entities.Views.Create": "Tworzenie osobistych widoków encji",
+    "Permission:Entities.Views.Share": "Udostępnianie widoków encji rolom lub użytkownikom",
+    "Permission:Entities.Views.Manage": "Zarządzanie widokami encji (przypinanie / ustawianie domyślnego dla najemcy / promowanie)",
+    "Permission:Entities.Views.Delete.Any": "Usuwanie dowolnego widoku encji (moderacja)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pt-BR.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pt-BR.json
@@ -1,8 +1,7 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "pt-BR",
+  "texts": {
+    "Permission:Entities.Views.Share": "Compartilhar vistas de entidades com perfis ou usuários",
+    "Permission:Entities.Views.Manage": "Gerenciar vistas de entidades (fixar / definir padrão do tenant / promover)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pt.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/pt.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "pt",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Vistas de entidades",
+    "Permission:Entities.Views.Read": "Ver vistas de entidades",
+    "Permission:Entities.Views.Create": "Criar vistas de entidades pessoais",
+    "Permission:Entities.Views.Share": "Partilhar vistas de entidades com perfis ou utilizadores",
+    "Permission:Entities.Views.Manage": "Gerir vistas de entidades (fixar / definir padrão do tenant / promover)",
+    "Permission:Entities.Views.Delete.Any": "Eliminar qualquer vista de entidade (moderação)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/sv.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/sv.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "sv",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Entitetsvyer",
+    "Permission:Entities.Views.Read": "Visa entitetsvyer",
+    "Permission:Entities.Views.Create": "Skapa personliga entitetsvyer",
+    "Permission:Entities.Views.Share": "Dela entitetsvyer med roller eller användare",
+    "Permission:Entities.Views.Manage": "Hantera entitetsvyer (fäst / ange tenant-standard / befordra)",
+    "Permission:Entities.Views.Delete.Any": "Ta bort valfri entitetsvy (moderering)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/tr.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/tr.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "tr",
+  "texts": {
+    "PermissionGroup:Entities.Views": "Varlık görünümleri",
+    "Permission:Entities.Views.Read": "Varlık görünümlerini görüntüle",
+    "Permission:Entities.Views.Create": "Kişisel varlık görünümleri oluştur",
+    "Permission:Entities.Views.Share": "Varlık görünümlerini rollerle veya kullanıcılarla paylaş",
+    "Permission:Entities.Views.Manage": "Varlık görünümlerini yönet (sabitle / kiracı varsayılanı ayarla / yükselt)",
+    "Permission:Entities.Views.Delete.Any": "Herhangi bir varlık görünümünü sil (moderasyon)"
+  }
 }

--- a/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/zh.json
+++ b/src/Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/zh.json
@@ -1,8 +1,11 @@
 {
-  "PermissionGroup:Entities.Views": "Entity views",
-  "Permission:Entities.Views.Read": "Read entity views",
-  "Permission:Entities.Views.Create": "Create personal entity views",
-  "Permission:Entities.Views.Share": "Share entity views with roles or users",
-  "Permission:Entities.Views.Manage": "Manage entity views (pin / set tenant default / promote)",
-  "Permission:Entities.Views.Delete.Any": "Delete any entity view (moderation)"
+  "culture": "zh",
+  "texts": {
+    "PermissionGroup:Entities.Views": "实体视图",
+    "Permission:Entities.Views.Read": "查看实体视图",
+    "Permission:Entities.Views.Create": "创建个人实体视图",
+    "Permission:Entities.Views.Share": "与角色或用户共享实体视图",
+    "Permission:Entities.Views.Manage": "管理实体视图（固定 / 设为租户默认 / 提升）",
+    "Permission:Entities.Views.Delete.Any": "删除任何实体视图（审核）"
+  }
 }

--- a/tests/Granit.ArchitectureTests/LocalizationFileShapeTests.cs
+++ b/tests/Granit.ArchitectureTests/LocalizationFileShapeTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Every JSON file under <c>src/**/Localization/**/*.json</c> MUST follow the framework
+/// envelope <c>{ "culture": "&lt;code&gt;", "texts": { ... } }</c>. Files missing the
+/// envelope crash the host at startup with a runtime
+/// <c>InvalidOperationException</c> from <c>JsonLocalizationDictionaryBuilder</c> the
+/// first time someone hits a culture that triggers the lazy resource load — typically
+/// in production, far from where the bad commit was authored.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reproduces the actual failure mode observed when <c>Granit.Entities.Views.Endpoints</c>
+/// shipped with flat-shape locale files (PR #1638): the framework swallowed the
+/// shape mismatch silently in CI and only surfaced when a Czech (cs) request was
+/// served. This test catches the flat shape at build time across every culture file
+/// in the repository in a single fact, so the next missing-envelope file fails CI
+/// before merge.
+/// </para>
+/// <para>
+/// The check also asserts the <c>culture</c> property matches the file basename
+/// (e.g. <c>cs.json</c> → <c>"cs"</c>) so a copy-paste rename like <c>en.json → de.json</c>
+/// without updating the inner <c>"culture"</c> field is also caught.
+/// </para>
+/// </remarks>
+public sealed class LocalizationFileShapeTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Every_localization_json_file_should_use_the_culture_envelope()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        IReadOnlyList<string> files = EnumerateLocalizationFiles(srcDir).ToList();
+
+        files.ShouldNotBeEmpty(
+            "No localization JSON files discovered — the test cannot run. " +
+            "Expected at least one file under src/**/Localization/**/.");
+
+        List<string> violations = [];
+
+        foreach (string file in files)
+        {
+            string relativePath = Path.GetRelativePath(RepoRoot, file);
+            string expectedCulture = Path.GetFileNameWithoutExtension(file);
+
+            JsonDocument document;
+            try
+            {
+                using FileStream stream = File.OpenRead(file);
+                document = JsonDocument.Parse(stream);
+            }
+            catch (JsonException ex)
+            {
+                violations.Add($"{relativePath}: invalid JSON ({ex.Message})");
+                continue;
+            }
+
+            using (document)
+            {
+                JsonElement root = document.RootElement;
+
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    violations.Add($"{relativePath}: root must be a JSON object, was {root.ValueKind}");
+                    continue;
+                }
+
+                if (!root.TryGetProperty("culture", out JsonElement culture)
+                    || culture.ValueKind != JsonValueKind.String)
+                {
+                    violations.Add(
+                        $"{relativePath}: missing top-level 'culture' string property — " +
+                        $"wrap content in {{ \"culture\": \"{expectedCulture}\", \"texts\": {{ ... }} }}");
+                    continue;
+                }
+
+                if (!root.TryGetProperty("texts", out JsonElement texts)
+                    || texts.ValueKind != JsonValueKind.Object)
+                {
+                    violations.Add(
+                        $"{relativePath}: missing top-level 'texts' object property — " +
+                        $"wrap content in {{ \"culture\": \"{expectedCulture}\", \"texts\": {{ ... }} }}");
+                    continue;
+                }
+
+                string declaredCulture = culture.GetString()!;
+                if (!string.Equals(declaredCulture, expectedCulture, StringComparison.Ordinal))
+                {
+                    violations.Add(
+                        $"{relativePath}: 'culture' is \"{declaredCulture}\" but file is named " +
+                        $"\"{expectedCulture}.json\" — they must match");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            $"{violations.Count} localization JSON file(s) violate the framework envelope. " +
+            "Every src/**/Localization/**/*.json must be of the form " +
+            "{ \"culture\": \"<code>\", \"texts\": { ... } }:" + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Order(StringComparer.Ordinal)));
+    }
+
+    private static IEnumerable<string> EnumerateLocalizationFiles(string srcDir)
+    {
+        foreach (string file in Directory.EnumerateFiles(srcDir, "*.json", SearchOption.AllDirectories))
+        {
+            if (file.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                || file.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string normalized = file.Replace(Path.DirectorySeparatorChar, '/');
+            int marker = normalized.IndexOf("/Localization/", StringComparison.Ordinal);
+            if (marker < 0)
+            {
+                continue;
+            }
+
+            yield return file;
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(LocalizationFileShapeTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}


### PR DESCRIPTION
## Summary

- Wraps the 18 locale files in `Granit.Entities.Views.Endpoints/Localization/EntityViewsEndpoints/` with the framework's mandatory `{ "culture": "...", "texts": {...} }` envelope, fixing a startup-time runtime crash on the first Czech (or any non-EN) hit to `GET /api/{v}/localization`. The bug was introduced in #1638 and surfaced as `InvalidOperationException: The JSON file '...cs.json' does not contain a 'culture' property`.
- Replaces the English placeholder content in the 14 non-EN/FR base cultures with proper translations; regional files (`en-GB`, `fr-CA`, `pt-BR`) are now diff-only per `langues.md`.
- Adds `LocalizationFileShapeTests` (architecture-test shard): a single `[Fact]` that walks `src/**/Localization/**/*.json` and asserts every file has the envelope and that the `"culture"` value matches the file basename. Aggregates all violations into one failure so the next missing-envelope file fails CI before merge.

Repo-wide scan confirms no other module is affected — bug was isolated to `EntityViewsEndpoints`.

## Test plan

- [x] All 18 locale files validate against the envelope shape (Python JSON parse).
- [x] `dotnet build .github/shard-filters/architecture.slnf` — 0 warnings, 0 errors.
- [x] `dotnet test --filter LocalizationFileShapeTests` — green on the fixed tree.
- [x] **Negative test**: temporarily restored the original flat-shape `cs.json`, confirmed the new test fails with an actionable message naming the file and showing the exact wrapper to apply, then restored the fix and re-verified green.
- [x] `dotnet format style --verify-no-changes` — clean.
- [ ] CI: `architecture` + `infrastructure` shards pass (the latter holds `*.Endpoints` tests).
