### PR TITLE
feat(odata-exposure): host-feed mount for cross-tenant BI (#1665, PR 1/3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22779,7 +22779,7 @@
         {
           "name": "RecordTopClamped",
           "kind": "method",
-          "signature": "RecordTopClamped(string entitySet, string? tenantId)",
+          "signature": "RecordTopClamped(string entitySet, string? tenantId, string feedKind)",
           "returnType": "void"
         }
       ]
@@ -22790,7 +22790,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "MapGranitODataEndpoints",
@@ -22867,6 +22867,37 @@
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Options/ODataExposureOptions.cs",
       "line": 20,
+      "members": []
+    },
+    {
+      "name": "ODataHostEntitySetBuilder",
+      "fqn": "Granit.Http.ODataExposure.Options.ODataHostEntitySetBuilder",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Options/ODataHostExposureOptions.cs",
+      "line": 86,
+      "members": [
+        {
+          "name": "ExpandWhitelist",
+          "kind": "method",
+          "signature": "ExpandWhitelist(params string[] properties)",
+          "returnType": "ODataHostEntitySetBuilder<TEntity>"
+        },
+        {
+          "name": "MaxExpansionDepth",
+          "kind": "method",
+          "signature": "MaxExpansionDepth(int depth)",
+          "returnType": "ODataHostEntitySetBuilder<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "ODataHostExposureOptions",
+      "fqn": "Granit.Http.ODataExposure.Options.ODataHostExposureOptions",
+      "kind": "class",
+      "project": "Granit.Http.ODataExposure",
+      "file": "src/Granit.Http.ODataExposure/Options/ODataHostExposureOptions.cs",
+      "line": 26,
       "members": []
     },
     {

--- a/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
+++ b/src/Granit.Http.ODataExposure/Diagnostics/ODataExposureMetrics.cs
@@ -16,6 +16,7 @@ public sealed class ODataExposureMetrics
     private const string TagTenantId = "tenant_id";
     private const string TagEntitySet = "entity_set";
     private const string TagReason = "reason";
+    private const string TagFeedKind = "feed_kind";
     private const string DefaultTenant = "global";
 
     private readonly Counter<long> _rejectedQueries;
@@ -39,20 +40,26 @@ public sealed class ODataExposureMetrics
     /// <summary>Records a rejection at the C3 hardening layer.</summary>
     /// <param name="entitySet">EntitySet name surfaced on the route (e.g. <c>"Invoices"</c>).</param>
     /// <param name="reason">Stable snake_case reason tag (<c>"count_disabled"</c>, <c>"expand_not_whitelisted"</c>).</param>
-    /// <param name="tenantId">Resolved tenant id, or <see langword="null"/> when no tenant is active.</param>
-    public void RecordRejectedQuery(string entitySet, string reason, string? tenantId) =>
+    /// <param name="tenantId">Resolved tenant id, or <see langword="null"/> when no tenant is active. Coalesced to <c>"global"</c> on the metric.</param>
+    /// <param name="feedKind">Feed origin (<c>"tenant"</c> or <c>"host"</c>) — distinguishes per-tenant exposure events from cross-tenant host-feed events for audit dashboards.</param>
+    public void RecordRejectedQuery(string entitySet, string reason, string? tenantId, string feedKind) =>
         _rejectedQueries.Add(1, new TagList
         {
             { TagEntitySet, entitySet },
             { TagReason, reason },
             { TagTenantId, tenantId ?? DefaultTenant },
+            { TagFeedKind, feedKind },
         });
 
     /// <summary>Records a $top clamp.</summary>
-    public void RecordTopClamped(string entitySet, string? tenantId) =>
+    /// <param name="entitySet">EntitySet name surfaced on the route.</param>
+    /// <param name="tenantId">Resolved tenant id, or <see langword="null"/> when no tenant is active. Coalesced to <c>"global"</c> on the metric.</param>
+    /// <param name="feedKind">Feed origin (<c>"tenant"</c> or <c>"host"</c>).</param>
+    public void RecordTopClamped(string entitySet, string? tenantId, string feedKind) =>
         _topClamped.Add(1, new TagList
         {
             { TagEntitySet, entitySet },
             { TagTenantId, tenantId ?? DefaultTenant },
+            { TagFeedKind, feedKind },
         });
 }

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Granit.Authorization;
+using Granit.Domain;
 using Granit.Http.ODataExposure.Diagnostics;
 using Granit.Http.ODataExposure.Internal;
 using Granit.Http.ODataExposure.Options;
@@ -29,8 +30,11 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// <summary>Header set on the response when a user-supplied <c>$top</c> was clamped to the EntitySet's <see cref="ODataEntitySetDescriptor.MaxTop"/>. Lets observability tools spot misconfigured BI refresh jobs.</summary>
     internal const string MaxTopAppliedHeader = "OData-MaxTop-Applied";
 
-    /// <summary>Rate-limit policy name applied to every OData route in the group. Hosts configure quotas under <c>RateLimiting:Policies:granit-odata</c>.</summary>
+    /// <summary>Rate-limit policy name applied to every tenant-feed OData route. Hosts configure quotas under <c>RateLimiting:Policies:granit-odata</c>.</summary>
     public const string RateLimitPolicyName = "granit-odata";
+
+    /// <summary>Rate-limit policy name applied to every host-feed OData route. Distinct policy so the wider quotas typical of host-side BI workflows do not bleed onto tenant-facing routes. Hosts configure quotas under <c>RateLimiting:Policies:granit-odata-host</c> (recommended <c>PartitionBy: User</c>).</summary>
+    public const string HostRateLimitPolicyName = "granit-odata-host";
 
     /// <summary>
     /// Maps the configured OData EntitySets under <paramref name="prefix"/>.
@@ -70,25 +74,107 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                 nameof(configure));
         }
 
-        ValidateStrictConfiguration(options.Descriptors);
+        return MapEndpointsCore(
+            endpoints,
+            prefix,
+            options.Descriptors,
+            ODataFeedKind.Tenant,
+            RateLimitPolicyName,
+            ODataEdmModelBuilder.TenantContainerName);
+    }
 
-        IEdmModel edmModel = ODataEdmModelBuilder.Build(options.Descriptors);
+    /// <summary>
+    /// Maps the configured <b>host-feed</b> OData EntitySets under
+    /// <paramref name="prefix"/> — the cross-tenant feed reserved for host
+    /// operators (finance ops, compliance, capacity planning).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Three strict-config gates apply on top of the tenant-feed validator:
+    /// </para>
+    /// <list type="number">
+    ///   <item>The required permission MUST resolve to a <c>PermissionDefinition</c> with <c>MultiTenancySides == Host</c>; <c>Tenant</c> and <c>Both</c> are rejected at startup.</item>
+    ///   <item>Anonymous access is not allowed (the host builder does not expose <c>AllowAnonymousAccess</c>).</item>
+    ///   <item>Every host-feed EntitySet whose entity implements <c>IMultiTenant</c> MUST have called <c>AcknowledgeCrossTenantExposure(q =&gt; q.IgnoreQueryFilters([GranitFilterNames.MultiTenant]))</c>. The bypass lambda is supplied by the host so this module stays free of an EF Core dependency, and so the explicit "I know what I'm doing" lives in code, not in a flag.</item>
+    /// </list>
+    /// <para>
+    /// Container name for the EDM is <c>HostContainer</c> (vs <c>Container</c>
+    /// on the tenant-feed) so any BI client that mistakenly reuses the wrong
+    /// <c>$metadata</c> document gets an immediate schema mismatch.
+    /// </para>
+    /// </remarks>
+    /// <param name="endpoints">Endpoint route builder (the host's <c>app</c>).</param>
+    /// <param name="prefix">Route prefix mounted at, conventionally <c>"/api/{version}/odata/host"</c>.</param>
+    /// <param name="configure">Configuration callback declaring host-feed EntitySets via <see cref="ODataHostExposureOptions"/>.</param>
+    /// <returns>The outer <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    /// <exception cref="ArgumentException">No EntitySet was declared in <paramref name="configure"/>.</exception>
+    /// <exception cref="InvalidOperationException">Strict-config validation failed (missing permission, wrong <c>MultiTenancySides</c>, missing <c>AcknowledgeCrossTenantExposure</c>, missing <c>$expand</c> intent, or unresolvable permission definition).</exception>
+    public static RouteGroupBuilder MapGranitODataHostEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        string prefix,
+        Action<ODataHostExposureOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        ODataHostExposureOptions options = new();
+        configure(options);
+
+        if (options.Descriptors.Count == 0)
+        {
+            throw new ArgumentException(
+                "MapGranitODataHostEndpoints requires at least one EntitySet — call options.EntitySet<TEntity, TQueryDefinition>(name) inside the configure callback.",
+                nameof(configure));
+        }
+
+        return MapEndpointsCore(
+            endpoints,
+            prefix,
+            options.Descriptors,
+            ODataFeedKind.Host,
+            HostRateLimitPolicyName,
+            ODataEdmModelBuilder.HostContainerName);
+    }
+
+    /// <summary>
+    /// Shared route-mapping pipeline used by both <see cref="MapGranitODataEndpoints"/>
+    /// and <see cref="MapGranitODataHostEndpoints"/>. Validates strict-config
+    /// (feed-kind aware), builds the EDM model with the appropriate container
+    /// name, and wires the service document, <c>$metadata</c>, and per-set
+    /// routes under <paramref name="rateLimitPolicy"/>.
+    /// </summary>
+    private static RouteGroupBuilder MapEndpointsCore(
+        IEndpointRouteBuilder endpoints,
+        string prefix,
+        IReadOnlyList<ODataEntitySetDescriptor> descriptors,
+        ODataFeedKind feedKind,
+        string rateLimitPolicy,
+        string containerName)
+    {
+        ValidateStrictConfiguration(descriptors, endpoints.ServiceProvider);
+
+        IEdmModel edmModel = ODataEdmModelBuilder.Build(descriptors, containerName);
+
+        string tagSuffix = feedKind == ODataFeedKind.Host ? "OData (Host)" : "OData";
+        string serviceDocOpName = feedKind == ODataFeedKind.Host ? "ODataHostServiceDocument" : "ODataServiceDocument";
+        string metadataOpName = feedKind == ODataFeedKind.Host ? "ODataHostMetadata" : "ODataMetadata";
 
         RouteGroupBuilder root = endpoints.MapGroup(prefix)
-            .WithTags("OData")
-            .RequireGranitRateLimiting(RateLimitPolicyName);
+            .WithTags(tagSuffix)
+            .RequireGranitRateLimiting(rateLimitPolicy);
 
         root.MapODataServiceDocument("", edmModel)
-            .WithName("ODataServiceDocument")
+            .WithName(serviceDocOpName)
             .WithSummary("OData v4 service document — lists every exposed EntitySet with its metadata link.")
-            .WithDescription("Power BI / Excel / Tableau read this document to discover which EntitySets are available. Each set is queryable via the standard $filter / $select / $top / $skip / $orderby clauses.");
+            .WithDescription("BI clients (Power BI / Excel / Tableau) read this document to discover which EntitySets are available. Each set is queryable via the standard $filter / $select / $top / $skip / $orderby clauses.");
 
         root.MapODataMetadata("$metadata", edmModel)
-            .WithName("ODataMetadata")
+            .WithName(metadataOpName)
             .WithSummary("OData v4 EDM metadata document (CSDL XML).")
             .WithDescription("BI tools consume this CSDL document to populate their Navigator / table picker. The EDM is built from the application's registered QueryDefinition&lt;T&gt; instances.");
 
-        foreach (ODataEntitySetDescriptor descriptor in options.Descriptors)
+        foreach (ODataEntitySetDescriptor descriptor in descriptors)
         {
             MethodInfo mapper = typeof(ODataExposureEndpointRouteBuilderExtensions)
                 .GetMethod(nameof(MapEntitySetRoute), BindingFlags.NonPublic | BindingFlags.Static)!
@@ -111,13 +197,22 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// that lives inside a closure (and is therefore not statically
     /// reflectable).
     /// </summary>
-    /// <exception cref="InvalidOperationException">Any descriptor lacks both <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/> and <see cref="ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/>, OR neither <see cref="ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/> nor <see cref="ODataEntitySetBuilder{TEntity}.DisableExpand"/>.</exception>
-    private static void ValidateStrictConfiguration(IReadOnlyList<ODataEntitySetDescriptor> descriptors)
+    /// <exception cref="InvalidOperationException">Any descriptor lacks both <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/> and <see cref="ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/>, OR neither <see cref="ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/> nor <see cref="ODataEntitySetBuilder{TEntity}.DisableExpand"/>; or — for host-feed mounts — the permission resolves to a non-<c>Host</c> <see cref="MultiTenancySides"/>, the entity is <c>IMultiTenant</c> without a matching <c>AcknowledgeCrossTenantExposure</c> call, or the permission is unresolvable.</exception>
+    private static void ValidateStrictConfiguration(
+        IReadOnlyList<ODataEntitySetDescriptor> descriptors,
+        IServiceProvider services)
     {
         List<string> errors = [];
 
+        IPermissionDefinitionManager? permissionDefinitions =
+            descriptors.Any(d => d.FeedKind == ODataFeedKind.Host && d.RequiredPermission is not null)
+                ? services.GetService<IPermissionDefinitionManager>()
+                : null;
+
         foreach (ODataEntitySetDescriptor descriptor in descriptors)
         {
+            // Tenant-feed (default) and host-feed share the permission +
+            // expand intent gates. Host-feed adds two extra checks below.
             if (descriptor.RequiredPermission is null && !descriptor.AnonymousAccessAcknowledged)
             {
                 errors.Add(
@@ -129,6 +224,35 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                 errors.Add(
                     $"EntitySet '{descriptor.EntitySetName}' must call either ExpandWhitelist(...) or DisableExpand() — implicit \"$expand disabled\" is rejected by the strict-config validator (C6 #1395). Use DisableExpand() to declare the intent, or ExpandWhitelist(\"NavProp1\", ...) to allow specific navigations.");
             }
+
+            if (descriptor.FeedKind != ODataFeedKind.Host)
+            {
+                continue;
+            }
+
+            // Host-feed gate #1: permission must resolve to MultiTenancySides.Host (NOT Both, NOT Tenant).
+            if (descriptor.RequiredPermission is { } perm)
+            {
+                PermissionDefinition? permission = permissionDefinitions?.Find(perm);
+                if (permission is null)
+                {
+                    errors.Add(
+                        $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' but no PermissionDefinition with that name is registered. Declare it in an IPermissionDefinitionProvider with MultiTenancySides.Host before mounting the host-feed.");
+                }
+                else if (permission.MultiTenancySides != MultiTenancySides.Host)
+                {
+                    errors.Add(
+                        $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' which is declared as MultiTenancySides.{permission.MultiTenancySides} — host-feed access requires MultiTenancySides.Host. Either declare a dedicated host-side permission, or move this EntitySet to the tenant-feed (MapGranitODataEndpoints).");
+                }
+            }
+
+            // Host-feed gate #2: IMultiTenant entities require AcknowledgeCrossTenantExposure(...).
+            if (typeof(IMultiTenant).IsAssignableFrom(descriptor.EntityType)
+                && !descriptor.CrossTenantExposureAcknowledged)
+            {
+                errors.Add(
+                    $"Host-feed EntitySet '{descriptor.EntitySetName}' targets IMultiTenant entity '{descriptor.EntityType.Name}' but did not call AcknowledgeCrossTenantExposure(...). Without an explicit per-query bypass lambda, the framework's tenant filter (tenantId == currentTenant.Id) returns no rows for a tenantless caller — fail-closed. Add: .AcknowledgeCrossTenantExposure(q => q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])).");
+            }
         }
 
         if (errors.Count > 0)
@@ -139,9 +263,14 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         }
     }
 
-    /// <summary>Suggests the conventional <c>OData.{Module}.{Entity}.Read</c> permission name for the descriptor's entity, used in the strict-config error message.</summary>
-    private static string RequiredPermissionConvention(ODataEntitySetDescriptor descriptor) =>
-        $"OData.{descriptor.EntityType.Namespace?.Split('.').LastOrDefault() ?? "Module"}.{descriptor.EntityType.Name}.Read";
+    /// <summary>Suggests the conventional <c>OData.{Module}.{Entity}.Read</c> (or <c>OData.Host.{Module}.{Entity}.Read</c> for host-feed) permission name, used in the strict-config error message.</summary>
+    private static string RequiredPermissionConvention(ODataEntitySetDescriptor descriptor)
+    {
+        string segment = descriptor.EntityType.Namespace?.Split('.').LastOrDefault() ?? "Module";
+        return descriptor.FeedKind == ODataFeedKind.Host
+            ? $"OData.Host.{segment}.{descriptor.EntityType.Name}.Read"
+            : $"OData.{segment}.{descriptor.EntityType.Name}.Read";
+    }
 
     /// <summary>
     /// Wires one EntitySet's <c>GET /{EntitySetName}</c> route. Closed over
@@ -155,6 +284,9 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         IEdmModel edmModel)
         where TEntity : class
     {
+        // Captured once at Map time — typed Func used per-request without a cast.
+        var crossTenantBypass = descriptor.CrossTenantBypass as Func<IQueryable<TEntity>, IQueryable<TEntity>>;
+
         RouteHandlerBuilder route = root.MapGet(descriptor.EntitySetName, async Task<object?> (
                 ODataQueryOptions<TEntity> options,
                 HttpContext httpContext,
@@ -171,26 +303,42 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                     return TypedResults.Forbid();
                 }
 
-                string? tenantTag = currentTenant is { IsAvailable: true, Id: { } tid }
-                    ? tid.ToString()
-                    : null;
+                // Host-feed: there is no ambient tenant. Coalesce to "global"
+                // upstream of the metric tag so the dimension is never null
+                // (no confusion with "tenant not yet resolved").
+                string? tenantTag = descriptor.FeedKind == ODataFeedKind.Host
+                    ? "global"
+                    : currentTenant is { IsAvailable: true, Id: { } tid } ? tid.ToString() : null;
+
+                string feedKindTag = descriptor.FeedKind == ODataFeedKind.Host ? "host" : "tenant";
 
                 if (RejectIfCountDisallowed(httpContext, descriptor) is { } countRejection)
                 {
-                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "count_disabled", tenantTag);
+                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "count_disabled", tenantTag, feedKindTag);
                     return countRejection;
                 }
 
                 if (RejectIfExpandUnauthorised(httpContext, descriptor) is { } expandRejection)
                 {
-                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "expand_not_whitelisted", tenantTag);
+                    metrics.RecordRejectedQuery(descriptor.EntitySetName, "expand_not_whitelisted", tenantTag, feedKindTag);
                     return expandRejection;
                 }
 
-                ApplyMaxTopAppliedHeader(httpContext, descriptor, metrics, tenantTag);
+                ApplyMaxTopAppliedHeader(httpContext, descriptor, metrics, tenantTag, feedKindTag);
+
+                IQueryable<TEntity> baseQueryable = source.GetQueryable();
+
+                // Host-feed: apply the host-supplied per-query bypass BEFORE
+                // the QueryEngine pipeline runs, so the QueryEngine sees an
+                // already-untenanted queryable. Tenant-feed: no bypass; the
+                // QueryEngine receives the source as-is.
+                if (crossTenantBypass is not null)
+                {
+                    baseQueryable = crossTenantBypass(baseQueryable);
+                }
 
                 IQueryable<TEntity> filtered = engine.BuildFilteredQuery(
-                    source.GetQueryable(), new QueryRequest());
+                    baseQueryable, new QueryRequest());
 
                 ODataQuerySettings querySettings = new() { PageSize = descriptor.PageSize };
                 IQueryable applied = options.ApplyTo(filtered, querySettings);
@@ -318,7 +466,8 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         HttpContext httpContext,
         ODataEntitySetDescriptor descriptor,
         ODataExposureMetrics metrics,
-        string? tenantTag)
+        string? tenantTag,
+        string feedKindTag)
     {
         if (!httpContext.Request.Query.TryGetValue("$top", out StringValues topRaw)
             || !int.TryParse(topRaw.ToString(), out int requestedTop)
@@ -329,6 +478,6 @@ public static class ODataExposureEndpointRouteBuilderExtensions
 
         httpContext.Response.Headers[MaxTopAppliedHeader] =
             descriptor.MaxTop.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        metrics.RecordTopClamped(descriptor.EntitySetName, tenantTag);
+        metrics.RecordTopClamped(descriptor.EntitySetName, tenantTag, feedKindTag);
     }
 }

--- a/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
@@ -12,15 +12,25 @@ namespace Granit.Http.ODataExposure.Internal;
 /// </summary>
 internal static class ODataEdmModelBuilder
 {
+    /// <summary>Default OData container name for the tenant-feed mount.</summary>
+    public const string TenantContainerName = "Container";
+
+    /// <summary>OData container name for the host-feed mount. Distinct from <see cref="TenantContainerName"/> so a BI client cannot reuse one feed's <c>$metadata</c> document on the other URL by accident — schema mismatch surfaces immediately.</summary>
+    public const string HostContainerName = "HostContainer";
+
     /// <summary>
     /// Builds the EDM model for the supplied descriptors.
     /// </summary>
     /// <param name="descriptors">EntitySet descriptors registered via the fluent options.</param>
+    /// <param name="containerName">OData container name; defaults to <see cref="TenantContainerName"/>. Host-feed callers pass <see cref="HostContainerName"/>.</param>
     /// <returns>The built <see cref="IEdmModel"/>, ready to wire into <c>WithODataModel</c>.</returns>
     /// <exception cref="ArgumentException"><paramref name="descriptors"/> is empty.</exception>
-    public static IEdmModel Build(IReadOnlyList<ODataEntitySetDescriptor> descriptors)
+    public static IEdmModel Build(
+        IReadOnlyList<ODataEntitySetDescriptor> descriptors,
+        string containerName = TenantContainerName)
     {
         ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
 
         if (descriptors.Count == 0)
         {
@@ -29,7 +39,7 @@ internal static class ODataEdmModelBuilder
                 nameof(descriptors));
         }
 
-        ODataConventionModelBuilder builder = new();
+        ODataConventionModelBuilder builder = new() { ContainerName = containerName };
 
         foreach (ODataEntitySetDescriptor descriptor in descriptors)
         {

--- a/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEntitySetDescriptor.cs
@@ -19,6 +19,9 @@ namespace Granit.Http.ODataExposure.Internal;
 /// <param name="MaxExpansionDepth">Maximum nesting depth allowed for <c>$expand</c>. Default <c>1</c> — flat expand only; nested expand requires explicit opt-in.</param>
 /// <param name="AnonymousAccessAcknowledged">Set by <see cref="Options.ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/> to declare that the absence of <see cref="RequiredPermission"/> is intentional. Without this flag, the strict-config validator (C6 #1395) refuses to start the host — every OData EntitySet must be either gated or explicitly anonymous.</param>
 /// <param name="ExpandConfigurationAcknowledged">Set by <see cref="Options.ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/>, <see cref="Options.ODataEntitySetBuilder{TEntity}.DisableExpand"/>, or implicit via <see cref="Options.ODataEntitySetBuilder{TEntity}.AllowNoExpansion"/>. The strict-config validator refuses to start the host until one of these is called — implicit "expand disabled" is a security smell, the host must declare the intent.</param>
+/// <param name="FeedKind">Tenant-feed (default) or host-feed (cross-tenant, <see cref="ODataFeedKind.Host"/>). Set by <c>MapGranitODataHostEndpoints</c> on every host-feed descriptor. Drives feed-kind-aware strict-config rules (Host permission, cross-tenant acknowledgement) and the <c>feed_kind</c> OTel tag.</param>
+/// <param name="CrossTenantBypass">Host-supplied bypass lambda applied to the queryable before the QueryEngine pipeline runs. Typed <c>Func&lt;IQueryable&lt;TEntity&gt;, IQueryable&lt;TEntity&gt;&gt;</c> erased to <see cref="Delegate"/> so the descriptor stays non-generic. Required for <see cref="FeedKind"/> = <see cref="ODataFeedKind.Host"/> when the entity is <c>IMultiTenant</c> — the host writes <c>q =&gt; q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])</c> at the call site so the explicit "I know what I'm doing" lives in code, not in a flag.</param>
+/// <param name="CrossTenantExposureAcknowledged">Set by <c>AcknowledgeCrossTenantExposure</c> on the host-feed builder. Required for any host-feed EntitySet whose entity implements <c>IMultiTenant</c>; the strict-config validator throws at <c>MapGranitODataHostEndpoints</c> time when missing.</param>
 internal sealed record ODataEntitySetDescriptor(
     string EntitySetName,
     Type EntityType,
@@ -30,4 +33,7 @@ internal sealed record ODataEntitySetDescriptor(
     IReadOnlyList<string>? ExpandWhitelist = null,
     int MaxExpansionDepth = 1,
     bool AnonymousAccessAcknowledged = false,
-    bool ExpandConfigurationAcknowledged = false);
+    bool ExpandConfigurationAcknowledged = false,
+    ODataFeedKind FeedKind = ODataFeedKind.Tenant,
+    Delegate? CrossTenantBypass = null,
+    bool CrossTenantExposureAcknowledged = false);

--- a/src/Granit.Http.ODataExposure/Internal/ODataFeedKind.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataFeedKind.cs
@@ -1,0 +1,16 @@
+namespace Granit.Http.ODataExposure.Internal;
+
+/// <summary>
+/// Distinguishes the two OData mounts the module exposes. Tenant-feed
+/// inherits the framework's per-tenant filter; host-feed bypasses it
+/// per-query for cross-tenant analytics by SuperAdmins, behind explicit
+/// strict-config gates.
+/// </summary>
+internal enum ODataFeedKind
+{
+    /// <summary>Standard tenant-scoped feed (default). Tenant filter applies; cross-tenant data is invisible.</summary>
+    Tenant,
+
+    /// <summary>Cross-tenant feed for host operators. Tenant filter is bypassed per-query via a host-supplied lambda; permissions must resolve to <c>MultiTenancySides.Host</c>; <c>IMultiTenant</c> entities require an explicit <c>AcknowledgeCrossTenantExposure</c> call.</summary>
+    Host,
+}

--- a/src/Granit.Http.ODataExposure/Options/ODataHostExposureOptions.cs
+++ b/src/Granit.Http.ODataExposure/Options/ODataHostExposureOptions.cs
@@ -1,0 +1,187 @@
+using Granit.Http.ODataExposure.Internal;
+using Granit.QueryEngine;
+
+namespace Granit.Http.ODataExposure.Options;
+
+/// <summary>
+/// Fluent registration surface for the <b>host-feed</b> mount — the
+/// cross-tenant OData feed reserved for host operators (finance ops,
+/// compliance, capacity planning) and gated by <c>MultiTenancySides.Host</c>
+/// permissions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <see cref="ODataExposureOptions"/> by design: the configure
+/// callbacks of the two mounts cannot be confused at the call site, and the
+/// host-feed builder forces the developer to write <c>IgnoreQueryFilters</c>
+/// at the lambda level rather than flicking a flag.
+/// </para>
+/// <para>
+/// The strict-config validator additions on this options surface (host-only
+/// permissions, mandatory <c>AcknowledgeCrossTenantExposure</c> for
+/// <c>IMultiTenant</c> entities, no anonymous access) are described on
+/// <see cref="Extensions.ODataExposureEndpointRouteBuilderExtensions.MapGranitODataHostEndpoints"/>.
+/// </para>
+/// </remarks>
+public sealed class ODataHostExposureOptions
+{
+    private readonly List<ODataEntitySetDescriptor> _descriptors = [];
+
+    /// <summary>All host-feed EntitySets registered so far. Internal — consumed by the route builder once the configuration closure returns.</summary>
+    internal IReadOnlyList<ODataEntitySetDescriptor> Descriptors => _descriptors;
+
+    /// <summary>
+    /// Registers a host-feed EntitySet backed by <typeparamref name="TQueryDefinition"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Entity type — appears as an EntityType in the host-feed EDM model.</typeparam>
+    /// <typeparam name="TQueryDefinition">The <c>QueryDefinition&lt;TEntity&gt;</c> shipped by the owning module — resolved through DI at request time.</typeparam>
+    /// <param name="entitySetName">OData EntitySet name and route segment (PascalCase plural noun).</param>
+    /// <returns>A host-feed builder for chaining further configuration on this set.</returns>
+    /// <exception cref="ArgumentException"><paramref name="entitySetName"/> is empty or already registered in this options instance.</exception>
+    public ODataHostEntitySetBuilder<TEntity> EntitySet<TEntity, TQueryDefinition>(string entitySetName)
+        where TEntity : class
+        where TQueryDefinition : QueryDefinition<TEntity>
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entitySetName);
+
+        if (_descriptors.Any(d => string.Equals(d.EntitySetName, entitySetName, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                $"Host-feed EntitySet '{entitySetName}' is already registered.",
+                nameof(entitySetName));
+        }
+
+        ODataEntitySetDescriptor descriptor = new(
+            EntitySetName: entitySetName,
+            EntityType: typeof(TEntity),
+            QueryDefinitionType: typeof(TQueryDefinition),
+            RequiredPermission: null,
+            FeedKind: ODataFeedKind.Host);
+
+        _descriptors.Add(descriptor);
+        return new ODataHostEntitySetBuilder<TEntity>(this, descriptor);
+    }
+
+    /// <summary>Replaces a descriptor in-place. Used by <see cref="ODataHostEntitySetBuilder{TEntity}"/> for fluent updates.</summary>
+    internal void Replace(ODataEntitySetDescriptor old, ODataEntitySetDescriptor updated)
+    {
+        int index = _descriptors.IndexOf(old);
+        if (index < 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot replace descriptor for host-feed EntitySet '{old.EntitySetName}' — original instance not tracked.");
+        }
+        _descriptors[index] = updated;
+    }
+}
+
+/// <summary>
+/// Fluent builder for a host-feed EntitySet. Mirrors most of
+/// <see cref="ODataEntitySetBuilder{TEntity}"/>'s surface, with two
+/// host-specific changes: <see cref="AllowAnonymousAccess"/> is intentionally
+/// absent (host-feed access is always gated), and
+/// <see cref="AcknowledgeCrossTenantExposure"/> is mandatory for
+/// <c>IMultiTenant</c> entities.
+/// </summary>
+public sealed class ODataHostEntitySetBuilder<TEntity>
+    where TEntity : class
+{
+    private readonly ODataHostExposureOptions _options;
+    private ODataEntitySetDescriptor _descriptor;
+
+    internal ODataHostEntitySetBuilder(ODataHostExposureOptions options, ODataEntitySetDescriptor descriptor)
+    {
+        _options = options;
+        _descriptor = descriptor;
+    }
+
+    /// <summary>
+    /// Gates this host-feed EntitySet behind the named permission. The
+    /// permission MUST resolve to a definition with
+    /// <c>MultiTenancySides.Host</c>; the strict-config validator rejects
+    /// <c>Tenant</c> or <c>Both</c> at <c>MapGranitODataHostEndpoints</c>
+    /// time. Convention: <c>"OData.Host.{Module}.{Entity}.Read"</c>.
+    /// </summary>
+    public ODataHostEntitySetBuilder<TEntity> RequirePermission(string permission)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+        return Update(_descriptor with { RequiredPermission = permission });
+    }
+
+    /// <summary>
+    /// Acknowledges that this set returns data across tenants and supplies
+    /// the per-query filter bypass. The host writes the bypass at the call
+    /// site so the explicit "I know what I'm doing" lives in actual code,
+    /// not in a flag — and the OData module stays free of the EF Core
+    /// dependency. Typical usage:
+    /// <code>
+    /// .AcknowledgeCrossTenantExposure(q =&gt; q.IgnoreQueryFilters([GranitFilterNames.MultiTenant]))
+    /// </code>
+    /// Without this call, an <c>IMultiTenant</c> EntitySet on the host-feed
+    /// throws at startup. Without the bypass lambda, the framework filter
+    /// <c>tenantId == currentTenant.Id</c> returns no rows for a tenantless
+    /// caller — fail-closed.
+    /// </summary>
+    /// <param name="bypass">Per-query transform applied to the queryable BEFORE the QueryEngine pipeline runs. Typed <c>Func&lt;IQueryable&lt;TEntity&gt;, IQueryable&lt;TEntity&gt;&gt;</c>.</param>
+    public ODataHostEntitySetBuilder<TEntity> AcknowledgeCrossTenantExposure(
+        Func<IQueryable<TEntity>, IQueryable<TEntity>> bypass)
+    {
+        ArgumentNullException.ThrowIfNull(bypass);
+        return Update(_descriptor with
+        {
+            CrossTenantBypass = bypass,
+            CrossTenantExposureAcknowledged = true,
+        });
+    }
+
+    /// <summary>Caps the user-supplied <c>$top</c>. See <see cref="ODataEntitySetBuilder{TEntity}.MaxTop"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> MaxTop(int maxTop)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxTop);
+        return Update(_descriptor with { MaxTop = maxTop });
+    }
+
+    /// <summary>Sets the server-side default page size returned when the caller omits <c>$top</c>. See <see cref="ODataEntitySetBuilder{TEntity}.PageSize"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> PageSize(int pageSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+        return Update(_descriptor with { PageSize = pageSize });
+    }
+
+    /// <summary>Enables <c>$count=true</c>. See <see cref="ODataEntitySetBuilder{TEntity}.EnableCount"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> EnableCount()
+        => Update(_descriptor with { CountEnabled = true });
+
+    /// <summary>Whitelists top-level navigation properties. See <see cref="ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> ExpandWhitelist(params string[] properties)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        return Update(_descriptor with
+        {
+            ExpandWhitelist = [.. properties],
+            ExpandConfigurationAcknowledged = true,
+        });
+    }
+
+    /// <summary>Explicitly disables <c>$expand</c> on this set. See <see cref="ODataEntitySetBuilder{TEntity}.DisableExpand"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> DisableExpand()
+        => Update(_descriptor with
+        {
+            ExpandWhitelist = [],
+            ExpandConfigurationAcknowledged = true,
+        });
+
+    /// <summary>Sets the maximum nesting depth for <c>$expand</c>. See <see cref="ODataEntitySetBuilder{TEntity}.MaxExpansionDepth"/>.</summary>
+    public ODataHostEntitySetBuilder<TEntity> MaxExpansionDepth(int depth)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(depth);
+        return Update(_descriptor with { MaxExpansionDepth = depth });
+    }
+
+    private ODataHostEntitySetBuilder<TEntity> Update(ODataEntitySetDescriptor updated)
+    {
+        _options.Replace(_descriptor, updated);
+        _descriptor = updated;
+        return this;
+    }
+}

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -142,3 +142,65 @@ request can trigger a long-running query.
   the OData metadata document at `/{prefix}/$metadata` (CSDL XML) is the
   authoritative discovery surface — Power BI / Excel / Tableau consume it
   natively.
+
+## Host-feed (cross-tenant BI for host operators)
+
+`MapGranitODataEndpoints` (above) covers the standard tenant-scoped feed: a
+tenant analyst sees only their tenant's rows. For legitimate cross-tenant
+analytics — finance ops (MRR/ARR across all tenants), compliance (audit
+entries cross-tenant), capacity planning — use the dedicated host-feed mount.
+
+```csharp
+app.MapGranitODataHostEndpoints("/api/{version}/odata/host", opts =>
+{
+    opts.EntitySet<Tenant, TenantQueryDefinition>("Tenants")
+        .RequirePermission("OData.Host.Platform.Tenants.Read")  // MUST be MultiTenancySides.Host
+        .DisableExpand();
+
+    opts.EntitySet<Invoice, InvoiceQueryDefinition>("InvoicesAllTenants")
+        .RequirePermission("OData.Host.Invoicing.Invoices.Read")
+        .AcknowledgeCrossTenantExposure(q =>
+            q.IgnoreQueryFilters([GranitFilterNames.MultiTenant]))    // explicit per-query bypass
+        .ExpandWhitelist("Customer");
+});
+```
+
+Three strict-config gates are added on top of the tenant-feed validator:
+
+1. **Permission must be `MultiTenancySides.Host`.** The validator resolves
+   the permission name through `IPermissionDefinitionManager` at startup
+   and refuses `Tenant` or `Both`. A permission without an `IPermissionDefinitionProvider`
+   declaration is also refused.
+2. **No anonymous access.** The host builder does not expose
+   `AllowAnonymousAccess()` — every host-feed set is gated.
+3. **`AcknowledgeCrossTenantExposure(...)` mandatory for `IMultiTenant` entities.**
+   The host writes the per-query bypass lambda at the call site. Without it,
+   the framework filter `tenantId == currentTenant.Id` returns no rows for a
+   tenantless caller — fail-closed. The bypass lambda is `q => q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])`
+   on EF Core; alternative providers can plug their own.
+
+Other distinctions:
+
+- **Distinct OData container name.** Tenant-feed uses `Container`; host-feed uses
+  `HostContainer`. A BI client that mixes the two `$metadata` documents sees an
+  immediate schema mismatch.
+- **Distinct rate-limit policy.** `granit-odata-host` (recommended `PartitionBy: User`,
+  wider quotas — fewer users, heavier queries) vs `granit-odata` (recommended
+  `PartitionBy: Tenant`).
+- **Telemetry tag `feed_kind=host|tenant`** on every `ODataExposureMetrics`
+  counter so audit dashboards can filter cross-tenant access events distinctly
+  (ISO 27001 A.12.4).
+
+### When to use Host-feed vs Granit.Analytics
+
+| Need | Use |
+| ---- | --- |
+| Cross-tenant aggregate KPI for a host dashboard | `Granit.Analytics` (`MetricDefinition`) |
+| Cross-tenant tabular data for Power BI / Excel / Tableau | Host-feed (this module) |
+| Per-tenant tabular data for tenant admins | Tenant-feed (this module) |
+| Per-tenant aggregate KPI inside an admin grid | `Granit.Analytics` |
+
+`Granit.Analytics` is the right fit when the consumer is the application's own
+admin UI and the value is one or a few aggregated numbers per call. Host-feed
+is the right fit when the consumer is an external BI tool that needs full
+tabular data and benefits from `$filter` / `$select` / `$top` composition.

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/LayerDependencyRules.cs
@@ -139,19 +139,21 @@ public static class LayerDependencyRules
     /// <summary>
     /// IQueryable must not escape the persistence/data layer.
     /// Types whose namespace contains a default-allowed fragment (EntityFrameworkCore,
-    /// QueryEngine, Persistence) are exempt, as are types following the
-    /// <c>*QueryableSource</c> convention — the standard bridge for exposing
-    /// IQueryable to the QueryEngine endpoints layer — and concrete
-    /// <c>*MetricDefinition</c> types deriving from
-    /// <c>JoinedMetricDefinition&lt;TEntity, TJoined, TValue&gt;</c>, whose
-    /// <c>Project</c> method intrinsically takes <c>IQueryable</c> on both sides
-    /// of the join (the projection is the unit of aggregation; running it
-    /// elsewhere would force materialisation in memory).
+    /// QueryEngine, Persistence, Analytics, ODataExposure) are exempt — these
+    /// modules ARE the query pipeline; surfacing <c>IQueryable</c> on a bridge
+    /// type (e.g. the OData host-feed builder's user-supplied bypass lambda)
+    /// is part of their contract. Types following the <c>*QueryableSource</c>
+    /// convention — the standard bridge for exposing IQueryable to the
+    /// QueryEngine endpoints layer — and concrete <c>*MetricDefinition</c> types
+    /// deriving from <c>JoinedMetricDefinition&lt;TEntity, TJoined, TValue&gt;</c>,
+    /// whose <c>Project</c> method intrinsically takes <c>IQueryable</c> on both
+    /// sides of the join (the projection is the unit of aggregation; running it
+    /// elsewhere would force materialisation in memory), are also exempt.
     /// </summary>
     public static void IQueryableShouldNotEscapePersistenceLayer(
         ArchUnitNET.Domain.Architecture architecture)
     {
-        string[] allowedNamespaceFragments = ["EntityFrameworkCore", "QueryEngine", "Persistence", "Export", "Identity.Local", "Identity.OpenIddict", "Analytics"];
+        string[] allowedNamespaceFragments = ["EntityFrameworkCore", "QueryEngine", "Persistence", "Export", "Identity.Local", "Identity.OpenIddict", "Analytics", "ODataExposure"];
 
         IEnumerable<IType> violators = architecture.Types
             .Where(t => !allowedNamespaceFragments.Any(ns =>

--- a/tests/Granit.Http.ODataExposure.Tests/HostFeedStrictConfigValidatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/HostFeedStrictConfigValidatorTests.cs
@@ -1,0 +1,231 @@
+using Granit.Authorization;
+using Granit.Domain;
+using Granit.Http.ODataExposure.Extensions;
+using Granit.Http.ODataExposure.Options;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.RateLimiting.Extensions;
+using Granit.RateLimiting.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// Host-feed strict-config gates locked at <c>MapGranitODataHostEndpoints</c>
+/// time. Three rules on top of the tenant-feed validator: permission must
+/// resolve to <c>MultiTenancySides.Host</c>, anonymous access is not
+/// available, and <c>IMultiTenant</c> entities require an explicit
+/// <c>AcknowledgeCrossTenantExposure</c> bypass lambda.
+/// </summary>
+public sealed class HostFeedStrictConfigValidatorTests
+{
+    [Fact]
+    public void HostFeed_PermissionWithMultiTenancySidesTenant_Throws()
+    {
+        // Gate #1: host-feed sets must use a Host-only permission. Tenant or
+        // Both permissions would let a tenant user be granted host-feed
+        // access through tenant-side role inheritance.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Tenants.Read", MultiTenancySides.Tenant),
+                configure: opts => opts.EntitySet<TenantStub, TenantStubQueryDefinition>("Tenants")
+                    .RequirePermission("OData.Test.Tenants.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("MultiTenancySides.Tenant");
+        ex.Message.ShouldContain("Tenants");
+    }
+
+    [Fact]
+    public void HostFeed_PermissionWithMultiTenancySidesBoth_Throws()
+    {
+        // Both is also rejected — host-feed requires strict Host-side scope.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Tenants.Read", MultiTenancySides.Both),
+                configure: opts => opts.EntitySet<TenantStub, TenantStubQueryDefinition>("Tenants")
+                    .RequirePermission("OData.Test.Tenants.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("MultiTenancySides.Both");
+    }
+
+    [Fact]
+    public void HostFeed_UnregisteredPermission_Throws()
+    {
+        // Gate #1 (lookup): a permission with no IPermissionDefinitionProvider
+        // declaration is rejected. Defending against typos in the permission
+        // string at the host's call site.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                hostPermissions: HostPermissionsProvider.Empty,
+                configure: opts => opts.EntitySet<TenantStub, TenantStubQueryDefinition>("Tenants")
+                    .RequirePermission("OData.Test.Typo")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("OData.Test.Typo");
+        ex.Message.ShouldContain("no PermissionDefinition");
+    }
+
+    [Fact]
+    public void HostFeed_IMultiTenantEntity_WithoutAcknowledge_Throws()
+    {
+        // Gate #2: IMultiTenant entity exposed on host-feed without the
+        // explicit bypass lambda. Without it, the framework filter
+        // tenantId == currentTenant.Id returns no rows for tenantless callers
+        // — fail-closed but confusing. Force the developer to write the
+        // bypass at the call site.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Invoices.Read", MultiTenancySides.Host),
+                configure: opts => opts.EntitySet<MultiTenantInvoice, MultiTenantInvoiceQueryDefinition>("Invoices")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("AcknowledgeCrossTenantExposure");
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("IMultiTenant");
+    }
+
+    [Fact]
+    public void HostFeed_NonMultiTenantEntity_WithoutAcknowledge_DoesNotThrow()
+    {
+        // Non-IMultiTenant entities (e.g. the Tenant table itself) do not
+        // need the bypass — the framework filter does not apply to them.
+        Should.NotThrow(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Tenants.Read", MultiTenancySides.Host),
+                configure: opts => opts.EntitySet<TenantStub, TenantStubQueryDefinition>("Tenants")
+                    .RequirePermission("OData.Test.Tenants.Read")
+                    .DisableExpand()));
+    }
+
+    [Fact]
+    public void HostFeed_FullyConfigured_DoesNotThrow()
+    {
+        // Happy path: Host permission + IMultiTenant entity + bypass lambda + expand intent.
+        Should.NotThrow(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Invoices.Read", MultiTenancySides.Host),
+                configure: opts => opts.EntitySet<MultiTenantInvoice, MultiTenantInvoiceQueryDefinition>("InvoicesAllTenants")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .AcknowledgeCrossTenantExposure(q => q)
+                    .DisableExpand()));
+    }
+
+    [Fact]
+    public void HostFeed_ErrorMessage_AccumulatesAllOffendingSets()
+    {
+        // Same accumulation behaviour as the tenant-feed validator — a single
+        // error listing every misconfigured set, not a one-by-one drip-fix loop.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                hostPermissions: new HostPermissionsProvider(
+                    "OData.Test.Invoices.Read", MultiTenancySides.Tenant),
+                configure: opts =>
+                {
+                    opts.EntitySet<MultiTenantInvoice, MultiTenantInvoiceQueryDefinition>("Invoices")
+                        .RequirePermission("OData.Test.Invoices.Read")  // wrong side
+                        .DisableExpand();                                 // missing acknowledge
+                    opts.EntitySet<TenantStub, TenantStubQueryDefinition>("Tenants")
+                        .RequirePermission("OData.Test.Unknown")          // unregistered
+                        .DisableExpand();
+                }));
+
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("Tenants");
+        ex.Message.ShouldContain("MultiTenancySides.Tenant");
+        ex.Message.ShouldContain("OData.Test.Unknown");
+    }
+
+    private static void CallMap(
+        IPermissionDefinitionManager hostPermissions,
+        Action<ODataHostExposureOptions> configure)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+        builder.Services.AddSingleton<IPermissionChecker>(Substitute.For<IPermissionChecker>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<MultiTenantInvoice>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<TenantStub>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<MultiTenantInvoice>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<TenantStub>>());
+        builder.Services.AddSingleton<QueryDefinition<MultiTenantInvoice>>(new MultiTenantInvoiceQueryDefinition());
+        builder.Services.AddSingleton<QueryDefinition<TenantStub>>(new TenantStubQueryDefinition());
+
+        builder.Services.AddGranitODataExposure();
+        builder.Services.AddSingleton(hostPermissions);
+
+        builder.Services.AddGranitRateLimiting(o =>
+        {
+            o.Enabled = true;
+            o.Policies[ODataExposureEndpointRouteBuilderExtensions.HostRateLimitPolicyName] =
+                new RateLimitPolicyOptions
+                {
+                    PermitLimit = 1000,
+                    Window = TimeSpan.FromMinutes(1),
+                };
+        });
+
+        using WebApplication app = builder.Build();
+        app.MapGranitODataHostEndpoints("/api/granit/odata/host", configure);
+    }
+
+    /// <summary>
+    /// Minimal in-memory <see cref="IPermissionDefinitionManager"/> stub —
+    /// the validator only calls <see cref="IPermissionDefinitionManager.Find"/>,
+    /// so the rest of the surface returns empties.
+    /// </summary>
+    private sealed class HostPermissionsProvider : IPermissionDefinitionManager
+    {
+        public static HostPermissionsProvider Empty { get; } = new();
+
+        private readonly Dictionary<string, PermissionDefinition> _definitions;
+
+        public HostPermissionsProvider() => _definitions = [];
+
+        public HostPermissionsProvider(string name, MultiTenancySides sides)
+            : this() => _definitions[name] = new PermissionDefinition(name, DisplayName: null, GroupName: "Test", sides);
+
+        public bool Exists(string name) => _definitions.ContainsKey(name);
+        public PermissionDefinition? Find(string name) => _definitions.GetValueOrDefault(name);
+        public IReadOnlyList<PermissionDefinition> GetAll() => [.. _definitions.Values];
+        public IReadOnlyList<PermissionGroup> GetGroups() => [];
+    }
+
+    public sealed class TenantStub
+    {
+        public Guid Id { get; init; }
+        public string Slug { get; init; } = string.Empty;
+    }
+
+    public sealed class TenantStubQueryDefinition : QueryDefinition<TenantStub>
+    {
+        public override string Name => "Test.Tenants";
+        protected override void Configure(QueryDefinitionBuilder<TenantStub> builder) =>
+            builder.Column(t => t.Slug, c => c.Filterable());
+    }
+
+    public sealed class MultiTenantInvoice : IMultiTenant
+    {
+        public Guid Id { get; init; }
+        public Guid? TenantId { get; set; }
+        public string Number { get; init; } = string.Empty;
+    }
+
+    public sealed class MultiTenantInvoiceQueryDefinition : QueryDefinition<MultiTenantInvoice>
+    {
+        public override string Name => "Test.Invoices";
+        protected override void Configure(QueryDefinitionBuilder<MultiTenantInvoice> builder) =>
+            builder.Column(i => i.Number, c => c.Filterable());
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
@@ -72,6 +72,37 @@ public sealed class ODataEdmModelBuilderTests
         Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!));
     }
 
+    [Fact]
+    public void Build_DefaultContainerName_IsTenantContainer()
+    {
+        // Tenant-feed default. Locks the convention so a BI client can rely
+        // on the same container name across releases.
+        ODataEntitySetDescriptor descriptor = new(
+            "Invoices", typeof(Invoice), typeof(string), null);
+
+        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+
+        model.EntityContainer.Name.ShouldBe(ODataEdmModelBuilder.TenantContainerName);
+        model.EntityContainer.Name.ShouldBe("Container");
+    }
+
+    [Fact]
+    public void Build_HostContainerName_DistinguishesTheFeed()
+    {
+        // Host-feed gate #3: a distinct container name surfaces an immediate
+        // schema mismatch when a BI client mistakenly reuses one feed's
+        // $metadata document on the other URL.
+        ODataEntitySetDescriptor descriptor = new(
+            "Tenants", typeof(Invoice), typeof(string), null);
+
+        IEdmModel model = ODataEdmModelBuilder.Build(
+            [descriptor],
+            ODataEdmModelBuilder.HostContainerName);
+
+        model.EntityContainer.Name.ShouldBe("HostContainer");
+        model.EntityContainer.Name.ShouldNotBe(ODataEdmModelBuilder.TenantContainerName);
+    }
+
     private sealed class Invoice
     {
         public Guid Id { get; init; }


### PR DESCRIPTION
## Summary

Adds `MapGranitODataHostEndpoints` alongside the existing tenant-feed mount, enabling cross-tenant OData access for host operators (finance ops, compliance, capacity planning) — the use case that is impossible today because the tenant-feed filter neutralises any SuperAdmin query.

PR 1 of 3 for the host-feed track (#1665). PR 2 migrates `granit-showcase-dotnet` (`Tenants` set leaves the tenant-feed for the host-feed); PR 3 adds the matching C6 architecture tests and the docs-site host-feed page.

## What changes

- `MapGranitODataHostEndpoints("/api/{version}/odata/host", ...)` — new public extension method, separate prefix, separate options type (`ODataHostExposureOptions` — cannot copy-paste a tenant-feed config by accident).
- `ODataHostEntitySetBuilder<TEntity>` — same fluent surface as the tenant builder minus `AllowAnonymousAccess` (host-feed is always gated), plus `AcknowledgeCrossTenantExposure(Func<IQueryable<TEntity>, IQueryable<TEntity>>)`.
- Three strict-config gates added at `Map*` time:
  1. The required permission MUST resolve via `IPermissionDefinitionManager` to `MultiTenancySides.Host`. `Tenant` or `Both` are rejected, as is an unregistered permission name.
  2. Anonymous access is not exposed — every host-feed set is gated.
  3. `IMultiTenant` entities require an explicit `AcknowledgeCrossTenantExposure` lambda from the host (typically `q => q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])`). The bypass lives in user code at the call site rather than in a flag, so the OData module stays free of an EF Core dependency and the explicit "I know what I'm doing" lives in actual code.
- Distinct EDM container name `HostContainer` (vs `Container`) — a BI client that mistakenly reuses one feed's `$metadata` document on the other URL surfaces an immediate schema mismatch.
- Distinct rate-limit policy `granit-odata-host` (recommended `PartitionBy: User`, wider quotas — fewer users, heavier queries).
- `feed_kind=host|tenant` tag added to every `ODataExposureMetrics` counter (`granit.odata.query.rejected`, `granit.odata.query.top_clamped`) so audit dashboards can filter cross-tenant access events distinctly (ISO 27001 A.12.4).

Tenant-feed behaviour is unchanged — zero breaking change for hosts that only call `MapGranitODataEndpoints`.

## Why this design

Discussed and agreed on #1665. Three options were on the table; B (separate mount, same module, dedicated types) won over A (flat refusal — closes the door to BI tools) and C (separate package — duplicates ~80% of the code). Option D (capability flag inside the same mount) was rejected because mixing tenant-scoped and cross-tenant sets in the same `$metadata` document defeats the analyst's ability to reason about scope.

The bypass-via-host-supplied-lambda design avoids two pitfalls:
- No new EF Core dependency on `Granit.Http.ODataExposure`.
- No reliance on `IDataFilter.Disable<IMultiTenant>()` (AsyncLocal — the unresolved leak documented in our defensive-bypass history #1180/#1182/#1185 makes this path unsafe). Per-query `IgnoreQueryFilters` is localised to the request's expression tree.

## Tests

- 7 new tests in `HostFeedStrictConfigValidatorTests` lock the three host-feed gates (Tenant permission rejected, Both rejected, unregistered permission rejected, `IMultiTenant` without acknowledge rejected, non-`IMultiTenant` does not need acknowledge, fully-configured passes, multi-error accumulation).
- 2 new tests in `ODataEdmModelBuilderTests` lock the default container name (`Container`) and the host container name (`HostContainer`).
- Existing 28 tests still pass — no API regression on the tenant-feed.
- `LayerDependencyRules.IQueryableShouldNotEscapePersistenceLayer` extended to allow the `ODataExposure` namespace (alongside `QueryEngine` / `Analytics` / `Persistence`) — this module is part of the query pipeline.

## Test plan

- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests` — 37/37 pass
- [x] `dotnet test .github/shard-filters/api-data.slnf` — green
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 203/203 pass after `IQueryable` rule extension
- [x] `dotnet format .github/shard-filters/api-data.slnf --verify-no-changes` — clean
- [ ] Manual smoke (PR 2): mount `MapGranitODataHostEndpoints` on `granit-showcase-dotnet`, verify SuperAdmin → 200 + all rows; tenant user → 403.
