### PR TITLE
refactor(privacy-endpoints): rename MapGranitGpcDiscovery to MapGranitPrivacyGpcDiscovery

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44754,9 +44754,9 @@
       "line": 12,
       "members": [
         {
-          "name": "MapGranitGpcDiscovery",
+          "name": "MapGranitPrivacyGpcDiscovery",
           "kind": "method",
-          "signature": "MapGranitGpcDiscovery(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitPrivacyGpcDiscovery(this IEndpointRouteBuilder endpoints)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/consent.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/consent.mdx
@@ -84,7 +84,7 @@ the document at the host root.
 ```csharp
 // Program.cs
 app.MapGranitPrivacy();        // existing privacy endpoints
-app.MapGranitGpcDiscovery();   // /.well-known/gpc.json — no-op when disabled
+app.MapGranitPrivacyGpcDiscovery();   // /.well-known/gpc.json — no-op when disabled
 ```
 
 ```jsonc

--- a/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Discovery/GpcDiscoveryEndpointRouteBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class GpcDiscoveryEndpointRouteBuilderExtensions
     /// versioning prefix.
     /// </para>
     /// </remarks>
-    public static IEndpointRouteBuilder MapGranitGpcDiscovery(this IEndpointRouteBuilder endpoints)
+    public static IEndpointRouteBuilder MapGranitPrivacyGpcDiscovery(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 

--- a/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
+++ b/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
@@ -24,7 +24,7 @@ namespace Granit.Privacy.Endpoints;
 /// <para>Exposes the following endpoint groups:</para>
 /// <list type="bullet">
 /// <item><see cref="Extensions.PrivacyEndpointRouteBuilderExtensions.MapGranitPrivacy"/> — regulation, export, deletion, agreements (authenticated, under the privacy prefix).</item>
-/// <item><see cref="GpcDiscoveryEndpointRouteBuilderExtensions.MapGranitGpcDiscovery"/> — opt-in <c>/.well-known/gpc.json</c> at the host root (anonymous, excluded from OpenAPI).</item>
+/// <item><see cref="GpcDiscoveryEndpointRouteBuilderExtensions.MapGranitPrivacyGpcDiscovery"/> — opt-in <c>/.well-known/gpc.json</c> at the host root (anonymous, excluded from OpenAPI).</item>
 /// </list>
 /// <para>
 /// <b>Reverse proxy note:</b> The consent acceptance endpoint reads the client IP address

--- a/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryEndpointTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Discovery/GpcDiscoveryEndpointTests.cs
@@ -135,7 +135,7 @@ public sealed class GpcDiscoveryEndpointTests
             WebApplication app = builder.Build();
             app.UseAuthentication();
             app.UseAuthorization();
-            app.MapGranitGpcDiscovery();
+            app.MapGranitPrivacyGpcDiscovery();
             await app.StartAsync(cancellationToken).ConfigureAwait(false);
 
             return new TestApp(app, app.GetTestClient());


### PR DESCRIPTION
## Summary

Renames `MapGranitGpcDiscovery` → `MapGranitPrivacyGpcDiscovery` to align with the framework convention `MapGranit{Module}{SubFeature}`. Same behavior, same placement (host root, anonymous, opt-in).

## Why

- IntelliSense: typing `MapGranitPrivacy` now lists both `MapGranitPrivacy()` and `MapGranitPrivacyGpcDiscovery()` together.
- Module ownership becomes unambiguous in the API surface — useful when other Granit modules later ship their own `.well-known/*` resources (e.g. `MapGranitSecurityHeadersSecurityTxt`, `MapGranitPrivacyDntPolicy`).
- Restores the invariant "extension prefix = owning module" that holds across the rest of the framework.

## Why not consolidate into MapGranitPrivacy

The two-call layout is intentional and justified by typical host wiring:

```csharp
RouteGroupBuilder api = app.MapGroup("api/v{version:apiVersion}")...;
api.MapGranitPrivacy();                  // /api/v1/privacy/*
app.MapGranitPrivacyGpcDiscovery();      // /.well-known/gpc.json — host root, RFC 8615
```

Inlining the GPC mapping inside `MapGranitPrivacy` would mount the document at `/api/v1/.well-known/gpc.json` when the host wires Privacy under a versioned group — that violates RFC 8615 and would not be discovered by browsers / regulators.

## Backwards compatibility

Granit is pre-1.0 — straight rename, no `[Obsolete]` shim. Follows the [pre-release breaking-change policy](../../granit-dotnet/CLAUDE.md).

## Follow-ups

- granit-dotnet#1666 hand-off prompts (showcase BFF wiring + front static publication) need to use the new name. I'll re-issue them updated.

## Test plan

- [x] `dotnet test tests/Granit.Privacy.Endpoints.Tests` — 116/116 green
- [x] `dotnet format style` — clean on src + tests
- [x] No remaining references to the old name (`git grep` clean outside the auto-generated `.mcp-code-index.json`)