### PR TITLE
feat(odata-exposure): EDM whitelist via EntityDefinition (ADR-050, #1668)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1062,6 +1062,8 @@
       "deps": [
         "Granit",
         "Granit.Authorization",
+        "Granit.DataExchange.Abstractions",
+        "Granit.Entities.Abstractions",
         "Granit.Http.Abstractions",
         "Granit.QueryEngine.Abstractions",
         "Granit.RateLimiting"
@@ -22790,7 +22792,7 @@
       "kind": "class",
       "project": "Granit.Http.ODataExposure",
       "file": "src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs",
-      "line": 28,
+      "line": 30,
       "members": [
         {
           "name": "MapGranitODataEndpoints",

--- a/docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md
@@ -1,0 +1,190 @@
+---
+title: "ADR-050 — OData EDM whitelist via EntityDefinition"
+description: "The Granit.Http.ODataExposure module derives its EDM property whitelist from the registered EntityDefinition (gate) and the referenced ExportDefinition (field source). Convention-based AddEntityType is rejected because it leaks framework-internal collections (DomainEvents, IntegrationEvents) into $metadata."
+sidebar:
+  label: ADR-050 OData EDM via EntityDefinition
+  order: 50
+---
+
+**Status**: Accepted — 2026-05-01
+**Deciders**: JF Meyers
+**Issue**: [#1668](https://github.com/granit-fx/granit-dotnet/issues/1668) (data-extraction contract)
+**Parent**: [#1369](https://github.com/granit-fx/granit-dotnet/issues/1369) (FEATURE — OData v4 connector)
+
+## Context
+
+`Granit.Http.ODataExposure` v1 builds the EDM model via
+`ODataConventionModelBuilder.AddEntityType(typeof(TEntity))`. The convention
+builder reflects on every public CLR property of the entity, which means
+`AggregateRoot` implementors (every business entity in the framework) leak
+their `IDomainEventSource` / `IIntegrationEventSource` contracts into
+`$metadata`:
+
+```xml
+<Property Name="DomainEvents" Type="Collection(Granit.Events.IDomainEvent)"/>
+<Property Name="IntegrationEvents" Type="Collection(Granit.Events.IIntegrationEvent)"/>
+```
+
+These properties are visible to every BI consumer (Power BI's Navigator
+shows them as queryable fields), they fail to translate to anything useful
+when included in `$select`, and they expose framework-internal contracts
+the application never intended to publish.
+
+The leak is one symptom of a broader gap: there is no explicit
+**data-extraction contract** between the application's entity model and
+the OData surface. The convention-based approach treats every public
+property as fair game, which is the wrong default for a security-sensitive
+boundary.
+
+## Decision drivers
+
+- **Defense-in-depth at field level (ADR-040).** Some fields are
+  legitimate columns on the admin grid but must NOT cross the OData
+  boundary unless the caller carries a specific permission
+  (e.g. `Customer.RiskScore`, `User.PasswordHash`).
+- **Cross-module navigation (ADR-048).** OData consumers want
+  `NavigationProperty` declarations matching the entity graph
+  (`Invoice → Customer`) so Power BI's relationship view works.
+  Hand-rolling these from each module's EDM is wasteful when
+  `EntityDefinition.Relations` already declares them.
+- **Mental model.** OData = "API de données pour le métier" — an
+  ongoing, queryable, navigable surface. Distinct from `Export` whose
+  job is "ship a CSV/XLSX file for one specific use case". The two
+  surfaces share fields today but will diverge.
+- **Solo-maintainer cost of doing this twice.** Pinning OData on
+  `Export` today means re-pinning to `EntityDefinition` once
+  navigation lands. Two refactors, two ADRs, two test rewrites.
+
+## Considered alternatives
+
+### A — Use `QueryDefinition.GetColumns()`
+
+`QueryDefinition` declares the admin-grid filterable / sortable columns.
+Typed property selectors (Expression-based), so type info is recoverable.
+
+**Rejected.** A strict subset of "what an entity exposes". Modules
+routinely omit non-filterable but BI-relevant fields (`Subtotal`,
+`TaxTotal`, `AmountPaid` per #1584). Forces module owners to make a
+column `Filterable()` purely to get it onto OData — pollutes the
+QueryDefinition.
+
+### B — Use `ExportDefinition.GetFields()` directly
+
+`ExportDefinition` carries the "what we accept to extract from the
+system" semantics — a clean match for BI. The pairing rule (ADR-020)
+guarantees every admin-visible entity has one.
+
+**Rejected as the primary contract** but kept as the field source
+under (C). Reasons it is not the right primary contract:
+
+- **No field-level `RequiresPermission`.** Adding it to
+  `ExportFieldBuilder` works mechanically but duplicates the same
+  declaration that already lives on `EntityDefinition.Forms` /
+  `Details` `FieldBuilder`. Two sources of truth for the same
+  field-permission decision is a drift accelerator.
+- **No cross-module navigation.** `ExportFieldDescriptor.PropertyPath`
+  flattens `"Customer.Name"`. Generating OData `NavigationProperty`
+  from these flat paths would require a parallel relation declaration
+  somewhere — `EntityDefinition.Relations` is that somewhere.
+- **Diverging audiences.** Export will gain CSV-specific semantics
+  (encoding, separators, cell formatting); OData will gain
+  navigation, filter pushdown, expansion. Pinning OData to Export
+  freezes the contract on Export's mental model.
+
+### C — Use `EntityDefinition` as gate, `ExportDefinition` as field source (CHOSEN)
+
+`EntityDefinition` orchestrates the entity surface — references
+`Query`, `Export`, `Metric`, `Dashboard`, `Workflow`, declares `Forms`,
+`Details`, `Relations`. The OData EDM consumer:
+
+1. Resolves the `EntityDefinition` for each registered EntitySet's
+   entity type. Throws at startup when missing — strict-config gate.
+2. Follows `EntityDefinitionDescriptor.ExportDefinitionType` to the
+   resolved `ExportDefinition`.
+3. Whitelists scalar properties from `ExportDefinition.GetFields()`
+   where `IsNavigation == false` and `PropertyPath` contains no `.`
+   (flat scalar fields only for v1).
+4. Keeps the existing `ExpandWhitelist` mechanism for navigation
+   properties; future iterations derive these from
+   `EntityDefinition.Relations` automatically.
+
+Future iterations layer on top without breaking the contract:
+
+- **Phase 1 follow-up** — overlay `RequiresPermission` from
+  `EntityDefinition.Forms` / `Details` matching property path. Each
+  module that ships an `EntityDefinition` automatically gains
+  field-level perm gating on OData.
+- **Phase 2** — derive `NavigationProperty` declarations from
+  `EntityDefinition.Relations`, deprecate the manual
+  `ExpandWhitelist`.
+- **Phase 3** — `b.OData(...)` sugar (#1573) on `EntityDefinition`
+  for cases where the OData surface diverges from Export.
+
+## Consequences
+
+### Positive
+
+- **No more `DomainEvents` / `IntegrationEvents` leak.** Pinned by
+  unit test on the EDM builder.
+- **OData feed = state-of-progress indicator.** An entity needs an
+  `EntityDefinition` to be exposed via BI; this aligns the OData
+  surface with the framework's entity-modeling direction (Phase 2+
+  will progressively add modules).
+- **Single source of truth for field-level permissions** when the
+  Phase 1 follow-up lands.
+- **Single migration** instead of two.
+
+### Negative
+
+- **Showcase OData feed shrinks immediately.** Today (2026-05-01)
+  only `Party` and `Invoice` have an `EntityDefinition` in
+  `granit-dotnet`. The other 8 EntitySets currently wired in
+  `granit-showcase-dotnet` (`Product`, `Tenant`, `PaymentTransaction`,
+  `Subscription`, `BalanceAccount`, `BalanceTransaction`,
+  `UsageAggregate`, `AuditEntry`) must either gain an
+  `EntityDefinition` or leave the feed.
+- **Adopters must declare an `EntityDefinition` before exposing an
+  EntitySet.** This raises the bar — a deliberate design choice: if
+  an entity is not yet ready for the framework's full declarative
+  surface, it is not ready to be exposed to BI consumers either.
+- **Strict-config error at startup** when an EntitySet has no
+  matching `EntityDefinition`. Hosts that previously shipped without
+  an `EntityDefinition` need to adapt. This is acceptable because:
+  - The framework is pre-1.0 (CLAUDE.md global rule —
+    breaking changes are clean, no `[Obsolete]` graduation).
+  - The error message names the missing entity and the convention.
+
+### Neutral
+
+- The convention-based discovery is replaced by an explicit
+  whitelist. Adopters lose the "everything public is exposed" model
+  in exchange for explicit control. Aligns with the
+  strict-config-validator philosophy already used elsewhere in the
+  module (no silent defaults).
+
+## Implementation notes
+
+- `ODataEdmModelBuilder.Build(...)` consumes a per-entity field-set
+  resolved at startup time. Field set comes from `ExportDefinition.GetFields()`
+  with `IsNavigation == false` and `PropertyPath` containing no `.`.
+- The CLR `Type` for each field is resolved via
+  `entityType.GetProperty(propertyPath)?.PropertyType` at startup — the
+  `ClrTypeName` string on `ExportFieldDescriptor` is informational.
+- `ExpandWhitelist` properties continue to be declared as
+  `NavigationProperty` via the convention builder's behaviour; only
+  scalar property convention discovery is overridden.
+- The strict-config validator is extended to: refuse a registered
+  EntitySet whose entity has no `IEntityDefinitionRegistry.GetByEntityType`
+  match, and refuse a registered EntitySet whose `EntityDefinition`
+  does not declare a `b.Export<T>()` reference.
+
+## References
+
+- Reflection that drove this decision: [#1668](https://github.com/granit-fx/granit-dotnet/issues/1668)
+- Sister story superseded: [#1575](https://github.com/granit-fx/granit-dotnet/issues/1575) — column whitelist via QueryDefinition (closed-as-superseded by this ADR)
+- Long-term consolidation target: [#1584](https://github.com/granit-fx/granit-dotnet/issues/1584) — Granit.Entities-driven OData surface (this ADR is the v1 contract along that path)
+- Sugar follow-up: [#1573](https://github.com/granit-fx/granit-dotnet/issues/1573) — `EntityDefinition.OData()` sugar
+- Parent FEATURE: [#1369](https://github.com/granit-fx/granit-dotnet/issues/1369) — Layer 3: OData v4 connector for Power BI / Excel / Tableau
+- ADR-020 — Query/Export/Metric pairing rule
+- ADR-040 — Defense-in-depth on entity surface (field-level permissions)
+- ADR-048 — Cross-module entity relations

--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using Granit.Authorization;
+using Granit.DataExchange.Export;
 using Granit.Domain;
+using Granit.Entities;
 using Granit.Http.ODataExposure.Diagnostics;
 using Granit.Http.ODataExposure.Internal;
 using Granit.Http.ODataExposure.Options;
@@ -140,7 +142,9 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// <summary>
     /// Shared route-mapping pipeline used by both <see cref="MapGranitODataEndpoints"/>
     /// and <see cref="MapGranitODataHostEndpoints"/>. Validates strict-config
-    /// (feed-kind aware), builds the EDM model with the appropriate container
+    /// (feed-kind aware), resolves each entity's scalar property whitelist
+    /// from its <c>EntityDefinition</c>'s referenced <c>ExportDefinition</c>
+    /// (per ADR-050), builds the EDM model with the appropriate container
     /// name, and wires the service document, <c>$metadata</c>, and per-set
     /// routes under <paramref name="rateLimitPolicy"/>.
     /// </summary>
@@ -152,9 +156,10 @@ public static class ODataExposureEndpointRouteBuilderExtensions
         string rateLimitPolicy,
         string containerName)
     {
-        ValidateStrictConfiguration(descriptors, endpoints.ServiceProvider);
+        Dictionary<Type, IReadOnlyList<string>> scalarWhitelistByEntity =
+            ValidateAndResolveWhitelists(descriptors, endpoints.ServiceProvider);
 
-        IEdmModel edmModel = ODataEdmModelBuilder.Build(descriptors, containerName);
+        IEdmModel edmModel = ODataEdmModelBuilder.Build(descriptors, scalarWhitelistByEntity, containerName);
 
         string tagSuffix = feedKind == ODataFeedKind.Host ? "OData (Host)" : "OData";
         string serviceDocOpName = feedKind == ODataFeedKind.Host ? "ODataHostServiceDocument" : "ODataServiceDocument";
@@ -197,17 +202,40 @@ public static class ODataExposureEndpointRouteBuilderExtensions
     /// that lives inside a closure (and is therefore not statically
     /// reflectable).
     /// </summary>
-    /// <exception cref="InvalidOperationException">Any descriptor lacks both <see cref="ODataEntitySetBuilder{TEntity}.RequirePermission"/> and <see cref="ODataEntitySetBuilder{TEntity}.AllowAnonymousAccess"/>, OR neither <see cref="ODataEntitySetBuilder{TEntity}.ExpandWhitelist"/> nor <see cref="ODataEntitySetBuilder{TEntity}.DisableExpand"/>; or — for host-feed mounts — the permission resolves to a non-<c>Host</c> <see cref="MultiTenancySides"/>, the entity is <c>IMultiTenant</c> without a matching <c>AcknowledgeCrossTenantExposure</c> call, or the permission is unresolvable.</exception>
-    private static void ValidateStrictConfiguration(
+    /// <summary>
+    /// Validates the strict-config rules for every <see cref="ODataEntitySetDescriptor"/>
+    /// AND resolves the per-entity scalar property whitelist consumed by the
+    /// EDM builder (per ADR-050). Both passes share the same DI lookups, so
+    /// they are folded into a single helper to avoid resolving the registries
+    /// twice on the boot-time hot path.
+    /// </summary>
+    /// <returns>Per-entity scalar property names allowed on the EDM EntityType, derived from each entity's <c>ExportDefinition.GetFields()</c> filtered to <c>IsNavigation == false</c> and <c>PropertyPath</c> containing no <c>'.'</c>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Any descriptor fails one of:
+    /// (a) permission gate (missing or implicit anonymous);
+    /// (b) <c>$expand</c>-intent gate (missing whitelist or DisableExpand);
+    /// (c) host-feed gates (non-Host permission, missing AcknowledgeCrossTenantExposure on IMultiTenant);
+    /// (d) ADR-050 gates: no registered <c>EntityDefinition</c> for the entity type, or the <c>EntityDefinition</c> declares no <c>b.Export&lt;T&gt;()</c> reference, or no <c>IExportDefinitionDescriptor</c> is registered for the entity type.
+    /// </exception>
+    private static Dictionary<Type, IReadOnlyList<string>> ValidateAndResolveWhitelists(
         IReadOnlyList<ODataEntitySetDescriptor> descriptors,
         IServiceProvider services)
     {
         List<string> errors = [];
+        Dictionary<Type, IReadOnlyList<string>> whitelistByEntity = [];
 
         IPermissionDefinitionManager? permissionDefinitions =
             descriptors.Any(d => d.FeedKind == ODataFeedKind.Host && d.RequiredPermission is not null)
                 ? services.GetService<IPermissionDefinitionManager>()
                 : null;
+
+        // ADR-050 gates: resolve EntityDefinition + Export descriptors once.
+        // Both abstractions live in their *.Abstractions packages so this
+        // module avoids a hard dep on the runtime registries.
+        IReadOnlyList<IEntityDefinitionDescriptor> entityDefinitions =
+            [.. services.GetServices<IEntityDefinitionDescriptor>()];
+        IReadOnlyList<IExportDefinitionDescriptor> exportDefinitions =
+            [.. services.GetServices<IExportDefinitionDescriptor>()];
 
         foreach (ODataEntitySetDescriptor descriptor in descriptors)
         {
@@ -225,34 +253,47 @@ public static class ODataExposureEndpointRouteBuilderExtensions
                     $"EntitySet '{descriptor.EntitySetName}' must call either ExpandWhitelist(...) or DisableExpand() — implicit \"$expand disabled\" is rejected by the strict-config validator (C6 #1395). Use DisableExpand() to declare the intent, or ExpandWhitelist(\"NavProp1\", ...) to allow specific navigations.");
             }
 
-            if (descriptor.FeedKind != ODataFeedKind.Host)
+            if (descriptor.FeedKind == ODataFeedKind.Host)
             {
+                ValidateHostFeedGates(descriptor, permissionDefinitions, errors);
+            }
+
+            // ADR-050 gate #1: every EntitySet's entity MUST have a registered EntityDefinition.
+            IEntityDefinitionDescriptor? entityDefinition = entityDefinitions
+                .FirstOrDefault(e => e.EntityType == descriptor.EntityType);
+            if (entityDefinition is null)
+            {
+                errors.Add(
+                    $"EntitySet '{descriptor.EntitySetName}' targets entity '{descriptor.EntityType.Name}' which has no registered EntityDefinition. Per ADR-050, every OData EntitySet requires an EntityDefinition gate — register one via services.AddEntityDefinition<{descriptor.EntityType.Name}, {descriptor.EntityType.Name}EntityDefinition>() before mounting this set.");
                 continue;
             }
 
-            // Host-feed gate #1: permission must resolve to MultiTenancySides.Host (NOT Both, NOT Tenant).
-            if (descriptor.RequiredPermission is { } perm)
-            {
-                PermissionDefinition? permission = permissionDefinitions?.Find(perm);
-                if (permission is null)
-                {
-                    errors.Add(
-                        $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' but no PermissionDefinition with that name is registered. Declare it in an IPermissionDefinitionProvider with MultiTenancySides.Host before mounting the host-feed.");
-                }
-                else if (permission.MultiTenancySides != MultiTenancySides.Host)
-                {
-                    errors.Add(
-                        $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' which is declared as MultiTenancySides.{permission.MultiTenancySides} — host-feed access requires MultiTenancySides.Host. Either declare a dedicated host-side permission, or move this EntitySet to the tenant-feed (MapGranitODataEndpoints).");
-                }
-            }
-
-            // Host-feed gate #2: IMultiTenant entities require AcknowledgeCrossTenantExposure(...).
-            if (typeof(IMultiTenant).IsAssignableFrom(descriptor.EntityType)
-                && !descriptor.CrossTenantExposureAcknowledged)
+            // ADR-050 gate #2: the EntityDefinition MUST reference an ExportDefinition via b.Export<T>().
+            if (entityDefinition.Descriptor.ExportDefinitionType is null)
             {
                 errors.Add(
-                    $"Host-feed EntitySet '{descriptor.EntitySetName}' targets IMultiTenant entity '{descriptor.EntityType.Name}' but did not call AcknowledgeCrossTenantExposure(...). Without an explicit per-query bypass lambda, the framework's tenant filter (tenantId == currentTenant.Id) returns no rows for a tenantless caller — fail-closed. Add: .AcknowledgeCrossTenantExposure(q => q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])).");
+                    $"EntitySet '{descriptor.EntitySetName}' uses EntityDefinition '{entityDefinition.Name}' which does not declare a b.Export<T>() reference. Per ADR-050, the OData EDM whitelist is derived from the referenced ExportDefinition — add b.Export<{descriptor.EntityType.Name}ExportDefinition>() to the EntityDefinition's Configure method.");
+                continue;
             }
+
+            // ADR-050 gate #3: the referenced Export must be DI-registered as IExportDefinitionDescriptor.
+            IExportDefinitionDescriptor? export = exportDefinitions
+                .FirstOrDefault(e => e.EntityType == descriptor.EntityType);
+            if (export is null)
+            {
+                errors.Add(
+                    $"EntitySet '{descriptor.EntitySetName}' references Export '{entityDefinition.Descriptor.ExportDefinitionType.Name}' but no IExportDefinitionDescriptor is registered for entity type '{descriptor.EntityType.Name}'. Did you forget services.AddExportDefinition<{descriptor.EntityType.Name}, {entityDefinition.Descriptor.ExportDefinitionType.Name}>()?");
+                continue;
+            }
+
+            // Resolved field set: scalars only (flat paths, IsNavigation == false).
+            // Flat paths (no dot) keep v1 simple — nested navigation paths
+            // ("Customer.Name") will be lifted to OData NavigationProperty in
+            // a follow-up PR derived from EntityDefinition.Relations.
+            whitelistByEntity[descriptor.EntityType] =
+                [.. export.GetFields()
+                    .Where(f => !f.IsNavigation && !f.PropertyPath.Contains('.', StringComparison.Ordinal))
+                    .Select(f => f.PropertyPath)];
         }
 
         if (errors.Count > 0)
@@ -260,6 +301,41 @@ public static class ODataExposureEndpointRouteBuilderExtensions
             throw new InvalidOperationException(
                 "OData EntitySet configuration is incomplete:" + Environment.NewLine
                 + string.Join(Environment.NewLine, errors.Select(e => "  - " + e)));
+        }
+
+        return whitelistByEntity;
+    }
+
+    /// <summary>
+    /// Host-feed-only gates: the permission must resolve to <see cref="MultiTenancySides.Host"/>,
+    /// and any <c>IMultiTenant</c> entity must have called
+    /// <c>AcknowledgeCrossTenantExposure(...)</c>.
+    /// </summary>
+    private static void ValidateHostFeedGates(
+        ODataEntitySetDescriptor descriptor,
+        IPermissionDefinitionManager? permissionDefinitions,
+        List<string> errors)
+    {
+        if (descriptor.RequiredPermission is { } perm)
+        {
+            PermissionDefinition? permission = permissionDefinitions?.Find(perm);
+            if (permission is null)
+            {
+                errors.Add(
+                    $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' but no PermissionDefinition with that name is registered. Declare it in an IPermissionDefinitionProvider with MultiTenancySides.Host before mounting the host-feed.");
+            }
+            else if (permission.MultiTenancySides != MultiTenancySides.Host)
+            {
+                errors.Add(
+                    $"Host-feed EntitySet '{descriptor.EntitySetName}' requires permission '{perm}' which is declared as MultiTenancySides.{permission.MultiTenancySides} — host-feed access requires MultiTenancySides.Host. Either declare a dedicated host-side permission, or move this EntitySet to the tenant-feed (MapGranitODataEndpoints).");
+            }
+        }
+
+        if (typeof(IMultiTenant).IsAssignableFrom(descriptor.EntityType)
+            && !descriptor.CrossTenantExposureAcknowledged)
+        {
+            errors.Add(
+                $"Host-feed EntitySet '{descriptor.EntitySetName}' targets IMultiTenant entity '{descriptor.EntityType.Name}' but did not call AcknowledgeCrossTenantExposure(...). Without an explicit per-query bypass lambda, the framework's tenant filter (tenantId == currentTenant.Id) returns no rows for a tenantless caller — fail-closed. Add: .AcknowledgeCrossTenantExposure(q => q.IgnoreQueryFilters([GranitFilterNames.MultiTenant])).");
         }
     }
 

--- a/src/Granit.Http.ODataExposure/Granit.Http.ODataExposure.csproj
+++ b/src/Granit.Http.ODataExposure/Granit.Http.ODataExposure.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.RateLimiting\Granit.RateLimiting.csproj" />

--- a/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
+++ b/src/Granit.Http.ODataExposure/Internal/ODataEdmModelBuilder.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.ModelBuilder;
 
@@ -5,10 +6,12 @@ namespace Granit.Http.ODataExposure.Internal;
 
 /// <summary>
 /// Builds an <see cref="IEdmModel"/> from the registered
-/// <see cref="ODataEntitySetDescriptor"/>s. Convention-based — all public
-/// CLR properties on the entity type appear on the EDM EntityType. Column
-/// pruning beyond that (e.g. masking <c>QueryDefinition.AllowedColumns</c>)
-/// is a follow-up; v1 mirrors the shape of the entity directly.
+/// <see cref="ODataEntitySetDescriptor"/>s. Per ADR-050, the EDM property set
+/// is **explicitly whitelisted** from the entity's <c>ExportDefinition</c>
+/// (resolved via the <c>EntityDefinition</c> orchestrator); convention-based
+/// reflection on every public CLR property is rejected because it leaks
+/// <see cref="Granit.Events.IDomainEvent"/> / <see cref="Granit.Events.IIntegrationEvent"/>
+/// collections from <c>AggregateRoot</c> implementors into <c>$metadata</c>.
 /// </summary>
 internal static class ODataEdmModelBuilder
 {
@@ -19,17 +22,28 @@ internal static class ODataEdmModelBuilder
     public const string HostContainerName = "HostContainer";
 
     /// <summary>
-    /// Builds the EDM model for the supplied descriptors.
+    /// Builds the EDM model for the supplied descriptors, applying a per-entity
+    /// scalar-property whitelist resolved from each entity's
+    /// <c>ExportDefinition</c>. Properties absent from the whitelist (including
+    /// framework-internal collections such as <c>DomainEvents</c> /
+    /// <c>IntegrationEvents</c>) are <see cref="EntityTypeConfiguration.Ignore(PropertyInfo)"/>-ed
+    /// before the convention pass runs. Navigation properties listed in the
+    /// descriptor's <see cref="ODataEntitySetDescriptor.ExpandWhitelist"/>
+    /// remain available to the consumer; un-whitelisted navigation properties
+    /// are ignored too.
     /// </summary>
     /// <param name="descriptors">EntitySet descriptors registered via the fluent options.</param>
+    /// <param name="scalarWhitelistByEntity">Scalar property names allowed on the EDM EntityType, per entity CLR type. Resolved from <c>ExportDefinition.GetFields()</c> at startup.</param>
     /// <param name="containerName">OData container name; defaults to <see cref="TenantContainerName"/>. Host-feed callers pass <see cref="HostContainerName"/>.</param>
     /// <returns>The built <see cref="IEdmModel"/>, ready to wire into <c>WithODataModel</c>.</returns>
     /// <exception cref="ArgumentException"><paramref name="descriptors"/> is empty.</exception>
     public static IEdmModel Build(
         IReadOnlyList<ODataEntitySetDescriptor> descriptors,
+        IReadOnlyDictionary<Type, IReadOnlyList<string>> scalarWhitelistByEntity,
         string containerName = TenantContainerName)
     {
         ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentNullException.ThrowIfNull(scalarWhitelistByEntity);
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
 
         if (descriptors.Count == 0)
@@ -43,15 +57,91 @@ internal static class ODataEdmModelBuilder
 
         foreach (ODataEntitySetDescriptor descriptor in descriptors)
         {
-            // AddEntitySet wires both the EntityType (via reflection on the
-            // entity's public properties) AND the EntitySet declaration in a
-            // single call — the convention model builder picks up keys
-            // from properties named "Id" / "{Type}Id".
-            builder.AddEntitySet(
-                descriptor.EntitySetName,
-                builder.AddEntityType(descriptor.EntityType));
+            // AddEntitySet wires both the EntityType and the EntitySet
+            // declaration; the convention model builder picks up keys from
+            // properties named "Id" / "{Type}Id" during GetEdmModel.
+            EntityTypeConfiguration entityTypeConfig = builder.AddEntityType(descriptor.EntityType);
+            builder.AddEntitySet(descriptor.EntitySetName, entityTypeConfig);
+
+            ApplyPropertyWhitelist(
+                entityTypeConfig,
+                descriptor,
+                scalarWhitelistByEntity[descriptor.EntityType]);
         }
 
         return builder.GetEdmModel();
+    }
+
+    /// <summary>
+    /// Calls <see cref="StructuralTypeConfiguration.RemoveProperty(PropertyInfo)"/>
+    /// for every public CLR property of the entity that is not (a) the entity's
+    /// <c>Id</c> key, (b) a scalar property listed in the export-derived
+    /// whitelist, or (c) a navigation property listed in the descriptor's
+    /// <see cref="ODataEntitySetDescriptor.ExpandWhitelist"/>. <c>RemoveProperty</c>
+    /// adds to the type configuration's removed-properties list, which the
+    /// <see cref="ODataConventionModelBuilder"/> consults during discovery —
+    /// ignored properties never make it into the EDM model, and notably never
+    /// into <c>$metadata</c>.
+    /// </summary>
+    private static void ApplyPropertyWhitelist(
+        EntityTypeConfiguration entityTypeConfig,
+        ODataEntitySetDescriptor descriptor,
+        IReadOnlyList<string> allowedScalarProperties)
+    {
+        HashSet<string> allowedScalars = new(allowedScalarProperties, StringComparer.Ordinal);
+        HashSet<string> allowedNavs = new(
+            descriptor.ExpandWhitelist ?? [],
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (PropertyInfo property in descriptor.EntityType.GetProperties(
+            BindingFlags.Public | BindingFlags.Instance))
+        {
+            // The Id key stays — the convention builder identifies it by name.
+            if (string.Equals(property.Name, "Id", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            bool isNavigationLike = IsNavigationOrCollection(property.PropertyType);
+            bool allowed = isNavigationLike
+                ? allowedNavs.Contains(property.Name)
+                : allowedScalars.Contains(property.Name);
+
+            if (!allowed)
+            {
+                entityTypeConfig.RemoveProperty(property);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the property type is a
+    /// non-primitive non-string class or a collection type — these are the
+    /// "navigation-like" shapes that the convention builder maps to
+    /// <see cref="IEdmNavigationProperty"/> or treats as complex types.
+    /// Strings, primitives, enums, value types, <see cref="Guid"/>,
+    /// <see cref="DateTime"/>/<see cref="DateTimeOffset"/> and friends are
+    /// scalar.
+    /// </summary>
+    private static bool IsNavigationOrCollection(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return false;
+        }
+
+        Type effective = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (effective.IsPrimitive || effective.IsEnum || effective == typeof(Guid)
+            || effective == typeof(DateTime) || effective == typeof(DateTimeOffset)
+            || effective == typeof(TimeSpan) || effective == typeof(decimal)
+            || effective == typeof(DateOnly) || effective == typeof(TimeOnly))
+        {
+            return false;
+        }
+
+        // Anything else (IEnumerable<T>, custom class, IReadOnlyCollection<T>, …)
+        // is a navigation-like shape from the EDM's perspective.
+        return true;
     }
 }

--- a/src/Granit.Http.ODataExposure/README.md
+++ b/src/Granit.Http.ODataExposure/README.md
@@ -41,6 +41,56 @@ through the OData service document, queries them with `$filter` /
 `$select` / `$top` / `$orderby`, and never sees rows belonging to other
 tenants.
 
+## Surface contract — EntityDefinition required (ADR-050)
+
+Every EntitySet MUST target an entity for which an
+`EntityDefinition<TEntity>` is registered, AND the EntityDefinition MUST
+reference an `ExportDefinition<TEntity>` via `b.Export<TExportDefinition>()`.
+The startup validator throws otherwise — there is no silent fallback.
+
+```csharp
+public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
+{
+    public override string Name => "Granit.Invoicing.Invoice";
+
+    protected override void Configure(EntityDefinitionBuilder<Invoice> b)
+    {
+        b.DisplayKey("Entity:Invoice").PermissionGroup("Invoicing.Invoices");
+        b.Query<InvoiceQueryDefinition>();
+        b.Export<InvoiceExportDefinition>();   // ← drives the OData EDM whitelist
+        // Form / Detail / Relations as usual…
+    }
+}
+```
+
+The OData EDM EntityType is built by:
+
+1. Resolving the `EntityDefinition` for the target entity from
+   `IEnumerable<IEntityDefinitionDescriptor>` (registered via
+   `services.AddEntityDefinition<...>()`).
+2. Following `EntityDefinition.Descriptor.ExportDefinitionType` to the
+   matching `ExportDefinition`.
+3. Whitelisting properties from `ExportDefinition.GetFields()` filtered to
+   `IsNavigation == false` and `PropertyPath` containing no `.` (flat
+   scalar fields only for v1; navigation paths land in a follow-up that
+   derives `NavigationProperty` from `EntityDefinition.Relations`).
+4. Allowing the navigation properties listed in
+   `.ExpandWhitelist(...)` on the EntitySet builder (existing mechanism).
+
+Properties not in the whitelist are removed from the EDM via
+`EntityTypeConfiguration.RemoveProperty(...)` BEFORE convention discovery
+runs — notably `AggregateRoot.DomainEvents` /
+`AggregateRoot.IntegrationEvents`, which would otherwise leak into
+`$metadata` because they are publicly exposed on every aggregate root to
+satisfy `IDomainEventSource` / `IIntegrationEventSource`.
+
+> **Why EntityDefinition rather than Export directly?** EntityDefinition
+> is the orchestrator (Phase 1 — `Granit.Entities`). Pinning OData to it
+> aligns the BI surface with the framework's entity-modeling direction:
+> as more modules ship `EntityDefinition`s in subsequent phases, their
+> entities become OData-exposable. See [ADR-050](../../docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md)
+> for the full trade-off analysis.
+
 ## Request flow
 
 Per EntitySet `GET /api/{version}/odata/{Name}?$filter=…&$select=…&$top=…`:

--- a/src/Granit.Http.ODataExposure/packages.lock.json
+++ b/src/Granit.Http.ODataExposure/packages.lock.json
@@ -78,6 +78,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -97,6 +103,14 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -107,6 +121,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.features": {
@@ -152,6 +177,12 @@
         }
       },
       "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workflow.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2448,6 +2448,8 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.RateLimiting": "[0.1.0-dev, )",

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/Granit.Http.ODataExposure.Tests.Integration.csproj
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/Granit.Http.ODataExposure.Tests.Integration.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\..\src\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.ODataExposure\Granit.Http.ODataExposure.csproj" />
     <ProjectReference Include="..\..\src\Granit.RateLimiting\Granit.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/ODataTestApp.cs
@@ -1,4 +1,6 @@
 using Granit.Authorization;
+using Granit.DataExchange.Export;
+using Granit.Entities;
 using Granit.Http.ODataExposure.Extensions;
 using Granit.Http.ODataExposure.Options;
 using Granit.MultiTenancy;
@@ -95,6 +97,13 @@ internal sealed class ODataTestApp : IAsyncDisposable
         });
 
         builder.Services.AddScoped<IQueryableSource<Invoice>, InvoiceSource>();
+
+        // ADR-050 plumbing: EntityDefinition gate + Export field source.
+        // Singleton registrations match the production patterns used by
+        // AddEntityDefinition / AddExportDefinition.
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new InvoiceEntityDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new InvoiceExportDefinition());
+
         builder.Services.AddGranitODataExposure();
 
         // C3b — every OData route is gated by the "granit-odata" rate-limit

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/TestEntities.cs
@@ -1,4 +1,6 @@
+using Granit.DataExchange.Export;
 using Granit.Domain;
+using Granit.Entities;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
@@ -66,4 +68,33 @@ internal sealed class InvoiceSource(TestDbContext db) : IQueryableSource<Invoice
 {
     private readonly TestDbContext _db = db;
     public IQueryable<Invoice> GetQueryable() => _db.Invoices.AsNoTracking();
+}
+
+/// <summary>
+/// Per ADR-050, OData EntitySets require a registered EntityDefinition that
+/// references an ExportDefinition. The integration suites use the simplest
+/// possible pair to land the v1 contract — Number, Amount, TenantId scalars
+/// (the latter intentionally exposed because hostile <c>$filter</c> targets
+/// it; tenant isolation is enforced by the framework filter, not by hiding
+/// the column).
+/// </summary>
+internal sealed class InvoiceExportDefinition : ExportDefinition<Invoice>
+{
+    public override string Name => "Test.InvoiceExport";
+
+    protected override void Configure(ExportDefinitionBuilder<Invoice> builder) =>
+        builder
+            .Field(i => i.Number)
+            .Field(i => i.Amount)
+            .Field(i => i.TenantId);
+}
+
+internal sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
+{
+    public override string Name => "Test.Invoice";
+
+    protected override void Configure(EntityDefinitionBuilder<Invoice> builder) =>
+        builder
+            .Query<InvoiceQueryDefinition>()
+            .Export<InvoiceExportDefinition>();
 }

--- a/tests/Granit.Http.ODataExposure.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/packages.lock.json
@@ -634,6 +634,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -659,6 +665,14 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -669,6 +683,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.features": {
@@ -700,6 +725,8 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.RateLimiting": "[0.1.0-dev, )",
@@ -785,6 +812,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.AspNetCore.OData": {

--- a/tests/Granit.Http.ODataExposure.Tests/EntityDefinitionStrictConfigTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/EntityDefinitionStrictConfigTests.cs
@@ -1,0 +1,172 @@
+using Granit.Authorization;
+using Granit.DataExchange.Export;
+using Granit.Entities;
+using Granit.Http.ODataExposure.Extensions;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.RateLimiting.Extensions;
+using Granit.RateLimiting.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// ADR-050 strict-config gates. Locks the rule that every OData EntitySet
+/// must have a registered <see cref="EntityDefinition{TEntity}"/> AND that
+/// the EntityDefinition must reference an <see cref="ExportDefinition{TEntity}"/>
+/// via <c>b.Export&lt;T&gt;()</c>. Failure paths are captured here as a
+/// dedicated suite so the messaging on each missing piece stays clear.
+/// </summary>
+public sealed class EntityDefinitionStrictConfigTests
+{
+    [Fact]
+    public void EntitySet_WithoutEntityDefinition_Throws()
+    {
+        // Showcase migration scenario: an entity is wired on the OData feed
+        // before its EntityDefinition has been written. Per ADR-050, the
+        // OData feed represents the application's Granit.Entities adoption
+        // state — entities without an EntityDefinition cannot be exposed.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                registerEntityDefinitions: false,
+                registerExports: true,
+                configure: opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("no registered EntityDefinition");
+        ex.Message.ShouldContain("ADR-050");
+    }
+
+    [Fact]
+    public void EntitySet_WithEntityDefinitionMissingExport_Throws()
+    {
+        // The EntityDefinition exists but did not call b.Export<T>().
+        // Per ADR-050, the OData EDM whitelist is derived from the
+        // referenced Export — without it, there is no contract to apply.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                registerEntityDefinitions: true,
+                registerExports: true,
+                useExportlessEntityDefinition: true,
+                configure: opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("does not declare a b.Export<T>() reference");
+    }
+
+    [Fact]
+    public void EntitySet_WithEntityDefinitionButNoExportRegistered_Throws()
+    {
+        // The EntityDefinition references an Export but no
+        // IExportDefinitionDescriptor is registered for the entity. Common
+        // misconfiguration: forgetting AddExportDefinition<TEntity, TDef>()
+        // in the host's Program.cs.
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CallMap(
+                registerEntityDefinitions: true,
+                registerExports: false,
+                configure: opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .DisableExpand()));
+
+        ex.Message.ShouldContain("Invoices");
+        ex.Message.ShouldContain("AddExportDefinition");
+    }
+
+    [Fact]
+    public void EntitySet_FullyConfigured_DoesNotThrow()
+    {
+        Should.NotThrow(() =>
+            CallMap(
+                registerEntityDefinitions: true,
+                registerExports: true,
+                configure: opts => opts.EntitySet<Invoice, InvoiceQueryDefinition>("Invoices")
+                    .RequirePermission("OData.Test.Invoices.Read")
+                    .DisableExpand()));
+    }
+
+    private static void CallMap(
+        bool registerEntityDefinitions,
+        bool registerExports,
+        Action<Options.ODataExposureOptions> configure,
+        bool useExportlessEntityDefinition = false)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+        builder.Services.AddSingleton<IPermissionChecker>(Substitute.For<IPermissionChecker>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<Invoice>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<Invoice>>());
+        builder.Services.AddSingleton<QueryDefinition<Invoice>>(new InvoiceQueryDefinition());
+
+        if (registerEntityDefinitions)
+        {
+            IEntityDefinitionDescriptor entityDef = useExportlessEntityDefinition
+                ? new InvoiceEntityDefinitionWithoutExport()
+                : new InvoiceEntityDefinition();
+            builder.Services.AddSingleton(entityDef);
+        }
+
+        if (registerExports)
+        {
+            builder.Services.AddSingleton<IExportDefinitionDescriptor>(new InvoiceExportDefinition());
+        }
+
+        builder.Services.AddGranitODataExposure();
+        builder.Services.AddGranitRateLimiting(o =>
+        {
+            o.Enabled = true;
+            o.Policies["granit-odata"] = new RateLimitPolicyOptions
+            {
+                PermitLimit = 1000,
+                Window = TimeSpan.FromMinutes(1),
+            };
+        });
+
+        using WebApplication app = builder.Build();
+        app.MapGranitODataEndpoints("/api/granit/odata", configure);
+    }
+
+    public sealed class Invoice
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+    }
+
+    public sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
+    {
+        public override string Name => "Test.Invoices";
+        protected override void Configure(QueryDefinitionBuilder<Invoice> builder) =>
+            builder.Column(i => i.Number, c => c.Filterable());
+    }
+
+    public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
+    {
+        public override string Name => "Test.Invoice";
+        protected override void Configure(EntityDefinitionBuilder<Invoice> builder) =>
+            builder.Query<InvoiceQueryDefinition>().Export<InvoiceExportDefinition>();
+    }
+
+    /// <summary>EntityDefinition that intentionally omits the b.Export call — exercises gate #2.</summary>
+    public sealed class InvoiceEntityDefinitionWithoutExport : EntityDefinition<Invoice>
+    {
+        public override string Name => "Test.InvoiceNoExport";
+        protected override void Configure(EntityDefinitionBuilder<Invoice> builder) =>
+            builder.Query<InvoiceQueryDefinition>();
+    }
+
+    public sealed class InvoiceExportDefinition : ExportDefinition<Invoice>
+    {
+        public override string Name => "Test.InvoiceExport";
+        protected override void Configure(ExportDefinitionBuilder<Invoice> builder) =>
+            builder.Field(i => i.Number);
+    }
+}

--- a/tests/Granit.Http.ODataExposure.Tests/HostFeedStrictConfigValidatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/HostFeedStrictConfigValidatorTests.cs
@@ -1,5 +1,7 @@
 using Granit.Authorization;
+using Granit.DataExchange.Export;
 using Granit.Domain;
+using Granit.Entities;
 using Granit.Http.ODataExposure.Extensions;
 using Granit.Http.ODataExposure.Options;
 using Granit.MultiTenancy;
@@ -162,6 +164,16 @@ public sealed class HostFeedStrictConfigValidatorTests
         builder.Services.AddSingleton<QueryDefinition<MultiTenantInvoice>>(new MultiTenantInvoiceQueryDefinition());
         builder.Services.AddSingleton<QueryDefinition<TenantStub>>(new TenantStubQueryDefinition());
 
+        // ADR-050 plumbing: every entity exposed on a host-feed needs an
+        // EntityDefinition + Export pair. Registered minimally so the
+        // strict-config validator gates land on host-feed-specific failures
+        // (the focus of these tests), not on missing-EntityDefinition
+        // failures (covered in EntityDefinitionStrictConfigTests).
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new MultiTenantInvoiceEntityDefinition());
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new TenantStubEntityDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new MultiTenantInvoiceExportDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new TenantStubExportDefinition());
+
         builder.Services.AddGranitODataExposure();
         builder.Services.AddSingleton(hostPermissions);
 
@@ -227,5 +239,33 @@ public sealed class HostFeedStrictConfigValidatorTests
         public override string Name => "Test.Invoices";
         protected override void Configure(QueryDefinitionBuilder<MultiTenantInvoice> builder) =>
             builder.Column(i => i.Number, c => c.Filterable());
+    }
+
+    public sealed class MultiTenantInvoiceEntityDefinition : EntityDefinition<MultiTenantInvoice>
+    {
+        public override string Name => "Test.MultiTenantInvoice";
+        protected override void Configure(EntityDefinitionBuilder<MultiTenantInvoice> builder) =>
+            builder.Query<MultiTenantInvoiceQueryDefinition>().Export<MultiTenantInvoiceExportDefinition>();
+    }
+
+    public sealed class TenantStubEntityDefinition : EntityDefinition<TenantStub>
+    {
+        public override string Name => "Test.TenantStub";
+        protected override void Configure(EntityDefinitionBuilder<TenantStub> builder) =>
+            builder.Query<TenantStubQueryDefinition>().Export<TenantStubExportDefinition>();
+    }
+
+    public sealed class MultiTenantInvoiceExportDefinition : ExportDefinition<MultiTenantInvoice>
+    {
+        public override string Name => "Test.MultiTenantInvoiceExport";
+        protected override void Configure(ExportDefinitionBuilder<MultiTenantInvoice> builder) =>
+            builder.Field(i => i.Number);
+    }
+
+    public sealed class TenantStubExportDefinition : ExportDefinition<TenantStub>
+    {
+        public override string Name => "Test.TenantStubExport";
+        protected override void Configure(ExportDefinitionBuilder<TenantStub> builder) =>
+            builder.Field(t => t.Slug);
     }
 }

--- a/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/ODataEdmModelBuilderTests.cs
@@ -6,23 +6,32 @@ using Xunit;
 namespace Granit.Http.ODataExposure.Tests;
 
 /// <summary>
-/// Locks the EDM model shape produced by the convention-based builder — one
-/// EntitySet per descriptor, EntityType columns mirror the public CLR
-/// properties, key auto-detected on the <c>Id</c> property. These shape
-/// guarantees feed Power BI / Excel directly via <c>$metadata</c>.
+/// Locks the EDM model shape produced by the explicit-whitelist builder
+/// (per ADR-050) — one EntitySet per descriptor, EntityType columns
+/// strictly limited to the property whitelist passed by
+/// <c>ValidateAndResolveWhitelists</c> (resolved from <c>ExportDefinition.GetFields()</c>),
+/// key auto-detected on <c>Id</c>. Properties absent from the whitelist —
+/// notably the framework-internal <c>DomainEvents</c> /
+/// <c>IntegrationEvents</c> collections from <c>AggregateRoot</c> — must
+/// not appear in the EDM.
 /// </summary>
 public sealed class ODataEdmModelBuilderTests
 {
+    private static Dictionary<Type, IReadOnlyList<string>> Whitelist(Type t, params string[] names) =>
+        new() { [t] = names };
+
     [Fact]
     public void Build_SingleEntitySet_RegistersInTheModel()
     {
         ODataEntitySetDescriptor descriptor = new(
             EntitySetName: "Invoices",
             EntityType: typeof(Invoice),
-            QueryDefinitionType: typeof(string), // unused by the EDM builder
+            QueryDefinitionType: typeof(string),
             RequiredPermission: null);
 
-        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+        IEdmModel model = ODataEdmModelBuilder.Build(
+            [descriptor],
+            Whitelist(typeof(Invoice), nameof(Invoice.Number), nameof(Invoice.Total)));
 
         IEdmEntitySet? set = model.EntityContainer.FindEntitySet("Invoices");
         set.ShouldNotBeNull();
@@ -38,49 +47,117 @@ public sealed class ODataEdmModelBuilderTests
             new("Customers", typeof(Customer), typeof(string), "OData.Test.Customers.Read"),
         ];
 
-        IEdmModel model = ODataEdmModelBuilder.Build(descriptors);
+        Dictionary<Type, IReadOnlyList<string>> whitelist = new()
+        {
+            [typeof(Invoice)] = [nameof(Invoice.Number), nameof(Invoice.Total)],
+            [typeof(Customer)] = [nameof(Customer.Name)],
+        };
+
+        IEdmModel model = ODataEdmModelBuilder.Build(descriptors, whitelist);
 
         model.EntityContainer.FindEntitySet("Invoices").ShouldNotBeNull();
         model.EntityContainer.FindEntitySet("Customers").ShouldNotBeNull();
     }
 
     [Fact]
-    public void Build_EntityType_ExposesPublicProperties()
+    public void Build_EntityType_ExposesOnlyWhitelistedProperties()
     {
+        // Whitelist drives the shape — the entity has 4 public properties
+        // (Id, Number, Total, InternalNotes), the test only allows two.
+        // InternalNotes must not appear in the EDM.
         ODataEntitySetDescriptor descriptor = new(
-            "Invoices", typeof(Invoice), typeof(string), null);
+            "Invoices", typeof(InvoiceWithSensitiveField), typeof(string), null);
 
-        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+        IEdmModel model = ODataEdmModelBuilder.Build(
+            [descriptor],
+            Whitelist(typeof(InvoiceWithSensitiveField),
+                nameof(InvoiceWithSensitiveField.Number),
+                nameof(InvoiceWithSensitiveField.Total)));
 
         var entityType = (IEdmEntityType)model.EntityContainer.FindEntitySet("Invoices")!.EntityType;
         IReadOnlyList<string> propertyNames = [.. entityType.Properties().Select(p => p.Name)];
 
-        propertyNames.ShouldContain(nameof(Invoice.Id));
-        propertyNames.ShouldContain(nameof(Invoice.Number));
-        propertyNames.ShouldContain(nameof(Invoice.Total));
+        propertyNames.ShouldContain(nameof(InvoiceWithSensitiveField.Id));
+        propertyNames.ShouldContain(nameof(InvoiceWithSensitiveField.Number));
+        propertyNames.ShouldContain(nameof(InvoiceWithSensitiveField.Total));
+        propertyNames.ShouldNotContain(nameof(InvoiceWithSensitiveField.InternalNotes));
+    }
+
+    [Fact]
+    public void Build_DomainEventsCollection_NeverAppearsInEdm()
+    {
+        // ADR-050 anchor test. The leak that drove this ADR: AggregateRoot
+        // exposes DomainEvents / IntegrationEvents as public collections to
+        // satisfy IDomainEventSource / IIntegrationEventSource. Convention
+        // discovery would surface them on $metadata; the explicit whitelist
+        // must not.
+        ODataEntitySetDescriptor descriptor = new(
+            "OrderEntries", typeof(AggregateRootLikeEntity), typeof(string), null);
+
+        IEdmModel model = ODataEdmModelBuilder.Build(
+            [descriptor],
+            Whitelist(typeof(AggregateRootLikeEntity),
+                nameof(AggregateRootLikeEntity.Number)));
+
+        var entityType = (IEdmEntityType)model.EntityContainer.FindEntitySet("OrderEntries")!.EntityType;
+        IReadOnlyList<string> propertyNames = [.. entityType.Properties().Select(p => p.Name)];
+
+        propertyNames.ShouldContain(nameof(AggregateRootLikeEntity.Id));
+        propertyNames.ShouldContain(nameof(AggregateRootLikeEntity.Number));
+        propertyNames.ShouldNotContain(nameof(AggregateRootLikeEntity.DomainEvents));
+        propertyNames.ShouldNotContain(nameof(AggregateRootLikeEntity.IntegrationEvents));
+    }
+
+    [Fact]
+    public void Build_NavigationProperty_AppearsOnlyWhenInExpandWhitelist()
+    {
+        // Customer is a navigation-like property (custom class). With it in
+        // ExpandWhitelist, the EDM must expose it; without, it must be
+        // suppressed even though it is a public property.
+        ODataEntitySetDescriptor withExpand = new(
+            "Invoices", typeof(InvoiceWithCustomerNav), typeof(string), null,
+            ExpandWhitelist: ["Customer"]);
+
+        IEdmModel withModel = ODataEdmModelBuilder.Build(
+            [withExpand],
+            Whitelist(typeof(InvoiceWithCustomerNav), nameof(InvoiceWithCustomerNav.Number)));
+
+        var entityType = (IEdmEntityType)withModel.EntityContainer.FindEntitySet("Invoices")!.EntityType;
+        entityType.NavigationProperties().Select(p => p.Name).ShouldContain("Customer");
+
+        ODataEntitySetDescriptor withoutExpand = new(
+            "Invoices2", typeof(InvoiceWithCustomerNav), typeof(string), null,
+            ExpandWhitelist: null);
+
+        IEdmModel withoutModel = ODataEdmModelBuilder.Build(
+            [withoutExpand],
+            Whitelist(typeof(InvoiceWithCustomerNav), nameof(InvoiceWithCustomerNav.Number)));
+
+        var entityType2 = (IEdmEntityType)withoutModel.EntityContainer.FindEntitySet("Invoices2")!.EntityType;
+        entityType2.NavigationProperties().Select(p => p.Name).ShouldNotContain("Customer");
     }
 
     [Fact]
     public void Build_EmptyDescriptorList_Throws()
     {
-        Should.Throw<ArgumentException>(() => ODataEdmModelBuilder.Build([]));
+        Should.Throw<ArgumentException>(() => ODataEdmModelBuilder.Build([], Whitelist(typeof(Invoice))));
     }
 
     [Fact]
     public void Build_NullDescriptors_Throws()
     {
-        Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!));
+        Should.Throw<ArgumentNullException>(() => ODataEdmModelBuilder.Build(null!, Whitelist(typeof(Invoice))));
     }
 
     [Fact]
     public void Build_DefaultContainerName_IsTenantContainer()
     {
-        // Tenant-feed default. Locks the convention so a BI client can rely
-        // on the same container name across releases.
         ODataEntitySetDescriptor descriptor = new(
             "Invoices", typeof(Invoice), typeof(string), null);
 
-        IEdmModel model = ODataEdmModelBuilder.Build([descriptor]);
+        IEdmModel model = ODataEdmModelBuilder.Build(
+            [descriptor],
+            Whitelist(typeof(Invoice), nameof(Invoice.Number)));
 
         model.EntityContainer.Name.ShouldBe(ODataEdmModelBuilder.TenantContainerName);
         model.EntityContainer.Name.ShouldBe("Container");
@@ -89,14 +166,12 @@ public sealed class ODataEdmModelBuilderTests
     [Fact]
     public void Build_HostContainerName_DistinguishesTheFeed()
     {
-        // Host-feed gate #3: a distinct container name surfaces an immediate
-        // schema mismatch when a BI client mistakenly reuses one feed's
-        // $metadata document on the other URL.
         ODataEntitySetDescriptor descriptor = new(
             "Tenants", typeof(Invoice), typeof(string), null);
 
         IEdmModel model = ODataEdmModelBuilder.Build(
             [descriptor],
+            Whitelist(typeof(Invoice), nameof(Invoice.Number)),
             ODataEdmModelBuilder.HostContainerName);
 
         model.EntityContainer.Name.ShouldBe("HostContainer");
@@ -111,6 +186,42 @@ public sealed class ODataEdmModelBuilderTests
     }
 
     private sealed class Customer
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private sealed class InvoiceWithSensitiveField
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+        public decimal Total { get; init; }
+        public string InternalNotes { get; init; } = string.Empty;  // not in whitelist — must NOT appear in EDM
+    }
+
+    /// <summary>
+    /// Stand-in for an <c>AggregateRoot</c>-derived entity: surfaces public
+    /// <c>DomainEvents</c> / <c>IntegrationEvents</c> collections that the
+    /// real <c>AggregateRoot</c> requires for <c>IDomainEventSource</c> /
+    /// <c>IIntegrationEventSource</c>. The whitelist must keep them out of
+    /// <c>$metadata</c>.
+    /// </summary>
+    private sealed class AggregateRootLikeEntity
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+        public IReadOnlyCollection<object> DomainEvents { get; } = [];
+        public IReadOnlyCollection<object> IntegrationEvents { get; } = [];
+    }
+
+    private sealed class InvoiceWithCustomerNav
+    {
+        public Guid Id { get; init; }
+        public string Number { get; init; } = string.Empty;
+        public CustomerNav? Customer { get; init; }
+    }
+
+    private sealed class CustomerNav
     {
         public Guid Id { get; init; }
         public string Name { get; init; } = string.Empty;

--- a/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/StrictConfigValidatorTests.cs
@@ -1,4 +1,6 @@
 using Granit.Authorization;
+using Granit.DataExchange.Export;
+using Granit.Entities;
 using Granit.Http.ODataExposure.Extensions;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
@@ -100,6 +102,16 @@ public sealed class StrictConfigValidatorTests
         builder.Services.AddSingleton<QueryDefinition<Invoice>>(new InvoiceQueryDefinition());
         builder.Services.AddSingleton<QueryDefinition<Customer>>(new CustomerQueryDefinition());
 
+        // Per ADR-050: every OData EntitySet's entity must have a registered
+        // EntityDefinition referencing an Export. Tests here register the
+        // minimum needed for the validator's lookups to succeed; the
+        // dedicated EntityDefinitionStrictConfigTests file covers the gate
+        // failure paths.
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new InvoiceEntityDefinition());
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new CustomerEntityDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new InvoiceExportDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new CustomerExportDefinition());
+
         builder.Services.AddGranitODataExposure();
         builder.Services.AddGranitRateLimiting(o =>
         {
@@ -139,5 +151,33 @@ public sealed class StrictConfigValidatorTests
         public override string Name => "Test.Customers";
         protected override void Configure(QueryDefinitionBuilder<Customer> builder) =>
             builder.Column(c => c.Name, b => b.Filterable());
+    }
+
+    public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
+    {
+        public override string Name => "Test.Invoice";
+        protected override void Configure(EntityDefinitionBuilder<Invoice> builder) =>
+            builder.Query<InvoiceQueryDefinition>().Export<InvoiceExportDefinition>();
+    }
+
+    public sealed class CustomerEntityDefinition : EntityDefinition<Customer>
+    {
+        public override string Name => "Test.Customer";
+        protected override void Configure(EntityDefinitionBuilder<Customer> builder) =>
+            builder.Query<CustomerQueryDefinition>().Export<CustomerExportDefinition>();
+    }
+
+    public sealed class InvoiceExportDefinition : ExportDefinition<Invoice>
+    {
+        public override string Name => "Test.InvoiceExport";
+        protected override void Configure(ExportDefinitionBuilder<Invoice> builder) =>
+            builder.Field(i => i.Number);
+    }
+
+    public sealed class CustomerExportDefinition : ExportDefinition<Customer>
+    {
+        public override string Name => "Test.CustomerExport";
+        protected override void Configure(ExportDefinitionBuilder<Customer> builder) =>
+            builder.Field(c => c.Name);
     }
 }

--- a/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
+++ b/tests/Granit.Http.ODataExposure.Tests/packages.lock.json
@@ -285,6 +285,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.authorization": {
         "type": "Project",
         "dependencies": {
@@ -304,6 +310,14 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -314,6 +328,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.features": {
@@ -337,6 +362,8 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.RateLimiting": "[0.1.0-dev, )",
@@ -378,6 +405,12 @@
         }
       },
       "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workflow.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

Drives the OData EDM property surface from the registered `EntityDefinition` (gate) and the referenced `ExportDefinition` (field source) per ADR-050. Replaces the convention-based `ODataConventionModelBuilder.AddEntityType(t)` discovery, which leaked `AggregateRoot.DomainEvents` / `AggregateRoot.IntegrationEvents` into `$metadata` for every business entity.

Closes the #1668 contract decision; supersedes #1575 (column whitelist via QueryDefinition).

## Why EntityDefinition rather than Export directly

EntityDefinition is the framework's entity-modeling orchestrator (Granit.Entities Phase 1, ADR-048). It already references Query / Export / Metric / Dashboard / Workflow and declares Forms / Details / Relations with `RequiresPermission` field-level annotations.

Pinning OData on it instead of on Export gives:

- A single source of truth for field-level permissions when the defense-in-depth overlay lands (no dual `RequiresPermission` declaration on Export and Form).
- A natural home for cross-module navigation (`EntityDefinition.Relations` → OData `NavigationProperty` in a follow-up).
- One migration instead of two — Export-improved would have to be re-pinned to EntityDefinition once navigation lands anyway.

The trade-off analysis (Query / Export-improved / EntityDefinition-orchestrates) is in [`docs-site/.../adr/050-odata-edm-whitelist-via-entity-definition.md`](docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md).

## What changes

### Three new strict-config gates at `Map{Granit,GranitHost}ODataEndpoints` time

1. **EntityDefinition required.** Every EntitySet's entity MUST have a registered `IEntityDefinitionDescriptor`. Throws with a pointer to `AddEntityDefinition<TEntity, TDef>()`.
2. **Export reference required.** The `EntityDefinition` MUST declare `b.Export<TExportDefinition>()` — otherwise no field contract to apply.
3. **Export descriptor registered.** The referenced Export MUST be DI-registered as `IExportDefinitionDescriptor`. Catches the common `AddExportDefinition` typo.

Existing strict-config gates (permission intent, `$expand` intent, host-feed gates) keep working unchanged.

### EDM builder

`ODataEdmModelBuilder.Build` now takes a per-entity scalar property whitelist resolved from `ExportDefinition.GetFields()` (filtered to `IsNavigation == false` and `PropertyPath` without dots — flat scalars only for v1; navigation paths land in the `EntityDefinition.Relations` follow-up).

Properties absent from the whitelist are removed via `EntityTypeConfiguration.RemoveProperty(...)` BEFORE the convention pass runs. The convention builder is kept (for key auto-detection and navigation property discovery from `ExpandWhitelist`); only scalar property convention is overridden.

### Project references

`Granit.Http.ODataExposure` adds project refs to `Granit.Entities.Abstractions` and `Granit.DataExchange.Abstractions`. The lookups go through the abstraction packages, not the runtime registries — keeps the dependency surface tight.

## Tests

- **4 new tests** in `EntityDefinitionStrictConfigTests` pin each gate's failure path (missing EntityDefinition, missing `b.Export`, unregistered Export descriptor) and the happy path.
- **3 new tests** in `ODataEdmModelBuilderTests` lock:
  - `DomainEvents` / `IntegrationEvents` never appear in the EDM (ADR-050 anchor test).
  - Non-whitelisted scalar properties are pruned.
  - `NavigationProperty` appears only when in `ExpandWhitelist`.
- Existing tenant-feed + host-feed strict-config tests updated to register the EntityDefinition + Export pairs.
- Integration test app (`TestEntities` / `ODataTestApp`) updated to register the plumbing for its `Invoice` fixture.

`dotnet test tests/Granit.Http.ODataExposure.Tests` — 43/43 pass.
`dotnet test .github/shard-filters/api-data.slnf` — green.
`dotnet test .github/shard-filters/architecture.slnf` — 204/204 pass.
`dotnet format .github/shard-filters/api-data.slnf --verify-no-changes` — clean.

## Showcase impact (cross-repo follow-up)

`granit-showcase-dotnet` currently wires 10 EntitySets on the OData feed. Only `Party` and `Invoice` have an `EntityDefinition` today — the other 8 (Product, Tenant, PaymentTransaction, Subscription, BalanceAccount, BalanceTransaction, UsageAggregate, AuditEntry) will trigger the strict-config gate at startup once this PR merges.

That's the deliberate "OData feed = state-of-progress" outcome from the design discussion: an entity needs an `EntityDefinition` to be exposed to BI consumers. The migration is a separate cross-repo PR — write the missing `EntityDefinition`s (incremental), or remove the unsupported sets from the OData mount until their `EntityDefinition` ships.

## References

- ADR: [`docs-site/.../050-odata-edm-whitelist-via-entity-definition.md`](docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md)
- Issue: #1668 (data-extraction contract decision)
- Supersedes: #1575 (column whitelist via QueryDefinition — closed-as-superseded)
- Long-term consolidation target: #1584 (EntityDefinition.OData() sugar #1573)
- Parent FEATURE: #1369 (Layer 3: OData v4 connector)

## Test plan

- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests` — 43/43.
- [x] `dotnet test .github/shard-filters/api-data.slnf` — all green.
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 204/204.
- [x] `dotnet format .github/shard-filters/api-data.slnf --verify-no-changes` — clean.
- [ ] Integration tests (Testcontainers Postgres, in `integration` shard) — will run in CI.
- [ ] Showcase manual smoke (cross-repo PR): mount the new validator on `granit-showcase-dotnet`, verify that the missing-EntityDefinition error message is actionable.
