### PR TITLE
test(odata-exposure): cross-tenant attack scenarios (C2 #1391)

### DIFF
--- a/tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs
@@ -140,6 +140,54 @@ public sealed class TenantIsolationTests(PostgresFixture postgres)
             $"tenant filter must come before user $filter — actual SQL:\n{selectCommand}");
     }
 
+    [Fact]
+    public async Task TenantA_NarrowSelectOnTenantId_StillScopedToTenantA()
+    {
+        // $select=TenantId returns only the tenant column. Even when the
+        // user picks the smallest possible projection, the framework
+        // filter still keeps the row set bound to TenantA — projection
+        // does not move filtering to the client.
+        HttpResponseMessage response = await GetAsync(
+            TenantA, "Invoices?$select=TenantId");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.Count.ShouldBe(5);
+        rows.ShouldAllBe(r => r.GetProperty("TenantId").GetGuid() == TenantA);
+    }
+
+    [Fact]
+    public async Task TenantA_OrderByTenantIdDesc_DoesNotLeakOtherTenants()
+    {
+        // $orderby on the TenantId column itself: a hostile actor could
+        // hope sorting somehow includes other tenants' rows. The framework
+        // filter is unaffected by ORDER BY — only the row order changes,
+        // and only T1's rows ever enter the sort.
+        HttpResponseMessage response = await GetAsync(
+            TenantA, "Invoices?$orderby=TenantId desc");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.Count.ShouldBe(5);
+        rows.ShouldAllBe(r => r.GetProperty("TenantId").GetGuid() == TenantA);
+    }
+
+    [Fact]
+    public async Task TenantA_FunctionCallCombinedWithHostilePredicate_StaysScopedToTenantA()
+    {
+        // Composes a built-in OData function (contains) with the hostile
+        // filter — defends against the hypothesis that an OData translator
+        // optimisation might re-order or short-circuit when a function is
+        // present in the user predicate. AND-prefix wins regardless.
+        HttpResponseMessage response = await GetAsync(
+            TenantA,
+            $"Invoices?$filter=contains(Number, 'A') and TenantId eq {TenantB:D}");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        IReadOnlyList<JsonElement> rows = await ReadValueAsync(response);
+        rows.ShouldBeEmpty();
+    }
+
     [Fact(Skip =
         "Reveals a constant-folding bug in ApplyGranitConventions's multi-tenant filter: " +
         "EF Core inlines currentTenant.Id into the compiled SQL at first model build " +


### PR DESCRIPTION
## Summary

Closes #1391 (C2 — multi-tenancy + soft-delete enforcement filter ordering integration test). The bulk of the test suite already existed in `tests/Granit.Http.ODataExposure.Tests.Integration/TenantIsolationTests.cs` (5 enabled tests covering ACs #1-5). This PR adds 3 more attack scenarios to broaden coverage.

## What changes

- `$select=TenantId` — narrow projection stays scoped to T1.
- `$orderby=TenantId desc` — ordering doesn't leak.
- `contains()` function combined with hostile `$filter` — no OData translator optimisation can reorder the framework's tenant filter.

Total: 9 scenarios — 8 enabled, 1 skipped (the documented AsyncLocal leak in `ApplyGranitConventions`'s multi-tenant filter — separate framework issue, see in-test comment).

## Test plan

- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests.Integration --filter TenantIsolationTests` — 8/9 pass (1 skipped, with documented reason).
- [x] `dotnet test tests/Granit.Http.ODataExposure.Tests.Integration` — full suite green (18 passed, 1 skipped).
- [x] Integration project already registered in the `integration` shard (per CLAUDE.md `*.Tests.Integration` rule).

## References

- Issue: #1391 (C2)
- Parent FEATURE: #1369 (Layer 3 OData v4 connector)
