### PR TITLE
docs(odata-power-bi): host-feed .pbids + auth method mapping (C5 #1394)

### DIFF
--- a/docs-site/src/content/docs/dotnet/business/analytics/odata-host-feed.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/odata-host-feed.mdx
@@ -210,9 +210,14 @@ as-is. Two configuration changes worth highlighting:
 
 <Steps>
 
-1. **Edit the `.pbids` URL** to point at `/api/v1/odata/host` instead of
-   `/api/v1/odata`. The container name in the discovered `$metadata` is
-   `HostContainer`; Power BI discovers EntitySets identically.
+1. **Use the host-feed `.pbids` template.** The repo ships
+   [`samples/PowerBI/granit-showcase-host.pbids`](https://github.com/granit-fx/granit-dotnet/blob/develop/samples/PowerBI/granit-showcase-host.pbids)
+   pointing at `/api/v1/odata/host`; replace
+   `https://your-app.example.com` with your deployment's host. The
+   container name in the discovered `$metadata` is `HostContainer`,
+   distinct from the tenant-feed's `Container` — Power BI discovers
+   EntitySets identically; the distinct name surfaces an immediate
+   schema mismatch if the wrong file is used against the wrong URL.
 
 2. **Sign in with a host SuperAdmin account.** A tenant user's bearer
    token will not carry the `OData.Host.*` permissions, so the Navigator
@@ -221,6 +226,16 @@ as-is. Two configuration changes worth highlighting:
    Service refresh jobs.
 
 </Steps>
+
+<Aside type="tip" title="Auth methods on the host-feed">
+  The same [auth-method mapping table](/dotnet/business/analytics/odata-power-bi/#power-bi-auth-methods--picking-the-right-one)
+  applies. For interactive host operators, *Organizational account*
+  (OAuth2 / OIDC). For Power BI Service refresh jobs, an API key issued
+  by `Granit.Authentication.ApiKeys` and pasted into Power BI's *Web API*
+  method — the API key holder's identity must carry an
+  `OData.Host.{Module}.{Entity}.Read` permission with
+  `MultiTenancySides.Host`.
+</Aside>
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/business/analytics/odata-power-bi.mdx
+++ b/docs-site/src/content/docs/dotnet/business/analytics/odata-power-bi.mdx
@@ -121,6 +121,23 @@ and rate limiting.
   with Organizational account*. Same end result.
 </Aside>
 
+## Power BI auth methods — picking the right one
+
+Power BI Desktop's auth picker for an OData source offers five labels.
+The right one depends on the Granit identity stack you've wired:
+
+| Granit auth | Power BI method | When to use |
+| ----------- | --------------- | ----------- |
+| OIDC / OAuth2 — Entra ID, Keycloak, OpenIddict, Cognito, Google… | **Organizational account** | Interactive analyst sessions (Power BI Desktop). The "Organizational account" label is OAuth2 / OIDC under the hood — Authorization Code + PKCE, browser redirect to your IdP, refresh-token persistence. Works against any standards-compliant IdP, not just Microsoft Entra ID. |
+| API key (`Granit.Authentication.ApiKeys`) | **Web API** | Power BI Service refresh jobs, scheduled imports, headless integrations. The analyst pastes the API key value; Power BI sets the `Authorization: Bearer <key>` header on every request. Use a dedicated service-principal API key, never a personal one. |
+| Anonymous | **Anonymous** | Public reference-data feeds — only when an EntitySet has called `.AllowAnonymousAccess()` on the framework side. |
+
+<Aside type="caution" title="Avoid Basic / Windows for OData">
+  Granit's OData layer does NOT accept HTTP Basic or Windows
+  authentication. Pick those in Power BI Desktop and the request fails
+  with `401 Unauthorized` regardless of the credentials supplied.
+</Aside>
+
 ## Refresh schedules and rate-limit awareness
 
 Power BI Service refresh jobs hit the OData feed periodically — every 30

--- a/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/business/dashboards/endpoints.mdx
@@ -426,6 +426,7 @@ The bundle response is a transport optimisation (one HTTP round-trip over N widg
 
 - [Conventions](/dotnet/business/dashboards/conventions/) — `DashboardDefinition` declarative shape, widget catalogue, JSON wire format.
 - [Analytics inline metrics](/dotnet/business/analytics/inline-metrics/) — How the metrics surfaced by `KpiWidget` are declared and rendered.
+- [OData feed (Power BI / Excel / Tableau)](/dotnet/business/analytics/odata-power-bi/) — Layer 3: external BI tools consume the same `QueryDefinition`s exposed here as dashboard widgets.
 - [Analytics conventions](/dotnet/business/analytics/conventions/) — Naming formula, period tokens, and the empty-set semantics shared with widget renderers.
 - [ADR-038](/dotnet/architecture/adr/038-analytics-dashboard-definition-vs-aggregate/) — boundary between the catalogue entry and the persisted aggregate.
 - [ADR-039](/dotnet/architecture/adr/039-widget-renderer-architecture/) — widget renderer architecture: `IWidgetInstanceRenderer`, `IDashboardRenderer`, JSON boundary, error isolation, frontend cache identity.

--- a/samples/PowerBI/README.md
+++ b/samples/PowerBI/README.md
@@ -1,18 +1,24 @@
-# Power BI Desktop sample
+# Power BI Desktop samples
 
-`granit-showcase.pbids` is a Power BI Desktop connector descriptor that
-points at a Granit-based application's OData v4 feed. Open it from
-Power BI Desktop → *File → Open report* and Power BI prompts for
-authentication, then lands the analyst in the Navigator.
+Two `.pbids` connector descriptors for Power BI Desktop, one per OData
+mount that `Granit.Http.ODataExposure` can expose:
+
+| File | Mount | Audience |
+| ---- | ----- | -------- |
+| `granit-showcase.pbids` | `/api/v1/odata` (tenant-feed) | Tenant analysts — sees only their tenant's rows. |
+| `granit-showcase-host.pbids` | `/api/v1/odata/host` (host-feed) | Host operators (finance ops, compliance, capacity planning) — sees data **across** tenants. Gated by `MultiTenancySides.Host` permissions. |
+
+Open either file from Power BI Desktop → *File → Open report*. Power BI
+prompts for authentication, then lands the analyst in the Navigator
+listing the EntitySets they have permission to read.
 
 ## Customise the URL
 
-Replace `https://your-app.example.com/api/v1/odata` with your
-deployment's actual OData root (the prefix you passed to
-`MapGranitODataEndpoints`). The path follows the framework's API
-versioning convention `/api/{version}/odata` — `{version}` resolves
-to `v1` / `v2` / … per the host's `Granit.Http.ApiVersioning`
-configuration. This sample pins `v1`; bump to match your deployment.
+Replace `https://your-app.example.com` with your deployment's actual
+host. The path follows the framework's API versioning convention
+`/api/{version}/odata{/host}` — `{version}` resolves to `v1` / `v2` /
+… per the host's `Granit.Http.ApiVersioning` configuration. These
+samples pin `v1`; bump to match your deployment.
 
 ## Authentication
 
@@ -20,9 +26,29 @@ The Granit OData layer uses the host's existing OAuth2 / DPoP stack
 from `Granit.Identity`. Power BI Desktop signs the analyst in via the
 "Organizational account" auth method on first connection.
 
-## Full guide
+For the host-feed, the analyst must be authenticated against an
+identity that carries an `OData.Host.{Module}.{Entity}.Read` permission
+declared as `MultiTenancySides.Host`. A tenant user's bearer token will
+not carry these permissions; the Navigator will return zero EntitySets
+(every set is `403`). For unattended Power BI Service refresh jobs, use
+a dedicated service principal scoped to the host realm.
 
-See [`dotnet/business/analytics/odata-power-bi`](https://granit-fx.github.io/granit-dotnet/dotnet/business/analytics/odata-power-bi/)
-in the docs-site for the end-to-end walkthrough — auth setup, refresh
-schedules, rate-limit awareness, known limits, example DAX measures,
-and troubleshooting.
+## Tenant-feed vs host-feed — pick the right one
+
+- **Tenant-feed** (`granit-showcase.pbids`) — your default. Every BI
+  use case scoped to a single tenant's data goes here.
+- **Host-feed** (`granit-showcase-host.pbids`) — only when the use case
+  is legitimately cross-tenant: MRR/ARR rollups, compliance audit
+  trails across tenants, capacity-planning aggregates, churn analysis
+  by plan. Mounting it is an explicit opt-in on the application side
+  (`MapGranitODataHostEndpoints`); using the wrong file with the wrong
+  identity will surface a `403` immediately.
+
+## Full guides
+
+- [Tenant-feed walkthrough](https://granit-fx.github.io/granit-dotnet/dotnet/business/analytics/odata-power-bi/) —
+  end-to-end auth setup, refresh schedules, rate-limit awareness, known
+  limits, example DAX measures, troubleshooting.
+- [Host-feed walkthrough](https://granit-fx.github.io/granit-dotnet/dotnet/business/analytics/odata-host-feed/) —
+  cross-tenant BI, three strict-config gates, `MultiTenancySides.Host`
+  permission convention, decision matrix vs `Granit.Analytics`.

--- a/samples/PowerBI/granit-showcase-host.pbids
+++ b/samples/PowerBI/granit-showcase-host.pbids
@@ -1,0 +1,15 @@
+{
+  "version": "0.1",
+  "connections": [
+    {
+      "details": {
+        "protocol": "odata",
+        "address": {
+          "url": "https://your-app.example.com/api/v1/odata/host"
+        }
+      },
+      "options": {},
+      "mode": "DirectQuery"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the C5 #1394 polish — the framework-side artefacts (tenant-feed `.pbids`, docs page) had already shipped in earlier work; this PR fills the host-feed gap and clarifies auth methods.

## What changes

- **`samples/PowerBI/granit-showcase-host.pbids`** — sibling of the tenant-feed `.pbids` pointing at `/api/v1/odata/host`. Distinct EDM container (`HostContainer`) means analysts who mistakenly load this against the wrong URL surface a schema mismatch immediately.
- **`samples/PowerBI/README.md`** — reshaped as a two-column decision matrix (tenant-feed vs host-feed) with audience-specific guidance on auth and permission gating.
- **`docs-site/.../odata-host-feed.mdx`** — Power BI section now points at the dedicated host `.pbids` file (analyst no longer manually edits the URL) and cross-links to the shared auth-method table.
- **`docs-site/.../odata-power-bi.mdx`** — new "Power BI auth methods — picking the right one" section. Captures the recurring "what does Organizational account map to on the Granit side?" question with a Granit-auth → Power-BI-method mapping table (OIDC/OAuth2 → Organizational account, API key → Web API, anonymous → Anonymous), plus an explicit caution that Basic/Windows are rejected.
- **`docs-site/.../dashboards/endpoints.mdx`** — cross-link added to the OData feed page (closes the DoD requirement that dashboards readers find the BI surface).

## Test plan

- [x] `cd docs-site && npx astro build` — 460 pages, all internal links valid (including new fragment anchors), 0 errors.
- [x] `markdownlint-cli2 samples/PowerBI/README.md` — 0 errors.
- [ ] Hands-on validation by JF (Power BI Desktop end-to-end against a Granit deployment) — out of CI scope.

## References

- Issue: #1394 (C5)
- Sister: #1672 (host-feed runtime), #1674 (host-feed docs page that this PR completes)
- Parent FEATURE: #1369 (Layer 3 OData v4 connector)
