### PR TITLE
feat(entities-abstractions): calendar list-view layout primitive (Phase 1.5 #1684)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19524,6 +19524,31 @@
       ]
     },
     {
+      "name": "CalendarLayoutBuilder",
+      "fqn": "Granit.Entities.Layouts.CalendarLayoutBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/CalendarLayoutBuilder.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "StartField",
+          "kind": "method",
+          "signature": "StartField(Expression<Func<TEntity, DateTimeOffset>> propertySelector)",
+          "returnType": "CalendarLayoutBuilder<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "CalendarLayoutDescriptor",
+      "fqn": "Granit.Entities.Layouts.CalendarLayoutDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/CalendarLayoutDescriptor.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "EntityListLayoutDescriptor",
       "fqn": "Granit.Entities.Layouts.EntityListLayoutDescriptor",
       "kind": "record",

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -221,6 +221,26 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     }
 
     /// <summary>
+    /// Declares a calendar list-view layout for this entity. The renderer
+    /// (<c>EntityCalendar</c>) reads items via the range-query endpoint
+    /// (<c>GET /api/entities/{name}/calendar</c>) and positions each one
+    /// between <see cref="CalendarLayoutBuilder{TEntity}.StartField"/> and the
+    /// optional <see cref="CalendarLayoutBuilder{TEntity}.EndField"/>. The list
+    /// layout is always available implicitly — adding calendar exposes the
+    /// <c>EntityListViewSwitcher</c> with a second tab.
+    /// </summary>
+    public EntityDefinitionBuilder<TEntity> CalendarView(
+        Action<CalendarLayoutBuilder<TEntity>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        CalendarLayoutBuilder<TEntity> builder = new();
+        configure(builder);
+        _layoutFactories.Add(builder.Build);
+        return this;
+    }
+
+    /// <summary>
     /// Declares an action exposed on this entity (button on the detail header,
     /// row action, kanban tile quick-action — surface decided by the renderer).
     /// One of <see cref="EntityActionBuilder{TEntity}.ApiCall"/>,

--- a/src/Granit.Entities.Abstractions/Layouts/CalendarLayoutBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/CalendarLayoutBuilder.cs
@@ -1,0 +1,126 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Fluent builder for a calendar layout declaration. Mirrors the kanban
+/// builder shape: typed property selectors, opt-ins for
+/// <see cref="EntityListLayoutDescriptor.IsDefault"/> and
+/// <see cref="EntityListLayoutDescriptor.RequiresPermission"/>, and a
+/// <c>Build()</c> step that surfaces missing-required-config as an
+/// <see cref="InvalidOperationException"/> at host startup.
+/// </summary>
+/// <typeparam name="TEntity">The entity rendered on the time axis.</typeparam>
+public sealed class CalendarLayoutBuilder<TEntity>
+{
+    private string? _startPropertyName;
+    private string? _endPropertyName;
+    private string? _titlePropertyName;
+    private string? _colorByPropertyName;
+    private bool _isDefault;
+    private string? _requiresPermission;
+
+    internal CalendarLayoutBuilder() { }
+
+    /// <summary>
+    /// Names the property carrying the event start. The lambda must be a direct
+    /// property access (e.g. <c>i =&gt; i.StartsAt</c>); <c>DateTimeOffset</c>
+    /// is the framework-mandated date type.
+    /// </summary>
+    public CalendarLayoutBuilder<TEntity> StartField(Expression<Func<TEntity, DateTimeOffset>> propertySelector)
+    {
+        _startPropertyName = ReadPropertyName(propertySelector, "StartField");
+        return this;
+    }
+
+    /// <summary>
+    /// Names the property carrying the event end. Optional — events without an
+    /// end render as point-in-time markers. Nullable to support open-ended
+    /// events (a meeting with no scheduled finish).
+    /// </summary>
+    public CalendarLayoutBuilder<TEntity> EndField(Expression<Func<TEntity, DateTimeOffset?>> propertySelector)
+    {
+        _endPropertyName = ReadPropertyName(propertySelector, "EndField");
+        return this;
+    }
+
+    /// <summary>Names the property used as the event headline on the tile.</summary>
+    public CalendarLayoutBuilder<TEntity> TitleField(Expression<Func<TEntity, string>> propertySelector)
+    {
+        _titlePropertyName = ReadPropertyName(propertySelector, "TitleField");
+        return this;
+    }
+
+    /// <summary>
+    /// Names the property used to bucket events into colour groups (typically
+    /// an enum or status). The renderer maps each distinct value to a colour
+    /// from a stable palette.
+    /// </summary>
+    public CalendarLayoutBuilder<TEntity> ColorBy<TValue>(Expression<Func<TEntity, TValue>> propertySelector)
+    {
+        _colorByPropertyName = ReadPropertyName(propertySelector, "ColorBy");
+        return this;
+    }
+
+    /// <summary>
+    /// Marks this layout as the one the renderer picks on first load. At most
+    /// one layout per entity may opt in.
+    /// </summary>
+    public CalendarLayoutBuilder<TEntity> IsDefault()
+    {
+        _isDefault = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Drops the layout from the manifest payload entirely when the user lacks
+    /// this permission — defense in depth, never just hidden.
+    /// </summary>
+    public CalendarLayoutBuilder<TEntity> RequiresPermission(string permissionName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permissionName);
+        _requiresPermission = permissionName;
+        return this;
+    }
+
+    internal CalendarLayoutDescriptor Build()
+    {
+        if (_startPropertyName is null)
+        {
+            throw new InvalidOperationException(
+                "CalendarView requires StartField(...) — declare which property carries the event start.");
+        }
+
+        return new CalendarLayoutDescriptor
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            IsDefault = _isDefault,
+            RequiresPermission = _requiresPermission,
+            StartPropertyName = _startPropertyName,
+            EndPropertyName = _endPropertyName,
+            TitlePropertyName = _titlePropertyName,
+            ColorByPropertyName = _colorByPropertyName,
+        };
+    }
+
+    private static string ReadPropertyName<TValue>(
+        Expression<Func<TEntity, TValue>> selector,
+        string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        Expression body = selector.Body is UnaryExpression { NodeType: ExpressionType.Convert } unary
+            ? unary.Operand
+            : selector.Body;
+
+        if (body is not MemberExpression member || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                $"{parameterName} selector must be a direct property access expression (e.g. i => i.StartsAt).",
+                nameof(selector));
+        }
+
+        return property.Name;
+    }
+}

--- a/src/Granit.Entities.Abstractions/Layouts/CalendarLayoutDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/CalendarLayoutDescriptor.cs
@@ -1,0 +1,29 @@
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Calendar layout — time-axis presentation (month / week / day grid) keyed on
+/// a date or datetime property. The renderer (<c>EntityCalendar</c>) reads
+/// items via the range-query endpoint and positions each one between
+/// <see cref="StartPropertyName"/> and the optional <see cref="EndPropertyName"/>.
+/// </summary>
+/// <remarks>
+/// Per ADR-042 §1, only <see cref="StartPropertyName"/> is mandatory; events
+/// without an end render as point-in-time markers. <see cref="ColorByPropertyName"/>
+/// — when set — drives per-event colour grouping client-side; the property
+/// must appear in the matching <c>QueryDefinition</c> column whitelist (enforced
+/// by an architecture test).
+/// </remarks>
+public sealed record CalendarLayoutDescriptor : EntityListLayoutDescriptor
+{
+    /// <summary>Property carrying the event start (required).</summary>
+    public required string StartPropertyName { get; init; }
+
+    /// <summary>Property carrying the event end. <see langword="null"/> renders point-in-time markers.</summary>
+    public string? EndPropertyName { get; init; }
+
+    /// <summary>Property used as the event's headline on the tile.</summary>
+    public string? TitlePropertyName { get; init; }
+
+    /// <summary>Property used to bucket events into colour groups (typically an enum or status).</summary>
+    public string? ColorByPropertyName { get; init; }
+}

--- a/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/EntityListLayoutKind.cs
@@ -13,4 +13,7 @@ public enum EntityListLayoutKind
 
     /// <summary>Card-board layout grouped by a discrete property (typically an enum or lookup).</summary>
     Kanban = 1,
+
+    /// <summary>Time-axis layout (month / week / day grid) keyed on a date or datetime property.</summary>
+    Calendar = 2,
 }

--- a/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarLayoutTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarLayoutTests.cs
@@ -1,0 +1,181 @@
+using Granit.Entities.Layouts;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Layouts;
+
+public sealed class CalendarLayoutTests
+{
+    [Fact]
+    public void Descriptor_carries_start_end_title_and_color_by()
+    {
+        EntityDefinitionDescriptor d = new SampleMeetingDefinition().Descriptor;
+
+        d.ListLayouts.ShouldHaveSingleItem();
+        CalendarLayoutDescriptor calendar = d.ListLayouts.Single().ShouldBeOfType<CalendarLayoutDescriptor>();
+
+        calendar.Kind.ShouldBe(EntityListLayoutKind.Calendar);
+        calendar.StartPropertyName.ShouldBe("StartsAt");
+        calendar.EndPropertyName.ShouldBe("EndsAt");
+        calendar.TitlePropertyName.ShouldBe("Subject");
+        calendar.ColorByPropertyName.ShouldBe("Status");
+    }
+
+    [Fact]
+    public void IsDefault_and_RequiresPermission_round_trip()
+    {
+        EntityDefinitionDescriptor d = new SampleMeetingDefinition().Descriptor;
+        EntityListLayoutDescriptor calendar = d.ListLayouts.Single();
+
+        calendar.IsDefault.ShouldBeTrue();
+        calendar.RequiresPermission.ShouldBe("Meetings.Meetings.Calendar");
+    }
+
+    [Fact]
+    public void End_title_and_color_by_are_optional()
+    {
+        EntityDefinitionDescriptor d = new MinimalCalendarDefinition().Descriptor;
+        var calendar = (CalendarLayoutDescriptor)d.ListLayouts.Single();
+
+        calendar.StartPropertyName.ShouldBe("StartsAt");
+        calendar.EndPropertyName.ShouldBeNull();
+        calendar.TitlePropertyName.ShouldBeNull();
+        calendar.ColorByPropertyName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Build_rejects_missing_start_field()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new MissingStartFieldDefinition().Descriptor);
+
+        ex.Message.ShouldContain("StartField");
+    }
+
+    [Fact]
+    public void Build_rejects_non_property_start_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadStartLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("StartField selector must be a direct property access");
+    }
+
+    [Fact]
+    public void Build_rejects_non_property_title_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadTitleLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("TitleField selector must be a direct property access");
+    }
+
+    [Fact]
+    public void Build_rejects_non_property_color_by_lambda()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() =>
+            _ = new BadColorByLambdaDefinition().Descriptor);
+
+        ex.Message.ShouldContain("ColorBy selector must be a direct property access");
+    }
+
+    [Fact]
+    public void Build_rejects_two_default_layouts()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new TwoDefaultsDefinition().Descriptor);
+
+        ex.Message.ShouldContain("At most one list-view layout may be marked IsDefault");
+    }
+
+    [Fact]
+    public void Build_rejects_duplicate_calendar_kinds()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new DuplicateCalendarsDefinition().Descriptor);
+
+        ex.Message.ShouldContain("Duplicate list-view layout kind 'Calendar'");
+    }
+
+    private enum SampleMeetingStatus { Tentative, Confirmed, Cancelled }
+
+    private sealed class SampleMeeting
+    {
+        public string Subject { get; set; } = string.Empty;
+        public DateTimeOffset StartsAt { get; set; }
+        public DateTimeOffset? EndsAt { get; set; }
+        public SampleMeetingStatus Status { get; set; }
+    }
+
+    private sealed class SampleMeetingDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.Meeting";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c
+                .IsDefault()
+                .RequiresPermission("Meetings.Meetings.Calendar")
+                .StartField(m => m.StartsAt)
+                .EndField(m => m.EndsAt)
+                .TitleField(m => m.Subject)
+                .ColorBy(m => m.Status));
+    }
+
+    private sealed class MinimalCalendarDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.MinimalCalendar";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c.StartField(m => m.StartsAt));
+    }
+
+    private sealed class MissingStartFieldDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.MissingStart";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c.TitleField(m => m.Subject));
+    }
+
+    private sealed class BadStartLambdaDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.BadStart";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c.StartField(m => m.StartsAt.AddHours(1)));
+    }
+
+    private sealed class BadTitleLambdaDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.BadTitle";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c
+                .StartField(m => m.StartsAt)
+                .TitleField(m => m.Subject.ToUpperInvariant()));
+    }
+
+    private sealed class BadColorByLambdaDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.BadColorBy";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder.CalendarView(c => c
+                .StartField(m => m.StartsAt)
+                .ColorBy(m => m.Status.ToString()));
+    }
+
+    private sealed class TwoDefaultsDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.TwoCalendarDefaults";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder
+                .CalendarView(c => c.IsDefault().StartField(m => m.StartsAt))
+                .KanbanView<SampleMeetingStatus>(k => k.IsDefault().GroupBy(m => m.Status));
+    }
+
+    private sealed class DuplicateCalendarsDefinition : EntityDefinition<SampleMeeting>
+    {
+        public override string Name => "Granit.Sample.DuplicateCalendars";
+        protected override void Configure(EntityDefinitionBuilder<SampleMeeting> builder) =>
+            builder
+                .CalendarView(c => c.StartField(m => m.StartsAt))
+                .CalendarView(c => c.StartField(m => m.StartsAt));
+    }
+}


### PR DESCRIPTION
## Summary

First story of Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509) — adds the `Calendar` layout to `EntityDefinition`'s collections facet, mirroring the kanban primitive shape (PR #1658). Closes story [#1684](https://github.com/granit-fx/granit-dotnet/issues/1684).

## What ships

- `EntityListLayoutKind.Calendar` enum value
- [`CalendarLayoutDescriptor`](src/Granit.Entities.Abstractions/Layouts/CalendarLayoutDescriptor.cs) — `StartPropertyName` required; `EndPropertyName` / `TitlePropertyName` / `ColorByPropertyName` optional, per ADR-042 §1
- [`CalendarLayoutBuilder<TEntity>`](src/Granit.Entities.Abstractions/Layouts/CalendarLayoutBuilder.cs) with typed selectors:
  - `StartField` — `Expression<Func<TEntity, DateTimeOffset>>` (required)
  - `EndField` — `Expression<Func<TEntity, DateTimeOffset?>>` (optional, nullable for open-ended events)
  - `TitleField` — `Expression<Func<TEntity, string>>`
  - `ColorBy<TValue>` — generic, accepts any property value (typically an enum or status)
- [`EntityDefinitionBuilder<TEntity>.CalendarView(...)`](src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs) entry point

## Example

```csharp
public sealed class MeetingEntityDefinition : EntityDefinition<Meeting>
{
    public override string Name => "Showcase.Meeting";

    protected override void Configure(EntityDefinitionBuilder<Meeting> builder) =>
        builder
            .DisplayKey("Showcase:Entity.Meeting")
            .CalendarView(c => c
                .StartField(m => m.StartsAt)
                .EndField(m => m.EndsAt)
                .TitleField(m => m.Subject)
                .ColorBy(m => m.Status));
}
```

## Guardrails

- DSL rejects non-property-access lambdas at build time (e.g. `m => m.StartsAt.AddHours(1)` throws `ArgumentException` naming the offending parameter).
- Integrity check fails fast at host startup when `StartField` is missing.
- Existing duplicate-kind and two-defaults guards in `EntityDefinitionBuilder` cover `Calendar` without changes (`AssertUniqueLayoutKinds` + `AssertAtMostOneDefaultLayout`).

## Out of scope (other stories)

- `GET /api/entities/{name}/calendar` range-query endpoint — Feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681)
- Architecture test (calendar field-whitelist pairing with `QueryDefinition`) — story [#1686](https://github.com/granit-fx/granit-dotnet/issues/1686)
- Localization keys for `Collection:{Entity}.{Name}` (18 cultures) — story [#1687](https://github.com/granit-fx/granit-dotnet/issues/1687)

## Test plan

- [x] 9 new tests in `CalendarLayoutTests` (descriptor round-trip, optional fields, missing-required rejection, lambda validation for Start/Title/ColorBy, two-defaults rejection, duplicate-kind rejection)
- [x] Full `Granit.Entities.Abstractions.Tests` suite green: 58 tests pass (no Kanban regression)
- [x] `dotnet format` clean on both projects
- [x] No new package dependency — lockfile unchanged