### PR TITLE
feat(entities-endpoints): calendar layout in manifest payload (Phase 1.5 #1685)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18993,6 +18993,15 @@
       "members": []
     },
     {
+      "name": "EntityCalendarLayoutManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCalendarLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 60,
+      "members": []
+    },
+    {
       "name": "EntityCollectionReference",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityCollectionReference",
       "kind": "record",
@@ -19124,7 +19133,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 101,
+      "line": 119,
       "members": []
     },
     {
@@ -19133,7 +19142,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 69,
+      "line": 87,
       "members": []
     },
     {
@@ -19142,7 +19151,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 85,
+      "line": 103,
       "members": []
     },
     {
@@ -19151,7 +19160,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 111,
+      "line": 129,
       "members": []
     },
     {
@@ -19160,7 +19169,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 53,
+      "line": 71,
       "members": []
     },
     {
@@ -19169,7 +19178,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 43,
+      "line": 44,
       "members": []
     },
     {

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -35,15 +35,33 @@ public sealed record EntityCollectionReference(
 /// <summary>
 /// One alternative list-view layout exposed in the manifest. The kind drives
 /// front-end component selection; per-kind config lives in <see cref="Kanban"/>
-/// (and future <c>Calendar</c> / <c>Map</c> / <c>Gallery</c> sub-records).
+/// or <see cref="Calendar"/> (and future <c>Map</c> / <c>Gallery</c> sub-records).
 /// </summary>
 /// <param name="Kind">Layout kind from the closed catalog.</param>
 /// <param name="IsDefault">Whether this layout is the default tab on first render.</param>
 /// <param name="Kanban">Kanban-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Kanban"/>.</param>
+/// <param name="Calendar">Calendar-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Calendar"/>.</param>
 public sealed record EntityListLayoutManifest(
     EntityListLayoutKind Kind,
     bool IsDefault,
-    EntityKanbanLayoutManifest? Kanban);
+    EntityKanbanLayoutManifest? Kanban,
+    EntityCalendarLayoutManifest? Calendar);
+
+/// <summary>
+/// Calendar-specific layout configuration carried in the manifest. Property
+/// names address fields on the entity; the renderer (<c>EntityCalendar</c>)
+/// reads the actual values via the range-query endpoint
+/// (<c>GET /api/entities/{name}/calendar</c>).
+/// </summary>
+/// <param name="StartPropertyName">Entity property carrying the event start (required).</param>
+/// <param name="EndPropertyName">Entity property carrying the event end. <see langword="null"/> for point-in-time markers.</param>
+/// <param name="TitlePropertyName">Entity property used as the event headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
+/// <param name="ColorByPropertyName">Entity property used to bucket events into colour groups, or <see langword="null"/> for theme default.</param>
+public sealed record EntityCalendarLayoutManifest(
+    string StartPropertyName,
+    string? EndPropertyName,
+    string? TitlePropertyName,
+    string? ColorByPropertyName);
 
 /// <summary>Kanban-specific layout configuration carried in the manifest.</summary>
 /// <param name="GroupByPropertyName">Entity property used to bucket rows into columns.</param>

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -346,6 +346,12 @@ internal static class EntityManifestComposer
                 _ => null,
             };
 
+            EntityCalendarLayoutManifest? calendar = layout switch
+            {
+                CalendarLayoutDescriptor c => ComposeCalendar(c),
+                _ => null,
+            };
+
             // Layout produced no usable shape (e.g. kanban whose card lost every
             // field to permission filtering). Drop the layout — empty switcher
             // tabs would be UX clutter.
@@ -357,10 +363,17 @@ internal static class EntityManifestComposer
             layouts.Add(new EntityListLayoutManifest(
                 layout.Kind,
                 layout.IsDefault,
-                kanban));
+                kanban,
+                calendar));
         }
         return layouts;
     }
+
+    private static EntityCalendarLayoutManifest ComposeCalendar(CalendarLayoutDescriptor descriptor) =>
+        new(descriptor.StartPropertyName,
+            descriptor.EndPropertyName,
+            descriptor.TitlePropertyName,
+            descriptor.ColorByPropertyName);
 
     private static EntityKanbanLayoutManifest? ComposeKanban(
         KanbanLayoutDescriptor descriptor,

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -451,6 +451,80 @@ public sealed class EntityManifestComposerTests
             .Kanban!.Card.Fields.Select(f => f.PropertyName).ShouldBe(["Owner"]);
     }
 
+    [Fact]
+    public void Compose_emits_calendar_layout_with_start_end_title_and_color_by()
+    {
+        Granit.Entities.Layouts.CalendarLayoutDescriptor calendar = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Calendar,
+            IsDefault = true,
+            StartPropertyName = "StartsAt",
+            EndPropertyName = "EndsAt",
+            TitlePropertyName = "Subject",
+            ColorByPropertyName = "Status",
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [calendar]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityListLayoutManifest layout = manifest.Collections!.ListLayouts.ShouldHaveSingleItem();
+        layout.Kind.ShouldBe(Granit.Entities.Layouts.EntityListLayoutKind.Calendar);
+        layout.IsDefault.ShouldBeTrue();
+        layout.Kanban.ShouldBeNull();
+        layout.Calendar.ShouldNotBeNull();
+        layout.Calendar!.StartPropertyName.ShouldBe("StartsAt");
+        layout.Calendar.EndPropertyName.ShouldBe("EndsAt");
+        layout.Calendar.TitlePropertyName.ShouldBe("Subject");
+        layout.Calendar.ColorByPropertyName.ShouldBe("Status");
+    }
+
+    [Fact]
+    public void Compose_emits_minimal_calendar_with_only_start_field()
+    {
+        Granit.Entities.Layouts.CalendarLayoutDescriptor calendar = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Calendar,
+            StartPropertyName = "OccurredAt",
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [calendar]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityCalendarLayoutManifest emitted = manifest.Collections!.ListLayouts.ShouldHaveSingleItem().Calendar!;
+        emitted.StartPropertyName.ShouldBe("OccurredAt");
+        emitted.EndPropertyName.ShouldBeNull();
+        emitted.TitlePropertyName.ShouldBeNull();
+        emitted.ColorByPropertyName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Compose_drops_calendar_layout_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Layouts.CalendarLayoutDescriptor calendar = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Calendar,
+            RequiresPermission = "Meetings.Meetings.Calendar",
+            StartPropertyName = "StartsAt",
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [calendar]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.ListLayouts.ShouldBeEmpty();
+    }
+
     private enum SampleStatus { Open, Done }
 
     [Fact]


### PR DESCRIPTION
## Summary

Second story of Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509) — wires the `CalendarLayoutDescriptor` (shipped in #1696) through the entity manifest composer so the frontend can address the calendar layout from the `EntityListViewSwitcher`. Closes story [#1685](https://github.com/granit-fx/granit-dotnet/issues/1685).

## What ships

### New wire shape — [`EntityCalendarLayoutManifest`](src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs)

```csharp
public sealed record EntityCalendarLayoutManifest(
    string StartPropertyName,
    string? EndPropertyName,
    string? TitlePropertyName,
    string? ColorByPropertyName);
```

`EntityListLayoutManifest` now carries an optional `Calendar` slot alongside the existing `Kanban` slot — mutually exclusive, driven by `Kind`. Future view-kinds (`Map`, `Gallery`) follow the same shape.

### Composer wiring — [`EntityManifestComposer`](src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs)

`ComposeListLayouts` now pattern-matches `CalendarLayoutDescriptor` and maps it to `EntityCalendarLayoutManifest`. The existing layout-level `RequiresPermission` drop-not-hide path already covers calendar without changes (per ADR-040 §6 — anything filtered by permission is **absent** from the payload, never just hidden).

## Test plan

- [x] 3 new composer tests pin the shape:
  - Happy path (Start / End / Title / ColorBy round-trip + IsDefault)
  - Minimal calendar (only `StartField`, all other fields null)
  - Drop-not-hide when `RequiresPermission` is not granted
- [x] Full `Granit.Entities.Endpoints.Tests` suite green: 56 tests pass (no kanban regression)
- [x] `dotnet format` clean on both projects
- [x] No public-API break — only `EntityListLayoutManifest` constructor signature changed; only consumer is the composer itself

## Out of scope (other stories)

- Architecture test — calendar field-whitelist pairing — story [#1686](https://github.com/granit-fx/granit-dotnet/issues/1686)
- `GET /api/entities/{name}/calendar` range-query endpoint — feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681)
- Localization keys for `Collection:{Entity}.{Name}` — story [#1687](https://github.com/granit-fx/granit-dotnet/issues/1687)