### PR TITLE
test(architecture): calendar field-whitelist pairing + extract scan helper (Phase 1.5 #1686)

### DIFF
--- a/tests/Granit.ArchitectureTests/CalendarFieldWhitelistPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/CalendarFieldWhitelistPairingTests.cs
@@ -1,0 +1,80 @@
+using Granit.ArchitectureTests.Internal;
+using Granit.Entities;
+using Granit.Entities.Layouts;
+using Granit.QueryEngine;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Calendar counterpart to <see cref="KanbanCardWhitelistPairingTests"/> — every
+/// property a calendar surfaces (<c>StartPropertyName</c> + optional
+/// <c>EndPropertyName</c> / <c>TitlePropertyName</c> / <c>ColorByPropertyName</c>)
+/// must appear in the matching <c>QueryDefinition&lt;TEntity&gt;.GetColumns()</c>
+/// whitelist. The range-query endpoint reads each event's start / end / title /
+/// colour via the same projection — a non-whitelisted property either renders
+/// blank or leaks data the security model intentionally hid.
+/// </summary>
+/// <remarks>
+/// An entity with a calendar layout but NO <c>QueryDefinition</c> at all is a
+/// separate hard failure (the calendar can't render) — also reported.
+/// </remarks>
+public sealed class CalendarFieldWhitelistPairingTests
+{
+    [Fact]
+    public void Every_calendar_property_must_be_whitelisted_in_the_matching_QueryDefinition()
+    {
+        List<IEntityDefinitionDescriptor> entities = EntityDefinitionScan.ScanEntityDefinitions();
+        Dictionary<Type, IQueryDefinitionDescriptor> queriesByEntityType = EntityDefinitionScan.ScanQueryDefinitions();
+
+        List<string> violations = [];
+
+        foreach (IEntityDefinitionDescriptor entity in entities)
+        {
+            EntityDefinitionDescriptor descriptor = entity.Descriptor;
+            CalendarLayoutDescriptor? calendar = descriptor.ListLayouts
+                .OfType<CalendarLayoutDescriptor>()
+                .FirstOrDefault();
+
+            if (calendar is null)
+            {
+                continue;
+            }
+
+            if (!queriesByEntityType.TryGetValue(descriptor.EntityType, out IQueryDefinitionDescriptor? query))
+            {
+                violations.Add(
+                    $"Entity '{descriptor.Name}' declares a CalendarView but no matching QueryDefinition<{descriptor.EntityType.Name}> was found. "
+                    + "The calendar reads its rows from the entity's QueryDefinition projection — without one, the board can't render. "
+                    + "Add a QueryDefinition<T> in the same module's Queries/ folder and register it via AddQueryDefinition<T, TDefinition>().");
+                continue;
+            }
+
+            HashSet<string> whitelistedProperties = EntityDefinitionScan.ReadColumnPropertyNames(query);
+
+            CheckProperty(calendar.StartPropertyName, "StartField", required: true);
+            CheckProperty(calendar.EndPropertyName, "EndField");
+            CheckProperty(calendar.TitlePropertyName, "TitleField");
+            CheckProperty(calendar.ColorByPropertyName, "ColorBy");
+
+            void CheckProperty(string? propertyName, string dslName, bool required = false)
+            {
+                if (propertyName is null)
+                {
+                    return;
+                }
+
+                if (!whitelistedProperties.Contains(propertyName))
+                {
+                    string severity = required ? "required " : string.Empty;
+                    violations.Add(
+                        $"Entity '{descriptor.Name}' calendar {severity}{dslName}='{propertyName}' is not in the QueryDefinition column whitelist. "
+                        + $"Add `.Column(e => e.{propertyName})` in the matching QueryDefinition or change the calendar {dslName} to a whitelisted property.");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(string.Join(Environment.NewLine, violations));
+    }
+}

--- a/tests/Granit.ArchitectureTests/Internal/EntityDefinitionScan.cs
+++ b/tests/Granit.ArchitectureTests/Internal/EntityDefinitionScan.cs
@@ -1,0 +1,157 @@
+using System.Reflection;
+using Granit.Entities;
+using Granit.QueryEngine;
+
+namespace Granit.ArchitectureTests.Internal;
+
+/// <summary>
+/// Reflection helpers shared by every <c>EntityDefinition</c> ↔ <c>QueryDefinition</c>
+/// pairing test (kanban / calendar / gallery / future view kinds). Each test
+/// indexes <see cref="EntityDefinition{TEntity}"/> instances by their generic
+/// <c>TEntity</c> argument and cross-checks the layout's surfaced properties
+/// against <c>QueryDefinition&lt;TEntity&gt;.GetColumns()</c> — the helpers
+/// here factor out the boilerplate so each test stays focused on its
+/// layout-specific assertion.
+/// </summary>
+internal static class EntityDefinitionScan
+{
+    public static List<IEntityDefinitionDescriptor> ScanEntityDefinitions()
+    {
+        Type baseType = typeof(EntityDefinition<>);
+        List<IEntityDefinitionDescriptor> instances = [];
+
+        foreach (Assembly assembly in LoadGranitAssemblies())
+        {
+            foreach (Type type in SafeGetTypes(assembly))
+            {
+                if (!type.IsClass || type.IsAbstract || type.IsGenericTypeDefinition)
+                {
+                    continue;
+                }
+
+                if (!InheritsFromOpenGeneric(type, baseType))
+                {
+                    continue;
+                }
+
+                if (Activator.CreateInstance(type) is IEntityDefinitionDescriptor instance)
+                {
+                    instances.Add(instance);
+                }
+            }
+        }
+
+        return instances;
+    }
+
+    public static Dictionary<Type, IQueryDefinitionDescriptor> ScanQueryDefinitions()
+    {
+        Type baseType = typeof(QueryDefinition<>);
+        Dictionary<Type, IQueryDefinitionDescriptor> byEntityType = [];
+
+        foreach (Assembly assembly in LoadGranitAssemblies())
+        {
+            foreach (Type type in SafeGetTypes(assembly))
+            {
+                if (!type.IsClass || type.IsAbstract || type.IsGenericTypeDefinition)
+                {
+                    continue;
+                }
+
+                if (!InheritsFromOpenGeneric(type, baseType))
+                {
+                    continue;
+                }
+
+                if (type.GetConstructor(Type.EmptyTypes) is null)
+                {
+                    continue;
+                }
+
+                if (Activator.CreateInstance(type) is IQueryDefinitionDescriptor instance)
+                {
+                    byEntityType[instance.EntityType] = instance;
+                }
+            }
+        }
+
+        return byEntityType;
+    }
+
+    /// <summary>
+    /// Reads <c>QueryDefinition&lt;TEntity&gt;.GetColumns()</c> via reflection — the
+    /// method lives on the generic base, not on <see cref="IQueryDefinitionDescriptor"/>,
+    /// so a static cast isn't enough.
+    /// </summary>
+    public static HashSet<string> ReadColumnPropertyNames(IQueryDefinitionDescriptor query)
+    {
+        MethodInfo? getColumns = query.GetType().GetMethod(
+            "GetColumns",
+            BindingFlags.Instance | BindingFlags.Public,
+            Type.EmptyTypes);
+
+        if (getColumns is null)
+        {
+            return [];
+        }
+
+        if (getColumns.Invoke(query, null) is not System.Collections.IEnumerable columns)
+        {
+            return [];
+        }
+
+        HashSet<string> names = new(StringComparer.Ordinal);
+        foreach (object? column in columns)
+        {
+            if (column is null) { continue; }
+            string? propertyName = column.GetType()
+                .GetProperty("PropertyName", BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(column) as string;
+            if (propertyName is { Length: > 0 })
+            {
+                names.Add(propertyName);
+            }
+        }
+
+        return names;
+    }
+
+    private static IEnumerable<Assembly> LoadGranitAssemblies()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(EntityDefinitionScan).Assembly.Location)!;
+
+        return Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path =>
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                return !name.Contains("Tests", StringComparison.Ordinal)
+                    && !name.EndsWith(".resources", StringComparison.Ordinal);
+            })
+            .Select(path =>
+            {
+                try { return Assembly.LoadFrom(path); }
+                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
+            })
+            .Where(a => a is not null)!;
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try { return assembly.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+    }
+
+    private static bool InheritsFromOpenGeneric(Type candidate, Type openGenericBase)
+    {
+        Type? cursor = candidate.BaseType;
+        while (cursor is not null && cursor != typeof(object))
+        {
+            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
+            {
+                return true;
+            }
+            cursor = cursor.BaseType;
+        }
+        return false;
+    }
+}

--- a/tests/Granit.ArchitectureTests/KanbanCardWhitelistPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/KanbanCardWhitelistPairingTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using Granit.ArchitectureTests.Internal;
 using Granit.Entities;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
@@ -14,20 +14,11 @@ namespace Granit.ArchitectureTests;
 /// in the matching <c>QueryDefinition&lt;TEntity&gt;.GetColumns()</c> whitelist.
 /// </summary>
 /// <remarks>
-/// <para>
 /// The kanban tile reads its rows from the entity's <c>QueryDefinition</c> projection.
 /// Card fields outside the whitelist either render blank (the SELECT does not include
 /// the column) or — worse — leak a property the security model intentionally hid from
 /// the list endpoint. Either way the host has a bug; this test fails fast at boot
 /// instead of letting the regression reach production.
-/// </para>
-/// <para>
-/// Reflection scans every <c>Granit.*.dll</c> in the test output directory and indexes
-/// concrete <see cref="EntityDefinition{TEntity}"/> subclasses by their generic
-/// <c>TEntity</c> argument. For each entity that declares a kanban layout, the test
-/// finds the matching <see cref="QueryDefinition{TEntity}"/> and cross-checks the
-/// card's property names against <c>GetColumns()</c>.
-/// </para>
 /// <para>
 /// An entity with a kanban layout but NO <c>QueryDefinition</c> at all is a separate
 /// hard failure (the kanban can't render) — also reported by this test.
@@ -38,8 +29,8 @@ public sealed class KanbanCardWhitelistPairingTests
     [Fact]
     public void Every_kanban_card_property_must_be_whitelisted_in_the_matching_QueryDefinition()
     {
-        List<IEntityDefinitionDescriptor> entities = ScanEntityDefinitions();
-        Dictionary<Type, IQueryDefinitionDescriptor> queriesByEntityType = ScanQueryDefinitions();
+        List<IEntityDefinitionDescriptor> entities = EntityDefinitionScan.ScanEntityDefinitions();
+        Dictionary<Type, IQueryDefinitionDescriptor> queriesByEntityType = EntityDefinitionScan.ScanQueryDefinitions();
 
         List<string> violations = [];
 
@@ -64,7 +55,7 @@ public sealed class KanbanCardWhitelistPairingTests
                 continue;
             }
 
-            HashSet<string> whitelistedProperties = ReadColumnPropertyNames(query);
+            HashSet<string> whitelistedProperties = EntityDefinitionScan.ReadColumnPropertyNames(query);
 
             if (kanban.Card.TitleProperty is { } title && !whitelistedProperties.Contains(title))
             {
@@ -85,145 +76,5 @@ public sealed class KanbanCardWhitelistPairingTests
         }
 
         violations.ShouldBeEmpty(string.Join(Environment.NewLine, violations));
-    }
-
-    private static List<IEntityDefinitionDescriptor> ScanEntityDefinitions()
-    {
-        Type baseType = typeof(EntityDefinition<>);
-        List<IEntityDefinitionDescriptor> instances = [];
-
-        foreach (Assembly assembly in LoadGranitAssemblies())
-        {
-            foreach (Type type in SafeGetTypes(assembly))
-            {
-                if (!type.IsClass || type.IsAbstract || type.IsGenericTypeDefinition)
-                {
-                    continue;
-                }
-
-                if (!InheritsFromOpenGeneric(type, baseType))
-                {
-                    continue;
-                }
-
-                if (Activator.CreateInstance(type) is IEntityDefinitionDescriptor instance)
-                {
-                    instances.Add(instance);
-                }
-            }
-        }
-
-        return instances;
-    }
-
-    private static Dictionary<Type, IQueryDefinitionDescriptor> ScanQueryDefinitions()
-    {
-        Type baseType = typeof(QueryDefinition<>);
-        Dictionary<Type, IQueryDefinitionDescriptor> byEntityType = [];
-
-        foreach (Assembly assembly in LoadGranitAssemblies())
-        {
-            foreach (Type type in SafeGetTypes(assembly))
-            {
-                if (!type.IsClass || type.IsAbstract || type.IsGenericTypeDefinition)
-                {
-                    continue;
-                }
-
-                if (!InheritsFromOpenGeneric(type, baseType))
-                {
-                    continue;
-                }
-
-                if (type.GetConstructor(Type.EmptyTypes) is null)
-                {
-                    continue;
-                }
-
-                if (Activator.CreateInstance(type) is IQueryDefinitionDescriptor instance)
-                {
-                    byEntityType[instance.EntityType] = instance;
-                }
-            }
-        }
-
-        return byEntityType;
-    }
-
-    /// <summary>
-    /// Reads <c>QueryDefinition&lt;TEntity&gt;.GetColumns()</c> via reflection — the
-    /// method lives on the generic base, not on <see cref="IQueryDefinitionDescriptor"/>,
-    /// so a static cast isn't enough.
-    /// </summary>
-    private static HashSet<string> ReadColumnPropertyNames(IQueryDefinitionDescriptor query)
-    {
-        MethodInfo? getColumns = query.GetType().GetMethod(
-            "GetColumns",
-            BindingFlags.Instance | BindingFlags.Public,
-            Type.EmptyTypes);
-
-        if (getColumns is null)
-        {
-            return [];
-        }
-
-        if (getColumns.Invoke(query, null) is not System.Collections.IEnumerable columns)
-        {
-            return [];
-        }
-
-        HashSet<string> names = new(StringComparer.Ordinal);
-        foreach (object? column in columns)
-        {
-            if (column is null) { continue; }
-            string? propertyName = column.GetType()
-                .GetProperty("PropertyName", BindingFlags.Instance | BindingFlags.Public)
-                ?.GetValue(column) as string;
-            if (propertyName is { Length: > 0 })
-            {
-                names.Add(propertyName);
-            }
-        }
-
-        return names;
-    }
-
-    private static IEnumerable<Assembly> LoadGranitAssemblies()
-    {
-        string outputDir = Path.GetDirectoryName(typeof(KanbanCardWhitelistPairingTests).Assembly.Location)!;
-
-        return Directory.GetFiles(outputDir, "Granit.*.dll")
-            .Where(path =>
-            {
-                string name = Path.GetFileNameWithoutExtension(path);
-                return !name.Contains("Tests", StringComparison.Ordinal)
-                    && !name.EndsWith(".resources", StringComparison.Ordinal);
-            })
-            .Select(path =>
-            {
-                try { return Assembly.LoadFrom(path); }
-                catch (Exception ex) when (ex is BadImageFormatException or FileLoadException) { return null; }
-            })
-            .Where(a => a is not null)!;
-    }
-
-    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
-    {
-        try { return assembly.GetTypes(); }
-        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
-    }
-
-    private static bool InheritsFromOpenGeneric(Type candidate, Type openGenericBase)
-    {
-        Type? cursor = candidate.BaseType;
-        while (cursor is not null && cursor != typeof(object))
-        {
-            if (cursor.IsGenericType && cursor.GetGenericTypeDefinition() == openGenericBase)
-            {
-                return true;
-            }
-            cursor = cursor.BaseType;
-        }
-        return false;
     }
 }


### PR DESCRIPTION
## Summary

Third story of Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509) — adds `CalendarFieldWhitelistPairingTests` mirroring the kanban guard (PR #1667). Closes story [#1686](https://github.com/granit-fx/granit-dotnet/issues/1686).

## Why

The range-query endpoint (`GET /api/entities/{name}/calendar`, ships in feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681)) reads each event's `Start` / `End` / `Title` / `ColorBy` from the entity's `QueryDefinition` projection. A property declared in `CalendarView(...)` that's not whitelisted in `QueryDefinition.GetColumns()` either renders blank (the SELECT doesn't include the column) or — worse — leaks a property the security model intentionally hid from the list endpoint. Either way the host has a bug; this test fails fast at boot instead of letting the regression reach production.

## What ships

### New test — [`CalendarFieldWhitelistPairingTests`](tests/Granit.ArchitectureTests/CalendarFieldWhitelistPairingTests.cs)

For every entity that declares a `CalendarView`:
- Hard-failure if no matching `QueryDefinition<TEntity>` exists at all
- Per-property check on `StartField` (required), `EndField`, `TitleField`, `ColorBy`
- Violation messages name the entity, the offending property, the DSL slot, and the fix (`Add .Column(e => e.X) in the matching QueryDefinition`)

### Refactor — [`EntityDefinitionScan`](tests/Granit.ArchitectureTests/Internal/EntityDefinitionScan.cs) helper

Extracts the ~140 lines of assembly-scan boilerplate (`ScanEntityDefinitions`, `ScanQueryDefinitions`, `ReadColumnPropertyNames`, `LoadGranitAssemblies`, `SafeGetTypes`, `InheritsFromOpenGeneric`) out of the kanban test. `KanbanCardWhitelistPairingTests` now consumes the helper — dropping ~140 lines of duplication. The Gallery test (story [#1694](https://github.com/granit-fx/granit-dotnet/issues/1694), F3.3) will reuse the same helpers without further extraction.

## Test plan

- [x] 2 whitelist tests green (kanban refactored + new calendar) — currently zero violations across the framework (no entity declares a CalendarView yet; the showcase repo will adopt one in granit-showcase-dotnet Phase 1.5)
- [x] `dotnet format` clean
- [x] No new dependency