### PR TITLE
feat(entities-endpoints): calendar range-query endpoint shape (Phase 1.5 #1688)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18984,6 +18984,24 @@
       "members": []
     },
     {
+      "name": "CalendarItemResponse",
+      "fqn": "Granit.Entities.Endpoints.Dtos.CalendarItemResponse",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "CalendarRangeRequest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.CalendarRangeRequest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "EntityActionManifest",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityActionManifest",
       "kind": "record",
@@ -19282,6 +19300,38 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICalendarRangeService",
+      "fqn": "Granit.Entities.Endpoints.Internal.ICalendarRangeService",
+      "kind": "interface",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "GetItemsAsync",
+          "kind": "method",
+          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.Endpoints.Internal.struct",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "GetItemsAsync",
+          "kind": "method",
+          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
         }
       ]
     },

--- a/src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs
@@ -1,0 +1,17 @@
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// One event positioned on the calendar's time axis. The renderer
+/// (<c>EntityCalendar</c>) reads this shape to lay out tiles.
+/// </summary>
+/// <param name="Id">Stable identifier of the underlying entity row — drives the detail-page link.</param>
+/// <param name="Start">Event start, projected from the calendar's <c>StartField</c>.</param>
+/// <param name="End">Event end, projected from the calendar's <c>EndField</c>. <see langword="null"/> renders a point-in-time marker.</param>
+/// <param name="Title">Event headline, projected from the calendar's <c>TitleField</c> when set, otherwise the entity's <c>DisplayProperty</c>.</param>
+/// <param name="Color">Stable colour bucket for this event, projected from the calendar's <c>ColorBy</c> when set. <see langword="null"/> falls back to the theme default.</param>
+public sealed record CalendarItemResponse(
+    Guid Id,
+    DateTimeOffset Start,
+    DateTimeOffset? End,
+    string Title,
+    string? Color);

--- a/src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs
@@ -1,0 +1,18 @@
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Wire shape for the range-query parameters of <c>GET /api/entities/{name}/calendar</c>.
+/// Bound from the query string by ASP.NET Core's model binder.
+/// </summary>
+/// <param name="From">Inclusive start of the requested window.</param>
+/// <param name="To">Inclusive end of the requested window.</param>
+/// <param name="Calendar">
+/// Optional name of the target <c>CalendarLayoutDescriptor</c> when an entity
+/// declares more than one (reserved for future kinds — today the framework
+/// rejects duplicate layout kinds, so leaving this <see langword="null"/>
+/// always picks the entity's single calendar).
+/// </param>
+public sealed record CalendarRangeRequest(
+    DateTimeOffset From,
+    DateTimeOffset To,
+    string? Calendar);

--- a/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
@@ -1,0 +1,87 @@
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using Granit.Entities.Layouts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Entities.Endpoints.Endpoints;
+
+/// <summary>
+/// Range-query handler for the calendar list-view layout. Mounted under
+/// <c>{prefix}/{name}/calendar</c> by <c>MapEntitiesEndpoints</c>.
+/// </summary>
+internal static class CalendarRangeEndpoint
+{
+    public static RouteGroupBuilder MapCalendarRangeEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapGet("/{name}/calendar", HandleAsync)
+            .WithName("GetEntityCalendarRange")
+            .WithSummary("Returns calendar items for one entity within a time window.")
+            .WithDescription(
+                "Reads the entity's CalendarLayoutDescriptor (selected by the optional ?calendar= name when an entity exposes more than one) "
+                + "and returns the events whose Start/End falls inside [from, to]. The range is enforced server-side: a window wider than 366 days "
+                + "or with To < From is rejected with 400. Returns an empty list when the entity declares no calendar layout, no item matches, or "
+                + "the host has not yet wired a real ICalendarRangeService implementation. Permission filtering and FusionCache layer in via separate stories.")
+            .Produces<IReadOnlyList<CalendarItemResponse>>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<CalendarItemResponse>>, ProblemHttpResult>> HandleAsync(
+        string name,
+        [AsParameters] CalendarRangeRequest request,
+        [FromServices] IEntityDefinitionRegistry registry,
+        [FromServices] ICalendarRangeService calendarRangeService,
+        CancellationToken cancellationToken)
+    {
+        IEntityDefinitionDescriptor? definitionRef = registry.GetByName(name);
+        if (definitionRef is null)
+        {
+            return TypedResults.Problem(
+                detail: $"No EntityDefinition is registered with name '{name}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        EntityDefinitionDescriptor descriptor = definitionRef.Descriptor;
+        CalendarLayoutDescriptor? layout = SelectCalendarLayout(descriptor, request.Calendar);
+
+        if (layout is null)
+        {
+            // No matching calendar layout — return empty rather than 404. The
+            // wire shape stays predictable for hosts that mount the endpoint
+            // generically; a 404 here would surface as a hard error in the
+            // EntityListViewSwitcher even though the situation is benign
+            // (entity simply has no calendar tab).
+            return TypedResults.Ok<IReadOnlyList<CalendarItemResponse>>([]);
+        }
+
+        IReadOnlyList<CalendarItemResponse> items = await calendarRangeService
+            .GetItemsAsync(descriptor, layout, new CalendarRange(request.From, request.To), cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(items);
+    }
+
+    private static CalendarLayoutDescriptor? SelectCalendarLayout(
+        EntityDefinitionDescriptor descriptor,
+        string? requestedName)
+    {
+        IEnumerable<CalendarLayoutDescriptor> candidates = descriptor.ListLayouts.OfType<CalendarLayoutDescriptor>();
+
+        if (requestedName is null)
+        {
+            return candidates.FirstOrDefault();
+        }
+
+        // Layout descriptors carry no Name field today (one layout per kind is
+        // enforced by AssertUniqueLayoutKinds), so a non-null requestedName
+        // matches if and only if the entity has any calendar layout. Reserved
+        // for the day multi-instance layouts ship per ADR-042 §4.
+        return candidates.FirstOrDefault();
+    }
+}

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -39,6 +39,7 @@ internal static class EntitiesEndpoints
             .ProducesProblem(StatusCodes.Status403Forbidden);
 
         group.MapRelationAggregatesEndpoint();
+        group.MapCalendarRangeEndpoint();
 
         return group;
     }

--- a/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
@@ -64,6 +64,11 @@ public static class EntitiesEndpointRouteBuilderExtensions
         // parallelism is the implementation's responsibility (story #1561).
         services.TryAddSingleton<Granit.Entities.Relations.IRelationAggregateService,
             Granit.Entities.Relations.NullRelationAggregateService>();
+        // Calendar range queries default to a no-op until a host plugs an EF
+        // Core executor in (story #1689). Hosts override by registering a
+        // concrete ICalendarRangeService BEFORE calling AddGranitEntitiesEndpoints,
+        // or by calling Replace afterwards.
+        services.TryAddSingleton<ICalendarRangeService, NullCalendarRangeService>();
         services.AddOptions<EntitiesEndpointsOptions>();
         Granit.Diagnostics.GranitActivitySourceRegistry.Register(EntityActivitySource.Name);
         return services;

--- a/src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs
+++ b/src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs
@@ -1,0 +1,49 @@
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Layouts;
+
+namespace Granit.Entities.Endpoints.Internal;
+
+/// <summary>
+/// Resolves calendar items for one entity within a time window. The default
+/// in-package implementation returns an empty list — hosts wire up a real
+/// EF Core executor (story #1689) by replacing this registration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface lives in <c>.Endpoints</c> rather than the abstractions
+/// package so the wire DTO (<see cref="CalendarItemResponse"/>) stays adjacent
+/// to its only producer / consumer. Same placement rule as
+/// <c>IRelationAggregateService</c>.
+/// </para>
+/// </remarks>
+public interface ICalendarRangeService
+{
+    /// <summary>Returns the calendar items in <paramref name="range"/> for one entity layout.</summary>
+    /// <param name="entity">The entity descriptor (carries the EntityType + name).</param>
+    /// <param name="layout">The selected calendar layout (drives the StartField / EndField / Title / ColorBy projection).</param>
+    /// <param name="range">Inclusive time window — already validated as <c>To &gt;= From</c> and within the maximum span.</param>
+    /// <param name="cancellationToken">Cancellation.</param>
+    Task<IReadOnlyList<CalendarItemResponse>> GetItemsAsync(
+        EntityDefinitionDescriptor entity,
+        CalendarLayoutDescriptor layout,
+        CalendarRange range,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>Inclusive time window for the calendar query.</summary>
+public readonly record struct CalendarRange(DateTimeOffset From, DateTimeOffset To);
+
+/// <summary>
+/// No-op implementation registered by default. Returns an empty result —
+/// suitable for hosts that have not yet wired the EF Core executor or for
+/// modules that expose a calendar layout purely for the manifest.
+/// </summary>
+internal sealed class NullCalendarRangeService : ICalendarRangeService
+{
+    public Task<IReadOnlyList<CalendarItemResponse>> GetItemsAsync(
+        EntityDefinitionDescriptor entity,
+        CalendarLayoutDescriptor layout,
+        CalendarRange range,
+        CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<CalendarItemResponse>>([]);
+}

--- a/src/Granit.Entities.Endpoints/Validators/CalendarRangeRequestValidator.cs
+++ b/src/Granit.Entities.Endpoints/Validators/CalendarRangeRequestValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Validation.Extensions;
+
+namespace Granit.Entities.Endpoints.Validators;
+
+internal sealed class CalendarRangeRequestValidator : AbstractValidator<CalendarRangeRequest>
+{
+    /// <summary>
+    /// Maximum window the calendar endpoint is willing to fetch in one round-trip.
+    /// One year is the largest band a typical calendar UI scrolls without hard
+    /// re-fetching; anything wider risks dragging back a multi-million-row page
+    /// that the renderer would just discard.
+    /// </summary>
+    public static readonly TimeSpan MaxRange = TimeSpan.FromDays(366);
+
+    public CalendarRangeRequestValidator()
+    {
+        RuleFor(x => x.To)
+            .GreaterThanOrEqualTo(x => x.From)
+            .WithErrorCodeAndMessage("Granit:Validation:CalendarRangeInverted");
+
+        RuleFor(x => x)
+            .Must(x => x.To - x.From <= MaxRange)
+            .WithErrorCodeAndMessage("Granit:Validation:CalendarRangeTooWide");
+
+        RuleFor(x => x.Calendar)
+            .MaximumLength(128)
+            .When(x => x.Calendar is not null);
+    }
+}

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "Zadaná podmínka nebyla splněna pro '{PropertyName}'.",
     "Granit:Validation:AtLeastOneMappingTarget": "Alespoň jedno mapování musí mít nenulovou cílovou vlastnost.",
     "Granit:Validation:BulkSettingsTooLarge": "Povoleno je maximálně 200 nastavení na hromadný požadavek.",
+    "Granit:Validation:CalendarRangeInverted": "Rozsah kalendáře je obrácený: hodnota 'Do' musí být větší nebo rovna 'Od'.",
+    "Granit:Validation:CalendarRangeTooWide": "Rozsah kalendáře je příliš široký: požadované okno nesmí přesáhnout 366 dní.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' může obsahovat pouze písmena, číslice, pomlčky, podtržítka nebo tečky.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' není platné číslo kreditní karty.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' a 'Page' nelze použít současně.",

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "Die angegebene Bedingung für '{PropertyName}' wurde nicht erfüllt.",
     "Granit:Validation:AtLeastOneMappingTarget": "Mindestens eine Zuordnung muss eine nicht-null Zieleigenschaft haben.",
     "Granit:Validation:BulkSettingsTooLarge": "Maximal 200 Einstellungen pro Sammelanfrage erlaubt.",
+    "Granit:Validation:CalendarRangeInverted": "Der Kalenderbereich ist invertiert: 'Bis' muss größer oder gleich 'Von' sein.",
+    "Granit:Validation:CalendarRangeTooWide": "Der Kalenderbereich ist zu breit: das angeforderte Fenster darf 366 Tage nicht überschreiten.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' darf nur Buchstaben, Ziffern, Bindestriche, Unterstriche oder Punkte enthalten.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' ist keine gültige Kreditkartennummer.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' und 'Page' schließen sich gegenseitig aus.",

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "The specified condition was not met for '{PropertyName}'.",
     "Granit:Validation:AtLeastOneMappingTarget": "At least one mapping must have a non-null target property.",
     "Granit:Validation:BulkSettingsTooLarge": "Maximum 200 settings allowed per bulk request.",
+    "Granit:Validation:CalendarRangeInverted": "The calendar range is inverted: 'To' must be greater than or equal to 'From'.",
+    "Granit:Validation:CalendarRangeTooWide": "The calendar range is too wide: the requested window cannot exceed 366 days.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' must only contain letters, digits, hyphens, underscores, or dots.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' is not a valid credit card number.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' and 'Page' are mutually exclusive.",

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "La condición especificada para '{PropertyName}' no se ha cumplido.",
     "Granit:Validation:AtLeastOneMappingTarget": "Al menos una asignación debe tener una propiedad destino no nula.",
     "Granit:Validation:BulkSettingsTooLarge": "Se permiten un máximo de 200 configuraciones por solicitud en lote.",
+    "Granit:Validation:CalendarRangeInverted": "El rango del calendario está invertido: 'Hasta' debe ser mayor o igual que 'Desde'.",
+    "Granit:Validation:CalendarRangeTooWide": "El rango del calendario es demasiado amplio: la ventana solicitada no puede superar los 366 días.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' solo puede contener letras, dígitos, guiones, guiones bajos o puntos.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' no es un número de tarjeta de crédito válido.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' y 'Page' son mutuamente excluyentes.",

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "La condition spécifiée n'a pas été remplie pour '{PropertyName}'.",
     "Granit:Validation:AtLeastOneMappingTarget": "Au moins un mappage doit avoir une propriété cible non nulle.",
     "Granit:Validation:BulkSettingsTooLarge": "Maximum 200 paramètres autorisés par requête groupée.",
+    "Granit:Validation:CalendarRangeInverted": "La plage du calendrier est inversée : 'Jusqu'à' doit être supérieur ou égal à 'À partir de'.",
+    "Granit:Validation:CalendarRangeTooWide": "La plage du calendrier est trop large : la fenêtre demandée ne peut pas dépasser 366 jours.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' ne peut contenir que des lettres, des chiffres, des tirets, des underscores ou des points.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' n'est pas un numéro de carte bancaire valide.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' et 'Page' sont mutuellement exclusifs.",

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' के लिए निर्दिष्ट शर्त पूरी नहीं हुई।",
     "Granit:Validation:AtLeastOneMappingTarget": "कम से कम एक मैपिंग में नॉन-नल लक्ष्य प्रॉपर्टी होनी चाहिए।",
     "Granit:Validation:BulkSettingsTooLarge": "प्रति बल्क अनुरोध अधिकतम 200 सेटिंग्स अनुमत हैं।",
+    "Granit:Validation:CalendarRangeInverted": "कैलेंडर सीमा उलट गई है: 'तक' 'से' से बड़ा या उसके बराबर होना चाहिए.",
+    "Granit:Validation:CalendarRangeTooWide": "कैलेंडर सीमा बहुत व्यापक है: अनुरोधित विंडो 366 दिनों से अधिक नहीं हो सकती.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' में केवल अक्षर, अंक, हाइफ़न, अंडरस्कोर या बिंदु होने चाहिए।",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' एक मान्य क्रेडिट कार्ड नंबर नहीं है।",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' और 'Page' परस्पर अनन्य हैं।",

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "La condizione specificata per '{PropertyName}' non è stata soddisfatta.",
     "Granit:Validation:AtLeastOneMappingTarget": "Almeno una mappatura deve avere una proprietà destinazione non nulla.",
     "Granit:Validation:BulkSettingsTooLarge": "Sono consentite al massimo 200 impostazioni per richiesta in blocco.",
+    "Granit:Validation:CalendarRangeInverted": "L'intervallo del calendario è invertito: 'A' deve essere maggiore o uguale a 'Da'.",
+    "Granit:Validation:CalendarRangeTooWide": "L'intervallo del calendario è troppo ampio: la finestra richiesta non può superare i 366 giorni.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' può contenere solo lettere, cifre, trattini, underscore o punti.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' non è un numero di carta di credito valido.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' e 'Page' si escludono a vicenda.",

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' に対する指定された条件が満たされていません。",
     "Granit:Validation:AtLeastOneMappingTarget": "少なくとも1つのマッピングにnullでないターゲットプロパティが必要です。",
     "Granit:Validation:BulkSettingsTooLarge": "一括リクエストあたり最大200件の設定が許可されます。",
+    "Granit:Validation:CalendarRangeInverted": "カレンダーの範囲が逆転しています。「終了」は「開始」以上である必要があります。",
+    "Granit:Validation:CalendarRangeTooWide": "カレンダーの範囲が広すぎます。要求されたウィンドウは366日を超えることはできません。",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' には英数字、ハイフン、アンダースコア、ドットのみ使用できます。",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' は有効なクレジットカード番号ではありません。",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' と 'Page' は同時に使用できません。",

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}'에 대해 지정된 조건이 충족되지 않았습니다.",
     "Granit:Validation:AtLeastOneMappingTarget": "하나 이상의 매핑에 null이 아닌 대상 속성이 있어야 합니다.",
     "Granit:Validation:BulkSettingsTooLarge": "일괄 요청당 최대 200개의 설정이 허용됩니다.",
+    "Granit:Validation:CalendarRangeInverted": "캘린더 범위가 반전되었습니다. '종료'는 '시작'보다 크거나 같아야 합니다.",
+    "Granit:Validation:CalendarRangeTooWide": "캘린더 범위가 너무 넓습니다. 요청된 창은 366일을 초과할 수 없습니다.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}'은(는) 문자, 숫자, 하이픈, 밑줄 또는 점만 포함할 수 있습니다.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}'은(는) 유효한 신용카드 번호가 아닙니다.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor'와 'Page'는 동시에 사용할 수 없습니다.",

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "Aan de opgegeven voorwaarde voor '{PropertyName}' is niet voldaan.",
     "Granit:Validation:AtLeastOneMappingTarget": "Minstens één toewijzing moet een niet-null doeleigenschap hebben.",
     "Granit:Validation:BulkSettingsTooLarge": "Maximaal 200 instellingen toegestaan per bulkverzoek.",
+    "Granit:Validation:CalendarRangeInverted": "Het kalenderbereik is omgekeerd: 'Tot' moet groter dan of gelijk aan 'Van' zijn.",
+    "Granit:Validation:CalendarRangeTooWide": "Het kalenderbereik is te breed: het aangevraagde venster mag niet groter zijn dan 366 dagen.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' mag alleen letters, cijfers, koppeltekens, underscores of punten bevatten.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' is geen geldig creditcardnummer.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' en 'Page' sluiten elkaar uit.",

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "Określony warunek nie został spełniony dla '{PropertyName}'.",
     "Granit:Validation:AtLeastOneMappingTarget": "Co najmniej jedno mapowanie musi mieć niepustą właściwość docelową.",
     "Granit:Validation:BulkSettingsTooLarge": "Dozwolonych jest maksymalnie 200 ustawień na żądanie zbiorcze.",
+    "Granit:Validation:CalendarRangeInverted": "Zakres kalendarza jest odwrócony: 'Do' musi być większe lub równe 'Od'.",
+    "Granit:Validation:CalendarRangeTooWide": "Zakres kalendarza jest zbyt szeroki: żądane okno nie może przekraczać 366 dni.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' może zawierać tylko litery, cyfry, myślniki, podkreślenia lub kropki.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' nie jest prawidłowym numerem karty kredytowej.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' i 'Page' wykluczają się wzajemnie.",

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "A condição especificada para '{PropertyName}' não foi cumprida.",
     "Granit:Validation:AtLeastOneMappingTarget": "Pelo menos um mapeamento deve ter uma propriedade de destino não nula.",
     "Granit:Validation:BulkSettingsTooLarge": "São permitidas no máximo 200 configurações por solicitação em lote.",
+    "Granit:Validation:CalendarRangeInverted": "O intervalo do calendário está invertido: 'Até' deve ser maior ou igual a 'De'.",
+    "Granit:Validation:CalendarRangeTooWide": "O intervalo do calendário é demasiado amplo: a janela solicitada não pode exceder 366 dias.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' só pode conter letras, dígitos, hífens, underscores ou pontos.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' não é um número de cartão de crédito válido.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' e 'Page' são mutuamente exclusivos.",

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "Det angivna villkoret uppfylldes inte för '{PropertyName}'.",
     "Granit:Validation:AtLeastOneMappingTarget": "Minst en mappning måste ha en icke-null målegenskap.",
     "Granit:Validation:BulkSettingsTooLarge": "Högst 200 inställningar tillåtna per bulkbegäran.",
+    "Granit:Validation:CalendarRangeInverted": "Kalenderintervallet är omvänt: 'Till' måste vara större än eller lika med 'Från'.",
+    "Granit:Validation:CalendarRangeTooWide": "Kalenderintervallet är för brett: det begärda fönstret får inte överstiga 366 dagar.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' får bara innehålla bokstäver, siffror, bindestreck, understreck eller punkter.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' är inte ett giltigt kreditkortsnummer.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' och 'Page' kan inte användas samtidigt.",

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' için belirtilen koşul karşılanmadı.",
     "Granit:Validation:AtLeastOneMappingTarget": "En az bir eşleme, boş olmayan bir hedef özelliğe sahip olmalıdır.",
     "Granit:Validation:BulkSettingsTooLarge": "Toplu istek başına en fazla 200 ayara izin verilir.",
+    "Granit:Validation:CalendarRangeInverted": "Takvim aralığı ters: 'Bitiş', 'Başlangıç' değerine eşit veya ondan büyük olmalıdır.",
+    "Granit:Validation:CalendarRangeTooWide": "Takvim aralığı çok geniş: istenen pencere 366 günü aşamaz.",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' yalnızca harf, rakam, tire, alt çizgi veya nokta içerebilir.",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' geçerli bir kredi kartı numarası değil.",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' ve 'Page' birlikte kullanılamaz.",

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -5,6 +5,8 @@
     "Granit:Validation:AsyncPredicateValidator": "'{PropertyName}' 的指定条件未满足。",
     "Granit:Validation:AtLeastOneMappingTarget": "至少一个映射必须具有非空的目标属性。",
     "Granit:Validation:BulkSettingsTooLarge": "每个批量请求最多允许 200 个设置。",
+    "Granit:Validation:CalendarRangeInverted": "日历范围已颠倒:“至”必须大于或等于“从”。",
+    "Granit:Validation:CalendarRangeTooWide": "日历范围过宽:请求的时间窗口不能超过366天。",
     "Granit:Validation:CodeInvalidFormat": "'{PropertyName}' 只能包含字母、数字、连字符、下划线或点。",
     "Granit:Validation:CreditCardValidator": "'{PropertyName}' 不是有效的信用卡号。",
     "Granit:Validation:CursorPageMutuallyExclusive": "'Cursor' 和 'Page' 不能同时使用。",

--- a/tests/Granit.Entities.Endpoints.Tests/CalendarRangeRequestValidatorTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/CalendarRangeRequestValidatorTests.cs
@@ -1,0 +1,65 @@
+using FluentValidation.Results;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Endpoints.Tests;
+
+public sealed class CalendarRangeRequestValidatorTests
+{
+    private static readonly DateTimeOffset Anchor = new(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+    private readonly CalendarRangeRequestValidator _sut = new();
+
+    [Fact]
+    public void Same_From_and_To_is_valid()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor, null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void One_month_window_is_valid()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor.AddDays(30), null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void To_before_From_is_rejected_with_inverted_code()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor.AddDays(-1), null));
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.ErrorCode == "Granit:Validation:CalendarRangeInverted");
+    }
+
+    [Fact]
+    public void Window_wider_than_366_days_is_rejected_with_too_wide_code()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor.AddDays(367), null));
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.ErrorCode == "Granit:Validation:CalendarRangeTooWide");
+    }
+
+    [Fact]
+    public void Window_at_max_range_366_days_is_valid()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor.AddDays(366), null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Calendar_name_longer_than_128_chars_is_rejected()
+    {
+        string oversize = new('a', 129);
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor, oversize));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Null_calendar_name_is_accepted()
+    {
+        ValidationResult result = _sut.Validate(new CalendarRangeRequest(Anchor, Anchor, null));
+        result.IsValid.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/NullCalendarRangeServiceTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/NullCalendarRangeServiceTests.cs
@@ -1,0 +1,43 @@
+using Granit.Entities;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using Granit.Entities.Layouts;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Endpoints.Tests;
+
+public sealed class NullCalendarRangeServiceTests
+{
+    [Fact]
+    public async Task Default_implementation_returns_an_empty_list()
+    {
+        NullCalendarRangeService sut = new();
+
+        EntityDefinitionDescriptor descriptor = new()
+        {
+            Name = "Sample",
+            EntityType = typeof(object),
+            Forms = [],
+            Details = [],
+            Relations = [],
+            ListLayouts = [],
+            Actions = [],
+            MetricDefinitionTypes = [],
+            DashboardDefinitionTypes = [],
+        };
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = "StartsAt",
+        };
+
+        IReadOnlyList<CalendarItemResponse> items = await sut.GetItemsAsync(
+            descriptor,
+            layout,
+            new CalendarRange(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(7)),
+            TestContext.Current.CancellationToken);
+
+        items.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

First slice of feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681) (Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509)) — wires the wire shape of `GET /api/entities/{name}/calendar` end-to-end with a no-op data path. Closes story [#1688](https://github.com/granit-fx/granit-dotnet/issues/1688).

The actual EF Core executor lands in [#1689](https://github.com/granit-fx/granit-dotnet/issues/1689); permission gating in [#1690](https://github.com/granit-fx/granit-dotnet/issues/1690); FusionCache in [#1691](https://github.com/granit-fx/granit-dotnet/issues/1691).

## What ships

- [`CalendarRangeRequest(From, To, Calendar?)`](src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs) — bound from query string via `[AsParameters]`
- [`CalendarItemResponse(Id, Start, End?, Title, Color?)`](src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs) — wire item
- [`CalendarRangeRequestValidator`](src/Granit.Entities.Endpoints/Validators/CalendarRangeRequestValidator.cs) — server-side enforcement:
  - `To >= From` → `Granit:Validation:CalendarRangeInverted`
  - `(To - From) <= 366 days` → `Granit:Validation:CalendarRangeTooWide`
  - Calendar name <= 128 chars
- [`ICalendarRangeService` + `NullCalendarRangeService`](src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs) — same shape as `IRelationAggregateService` (interface in `.Endpoints`, hosts plug a real EF executor over it). Default returns an empty list so hosts that haven't wired an executor yet still get a predictable `200 OK` response rather than a `404` / `501`.
- [`CalendarRangeEndpoint.MapCalendarRangeEndpoint`](src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs) mounted via the existing `MapEntitiesEndpoints` group; carries the full 5-element OpenAPI metadata
- 2 new validation message keys added to all 15 base cultures (regional variants `en-GB` / `fr-CA` / `pt-BR` fall through per the convention)

## Behavior notes

When the entity declares no calendar layout, the endpoint returns `Ok([])` rather than `404` — a hard `404` would fire as a UI error in the `EntityListViewSwitcher` even though the situation is benign (entity simply has no calendar tab).

Calendar selection by `?calendar=` is reserved for the day multi-instance layouts ship per ADR-042 §4. Today the framework rejects duplicate layout kinds (`AssertUniqueLayoutKinds`), so leaving `?calendar=` null always picks the entity's single calendar.

## Test plan

- [x] 7 validator tests (inverted, too-wide, max-range edge, calendar name length, null name)
- [x] 1 null-service test (returns empty)
- [x] Full `Granit.Entities.Endpoints.Tests` suite green: 64 tests pass
- [x] `LocalizationFileShapeTests` + 3 sibling localization archi tests green (4/4)
- [x] `dotnet format` clean on `Granit.Entities.Endpoints`, the test project, and `Granit.Validation`