### PR TITLE
feat(entities-abstractions): calendar range filter builder (Phase 1.5 #1689)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19608,6 +19608,15 @@
       "members": []
     },
     {
+      "name": "CalendarRangeFilterBuilder",
+      "fqn": "Granit.Entities.Layouts.CalendarRangeFilterBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs",
+      "line": 47,
+      "members": []
+    },
+    {
       "name": "EntityListLayoutDescriptor",
       "fqn": "Granit.Entities.Layouts.EntityListLayoutDescriptor",
       "kind": "record",
@@ -19716,6 +19725,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Layouts/KanbanLayoutDescriptor.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.Layouts.struct",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs",
+      "line": 10,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs
@@ -1,0 +1,120 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.Entities.Layouts;
+
+/// <summary>
+/// Inclusive time window for a calendar range query — duplicated here so the
+/// filter builder stays independent of <c>Granit.Entities.Endpoints</c>.
+/// </summary>
+public readonly record struct CalendarFilterRange(DateTimeOffset From, DateTimeOffset To);
+
+/// <summary>
+/// Composes the LINQ filter expression that a calendar runner applies to its
+/// underlying <see cref="IQueryable{T}"/>. The expression keys on the layout's
+/// <see cref="CalendarLayoutDescriptor.StartPropertyName"/> (and optional
+/// <see cref="CalendarLayoutDescriptor.EndPropertyName"/>) — never on hard-coded
+/// property names — so the same builder serves any entity that exposes a
+/// calendar layout.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder produces an <b>additive</b> predicate, intended to be composed
+/// with <c>Where(...)</c> on top of the base queryable, AFTER any entity-baked
+/// filters declared on the underlying <c>QueryDefinition</c>. The range filter
+/// can only narrow the result set — it never widens it. This matches the
+/// additive-only contract from ADR-048 §4 (cross-workspace presets).
+/// </para>
+/// <para>
+/// Overlap semantics — adopted from the standard interval-overlap formula:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     Events with a non-null end (<c>EndField</c>) overlap the window
+///     <c>[from, to]</c> when <c>Start &lt;= to</c> AND <c>from &lt;= End</c>.
+///   </description></item>
+///   <item><description>
+///     Point-in-time events (no <c>EndField</c>, or End is <see langword="null"/>)
+///     overlap when <c>from &lt;= Start &lt;= to</c>.
+///   </description></item>
+/// </list>
+/// <para>
+/// The two cases are unified into a single SQL-translatable expression by
+/// coalescing <c>End</c> to <c>Start</c> on the right-hand bound:
+/// <c>Start &lt;= to AND from &lt;= (End ?? Start)</c>.
+/// </para>
+/// </remarks>
+public static class CalendarRangeFilterBuilder
+{
+    /// <summary>
+    /// Builds an <c>Expression&lt;Func&lt;TEntity, bool&gt;&gt;</c> that retains
+    /// only the events overlapping <paramref name="range"/>, keyed on the
+    /// property names declared by <paramref name="layout"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">Entity type the layout was declared on.</typeparam>
+    /// <param name="layout">Calendar layout descriptor naming the start / end properties.</param>
+    /// <param name="range">Inclusive time window.</param>
+    /// <returns>A LINQ expression suitable for <c>IQueryable&lt;TEntity&gt;.Where(...)</c>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the layout names a property that is not declared on
+    /// <typeparamref name="TEntity"/> — surfaces a typo from the
+    /// <c>CalendarView(...)</c> declaration (defensive: the builder guards
+    /// against ToString-based bypasses but cannot catch property renames at
+    /// compile time once the descriptor is built).
+    /// </exception>
+    public static Expression<Func<TEntity, bool>> BuildOverlapFilter<TEntity>(
+        CalendarLayoutDescriptor layout,
+        CalendarFilterRange range)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+
+        ParameterExpression entity = Expression.Parameter(typeof(TEntity), "e");
+        MemberExpression startMember = ResolvePropertyAccess(entity, layout.StartPropertyName, "StartField");
+        ConstantExpression from = Expression.Constant(range.From, typeof(DateTimeOffset));
+        ConstantExpression to = Expression.Constant(range.To, typeof(DateTimeOffset));
+
+        Expression body;
+        if (layout.EndPropertyName is null)
+        {
+            // Point-in-time events only: from <= Start <= to.
+            body = Expression.AndAlso(
+                Expression.GreaterThanOrEqual(startMember, from),
+                Expression.LessThanOrEqual(startMember, to));
+        }
+        else
+        {
+            MemberExpression endMember = ResolvePropertyAccess(entity, layout.EndPropertyName, "EndField");
+            // Coalesce End to Start so the right-hand bound is always a non-null
+            // DateTimeOffset; SQL providers translate (End ?? Start) to COALESCE
+            // without needing an explicit branch.
+            Expression rightBound = endMember.Type == typeof(DateTimeOffset?)
+                ? Expression.Coalesce(endMember, startMember)
+                : endMember;
+
+            body = Expression.AndAlso(
+                Expression.LessThanOrEqual(startMember, to),
+                Expression.LessThanOrEqual(from, rightBound));
+        }
+
+        return Expression.Lambda<Func<TEntity, bool>>(body, entity);
+    }
+
+    private static MemberExpression ResolvePropertyAccess(
+        ParameterExpression entity,
+        string propertyName,
+        string dslSlot)
+    {
+        PropertyInfo? property = entity.Type.GetProperty(
+            propertyName,
+            BindingFlags.Instance | BindingFlags.Public);
+
+        if (property is null)
+        {
+            throw new InvalidOperationException(
+                $"Calendar {dslSlot}='{propertyName}' is not a public instance property on '{entity.Type.FullName}'. "
+                + "The descriptor was likely built for a different type, or the property was renamed since the EntityDefinition was declared.");
+        }
+
+        return Expression.Property(entity, property);
+    }
+}

--- a/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarRangeFilterBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Layouts/CalendarRangeFilterBuilderTests.cs
@@ -1,0 +1,153 @@
+using Granit.Entities.Layouts;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Layouts;
+
+public sealed class CalendarRangeFilterBuilderTests
+{
+    private static readonly DateTimeOffset Anchor = new(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void StartOnly_layout_keeps_only_events_inside_the_window()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = nameof(PointInTimeEvent.OccurredAt),
+        };
+
+        Func<PointInTimeEvent, bool> filter = CalendarRangeFilterBuilder
+            .BuildOverlapFilter<PointInTimeEvent>(layout, new CalendarFilterRange(Anchor, Anchor.AddDays(7)))
+            .Compile();
+
+        filter(new PointInTimeEvent { OccurredAt = Anchor.AddDays(-1) }).ShouldBeFalse();
+        filter(new PointInTimeEvent { OccurredAt = Anchor }).ShouldBeTrue();
+        filter(new PointInTimeEvent { OccurredAt = Anchor.AddDays(3) }).ShouldBeTrue();
+        filter(new PointInTimeEvent { OccurredAt = Anchor.AddDays(7) }).ShouldBeTrue();
+        filter(new PointInTimeEvent { OccurredAt = Anchor.AddDays(8) }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void StartEnd_layout_keeps_events_overlapping_the_window()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = nameof(Meeting.StartsAt),
+            EndPropertyName = nameof(Meeting.EndsAt),
+        };
+
+        Func<Meeting, bool> filter = CalendarRangeFilterBuilder
+            .BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor.AddDays(7)))
+            .Compile();
+
+        // Entirely before the window
+        filter(new Meeting { StartsAt = Anchor.AddDays(-3), EndsAt = Anchor.AddDays(-2) }).ShouldBeFalse();
+        // Spans the window
+        filter(new Meeting { StartsAt = Anchor.AddDays(-3), EndsAt = Anchor.AddDays(10) }).ShouldBeTrue();
+        // Starts before, ends inside
+        filter(new Meeting { StartsAt = Anchor.AddDays(-1), EndsAt = Anchor.AddDays(2) }).ShouldBeTrue();
+        // Starts inside, ends after
+        filter(new Meeting { StartsAt = Anchor.AddDays(5), EndsAt = Anchor.AddDays(10) }).ShouldBeTrue();
+        // Entirely inside
+        filter(new Meeting { StartsAt = Anchor.AddDays(1), EndsAt = Anchor.AddDays(2) }).ShouldBeTrue();
+        // Entirely after
+        filter(new Meeting { StartsAt = Anchor.AddDays(8), EndsAt = Anchor.AddDays(10) }).ShouldBeFalse();
+        // Touches the boundary at the start
+        filter(new Meeting { StartsAt = Anchor.AddDays(-1), EndsAt = Anchor }).ShouldBeTrue();
+        // Touches the boundary at the end
+        filter(new Meeting { StartsAt = Anchor.AddDays(7), EndsAt = Anchor.AddDays(10) }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Open_ended_event_is_kept_when_start_is_inside_the_window()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = nameof(Meeting.StartsAt),
+            EndPropertyName = nameof(Meeting.EndsAt),
+        };
+
+        Func<Meeting, bool> filter = CalendarRangeFilterBuilder
+            .BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor.AddDays(7)))
+            .Compile();
+
+        // Open-ended (EndsAt null) inside window — kept because End coalesces to Start, satisfying from <= Start.
+        filter(new Meeting { StartsAt = Anchor.AddDays(2), EndsAt = null }).ShouldBeTrue();
+        // Open-ended starting before window — dropped (Start <= to is true but from <= (End ?? Start) = from <= Start fails).
+        filter(new Meeting { StartsAt = Anchor.AddDays(-1), EndsAt = null }).ShouldBeFalse();
+        // Open-ended starting after window — Start <= to fails, so dropped.
+        filter(new Meeting { StartsAt = Anchor.AddDays(10), EndsAt = null }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void BuildOverlapFilter_throws_when_StartField_does_not_exist_on_TEntity()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = "DoesNotExist",
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CalendarRangeFilterBuilder.BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor)));
+
+        ex.Message.ShouldContain("DoesNotExist");
+        ex.Message.ShouldContain("StartField");
+    }
+
+    [Fact]
+    public void BuildOverlapFilter_throws_when_EndField_does_not_exist_on_TEntity()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = nameof(Meeting.StartsAt),
+            EndPropertyName = "DoesNotExist",
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            CalendarRangeFilterBuilder.BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor)));
+
+        ex.Message.ShouldContain("DoesNotExist");
+        ex.Message.ShouldContain("EndField");
+    }
+
+    [Fact]
+    public void Compiled_filter_supports_LINQ_to_objects_pipeline()
+    {
+        CalendarLayoutDescriptor layout = new()
+        {
+            Kind = EntityListLayoutKind.Calendar,
+            StartPropertyName = nameof(Meeting.StartsAt),
+            EndPropertyName = nameof(Meeting.EndsAt),
+        };
+
+        IReadOnlyList<Meeting> meetings =
+        [
+            new Meeting { Id = Guid.NewGuid(), StartsAt = Anchor.AddDays(-5), EndsAt = Anchor.AddDays(-4) }, // before
+            new Meeting { Id = Guid.NewGuid(), StartsAt = Anchor.AddDays(1), EndsAt = Anchor.AddDays(2) },   // inside
+            new Meeting { Id = Guid.NewGuid(), StartsAt = Anchor.AddDays(10), EndsAt = Anchor.AddDays(11) }, // after
+        ];
+
+        Func<Meeting, bool> filter = CalendarRangeFilterBuilder
+            .BuildOverlapFilter<Meeting>(layout, new CalendarFilterRange(Anchor, Anchor.AddDays(7)))
+            .Compile();
+
+        meetings.Where(filter).Count().ShouldBe(1);
+    }
+
+    private sealed class PointInTimeEvent
+    {
+        public DateTimeOffset OccurredAt { get; set; }
+    }
+
+    private sealed class Meeting
+    {
+        public Guid Id { get; set; }
+        public DateTimeOffset StartsAt { get; set; }
+        public DateTimeOffset? EndsAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Ships `CalendarRangeFilterBuilder.BuildOverlapFilter<TEntity>(layout, range)` — the pure expression-composition piece of feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681) (Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509)). Closes story [#1689](https://github.com/granit-fx/granit-dotnet/issues/1689).

The actual EF Core executor is split out into follow-up story [#1700](https://github.com/granit-fx/granit-dotnet/issues/1700) — it needs a brand-new package (`Granit.Entities.EntityFrameworkCore`) plus a sample entity to integration-test against, both of which deserve their own focused PR.

## What ships

- [`CalendarRangeFilterBuilder.BuildOverlapFilter<TEntity>(...)`](src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs) — returns a typed `Expression<Func<TEntity, bool>>` keyed on the layout's `StartField` / `EndField` property names (no hard-coded property names).
- [`CalendarFilterRange(From, To)`](src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs) — local time-window record that keeps the builder independent of the `.Endpoints` package's `CalendarRange`.

### Overlap semantics — standard interval-overlap formula

- **Events with `EndField`**: `Start <= to AND from <= (End ?? Start)`
  - Coalesce form translates to SQL `COALESCE(End, Start)` without a `CASE` branch, so any provider supporting `Where()` over `IQueryable<T>` gets consistent SQL.
- **Point-in-time events** (no `EndField`, or `End` is null): `from <= Start <= to`

### Additive guarantee

The expression can only **narrow** the result set, never widen it. It's intended to compose on top of any entity-baked filter (declared on the underlying `QueryDefinition`) without bypassing the projection — same additive-only contract as ADR-048 §4 for cross-workspace presets.

## Placement

Lives in `Granit.Entities.Abstractions` (no DI, no IO, pure expression code) so any future runner — in-process, EF Core, in-memory test fixture — consumes the same composition logic.

## Test plan

- [x] 6 unit tests covering:
  - Point-in-time events inside / outside / on the boundary
  - Finite events spanning / straddling start / straddling end / inside / outside the window
  - Boundary touches at `from` and `to`
  - Open-ended events (End is null) — kept iff Start is inside the window
  - Defensive errors when the layout names a property missing on `TEntity` (StartField / EndField slot mentioned in the message)
  - LINQ-to-objects pipeline smoke test
- [x] Full `Granit.Entities.Abstractions.Tests` suite green: 64/64
- [x] `dotnet format` clean

## Out of scope (other stories)

- EF Core executor + `Granit.Entities.EntityFrameworkCore` package + Postgres integration test — story [#1700](https://github.com/granit-fx/granit-dotnet/issues/1700)
- Permission gate inherited from entity Read — story [#1690](https://github.com/granit-fx/granit-dotnet/issues/1690)
- FusionCache + ETag — story [#1691](https://github.com/granit-fx/granit-dotnet/issues/1691)