### PR TITLE
feat(entities-endpoints): permission gate on calendar range endpoint (Phase 1.5 #1690)

### DIFF
--- a/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
@@ -23,10 +23,13 @@ internal static class CalendarRangeEndpoint
             .WithDescription(
                 "Reads the entity's CalendarLayoutDescriptor (selected by the optional ?calendar= name when an entity exposes more than one) "
                 + "and returns the events whose Start/End falls inside [from, to]. The range is enforced server-side: a window wider than 366 days "
-                + "or with To < From is rejected with 400. Returns an empty list when the entity declares no calendar layout, no item matches, or "
-                + "the host has not yet wired a real ICalendarRangeService implementation. Permission filtering and FusionCache layer in via separate stories.")
+                + "or with To < From is rejected with 400. Permission gate inherited from the underlying entity's Read permission — same defense-in-depth "
+                + "as the manifest endpoint (no calendar-specific permission, rationale: the calendar exposes an aggregate of data the user could already "
+                + "see via the list endpoint). Returns an empty list when the entity declares no calendar layout, no item matches, or "
+                + "the host has not yet wired a real ICalendarRangeService implementation. FusionCache layers in via a separate story.")
             .Produces<IReadOnlyList<CalendarItemResponse>>()
             .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;
@@ -36,6 +39,7 @@ internal static class CalendarRangeEndpoint
         string name,
         [AsParameters] CalendarRangeRequest request,
         [FromServices] IEntityDefinitionRegistry registry,
+        [FromServices] EntityPermissionResolver permissionResolver,
         [FromServices] ICalendarRangeService calendarRangeService,
         CancellationToken cancellationToken)
     {
@@ -48,6 +52,19 @@ internal static class CalendarRangeEndpoint
         }
 
         EntityDefinitionDescriptor descriptor = definitionRef.Descriptor;
+        EntityPermissionSnapshot snapshot = await permissionResolver
+            .ResolveAsync(descriptor.PermissionGroup, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!snapshot.IsVisible)
+        {
+            // 403 — defense-in-depth: same shape as the manifest endpoint
+            // (a denied read leaks no calendar data, not even row counts).
+            return TypedResults.Problem(
+                detail: $"You do not have permission to read entity '{name}'.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         CalendarLayoutDescriptor? layout = SelectCalendarLayout(descriptor, request.Calendar);
 
         if (layout is null)


### PR DESCRIPTION
## Summary

Adds the entity-Read permission gate to `GET /api/entities/{name}/calendar`, mirroring the manifest endpoint's defense-in-depth model. Closes story [#1690](https://github.com/granit-fx/granit-dotnet/issues/1690) (Phase 1.5 epic [#1509](https://github.com/granit-fx/granit-dotnet/issues/1509), feature [#1681](https://github.com/granit-fx/granit-dotnet/issues/1681)).

## What changes

[`CalendarRangeEndpoint.HandleAsync`](src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs):

- Inject `EntityPermissionResolver` via DI
- Resolve `EntityPermissionSnapshot` from the entity's `PermissionGroup` immediately after the registry lookup
- Return `403 Forbidden` with the same shape as the manifest endpoint when `!snapshot.IsVisible` — no calendar data leaks for entities the caller cannot read, not even row counts via empty-result heuristics

OpenAPI metadata updated: `ProducesProblem(403)` added; `WithDescription` mentions the permission inheritance rule.

## Why permission inheritance, not a calendar-specific permission

The calendar exposes an aggregate of data the user could already see via the list endpoint. Granting a separate calendar-specific permission would add a confusing layer without security value — same rationale as the manifest endpoint and the OData entity-set permissions.

## Out of scope (deferred)

Per-property item-level filtering — drop `Title` / `Color` from the response when the user lacks the matching field permission. The calendar layout descriptor doesn't carry per-property `RequiresPermission` today, and the symmetric kanban primitive has the same gap. Adding it deserves its own primitive design story across both layouts.

## Test plan

- [x] Full `Granit.Entities.Endpoints.Tests` suite green: 64/64
- [x] `dotnet format` clean
- [x] Handler-level integration tests for the gate land alongside [#1700](https://github.com/granit-fx/granit-dotnet/issues/1700) (EF executor + Postgres integration tests) — no existing in-process TestServer harness in this package, and the manifest endpoint's gate has the same coverage gap