### PR TITLE
feat(entities): SubtitleProperty for entity references

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19142,7 +19142,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -19,6 +19,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     private string? _icon;
     private string? _permissionGroup;
     private string? _displayProperty;
+    private string? _subtitleProperty;
 
     private Type? _queryDefinitionType;
     private Type? _exportDefinitionType;
@@ -76,6 +77,29 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         }
 
         _displayProperty = property.Name;
+        return this;
+    }
+
+    /// <summary>
+    /// Names a secondary property displayed alongside <see cref="DisplayProperty{TProperty}"/>
+    /// to give context in references and list rows (lambda must be a direct property
+    /// access). Typical pattern: <c>DisplayProperty</c> = <c>"Number"</c>, <c>SubtitleProperty</c> =
+    /// <c>"PartyName"</c>, frontend renders "INV-001 — Acme Corp". Optional; absent
+    /// means the renderer shows only the display label.
+    /// </summary>
+    public EntityDefinitionBuilder<TEntity> SubtitleProperty<TProperty>(Expression<Func<TEntity, TProperty>> propertySelector)
+    {
+        ArgumentNullException.ThrowIfNull(propertySelector);
+
+        if (propertySelector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "SubtitleProperty selector must be a direct property access expression (e.g. x => x.CustomerName).",
+                nameof(propertySelector));
+        }
+
+        _subtitleProperty = property.Name;
         return this;
     }
 
@@ -295,6 +319,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
             Icon = _icon,
             PermissionGroup = _permissionGroup,
             DisplayProperty = _displayProperty,
+            SubtitleProperty = _subtitleProperty,
             QueryDefinitionType = _queryDefinitionType,
             ExportDefinitionType = _exportDefinitionType,
             MetricDefinitionTypes = _metricDefinitionTypes.AsReadOnly(),

--- a/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
@@ -49,6 +49,14 @@ public sealed record EntityDefinitionDescriptor
     public string? DisplayProperty { get; init; }
 
     /// <summary>
+    /// Property name (PascalCase) shown alongside <see cref="DisplayProperty"/> in
+    /// references and list rows to provide context (e.g. <c>"PartyName"</c> on an
+    /// Invoice → renderer composes "INV-001 — Acme Corp"). Optional; when absent the
+    /// renderer shows only the display label.
+    /// </summary>
+    public string? SubtitleProperty { get; init; }
+
+    /// <summary>
     /// CLR type of the referenced <c>QueryDefinition&lt;TEntity&gt;</c>, or <see langword="null"/>
     /// when no list collection is exposed.
     /// </summary>

--- a/src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs
@@ -7,10 +7,12 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="Icon">Icon from the standard catalog, or <see langword="null"/>.</param>
 /// <param name="PermissionGroup">Permission-group prefix (e.g. <c>"Parties.Parties"</c>).</param>
 /// <param name="DisplayProperty">Property used to label references (e.g. <c>"Number"</c>), or <see langword="null"/>.</param>
+/// <param name="SubtitleProperty">Optional secondary property displayed alongside <paramref name="DisplayProperty"/> for context (e.g. <c>"PartyName"</c> on an Invoice → renderer shows "INV-001 — Acme Corp"). <see langword="null"/> when the entity declares no subtitle.</param>
 public sealed record EntityIdentitySection(
     string Name,
     string EntityClrType,
     string? DisplayKey,
     string? Icon,
     string? PermissionGroup,
-    string? DisplayProperty);
+    string? DisplayProperty,
+    string? SubtitleProperty);

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -151,7 +151,8 @@ internal static class EntityManifestComposer
             d.DisplayKey,
             d.Icon,
             d.PermissionGroup,
-            d.DisplayProperty);
+            d.DisplayProperty,
+            d.SubtitleProperty);
 
     private static EntityPermissionsSection ComposePermissions(EntityPermissionSnapshot s) =>
         new(s.CanRead, s.CanCreate, s.CanUpdate, s.CanDelete, s.CanManage, s.CanExecute);

--- a/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
+++ b/src/Granit.Invoicing/Entities/InvoiceEntityDefinition.cs
@@ -26,6 +26,7 @@ public sealed class InvoiceEntityDefinition : EntityDefinition<Invoice>
             .Icon("file-text")
             .PermissionGroup("Invoicing.Invoices")
             .DisplayProperty(i => i.InvoiceNumber)
+            .SubtitleProperty(i => i.Status)
             .Query<InvoiceQueryDefinition>()
             .Export<InvoiceExportDefinition>()
             .Metric<UnpaidInvoiceCountMetricDefinition>()

--- a/src/Granit.Parties/Entities/PartyEntityDefinition.cs
+++ b/src/Granit.Parties/Entities/PartyEntityDefinition.cs
@@ -42,6 +42,7 @@ public sealed class PartyEntityDefinition : EntityDefinition<Party>
             .Icon("users")
             .PermissionGroup("Parties.Parties")
             .DisplayProperty(p => p.Name)
+            .SubtitleProperty(p => p.Kind)
             .Query<PartyQueryDefinition>()
             .Export<PartyExportDefinition>()
             .Metric<PartyCountMetricDefinition>()

--- a/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
@@ -47,6 +47,29 @@ public sealed class EntityDefinitionTests
         d.Icon.ShouldBe("box");
         d.PermissionGroup.ShouldBe("Sample.SampleEntities");
         d.DisplayProperty.ShouldBe("Title");
+        d.SubtitleProperty.ShouldBe("Status");
+    }
+
+    [Fact]
+    public void SubtitleProperty_DefaultsToNull_WhenNotConfigured()
+    {
+        // SubtitleProperty is optional — entities with only DisplayProperty
+        // surface no subtitle, and the renderer falls back to a single label.
+        EntityDefinitionDescriptor d = new MinimalEntityDefinition().Descriptor;
+
+        d.DisplayProperty.ShouldBe("Title");
+        d.SubtitleProperty.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SubtitleProperty_RejectsNonDirectPropertyAccess()
+    {
+        // Mirror of DisplayProperty's contract: only direct property access
+        // expressions are accepted (no method calls, no compound expressions).
+        EntityDefinitionBuilder<SampleEntity> builder = new();
+
+        Should.Throw<ArgumentException>(() =>
+            builder.SubtitleProperty(x => x.Title.ToUpperInvariant()));
     }
 
     [Fact]
@@ -182,7 +205,8 @@ public sealed class EntityDefinitionTests
             b.DisplayKey("Entity:SampleEntity")
              .Icon("box")
              .PermissionGroup("Sample.SampleEntities")
-             .DisplayProperty(s => s.Title);
+             .DisplayProperty(s => s.Title)
+             .SubtitleProperty(s => s.Status);
 
             b.Query<SampleQueryDefinition>();
             b.Export<SampleExportDefinition>();
@@ -211,6 +235,14 @@ public sealed class EntityDefinitionTests
                 .SectionsFromForm()
                 .SidePanel.Audit().Timeline());
         }
+    }
+
+    private sealed class MinimalEntityDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.Minimal";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b) =>
+            b.DisplayProperty(s => s.Title);
     }
 
     private sealed class DuplicateFormDefinition : EntityDefinition<SampleEntity>


### PR DESCRIPTION
## Summary

Adds `SubtitleProperty` to `EntityDefinition` so the manifest payload exposes a secondary label alongside `DisplayProperty`. granit-front flagged the missing piece — the canonical pattern "INV-001 — Open" needs both the headline (`DisplayProperty`) and the subtitle (`SubtitleProperty`) to render.

## What ships

- `EntityDefinitionBuilder.SubtitleProperty<TProperty>(Expression<...>)` — mirror of `DisplayProperty`. Direct property-access selector required.
- `EntityDefinitionDescriptor.SubtitleProperty: string?` — null when not configured (renderer falls back to display label only).
- `EntityIdentitySection.SubtitleProperty` on the manifest payload.
- Cobaye examples: `PartyEntityDefinition` uses `Kind` as subtitle, `InvoiceEntityDefinition` uses `Status`.

## Note for granit-front (asked alongside this question)

`field.format` stays out of scope per ADR-041 — `Widget` + `Config` is the canonical shape on the .NET side (e.g. `widget: "money", config: { currencyCode: "EUR" }`). The granit-front `format` prop maps client-side to the matching widget id. No .NET change needed there.

## Tests

- `Builder_CapturesIdentityFields` — extended with `SubtitleProperty` assertion.
- `SubtitleProperty_DefaultsToNull_WhenNotConfigured` — locks the optional contract.
- `SubtitleProperty_RejectsNonDirectPropertyAccess` — same input-validation contract as `DisplayProperty`.

## Test plan

- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 16/16 pass (was 14, +2 new + 1 extension).
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 64/64 pass (positional record constructor change picked up by tests cleanly).
- [x] `dotnet format` clean on all touched projects.

## Known unrelated CI signal

`Granit.ArchitectureTests.ClassDesignTests.Public_types_should_not_reside_in_Internal_namespaces` is failing on develop (pre-existing) because PR #1699 introduced `ICalendarRangeService` and `CalendarRange` as public types in `Granit.Entities.Endpoints.Internal.*`. Not introduced by this PR; will surface on every PR until a separate fix lands (move out of `Internal/` or make them `internal`).
