### PR TITLE
refactor(entities): rename Widget → Component at the field level

### DIFF
--- a/docs-site/src/content/docs/dotnet/architecture/adr/040-three-tier-metadata-architecture.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/040-three-tier-metadata-architecture.md
@@ -110,7 +110,7 @@ These are direct inversions of pain points documented in our research (see [`PR 
 
 ## Cross-references
 
-- [ADR-041](./041-widget-catalog) — Widget catalog and naming convention (the visual primitives Tier A declares; consumed by all three tiers' renderers).
+- [ADR-041](./041-component-catalog) — Component catalog and naming convention (the visual primitives Tier A declares; consumed by all three tiers' renderers).
 - [ADR-042](./042-view-catalog) — View catalog (List / Kanban / Calendar / Gallery / …) for collections, declared at Tier A; user views (Tier-A-style `EntityView` deltas) layer on top.
 - [ADR-047](./047-entity-view) — `EntityView` supersedes `Granit.QueryEngine.SavedViews`; Personal / Shared / Tenant promotion model is a clean Layer 1.5 (per-user runtime delta) that sits between Tier A and Tier B without compromising the Golden Rule.
 - [ADR-045](./045-contributor-pattern) — Inversion-of-control contributors; how cross-module modules graft onto a Tier A entity without coupling.

--- a/docs-site/src/content/docs/dotnet/architecture/adr/041-component-catalog.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/041-component-catalog.md
@@ -1,17 +1,19 @@
 ---
-title: "ADR-041: Widget catalog and naming convention"
-description: "Granit ships a closed catalog of standard widget names that the manifest exposes for form fields and detail panels (text, money, date, lookup, file, textarea, select, …). The backend declares names; the front interprets them. App-custom widgets are namespaced as `custom:<app-prefix>-<name>` to avoid collisions and signal to the renderer that no built-in implementation exists."
+title: "ADR-041: Field component catalog and naming convention"
+description: "Granit ships a closed catalog of standard component names that the manifest exposes for form fields and detail panels (text, money, date, lookup, file, textarea, select, …). The backend declares names; the front interprets them. App-custom components are namespaced as `custom:<app-prefix>-<name>` to avoid collisions and signal to the renderer that no built-in implementation exists."
 sidebar:
   order: 41
-  label: "041 - Widget Catalog"
+  label: "041 - Component Catalog"
 ---
 
-> **Date:** 2026-04-30
+> **Date:** 2026-04-30 (component rename: 2026-05-01)
 > **Authors:** Jean-Francois Meyers
 > **Scope:** granit-dotnet (`Granit.Entities` form / detail builders); granit-front (`@granit/entities-react` renderer)
 > **Epic:** [#1506](https://github.com/granit-fx/granit-dotnet/issues/1506) — Refonte UI Hybride
-> **Story:** [#1521](https://github.com/granit-fx/granit-dotnet/issues/1521) — ADR-041 Widget catalog
+> **Story:** [#1521](https://github.com/granit-fx/granit-dotnet/issues/1521) — ADR-041 component catalog
 > **Status:** Accepted
+
+**Naming note (2026-05-01).** The original ADR called these "widgets". Renamed to "components" at the field level to avoid collision with dashboard panels (KPI / Chart / Table / …) which keep the "Widget" naming because they are page-level units. Field-level renderers are small UI controls bound to a single property and "Component" matches the React mental model the front consumes.
 
 ## Context
 
@@ -19,16 +21,16 @@ sidebar:
 
 Two anti-patterns to avoid:
 
-- **Frappe** ships ~30 `fieldtype` strings (`Data`, `Currency`, `Link`, `Table`, `Long Text`, …) baked into the platform. Adding a new fieldtype requires patching the framework. Custom apps that need novel widgets either monkey-patch the JS bundle or fall back to `Code` fields with hand-rolled scripts — both routes broken.
-- **Odoo** uses XML `widget="..."` attributes that map to JS components in a registry, but the registry is open and untyped: any string works at write time, only fails at render time. Misspellings silently render the default widget; tenant customization through Studio adds new widget references that may not exist on every install.
+- **Frappe** ships ~30 `fieldtype` strings (`Data`, `Currency`, `Link`, `Table`, `Long Text`, …) baked into the platform. Adding a new fieldtype requires patching the framework. Custom apps that need novel renderers either monkey-patch the JS bundle or fall back to `Code` fields with hand-rolled scripts — both routes broken.
+- **Odoo** uses XML `widget="..."` attributes that map to JS components in a registry, but the registry is open and untyped: any string works at write time, only fails at render time. Misspellings silently render the default component; tenant customization through Studio adds new component references that may not exist on every install.
 
-Granit needs the closed-set ergonomics of Frappe (predictable, type-safe, testable) **and** an open extension point for app-specific widgets — without inviting the runtime-script Pandora's box.
+Granit needs the closed-set ergonomics of Frappe (predictable, type-safe, testable) **and** an open extension point for app-specific components — without inviting the runtime-script Pandora's box.
 
 ## Decision
 
-### 1. Standard widget catalog (closed set, framework-owned)
+### 1. Standard component catalog (closed set, framework-owned)
 
-The framework ships a fixed catalog of **standard widget names** that every Granit React renderer is expected to support out of the box. The backend declares a name; the front maps it to a concrete component. Both sides own this catalog as a contract.
+The framework ships a fixed catalog of **standard component names** that every Granit React renderer is expected to support out of the box. The backend declares a name; the front maps it to a concrete component. Both sides own this catalog as a contract.
 
 | Name | Semantics | Rendered as | Default config |
 | ---- | --------- | ----------- | -------------- |
@@ -68,9 +70,9 @@ The framework ships a fixed catalog of **standard widget names** that every Gran
 
 This is the **v1 catalog**. Adding a new standard name requires an ADR amendment and coordinated change in `@granit/entities-react`. Removing a name is a breaking change.
 
-### 2. Custom widget namespacing — `custom:<app-prefix>-<name>`
+### 2. Custom component namespacing — `custom:<app-prefix>-<name>`
 
-When an app needs a widget that isn't in the standard catalog, the backend declares `custom:<app-prefix>-<name>` and the front-end registers a matching component in its `customWidgetRegistry`. Examples:
+When an app needs a component that isn't in the standard catalog, the backend declares `custom:<app-prefix>-<name>` and the front-end registers a matching component in its `customComponentRegistry`. Examples:
 
 - `custom:invoicing-line-editor` (the showcase app's bespoke invoice-line grid)
 - `custom:crm-opportunity-pipeline` (a Kanban-of-Kanbans for sales)
@@ -81,32 +83,32 @@ When an app needs a widget that isn't in the standard catalog, the backend decla
 - The `custom:` prefix is mandatory. Any non-prefixed name not in the standard catalog is a hard error in `Granit.Entities.Endpoints` (rejected at boot via the integrity check from story #1541).
 - The `<app-prefix>` segment must match `^[a-z][a-z0-9]*$` and identify the owning module / app (avoid collisions across customers).
 - The `<name>` segment must match `^[a-z][a-z0-9-]*$` (kebab-case, no underscores).
-- The frontend `customWidgetRegistry` is a **typed map** in TypeScript — missing-key access is a compile-time error in the showcase app, not a runtime fallthrough.
-- Manifest payload includes `widget: "custom:..."` exactly as-declared; the front looks up the registry, falls back to a deliberately ugly placeholder + console error if missing (so the gap is loud in dev and CI screenshots).
+- The frontend `customComponentRegistry` is a **typed map** in TypeScript — missing-key access is a compile-time error in the showcase app, not a runtime fallthrough.
+- Manifest payload includes `component: "custom:..."` exactly as-declared; the front looks up the registry, falls back to a deliberately ugly placeholder + console error if missing (so the gap is loud in dev and CI screenshots).
 
-### 3. Widget config — typed via JSON Schema, optional per widget
+### 3. Component config — typed via JSON Schema, optional per component
 
-A widget can carry a config payload alongside its name:
+A component can carry a config payload alongside its name:
 
 ```json
 {
   "field": "amount",
-  "widget": "money",
+  "component": "money",
   "config": { "currencyCode": "EUR", "precision": 2 }
 }
 ```
 
-Each standard widget has a documented config schema (lives next to the widget in `@granit/entities-react`). The C# fluent builder exposes typed wrappers — `f.Field(x => x.Amount).Money("EUR", precision: 2)` — so the developer never types a JSON blob by hand.
+Each standard component has a documented config schema (lives next to the component in `@granit/entities-react`). The C# fluent builder exposes typed wrappers — `f.Field(x => x.Amount).Money("EUR", precision: 2)` — so the developer never types a JSON blob by hand.
 
-For `custom:` widgets, the backend may pass any opaque JSON object; the front's typed registry validates it.
+For `custom:` components, the backend may pass any opaque JSON object; the front's typed registry validates it.
 
-### 4. Validation surfaces in the schema, not the widget config
+### 4. Validation surfaces in the schema, not the component config
 
-Per [ADR-040](./040-three-tier-metadata-architecture)'s Golden Rule, validation lives in Tier A (FluentValidation). The widget config carries **rendering hints** only (currency code, precision, accepted file types); it never declares `required`, `maxLength`, `pattern`, or other constraints. Those flow through the `schema` facet of the manifest (JSON Schema generated by `IJsonSchemaWriter` per #1517 / PR #1599).
+Per [ADR-040](./040-three-tier-metadata-architecture)'s Golden Rule, validation lives in Tier A (FluentValidation). The component config carries **rendering hints** only (currency code, precision, accepted file types); it never declares `required`, `maxLength`, `pattern`, or other constraints. Those flow through the `schema` facet of the manifest (JSON Schema generated by `IJsonSchemaWriter` per #1517 / PR #1599).
 
 This split keeps the contract clean:
 
-- The widget tells the front *how to ask*.
+- The component tells the front *how to ask*.
 - The schema tells the front (and the back) *what to accept*.
 
 Both are sourced from the same `EntityDefinition`; the manifest emits them in parallel sections.
@@ -116,24 +118,24 @@ Both are sourced from the same `EntityDefinition`; the manifest emits them in pa
 ### Positive
 
 - The standard catalog is **35 names long** and covers the vast majority of admin-CRUD needs (form fields, detail cells, kanban cards). Most apps will never need `custom:`.
-- Adding a new standard widget is a deliberate, reviewed decision — caught at ADR review, never accidentally introduced via "let me just hardcode this string."
+- Adding a new standard component is a deliberate, reviewed decision — caught at ADR review, never accidentally introduced via "let me just hardcode this string."
 - The `custom:` namespace is a clean escape hatch with a hard prefix check; misspelling a standard name fails at boot, not at render time.
 - Backend and frontend can evolve the catalog in lockstep via shared schema files (a future codegen story can emit TypeScript types from the C# enum).
 
 ### Negative / accepted trade-offs
 
 - The catalog is opinionated: there's no `WYSIWYG-with-track-changes`, no `signature-with-handwriting-recognition`, no `voice-input`. Apps that need those use `custom:` — which means writing a React component, not just changing config.
-- Tenant admins (Tier B Layer 1, ADR-040) cannot change a field's widget. They reorder, regroup, hide, but the widget choice is locked at compile time. Right boundary for ISO 27001 ("the bookkeeper sees a money input, not a code editor"); restrictive for unstructured personal-productivity scenarios (which Granit doesn't target — see ADR-040).
-- Frontend renderer must be implemented for every standard name in v1 before the showcase ships Phase 1. The cobaye selection (Party + Invoice — see #1530) covers ~14 of the 35 standard widgets in real use; the remaining ~21 ship with placeholder renderers and integration tests in `granit-front` Phase 1.
+- Tenant admins (Tier B Layer 1, ADR-040) cannot change a field's component. They reorder, regroup, hide, but the component choice is locked at compile time. Right boundary for ISO 27001 ("the bookkeeper sees a money input, not a code editor"); restrictive for unstructured personal-productivity scenarios (which Granit doesn't target — see ADR-040).
+- Frontend renderer must be implemented for every standard name in v1 before the showcase ships Phase 1. The cobaye selection (Party + Invoice — see #1530) covers ~14 of the 35 standard components in real use; the remaining ~21 ship with placeholder renderers and integration tests in `granit-front` Phase 1.
 
 ## Cross-references
 
-- [ADR-040](./040-three-tier-metadata-architecture) — Three-tier metadata architecture. Establishes that widget choice is a Tier A concern (compiled), not Tier B (runtime customization).
+- [ADR-040](./040-three-tier-metadata-architecture) — Three-tier metadata architecture. Establishes that component choice is a Tier A concern (compiled), not Tier B (runtime customization).
 - [ADR-042](./042-view-catalog) — View catalog. Same closed-set + namespaced-extension pattern, applied to collection display strategies (List, Kanban, Calendar, …).
-- [ADR-047](./047-entity-view) — `EntityView`. User-saved views may not change a collection's `kind`, mirroring the rule that user-saved field state may not change a widget.
+- [ADR-047](./047-entity-view) — `EntityView`. User-saved views may not change a collection's `kind`, mirroring the rule that user-saved field state may not change a component.
 
 ## References
 
 - Frappe DocField fieldtypes — research compiled in PR #1599 conversation. Closed set, no extension point ⇒ tenant apps work around with `Code` fields and JS overrides.
 - Odoo widget registry — open string-based, no compile-time check. Misspellings fall back to the default widget silently.
-- Notion property types — fully closed (~25 types), no extension. Same ergonomic dividend as Granit's standard catalog; no story for app-custom widgets — Notion users live within the catalog.
+- Notion property types — fully closed (~25 types), no extension. Same ergonomic dividend as Granit's standard catalog; no story for app-custom components — Notion users live within the catalog.

--- a/docs-site/src/content/docs/dotnet/architecture/adr/042-view-catalog.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/042-view-catalog.md
@@ -22,7 +22,7 @@ The Notion-style mental model locked during planning splits a collection of reco
 
 Frappe ships ~10 view types (List, Report, Kanban, Calendar, Gantt, Image, Tree, Map, Dashboard) with config conventions per type but no formal catalog or schema. The result: each app reinvents the binding (Calendar needs a `start_date`; Kanban needs a `Select` field; Tree needs `is_tree: 1`); errors surface at user click time, not at developer boot time.
 
-Granit needs the same multi-view dividend with the type-safety it gets from compile-time enums and JSON Schema validation. ADR-041 (widget catalog) established the pattern for fields; this ADR extends it to view kinds.
+Granit needs the same multi-view dividend with the type-safety it gets from compile-time enums and JSON Schema validation. ADR-041 (component catalog) established the pattern for fields; this ADR extends it to view kinds.
 
 ## Decision
 
@@ -50,7 +50,7 @@ This is the **v1 catalog**. Adding a new kind requires an ADR amendment, a rende
 
 ### 2. Custom view-kind namespacing — `custom:<app-prefix>-<name>`
 
-When an app needs a view that isn't in the standard catalog (e.g., a sales pipeline with custom drag-and-drop semantics, an org chart, a flow diagram), the backend declares `custom:<app-prefix>-<name>` and the front-end registers a matching renderer in its `customViewRegistry`. Same rules as the widget catalog (ADR-041 §2):
+When an app needs a view that isn't in the standard catalog (e.g., a sales pipeline with custom drag-and-drop semantics, an org chart, a flow diagram), the backend declares `custom:<app-prefix>-<name>` and the front-end registers a matching renderer in its `customViewRegistry`. Same rules as the component catalog (ADR-041 §2):
 
 - `custom:` prefix mandatory; bare unknown names rejected at boot via the integrity check.
 - `<app-prefix>` matches `^[a-z][a-z0-9]*$`, identifies the owning module / app.
@@ -127,7 +127,7 @@ This rule has two consequences:
 ## Cross-references
 
 - [ADR-040](./040-three-tier-metadata-architecture) — Three-tier metadata. The kind catalog is Tier A (compiled); user-saved views (`EntityView`) are an additive layer that cannot mutate the kind.
-- [ADR-041](./041-widget-catalog) — Widget catalog. Same closed-set + `custom:<prefix>-<name>` namespace pattern, applied to field renderers.
+- [ADR-041](./041-component-catalog) — Component catalog. Same closed-set + `custom:<prefix>-<name>` namespace pattern, applied to field renderers.
 - [ADR-047](./047-entity-view) — `EntityView` supersedes `Granit.QueryEngine.SavedViews`. Documents the immutable `basedOn` rule referenced in §5 above.
 
 ## References

--- a/docs-site/src/content/docs/dotnet/architecture/adr/048-cross-module-entity-relations.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/048-cross-module-entity-relations.md
@@ -82,7 +82,7 @@ services.AddEntityRelationContribution<InvoicesOnPartyRelationContribution>();
 | `Tab` | Embedded grid as a tab inside the detail (intra-module collections) | Owned child collections that belong to the parent's editing context (InvoiceLines, Addresses) |
 | `InlineChips` | Chip row inline with the detail content | Many-to-many relations where the items are short labels (Tags, Categories) |
 
-This is the **v1 catalog** — same closed-set + `custom:` namespace pattern as [ADR-041](./041-widget-catalog) §2 / [ADR-042](./042-view-catalog) §2. Adding a new display mode requires an ADR amendment + renderer in `@granit/entities-react`.
+This is the **v1 catalog** — same closed-set + `custom:` namespace pattern as [ADR-041](./041-component-catalog) §2 / [ADR-042](./042-view-catalog) §2. Adding a new display mode requires an ADR amendment + renderer in `@granit/entities-react`.
 
 ### 3. Aggregates — closed primitive set
 
@@ -186,7 +186,7 @@ Plus the intra-module `Addresses` tab on `Party`. Five total relations on a sing
 
 - [ADR-040](./040-three-tier-metadata-architecture) — Three-tier metadata. Relations are Tier A (compiled); tenant admins cannot add cross-module relations from the UI.
 - [ADR-038](./038-analytics-dashboard-definition-vs-aggregate) — Aggregate computation reuses `MetricDefinition` machinery internally; no parallel pipeline.
-- [ADR-041](./041-widget-catalog) §2 — Same closed-set + `custom:` namespace pattern, applied to display modes.
+- [ADR-041](./041-component-catalog) §2 — Same closed-set + `custom:` namespace pattern, applied to display modes.
 - [ADR-045](./045-contributor-pattern) — IoC contributor pattern. `IEntityRelationContributor` is the third primitive served (after `IWorkspaceContributor` and `IActivityTypeProvider`).
 
 ## References

--- a/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
@@ -116,7 +116,7 @@ boot — name conflicts resolve in favour of the entity's intra-module declarati
 - [Entity View](/dotnet/data/entity-view/) — user-saved view configurations (filters, sort, columns, kanban overlays)
 - [Workspace](/dotnet/data/workspace/) — navigation tree that hosts entities
 - [ADR-040](/dotnet/architecture/adr/040-three-tier-metadata-architecture/) — three-tier metadata architecture
-- [ADR-041](/dotnet/architecture/adr/041-widget-catalog/) — widget catalog
+- [ADR-041](/dotnet/architecture/adr/041-component-catalog/) — component catalog
 - [ADR-042](/dotnet/architecture/adr/042-view-catalog/) — view catalog
 - [ADR-045](/dotnet/architecture/adr/045-contributor-pattern/) — IoC contributor pattern
 - [ADR-048](/dotnet/architecture/adr/048-cross-module-entity-relations/) — cross-module relations

--- a/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldBuilder.cs
@@ -16,7 +16,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
     private readonly string _propertyName;
     private readonly Type _clrType;
 
-    private string _widget;
+    private string _component;
     private Dictionary<string, object?>? _config;
     private string? _labelKey;
     private string? _helpKey;
@@ -39,19 +39,25 @@ public sealed class FieldBuilder<TEntity, TProperty>
 
         _propertyName = property.Name;
         _clrType = typeof(TProperty);
-        _widget = ChooseDefaultWidget(typeof(TProperty));
+        _component = ChooseDefaultComponent(typeof(TProperty));
         _order = order;
     }
 
     /// <summary>
-    /// Sets the widget (per ADR-041): a name from the standard catalog
+    /// Sets the field component (per ADR-041): a name from the standard catalog
     /// (<c>"text"</c>, <c>"money"</c>, …) or <c>"custom:&lt;app-prefix&gt;-&lt;name&gt;"</c>
-    /// for app-specific widgets. Optional config payload carried opaquely to the renderer.
+    /// for app-specific components. Optional config payload carried opaquely to the renderer.
     /// </summary>
-    public FieldBuilder<TEntity, TProperty> Widget(string widget, IReadOnlyDictionary<string, object?>? config = null)
+    /// <remarks>
+    /// "Component" replaces the previous "Widget" naming — dashboard panels keep "Widget"
+    /// (KPI / Chart / Table / …) because they are large, page-level units; field-level
+    /// renderers are small UI controls bound to a single property and "Component" matches
+    /// the React mental model the front consumes.
+    /// </remarks>
+    public FieldBuilder<TEntity, TProperty> Component(string component, IReadOnlyDictionary<string, object?>? config = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(widget);
-        _widget = widget;
+        ArgumentException.ThrowIfNullOrWhiteSpace(component);
+        _component = component;
         _config = config is null ? null : new Dictionary<string, object?>(config, StringComparer.Ordinal);
         return this;
     }
@@ -107,7 +113,7 @@ public sealed class FieldBuilder<TEntity, TProperty>
         {
             PropertyName = _propertyName,
             ClrType = _clrType,
-            Widget = _widget,
+            Component = _component,
             Config = _config,
             LabelKey = _labelKey,
             HelpKey = _helpKey,
@@ -118,10 +124,10 @@ public sealed class FieldBuilder<TEntity, TProperty>
         };
 
     /// <summary>
-    /// Picks a sensible default widget from the standard catalog (per ADR-041) based on the
-    /// property's CLR type. Apps override via <see cref="Widget(string, IReadOnlyDictionary{string, object?}?)"/>.
+    /// Picks a sensible default component from the standard catalog (per ADR-041) based on the
+    /// property's CLR type. Apps override via <see cref="Component(string, IReadOnlyDictionary{string, object?}?)"/>.
     /// </summary>
-    private static string ChooseDefaultWidget(Type clrType)
+    private static string ChooseDefaultComponent(Type clrType)
     {
         Type unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
 

--- a/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Forms/FieldDescriptor.cs
@@ -15,14 +15,16 @@ public sealed record FieldDescriptor
     public required Type ClrType { get; init; }
 
     /// <summary>
-    /// Widget name from the standard catalog (e.g. <c>"text"</c>, <c>"money"</c>) or
-    /// <c>"custom:&lt;app-prefix&gt;-&lt;name&gt;"</c> for app-specific widgets — see ADR-041.
+    /// Component name from the standard catalog (e.g. <c>"text"</c>, <c>"money"</c>) or
+    /// <c>"custom:&lt;app-prefix&gt;-&lt;name&gt;"</c> for app-specific components — see ADR-041.
+    /// "Component" replaces "Widget" at the field level; dashboard panels (KPI / Chart /
+    /// Table / …) keep the "Widget" naming because they are page-level units.
     /// </summary>
-    public required string Widget { get; init; }
+    public required string Component { get; init; }
 
     /// <summary>
-    /// Optional widget-specific configuration carried opaquely to the renderer
-    /// (e.g. <c>{ currencyCode: "EUR" }</c> for the <c>money</c> widget).
+    /// Optional component-specific configuration carried opaquely to the renderer
+    /// (e.g. <c>{ currencyCode: "EUR" }</c> for the <c>money</c> component).
     /// </summary>
     public IReadOnlyDictionary<string, object?>? Config { get; init; }
 

--- a/src/Granit.Entities.Abstractions/Relations/RelationAggregateDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Relations/RelationAggregateDescriptor.cs
@@ -9,7 +9,7 @@ namespace Granit.Entities.Relations;
 /// <param name="Kind">The aggregate kind.</param>
 /// <param name="PropertyName">PascalCase property name on the related entity, or <see langword="null"/> for <see cref="RelationAggregateKind.Count"/>.</param>
 /// <param name="LabelKey">i18n key for the user-facing label (e.g. <c>"Relation:Party.Invoices.Total"</c>).</param>
-/// <param name="Format">Optional formatter hint (e.g. <c>"currency"</c>, <c>"int"</c>) — opaque to the framework, mirrored from <see cref="Forms.FieldDescriptor.Widget"/> conventions.</param>
+/// <param name="Format">Optional formatter hint (e.g. <c>"currency"</c>, <c>"int"</c>) — opaque to the framework, mirrored from <see cref="Forms.FieldDescriptor.Component"/> conventions.</param>
 public sealed record RelationAggregateDescriptor(
     RelationAggregateKind Kind,
     string? PropertyName,

--- a/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
@@ -28,9 +28,9 @@ public sealed record EntityFormSectionManifest(
 
 /// <summary>One form field.</summary>
 /// <param name="PropertyName">PascalCase property name on the entity.</param>
-/// <param name="ClrTypeName">Short CLR type name — drives the renderer when <see cref="Widget"/> doesn't override it.</param>
-/// <param name="Widget">Widget identifier from the standard catalog or <c>custom:</c> namespace (ADR-041).</param>
-/// <param name="Config">Opaque widget-specific configuration, or <see langword="null"/>.</param>
+/// <param name="ClrTypeName">Short CLR type name — drives the renderer when <see cref="Component"/> doesn't override it.</param>
+/// <param name="Component">Component identifier from the standard catalog or <c>custom:</c> namespace (ADR-041). "Component" replaces the previous "Widget" naming at the field level; dashboard panels keep "Widget" for page-level units.</param>
+/// <param name="Config">Opaque component-specific configuration, or <see langword="null"/>.</param>
 /// <param name="LabelKey">i18n key for the field label.</param>
 /// <param name="HelpKey">i18n key for the help text under the field.</param>
 /// <param name="Order">Display order within the section.</param>
@@ -39,7 +39,7 @@ public sealed record EntityFormSectionManifest(
 public sealed record EntityFormFieldManifest(
     string PropertyName,
     string ClrTypeName,
-    string Widget,
+    string Component,
     IReadOnlyDictionary<string, object?>? Config,
     string? LabelKey,
     string? HelpKey,

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -249,7 +249,7 @@ internal static class EntityManifestComposer
             fields.Add(new EntityFormFieldManifest(
                 field.PropertyName,
                 field.ClrType.Name,
-                field.Widget,
+                field.Component,
                 field.Config,
                 field.LabelKey,
                 field.HelpKey,

--- a/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/EntityDefinitionTests.cs
@@ -99,25 +99,25 @@ public sealed class EntityDefinitionTests
     }
 
     [Fact]
-    public void FieldBuilder_ChoosesDefaultWidget_FromClrType()
+    public void FieldBuilder_ChoosesDefaultComponent_FromClrType()
     {
         EntityDefinitionDescriptor d = new SampleEntityDefinition().Descriptor;
 
         var fields = d.Forms[0].Sections.SelectMany(s => s.Fields).ToDictionary(f => f.PropertyName);
 
-        fields["Title"].Widget.ShouldBe("text");
-        fields["Active"].Widget.ShouldBe("boolean");
-        fields["IssuedAt"].Widget.ShouldBe("datetime");
-        // Amount is overridden to "money" in the fixture (covered by FieldBuilder_OverridesWidget_AndConfig).
+        fields["Title"].Component.ShouldBe("text");
+        fields["Active"].Component.ShouldBe("boolean");
+        fields["IssuedAt"].Component.ShouldBe("datetime");
+        // Amount is overridden to "money" in the fixture (covered by FieldBuilder_OverridesComponent_AndConfig).
     }
 
     [Fact]
-    public void FieldBuilder_OverridesWidget_AndConfig()
+    public void FieldBuilder_OverridesComponent_AndConfig()
     {
         EntityDefinitionDescriptor d = new SampleEntityDefinition().Descriptor;
         FieldDescriptor amount = d.Forms[0].Sections.SelectMany(s => s.Fields).First(f => f.PropertyName == "Amount");
 
-        amount.Widget.ShouldBe("money");
+        amount.Component.ShouldBe("money");
         amount.Config.ShouldNotBeNull();
         amount.Config!["currencyCode"].ShouldBe("EUR");
     }
@@ -219,7 +219,7 @@ public sealed class EntityDefinitionTests
                 .Section("general", s => s
                     .Field(x => x.Title)
                     .Field(x => x.Amount, fld => fld
-                        .Widget("money", new Dictionary<string, object?>(StringComparer.Ordinal) { ["currencyCode"] = "EUR" })
+                        .Component("money", new Dictionary<string, object?>(StringComparer.Ordinal) { ["currencyCode"] = "EUR" })
                         .RequiresPermission("Sample.SampleEntities.Manage"))
                     .Field(x => x.Active)
                     .Field(x => x.IssuedAt)

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -30,14 +30,14 @@ public sealed class EntityManifestComposerTests
                                 {
                                     PropertyName = "Name",
                                     ClrType = typeof(string),
-                                    Widget = "text",
+                                    Component = "text",
                                     Order = 0,
                                 },
                                 new FieldDescriptor
                                 {
                                     PropertyName = "Amount",
                                     ClrType = typeof(decimal),
-                                    Widget = "money",
+                                    Component = "money",
                                     Order = 1,
                                     RequiresPermission = "Invoicing.Invoices.Manage",
                                 },
@@ -79,7 +79,7 @@ public sealed class EntityManifestComposerTests
                                 {
                                     PropertyName = "Vault",
                                     ClrType = typeof(string),
-                                    Widget = "text",
+                                    Component = "text",
                                     Order = 0,
                                     RequiresPermission = "Secrets.Vault.Read",
                                 },
@@ -185,14 +185,14 @@ public sealed class EntityManifestComposerTests
                                     {
                                         PropertyName = "Line1",
                                         ClrType = typeof(string),
-                                        Widget = "text",
+                                        Component = "text",
                                         Order = 0,
                                     },
                                     new FieldDescriptor
                                     {
                                         PropertyName = "City",
                                         ClrType = typeof(string),
-                                        Widget = "text",
+                                        Component = "text",
                                         Order = 1,
                                     },
                                 ],
@@ -244,14 +244,14 @@ public sealed class EntityManifestComposerTests
                                     {
                                         PropertyName = "Line1",
                                         ClrType = typeof(string),
-                                        Widget = "text",
+                                        Component = "text",
                                         Order = 0,
                                     },
                                     new FieldDescriptor
                                     {
                                         PropertyName = "Country",
                                         ClrType = typeof(string),
-                                        Widget = "text",
+                                        Component = "text",
                                         Order = 1,
                                         RequiresPermission = "Sample.Manage",
                                     },
@@ -298,7 +298,7 @@ public sealed class EntityManifestComposerTests
                                     {
                                         PropertyName = "Vault",
                                         ClrType = typeof(string),
-                                        Widget = "text",
+                                        Component = "text",
                                         Order = 0,
                                         RequiresPermission = "Sample.Manage",
                                     },
@@ -359,7 +359,7 @@ public sealed class EntityManifestComposerTests
             {
                 TitleProperty = "Title",
                 Fields = [
-                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 },
+                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 },
                 ],
             },
             Columns = [
@@ -433,8 +433,8 @@ public sealed class EntityManifestComposerTests
             Card = new Granit.Entities.Layouts.KanbanCardDescriptor
             {
                 Fields = [
-                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 },
-                    new FieldDescriptor { PropertyName = "Salary", ClrType = typeof(decimal), Widget = "money", Order = 1, RequiresPermission = "Tasks.Sensitive.Read" },
+                    new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 },
+                    new FieldDescriptor { PropertyName = "Salary", ClrType = typeof(decimal), Component = "money", Order = 1, RequiresPermission = "Tasks.Sensitive.Read" },
                 ],
             },
             Columns = [],
@@ -607,7 +607,7 @@ public sealed class EntityManifestComposerTests
             GroupByClrType = typeof(SampleStatus),
             Card = new Granit.Entities.Layouts.KanbanCardDescriptor
             {
-                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 }],
             },
             Columns = [],
         };
@@ -658,7 +658,7 @@ public sealed class EntityManifestComposerTests
             GroupByClrType = typeof(SampleStatus),
             Card = new Granit.Entities.Layouts.KanbanCardDescriptor
             {
-                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 }],
             },
             Columns = [],
         };
@@ -701,7 +701,7 @@ public sealed class EntityManifestComposerTests
             GroupByClrType = typeof(SampleStatus),
             Card = new Granit.Entities.Layouts.KanbanCardDescriptor
             {
-                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 }],
             },
             Columns = [],
         };
@@ -750,7 +750,7 @@ public sealed class EntityManifestComposerTests
             GroupByClrType = typeof(SampleStatus),
             Card = new Granit.Entities.Layouts.KanbanCardDescriptor
             {
-                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Widget = "text", Order = 0 }],
+                Fields = [new FieldDescriptor { PropertyName = "Owner", ClrType = typeof(string), Component = "text", Order = 0 }],
             },
             Columns = [],
         };


### PR DESCRIPTION
## Summary

Field-level renderer API renamed from `Widget` to `Component` to align with React conventions and eliminate the semantic collision with dashboard widgets (KPI / Chart / Table / …) which stay at the page-level scale.

## Why

Two scales were sharing the same word :

- **Dashboard panel** = KPI counter, Chart, Table, Map widget. Big, page-level, autonomous unit. "Widget" fits.
- **Field-level renderer** = text input, money input, date picker. Small UI control bound to a single property. "Widget" sounded oversized.

granit-front consumes both. Naming both "Widget" forces every reference to disambiguate by context. "Component" at the field level is a tighter match for the React mental model and removes the friction.

## What ships

API renames (BREAKING — pre-1.0 per CLAUDE.md, no `[Obsolete]` graduation):

- `FieldBuilder<T>.Widget(...)` → `FieldBuilder<T>.Component(...)`.
- `FieldDescriptor.Widget` (required init) → `FieldDescriptor.Component`.
- `EntityFormFieldManifest.Widget` → `EntityFormFieldManifest.Component`. **JSON wire change**: payload key `"widget": "money"` becomes `"component": "money"`.
- Internal `ChooseDefaultWidget` → `ChooseDefaultComponent`.
- Test method names updated to mirror the API.

Dashboard `WidgetDefinition` (KPI / Chart / Table / Pivot / Markdown / Map) **untouched** — those keep the "Widget" name because they are page-level units.

Docs:

- ADR-041 file rename: `041-widget-catalog.md` → `041-component-catalog.md`. Title, sidebar label, body sweep.
- Naming-note paragraph added in ADR-041 frontmatter explaining the rename.
- Cross-references in ADR-040, ADR-042, ADR-048, and `dotnet/data/entity-definition.mdx` updated to the new URL.

## What does NOT change

- Dashboard widget API and types (`WidgetDefinition`, `KpiWidget`, `ChartWidget`, …) — no change.
- `RelationAggregateDescriptor.Format` — kept as-is, only the cross-reference comment updated.
- The standard catalog of names (`text`, `money`, `date`, `lookup`, …) — those are component IDs, not the term itself.

## Cross-repo impact

`granit-front` consumes the manifest `field.widget` payload key. After this PR, the wire payload becomes `field.component`. granit-front needs a coordinated rename PR (`customWidgetRegistry` → `customComponentRegistry`, `field.widget` → `field.component`). Out of scope for this repo.

## Test plan

- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 66/66 pass.
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 64/64 pass.
- [x] `dotnet test tests/Granit.Entities.Tests` — 16/16 pass.
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 206/207 pass; remaining `ICalendarRangeService` Internal-namespace failure is pre-existing on develop (PR #1699), not affected here.
- [x] Astro docs build — 460 pages, all internal links valid (ADR-041 URL change rolled across all referrers).
- [x] `dotnet format` clean on all touched projects.
