### PR TITLE
fix(entities-endpoints): move ICalendarRangeService out of Internal namespace

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19305,27 +19305,11 @@
     },
     {
       "name": "ICalendarRangeService",
-      "fqn": "Granit.Entities.Endpoints.Internal.ICalendarRangeService",
+      "fqn": "Granit.Entities.Endpoints.ICalendarRangeService",
       "kind": "interface",
       "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs",
+      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
       "line": 19,
-      "members": [
-        {
-          "name": "GetItemsAsync",
-          "kind": "method",
-          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
-          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
-        }
-      ]
-    },
-    {
-      "name": "struct",
-      "fqn": "Granit.Entities.Endpoints.Internal.struct",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Internal/ICalendarRangeService.cs",
-      "line": 34,
       "members": [
         {
           "name": "GetItemsAsync",
@@ -19368,6 +19352,15 @@
           "returnType": "TimeSpan RelationAggregatesCacheTtl { get; set; } = TimeSpan."
         }
       ]
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.Endpoints.struct",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
+      "line": 34,
+      "members": []
     },
     {
       "name": "EntityDefinition",

--- a/src/Granit.Entities.Endpoints/ICalendarRangeService.cs
+++ b/src/Granit.Entities.Endpoints/ICalendarRangeService.cs
@@ -1,7 +1,7 @@
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Layouts;
 
-namespace Granit.Entities.Endpoints.Internal;
+namespace Granit.Entities.Endpoints;
 
 /// <summary>
 /// Resolves calendar items for one entity within a time window. The default
@@ -32,18 +32,3 @@ public interface ICalendarRangeService
 
 /// <summary>Inclusive time window for the calendar query.</summary>
 public readonly record struct CalendarRange(DateTimeOffset From, DateTimeOffset To);
-
-/// <summary>
-/// No-op implementation registered by default. Returns an empty result —
-/// suitable for hosts that have not yet wired the EF Core executor or for
-/// modules that expose a calendar layout purely for the manifest.
-/// </summary>
-internal sealed class NullCalendarRangeService : ICalendarRangeService
-{
-    public Task<IReadOnlyList<CalendarItemResponse>> GetItemsAsync(
-        EntityDefinitionDescriptor entity,
-        CalendarLayoutDescriptor layout,
-        CalendarRange range,
-        CancellationToken cancellationToken) =>
-        Task.FromResult<IReadOnlyList<CalendarItemResponse>>([]);
-}

--- a/src/Granit.Entities.Endpoints/Internal/NullCalendarRangeService.cs
+++ b/src/Granit.Entities.Endpoints/Internal/NullCalendarRangeService.cs
@@ -1,0 +1,19 @@
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Layouts;
+
+namespace Granit.Entities.Endpoints.Internal;
+
+/// <summary>
+/// No-op implementation registered by default. Returns an empty result —
+/// suitable for hosts that have not yet wired the EF Core executor or for
+/// modules that expose a calendar layout purely for the manifest.
+/// </summary>
+internal sealed class NullCalendarRangeService : ICalendarRangeService
+{
+    public Task<IReadOnlyList<CalendarItemResponse>> GetItemsAsync(
+        EntityDefinitionDescriptor entity,
+        CalendarLayoutDescriptor layout,
+        CalendarRange range,
+        CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<CalendarItemResponse>>([]);
+}


### PR DESCRIPTION
## Summary

Unblocks the architecture-test shard on `develop` by moving the public `ICalendarRangeService` interface (and its `CalendarRange` companion record struct) out of `Granit.Entities.Endpoints.Internal.*` to the root namespace `Granit.Entities.Endpoints`.

## Why

PR #1700 introduced these public types nested under `Internal/`. The archi rule `ClassDesignTests.Public_types_should_not_reside_in_Internal_namespaces` flagged it. Every PR opened against develop since has surfaced this same failure (PRs #1703, #1704, the in-flight Phase 2 EntityDefinitions PR). It is unrelated to whatever those PRs change — pure pre-existing convention drift.

The public types must stay public because hosts implement `ICalendarRangeService` to wire their EF Core executor (per #1689). They just shouldn't be in `Internal/`.

## What changes

- Public types `ICalendarRangeService` + `CalendarRange` move to `src/Granit.Entities.Endpoints/ICalendarRangeService.cs` (root namespace).
- The internal default impl `NullCalendarRangeService` stays in `Internal/`, renamed to `Internal/NullCalendarRangeService.cs` to satisfy the file-name-matches-type-name archi rule.
- DI registration in `EntitiesEndpointRouteBuilderExtensions.cs` is unaffected — it already imports the `Internal` namespace for `NullCalendarRangeService`, and the public namespace `Granit.Entities.Endpoints` is reachable via the existing using.

## Test plan

- [x] `dotnet build src/Granit.Entities.Endpoints` — clean.
- [x] `dotnet test .github/shard-filters/architecture.slnf` — **207/207 pass** (was 206/207 with this exact failure).
- [x] No behavior change. No archi tests added.

## Impact on in-flight PRs

Once merged, all open PRs (and future ones) get a clean architecture shard. The Phase 2 EntityDefinitions PR I'm preparing right after this rebases on develop and ships green.
