### PR TITLE
feat(identity-ef): EF Core companion for the User aggregate (ADR-051 B-step 1.5)

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -270,6 +270,7 @@
         "tests/Granit.Encryption.BackgroundJobs.Tests",
         "tests/Granit.Encryption.Tests",
         "tests/Granit.Identity.Endpoints.Tests",
+        "tests/Granit.Identity.EntityFrameworkCore.Tests",
         "tests/Granit.Identity.Federated.Cognito.Tests",
         "tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests",
         "tests/Granit.Identity.Federated.EntityFrameworkCore.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1130,6 +1130,14 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Identity.EntityFrameworkCore",
+      "deps": [
+        "Granit.Identity",
+        "Granit.Persistence.EntityFrameworkCore"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Identity.Federated",
       "deps": [
         "Granit.Analytics",
@@ -23936,6 +23944,56 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "IdentityEntityFrameworkCoreServiceCollectionExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityEntityFrameworkCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitIdentityEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitIdentityEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureDbContext)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IdentityModelBuilderExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureGranitIdentityModule",
+          "kind": "method",
+          "signature": "ConfigureGranitIdentityModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityDbProperties",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityDbProperties",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "GranitIdentityEntityFrameworkCoreModule",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
     },
     {
       "name": "IdentityGroupMembershipChangedEto",

--- a/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
@@ -1,0 +1,51 @@
+using Granit.Identity.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Identity.EntityFrameworkCore.EntityConfigurations;
+
+/// <summary>
+/// EF Core configuration for the canonical <see cref="User"/> aggregate
+/// (ADR-051). Maps the profile-only columns to the
+/// <c>granit_identity_users</c> table; auth secrets and security counters
+/// live on the <c>LocalIdentity</c> sibling and are configured by
+/// <c>Granit.Identity.Local</c> in B-step 2.
+/// </summary>
+internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitIdentityDbProperties.DbTablePrefix + "users",
+            GranitIdentityDbProperties.DbSchema);
+
+        builder.HasKey(u => u.Id);
+
+        // TenantId index — multi-tenant queries lean on it for the
+        // ApplyGranitConventions filter (`WHERE TenantId = currentTenant.Id`).
+        builder.HasIndex(u => u.TenantId)
+            .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}users_tenant_id");
+
+        // Email index — point lookups via IUserLookupService (case-insensitive
+        // search lives at the consumer, but the index supports the underlying
+        // equality probe). Not unique — Odoo-style: multiple Users may legitimately
+        // share an email (corporate inbox shared across role accounts).
+        builder.HasIndex(u => u.Email)
+            .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}users_email");
+
+        builder.Property(u => u.DisplayName).HasMaxLength(256).IsRequired();
+        builder.Property(u => u.Email).HasMaxLength(320).IsRequired();    // RFC 5321 max local + @ + domain
+        builder.Property(u => u.FirstName).HasMaxLength(128);
+        builder.Property(u => u.LastName).HasMaxLength(128);
+        builder.Property(u => u.PhoneNumber).HasMaxLength(32);            // E.164 max
+        builder.Property(u => u.PreferredLocale).HasMaxLength(20);        // BCP-47 worst case
+        builder.Property(u => u.Timezone).HasMaxLength(64);               // IANA tz worst case
+        builder.Property(u => u.IsEnabled).IsRequired();
+
+        // Audit columns inherited from AuditedAggregateRoot — already configured
+        // by ApplyGranitConventions (CreatedAt, CreatedBy, ModifiedAt, ModifiedBy
+        // dimensions, plus IConcurrencyAware token). Nothing to declare here.
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Granit.Identity.EntityFrameworkCore.Internal;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Granit.Identity.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Extension methods to register the Granit Identity EF Core services.
+/// </summary>
+public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="IdentityDbContext"/> + the EF Core
+    /// implementation of <see cref="IUserDirectoryQueryableSource"/>.
+    /// Hosts call this from their <c>Program.cs</c> alongside the other
+    /// <c>AddGranit*EntityFrameworkCore</c> companions; the
+    /// <paramref name="configureDbContext"/> callback supplies the
+    /// connection string and provider (Npgsql in production, SQLite for
+    /// in-memory tests).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureDbContext">Configures <see cref="DbContextOptionsBuilder"/> (connection string + provider).</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitIdentityEntityFrameworkCore(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> configureDbContext)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureDbContext);
+
+        services.AddGranitDbContext<IdentityDbContext>(configureDbContext);
+
+        services.TryAddScoped<IUserDirectoryQueryableSource, EfUserDirectoryQueryableSource>();
+
+        return services;
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityModelBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using Granit.Identity.EntityFrameworkCore.EntityConfigurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including the Granit Identity
+/// entity configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class IdentityModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Identity module
+    /// (currently the <see cref="Granit.Identity.Domain.User"/> aggregate
+    /// configured in <see cref="UserConfiguration"/>).
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureGranitIdentityModule(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        modelBuilder.ApplyConfiguration(new UserConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Granit.Identity.EntityFrameworkCore.csproj
+++ b/src/Granit.Identity.EntityFrameworkCore/Granit.Identity.EntityFrameworkCore.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Identity.EntityFrameworkCore</PackageId>
+    <Description>EF Core persistence for the canonical Granit.Identity User aggregate (ADR-051). Ships the isolated IdentityDbContext, entity configuration, and the EF Core implementation of IUserDirectoryQueryableSource consumed by the QueryEngine + OData feed. Migrations live in the consuming app.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Identity.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
@@ -1,0 +1,23 @@
+namespace Granit.Identity.EntityFrameworkCore;
+
+/// <summary>
+/// Schema- and table-naming constants for the Identity EF Core store.
+/// Pinned in one place so consuming apps' migrations and any custom
+/// projection layers stay aligned with the framework's choice.
+/// </summary>
+public static class GranitIdentityDbProperties
+{
+    /// <summary>
+    /// Table-name prefix applied to every Identity-owned table. Mirrors the
+    /// per-module prefix convention (<c>granit_</c>, <c>granit_apikeys_</c>,
+    /// etc.).
+    /// </summary>
+    public const string DbTablePrefix = "granit_identity_";
+
+    /// <summary>
+    /// PostgreSQL schema for the Identity tables, or <see langword="null"/>
+    /// to use the default schema. <see langword="null"/> means the host
+    /// decides (single-schema deployments simply don't set one).
+    /// </summary>
+    public const string? DbSchema = null;
+}

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
@@ -1,0 +1,20 @@
+using Granit.Modularity;
+using Granit.Persistence.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore;
+
+/// <summary>
+/// Granit module that registers EF Core persistence for the canonical
+/// <see cref="Domain.User"/> aggregate (ADR-051 B-step 1.5).
+/// </summary>
+/// <remarks>
+/// The DbContext is registered when the host calls
+/// <see cref="Extensions.IdentityEntityFrameworkCoreServiceCollectionExtensions.AddGranitIdentityEntityFrameworkCore"/>
+/// — this module class only declares the framework dependency edge.
+/// Migrations are owned by the consuming app per the framework convention
+/// (no migrations live inside framework packages).
+/// </remarks>
+[DependsOn(
+    typeof(GranitIdentityModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule))]
+public sealed class GranitIdentityEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/EfUserDirectoryQueryableSource.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/EfUserDirectoryQueryableSource.cs
@@ -1,0 +1,25 @@
+using Granit.Identity.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IUserDirectoryQueryableSource"/>.
+/// Returns an <see cref="IQueryable{User}"/> over the
+/// <see cref="IdentityDbContext.Users"/> set with the framework conventions
+/// (tenant + soft-delete) already woven into the model. Composes cleanly
+/// with the QueryEngine and OData pipelines per ADR-050 / ADR-051.
+/// </summary>
+internal sealed class EfUserDirectoryQueryableSource(
+    IDbContextFactory<IdentityDbContext> contextFactory)
+    : IUserDirectoryQueryableSource, IDisposable
+{
+    private readonly IdentityDbContext _context = contextFactory.CreateDbContext();
+
+    /// <inheritdoc />
+    public IQueryable<User> GetQueryable() =>
+        _context.Users.AsNoTracking();
+
+    /// <inheritdoc />
+    public void Dispose() => _context.Dispose();
+}

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
@@ -1,0 +1,44 @@
+using Granit.DataFiltering;
+using Granit.Identity.Domain;
+using Granit.Identity.EntityFrameworkCore.Extensions;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Isolated EF Core <see cref="DbContext"/> for the canonical
+/// <see cref="User"/> aggregate (ADR-051). Lives in <c>Granit.Identity</c>
+/// (foundation) so every Granit app, even tiny ones without
+/// <c>Granit.Parties</c>, gets the user table.
+/// </summary>
+/// <remarks>
+/// Per the framework convention (CLAUDE.md, "Isolated DbContext —
+/// MANDATORY"), this DbContext lazily injects <see cref="ICurrentTenant"/>
+/// and <see cref="IDataFilter"/> and applies the framework conventions
+/// (tenant + soft-delete + named query filters) via
+/// <see cref="ModelBuilderExtensions.ApplyGranitConventions"/>.
+/// </remarks>
+internal sealed class IdentityDbContext(
+    DbContextOptions<IdentityDbContext> options,
+    ICurrentTenant? currentTenant = null,
+    IDataFilter? dataFilter = null)
+    : DbContext(options)
+{
+    private readonly ICurrentTenant? _currentTenant = currentTenant;
+    private readonly IDataFilter? _dataFilter = dataFilter;
+
+    /// <summary>The <see cref="User"/> table.</summary>
+    public DbSet<User> Users => Set<User>();
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ConfigureGranitIdentityModule();
+        modelBuilder.ApplyGranitConventions(_currentTenant, _dataFilter);
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/README.md
+++ b/src/Granit.Identity.EntityFrameworkCore/README.md
@@ -1,0 +1,49 @@
+# Granit.Identity.EntityFrameworkCore
+
+EF Core persistence for the canonical `User` aggregate shipped by
+`Granit.Identity` (per [ADR-051](../../docs-site/src/content/docs/dotnet/architecture/adr/051-user-aggregate-and-parties-bridge.md)).
+Wires the isolated `IdentityDbContext`, the `User` entity configuration,
+and the EF Core implementation of `IUserDirectoryQueryableSource` consumed
+by the QueryEngine and OData feed.
+
+## Why
+
+`Granit.Identity` (foundation) declares the `User` aggregate root, the
+`UserQueryDefinition`, the `UserExportDefinition`, the `UserEntityDefinition`,
+and the `IUserDirectoryQueryableSource` abstraction — but never references
+EF Core. This companion package supplies the storage shell so consumers
+can host the user table in their existing PostgreSQL deployment.
+
+Migrations are NOT part of this package — they live in the consuming
+app per the framework convention. The DbContext exposes `Database.EnsureCreated`
+for tests; production hosts run `dotnet ef migrations add InitialIdentity`
+against their own migrations assembly.
+
+## Usage
+
+```csharp
+// Program.cs
+builder.Services
+    .AddGranitIdentityEntityFrameworkCore(opt =>
+        opt.UseNpgsql(connectionString));
+```
+
+The host's existing `dotnet ef migrations add` flow picks up the new
+DbContext alongside the other module DbContexts. The Showcase regenerates
+its seed; no migration required for greenfield apps.
+
+## What ships
+
+| Class | Purpose |
+| ----- | ------- |
+| `IdentityDbContext` | Isolated DbContext for the `User` aggregate. Calls `ApplyGranitConventions` so tenant + soft-delete + audit filters apply automatically. |
+| `EntityConfigurations.UserConfiguration` | EF Core entity configuration. Pins column lengths (Email up to 320 RFC 5321 chars, etc.), declares the tenant + email indexes. No unique index on email — multiple users may share an email per ADR-051's Odoo-style choice. |
+| `Internal.EfUserDirectoryQueryableSource` | Returns `IQueryable<User>` over the `Users` set with `AsNoTracking`. Composes with the QueryEngine pipeline + the OData feed per ADR-050. |
+| `Extensions.IdentityModelBuilderExtensions.ConfigureGranitIdentityModule` | `ModelBuilder` extension to fold the entity config into a host-owned DbContext if needed. |
+| `Extensions.IdentityEntityFrameworkCoreServiceCollectionExtensions.AddGranitIdentityEntityFrameworkCore` | DI registration entry point. |
+
+## Cross-references
+
+- [ADR-051](../../docs-site/src/content/docs/dotnet/architecture/adr/051-user-aggregate-and-parties-bridge.md) — User aggregate in Granit.Identity + optional Parties bridge.
+- [ADR-050](../../docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md) — OData EDM whitelist (the User aggregate becomes OData-eligible because its EntityDefinition references Query + Export).
+- `Granit.Identity` — declares the `User` aggregate, abstractions, and declarative companions.

--- a/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
@@ -1,0 +1,288 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -156,6 +156,7 @@
     <ProjectReference Include="..\..\src\Granit.Http.SecurityHeaders\Granit.Http.SecurityHeaders.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Endpoints\Granit.Identity.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.EntityFrameworkCore\Granit.Identity.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Federated.Cognito\Granit.Identity.Federated.Cognito.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Federated.Cognito.BackgroundJobs\Granit.Identity.Federated.Cognito.BackgroundJobs.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2511,6 +2511,15 @@
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
       "granit.identity.federated": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/EfUserDirectoryQueryableSourceTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/EfUserDirectoryQueryableSourceTests.cs
@@ -1,0 +1,95 @@
+using Granit.Identity.Domain;
+using Granit.Identity.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Locks the contract of <see cref="EfUserDirectoryQueryableSource"/> —
+/// returns an <see cref="IQueryable{User}"/> over the
+/// <see cref="IdentityDbContext.Users"/> set, with the framework's
+/// <c>ApplyGranitConventions</c> filters (tenant + soft-delete) applied
+/// transparently. Tests run on SQLite in-memory for fast, isolated relational
+/// coverage; integration tests against Postgres ship in a follow-up
+/// <c>*.Tests.Integration</c> project once the Showcase migration lands.
+/// </summary>
+public sealed class EfUserDirectoryQueryableSourceTests : IDisposable
+{
+    private readonly TestDbContextFactory _factory = TestDbContextFactory.Create();
+
+    public void Dispose() => _factory.Dispose();
+
+    [Fact]
+    public async Task GetQueryable_ReturnsUsers_FromTheUnderlyingTable()
+    {
+        await SeedAsync(
+            User.Create(Guid.NewGuid(), "alice@example.com", "Alice"),
+            User.Create(Guid.NewGuid(), "bob@example.com", "Bob"));
+
+        using EfUserDirectoryQueryableSource sut = new(_factory);
+
+        List<User> users = await sut.GetQueryable()
+            .OrderBy(u => u.DisplayName)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        users.Count.ShouldBe(2);
+        users[0].DisplayName.ShouldBe("Alice");
+        users[1].DisplayName.ShouldBe("Bob");
+    }
+
+    [Fact]
+    public async Task GetQueryable_AsNoTracking_DoesNotAttachEntities()
+    {
+        // The contract emits no-tracking queries (admin / OData read paths
+        // never write back through this surface). A mutated entity from
+        // GetQueryable is never persisted by SaveChanges.
+        await SeedAsync(User.Create(Guid.NewGuid(), "carol@example.com", "Carol"));
+
+        using EfUserDirectoryQueryableSource sut = new(_factory);
+
+        User user = await sut.GetQueryable().SingleAsync(TestContext.Current.CancellationToken);
+        user.UpdateProfile(
+            displayName: "Carol Renamed",
+            email: user.Email,
+            firstName: null,
+            lastName: null,
+            phoneNumber: null,
+            preferredLocale: null,
+            timezone: null);
+
+        await using IdentityDbContext fresh = _factory.CreateDbContext();
+        User reread = await fresh.Users.SingleAsync(TestContext.Current.CancellationToken);
+        reread.DisplayName.ShouldBe("Carol");
+    }
+
+    [Fact]
+    public async Task GetQueryable_ComposesWithFilterAndProjection()
+    {
+        // The contract is `IQueryable<User>` — consumers compose `Where`,
+        // `Select`, `OrderBy`, etc. End-to-end verification that LINQ
+        // composition translates to SQL through the factory-created context.
+        await SeedAsync(
+            User.Create(Guid.NewGuid(), "dave@example.com", "Dave", firstName: "Dave"),
+            User.Create(Guid.NewGuid(), "eve@example.com", "Eve", firstName: "Eve"),
+            User.Create(Guid.NewGuid(), "frank@example.com", "Frank Disabled"));
+
+        using EfUserDirectoryQueryableSource sut = new(_factory);
+
+        List<string> firstNames = await sut.GetQueryable()
+            .Where(u => u.FirstName != null)
+            .OrderBy(u => u.FirstName)
+            .Select(u => u.FirstName!)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        firstNames.ShouldBe(["Dave", "Eve"]);
+    }
+
+    private async Task SeedAsync(params User[] users)
+    {
+        await using IdentityDbContext db = _factory.CreateDbContext();
+        db.Users.AddRange(users);
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/Granit.Identity.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/Granit.Identity.EntityFrameworkCore.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- EF Store implementations are internal but tested via InternalsVisibleTo -->
+    <NoWarn>$(NoWarn);EF1001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Identity.EntityFrameworkCore\Granit.Identity.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,0 +1,90 @@
+using Granit.Identity.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Granit.Identity.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Creates <see cref="IdentityDbContext"/> instances backed by SQLite
+/// in-memory for fast, isolated relational tests. Mirrors the pattern
+/// used by every other <c>*.EntityFrameworkCore.Tests</c> project — see
+/// <c>Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests</c> for the
+/// same shape against a different DbContext.
+/// </summary>
+internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext>, IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<IdentityDbContext> _options;
+
+    private TestDbContextFactory(SqliteConnection connection, DbContextOptions<IdentityDbContext> options)
+    {
+        _connection = connection;
+        _options = options;
+    }
+
+    public DbContextOptions<IdentityDbContext> Options => _options;
+
+    public static TestDbContextFactory Create()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptionsBuilder<IdentityDbContext> optionsBuilder = new();
+        optionsBuilder.UseSqlite(connection);
+        optionsBuilder.ReplaceService<IModelCustomizer, SqliteCompatibleModelCustomizer>();
+
+        DbContextOptions<IdentityDbContext> options = optionsBuilder.Options;
+
+        // Create the schema once for the connection lifetime.
+        using (IdentityDbContext db = new(options))
+        {
+            db.Database.EnsureCreated();
+        }
+
+        return new TestDbContextFactory(connection, options);
+    }
+
+    public IdentityDbContext CreateDbContext() => new(_options);
+
+    public void Dispose() => _connection.Dispose();
+}
+
+/// <summary>
+/// Model customizer that remaps PostgreSQL-specific types
+/// (<see cref="DateTimeOffset"/>) to SQLite-compatible types with value
+/// converters. Same shape as the existing companion test factories.
+/// </summary>
+internal sealed class SqliteCompatibleModelCustomizer(ModelCustomizerDependencies dependencies)
+    : RelationalModelCustomizer(dependencies)
+{
+    private static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetConverter = new(
+        v => v.ToUnixTimeMilliseconds(),
+        v => DateTimeOffset.FromUnixTimeMilliseconds(v));
+
+    private static readonly ValueConverter<DateTimeOffset?, long?> NullableDateTimeOffsetConverter = new(
+        v => v.HasValue ? v.Value.ToUnixTimeMilliseconds() : null,
+        v => v.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds(v.Value) : null);
+
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (IMutableProperty property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTimeOffset))
+                {
+                    property.SetValueConverter(DateTimeOffsetConverter);
+                }
+                else if (property.ClrType == typeof(DateTimeOffset?))
+                {
+                    property.SetValueConverter(NullableDateTimeOffsetConverter);
+                }
+            }
+        }
+    }
+}

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
@@ -1,0 +1,576 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "0cnk9Chkuz2Jc6pbXRqdjy2CMAi62q4dJhvJzG25iCIvbavUYLxk/5ukwM+mzOl7ADN88WPmY1Lx1cAH2g8QSA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "xVrtBg3M1wJlBDkoT0dXEYB/wSc8bIHJPYtw/bu1AqpWgF79uPSs87DAhERR/Ilumre6TKZa1cjMg3VUUObVLA==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "XVjGSW98Z/f3nFZsZILL/tntgM8i2hxUDUB4Nzt7ZvJ63MczC/VG4zjQh+m+q88SU+IJBUDipJJpkYBU57YWXg==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Wires the storage shell for the canonical `User` aggregate shipped in B-step 1 (#1709). Hosts now have a working `IUserDirectoryQueryableSource` returning `IQueryable<User>` over a Postgres-backed table — the QueryEngine pipeline and OData feed compose `$filter` / `$select` / `$top` against it directly.

This is **B-step 1.5 of 6** per [ADR-051](docs-site/src/content/docs/dotnet/architecture/adr/051-user-aggregate-and-parties-bridge.md).

## What ships

New package `src/Granit.Identity.EntityFrameworkCore/`:

| File | Purpose |
| ---- | ------- |
| `IdentityDbContext` | Isolated DbContext, lazy-injects `ICurrentTenant` + `IDataFilter`, calls `ApplyGranitConventions` per CLAUDE.md. |
| `EntityConfigurations.UserConfiguration` | Column lengths (Email up to 320 RFC 5321 chars, etc.), tenant + email indexes. **No unique index on email** per ADR-051's Odoo-style choice (multiple users may legitimately share an email — corporate inbox, etc.). |
| `Internal.EfUserDirectoryQueryableSource` | `AsNoTracking()` queryable over `Users`. |
| `Extensions.IdentityModelBuilderExtensions.ConfigureGranitIdentityModule` | `ModelBuilder` extension to fold the config into a host-owned DbContext if needed. |
| `Extensions.IdentityEntityFrameworkCoreServiceCollectionExtensions.AddGranitIdentityEntityFrameworkCore` | DI entry point. |
| `GranitIdentityEntityFrameworkCoreModule` | Module class with `[DependsOn]`. |
| `GranitIdentityDbProperties` | Table prefix constants. |
| `README.md` | Package documentation. |

New test project `tests/Granit.Identity.EntityFrameworkCore.Tests/`:

- `TestDbContextFactory` — SQLite in-memory + DateTimeOffset converter customizer.
- `EfUserDirectoryQueryableSourceTests` — 3 tests pin the contract (rows return, `AsNoTracking` semantics, LINQ composition translates).

## Wiring

- `test-shards.json` — new project added to the `security` shard alongside the other Identity tests. Shard filters regenerated.
- `Granit.ArchitectureTests.csproj` — new src package added as project reference.
- Lockfiles cascade-refreshed via `dotnet restore Granit.slnx --force-evaluate`.

## Migrations

NOT included. Per the framework convention (CLAUDE.md — "Granit framework packages must NOT contain EF Core migrations"), migrations are owned by the consuming app. The Showcase regenerates seed; greenfield apps run `dotnet ef migrations add InitialIdentity` against their own migrations assembly.

## Test plan

- [x] `dotnet build src/Granit.Identity.EntityFrameworkCore` — clean.
- [x] `dotnet test tests/Granit.Identity.EntityFrameworkCore.Tests` — 3/3 pass.
- [x] `dotnet test .github/shard-filters/architecture.slnf` — **207/207** (had a transient missing-README violation on the new package, addressed here).
- [x] `dotnet format` — clean.

## Out of scope

Per the ADR-051 6-step plan:

- **B-step 2** — rename `GranitUser` → `LocalIdentity`, add FK to `User`, update ASP.NET Identity wiring.
- **B-step 3** — rename `UserCacheEntry` → `FederatedIdentity`, add FK to `User`.
- **B-step 4** — Authorization repointing (`PermissionGrant.UserId` → `User.Id`).
- **B-step 5** — `Granit.Identity.Parties` bridge module (3 Wolverine handlers).
- Postgres-backed integration tests (Testcontainers) — will land alongside the Showcase migration in a `*.Tests.Integration` project.

## References

- [ADR-051](docs-site/src/content/docs/dotnet/architecture/adr/051-user-aggregate-and-parties-bridge.md) — User aggregate and Parties bridge.
- [ADR-050](docs-site/src/content/docs/dotnet/architecture/adr/050-odata-edm-whitelist-via-entity-definition.md) — OData EDM whitelist (the User aggregate becomes OData-eligible because its EntityDefinition + Export are already wired by B-step 1).
- B-step 1 PR: granit-fx/granit-dotnet#1709 (merged).
