### PR TITLE
refactor(identity-local): rename GranitUser → LocalIdentity + add UserId FK (ADR-051 B-step 2)

### DIFF
--- a/src/Granit.Identity.Federated/Middleware/UserCacheSyncMiddleware.cs
+++ b/src/Granit.Identity.Federated/Middleware/UserCacheSyncMiddleware.cs
@@ -33,7 +33,7 @@ internal sealed class UserCacheSyncMiddleware(RequestDelegate next)
         IIdentityProviderCapabilities capabilities)
     {
         // Skip sync when users are stored locally (OpenIddict / ASP.NET Core Identity).
-        // GranitUser IS the source of truth — no cache needed.
+        // LocalIdentity IS the source of truth — no cache needed.
         if (capabilities.IsLocalStore)
         {
             await next(httpContext).ConfigureAwait(false);

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -41,8 +41,8 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         context.Services.Replace(ServiceDescriptor.Scoped<IUserLookupService,
             AspNetIdentityUserLookupService>());
 
-        // Replace default UserManager with GranitUserManager (exponential backoff lockout)
-        context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
+        // Replace default UserManager with LocalIdentityManager (exponential backoff lockout)
+        context.Services.Replace(ServiceDescriptor.Scoped<UserManager<LocalIdentity>, LocalIdentityManager>());
 
         // Tenant-aware role lookup: the normalizer prefixes every NormalizeName call
         // with the current tenant id when one is active, letting the same display name
@@ -61,7 +61,7 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // This ensures multi-tenancy middleware can resolve the tenant from the authenticated
         // cookie on subsequent requests (authorize, refresh, 2FA second step).
         context.Services.Replace(ServiceDescriptor.Scoped<
-            IUserClaimsPrincipalFactory<GranitUser>, GranitUserClaimsPrincipalFactory>());
+            IUserClaimsPrincipalFactory<LocalIdentity>, LocalIdentityClaimsPrincipalFactory>());
 
         // Role orchestration — dual-writes GranitRole (Identity DbContext) + RoleMetadata
         // (host DbContext) with compensating delete on metadata failure.
@@ -70,7 +70,7 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Seed SuperAdmin / TenantAdministrator / User on host data seed.
         context.Services.AddTransient<IHostDataSeedContributor, IdentityLocalRoleSeedContributor>();
 
-        // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
+        // ASP.NET Core Identity service implementations (depend on UserManager<LocalIdentity>)
         context.Services.TryAddScoped<ITotpService, TotpService>();
         context.Services.TryAddScoped<ITwoFactorService, AspNetTwoFactorService>();
         context.Services.TryAddScoped<IPasskeyService, AspNetPasskeyService>();
@@ -128,7 +128,7 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
         // Detect redundant Granit.Identity.Federated.EntityFrameworkCore registration.
-        // When OpenIddict is the identity provider, GranitUser is the source of truth —
+        // When OpenIddict is the identity provider, LocalIdentity is the source of truth —
         // UserCacheEntry and UserCacheSyncMiddleware are unnecessary.
         var userCacheDbContextType = Type.GetType(
             "Granit.Identity.Federated.EntityFrameworkCore.DbContext.IUserCacheDbContext, Granit.Identity.Federated.EntityFrameworkCore",
@@ -148,7 +148,7 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         [LoggerMessage(Level = LogLevel.Warning,
             Message = "Granit.Identity.Federated.EntityFrameworkCore is loaded alongside "
                 + "Granit.Identity.Local.AspNetIdentity. UserCacheEntry is redundant when the "
-                + "identity provider stores users locally (GranitUser). Remove the "
+                + "identity provider stores users locally (LocalIdentity). Remove the "
                 + "Granit.Identity.Federated.EntityFrameworkCore package reference to avoid an "
                 + "unnecessary database table and per-request cache sync overhead.")]
         public static partial void RedundantFederatedModuleDetected(ILogger logger);

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetEmailChangeService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetEmailChangeService.cs
@@ -12,14 +12,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// and publishes <see cref="EmailChangeRequestedEto"/> for downstream notification handlers.
 /// </summary>
 internal sealed class AspNetEmailChangeService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IDistributedEventBus eventBus) : IEmailChangeService
 {
     /// <inheritdoc/>
     public async Task<bool> RequestChangeAsync(
         string userId, string newEmail, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return false;
@@ -44,7 +44,7 @@ internal sealed class AspNetEmailChangeService(
     public async Task<bool> ConfirmChangeAsync(
         string userId, string newEmail, string token, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return false;

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetEmailConfirmationService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetEmailConfirmationService.cs
@@ -12,14 +12,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <see cref="EmailConfirmationRequestedEto"/> via <see cref="IDistributedEventBus"/>.
 /// </summary>
 internal sealed class AspNetEmailConfirmationService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IDistributedEventBus eventBus) : IEmailConfirmationService
 {
     /// <inheritdoc/>
     public async Task SendConfirmationEmailAsync(
         string userId, string email, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return;
@@ -37,7 +37,7 @@ internal sealed class AspNetEmailConfirmationService(
     public async Task<bool> ConfirmAsync(
         string userId, string token, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return false;

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityProvider.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityProvider.cs
@@ -21,7 +21,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <see cref="IIdentityCredentialVerifier"/>.
 /// </remarks>
 internal sealed partial class AspNetIdentityProvider(
-    UserManager<GranitUser> _userManager,
+    UserManager<LocalIdentity> _userManager,
     RoleManager<GranitRole> _roleManager,
     ILocalIdentityGroupStore _groupStore,
     ILogger<AspNetIdentityProvider> _logger) : IIdentityProvider
@@ -33,7 +33,7 @@ internal sealed partial class AspNetIdentityProvider(
         string? search = null, int? first = null, int? max = null,
         CancellationToken cancellationToken = default)
     {
-        IQueryable<GranitUser> query = _userManager.Users.AsNoTracking();
+        IQueryable<LocalIdentity> query = _userManager.Users.AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(search))
         {
@@ -56,7 +56,7 @@ internal sealed partial class AspNetIdentityProvider(
             query = query.Take(max.Value);
         }
 
-        List<GranitUser> users = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
+        List<LocalIdentity> users = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
         return users.Cast<IIdentityUser>().ToList();
     }
 
@@ -64,7 +64,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task<IIdentityUser?> GetUserAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
         return user;
     }
 
@@ -74,7 +74,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task<IIdentityUser> CreateUserAsync(
         IdentityUserCreate user, CancellationToken cancellationToken = default)
     {
-        GranitUser entity = new()
+        LocalIdentity entity = new()
         {
             UserName = user.Username,
             Email = user.Email,
@@ -105,7 +105,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task SetUserEnabledAsync(
         string userId, bool enabled, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         if (enabled)
@@ -124,7 +124,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task UpdateUserAsync(
         string userId, IdentityUserUpdate update, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         if (update.FirstName is not null)
@@ -166,7 +166,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task<IReadOnlyList<IIdentityUser>> GetRoleMembersAsync(
         string roleName, CancellationToken cancellationToken = default)
     {
-        IList<GranitUser> users = await _userManager.GetUsersInRoleAsync(roleName).ConfigureAwait(false);
+        IList<LocalIdentity> users = await _userManager.GetUsersInRoleAsync(roleName).ConfigureAwait(false);
         return users.Cast<IIdentityUser>().ToList();
     }
 
@@ -174,7 +174,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task<IReadOnlyList<GranitIdentityRole>> GetUserRolesAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return [];
@@ -188,7 +188,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task AssignRoleAsync(
         string userId, string roleName, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         IdentityResult result = await _userManager.AddToRoleAsync(user, roleName).ConfigureAwait(false);
@@ -204,7 +204,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task RemoveRoleAsync(
         string userId, string roleName, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         IdentityResult result = await _userManager.RemoveFromRoleAsync(user, roleName).ConfigureAwait(false);
@@ -279,7 +279,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task SetTemporaryPasswordAsync(
         string userId, string temporaryPassword, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         string token = await _userManager.GeneratePasswordResetTokenAsync(user).ConfigureAwait(false);
@@ -301,7 +301,7 @@ internal sealed partial class AspNetIdentityProvider(
     public async Task<bool> VerifyUserCredentialsAsync(
         string username, string password, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await _userManager.FindByNameAsync(username).ConfigureAwait(false);
+        LocalIdentity? user = await _userManager.FindByNameAsync(username).ConfigureAwait(false);
         if (user is null)
         {
             return false;

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityUserLookupService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityUserLookupService.cs
@@ -11,13 +11,13 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// bypassing any redundant cache layer.
 /// </summary>
 internal sealed class AspNetIdentityUserLookupService(
-    UserManager<GranitUser> _userManager) : IUserLookupService
+    UserManager<LocalIdentity> _userManager) : IUserLookupService
 {
     /// <inheritdoc/>
     public async Task<IIdentityUser?> FindByIdAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
         return user;
     }
 
@@ -26,7 +26,7 @@ internal sealed class AspNetIdentityUserLookupService(
         IReadOnlyCollection<string> userIds, CancellationToken cancellationToken = default)
     {
         var guidIds = userIds.Select(Guid.Parse).ToList();
-        List<GranitUser> users = await _userManager.Users.AsNoTracking()
+        List<LocalIdentity> users = await _userManager.Users.AsNoTracking()
             .Where(u => guidIds.Contains(u.Id))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         return users.Cast<IIdentityUser>().ToList();
@@ -36,7 +36,7 @@ internal sealed class AspNetIdentityUserLookupService(
     public async Task<PagedResult<IIdentityUser>> SearchAsync(
         string searchTerm, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        IQueryable<GranitUser> query = _userManager.Users.AsNoTracking();
+        IQueryable<LocalIdentity> query = _userManager.Users.AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(searchTerm))
         {
@@ -49,7 +49,7 @@ internal sealed class AspNetIdentityUserLookupService(
 
         int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
         int skip = (page - 1) * pageSize;
-        List<GranitUser> items = await query
+        List<LocalIdentity> items = await query
             .OrderBy(u => u.UserName)
             .Skip(skip)
             .Take(pageSize)

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
@@ -37,7 +37,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// </para>
 /// </remarks>
 internal sealed partial class AspNetPasskeyService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IFido2 fido2,
     PasskeyChallengeStore challengeStore,
     IClock clock,
@@ -51,7 +51,7 @@ internal sealed partial class AspNetPasskeyService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User '{userId}' not found.");
 
         IList<UserPasskeyInfo> passkeys = await userManager.GetPasskeysAsync(user).ConfigureAwait(false);
@@ -69,7 +69,7 @@ internal sealed partial class AspNetPasskeyService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User '{userId}' not found.");
 
         IList<UserPasskeyInfo> existing = await userManager.GetPasskeysAsync(user).ConfigureAwait(false);
@@ -114,7 +114,7 @@ internal sealed partial class AspNetPasskeyService(
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
         ArgumentException.ThrowIfNullOrWhiteSpace(credentialJson);
 
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User '{userId}' not found.");
 
         string? originalOptionsJson = await challengeStore
@@ -237,7 +237,7 @@ internal sealed partial class AspNetPasskeyService(
             .Deserialize<AssertionOptions>(originalOptionsJson, s_optionsJson)
             ?? throw new InvalidOperationException("Stored assertion options are corrupt.");
 
-        GranitUser? user = await userManager.FindByPasskeyIdAsync(assertionResponse.RawId)
+        LocalIdentity? user = await userManager.FindByPasskeyIdAsync(assertionResponse.RawId)
             .ConfigureAwait(false);
 
         if (user is null)
@@ -307,7 +307,7 @@ internal sealed partial class AspNetPasskeyService(
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
         ArgumentException.ThrowIfNullOrWhiteSpace(newName);
 
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User '{userId}' not found.");
 
         IList<UserPasskeyInfo> passkeys = await userManager.GetPasskeysAsync(user).ConfigureAwait(false);
@@ -341,7 +341,7 @@ internal sealed partial class AspNetPasskeyService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User '{userId}' not found.");
 
         // Safety check: cannot delete last passkey if no password is set

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasswordResetService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasswordResetService.cs
@@ -13,13 +13,13 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// </summary>
 #pragma warning disable GRSEC003 // Password reset token handling, not stored secrets
 internal sealed class AspNetPasswordResetService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IDistributedEventBus eventBus) : IPasswordResetService
 {
     /// <inheritdoc/>
     public async Task<bool> RequestResetAsync(string email, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByEmailAsync(email).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByEmailAsync(email).ConfigureAwait(false);
         if (user is null)
         {
             return false;
@@ -38,7 +38,7 @@ internal sealed class AspNetPasswordResetService(
     public async Task ResetPasswordAsync(
         string userId, string token, string newPassword, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         IdentityResult result = await userManager.ResetPasswordAsync(user, token, newPassword)

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetTwoFactorService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetTwoFactorService.cs
@@ -8,14 +8,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <see cref="ITwoFactorService"/> implementation backed by <see cref="UserManager{TUser}"/>.
 /// </summary>
 internal sealed class AspNetTwoFactorService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     ITotpService totpService) : ITwoFactorService
 {
     /// <inheritdoc/>
     public async Task<TwoFactorStatus> GetStatusAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
 
         bool isEnabled = await userManager.GetTwoFactorEnabledAsync(user).ConfigureAwait(false);
         string? key = await userManager.GetAuthenticatorKeyAsync(user).ConfigureAwait(false);
@@ -28,7 +28,7 @@ internal sealed class AspNetTwoFactorService(
     public async Task<AuthenticatorKeyInfo> GetAuthenticatorKeyAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
 
         string? key = await userManager.GetAuthenticatorKeyAsync(user).ConfigureAwait(false);
         if (string.IsNullOrEmpty(key))
@@ -47,7 +47,7 @@ internal sealed class AspNetTwoFactorService(
     public async Task<IReadOnlyList<string>> EnableAsync(
         string userId, string code, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
 
         string? key = await userManager.GetAuthenticatorKeyAsync(user).ConfigureAwait(false);
         if (string.IsNullOrEmpty(key) || !totpService.ValidateCode(key, code))
@@ -66,7 +66,7 @@ internal sealed class AspNetTwoFactorService(
     /// <inheritdoc/>
     public async Task DisableAsync(string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
         await userManager.SetTwoFactorEnabledAsync(user, false).ConfigureAwait(false);
 
         // Invalidate security stamp to force re-authentication on existing sessions
@@ -76,7 +76,7 @@ internal sealed class AspNetTwoFactorService(
     /// <inheritdoc/>
     public async Task ResetAuthenticatorAsync(string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
         await userManager.ResetAuthenticatorKeyAsync(user).ConfigureAwait(false);
     }
 
@@ -84,13 +84,13 @@ internal sealed class AspNetTwoFactorService(
     public async Task<IReadOnlyList<string>> GenerateRecoveryCodesAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await FindUserAsync(userId).ConfigureAwait(false);
+        LocalIdentity user = await FindUserAsync(userId).ConfigureAwait(false);
         IEnumerable<string>? codes = await userManager
             .GenerateNewTwoFactorRecoveryCodesAsync(user, 10).ConfigureAwait(false);
         return codes?.ToList() ?? [];
     }
 
-    private async Task<GranitUser> FindUserAsync(string userId) =>
+    private async Task<LocalIdentity> FindUserAsync(string userId) =>
         await userManager.FindByIdAsync(userId).ConfigureAwait(false)
         ?? throw new InvalidOperationException($"User {userId} not found.");
 }

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/LocalIdentityClaimsPrincipalFactory.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/LocalIdentityClaimsPrincipalFactory.cs
@@ -11,13 +11,13 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// middleware to resolve the tenant from the authenticated cookie on subsequent requests
 /// (authorize, refresh, 2FA second step).
 /// </summary>
-internal sealed class GranitUserClaimsPrincipalFactory(
-    UserManager<GranitUser> userManager,
+internal sealed class LocalIdentityClaimsPrincipalFactory(
+    UserManager<LocalIdentity> userManager,
     RoleManager<GranitRole> roleManager,
     IOptions<IdentityOptions> options)
-    : UserClaimsPrincipalFactory<GranitUser, GranitRole>(userManager, roleManager, options)
+    : UserClaimsPrincipalFactory<LocalIdentity, GranitRole>(userManager, roleManager, options)
 {
-    protected override async Task<ClaimsIdentity> GenerateClaimsAsync(GranitUser user)
+    protected override async Task<ClaimsIdentity> GenerateClaimsAsync(LocalIdentity user)
     {
         ClaimsIdentity identity = await base.GenerateClaimsAsync(user).ConfigureAwait(false);
 

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -26,7 +26,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <see cref="ILookupNormalizer.NormalizeName"/> is invoked by ASP.NET Identity for both
 /// <c>NormalizedUserName</c> and <c>NormalizedName</c> lookups — the contract has no way
 /// to distinguish users from roles from inside the normalizer. The universal prefix
-/// therefore also scopes <c>GranitUser.NormalizedUserName</c> per tenant: users created
+/// therefore also scopes <c>LocalIdentity.NormalizedUserName</c> per tenant: users created
 /// inside a tenant context are invisible to host-side <c>FindByNameAsync</c> lookups and
 /// vice-versa. This matches Granit's tenant-isolation intent — host and tenant admin
 /// contexts never share a user-by-name lookup in practice. Email-based lookups

--- a/src/Granit.Identity.Local.AspNetIdentity/LocalIdentityManager.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/LocalIdentityManager.cs
@@ -12,7 +12,7 @@ namespace Granit.Identity.Local.AspNetIdentity;
 /// <remarks>
 /// <para>
 /// Overrides <see cref="AccessFailedAsync"/> to compute an exponentially increasing
-/// lockout duration based on <see cref="GranitUser.ConsecutiveLockouts"/>. The stock
+/// lockout duration based on <see cref="LocalIdentity.ConsecutiveLockouts"/>. The stock
 /// <see cref="SignInManager{TUser}"/> calls <c>AccessFailedAsync</c> on each failed
 /// login — this is the single, stable extension point that avoids overriding
 /// <c>SignInManager</c> (fragile across .NET upgrades).
@@ -24,24 +24,24 @@ namespace Granit.Identity.Local.AspNetIdentity;
 /// </para>
 /// </remarks>
 #pragma warning disable GRSEC001 // TimeProvider not available in UserManager constructor — DateTimeOffset.UtcNow is acceptable here
-public class GranitUserManager(
-    IUserStore<GranitUser> store,
+public class LocalIdentityManager(
+    IUserStore<LocalIdentity> store,
     IOptions<IdentityOptions> optionsAccessor,
-    IPasswordHasher<GranitUser> passwordHasher,
-    IEnumerable<IUserValidator<GranitUser>> userValidators,
-    IEnumerable<IPasswordValidator<GranitUser>> passwordValidators,
+    IPasswordHasher<LocalIdentity> passwordHasher,
+    IEnumerable<IUserValidator<LocalIdentity>> userValidators,
+    IEnumerable<IPasswordValidator<LocalIdentity>> passwordValidators,
     ILookupNormalizer keyNormalizer,
     IdentityErrorDescriber errors,
     IServiceProvider services,
-    ILogger<GranitUserManager> logger,
+    ILogger<LocalIdentityManager> logger,
     IOptions<GranitLockoutOptions> lockoutOptions)
-    : UserManager<GranitUser>(store, optionsAccessor, passwordHasher,
+    : UserManager<LocalIdentity>(store, optionsAccessor, passwordHasher,
         userValidators, passwordValidators, keyNormalizer, errors, services, logger)
 {
     private readonly GranitLockoutOptions _lockoutOptions = lockoutOptions.Value;
 
     /// <inheritdoc/>
-    public override async Task<IdentityResult> AccessFailedAsync(GranitUser user)
+    public override async Task<IdentityResult> AccessFailedAsync(LocalIdentity user)
     {
         ArgumentNullException.ThrowIfNull(user);
 
@@ -72,7 +72,7 @@ public class GranitUserManager(
     }
 
     /// <inheritdoc/>
-    public override async Task<IdentityResult> ResetAccessFailedCountAsync(GranitUser user)
+    public override async Task<IdentityResult> ResetAccessFailedCountAsync(LocalIdentity user)
     {
         ArgumentNullException.ThrowIfNull(user);
 

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -67,8 +67,8 @@ internal static partial class AccountLoginEndpoints
 #pragma warning disable GRSEC003 // Method handles user credentials — server-side authentication
     private static async Task<Results<Ok<AccountLoginResponse>, ProblemHttpResult>> HandleLoginAsync(
         AccountLoginRequest request,
-        [FromServices] SignInManager<GranitUser> signInManager,
-        [FromServices] UserManager<GranitUser> userManager,
+        [FromServices] SignInManager<LocalIdentity> signInManager,
+        [FromServices] UserManager<LocalIdentity> userManager,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
@@ -91,8 +91,8 @@ internal static partial class AccountLoginEndpoints
 
     private static async Task<Results<Ok<AccountLoginResponse>, ProblemHttpResult>> HandleLoginCoreAsync(
         AccountLoginRequest request,
-        SignInManager<GranitUser> signInManager,
-        UserManager<GranitUser> userManager,
+        SignInManager<LocalIdentity> signInManager,
+        UserManager<LocalIdentity> userManager,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
@@ -111,7 +111,7 @@ internal static partial class AccountLoginEndpoints
         // does not match — making it impossible to log in as a host admin from a
         // browser that previously authenticated a tenant user, and vice-versa.
         // RequireUniqueEmail=true guarantees no ambiguity across tenants.
-        GranitUser? user;
+        LocalIdentity? user;
         IDisposable? tenantFilterScope = dataFilter?.Disable<IMultiTenant>();
         try
         {
@@ -200,7 +200,7 @@ internal static partial class AccountLoginEndpoints
 
     private static async Task<Results<Ok<AccountLoginResponse>, ProblemHttpResult>> HandleTwoFactorLoginAsync(
         AccountTwoFactorLoginRequest request,
-        [FromServices] SignInManager<GranitUser> signInManager,
+        [FromServices] SignInManager<LocalIdentity> signInManager,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
@@ -242,7 +242,7 @@ internal static partial class AccountLoginEndpoints
             // so re-sign the user with a persistent cookie when RememberMe is requested.
             if (result.Succeeded && request.RememberMe)
             {
-                GranitUser? user = await signInManager.UserManager
+                LocalIdentity? user = await signInManager.UserManager
                     .GetUserAsync(httpContext.User).ConfigureAwait(false);
 
                 if (user is not null)
@@ -269,7 +269,7 @@ internal static partial class AccountLoginEndpoints
 
         if (result.IsLockedOut)
         {
-            GranitUser? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+            LocalIdentity? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
                 .ConfigureAwait(false);
 
             LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
@@ -313,7 +313,7 @@ internal static partial class AccountLoginEndpoints
     /// the rest of the 2FA ceremony runs in the correct context.
     /// </remarks>
     private static async Task<IDisposable?> ResolveTenantFromTwoFactorSessionAsync(
-        SignInManager<GranitUser> signInManager,
+        SignInManager<LocalIdentity> signInManager,
         ICurrentTenant? currentTenant,
         IDataFilter? dataFilter)
     {
@@ -324,7 +324,7 @@ internal static partial class AccountLoginEndpoints
 
         using IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
 
-        GranitUser? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+        LocalIdentity? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
             .ConfigureAwait(false);
 
         return twoFactorUser is null ? null : currentTenant.Change(twoFactorUser.TenantId);
@@ -352,12 +352,12 @@ internal static partial class AccountLoginEndpoints
     /// real password verification.
     /// </summary>
     private static readonly string DummyPasswordHash =
-        new PasswordHasher<GranitUser>().HashPassword(null!, "K4$hDummyP@ssw0rd!");
+        new PasswordHasher<LocalIdentity>().HashPassword(null!, "K4$hDummyP@ssw0rd!");
 
     private static void PerformDummyPasswordHash(HttpContext httpContext)
     {
-        IPasswordHasher<GranitUser> hasher = httpContext.RequestServices
-            .GetRequiredService<IPasswordHasher<GranitUser>>();
+        IPasswordHasher<LocalIdentity> hasher = httpContext.RequestServices
+            .GetRequiredService<IPasswordHasher<LocalIdentity>>();
 
         // Use a random password each time to introduce natural timing jitter
         // and avoid a constant, fingerprint-able verification pattern.
@@ -368,8 +368,8 @@ internal static partial class AccountLoginEndpoints
 
     private static async Task PublishAccountLockedAsync(
         HttpContext httpContext,
-        UserManager<GranitUser> userManager,
-        GranitUser user,
+        UserManager<LocalIdentity> userManager,
+        LocalIdentity user,
         CancellationToken cancellationToken)
     {
         IDistributedEventBus? eventBus = httpContext.RequestServices.GetService<IDistributedEventBus>();

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
@@ -155,8 +155,8 @@ internal static class AccountPasskeyEndpoints
         AccountPasskeyLoginRequest request,
         HttpContext httpContext,
         [FromServices] IPasskeyService passkeyService,
-        [FromServices] SignInManager<GranitUser> signInManager,
-        [FromServices] UserManager<GranitUser> userManager,
+        [FromServices] SignInManager<LocalIdentity> signInManager,
+        [FromServices] UserManager<LocalIdentity> userManager,
         CancellationToken cancellationToken)
     {
         IdentityLocalMetrics? metrics = httpContext.RequestServices.GetService<IdentityLocalMetrics>();
@@ -174,7 +174,7 @@ internal static class AccountPasskeyEndpoints
                 statusCode: StatusCodes.Status401Unauthorized);
         }
 
-        GranitUser? user = await userManager.FindByIdAsync(assertion.UserId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(assertion.UserId).ConfigureAwait(false);
 
         if (user is null)
         {

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Local.Privacy.DataExport;
 
 /// <summary>
 /// Privacy data provider for Granit.Identity.Local. Emits the authenticated user's profile
-/// (<see cref="GranitUser"/>) and the roles they belong to as a JSON fragment during the
+/// (<see cref="LocalIdentity"/>) and the roles they belong to as a JSON fragment during the
 /// scatter-gather personal-data export saga (GDPR Art. 15/20).
 /// </summary>
 /// <remarks>
@@ -16,7 +16,7 @@ namespace Granit.Identity.Local.Privacy.DataExport;
 /// sentinel so the archive assembler records the provider in <c>manifest.EmptyProviders</c>
 /// rather than failing the whole export.
 /// </remarks>
-public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> userManager) : IPrivacyDataProvider
+public sealed class IdentityLocalPrivacyDataProvider(UserManager<LocalIdentity> userManager) : IPrivacyDataProvider
 {
     /// <inheritdoc />
     public static string ProviderName => "identity-local";
@@ -30,7 +30,7 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
     /// <inheritdoc />
     public async Task<ReadOnlyMemory<byte>> ExportAsync(Guid userId, CancellationToken cancellationToken)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId.ToString()).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId.ToString()).ConfigureAwait(false);
         if (user is null)
         {
             return ReadOnlyMemory<byte>.Empty;

--- a/src/Granit.Identity.Local/Domain/GranitRole.cs
+++ b/src/Granit.Identity.Local/Domain/GranitRole.cs
@@ -14,7 +14,7 @@ namespace Granit.Identity.Local.Domain;
 /// access is enforced at the permission/policy level, not at the role definition level.
 /// </para>
 /// <para>
-/// This differs from <see cref="GranitUser"/>, <see cref="GranitUserGroup"/>,
+/// This differs from <see cref="LocalIdentity"/>, <see cref="GranitUserGroup"/>,
 /// and <see cref="GranitUserGroupMember"/> which are all tenant-scoped.
 /// </para>
 /// </remarks>

--- a/src/Granit.Identity.Local/Domain/GranitUserGroupMember.cs
+++ b/src/Granit.Identity.Local/Domain/GranitUserGroupMember.cs
@@ -3,7 +3,7 @@ using Granit.Domain;
 namespace Granit.Identity.Local.Domain;
 
 /// <summary>
-/// Join entity linking a <see cref="GranitUser"/> to a <see cref="GranitUserGroup"/>.
+/// Join entity linking a <see cref="LocalIdentity"/> to a <see cref="GranitUserGroup"/>.
 /// </summary>
 public class GranitUserGroupMember : AuditedEntity, IMultiTenant
 {

--- a/src/Granit.Identity.Local/Domain/LocalIdentity.cs
+++ b/src/Granit.Identity.Local/Domain/LocalIdentity.cs
@@ -26,9 +26,26 @@ namespace Granit.Identity.Local.Domain;
 /// in <c>Granit.Persistence.EntityFrameworkCore</c> handles Shadow Property synchronization.
 /// </para>
 /// </remarks>
-public class GranitUser : IdentityUser<Guid>, IMultiTenant, IIdentityUser, IHasMetadata
+public class LocalIdentity : IdentityUser<Guid>, IMultiTenant, IIdentityUser, IHasMetadata
 {
     private IReadOnlyDictionary<string, string>? _parsedMetadata;
+
+    /// <summary>
+    /// Foreign key to the canonical <see cref="Granit.Identity.Domain.User"/>
+    /// aggregate (per ADR-051 B-step 2). Equal to <see cref="IdentityUser{TKey}.Id"/>
+    /// on greenfield records — the seed regeneration pre-populates both
+    /// tables with the same Guid so existing references continue to resolve.
+    /// </summary>
+    /// <remarks>
+    /// The FK is required: a <see cref="LocalIdentity"/> without a
+    /// corresponding <see cref="Granit.Identity.Domain.User"/> row would be
+    /// auth-only and unreachable from any of the canonical-user surfaces
+    /// (admin grid, OData feed, BI exports). Hosts populate this through
+    /// either the seed or a host-side handler that creates the
+    /// <see cref="Granit.Identity.Domain.User"/> row alongside the
+    /// <see cref="LocalIdentity"/> insert.
+    /// </remarks>
+    public Guid UserId { get; set; }
 
     /// <summary>Gets or sets the user's first name.</summary>
     public string? FirstName { get; set; }

--- a/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
+++ b/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
@@ -22,7 +22,7 @@ namespace Granit.Identity.Local;
 /// Granit module for shared local identity abstractions.
 /// </summary>
 /// <remarks>
-/// Provides <see cref="Entities.GranitUser"/>, <see cref="Entities.GranitRole"/>,
+/// Provides <see cref="Entities.LocalIdentity"/>, <see cref="Entities.GranitRole"/>,
 /// <see cref="Domain.GranitUserGroup"/>, provider-agnostic service interfaces,
 /// integration events, and <see cref="Services.ILocalIdentityGroupStore"/>.
 /// Used by both <c>Granit.OpenIddict.EntityFrameworkCore</c> and any future

--- a/src/Granit.Identity.Local/Services/ITwoFactorService.cs
+++ b/src/Granit.Identity.Local/Services/ITwoFactorService.cs
@@ -4,7 +4,7 @@ namespace Granit.Identity.Local.Services;
 /// High-level service for managing TOTP two-factor authentication state.
 /// </summary>
 /// <remarks>
-/// Wraps <c>UserManager&lt;GranitUser&gt;</c> 2FA operations behind an abstraction
+/// Wraps <c>UserManager&lt;LocalIdentity&gt;</c> 2FA operations behind an abstraction
 /// consumable by the endpoints layer without a direct EF Core dependency.
 /// </remarks>
 public interface ITwoFactorService

--- a/src/Granit.Identity/Domain/User.cs
+++ b/src/Granit.Identity/Domain/User.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Domain;
 
 /// <summary>
 /// Canonical user aggregate per ADR-051. Replaces the dual hierarchy
-/// <c>GranitUser</c> (local) / <c>UserCacheEntry</c> (federated) at the
+/// <c>LocalIdentity</c> (local) / <c>UserCacheEntry</c> (federated) at the
 /// "who is this person" level — auth-secret storage and IdP-cache fields
 /// live in their own siblings (<c>LocalIdentity</c> / <c>FederatedIdentity</c>)
 /// that reference <see cref="Id"/> via FK.
@@ -23,7 +23,7 @@ namespace Granit.Identity.Domain;
 /// Implements <see cref="IIdentityUser"/> so existing consumers
 /// (<see cref="IUserLookupService"/>, <see cref="IIdentityUserReader"/>,
 /// audit projections) see it interchangeably with the legacy
-/// <c>GranitUser</c> / <c>UserCacheEntry</c> implementations during the
+/// <c>LocalIdentity</c> / <c>UserCacheEntry</c> implementations during the
 /// staged migration.
 /// </para>
 /// </remarks>

--- a/src/Granit.Identity/IIdentityUser.cs
+++ b/src/Granit.Identity/IIdentityUser.cs
@@ -8,7 +8,7 @@ namespace Granit.Identity;
 /// Implemented by:
 /// <list type="bullet">
 /// <item><c>FederatedIdentityUser</c> — immutable snapshot from external providers (Keycloak, EntraID, etc.)</item>
-/// <item><c>GranitUser</c> — EF Core entity for local mode (OpenIddict / ASP.NET Core Identity)</item>
+/// <item><c>LocalIdentity</c> — EF Core entity for local mode (OpenIddict / ASP.NET Core Identity)</item>
 /// <item><c>CachedIdentityUser</c> — EF Core cache entry for external providers</item>
 /// </list>
 /// </para>
@@ -23,7 +23,7 @@ public interface IIdentityUser
     /// User identifier (string for all modes).
     /// </summary>
     /// <remarks>
-    /// For local mode (<c>GranitUser</c>), returns <c>Id.ToString()</c>.
+    /// For local mode (<c>LocalIdentity</c>), returns <c>Id.ToString()</c>.
     /// For external mode, returns the provider's native identifier (e.g., Keycloak subject).
     /// </remarks>
     string UserId { get; }
@@ -51,7 +51,7 @@ public interface IIdentityUser
     /// Never <see langword="null"/> — returns an empty dictionary when no extra properties are set.
     /// </para>
     /// <para>
-    /// For <c>GranitUser</c>: deserialized from <c>CustomAttributesJson</c> (JSONB column).
+    /// For <c>LocalIdentity</c>: deserialized from <c>CustomAttributesJson</c> (JSONB column).
     /// For Keycloak: flattened user attributes.
     /// For <c>CachedIdentityUser</c>: deserialized from <c>MetadataJson</c>.
     /// </para>

--- a/src/Granit.Identity/IUserDirectoryQueryableSource.cs
+++ b/src/Granit.Identity/IUserDirectoryQueryableSource.cs
@@ -5,7 +5,7 @@ namespace Granit.Identity;
 /// <summary>
 /// Provides an <see cref="IQueryable{User}"/> source for the user directory
 /// — admin grids, OData feed, BI exports. Per ADR-051 the
-/// <see cref="User"/> aggregate replaces the dual <c>GranitUser</c> /
+/// <see cref="User"/> aggregate replaces the dual <c>LocalIdentity</c> /
 /// <c>UserCacheEntry</c> read paths with a single canonical surface.
 /// </summary>
 /// <remarks>

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -109,11 +109,11 @@ internal static partial class ConnectAuthorizationEndpoints
         // hide the user whenever their TenantId does not match the active scope —
         // host admins (TenantId = null) in particular become invisible on every
         // request that has inherited a tenant context from another source.
-        UserManager<GranitUser> userManager = context.RequestServices
-            .GetRequiredService<UserManager<GranitUser>>();
+        UserManager<LocalIdentity> userManager = context.RequestServices
+            .GetRequiredService<UserManager<LocalIdentity>>();
         IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
 
-        GranitUser? user;
+        LocalIdentity? user;
         IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
         try
         {

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -105,10 +105,10 @@ internal static partial class ConnectTokenEndpoints
         try
         {
             // Retrieve the user from the subject claim.
-            UserManager<GranitUser> userManager = context.RequestServices
-                .GetRequiredService<UserManager<GranitUser>>();
+            UserManager<LocalIdentity> userManager = context.RequestServices
+                .GetRequiredService<UserManager<LocalIdentity>>();
 
-            GranitUser? user = subject is not null
+            LocalIdentity? user = subject is not null
                 ? await userManager.FindByIdAsync(subject).ConfigureAwait(false)
                 : null;
 

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
@@ -48,9 +48,9 @@ internal static class ConnectUserInfoEndpoints
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
-        UserManager<GranitUser> userManager = context.RequestServices
-            .GetRequiredService<UserManager<GranitUser>>();
-        GranitUser? user = await userManager.FindByIdAsync(subject).ConfigureAwait(false);
+        UserManager<LocalIdentity> userManager = context.RequestServices
+            .GetRequiredService<UserManager<LocalIdentity>>();
+        LocalIdentity? user = await userManager.FindByIdAsync(subject).ConfigureAwait(false);
 
         if (user is null)
         {

--- a/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
+++ b/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
@@ -10,11 +10,11 @@ using OpenIddict.Abstractions;
 namespace Granit.OpenIddict.Endpoints.Internal;
 
 /// <summary>
-/// Builds a <see cref="ClaimsPrincipal"/> from a <see cref="GranitUser"/> for OIDC token issuance.
+/// Builds a <see cref="ClaimsPrincipal"/> from a <see cref="LocalIdentity"/> for OIDC token issuance.
 /// Isolated from OpenIddict-specific types so the logic is reusable with other OIDC providers.
 /// </summary>
 internal sealed class OidcPrincipalFactory(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IClaimsDestinationProvider destinationProvider)
 {
     /// <summary>
@@ -27,7 +27,7 @@ internal sealed class OidcPrincipalFactory(
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A principal ready for token issuance.</returns>
     internal async Task<ClaimsPrincipal> CreateUserPrincipalAsync(
-        GranitUser user,
+        LocalIdentity user,
         ImmutableArray<string> scopes,
         string authenticationScheme,
         CancellationToken cancellationToken = default)

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -52,7 +52,7 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
 
         // 3. Register ASP.NET Core Identity
         builder.Services
-            .AddIdentity<GranitUser, GranitRole>(options =>
+            .AddIdentity<LocalIdentity, GranitRole>(options =>
             {
                 options.User.RequireUniqueEmail = true;
                 options.Lockout.MaxFailedAccessAttempts = lockoutOptions.MaxFailedAccessAttempts;

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class OpenIddictModelBuilderExtensions
 {
     /// <summary>
     /// Configures the OpenIddict module entities: table prefixes, column constraints,
-    /// indexes, and the manual soft-delete filter for <see cref="GranitUser"/>.
+    /// indexes, and the manual soft-delete filter for <see cref="LocalIdentity"/>.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -26,7 +26,7 @@ public static class OpenIddictModelBuilderExtensions
     /// but BEFORE <c>modelBuilder.ApplyGranitConventions()</c>.
     /// </para>
     /// <para>
-    /// <see cref="GranitUser"/> cannot implement <see cref="ISoftDeletable"/> because
+    /// <see cref="LocalIdentity"/> cannot implement <see cref="ISoftDeletable"/> because
     /// ASP.NET Core Identity's <c>UserManager&lt;T&gt;</c> uses reflection/metadata
     /// patterns that are incompatible with the interface. The soft-delete filter is
     /// therefore registered manually here, using the same <c>bypass || real</c> pattern
@@ -46,7 +46,7 @@ public static class OpenIddictModelBuilderExtensions
     public static ModelBuilder ConfigureOpenIddictModule(
         this ModelBuilder modelBuilder,
         IDataFilter? dataFilter = null,
-        MetadataMappingOptions<GranitUser>? extensionOptions = null)
+        MetadataMappingOptions<LocalIdentity>? extensionOptions = null)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
@@ -57,7 +57,7 @@ public static class OpenIddictModelBuilderExtensions
 
         SoftDeleteProxy proxy = new(dataFilter);
 
-        modelBuilder.Entity<GranitUser>(b =>
+        modelBuilder.Entity<LocalIdentity>(b =>
         {
             b.ToTable(prefix + "users", schema);
             b.Property(u => u.FirstName).HasMaxLength(256);
@@ -67,16 +67,16 @@ public static class OpenIddictModelBuilderExtensions
             b.Property(u => u.ModifiedBy).HasMaxLength(256);
 
             // Manual soft-delete filter with IDataFilter bypass support.
-            // GranitUser does NOT implement ISoftDeletable (incompatible with UserManager),
+            // LocalIdentity does NOT implement ISoftDeletable (incompatible with UserManager),
             // so ApplyGranitConventions cannot register this filter automatically.
             // Pattern: bypass (IDataFilter disabled) || real (!IsDeleted)
-            ParameterExpression param = Expression.Parameter(typeof(GranitUser), "u");
+            ParameterExpression param = Expression.Parameter(typeof(LocalIdentity), "u");
             UnaryExpression bypass = Expression.Not(
                 Expression.Property(Expression.Constant(proxy), nameof(SoftDeleteProxy.SoftDeleteEnabled)));
             UnaryExpression notDeleted = Expression.Not(
-                Expression.Property(param, nameof(GranitUser.IsDeleted)));
+                Expression.Property(param, nameof(LocalIdentity.IsDeleted)));
             var filter =
-                Expression.Lambda<Func<GranitUser, bool>>(Expression.OrElse(bypass, notDeleted), param);
+                Expression.Lambda<Func<LocalIdentity, bool>>(Expression.OrElse(bypass, notDeleted), param);
 
             b.HasQueryFilter(Granit.Persistence.EntityFrameworkCore.GranitFilterNames.SoftDelete, filter);
 
@@ -184,7 +184,7 @@ public static class OpenIddictModelBuilderExtensions
 
         if (extensionOptions is { Mappings.Count: > 0 })
         {
-            modelBuilder.Entity<GranitUser>(b =>
+            modelBuilder.Entity<LocalIdentity>(b =>
             {
                 foreach (MetadataMapping mapping in extensionOptions.Mappings)
                 {
@@ -211,7 +211,7 @@ public static class OpenIddictModelBuilderExtensions
     /// EF Core evaluates property access on a <see cref="ConstantExpression"/> as a query
     /// parameter re-evaluated on each query. This proxy mirrors the pattern used by
     /// <c>ApplyGranitConventions</c>'s internal <c>FilterProxy</c>, but only for the
-    /// <see cref="ISoftDeletable"/> filter needed by <see cref="GranitUser"/>.
+    /// <see cref="ISoftDeletable"/> filter needed by <see cref="LocalIdentity"/>.
     /// </summary>
     private sealed class SoftDeleteProxy(IDataFilter? dataFilter)
     {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -40,8 +40,8 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
 
-        // GranitUser implements IHasMetadata — apps can extend user properties
-        // by calling AddMetadataMappings<GranitUser> in their own module.
+        // LocalIdentity implements IHasMetadata — apps can extend user properties
+        // by calling AddMetadataMappings<LocalIdentity> in their own module.
         // The MetadataSyncInterceptor in Granit.Persistence handles sync automatically.
         context.Services.AddMetadataInfrastructure();
     }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -25,8 +25,8 @@ internal sealed class OpenIddictDbContext(
     DbContextOptions<OpenIddictDbContext> options,
     ICurrentTenant? currentTenant = null,
     IDataFilter? dataFilter = null,
-    IOptions<MetadataMappingOptions<GranitUser>>? extensionOptions = null)
-    : IdentityDbContext<GranitUser, GranitRole, Guid>(options)
+    IOptions<MetadataMappingOptions<LocalIdentity>>? extensionOptions = null)
+    : IdentityDbContext<LocalIdentity, GranitRole, Guid>(options)
 {
     /// <summary>Gets the user groups set.</summary>
     public DbSet<GranitUserGroup> UserGroups => Set<GranitUserGroup>();

--- a/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
@@ -42,7 +42,7 @@ public sealed partial class ClientSideAuthorizationHandler(
 {
     /// <summary>
     /// Well-known claim type for the tenant identifier carried on the principal,
-    /// as populated by <c>GranitUserClaimsPrincipalFactory</c> for tenant users.
+    /// as populated by <c>LocalIdentityClaimsPrincipalFactory</c> for tenant users.
     /// </summary>
     private const string TenantIdClaimType = "tenant_id";
 

--- a/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
@@ -14,7 +14,7 @@ namespace Granit.OpenIddict.Internal;
 /// via <see cref="IDistributedEventBus"/>.
 /// </summary>
 internal sealed class AspNetAccountDeletionService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IOpenIddictTokenManager tokenManager,
     IDistributedEventBus eventBus,
     IClock clock) : IAccountDeletionService
@@ -22,7 +22,7 @@ internal sealed class AspNetAccountDeletionService(
     /// <inheritdoc/>
     public async Task InitiateAsync(string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         // Soft-delete

--- a/src/Granit.OpenIddict/Internal/AspNetExternalLoginService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetExternalLoginService.cs
@@ -16,7 +16,7 @@ namespace Granit.OpenIddict.Internal;
 /// <see cref="UserManager{TUser}"/> external login support.
 /// </summary>
 internal sealed class AspNetExternalLoginService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     ExternalClaimsMapper claimsMapper,
     IDistributedEventBus eventBus,
     IOptions<GranitOpenIddictClientOptions> clientOptions) : IExternalLoginService
@@ -25,7 +25,7 @@ internal sealed class AspNetExternalLoginService(
     public async Task<IReadOnlyList<GranitExternalLoginInfo>> GetLoginsAsync(
         string userId, CancellationToken cancellationToken = default)
     {
-        GranitUser? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        LocalIdentity? user = await userManager.FindByIdAsync(userId).ConfigureAwait(false);
         if (user is null)
         {
             return [];
@@ -41,7 +41,7 @@ internal sealed class AspNetExternalLoginService(
     public async Task AddLoginAsync(
         string userId, GranitExternalLoginInfo info, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         IdentityResult result = await userManager.AddLoginAsync(
@@ -60,7 +60,7 @@ internal sealed class AspNetExternalLoginService(
     public async Task RemoveLoginAsync(
         string userId, string provider, string providerKey, CancellationToken cancellationToken = default)
     {
-        GranitUser user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
+        LocalIdentity user = await userManager.FindByIdAsync(userId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User {userId} not found.");
 
         // Guard: cannot remove last login method if no password is set
@@ -96,7 +96,7 @@ internal sealed class AspNetExternalLoginService(
             throw new InvalidOperationException("External provider did not return a user identifier.");
         }
 
-        GranitUser? existingUser = await userManager.FindByLoginAsync(provider, providerKey)
+        LocalIdentity? existingUser = await userManager.FindByLoginAsync(provider, providerKey)
             .ConfigureAwait(false);
 
         if (existingUser is not null)
@@ -130,7 +130,7 @@ internal sealed class AspNetExternalLoginService(
                 "Account not found. Party your administrator.");
         }
 
-        GranitUser newUser = new()
+        LocalIdentity newUser = new()
         {
             UserName = props.Email ?? props.UserName ?? providerKey,
             Email = props.Email,

--- a/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
@@ -21,7 +21,7 @@ namespace Granit.OpenIddict.Internal;
 /// with impersonator claims for administrator impersonation.
 /// </summary>
 internal sealed partial class AspNetImpersonationService(
-    UserManager<GranitUser> userManager,
+    UserManager<LocalIdentity> userManager,
     IOpenIddictTokenManager tokenManager,
     IDistributedEventBus eventBus,
     IdentityLocalMetrics metrics,
@@ -41,7 +41,7 @@ internal sealed partial class AspNetImpersonationService(
         ArgumentException.ThrowIfNullOrWhiteSpace(impersonatorId);
         ArgumentException.ThrowIfNullOrWhiteSpace(impersonatorName);
 
-        GranitUser targetUser = await userManager.FindByIdAsync(targetUserId).ConfigureAwait(false)
+        LocalIdentity targetUser = await userManager.FindByIdAsync(targetUserId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Target user '{targetUserId}' not found.");
 
         // Build claims principal for the impersonated user
@@ -132,7 +132,7 @@ internal sealed partial class AspNetImpersonationService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(impersonatorId);
 
-        GranitUser adminUser = await userManager.FindByIdAsync(impersonatorId).ConfigureAwait(false)
+        LocalIdentity adminUser = await userManager.FindByIdAsync(impersonatorId).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Impersonator user '{impersonatorId}' not found.");
 
         // Build a fresh claims principal for the admin (no impersonator claims)

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictClientOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictClientOptions.cs
@@ -15,7 +15,7 @@ public sealed class GranitOpenIddictClientOptions
     /// Gets or sets a value indicating whether to auto-register users from external providers.
     /// </summary>
     /// <remarks>
-    /// When <see langword="true"/>, a new <c>GranitUser</c> is created on first login
+    /// When <see langword="true"/>, a new <c>LocalIdentity</c> is created on first login
     /// via external provider. When <see langword="false"/>, returns 403 if no existing account.
     /// </remarks>
     public bool AutoRegisterExternalUsers { get; set; } = true;

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -63,7 +63,7 @@ public sealed partial class IsolatedDbContextTests
                 {
                     string rel = Path.GetRelativePath(RepoRoot, csFile);
 
-                    // GranitUser cannot implement ISoftDeletable (incompatible with UserManager),
+                    // LocalIdentity cannot implement ISoftDeletable (incompatible with UserManager),
                     // so OpenIddict's model builder must register the soft-delete filter manually.
                     if (rel.Contains("OpenIddict", StringComparison.Ordinal))
                     {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
@@ -70,7 +70,7 @@ public sealed class RoleEndpointsPermissionTestApplication : IAsyncLifetime
         builder.Services.AddDbContext<TestHostDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
 
-        builder.Services.AddIdentityCore<GranitUser>()
+        builder.Services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()
             .AddEntityFrameworkStores<TestIdentityDbContext>();
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
@@ -74,7 +74,7 @@ public sealed class RoleEndpointsTestApplication : IAsyncLifetime
         builder.Services.AddDbContext<TestHostDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
 
-        builder.Services.AddIdentityCore<GranitUser>()
+        builder.Services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()
             .AddEntityFrameworkStores<TestIdentityDbContext>();
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
@@ -52,7 +52,7 @@ public sealed class RoleOrchestratorAtomicTestApplication : IAsyncLifetime
         services.AddDbContextFactory<TestHostDbContext>(opts =>
             opts.UseNpgsql(_postgres.ConnectionString));
 
-        services.AddIdentityCore<GranitUser>()
+        services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()
             .AddEntityFrameworkStores<TestIdentityDbContext>();
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
@@ -16,7 +16,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
 /// <summary>
 /// Collection fixture that starts a PostgreSQL 17 container and builds a minimal service
 /// provider wiring everything the <see cref="GranitRoleOrchestrator"/> needs:
-/// ASP.NET Core Identity (with <c>GranitUser</c> / <c>GranitRole</c>), the
+/// ASP.NET Core Identity (with <c>LocalIdentity</c> / <c>GranitRole</c>), the
 /// authorization <see cref="TestHostDbContext"/> backing <c>IRoleMetadataStore</c>, and
 /// the orchestrator itself.
 /// </summary>
@@ -50,7 +50,7 @@ public sealed class RoleOrchestratorTestApplication : IAsyncLifetime
 
         // ASP.NET Core Identity — lightweight IdentityCore pipeline is enough for the
         // orchestrator; no cookies / token providers / email services required.
-        services.AddIdentityCore<GranitUser>()
+        services.AddIdentityCore<LocalIdentity>()
             .AddRoles<GranitRole>()
             .AddEntityFrameworkStores<TestIdentityDbContext>();
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestIdentityDbContext.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestIdentityDbContext.cs
@@ -6,9 +6,9 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
 
 /// <summary>
 /// Minimal ASP.NET Core Identity DbContext used by the orchestrator integration tests.
-/// Stores <c>GranitUser</c> / <c>GranitRole</c> via the stock Identity schema.
+/// Stores <c>LocalIdentity</c> / <c>GranitRole</c> via the stock Identity schema.
 /// Mirrors production deployments that keep Identity tables in a dedicated DbContext
 /// (in Granit's OIDC flow that role is played by the internal <c>OpenIddictDbContext</c>).
 /// </summary>
 internal sealed class TestIdentityDbContext(DbContextOptions<TestIdentityDbContext> options)
-    : IdentityDbContext<GranitUser, GranitRole, Guid>(options);
+    : IdentityDbContext<LocalIdentity, GranitRole, Guid>(options);

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasswordResetServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasswordResetServiceTests.cs
@@ -12,14 +12,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests;
 
 public sealed class AspNetPasswordResetServiceTests
 {
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly AspNetPasswordResetService _sut;
 
     public AspNetPasswordResetServiceTests()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
 
         _sut = new AspNetPasswordResetService(_userManager, _eventBus);
@@ -28,7 +28,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task RequestResetAsync_UserExists_ReturnsTrue()
     {
-        var user = new GranitUser { Id = Guid.NewGuid(), Email = "user@example.com" };
+        var user = new LocalIdentity { Id = Guid.NewGuid(), Email = "user@example.com" };
         _userManager.FindByEmailAsync("user@example.com").Returns(user);
         _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token-123");
 
@@ -42,7 +42,7 @@ public sealed class AspNetPasswordResetServiceTests
     {
         var userId = Guid.NewGuid();
         var tenantId = Guid.NewGuid();
-        var user = new GranitUser { Id = userId, Email = "user@example.com", TenantId = tenantId };
+        var user = new LocalIdentity { Id = userId, Email = "user@example.com", TenantId = tenantId };
         _userManager.FindByEmailAsync("user@example.com").Returns(user);
         _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token-123");
 
@@ -60,7 +60,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task RequestResetAsync_UserNotFound_ReturnsFalse()
     {
-        _userManager.FindByEmailAsync("unknown@example.com").Returns((GranitUser?)null);
+        _userManager.FindByEmailAsync("unknown@example.com").Returns((LocalIdentity?)null);
 
         bool result = await _sut.RequestResetAsync("unknown@example.com", TestContext.Current.CancellationToken);
 
@@ -70,7 +70,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task RequestResetAsync_UserNotFound_DoesNotPublishEvent()
     {
-        _userManager.FindByEmailAsync("unknown@example.com").Returns((GranitUser?)null);
+        _userManager.FindByEmailAsync("unknown@example.com").Returns((LocalIdentity?)null);
 
         await _sut.RequestResetAsync("unknown@example.com", TestContext.Current.CancellationToken);
 
@@ -81,7 +81,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task ResetPasswordAsync_ValidUserAndToken_Succeeds()
     {
-        var user = new GranitUser { Id = Guid.NewGuid() };
+        var user = new LocalIdentity { Id = Guid.NewGuid() };
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.ResetPasswordAsync(user, "token", "NewP@ss1").Returns(IdentityResult.Success);
         _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset?>()).Returns(IdentityResult.Success);
@@ -93,7 +93,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task ResetPasswordAsync_LockedOutUser_ClearsLockout()
     {
-        var user = new GranitUser { Id = Guid.NewGuid(), LockoutEnd = DateTimeOffset.UtcNow.AddHours(1) };
+        var user = new LocalIdentity { Id = Guid.NewGuid(), LockoutEnd = DateTimeOffset.UtcNow.AddHours(1) };
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.ResetPasswordAsync(user, "token", "NewP@ss1").Returns(IdentityResult.Success);
         _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset?>()).Returns(IdentityResult.Success);
@@ -106,20 +106,20 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task ResetPasswordAsync_NotLockedOutUser_DoesNotCallSetLockout()
     {
-        var user = new GranitUser { Id = Guid.NewGuid() };
+        var user = new LocalIdentity { Id = Guid.NewGuid() };
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.ResetPasswordAsync(user, "token", "NewP@ss1").Returns(IdentityResult.Success);
 
         await _sut.ResetPasswordAsync(user.Id.ToString(), "token", "NewP@ss1", TestContext.Current.CancellationToken);
 
-        await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<GranitUser>(), Arg.Any<DateTimeOffset?>());
+        await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<LocalIdentity>(), Arg.Any<DateTimeOffset?>());
     }
 
     [Fact]
     public async Task ResetPasswordAsync_UserNotFound_ThrowsInvalidOperation()
     {
         string unknownId = Guid.NewGuid().ToString();
-        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+        _userManager.FindByIdAsync(unknownId).Returns((LocalIdentity?)null);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.ResetPasswordAsync(unknownId, "token", "NewP@ss1", TestContext.Current.CancellationToken));
@@ -130,7 +130,7 @@ public sealed class AspNetPasswordResetServiceTests
     [Fact]
     public async Task ResetPasswordAsync_IdentityResultFailed_ThrowsWithErrors()
     {
-        var user = new GranitUser { Id = Guid.NewGuid() };
+        var user = new LocalIdentity { Id = Guid.NewGuid() };
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.ResetPasswordAsync(user, "bad-token", "NewP@ss1")
             .Returns(IdentityResult.Failed(new IdentityError { Description = "Invalid token" }));

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
@@ -12,18 +12,18 @@ public sealed class AspNetTwoFactorServiceTests
 {
     private static readonly string UserId = Guid.NewGuid().ToString();
 
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly ITotpService _totpService = Substitute.For<ITotpService>();
     private readonly AspNetTwoFactorService _sut;
-    private readonly GranitUser _user;
+    private readonly LocalIdentity _user;
 
     public AspNetTwoFactorServiceTests()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
 
-        _user = new GranitUser { Id = Guid.Parse(UserId), Email = "user@test.com", UserName = "testuser" };
+        _user = new LocalIdentity { Id = Guid.Parse(UserId), Email = "user@test.com", UserName = "testuser" };
         _userManager.FindByIdAsync(UserId).Returns(_user);
 
         _sut = new AspNetTwoFactorService(_userManager, _totpService);
@@ -62,7 +62,7 @@ public sealed class AspNetTwoFactorServiceTests
     [Fact]
     public async Task GetStatusAsync_UserNotFound_Throws()
     {
-        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+        _userManager.FindByIdAsync("unknown").Returns((LocalIdentity?)null);
 
         await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.GetStatusAsync("unknown", TestContext.Current.CancellationToken));
@@ -101,7 +101,7 @@ public sealed class AspNetTwoFactorServiceTests
     [Fact]
     public async Task GetAuthenticatorKeyAsync_NoEmail_UsesUserNameForQrCode()
     {
-        var user = new GranitUser { Id = Guid.NewGuid(), Email = null, UserName = "fallback-user" };
+        var user = new LocalIdentity { Id = Guid.NewGuid(), Email = null, UserName = "fallback-user" };
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.GetAuthenticatorKeyAsync(user).Returns("KEY123");
         _totpService.GetQrCodeUri("fallback-user", "KEY123").Returns("otpauth://...");
@@ -138,7 +138,7 @@ public sealed class AspNetTwoFactorServiceTests
             () => _sut.EnableAsync(UserId, "000000", TestContext.Current.CancellationToken));
 
         ex.Message.ShouldContain("Invalid TOTP");
-        await _userManager.DidNotReceive().SetTwoFactorEnabledAsync(Arg.Any<GranitUser>(), Arg.Any<bool>());
+        await _userManager.DidNotReceive().SetTwoFactorEnabledAsync(Arg.Any<LocalIdentity>(), Arg.Any<bool>());
     }
 
     [Fact]

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/GranitUserManagerTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/GranitUserManagerTests.cs
@@ -33,7 +33,7 @@ public sealed class GranitUserManagerTests
     [InlineData(10, 120)]    // 2h (cap)
     public void ComputeLockoutDuration_ExponentialBackoff(int consecutiveLockouts, int expectedMinutes)
     {
-        GranitUserManager manager = CreateManager(DefaultOptions);
+        LocalIdentityManager manager = CreateManager(DefaultOptions);
 
         TimeSpan duration = manager.ComputeLockoutDuration(consecutiveLockouts);
 
@@ -43,7 +43,7 @@ public sealed class GranitUserManagerTests
     [Fact]
     public void ComputeLockoutDuration_ZeroLockouts_ReturnsBaseDuration()
     {
-        GranitUserManager manager = CreateManager(DefaultOptions);
+        LocalIdentityManager manager = CreateManager(DefaultOptions);
 
         TimeSpan duration = manager.ComputeLockoutDuration(0);
 
@@ -59,7 +59,7 @@ public sealed class GranitUserManagerTests
             MaxLockoutDuration = TimeSpan.FromMinutes(30),
             ExponentialBase = 3.0,
         };
-        GranitUserManager manager = CreateManager(options);
+        LocalIdentityManager manager = CreateManager(options);
 
         // 1 * 3^0 = 1 min
         manager.ComputeLockoutDuration(1).ShouldBe(TimeSpan.FromMinutes(1));
@@ -76,7 +76,7 @@ public sealed class GranitUserManagerTests
     [Fact]
     public void ComputeLockoutDuration_VeryHighLockoutCount_DoesNotOverflow()
     {
-        GranitUserManager manager = CreateManager(DefaultOptions);
+        LocalIdentityManager manager = CreateManager(DefaultOptions);
 
         // 2^99 would overflow — should be capped safely
         TimeSpan duration = manager.ComputeLockoutDuration(100);
@@ -86,14 +86,14 @@ public sealed class GranitUserManagerTests
 
     // ──── Helper ────
 
-    private static GranitUserManager CreateManager(GranitLockoutOptions lockoutOptions)
+    private static LocalIdentityManager CreateManager(GranitLockoutOptions lockoutOptions)
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
         IOptions<IdentityOptions> identityOptions = Microsoft.Extensions.Options.Options.Create(new IdentityOptions());
-        IPasswordHasher<GranitUser> hasher = Substitute.For<IPasswordHasher<GranitUser>>();
-        ILogger<GranitUserManager> logger = Substitute.For<ILogger<GranitUserManager>>();
+        IPasswordHasher<LocalIdentity> hasher = Substitute.For<IPasswordHasher<LocalIdentity>>();
+        ILogger<LocalIdentityManager> logger = Substitute.For<ILogger<LocalIdentityManager>>();
 
-        return new GranitUserManager(
+        return new LocalIdentityManager(
             store,
             identityOptions,
             hasher,

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderTests.cs
@@ -20,7 +20,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Internal;
 /// </summary>
 public sealed class AspNetIdentityProviderTests
 {
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly RoleManager<GranitRole> _roleManager;
     private readonly ILocalIdentityGroupStore _groupStore;
     private readonly ILogger<AspNetIdentityProvider> _logger;
@@ -28,8 +28,8 @@ public sealed class AspNetIdentityProviderTests
 
     public AspNetIdentityProviderTests()
     {
-        IUserStore<GranitUser> userStore = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> userStore = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             userStore, null, null, null, null, null, null, null, null);
 
         IRoleStore<GranitRole> roleStore = Substitute.For<IRoleStore<GranitRole>>();
@@ -47,7 +47,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task GetUserAsync_WhenUserExists_ReturnsUser()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
 
         IIdentityUser? result = await _sut.GetUserAsync("user-1", TestContext.Current.CancellationToken);
@@ -71,66 +71,66 @@ public sealed class AspNetIdentityProviderTests
     public async Task CreateUserAsync_WithoutPassword_CallsCreateWithoutPassword()
     {
         IdentityUserCreate input = new("alice", "alice@test.com", "Alice", "Smith", true, null);
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(IdentityResult.Success);
 
         IIdentityUser result = await _sut.CreateUserAsync(input, TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
-        await _userManager.Received(1).CreateAsync(Arg.Is<GranitUser>(u =>
+        await _userManager.Received(1).CreateAsync(Arg.Is<LocalIdentity>(u =>
             u.UserName == "alice" &&
             u.Email == "alice@test.com" &&
             u.FirstName == "Alice" &&
             u.LastName == "Smith"));
-        await _userManager.DidNotReceive().CreateAsync(Arg.Any<GranitUser>(), Arg.Any<string>());
+        await _userManager.DidNotReceive().CreateAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>());
     }
 
     [Fact]
     public async Task CreateUserAsync_WithEmptyPassword_CallsCreateWithoutPassword()
     {
         IdentityUserCreate input = new("bob", "bob@test.com", "Bob", "Jones", true, string.Empty);
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(IdentityResult.Success);
 
         await _sut.CreateUserAsync(input, TestContext.Current.CancellationToken);
 
-        await _userManager.Received(1).CreateAsync(Arg.Any<GranitUser>());
-        await _userManager.DidNotReceive().CreateAsync(Arg.Any<GranitUser>(), Arg.Any<string>());
+        await _userManager.Received(1).CreateAsync(Arg.Any<LocalIdentity>());
+        await _userManager.DidNotReceive().CreateAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>());
     }
 
     [Fact]
     public async Task CreateUserAsync_WithTemporaryPassword_CallsCreateWithPassword()
     {
         IdentityUserCreate input = new("carol", "carol@test.com", "Carol", "Doe", true, "Temp123!");
-        _userManager.CreateAsync(Arg.Any<GranitUser>(), "Temp123!").Returns(IdentityResult.Success);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>(), "Temp123!").Returns(IdentityResult.Success);
 
         await _sut.CreateUserAsync(input, TestContext.Current.CancellationToken);
 
-        await _userManager.Received(1).CreateAsync(Arg.Any<GranitUser>(), "Temp123!");
+        await _userManager.Received(1).CreateAsync(Arg.Any<LocalIdentity>(), "Temp123!");
     }
 
     [Fact]
     public async Task CreateUserAsync_WhenDisabled_SetsLockoutToMaxValue()
     {
         IdentityUserCreate input = new("dave", "dave@test.com", "Dave", "Lee", false, null);
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
-        _userManager.SetLockoutEndDateAsync(Arg.Any<GranitUser>(), Arg.Any<DateTimeOffset?>())
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(Arg.Any<LocalIdentity>(), Arg.Any<DateTimeOffset?>())
             .Returns(IdentityResult.Success);
 
         await _sut.CreateUserAsync(input, TestContext.Current.CancellationToken);
 
         await _userManager.Received(1).SetLockoutEndDateAsync(
-            Arg.Any<GranitUser>(), DateTimeOffset.MaxValue);
+            Arg.Any<LocalIdentity>(), DateTimeOffset.MaxValue);
     }
 
     [Fact]
     public async Task CreateUserAsync_WhenEnabled_DoesNotSetLockout()
     {
         IdentityUserCreate input = new("eve", "eve@test.com", "Eve", "Ray", true, null);
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(IdentityResult.Success);
 
         await _sut.CreateUserAsync(input, TestContext.Current.CancellationToken);
 
         await _userManager.DidNotReceive().SetLockoutEndDateAsync(
-            Arg.Any<GranitUser>(), Arg.Any<DateTimeOffset?>());
+            Arg.Any<LocalIdentity>(), Arg.Any<DateTimeOffset?>());
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public sealed class AspNetIdentityProviderTests
         IdentityUserCreate input = new("fail", "fail@test.com", null, null, true, null);
         var failure = IdentityResult.Failed(
             new IdentityError { Code = "DuplicateUserName", Description = "Username already taken." });
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(failure);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(failure);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.CreateUserAsync(input, TestContext.Current.CancellationToken));
@@ -153,7 +153,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task SetUserEnabledAsync_EnableUser_ClearsLockout()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset?>())
             .Returns(IdentityResult.Success);
@@ -166,7 +166,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task SetUserEnabledAsync_DisableUser_SetsLockoutToMaxValue()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset?>())
             .Returns(IdentityResult.Success);
@@ -193,7 +193,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task UpdateUserAsync_UpdatesFirstNameAndLastName()
     {
-        GranitUser user = new() { UserName = "alice", FirstName = "Old", LastName = "Name" };
+        LocalIdentity user = new() { UserName = "alice", FirstName = "Old", LastName = "Name" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
         IdentityUserUpdate update = new(null, "New", "Last", null);
@@ -208,7 +208,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task UpdateUserAsync_UpdatesEmail()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.SetEmailAsync(user, "new@test.com").Returns(IdentityResult.Success);
         _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
@@ -222,7 +222,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task UpdateUserAsync_NullFields_DoesNotModify()
     {
-        GranitUser user = new() { UserName = "alice", FirstName = "Original", LastName = "Name" };
+        LocalIdentity user = new() { UserName = "alice", FirstName = "Original", LastName = "Name" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
         IdentityUserUpdate update = new(null, null, null, null);
@@ -231,7 +231,7 @@ public sealed class AspNetIdentityProviderTests
 
         user.FirstName.ShouldBe("Original");
         user.LastName.ShouldBe("Name");
-        await _userManager.DidNotReceive().SetEmailAsync(Arg.Any<GranitUser>(), Arg.Any<string>());
+        await _userManager.DidNotReceive().SetEmailAsync(Arg.Any<LocalIdentity>(), Arg.Any<string>());
     }
 
     [Fact]
@@ -250,7 +250,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task UpdateUserAsync_WhenUpdateFails_ThrowsInvalidOperationException()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         var failure = IdentityResult.Failed(
             new IdentityError { Code = "ConcurrencyFailure", Description = "Concurrency conflict." });
@@ -269,8 +269,8 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task GetRoleMembersAsync_ReturnsMappedUsers()
     {
-        GranitUser user1 = new() { UserName = "alice" };
-        GranitUser user2 = new() { UserName = "bob" };
+        LocalIdentity user1 = new() { UserName = "alice" };
+        LocalIdentity user2 = new() { UserName = "bob" };
         _userManager.GetUsersInRoleAsync("admin").Returns([user1, user2]);
 
         IReadOnlyList<IIdentityUser> result = await _sut.GetRoleMembersAsync(
@@ -284,7 +284,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task GetRoleMembersAsync_WhenNoMembers_ReturnsEmptyList()
     {
-        _userManager.GetUsersInRoleAsync("empty-role").Returns((IList<GranitUser>)[]);
+        _userManager.GetUsersInRoleAsync("empty-role").Returns((IList<LocalIdentity>)[]);
 
         IReadOnlyList<IIdentityUser> result = await _sut.GetRoleMembersAsync(
             "empty-role", TestContext.Current.CancellationToken);
@@ -297,7 +297,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task GetUserRolesAsync_WhenUserExists_ReturnsMappedRoles()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.GetRolesAsync(user).Returns((IList<string>)["admin", "editor"]);
 
@@ -325,7 +325,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task AssignRoleAsync_WhenSuccessful_AddsUserToRole()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.AddToRoleAsync(user, "admin").Returns(IdentityResult.Success);
 
@@ -349,7 +349,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task AssignRoleAsync_WhenFailed_ThrowsInvalidOperationException()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         var failure = IdentityResult.Failed(
             new IdentityError { Code = "InvalidRole", Description = "Role does not exist." });
@@ -367,7 +367,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task RemoveRoleAsync_WhenSuccessful_RemovesUserFromRole()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.RemoveFromRoleAsync(user, "admin").Returns(IdentityResult.Success);
 
@@ -391,7 +391,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task RemoveRoleAsync_WhenFailed_ThrowsInvalidOperationException()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         var failure = IdentityResult.Failed(
             new IdentityError { Code = "UserNotInRole", Description = "User is not in role." });
@@ -512,7 +512,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task SetTemporaryPasswordAsync_WhenSuccessful_ResetsPassword()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token");
         _userManager.ResetPasswordAsync(user, "reset-token", "NewPass123!")
@@ -539,7 +539,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task SetTemporaryPasswordAsync_WhenResetFails_ThrowsInvalidOperationException()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByIdAsync("user-1").Returns(user);
         _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token");
         var failure = IdentityResult.Failed(
@@ -559,7 +559,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task VerifyUserCredentialsAsync_WhenValid_ReturnsTrue()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByNameAsync("alice").Returns(user);
         _userManager.CheckPasswordAsync(user, "correct-password").Returns(true);
 
@@ -572,7 +572,7 @@ public sealed class AspNetIdentityProviderTests
     [Fact]
     public async Task VerifyUserCredentialsAsync_WhenInvalidPassword_ReturnsFalse()
     {
-        GranitUser user = new() { UserName = "alice" };
+        LocalIdentity user = new() { UserName = "alice" };
         _userManager.FindByNameAsync("alice").Returns(user);
         _userManager.CheckPasswordAsync(user, "wrong-password").Returns(false);
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
@@ -10,18 +10,18 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Internal;
 
 public sealed class AspNetIdentityUserLookupServiceTests
 {
-    private static UserManager<GranitUser> CreateUserManager()
+    private static UserManager<LocalIdentity> CreateUserManager()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        return Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        return Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
     }
 
     [Fact]
     public async Task FindByIdAsync_WhenUserNotFound_ReturnsNull()
     {
-        UserManager<GranitUser> userManager = CreateUserManager();
-        userManager.FindByIdAsync(Arg.Any<string>()).Returns((GranitUser?)null);
+        UserManager<LocalIdentity> userManager = CreateUserManager();
+        userManager.FindByIdAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
         AspNetIdentityUserLookupService sut = new(userManager);
 
         IIdentityUser? result = await sut.FindByIdAsync("nonexistent", TestContext.Current.CancellationToken);
@@ -32,8 +32,8 @@ public sealed class AspNetIdentityUserLookupServiceTests
     [Fact]
     public async Task FindByIdAsync_WhenUserFound_ReturnsUser()
     {
-        UserManager<GranitUser> userManager = CreateUserManager();
-        var user = new GranitUser { UserName = "alice" };
+        UserManager<LocalIdentity> userManager = CreateUserManager();
+        var user = new LocalIdentity { UserName = "alice" };
         userManager.FindByIdAsync("user-id").Returns(user);
         AspNetIdentityUserLookupService sut = new(userManager);
 

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -587,7 +587,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task CompletePasskeyAssertion_ValidCredential_Returns200()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.PasskeyService
             .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -635,7 +635,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
 
         _server.UserManager
             .FindByIdAsync("nonexistent-user-id")
-            .Returns((GranitUser?)null);
+            .Returns((LocalIdentity?)null);
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
             "/account/passkeys/assertion/complete",
@@ -999,11 +999,11 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     {
         _server.UserManager
             .FindByEmailAsync("unknown@example.com")
-            .Returns((GranitUser?)null);
+            .Returns((LocalIdentity?)null);
 
         _server.UserManager
             .FindByNameAsync("unknown@example.com")
-            .Returns((GranitUser?)null);
+            .Returns((LocalIdentity?)null);
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
             "/account/login",
@@ -1017,7 +1017,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     public async Task Login_LockedOut_Returns401AndPublishesEvent()
     {
         DateTimeOffset lockoutEnd = DateTimeOffset.UtcNow.AddMinutes(5);
-        var fakeUser = new GranitUser
+        var fakeUser = new LocalIdentity
         {
             Id = AccountEndpointsTestServer.TestUserId,
             Email = "locked@example.com",
@@ -1056,7 +1056,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Login_RequiresTwoFactor_Returns200WithFlag()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.UserManager
             .FindByEmailAsync("2fa@example.com")
@@ -1084,7 +1084,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Login_NotAllowed_Returns401()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.UserManager
             .FindByEmailAsync("unconfirmed@example.com")
@@ -1105,7 +1105,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Login_WrongPassword_Returns401()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.UserManager
             .FindByEmailAsync("user@example.com")
@@ -1126,7 +1126,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Login_RememberMe_PassesPersistentFlag()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.UserManager
             .FindByEmailAsync("remember@example.com")
@@ -1153,7 +1153,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Login_Success_Returns200()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.UserManager
             .FindByEmailAsync("success@example.com")
@@ -1191,7 +1191,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
         _server.CurrentTenant.IsAvailable.Returns(true);
         _server.CurrentTenant.Id.Returns(staleTenantId);
 
-        var hostAdmin = new GranitUser
+        var hostAdmin = new LocalIdentity
         {
             Id = AccountEndpointsTestServer.TestUserId,
             Email = "host-admin@example.com",
@@ -1294,7 +1294,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task TwoFactorLogin_RecoveryCode_RememberMe_ReSignsPersistent()
     {
-        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+        var fakeUser = new LocalIdentity { Id = AccountEndpointsTestServer.TestUserId };
 
         _server.SignInManager
             .TwoFactorRecoveryCodeSignInAsync("RECOVERY1")
@@ -1340,7 +1340,7 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     public async Task TwoFactorLogin_LockedOut_Returns401AndPublishesEvent()
     {
         DateTimeOffset lockoutEnd = DateTimeOffset.UtcNow.AddMinutes(10);
-        var fakeUser = new GranitUser
+        var fakeUser = new LocalIdentity
         {
             Id = AccountEndpointsTestServer.TestUserId,
             Email = "2fa-locked@example.com",

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -69,8 +69,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
     public IFusionCache FusionCache { get; }
     public ISettingProvider SettingProvider { get; }
     public TimeProvider TimeProvider { get; }
-    public SignInManager<GranitUser> SignInManager { get; }
-    public UserManager<GranitUser> UserManager { get; }
+    public SignInManager<LocalIdentity> SignInManager { get; }
+    public UserManager<LocalIdentity> UserManager { get; }
     public ICurrentTenant CurrentTenant { get; }
     public IDataFilter DataFilter { get; }
 
@@ -96,8 +96,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         IFusionCache fusionCache,
         ISettingProvider settingProvider,
         TimeProvider timeProvider,
-        SignInManager<GranitUser> signInManager,
-        UserManager<GranitUser> userManager,
+        SignInManager<LocalIdentity> signInManager,
+        UserManager<LocalIdentity> userManager,
         ICurrentTenant currentTenant,
         IDataFilter dataFilter)
     {
@@ -164,13 +164,13 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         timeProvider.GetUtcNow().Returns(FixedNow);
 
         // ASP.NET Identity mocks — SignInManager requires UserManager which requires IUserStore
-        IUserStore<GranitUser> userStore = Substitute.For<IUserStore<GranitUser>>();
-        UserManager<GranitUser> userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> userStore = Substitute.For<IUserStore<LocalIdentity>>();
+        UserManager<LocalIdentity> userManager = Substitute.For<UserManager<LocalIdentity>>(
             userStore, null, null, null, null, null, null, null, null);
-        SignInManager<GranitUser> signInManager = Substitute.For<SignInManager<GranitUser>>(
+        SignInManager<LocalIdentity> signInManager = Substitute.For<SignInManager<LocalIdentity>>(
             userManager,
             Substitute.For<Microsoft.AspNetCore.Http.IHttpContextAccessor>(),
-            Substitute.For<IUserClaimsPrincipalFactory<GranitUser>>(),
+            Substitute.For<IUserClaimsPrincipalFactory<LocalIdentity>>(),
             null, null, null, null);
 
         // Default: 2FA not enabled
@@ -222,7 +222,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(userManager);
         builder.Services.AddSingleton(currentTenant);
         builder.Services.AddSingleton(dataFilter);
-        builder.Services.AddSingleton<IPasswordHasher<GranitUser>, PasswordHasher<GranitUser>>();
+        builder.Services.AddSingleton<IPasswordHasher<LocalIdentity>, PasswordHasher<LocalIdentity>>();
 
         // Options
         builder.Services.AddSingleton(

--- a/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
+++ b/tests/Granit.Identity.Local.Privacy.Tests/DataExport/IdentityLocalPrivacyDataProviderTests.cs
@@ -10,8 +10,8 @@ namespace Granit.Identity.Local.Privacy.Tests.DataExport;
 
 public sealed class IdentityLocalPrivacyDataProviderTests
 {
-    private static UserManager<GranitUser> CreateUserManager(IUserStore<GranitUser> store) =>
-        Substitute.For<UserManager<GranitUser>>(store, null, null, null, null, null, null, null, null);
+    private static UserManager<LocalIdentity> CreateUserManager(IUserStore<LocalIdentity> store) =>
+        Substitute.For<UserManager<LocalIdentity>>(store, null, null, null, null, null, null, null, null);
 
     [Fact]
     public void ProviderName_Is_IdentityLocal() =>
@@ -31,9 +31,9 @@ public sealed class IdentityLocalPrivacyDataProviderTests
     [Fact]
     public async Task ExportAsync_UnknownUser_ReturnsEmpty()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        UserManager<GranitUser> userManager = CreateUserManager(store);
-        userManager.FindByIdAsync(Arg.Any<string>()).Returns((GranitUser?)null);
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        UserManager<LocalIdentity> userManager = CreateUserManager(store);
+        userManager.FindByIdAsync(Arg.Any<string>()).Returns((LocalIdentity?)null);
 
         IdentityLocalPrivacyDataProvider sut = new(userManager);
 
@@ -46,7 +46,7 @@ public sealed class IdentityLocalPrivacyDataProviderTests
     public async Task ExportAsync_KnownUser_ReturnsJsonWithProfileAndRoles()
     {
         var userId = Guid.NewGuid();
-        GranitUser user = new()
+        LocalIdentity user = new()
         {
             Id = userId,
             UserName = "alice",
@@ -59,8 +59,8 @@ public sealed class IdentityLocalPrivacyDataProviderTests
             CreatedBy = "system",
         };
 
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        UserManager<GranitUser> userManager = CreateUserManager(store);
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        UserManager<LocalIdentity> userManager = CreateUserManager(store);
         userManager.FindByIdAsync(userId.ToString()).Returns(user);
         userManager.GetRolesAsync(user).Returns<IList<string>>(["Admin", "User"]);
 

--- a/tests/Granit.Identity.Local.Tests/Entities/EntityTests.cs
+++ b/tests/Granit.Identity.Local.Tests/Entities/EntityTests.cs
@@ -10,7 +10,7 @@ public sealed class EntityTests
     [Fact]
     public void GranitUser_Default_Values()
     {
-        GranitUser user = new();
+        LocalIdentity user = new();
 
         user.FirstName.ShouldBeNull();
         user.LastName.ShouldBeNull();
@@ -30,7 +30,7 @@ public sealed class EntityTests
     {
         var tenantId = Guid.NewGuid();
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        GranitUser user = new()
+        LocalIdentity user = new()
         {
             FirstName = "Alice",
             LastName = "Doe",
@@ -61,7 +61,7 @@ public sealed class EntityTests
     [Fact]
     public void GranitUser_Implements_IMultiTenant()
     {
-        GranitUser user = new();
+        LocalIdentity user = new();
 
         user.ShouldBeAssignableTo<IMultiTenant>();
     }
@@ -70,7 +70,7 @@ public sealed class EntityTests
     public void GranitUser_IMultiTenant_TenantId()
     {
         var tenantId = Guid.NewGuid();
-        GranitUser user = new() { TenantId = tenantId };
+        LocalIdentity user = new() { TenantId = tenantId };
 
         ((IMultiTenant)user).TenantId.ShouldBe(tenantId);
     }

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
@@ -13,14 +13,14 @@ namespace Granit.OpenIddict.Endpoints.Tests.Integration;
 
 public sealed class OidcPrincipalFactoryTests
 {
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly IClaimsDestinationProvider _destinationProvider;
     private readonly OidcPrincipalFactory _factory;
 
     public OidcPrincipalFactoryTests()
     {
-        IUserStore<GranitUser> userStore = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> userStore = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             userStore, null, null, null, null, null, null, null, null);
 
         _destinationProvider = Substitute.For<IClaimsDestinationProvider>();
@@ -33,7 +33,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsSubjectClaim()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         SetupUserManager(user);
 
         ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
@@ -47,7 +47,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsPreferredUsername()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.UserName = "jdoe";
         SetupUserManager(user);
 
@@ -62,7 +62,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsNameFromFirstAndLast()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.FirstName = "John";
         user.LastName = "Doe";
         SetupUserManager(user);
@@ -79,7 +79,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_OnlyFirstName_SetsNameWithoutTrailingSpace()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.FirstName = "John";
         user.LastName = null;
         SetupUserManager(user);
@@ -96,7 +96,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_NullNames_NoNameClaim()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.FirstName = null;
         user.LastName = null;
         SetupUserManager(user);
@@ -113,7 +113,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsEmailClaims()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.Email = "john@example.com";
         user.EmailConfirmed = true;
         SetupUserManager(user);
@@ -129,7 +129,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_UnconfirmedEmail_SetsVerifiedFalse()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.Email = "john@example.com";
         user.EmailConfirmed = false;
         SetupUserManager(user);
@@ -144,7 +144,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_NullEmail_NoEmailClaim()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.Email = null;
         SetupUserManager(user);
 
@@ -158,7 +158,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsPhoneClaims()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.PhoneNumber = "+32471000000";
         user.PhoneNumberConfirmed = true;
         SetupUserManager(user);
@@ -174,7 +174,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_NullPhone_NoPhoneClaim()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         user.PhoneNumber = null;
         SetupUserManager(user);
 
@@ -188,7 +188,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_IncludesRoles()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         SetupUserManager(user, roles: ["admin", "editor"]);
 
         ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
@@ -204,7 +204,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_IncludesCustomClaims()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         List<Claim> customClaims = [new Claim("tenant_id", "abc-123")];
         SetupUserManager(user, customClaims: customClaims);
 
@@ -218,7 +218,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_SetsScopes()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         SetupUserManager(user);
 
         ImmutableArray<string> scopes = ["openid", "profile", "email"];
@@ -234,7 +234,7 @@ public sealed class OidcPrincipalFactoryTests
     [Fact]
     public async Task CreateUserPrincipal_CallsDestinationProvider()
     {
-        GranitUser user = CreateTestUser();
+        LocalIdentity user = CreateTestUser();
         SetupUserManager(user);
 
         await _factory.CreateUserPrincipalAsync(
@@ -279,7 +279,7 @@ public sealed class OidcPrincipalFactoryTests
     // Helpers
     // -------------------------------------------------------------------------
 
-    private static GranitUser CreateTestUser() => new()
+    private static LocalIdentity CreateTestUser() => new()
     {
         Id = Guid.NewGuid(),
         UserName = "testuser",
@@ -290,7 +290,7 @@ public sealed class OidcPrincipalFactoryTests
     };
 
     private void SetupUserManager(
-        GranitUser user,
+        LocalIdentity user,
         IList<string>? roles = null,
         IList<Claim>? customClaims = null)
     {

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -259,13 +259,13 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
         }
 
         // Seed test user
-        UserManager<GranitUser> userManager =
-            services.GetRequiredService<UserManager<GranitUser>>();
+        UserManager<LocalIdentity> userManager =
+            services.GetRequiredService<UserManager<LocalIdentity>>();
 
-        GranitUser? user = await userManager.FindByEmailAsync(TestUserEmail);
+        LocalIdentity? user = await userManager.FindByEmailAsync(TestUserEmail);
         if (user is null)
         {
-            user = new GranitUser
+            user = new LocalIdentity
             {
                 UserName = TestUserEmail,
                 Email = TestUserEmail,

--- a/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
@@ -16,7 +16,7 @@ public sealed class AspNetAccountDeletionServiceTests
 {
     private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 10, 0, 0, TimeSpan.Zero);
 
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly IClock _clock = Substitute.For<IClock>();
@@ -24,8 +24,8 @@ public sealed class AspNetAccountDeletionServiceTests
 
     public AspNetAccountDeletionServiceTests()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
 
         _clock.Now.Returns(FixedNow);
@@ -42,7 +42,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserExists_SoftDeletesUser()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -61,7 +61,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserExists_LocksAccount()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -78,7 +78,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserExists_UpdatesSecurityStamp()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -95,7 +95,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserExists_PublishesAccountDeletedEto()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         var tenantId = Guid.NewGuid();
         user.TenantId = tenantId;
         string userId = user.Id.ToString();
@@ -118,7 +118,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserWithNoTenant_PublishesEventWithNullTenant()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         user.TenantId = null;
         string userId = user.Id.ToString();
 
@@ -142,7 +142,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UserHasTokens_RevokesAllTokens()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -166,7 +166,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_NoTokens_StillSucceeds()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -185,7 +185,7 @@ public sealed class AspNetAccountDeletionServiceTests
     public async Task InitiateAsync_UserNotFound_ThrowsInvalidOperation()
     {
         string unknownId = Guid.NewGuid().ToString();
-        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+        _userManager.FindByIdAsync(unknownId).Returns((LocalIdentity?)null);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.InitiateAsync(unknownId, TestContext.Current.CancellationToken));
@@ -196,7 +196,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UpdateFails_ThrowsInvalidOperation()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -212,7 +212,7 @@ public sealed class AspNetAccountDeletionServiceTests
     [Fact]
     public async Task InitiateAsync_UpdateFails_DoesNotLockAccountOrRevokeTokens()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
@@ -222,14 +222,14 @@ public sealed class AspNetAccountDeletionServiceTests
         await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.InitiateAsync(userId, TestContext.Current.CancellationToken));
 
-        await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<GranitUser>(), Arg.Any<DateTimeOffset>());
-        await _userManager.DidNotReceive().UpdateSecurityStampAsync(Arg.Any<GranitUser>());
+        await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<LocalIdentity>(), Arg.Any<DateTimeOffset>());
+        await _userManager.DidNotReceive().UpdateSecurityStampAsync(Arg.Any<LocalIdentity>());
         await _eventBus.DidNotReceive().PublishAsync(Arg.Any<AccountDeletedEto>(), Arg.Any<CancellationToken>());
     }
 
     // ────────────────────── Helpers ──────────────────────
 
-    private static GranitUser CreateUser() => new()
+    private static LocalIdentity CreateUser() => new()
     {
         Id = Guid.NewGuid(),
         UserName = "testuser",

--- a/tests/Granit.OpenIddict.Tests/AspNetExternalLoginServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetExternalLoginServiceTests.cs
@@ -16,7 +16,7 @@ namespace Granit.OpenIddict.Tests;
 
 public sealed class AspNetExternalLoginServiceTests
 {
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly ExternalClaimsMapper _claimsMapper = Substitute.For<ExternalClaimsMapper>();
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly GranitOpenIddictClientOptions _clientOptions = new() { AutoRegisterExternalUsers = true };
@@ -24,8 +24,8 @@ public sealed class AspNetExternalLoginServiceTests
 
     public AspNetExternalLoginServiceTests()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
 
         _sut = new AspNetExternalLoginService(
@@ -40,7 +40,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task GetLoginsAsync_UserExists_ReturnsLogins()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.GetLoginsAsync(user).Returns(
         [
@@ -59,7 +59,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task GetLoginsAsync_UserNotFound_ReturnsEmpty()
     {
-        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+        _userManager.FindByIdAsync("unknown").Returns((LocalIdentity?)null);
 
         IReadOnlyList<GranitExternalLoginInfo> logins =
             await _sut.GetLoginsAsync("unknown", TestContext.Current.CancellationToken);
@@ -72,7 +72,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task AddLoginAsync_Success()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.AddLoginAsync(user, Arg.Any<UserLoginInfo>()).Returns(IdentityResult.Success);
 
@@ -86,7 +86,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task AddLoginAsync_UserNotFound_Throws()
     {
-        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+        _userManager.FindByIdAsync("unknown").Returns((LocalIdentity?)null);
 
         await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.AddLoginAsync(
@@ -98,7 +98,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task AddLoginAsync_IdentityResultFailed_Throws()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.AddLoginAsync(user, Arg.Any<UserLoginInfo>())
             .Returns(IdentityResult.Failed(new IdentityError { Description = "Duplicate login" }));
@@ -117,7 +117,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task RemoveLoginAsync_HasPasswordAndMultipleLogins_Succeeds()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(true);
         _userManager.GetLoginsAsync(user).Returns([new UserLoginInfo("Google", "key", "Google")]);
@@ -130,7 +130,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task RemoveLoginAsync_LastLoginWithoutPassword_Throws()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(false);
         _userManager.GetLoginsAsync(user).Returns([new UserLoginInfo("Google", "key", "Google")]);
@@ -144,7 +144,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task RemoveLoginAsync_NoPasswordButMultipleLogins_Succeeds()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(false);
         _userManager.GetLoginsAsync(user).Returns(
@@ -163,7 +163,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task ProcessCallbackAsync_ExistingUserByLogin_ReturnsExistingUser()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         ClaimsPrincipal principal = CreatePrincipal("sub", "provider-key-123");
         _userManager.FindByLoginAsync("Google", "provider-key-123").Returns(user);
 
@@ -177,9 +177,9 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task ProcessCallbackAsync_ExistingUserByEmail_LinksAndReturnsExisting()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         ClaimsPrincipal principal = CreatePrincipal("sub", "new-provider-key");
-        _userManager.FindByLoginAsync("Google", "new-provider-key").Returns((GranitUser?)null);
+        _userManager.FindByLoginAsync("Google", "new-provider-key").Returns((LocalIdentity?)null);
         _claimsMapper.MapToUserProperties(principal, "Google")
             .Returns(new ExternalUserProperties { Email = "user@test.com" });
         _userManager.FindByEmailAsync("user@test.com").Returns(user);
@@ -197,7 +197,7 @@ public sealed class AspNetExternalLoginServiceTests
     public async Task ProcessCallbackAsync_AutoRegister_CreatesUserAndPublishesEvent()
     {
         ClaimsPrincipal principal = CreatePrincipal("sub", "brand-new-key");
-        _userManager.FindByLoginAsync("Google", "brand-new-key").Returns((GranitUser?)null);
+        _userManager.FindByLoginAsync("Google", "brand-new-key").Returns((LocalIdentity?)null);
         _claimsMapper.MapToUserProperties(principal, "Google")
             .Returns(new ExternalUserProperties
             {
@@ -205,16 +205,16 @@ public sealed class AspNetExternalLoginServiceTests
                 FirstName = "Jane",
                 LastName = "Doe",
             });
-        _userManager.FindByEmailAsync("new@example.com").Returns((GranitUser?)null);
-        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
-        _userManager.AddLoginAsync(Arg.Any<GranitUser>(), Arg.Any<UserLoginInfo>())
+        _userManager.FindByEmailAsync("new@example.com").Returns((LocalIdentity?)null);
+        _userManager.CreateAsync(Arg.Any<LocalIdentity>()).Returns(IdentityResult.Success);
+        _userManager.AddLoginAsync(Arg.Any<LocalIdentity>(), Arg.Any<UserLoginInfo>())
             .Returns(IdentityResult.Success);
 
         ProcessCallbackResult result =
             await _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken);
 
         result.IsNewUser.ShouldBeTrue();
-        await _userManager.Received(1).CreateAsync(Arg.Is<GranitUser>(u =>
+        await _userManager.Received(1).CreateAsync(Arg.Is<LocalIdentity>(u =>
             u.Email == "new@example.com" &&
             u.FirstName == "Jane" &&
             u.LastName == "Doe" &&
@@ -229,10 +229,10 @@ public sealed class AspNetExternalLoginServiceTests
         _clientOptions.AutoRegisterExternalUsers = false;
 
         ClaimsPrincipal principal = CreatePrincipal("sub", "new-key");
-        _userManager.FindByLoginAsync("Google", "new-key").Returns((GranitUser?)null);
+        _userManager.FindByLoginAsync("Google", "new-key").Returns((LocalIdentity?)null);
         _claimsMapper.MapToUserProperties(principal, "Google")
             .Returns(new ExternalUserProperties { Email = "noone@example.com" });
-        _userManager.FindByEmailAsync("noone@example.com").Returns((GranitUser?)null);
+        _userManager.FindByEmailAsync("noone@example.com").Returns((LocalIdentity?)null);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken));
@@ -252,7 +252,7 @@ public sealed class AspNetExternalLoginServiceTests
     [Fact]
     public async Task ProcessCallbackAsync_UsesNameIdentifierAsFallback()
     {
-        GranitUser user = CreateUser();
+        LocalIdentity user = CreateUser();
         ClaimsPrincipal principal = CreatePrincipal(ClaimTypes.NameIdentifier, "ni-key");
         _userManager.FindByLoginAsync("Microsoft", "ni-key").Returns(user);
 
@@ -262,7 +262,7 @@ public sealed class AspNetExternalLoginServiceTests
         result.UserId.ShouldBe(user.Id);
     }
 
-    private static GranitUser CreateUser() => new() { Id = Guid.NewGuid(), Email = "user@test.com" };
+    private static LocalIdentity CreateUser() => new() { Id = Guid.NewGuid(), Email = "user@test.com" };
 
     private static ClaimsPrincipal CreatePrincipal(string claimType, string claimValue) =>
         new(new ClaimsIdentity([new Claim(claimType, claimValue)]));

--- a/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class AspNetImpersonationServiceTests
 {
     private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 10, 0, 0, TimeSpan.Zero);
 
-    private readonly UserManager<GranitUser> _userManager;
+    private readonly UserManager<LocalIdentity> _userManager;
     private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
     private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
     private readonly IClock _clock = Substitute.For<IClock>();
@@ -28,8 +28,8 @@ public sealed class AspNetImpersonationServiceTests
 
     public AspNetImpersonationServiceTests()
     {
-        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
-        _userManager = Substitute.For<UserManager<GranitUser>>(
+        IUserStore<LocalIdentity> store = Substitute.For<IUserStore<LocalIdentity>>();
+        _userManager = Substitute.For<UserManager<LocalIdentity>>(
             store, null, null, null, null, null, null, null, null);
 
         _clock.Now.Returns(FixedNow);
@@ -51,7 +51,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task ImpersonateAsync_ValidInputs_ReturnsTokenResult()
     {
-        GranitUser target = CreateUser();
+        LocalIdentity target = CreateUser();
         string targetId = target.Id.ToString();
         var impersonatorGuid = Guid.NewGuid();
         string impersonatorId = impersonatorGuid.ToString();
@@ -83,7 +83,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task ImpersonateAsync_PublishesUserImpersonatedEto()
     {
-        GranitUser target = CreateUser();
+        LocalIdentity target = CreateUser();
         var tenantId = Guid.NewGuid();
         target.TenantId = tenantId;
         string targetId = target.Id.ToString();
@@ -108,7 +108,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task ImpersonateAsync_CreatesAccessAndRefreshTokens()
     {
-        GranitUser target = CreateUser();
+        LocalIdentity target = CreateUser();
         string targetId = target.Id.ToString();
         var impersonatorGuid = Guid.NewGuid();
 
@@ -138,7 +138,7 @@ public sealed class AspNetImpersonationServiceTests
     public async Task ImpersonateAsync_UserNotFound_ThrowsInvalidOperation()
     {
         string unknownId = Guid.NewGuid().ToString();
-        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+        _userManager.FindByIdAsync(unknownId).Returns((LocalIdentity?)null);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.ImpersonateAsync(
@@ -183,7 +183,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task ImpersonateAsync_NullPayload_ReturnsEmptyToken()
     {
-        GranitUser target = CreateUser();
+        LocalIdentity target = CreateUser();
         string targetId = target.Id.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
@@ -205,7 +205,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task ImpersonateAsync_UserWithNoRoles_SucceedsWithoutRoleClaims()
     {
-        GranitUser target = CreateUser();
+        LocalIdentity target = CreateUser();
         string targetId = target.Id.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
@@ -223,7 +223,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task BackToImpersonatorAsync_ValidId_ReturnsTokenResult()
     {
-        GranitUser admin = CreateUser();
+        LocalIdentity admin = CreateUser();
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
@@ -253,7 +253,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task BackToImpersonatorAsync_CreatesTokensWithCorrectExpiry()
     {
-        GranitUser admin = CreateUser();
+        LocalIdentity admin = CreateUser();
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
@@ -281,7 +281,7 @@ public sealed class AspNetImpersonationServiceTests
     public async Task BackToImpersonatorAsync_UserNotFound_ThrowsInvalidOperation()
     {
         string unknownId = Guid.NewGuid().ToString();
-        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+        _userManager.FindByIdAsync(unknownId).Returns((LocalIdentity?)null);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.BackToImpersonatorAsync(unknownId, TestContext.Current.CancellationToken));
@@ -302,7 +302,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task BackToImpersonatorAsync_NullPayload_ReturnsEmptyToken()
     {
-        GranitUser admin = CreateUser();
+        LocalIdentity admin = CreateUser();
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
@@ -324,7 +324,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task BackToImpersonatorAsync_UserWithNullUserName_UsesEmptyString()
     {
-        GranitUser admin = CreateUser();
+        LocalIdentity admin = CreateUser();
         admin.UserName = null;
         string adminId = admin.Id.ToString();
 
@@ -341,7 +341,7 @@ public sealed class AspNetImpersonationServiceTests
     [Fact]
     public async Task BackToImpersonatorAsync_UserWithNullEmail_UsesEmptyString()
     {
-        GranitUser admin = CreateUser();
+        LocalIdentity admin = CreateUser();
         admin.Email = null;
         string adminId = admin.Id.ToString();
 
@@ -357,7 +357,7 @@ public sealed class AspNetImpersonationServiceTests
 
     // ────────────────────── Helpers ──────────────────────
 
-    private static GranitUser CreateUser() => new()
+    private static LocalIdentity CreateUser() => new()
     {
         Id = Guid.NewGuid(),
         UserName = "testuser",

--- a/tests/Granit.OpenIddict.Tests/CrossSideAuthIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Tests/CrossSideAuthIntegrationTests.cs
@@ -73,7 +73,7 @@ public sealed class CrossSideAuthIntegrationTests : IAsyncDisposable
         builder.Logging.ClearProviders();
 
         // The module registers services like IExternalLoginService that depend on
-        // UserManager<GranitUser> and IClock, which we don't wire in this focused
+        // UserManager<LocalIdentity> and IClock, which we don't wire in this focused
         // fixture. Disable DI validation on build — these services are never
         // resolved by the pipeline under test (we only exercise authentication).
         builder.Host.UseDefaultServiceProvider(options =>

--- a/tests/Granit.OpenIddict.Tests/Entities/EntityTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Entities/EntityTests.cs
@@ -12,7 +12,7 @@ public sealed class EntityTests
     [Fact]
     public void GranitUser_Default_Values()
     {
-        GranitUser user = new();
+        LocalIdentity user = new();
 
         user.FirstName.ShouldBeNull();
         user.LastName.ShouldBeNull();
@@ -32,7 +32,7 @@ public sealed class EntityTests
     {
         var tenantId = Guid.NewGuid();
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        GranitUser user = new()
+        LocalIdentity user = new()
         {
             FirstName = "Alice",
             LastName = "Doe",
@@ -63,7 +63,7 @@ public sealed class EntityTests
     [Fact]
     public void GranitUser_Implements_IMultiTenant()
     {
-        GranitUser user = new();
+        LocalIdentity user = new();
 
         user.ShouldBeAssignableTo<IMultiTenant>();
     }
@@ -72,7 +72,7 @@ public sealed class EntityTests
     public void GranitUser_IMultiTenant_TenantId()
     {
         var tenantId = Guid.NewGuid();
-        GranitUser user = new() { TenantId = tenantId };
+        LocalIdentity user = new() { TenantId = tenantId };
 
         ((IMultiTenant)user).TenantId.ShouldBe(tenantId);
     }


### PR DESCRIPTION
## Summary

ADR-051 B-step 2: rename `GranitUser` → `LocalIdentity` and add `LocalIdentity.UserId` FK to the canonical `User` aggregate (added in B-step 1, persisted in B-step 1.5). Profile fields stay duplicated on `LocalIdentity` for ASP.NET Identity compatibility — a future cleanup can strip them once the User-side sync handler is wired.

This is **B-step 2 of 6** per [ADR-051](docs-site/src/content/docs/dotnet/architecture/adr/051-user-aggregate-and-parties-bridge.md).

## What ships

| Change | Detail |
| ------ | ------ |
| Class rename | `GranitUser` → `LocalIdentity`. File `GranitUser.cs` renamed to `LocalIdentity.cs`. |
| File rename — wrapper | `GranitUserManager.cs` → `LocalIdentityManager.cs` (`UserManager<LocalIdentity>` wrapper). |
| File rename — claims | `GranitUserClaimsPrincipalFactory.cs` → `LocalIdentityClaimsPrincipalFactory.cs`. |
| FK column | `LocalIdentity.UserId: Guid` (required). Equal to `LocalIdentity.Id` on greenfield records — the seed regeneration uses the same Guid for both rows so existing references resolve unchanged. |
| Sweep | 58 source files updated by sed `\bGranitUser\b` → `LocalIdentity` + word-boundary equivalents. Word boundaries deliberately exclude `GranitUserGroup` and `GranitUserGroupMember` — those are distinct group entities and stay as-is per the ADR. |
| Doc references | `<see cref="GranitUser"/>` and prose mentions in `IIdentityUser.cs`, `IUserDirectoryQueryableSource.cs`, `User.cs`, etc. updated transitively. |

## What's NOT in

- **Runtime auto-creation of User rows** when `LocalIdentity` rows are inserted via `UserManager<LocalIdentity>.CreateAsync`. The seed regeneration pre-populates both tables with the same Guid; the runtime `CreateAsync` plumbing will land as a small follow-up PR (B-step 2.5 — likely an EF Core SaveChanges interceptor in `Granit.Identity.EntityFrameworkCore`).
- **Stripping profile fields** (FirstName, LastName, TenantId, CustomAttributesJson) off `LocalIdentity`. ASP.NET Identity's `UserManager<TUser>` requires Email/UserName on `TUser`, so those stay duplicated for now. A future cleanup can remove the duplicates by making `LocalIdentity` navigate to `User.*` — out of scope here.

## Test plan

- [x] `dotnet build` — clean across `Granit.Identity.Local`, `Granit.Identity.Local.AspNetIdentity`, `Granit.OpenIddict`, `Granit.OpenIddict.Endpoints`.
- [x] `dotnet test .github/shard-filters/security.slnf` — **66 packages all green** (no behavior change, just type renames).
- [x] `dotnet test .github/shard-filters/architecture.slnf` — **207/207** green.
- [x] `dotnet format` — clean across the touched modules.

## References

- B-step 1: granit-fx/granit-dotnet#1709 (User aggregate primitive — merged).
- B-step 1.5: granit-fx/granit-dotnet#1710 (EF Core companion — merged).
- ADR: granit-fx/granit-dotnet#1708 (User aggregate + Parties bridge).
