### PR TITLE
feat(identity-federated): joint User + FederatedIdentity hydration on cache miss (ADR-051 B-step 3.5)

### DIFF
--- a/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
+++ b/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.Identity.Domain;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Options;
 using Granit.MultiTenancy;
@@ -18,6 +19,7 @@ internal sealed partial class CachedUserLookupService(
     ICurrentTenant currentTenant,
     TimeProvider timeProvider,
     IGuidGenerator guidGenerator,
+    IUserDirectoryWriter userDirectoryWriter,
     IOptions<UserCacheOptions> options,
     ILogger<CachedUserLookupService> logger) : IUserLookupService
 {
@@ -46,8 +48,7 @@ internal sealed partial class CachedUserLookupService(
 
             if (providerUser is not null)
             {
-                FederatedIdentity cacheEntry = ToCacheEntry(providerUser);
-                await store.UpsertAsync(cacheEntry, cancellationToken).ConfigureAwait(false);
+                await EnsureCachedAndUserAsync(providerUser, entry, cancellationToken).ConfigureAwait(false);
                 return providerUser;
             }
 
@@ -113,8 +114,8 @@ internal sealed partial class CachedUserLookupService(
 
                 if (providerUser is not null)
                 {
-                    FederatedIdentity cacheEntry = ToCacheEntry(providerUser);
-                    await store.UpsertAsync(cacheEntry, cancellationToken).ConfigureAwait(false);
+                    cachedDict.TryGetValue(id, out FederatedIdentity? existing);
+                    await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
                     result.Add(providerUser);
                 }
                 else if (cachedDict.TryGetValue(id, out FederatedIdentity? staleEntry))
@@ -173,8 +174,11 @@ internal sealed partial class CachedUserLookupService(
             return null;
         }
 
-        FederatedIdentity cacheEntry = ToCacheEntry(providerUser);
-        await store.UpsertAsync(cacheEntry, cancellationToken).ConfigureAwait(false);
+        FederatedIdentity? existing = currentTenant.IsAvailable
+            ? await store.FindByExternalIdAsync(userId, currentTenant.Id, cancellationToken).ConfigureAwait(false)
+            : await store.FindFirstByExternalIdAsync(userId, cancellationToken).ConfigureAwait(false);
+
+        await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
         return providerUser;
     }
 
@@ -183,6 +187,8 @@ internal sealed partial class CachedUserLookupService(
         int synced = 0;
         int offset = 0;
         const int pageSize = 100;
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
         while (true)
         {
@@ -194,8 +200,19 @@ internal sealed partial class CachedUserLookupService(
                 break;
             }
 
-            var entries = page.Select(ToCacheEntry).ToList();
-            await store.UpsertManyAsync(entries, cancellationToken).ConfigureAwait(false);
+            // Pre-fetch the existing rows so the joint hydration knows which
+            // entries are inserts (need a User row) vs updates (preserve the
+            // existing Id / UserId pair).
+            var externalIds = page.Select(p => p.UserId).ToList();
+            IReadOnlyList<FederatedIdentity> existingBatch = await store
+                .FindByExternalIdsAsync(externalIds, tenantId, cancellationToken).ConfigureAwait(false);
+            var existingByExternalId = existingBatch.ToDictionary(e => e.ExternalUserId);
+
+            foreach (IIdentityUser providerUser in page)
+            {
+                existingByExternalId.TryGetValue(providerUser.UserId, out FederatedIdentity? existing);
+                await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+            }
 
             synced += page.Count;
             offset += page.Count;
@@ -225,12 +242,18 @@ internal sealed partial class CachedUserLookupService(
             IIdentityUser? providerUser = await identityProvider.GetUserAsync(userId, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (providerUser is not null)
+            if (providerUser is null)
             {
-                FederatedIdentity cacheEntry = ToCacheEntry(providerUser);
-                await store.UpsertAsync(cacheEntry, cancellationToken).ConfigureAwait(false);
-                refreshed++;
+                continue;
             }
+
+            // Stale rows are by definition existing — fetch and pass through
+            // so the joint hydration takes the update path (no User auto-create).
+            FederatedIdentity? existing = await store
+                .FindByExternalIdAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
+
+            await EnsureCachedAndUserAsync(providerUser, existing, cancellationToken).ConfigureAwait(false);
+            refreshed++;
         }
 
         LogRefreshStaleCompleted(refreshed, staleIds.Count);
@@ -254,6 +277,73 @@ internal sealed partial class CachedUserLookupService(
     }
 
     // -- Helpers --
+
+    /// <summary>
+    /// Joint hydration of <see cref="FederatedIdentity"/> + canonical
+    /// <see cref="User"/> per ADR-051 B-step 3.5. On the insert path the
+    /// canonical user is created first (mirroring the local-side B-step 2.5
+    /// pattern) so admin grids and BI exports see the row immediately.
+    /// On the update path only the federated cache row is touched —
+    /// the canonical user already exists.
+    /// </summary>
+    /// <remarks>
+    /// Compensation: if the <see cref="FederatedIdentity"/> insert fails
+    /// after the <see cref="User"/> row was created, the freshly-created
+    /// user is hard-deleted to keep the canonical directory consistent.
+    /// </remarks>
+    private async Task EnsureCachedAndUserAsync(
+        IIdentityUser providerUser,
+        FederatedIdentity? existing,
+        CancellationToken cancellationToken)
+    {
+        if (existing is not null)
+        {
+            // Update path — preserve the existing identifier pair so the
+            // canonical User row continues to resolve via FederatedIdentity.UserId.
+            FederatedIdentity entry = ToCacheEntry(providerUser);
+            entry.Id = existing.Id;
+            entry.UserId = existing.UserId;
+            await store.UpsertAsync(entry, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // Insert path — generate one Guid up front, materialise the
+        // canonical User first, then add the federated cache row.
+        FederatedIdentity newEntry = ToCacheEntry(providerUser);
+
+        var canonical = User.Create(
+            id: newEntry.Id,
+            email: providerUser.Email ?? string.Empty,
+            displayName: ResolveDisplayName(providerUser),
+            firstName: providerUser.FirstName,
+            lastName: providerUser.LastName,
+            tenantId: newEntry.TenantId);
+
+        await userDirectoryWriter.CreateAsync(canonical, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await store.UpsertAsync(newEntry, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await userDirectoryWriter.DeleteAsync(newEntry.Id, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static string ResolveDisplayName(IIdentityUser providerUser)
+    {
+        string composed = $"{providerUser.FirstName} {providerUser.LastName}".Trim();
+        if (!string.IsNullOrWhiteSpace(composed))
+        {
+            return composed;
+        }
+
+        return !string.IsNullOrWhiteSpace(providerUser.Email)
+            ? providerUser.Email
+            : providerUser.Username ?? providerUser.UserId;
+    }
 
     private bool IsFresh(FederatedIdentity entry) =>
         timeProvider.GetUtcNow() - entry.LastSyncedAt < _options.StalenessThreshold;

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.Identity;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.EntityFrameworkCore.Extensions;
 using Granit.Identity.Federated.EntityFrameworkCore.Internal;
@@ -27,6 +28,7 @@ public sealed class IdentityEfCoreDiRegistrationTests
         services.AddSingleton(NSubstitute.Substitute.For<ICurrentTenant>());
         services.AddSingleton(NSubstitute.Substitute.For<IUserLookupHasher>());
         services.AddSingleton(NSubstitute.Substitute.For<IGuidGenerator>());
+        services.AddSingleton(NSubstitute.Substitute.For<IUserDirectoryWriter>());
         services.AddLogging();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 

--- a/tests/Granit.Identity.Federated.Tests/Internal/CachedUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/Internal/CachedUserLookupServiceTests.cs
@@ -1,4 +1,6 @@
 using Granit.Guids;
+using Granit.Identity;
+using Granit.Identity.Domain;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Internal;
 using Granit.Identity.Federated.Options;
@@ -22,13 +24,14 @@ public sealed class CachedUserLookupServiceTests
     private readonly ICurrentTenant _tenant = Substitute.For<ICurrentTenant>();
     private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly IUserDirectoryWriter _userDirectoryWriter = Substitute.For<IUserDirectoryWriter>();
     private readonly IOptions<UserCacheOptions> _options = Microsoft.Extensions.Options.Options.Create(new UserCacheOptions
     {
         StalenessThreshold = TimeSpan.FromHours(24)
     });
 
     private CachedUserLookupService CreateService() => new(
-        _store, _provider, _tenant, _timeProvider, _guidGenerator, _options,
+        _store, _provider, _tenant, _timeProvider, _guidGenerator, _userDirectoryWriter, _options,
         NullLogger<CachedUserLookupService>.Instance);
 
     private static FederatedIdentityUser CreateUser(string id = "user-1") => new(
@@ -180,11 +183,15 @@ public sealed class CachedUserLookupServiceTests
         _provider.GetUsersAsync(null, 100, 100, Arg.Any<CancellationToken>())
             .Returns(page2);
 
+        // Joint hydration drives one UpsertAsync per provider row instead
+        // of a single UpsertManyAsync: per ADR-051 B-step 3.5 each new
+        // row materialises a canonical User first, so the batch path
+        // unfolds into per-row sequencing.
         CachedUserLookupService service = CreateService();
         int synced = await service.RefreshAllAsync(TestContext.Current.CancellationToken);
 
         synced.ShouldBe(150);
-        await _store.Received(2).UpsertManyAsync(Arg.Any<IReadOnlyList<FederatedIdentity>>(), Arg.Any<CancellationToken>());
+        await _store.Received(150).UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -217,5 +224,137 @@ public sealed class CachedUserLookupServiceTests
 
         result.Items.Count.ShouldBe(1);
         result.TotalCount.ShouldBe(1);
+    }
+
+    // ──── Joint User + FederatedIdentity hydration (ADR-051 B-step 3.5) ────
+
+    [Fact]
+    public async Task FindByIdAsync_OnCacheMiss_CreatesCanonicalUser_BeforeFederatedIdentity()
+    {
+        // No existing cache row. Provider returns the user. The joint
+        // hydration helper must create the canonical User row first
+        // (mirroring B-step 2.5) so admin grids see it immediately.
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((FederatedIdentity?)null);
+        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
+
+        CachedUserLookupService service = CreateService();
+        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u =>
+                u.Id == generatedId
+                && u.Email == "jdoe@test.com"
+                && u.DisplayName == "John Doe"),
+            Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == generatedId && e.UserId == generatedId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_OnExistingStaleEntry_DoesNotCreateUser_OnRefresh()
+    {
+        // Existing entry exists (with its own Id/UserId already aligned).
+        // The provider returns a fresh copy. The update path must
+        // preserve the existing identifier pair and SKIP the User create.
+        var existingId = Guid.NewGuid();
+        FederatedIdentity stale = CreateCacheEntry(lastSyncedAt: DateTimeOffset.UtcNow.AddDays(-2));
+        stale.Id = existingId;
+        stale.UserId = existingId;
+
+        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(stale);
+        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
+
+        CachedUserLookupService service = CreateService();
+        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_CompensatesUserDelete_WhenFederatedInsertFails()
+    {
+        // The User row is created first; if the FederatedIdentity insert
+        // throws, the canonical row would orphan — the helper must
+        // hard-delete it to keep the directory consistent.
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((FederatedIdentity?)null);
+        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
+        _store.UpsertAsync(Arg.Any<FederatedIdentity>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("store offline"));
+
+        CachedUserLookupService service = CreateService();
+
+        // FindByIdAsync wraps the cache-miss block in a try/catch that
+        // swallows non-cancellation exceptions and returns the stale
+        // entry — so the throw is absorbed by the caller, not surfaced.
+        // We just verify the compensation ran.
+        await service.FindByIdAsync("user-1", TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u => u.Id == generatedId), Arg.Any<CancellationToken>());
+        await _userDirectoryWriter.Received(1).DeleteAsync(generatedId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_FallsBackToEmail_AsDisplayName_WhenNamesAreMissing()
+    {
+        var generatedId = Guid.NewGuid();
+        _guidGenerator.Create().Returns(generatedId);
+
+        FederatedIdentityUser nameless = new(
+            UserId: "user-2", Username: "anon", Email: "anon@test.com",
+            FirstName: null, LastName: null, Enabled: true);
+
+        _store.FindByExternalIdAsync("user-2", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns((FederatedIdentity?)null);
+        _provider.GetUserAsync("user-2", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IIdentityUser?>(nameless));
+
+        CachedUserLookupService service = CreateService();
+        await service.FindByIdAsync("user-2", TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.Received(1).CreateAsync(
+            Arg.Is<User>(u => u.DisplayName == "anon@test.com"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RefreshByIdAsync_FetchesExistingFirst_BeforeJointHydration()
+    {
+        // RefreshByIdAsync didn't previously do an existence check — the
+        // joint hydration adds one so updates correctly preserve the
+        // existing Id/UserId pair instead of generating fresh ones.
+        var existingId = Guid.NewGuid();
+        FederatedIdentity existing = CreateCacheEntry();
+        existing.Id = existingId;
+        existing.UserId = existingId;
+
+        _store.FindByExternalIdAsync("user-1", Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(existing);
+        _provider.GetUserAsync("user-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IIdentityUser?>(CreateUser()));
+
+        CachedUserLookupService service = CreateService();
+        await service.RefreshByIdAsync("user-1", TestContext.Current.CancellationToken);
+
+        await _userDirectoryWriter.DidNotReceive().CreateAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+        await _store.Received(1).UpsertAsync(
+            Arg.Is<FederatedIdentity>(e => e.Id == existingId && e.UserId == existingId),
+            Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Mirror of [B-step 2.5 (#1712)](https://github.com/granit-fx/granit-dotnet/pull/1712)
on the federated side. When a user is hydrated into the federated
cache for the first time, the **canonical `User` row is materialised
first** — so admin grids, OData feeds, and BI exports see the user as
soon as the cache miss is served, not on the next bridge-handler tick.

## What ships

- **`CachedUserLookupService`** now injects `IUserDirectoryWriter`. A
  new private helper `EnsureCachedAndUserAsync(providerUser, existing, ct)`
  drives every cache-fill path:
  - `existing != null` → **update** path: preserves the existing
    `Id` / `UserId` pair and only refreshes the federated cache row.
  - `existing == null` → **insert** path: generates the Guid,
    materialises the canonical `User` row first, then upserts the
    `FederatedIdentity`. Compensates with
    `IUserDirectoryWriter.DeleteAsync` if the federated insert throws.
- **Five cache-fill paths share the helper**:
  - `FindByIdAsync` — passes the `entry` it already fetched.
  - `FetchMissingUsersAsync` (per-id from `FindByIdsAsync`) — passes
    the existing entry from the batch dictionary.
  - `RefreshByIdAsync` — now pre-fetches existing first.
  - `RefreshAllAsync` (batch refresh) — pre-fetches existing rows in
    one `FindByExternalIdsAsync` per page, then iterates per row.
    Joint-hydration compensation semantics make per-row sequencing the
    right shape, so the batch path unfolds into N
    `UpsertAsync` calls instead of one `UpsertManyAsync`.
  - `RefreshStaleAsync` — stale rows are by definition existing; the
    helper always takes the update path here, no `User` auto-create.
- **Display name resolution** mirrors `LocalIdentityManager`:
  `"{FirstName} {LastName}".Trim()`, falls back to email then
  username, then external id.

## Tests

5 new `CachedUserLookupService` facts:

- Insert path creates User first with the generated Guid.
- Update path preserves existing Id/UserId and skips User creation.
- Compensation deletes User when FederatedIdentity insert throws.
- Display-name fallback to email when first/last names are missing.
- `RefreshByIdAsync` pre-fetches existing before joint hydration.

Pre-existing `RefreshAllAsync_PaginatesThroughProvider` updated to
expect 150 per-row `UpsertAsync` calls (was 2 batched
`UpsertManyAsync`).

## Cross-DbContext consistency

Same best-effort pattern as B-step 2.5: the compensation path keeps
the canonical directory clean on the failure modes that actually
happen (transient store outage, constraint violation). The brief
crash window between `User` insert and `FederatedIdentity` insert is
acceptable pre-1.0.

## Test plan

- [x] `dotnet build src/Granit.Identity.Federated` clean
- [x] `dotnet test tests/Granit.Identity.Federated.Tests` — 17 / 17 (12 baseline + 5 new)
- [x] `dotnet test tests/Granit.Identity.Federated.EntityFrameworkCore.Tests` — 32 / 32
- [x] `dotnet test .github/shard-filters/security.slnf` — 0 failed assemblies
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 207 / 207
- [x] `dotnet format .github/shard-filters/security.slnf --verify-no-changes` clean
- [x] Lockfiles refreshed via `dotnet restore Granit.slnx --force-evaluate`

## ADR-051 EPIC progress

| Step | Status |
| ---- | ------ |
| B-step 0 — ADR-051 | ✅ #1708 |
| B-step 1 — `User` aggregate | ✅ #1709 |
| B-step 1.5 — EF Core companion | ✅ #1710 |
| B-step 2 — `GranitUser` → `LocalIdentity` rename + FK | ✅ #1711 |
| B-step 2.5 — `LocalIdentity` runtime auto-create | ✅ #1712 |
| B-step 3 — `UserCacheEntry` → `FederatedIdentity` rename + FK | ✅ #1713 |
| **B-step 3.5 — `FederatedIdentity` runtime auto-create** | **this PR** |
| B-step 4 — Authorization repointing | next |
| B-step 5 — `Granit.Identity.Parties` bridge | next |