### PR TITLE
docs(authorization): repoint user-side references to canonical User aggregate (ADR-051 B-step 4)

### DIFF
--- a/src/Granit.Authorization/Domain/PermissionGrant.cs
+++ b/src/Granit.Authorization/Domain/PermissionGrant.cs
@@ -39,8 +39,10 @@ public sealed class PermissionGrant : AuditedAggregateRoot, IMultiTenant
     public string ProviderName { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Provider-specific grantee key: role name for <c>"R"</c>, user id for <c>"U"</c>,
-    /// OIDC <c>client_id</c> for <c>"C"</c>. Max 256 characters.
+    /// Provider-specific grantee key: role name for <c>"R"</c>, the
+    /// canonical <see cref="Granit.Identity.Domain.User.Id"/> stringified
+    /// for <c>"U"</c> (per ADR-051 B-step 4), or OIDC <c>client_id</c> for
+    /// <c>"C"</c>. Max 256 characters.
     /// </summary>
     public string ProviderKey { get; private set; } = string.Empty;
 

--- a/src/Granit.Authorization/PermissionGrantLookupContext.cs
+++ b/src/Granit.Authorization/PermissionGrantLookupContext.cs
@@ -4,7 +4,14 @@ namespace Granit.Authorization;
 /// Immutable projection of the current principal consumed by
 /// <see cref="IPermissionGrantProvider"/> implementations.
 /// </summary>
-/// <param name="UserId">Subject (<c>sub</c>) claim value, or <see langword="null"/> for anonymous.</param>
+/// <param name="UserId">
+/// Subject (<c>sub</c>) claim value, or <see langword="null"/> for
+/// anonymous. Per ADR-051 B-step 4 this resolves to the canonical
+/// <see cref="Granit.Identity.Domain.User.Id"/> stringified — the
+/// same value is held in <c>LocalIdentity.Id</c> and
+/// <c>FederatedIdentity.UserId</c> so the lookup matches grants
+/// regardless of the login path.
+/// </param>
 /// <param name="Roles">Role claims associated with the principal (never <see langword="null"/>, possibly empty).</param>
 /// <param name="ClientId">OIDC <c>client_id</c> claim value, or <see langword="null"/> when absent.</param>
 public sealed record PermissionGrantLookupContext(

--- a/src/Granit.Authorization/PermissionGrantProviderNames.cs
+++ b/src/Granit.Authorization/PermissionGrantProviderNames.cs
@@ -14,7 +14,14 @@ public static class PermissionGrantProviderNames
     /// <summary>Provider name for role-based grants: <c>ProviderKey</c> holds the role name.</summary>
     public const string Role = "R";
 
-    /// <summary>Provider name for user-based grants: <c>ProviderKey</c> holds the user's <c>sub</c> (GUID or opaque id).</summary>
+    /// <summary>
+    /// Provider name for user-based grants: <c>ProviderKey</c> holds the
+    /// canonical <see cref="Granit.Identity.Domain.User.Id"/> (Guid string)
+    /// per ADR-051 B-step 4. The same Guid resolves both the local-side
+    /// <c>LocalIdentity</c> and the federated-side <c>FederatedIdentity</c>
+    /// rows when the alignment guarantee holds, so a single grant covers
+    /// any login path the user takes.
+    /// </summary>
     public const string User = "U";
 
     /// <summary>Provider name for OIDC client-based grants: <c>ProviderKey</c> holds the <c>client_id</c>.</summary>

--- a/src/Granit.Identity.Local/Domain/GranitUserGroupMember.cs
+++ b/src/Granit.Identity.Local/Domain/GranitUserGroupMember.cs
@@ -3,14 +3,29 @@ using Granit.Domain;
 namespace Granit.Identity.Local.Domain;
 
 /// <summary>
-/// Join entity linking a <see cref="LocalIdentity"/> to a <see cref="GranitUserGroup"/>.
+/// Join entity linking a canonical
+/// <see cref="Granit.Identity.Domain.User"/> to a
+/// <see cref="GranitUserGroup"/>.
 /// </summary>
+/// <remarks>
+/// Per ADR-051 B-step 4, <see cref="UserId"/> references the canonical
+/// <see cref="Granit.Identity.Domain.User.Id"/>, not
+/// <see cref="LocalIdentity.Id"/> directly. Both Ids share the same Guid
+/// value (alignment guarantee from B-step 2 / B-step 3) so historical
+/// references continue to resolve, but the *meaning* is now "any user
+/// — local or federated" rather than "a local-side credential record".
+/// Group membership therefore applies to federated users too once they
+/// are hydrated through <c>CachedUserLookupService</c>.
+/// </remarks>
 public class GranitUserGroupMember : AuditedEntity, IMultiTenant
 {
     /// <summary>Gets or sets the group identifier.</summary>
     public Guid GroupId { get; set; }
 
-    /// <summary>Gets or sets the user identifier.</summary>
+    /// <summary>
+    /// Gets or sets the canonical user identifier — references
+    /// <see cref="Granit.Identity.Domain.User.Id"/>.
+    /// </summary>
     public Guid UserId { get; set; }
 
     /// <summary>Gets or sets the tenant identifier for multi-tenant isolation.</summary>


### PR DESCRIPTION
## Summary

Authorization's user-side references **already store the right Guid** —
the alignment guarantee from B-steps 2/3 means
`LocalIdentity.Id == FederatedIdentity.UserId == User.Id`. B-step 4
makes the *meaning* explicit at the public surface so consumers stop
thinking "local-side user" when grants now apply to any login path
(local or federated).

## What ships

- **`GranitUserGroupMember`** — class doc now reads "links a canonical
  `User` to a `GranitUserGroup`" instead of "links a `LocalIdentity`".
  Adds the alignment-guarantee context so federated users hydrated
  through `CachedUserLookupService` (B-step 3.5) participate in groups
  too.
- **`PermissionGrant.ProviderKey`** — `"U"` provider documented as
  "canonical `User.Id` stringified" per ADR-051 B-step 4 instead of
  "user `sub` (Guid or opaque)".
- **`PermissionGrantProviderNames.User`** — same clarification, with the
  cross-path-coverage rationale: one grant matches both local and
  federated logins.
- **`PermissionGrantLookupContext.UserId`** — documents the resolution
  to `User.Id` and that the same value is held in the local + federated
  siblings.

## Why no schema change

- `PermissionGrant.ProviderKey` is a `string` column — opaque,
  provider-specific identifier with no DB-level FK constraint.
- `GranitUserGroupMember.UserId` is a `Guid` column — also no DB-level
  FK constraint to the local users table.
- The `RoleMetadataQueryDefinition` and `PermissionGrantQueryDefinition`
  don't join on user-side schema — they project the single entity, so
  no re-tuning needed.

## Code paths verified

- `OpenIddictGroupStore` parses string → Guid and stores in
  `GranitUserGroupMember.UserId` — value is now interpreted as
  `User.Id` (same Guid as before).
- `PermissionChecker` flows `currentUserService.UserId` directly into
  the lookup context — sub claim is now the canonical `User.Id`
  stringified.

Both paths continue to work unchanged.

## Test plan

- [x] `dotnet build src/Granit.Authorization` clean
- [x] `dotnet build src/Granit.Identity.Local` clean
- [x] `dotnet test .github/shard-filters/security.slnf` — 0 failed assemblies
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 207 / 207
- [x] `dotnet format .github/shard-filters/security.slnf --verify-no-changes` clean

## ADR-051 EPIC progress

| Step | Status |
| ---- | ------ |
| B-step 0 — ADR-051 | ✅ #1708 |
| B-step 1 — `User` aggregate | ✅ #1709 |
| B-step 1.5 — EF Core companion | ✅ #1710 |
| B-step 2 — `GranitUser` → `LocalIdentity` rename + FK | ✅ #1711 |
| B-step 2.5 — `LocalIdentity` runtime auto-create | ✅ #1712 |
| B-step 3 — `UserCacheEntry` → `FederatedIdentity` rename + FK | ✅ #1713 |
| B-step 3.5 — `FederatedIdentity` runtime auto-create | ✅ #1714 |
| **B-step 4 — Authorization repointing (doc-only)** | **this PR** |
| B-step 5 — `Granit.Identity.Parties` bridge | next |