### PR TITLE
feat(identity): emit UserCreatedEto / UserProfileChangedEto from User aggregate (ADR-051 B-step 4.5)

### DIFF
--- a/src/Granit.Identity/Domain/User.cs
+++ b/src/Granit.Identity/Domain/User.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Identity.Events;
 using Granit.MultiTenancy;
 
 namespace Granit.Identity.Domain;
@@ -136,6 +137,20 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
             TenantId = tenantId,
             IsEnabled = true,
         };
+
+        // ADR-051 B-step 5 bridge contract: the Granit.Identity.Parties
+        // module subscribes to this event to materialise a Party of
+        // kind Person. Tiny apps without Granit.Parties simply have no
+        // subscriber and the event is a no-op.
+        user.AddDistributedEvent(new UserCreatedEto(
+            UserId: id,
+            DisplayName: displayName,
+            Email: email,
+            FirstName: firstName,
+            LastName: lastName,
+            PhoneNumber: phoneNumber,
+            TenantId: tenantId));
+
         return user;
     }
 
@@ -165,6 +180,20 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
         PhoneNumber = phoneNumber;
         PreferredLocale = preferredLocale;
         Timezone = timezone;
+
+        // ADR-051 B-step 5 bridge contract: keeps the Party in sync.
+        // Bridge subscriber is optional; tiny apps without
+        // Granit.Parties have no subscriber and the event is a no-op.
+        AddDistributedEvent(new UserProfileChangedEto(
+            UserId: Id,
+            DisplayName: DisplayName,
+            Email: Email,
+            FirstName: FirstName,
+            LastName: LastName,
+            PhoneNumber: PhoneNumber,
+            PreferredLocale: PreferredLocale,
+            Timezone: Timezone,
+            TenantId: TenantId));
     }
 
     /// <summary>Enables sign-in for the user.</summary>

--- a/src/Granit.Identity/Events/UserCreatedEto.cs
+++ b/src/Granit.Identity/Events/UserCreatedEto.cs
@@ -1,0 +1,51 @@
+using Granit.DataProtection;
+using Granit.Events;
+using Granit.Identity.Domain;
+
+namespace Granit.Identity.Events;
+
+/// <summary>
+/// Distributed event raised by the canonical
+/// <see cref="User"/> aggregate the moment a row is materialised — by
+/// <c>LocalIdentityManager.CreateAsync</c> (local-side, B-step 2.5),
+/// <c>CachedUserLookupService.EnsureCachedAndUserAsync</c>
+/// (federated-side, B-step 3.5), or any future host-side path that
+/// constructs a <see cref="User"/> through <see cref="User.Create"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>Granit.Identity.Parties</c> bridge handler subscribes to this
+/// event to materialise a corresponding <c>Party</c> of kind
+/// <c>Person</c> when both modules are loaded (per ADR-051's bridge
+/// contract, B-step 5). Tiny apps without <c>Granit.Parties</c> simply
+/// have no subscriber and the event is a no-op.
+/// </para>
+/// <para>
+/// PII fields (<see cref="DisplayName"/>, <see cref="Email"/>,
+/// <see cref="FirstName"/>, <see cref="LastName"/>,
+/// <see cref="PhoneNumber"/>) carry <see cref="SensitiveDataAttribute"/>
+/// so they are redacted in audit logs, MCP output, and diagnostics.
+/// The Wolverine outbox should be pruned frequently to limit plaintext
+/// PII exposure in the database.
+/// </para>
+/// </remarks>
+/// <param name="UserId">Canonical <see cref="User.Id"/>.</param>
+/// <param name="DisplayName">Display label.</param>
+/// <param name="Email">Primary login email.</param>
+/// <param name="FirstName">Given name (optional).</param>
+/// <param name="LastName">Family name (optional).</param>
+/// <param name="PhoneNumber">E.164 phone number (optional).</param>
+/// <param name="TenantId">Tenant scope, or <see langword="null"/> for host-level users.</param>
+public sealed record UserCreatedEto(
+    Guid UserId,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string DisplayName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    string Email,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string? FirstName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string? LastName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    string? PhoneNumber,
+    Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Identity/Events/UserProfileChangedEto.cs
+++ b/src/Granit.Identity/Events/UserProfileChangedEto.cs
@@ -1,0 +1,43 @@
+using Granit.DataProtection;
+using Granit.Events;
+using Granit.Identity.Domain;
+
+namespace Granit.Identity.Events;
+
+/// <summary>
+/// Distributed event raised by <see cref="User.UpdateProfile"/> when
+/// any of the canonical user's profile fields change. The
+/// <c>Granit.Identity.Parties</c> bridge handler subscribes to this
+/// event to keep the matching <c>Party</c> in sync (per ADR-051's
+/// bridge contract, B-step 5).
+/// </summary>
+/// <remarks>
+/// PII fields carry <see cref="SensitiveDataAttribute"/> so they are
+/// redacted in audit logs, MCP output, and diagnostics. The Wolverine
+/// outbox should be pruned frequently to limit plaintext PII exposure
+/// in the database.
+/// </remarks>
+/// <param name="UserId">Canonical <see cref="User.Id"/>.</param>
+/// <param name="DisplayName">Updated display label.</param>
+/// <param name="Email">Updated login email.</param>
+/// <param name="FirstName">Updated given name (optional).</param>
+/// <param name="LastName">Updated family name (optional).</param>
+/// <param name="PhoneNumber">Updated E.164 phone (optional).</param>
+/// <param name="PreferredLocale">Updated BCP-47 locale (optional).</param>
+/// <param name="Timezone">Updated IANA timezone (optional).</param>
+/// <param name="TenantId">Tenant scope, or <see langword="null"/> for host-level users.</param>
+public sealed record UserProfileChangedEto(
+    Guid UserId,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string DisplayName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    string Email,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string? FirstName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string? LastName,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    string? PhoneNumber,
+    string? PreferredLocale,
+    string? Timezone,
+    Guid? TenantId) : IIntegrationEvent;

--- a/tests/Granit.Identity.Tests/Domain/UserTests.cs
+++ b/tests/Granit.Identity.Tests/Domain/UserTests.cs
@@ -1,0 +1,110 @@
+using Granit.Identity.Domain;
+using Granit.Identity.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Tests.Domain;
+
+/// <summary>
+/// Locks the contract of the canonical <see cref="User"/> aggregate per
+/// ADR-051. Focuses on the aggregate behaviour that downstream code
+/// relies on — the bridge subscriber from B-step 5 fails closed if
+/// these events stop firing.
+/// </summary>
+public sealed class UserTests
+{
+    [Fact]
+    public void Create_RaisesUserCreatedEto_WithCanonicalId()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+
+        var user = User.Create(
+            id: id,
+            email: "alice@example.com",
+            displayName: "Alice",
+            firstName: "Alice",
+            lastName: "Doe",
+            phoneNumber: "+32 470 12 34 56",
+            tenantId: tenantId);
+
+        UserCreatedEto evt = user.IntegrationEvents
+            .OfType<UserCreatedEto>()
+            .ShouldHaveSingleItem();
+
+        evt.UserId.ShouldBe(id);
+        evt.DisplayName.ShouldBe("Alice");
+        evt.Email.ShouldBe("alice@example.com");
+        evt.FirstName.ShouldBe("Alice");
+        evt.LastName.ShouldBe("Doe");
+        evt.PhoneNumber.ShouldBe("+32 470 12 34 56");
+        evt.TenantId.ShouldBe(tenantId);
+    }
+
+    [Fact]
+    public void Create_HostScopedUser_RaisesEvent_WithNullTenantId()
+    {
+        var user = User.Create(
+            id: Guid.NewGuid(),
+            email: "platform@example.com",
+            displayName: "Platform Admin",
+            tenantId: null);
+
+        UserCreatedEto evt = user.IntegrationEvents.OfType<UserCreatedEto>().ShouldHaveSingleItem();
+        evt.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void UpdateProfile_RaisesUserProfileChangedEto()
+    {
+        // The Created event lives in the integration outbox of the
+        // freshly-built aggregate; clear it so the test isolates the
+        // signal of the UpdateProfile call.
+        var user = User.Create(
+            id: Guid.NewGuid(),
+            email: "old@example.com",
+            displayName: "Old Name");
+        user.ClearIntegrationEvents();
+
+        user.UpdateProfile(
+            displayName: "New Name",
+            email: "new@example.com",
+            firstName: "New",
+            lastName: "Name",
+            phoneNumber: "+1 555 0100",
+            preferredLocale: "en-GB",
+            timezone: "Europe/London");
+
+        UserProfileChangedEto evt = user.IntegrationEvents
+            .OfType<UserProfileChangedEto>()
+            .ShouldHaveSingleItem();
+
+        evt.UserId.ShouldBe(user.Id);
+        evt.DisplayName.ShouldBe("New Name");
+        evt.Email.ShouldBe("new@example.com");
+        evt.FirstName.ShouldBe("New");
+        evt.LastName.ShouldBe("Name");
+        evt.PhoneNumber.ShouldBe("+1 555 0100");
+        evt.PreferredLocale.ShouldBe("en-GB");
+        evt.Timezone.ShouldBe("Europe/London");
+    }
+
+    [Fact]
+    public void Enable_Disable_TogglesIsEnabled_WithoutEmittingProfileEvent()
+    {
+        // Enable / Disable do not represent a profile change, so they
+        // do not raise UserProfileChangedEto. (A future story may add
+        // a dedicated UserEnabledChangedEto if a subscriber needs the
+        // signal — out of scope for B-step 5.)
+        var user = User.Create(
+            id: Guid.NewGuid(),
+            email: "user@example.com",
+            displayName: "User");
+        user.ClearIntegrationEvents();
+
+        user.Disable();
+        user.Enable();
+
+        user.IntegrationEvents.OfType<UserProfileChangedEto>().ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Pre-requisite for the **`Granit.Identity.Parties` bridge handlers**
(B-step 5). The canonical `User` aggregate now publishes the two
integration events the bridge contract subscribes to.

## What ships

- **`UserCreatedEto`** — raised by `User.Create`. Carries the canonical
  `Id` (Guid), profile fields (`DisplayName`, `Email`, `FirstName`,
  `LastName`, `PhoneNumber`), and `TenantId`. PII fields decorated with
  `SensitiveDataAttribute` so the outbox envelope is redacted in audit
  logs / MCP / diagnostics.
- **`UserProfileChangedEto`** — raised by `User.UpdateProfile`. Same
  shape plus `PreferredLocale` and `Timezone`. Same PII decoration.

Both events implement `IIntegrationEvent` and are added via
`AddDistributedEvent`, so the `SavingChangesInterceptor` persists the
Wolverine outbox envelope **atomically inside the EF Core transaction**
that writes the `User` row.

Tiny apps without `Granit.Parties` have no subscriber and the events
are a no-op. The events are emitted unconditionally from the aggregate
so the framework keeps a single shape for both modes (local-only and
CRM/ERP-with-Parties).

## Tests

4 new `UserTests` facts:
- `Create` raises `UserCreatedEto` with all fields including TenantId.
- Host-scoped user (`tenantId: null`) raises with `TenantId == null`.
- `UpdateProfile` raises `UserProfileChangedEto` with locale + tz.
- `Enable` / `Disable` do **not** emit a profile change event.

## Out of scope

- **`UserEnabledChangedEto`** — `IsEnabled` toggles do not currently
  raise an event since no subscriber needs the signal yet. A future
  story may add it (and a corresponding bridge handler that would
  block Party invitations on disabled users).

## Test plan

- [x] `dotnet build src/Granit.Identity` clean
- [x] `dotnet test tests/Granit.Identity.Tests` — 4 / 4 new + existing pass
- [x] `dotnet test .github/shard-filters/security.slnf` — 0 failed assemblies
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 207 / 207
- [x] `dotnet format .github/shard-filters/security.slnf --verify-no-changes` clean

## ADR-051 EPIC progress

| Step | Status |
| ---- | ------ |
| B-step 0 — ADR-051 | ✅ #1708 |
| B-step 1 — `User` aggregate | ✅ #1709 |
| B-step 1.5 — EF Core companion | ✅ #1710 |
| B-step 2 — `GranitUser` → `LocalIdentity` rename + FK | ✅ #1711 |
| B-step 2.5 — `LocalIdentity` runtime auto-create | ✅ #1712 |
| B-step 3 — `UserCacheEntry` → `FederatedIdentity` rename + FK | ✅ #1713 |
| B-step 3.5 — `FederatedIdentity` runtime auto-create | ✅ #1714 |
| B-step 4 — Authorization repointing | ✅ #1715 |
| **B-step 4.5 — User aggregate emits `*Eto`** | **this PR** |
| B-step 5 — `Granit.Identity.Parties` bridge | next |