### PR TITLE
docs: clarify UserId fields reference canonical User.Id (ADR-051 B-step 6)

### DIFF
--- a/src/Granit.AI/AIUsageRecord.cs
+++ b/src/Granit.AI/AIUsageRecord.cs
@@ -11,7 +11,11 @@ public sealed record AIUsageRecord
     /// <summary>Tenant that made the request, or <c>null</c> if no tenant context.</summary>
     public Guid? TenantId { get; init; }
 
-    /// <summary>User that made the request, or <c>null</c> if anonymous/system.</summary>
+    /// <summary>
+    /// Canonical <see cref="Granit.Identity.Domain.User.Id"/> that made
+    /// the request (per ADR-051), or <c>null</c> if anonymous / system.
+    /// The same Guid resolves both the local and federated login paths.
+    /// </summary>
     public Guid? UserId { get; init; }
 
     /// <summary>Workspace name used for the request.</summary>

--- a/src/Granit.Parties/Domain/Party.cs
+++ b/src/Granit.Parties/Domain/Party.cs
@@ -642,9 +642,14 @@ public sealed class Party : AuditedAggregateRoot, IMultiTenant, IHasMetadata, IM
     // ── User linkage ──────────────────────────────────────────────
 
     /// <summary>
-    /// Authenticated user identifier this party represents. Only meaningful for
-    /// <see cref="PartyKind.Individual"/>. One user → at most one party (enforced by
-    /// a partial unique index in the EF configuration).
+    /// Canonical <see cref="Granit.Identity.Domain.User.Id"/> this
+    /// party represents (per ADR-051). Only meaningful for
+    /// <see cref="PartyKind.Individual"/>. One user → at most one
+    /// party (enforced by a partial unique index in the EF
+    /// configuration). Auto-populated by
+    /// <c>EnsurePartyForUserHandler</c> in the optional
+    /// <c>Granit.Parties.Identity</c> bridge — apps that do not load
+    /// the bridge keep this as <c>null</c>.
     /// </summary>
     public Guid? UserId { get; private set; }
 

--- a/src/Granit.Subscriptions/Domain/SubscriptionSeat.cs
+++ b/src/Granit.Subscriptions/Domain/SubscriptionSeat.cs
@@ -18,7 +18,13 @@ public sealed class SubscriptionSeat : Entity
             AssignedAt = assignedAt,
         };
 
-    /// <summary>The user assigned to this seat.</summary>
+    /// <summary>
+    /// The canonical <see cref="Granit.Identity.Domain.User.Id"/>
+    /// assigned to this seat per ADR-051. The same Guid resolves
+    /// both <c>LocalIdentity</c> and <c>FederatedIdentity</c> rows
+    /// when the alignment guarantee holds, so a seat is satisfied
+    /// regardless of the user's login path.
+    /// </summary>
     public Guid UserId { get; private set; }
 
     /// <summary>When the seat was assigned.</summary>


### PR DESCRIPTION
## Summary

Polishes the ABI surface across the three remaining modules where a
`Guid UserId` field referenced an under-specified user. **The stored
value is already correct** (alignment guarantee from B-steps 2/3), so
this is purely XML doc — no schema, runtime, or behaviour change.

## What ships

- **`Subscriptions.SubscriptionSeat.UserId`** — was *"The user
  assigned to this seat"*; now explicitly the canonical
  `Granit.Identity.Domain.User.Id` with the cross-path-coverage note
  (the same Guid resolves both `LocalIdentity` and `FederatedIdentity`).
- **`AI.AIUsageRecord.UserId`** — was *"User that made the request"*;
  now the canonical `User.Id`, same coverage note, `null` still
  means anonymous / system.
- **`Parties.Party.UserId`** — was *"authenticated user
  identifier"*; now the canonical `User.Id` with the bridge-mode
  note (auto-populated by `EnsurePartyForUserHandler` when
  `Granit.Parties.Identity` is loaded, `null` otherwise).

## Out of scope

The EF Core entity `AIUsageRecordEntity.UserId` is internal data
shape and stays doc-less by convention — the user-facing record
`AIUsageRecord` is what consumers read.

## Test plan

- [x] `dotnet test .github/shard-filters/business.slnf` — 0 failed
- [x] `dotnet test .github/shard-filters/saas.slnf` — 0 failed
- [x] `dotnet test .github/shard-filters/core-ai.slnf` — 0 failed
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 207 / 207
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` clean

## ADR-051 EPIC progress — **complete**

| Step | Status |
| ---- | ------ |
| B-step 0 → B-step 5 | ✅ #1708 → #1717 |
| **B-step 6 — UserId doc cleanup** | **this PR — completes the EPIC tail** |