### PR TITLE
feat(entities-endpoints): wire Gallery layout to manifest payload

### DIFF
--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -34,18 +34,21 @@ public sealed record EntityCollectionReference(
 
 /// <summary>
 /// One alternative list-view layout exposed in the manifest. The kind drives
-/// front-end component selection; per-kind config lives in <see cref="Kanban"/>
-/// or <see cref="Calendar"/> (and future <c>Map</c> / <c>Gallery</c> sub-records).
+/// front-end component selection; per-kind config lives in <see cref="Kanban"/>,
+/// <see cref="Calendar"/>, or <see cref="Gallery"/> (and a future <c>Map</c>
+/// sub-record).
 /// </summary>
 /// <param name="Kind">Layout kind from the closed catalog.</param>
 /// <param name="IsDefault">Whether this layout is the default tab on first render.</param>
 /// <param name="Kanban">Kanban-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Kanban"/>.</param>
 /// <param name="Calendar">Calendar-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Calendar"/>.</param>
+/// <param name="Gallery">Gallery-specific configuration when <see cref="Kind"/> is <see cref="EntityListLayoutKind.Gallery"/>.</param>
 public sealed record EntityListLayoutManifest(
     EntityListLayoutKind Kind,
     bool IsDefault,
     EntityKanbanLayoutManifest? Kanban,
-    EntityCalendarLayoutManifest? Calendar);
+    EntityCalendarLayoutManifest? Calendar,
+    EntityGalleryLayoutManifest? Gallery);
 
 /// <summary>
 /// Calendar-specific layout configuration carried in the manifest. Property
@@ -62,6 +65,23 @@ public sealed record EntityCalendarLayoutManifest(
     string? EndPropertyName,
     string? TitlePropertyName,
     string? ColorByPropertyName);
+
+/// <summary>
+/// Gallery-specific layout configuration carried in the manifest. Property
+/// names address fields on the entity; the renderer (<c>EntityGallery</c>)
+/// reads each row's image via the host's blob-storage download endpoint and
+/// labels the card with <see cref="TitlePropertyName"/> /
+/// <see cref="SubtitlePropertyName"/>.
+/// </summary>
+/// <param name="ImagePropertyName">Entity property carrying the card image — typed <c>BlobReference</c> (or nullable). Required.</param>
+/// <param name="TitlePropertyName">Entity property used as the card headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
+/// <param name="SubtitlePropertyName">Optional secondary line under the title, or <see langword="null"/> for none.</param>
+/// <param name="CardSize">Card size — drives CSS-grid track sizing in the renderer.</param>
+public sealed record EntityGalleryLayoutManifest(
+    string ImagePropertyName,
+    string? TitlePropertyName,
+    string? SubtitlePropertyName,
+    GalleryCardSize CardSize);
 
 /// <summary>Kanban-specific layout configuration carried in the manifest.</summary>
 /// <param name="GroupByPropertyName">Entity property used to bucket rows into columns.</param>

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -353,6 +353,12 @@ internal static class EntityManifestComposer
                 _ => null,
             };
 
+            EntityGalleryLayoutManifest? gallery = layout switch
+            {
+                GalleryLayoutDescriptor g => ComposeGallery(g),
+                _ => null,
+            };
+
             // Layout produced no usable shape (e.g. kanban whose card lost every
             // field to permission filtering). Drop the layout — empty switcher
             // tabs would be UX clutter.
@@ -365,7 +371,8 @@ internal static class EntityManifestComposer
                 layout.Kind,
                 layout.IsDefault,
                 kanban,
-                calendar));
+                calendar,
+                gallery));
         }
         return layouts;
     }
@@ -375,6 +382,12 @@ internal static class EntityManifestComposer
             descriptor.EndPropertyName,
             descriptor.TitlePropertyName,
             descriptor.ColorByPropertyName);
+
+    private static EntityGalleryLayoutManifest ComposeGallery(GalleryLayoutDescriptor descriptor) =>
+        new(descriptor.ImagePropertyName,
+            descriptor.TitlePropertyName,
+            descriptor.SubtitlePropertyName,
+            descriptor.CardSize);
 
     private static EntityKanbanLayoutManifest? ComposeKanban(
         KanbanLayoutDescriptor descriptor,

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -452,6 +452,66 @@ public sealed class EntityManifestComposerTests
     }
 
     [Fact]
+    public void Compose_emits_gallery_layout_with_image_title_subtitle_and_card_size()
+    {
+        Granit.Entities.Layouts.GalleryLayoutDescriptor gallery = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Gallery,
+            IsDefault = true,
+            ImagePropertyName = "Cover",
+            TitlePropertyName = "Title",
+            SubtitlePropertyName = "Category",
+            CardSize = Granit.Entities.Layouts.GalleryCardSize.Large,
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [gallery]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityListLayoutManifest layout = manifest.Collections!.ListLayouts.ShouldHaveSingleItem();
+        layout.Kind.ShouldBe(Granit.Entities.Layouts.EntityListLayoutKind.Gallery);
+        layout.IsDefault.ShouldBeTrue();
+        layout.Kanban.ShouldBeNull();
+        layout.Calendar.ShouldBeNull();
+        layout.Gallery.ShouldNotBeNull();
+        layout.Gallery!.ImagePropertyName.ShouldBe("Cover");
+        layout.Gallery.TitlePropertyName.ShouldBe("Title");
+        layout.Gallery.SubtitlePropertyName.ShouldBe("Category");
+        layout.Gallery.CardSize.ShouldBe(Granit.Entities.Layouts.GalleryCardSize.Large);
+    }
+
+    [Fact]
+    public void Compose_emits_minimal_gallery_with_only_image_and_default_card_size()
+    {
+        // ImagePropertyName is the only required field per
+        // GalleryLayoutDescriptor. Title / subtitle fall back to the
+        // entity's DisplayProperty / SubtitleProperty in the renderer;
+        // CardSize defaults to Medium.
+        Granit.Entities.Layouts.GalleryLayoutDescriptor gallery = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Gallery,
+            ImagePropertyName = "Cover",
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [gallery]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityGalleryLayoutManifest emitted = manifest.Collections!.ListLayouts
+            .ShouldHaveSingleItem().Gallery.ShouldNotBeNull();
+        emitted.ImagePropertyName.ShouldBe("Cover");
+        emitted.TitlePropertyName.ShouldBeNull();
+        emitted.SubtitlePropertyName.ShouldBeNull();
+        emitted.CardSize.ShouldBe(Granit.Entities.Layouts.GalleryCardSize.Medium);
+    }
+
+    [Fact]
     public void Compose_emits_calendar_layout_with_start_end_title_and_color_by()
     {
         Granit.Entities.Layouts.CalendarLayoutDescriptor calendar = new()


### PR DESCRIPTION
## Summary

Closes the gap flagged by `granit-front`: the **Abstractions side has
been shipping** `GalleryLayoutDescriptor` / `GalleryCardSize` /
`EntityListLayoutKind.Gallery = 3` / `GalleryLayoutBuilder<T>` since
commit `014501da0`, but the **Endpoints side never serialised the
descriptor** — `EntityListLayoutManifest` only had `Kanban` /
`Calendar` slots and `ComposeListLayouts` had no Gallery branch.

A `.WithGalleryLayout(...)` declaration on a host-side
`EntityDefinition` therefore traversed the wire as an empty manifest
entry, blocking the front-end mirror in
`@granit/entities/types/layouts.ts`.

## What ships

- **`EntityCollectionsSection.cs`** — new
  `EntityGalleryLayoutManifest` record (`ImagePropertyName`,
  `TitlePropertyName?`, `SubtitlePropertyName?`, `CardSize`). The
  stale comment `"future Map / Gallery sub-records"` trimmed to just
  `"future Map sub-record"`.
- **`EntityListLayoutManifest`** — new `Gallery?` slot alongside
  `Kanban?` / `Calendar?`.
- **`EntityManifestComposer.ComposeListLayouts`** — routes
  `GalleryLayoutDescriptor` → `EntityGalleryLayoutManifest` via a thin
  `ComposeGallery` helper, mirroring `ComposeCalendar`'s shape.

Permission filtering and `RequiresPermission` gating already work via
the layout-level `RequiresPermission` check at the top of
`ComposeListLayouts` — no Gallery-specific permission plumbing
needed.

## Tests

2 new `EntityManifestComposerTests` facts:
- Full gallery payload (image + title + subtitle + Large card size).
- Minimal gallery (only `ImagePropertyName`, defaults to `Medium` /
  null title/subtitle).

## Test plan

- [x] `dotnet build src/Granit.Entities.Endpoints` clean
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 70 / 70 (68 baseline + 2 new)
- [x] `dotnet test .github/shard-filters/business.slnf` — 0 failed assemblies
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 207 / 207
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` clean

## Granit-front next step

Once this lands, `granit-front` can mirror
`EntityGalleryLayoutManifest` + `GalleryCardSize` in
`@granit/entities/types/layouts.ts`, extend the
`EntityListLayoutKind` union with `'Gallery'`, and add the
`gallery: EntityGalleryLayoutManifest | null` slot. The
`<EntityGallery />` renderer is a separate story.