### PR TITLE
feat(documents): diagnostics — DocumentsMetrics + DocumentsActivitySource (F1.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17977,6 +17977,34 @@
       ]
     },
     {
+      "name": "DocumentsMetrics",
+      "fqn": "Granit.Documents.Diagnostics.DocumentsMetrics",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Diagnostics/DocumentsMetrics.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "RecordDownload",
+          "kind": "method",
+          "signature": "RecordDownload(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordShareGranted",
+          "kind": "method",
+          "signature": "RecordShareGranted(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordQuotaRejected",
+          "kind": "method",
+          "signature": "RecordQuotaRejected(string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Documents.EntityFrameworkCore.Extensions.DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -18039,7 +18067,7 @@
       "kind": "class",
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDocuments",

--- a/src/Granit.Documents/Diagnostics/DocumentsActivitySource.cs
+++ b/src/Granit.Documents/Diagnostics/DocumentsActivitySource.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace Granit.Documents.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Documents distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class DocumentsActivitySource
+{
+    /// <summary>The name of the Granit.Documents <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Documents";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    // ──── Operation names ────────────────────────────────────────────────────
+    // Operations populate as the corresponding stories land. Phase-1 baseline:
+    internal const string DocumentUpload = "documents.upload";
+    internal const string DocumentDownload = "documents.download";
+    internal const string DocumentShareGrant = "documents.share.grant";
+    internal const string AclResolve = "documents.acl.resolve";
+}

--- a/src/Granit.Documents/Diagnostics/DocumentsMetrics.cs
+++ b/src/Granit.Documents/Diagnostics/DocumentsMetrics.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Documents.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the Granit.Documents module.
+/// Meter: <c>Granit.Documents</c>.
+/// </summary>
+/// <remarks>
+/// Phase-1 baseline counters; richer per-operation tags (content type, grantee type,
+/// permission, target type) arrive with the corresponding domain stories.
+/// </remarks>
+public sealed class DocumentsMetrics
+{
+    /// <summary>Meter name — <c>Granit.Documents</c>.</summary>
+    public const string MeterName = "Granit.Documents";
+
+    private const string TagTenantId = "tenant_id";
+    private const string DefaultTenant = "global";
+
+    private readonly Counter<long> _uploads;
+    private readonly Counter<long> _downloads;
+    private readonly Counter<long> _sharesGranted;
+    private readonly Counter<long> _quotaRejected;
+
+    /// <summary>Initialises the meter and counters.</summary>
+    public DocumentsMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _uploads = meter.CreateCounter<long>(
+            "granit.documents.upload.count",
+            description: "Number of document version uploads finalised successfully.");
+
+        _downloads = meter.CreateCounter<long>(
+            "granit.documents.download.count",
+            description: "Number of document downloads (signed-URL issuances).");
+
+        _sharesGranted = meter.CreateCounter<long>(
+            "granit.documents.share.granted.count",
+            description: "Number of document or folder share grants issued.");
+
+        _quotaRejected = meter.CreateCounter<long>(
+            "granit.documents.quota.rejected.count",
+            description: "Number of upload finalisations rejected because the tenant storage quota would be exceeded.");
+    }
+
+    /// <summary>Records a successful document upload (new document or new version).</summary>
+    public void RecordUpload(string? tenantId) =>
+        _uploads.Add(1, CreateTags(tenantId));
+
+    /// <summary>Records a document download (one signed-URL issuance).</summary>
+    public void RecordDownload(string? tenantId) =>
+        _downloads.Add(1, CreateTags(tenantId));
+
+    /// <summary>Records a share grant on a document or folder.</summary>
+    public void RecordShareGranted(string? tenantId) =>
+        _sharesGranted.Add(1, CreateTags(tenantId));
+
+    /// <summary>Records an upload rejection due to tenant storage quota being exceeded.</summary>
+    public void RecordQuotaRejected(string? tenantId) =>
+        _quotaRejected.Add(1, CreateTags(tenantId));
+
+    private static TagList CreateTags(string? tenantId) => new()
+    {
+        { TagTenantId, tenantId ?? DefaultTenant },
+    };
+}

--- a/src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs
+++ b/src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
+using Granit.Diagnostics;
+using Granit.Documents.Diagnostics;
 using Granit.Documents.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Documents.Extensions;
@@ -19,15 +22,19 @@ public static class DocumentsServiceCollectionExtensions
     /// (when present) and validated on application start.
     /// </param>
     /// <remarks>
-    /// Phase-1 scaffolding registration: only options binding is performed. Domain
-    /// services, endpoints, and persistence are wired by subsequent stories of the
-    /// Granit.Documents Epic.
+    /// Phase-1 scaffolding registration: option binding plus diagnostics
+    /// (<see cref="DocumentsMetrics"/> meter and <c>Granit.Documents</c>
+    /// <see cref="System.Diagnostics.ActivitySource"/>). Domain services, endpoints,
+    /// and persistence are wired by subsequent stories of the Granit.Documents Epic.
     /// </remarks>
     public static IServiceCollection AddGranitDocuments(
         this IServiceCollection services,
         Action<GranitDocumentsOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        GranitActivitySourceRegistry.Register(DocumentsActivitySource.Name);
+        services.TryAddSingleton<DocumentsMetrics>();
 
         OptionsBuilder<GranitDocumentsOptions> optionsBuilder = services
             .AddOptions<GranitDocumentsOptions>()

--- a/tests/Granit.Documents.Tests/Diagnostics/DocumentsActivitySourceTests.cs
+++ b/tests/Granit.Documents.Tests/Diagnostics/DocumentsActivitySourceTests.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using Granit.Documents.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Diagnostics;
+
+public sealed class DocumentsActivitySourceTests : IDisposable
+{
+    private readonly ActivityListener _listener;
+
+    public DocumentsActivitySourceTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == DocumentsActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose() => _listener.Dispose();
+
+    [Fact]
+    public void Name_IsGranitDocuments() =>
+        DocumentsActivitySource.Name.ShouldBe("Granit.Documents");
+
+    [Fact]
+    public void StartActivity_DocumentUpload_ReturnsActivity()
+    {
+        using Activity? activity = DocumentsActivitySource.Source.StartActivity(
+            DocumentsActivitySource.DocumentUpload);
+
+        activity.ShouldNotBeNull();
+        activity.OperationName.ShouldBe("documents.upload");
+    }
+
+    [Fact]
+    public void StartActivity_DocumentDownload_ReturnsActivity()
+    {
+        using Activity? activity = DocumentsActivitySource.Source.StartActivity(
+            DocumentsActivitySource.DocumentDownload);
+
+        activity.ShouldNotBeNull();
+        activity.OperationName.ShouldBe("documents.download");
+    }
+
+    [Fact]
+    public void StartActivity_DocumentShareGrant_ReturnsActivity()
+    {
+        using Activity? activity = DocumentsActivitySource.Source.StartActivity(
+            DocumentsActivitySource.DocumentShareGrant);
+
+        activity.ShouldNotBeNull();
+        activity.OperationName.ShouldBe("documents.share.grant");
+    }
+
+    [Fact]
+    public void StartActivity_AclResolve_ReturnsActivity()
+    {
+        using Activity? activity = DocumentsActivitySource.Source.StartActivity(
+            DocumentsActivitySource.AclResolve);
+
+        activity.ShouldNotBeNull();
+        activity.OperationName.ShouldBe("documents.acl.resolve");
+    }
+}

--- a/tests/Granit.Documents.Tests/Diagnostics/DocumentsMetricsTests.cs
+++ b/tests/Granit.Documents.Tests/Diagnostics/DocumentsMetricsTests.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.Metrics;
+using Granit.Documents.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Diagnostics;
+
+public sealed class DocumentsMetricsTests : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly DocumentsMetrics _metrics;
+
+    public DocumentsMetricsTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new DocumentsMetrics(_meterFactory);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    [Fact]
+    public void RecordUpload_IncrementsWithTenantTag()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, DocumentsMetrics.MeterName, "granit.documents.upload.count");
+
+        _metrics.RecordUpload("tenant-123");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["tenant_id"].ShouldBe("tenant-123");
+    }
+
+    [Fact]
+    public void RecordUpload_NullTenant_UsesGlobal()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, DocumentsMetrics.MeterName, "granit.documents.upload.count");
+
+        _metrics.RecordUpload(null);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe("global");
+    }
+
+    [Fact]
+    public void RecordDownload_Increments()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, DocumentsMetrics.MeterName, "granit.documents.download.count");
+
+        _metrics.RecordDownload("t1");
+
+        collector.GetMeasurementSnapshot().ShouldHaveSingleItem().Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RecordShareGranted_Increments()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, DocumentsMetrics.MeterName, "granit.documents.share.granted.count");
+
+        _metrics.RecordShareGranted("t1");
+
+        collector.GetMeasurementSnapshot().ShouldHaveSingleItem().Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RecordQuotaRejected_Increments()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, DocumentsMetrics.MeterName, "granit.documents.quota.rejected.count");
+
+        _metrics.RecordQuotaRejected("t1");
+
+        collector.GetMeasurementSnapshot().ShouldHaveSingleItem().Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Constructor_NullMeterFactory_Throws() =>
+        Should.Throw<ArgumentNullException>(() => new DocumentsMetrics(null!));
+}

--- a/tests/Granit.Documents.Tests/GranitDocumentsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Documents.Tests/GranitDocumentsServiceCollectionExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.Diagnostics;
 using Granit.Documents.Extensions;
 using Granit.Documents.Options;
 using Microsoft.Extensions.Configuration;
@@ -16,6 +17,8 @@ public sealed class GranitDocumentsServiceCollectionExtensionsTests
         // BindConfiguration requires an IConfiguration in DI — provide an empty one
         // so unit tests can resolve options without a host builder.
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        // DocumentsMetrics depends on IMeterFactory.
+        services.AddMetrics();
         return services;
     }
 
@@ -60,5 +63,19 @@ public sealed class GranitDocumentsServiceCollectionExtensionsTests
         IServiceCollection? services = null;
 
         Should.Throw<ArgumentNullException>(() => services!.AddGranitDocuments());
+    }
+
+    [Fact]
+    public void AddGranitDocuments_RegistersDocumentsMetrics_AsSingleton()
+    {
+        ServiceCollection services = NewServices();
+
+        services.AddGranitDocuments();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        DocumentsMetrics first = provider.GetRequiredService<DocumentsMetrics>();
+        DocumentsMetrics second = provider.GetRequiredService<DocumentsMetrics>();
+
+        first.ShouldBeSameAs(second);
     }
 }


### PR DESCRIPTION
## Summary

Wires OpenTelemetry diagnostics for `Granit.Documents` per the framework convention (CLAUDE.md §*Metrics & diagnostics MANDATORY*). Closes the third and last F1 scaffolding story before domain work begins.

- `DocumentsMetrics` — public sealed class injecting `IMeterFactory`. Meter `Granit.Documents`. Baseline counters per the F1.3 AC:
  - `granit.documents.upload.count`
  - `granit.documents.download.count`
  - `granit.documents.share.granted.count`
  - `granit.documents.quota.rejected.count`
  All record a `TagList` with `tenant_id` (snake_case, defaulted to `"global"` per the framework convention).
- `DocumentsActivitySource` — `internal static` declaring the `Granit.Documents` `ActivitySource` and Phase-1 operation names (`documents.upload`, `documents.download`, `documents.share.grant`, `documents.acl.resolve`). Operations populate as the corresponding stories land.
- `AddGranitDocuments` now:
  - Registers `DocumentsMetrics` as a singleton via `TryAddSingleton`.
  - Registers the `ActivitySource` name with `GranitActivitySourceRegistry.Register` so `Granit.Observability` picks it up automatically when both packages are loaded.
- 12 new unit tests covering counter increments, null-tenant default, `ActivitySource` name + `StartActivity` for each operation, DI singleton check, null-`IMeterFactory` guard.

## Tracking

- Story: #1725 (F1.3 — Diagnostics)
- Feature: #1722 (F1 — Module scaffolding)
- Epic: #1721

## Test plan

- [x] `dotnet build src/Granit.Documents` clean.
- [x] `dotnet test tests/Granit.Documents.Tests` — **15/15 passing** (3 from F1.1 + 12 new).
- [x] `dotnet test tests/Granit.ArchitectureTests` — **209/209 passing**.
- [x] `dotnet format` clean on touched projects.
- [ ] CI shards green.