### PR TITLE
feat(entities): EntityBulkUpdatedEvent + collapsed bulk invalidation (#1794)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20662,6 +20662,15 @@
       ]
     },
     {
+      "name": "EntityBulkUpdatedEvent",
+      "fqn": "Granit.Events.EntityBulkUpdatedEvent",
+      "kind": "record",
+      "project": "Granit",
+      "file": "src/Granit/Events/EntityBulkUpdatedEvent.cs",
+      "line": 31,
+      "members": []
+    },
+    {
       "name": "EntityCreatedEto",
       "fqn": "Granit.Events.EntityCreatedEto",
       "kind": "record",

--- a/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
@@ -141,6 +141,26 @@ carry an executable foreign-key predicate yet; cached entries also carry the
 finer per-(source, id) tag for future per-row invalidation when the source row
 itself changes.
 
+#### Batched invalidation for host-side bulk operations
+
+Hosts that mutate many rows in one operation (CSV import, batch archive, mass
+re-assignment) should emit a single `EntityBulkUpdatedEvent<TEntity>` carrying
+the affected rows instead of N per-row events:
+
+```csharp
+await _localEventBus.PublishAsync(
+    new EntityBulkUpdatedEvent<Invoice>(updatedInvoices),
+    cancellationToken);
+```
+
+The same `RelationAggregateCacheInvalidator<TRelated>` consumes the bulk event
+and collapses the eviction to one `RemoveByTagAsync` call per unique tag,
+regardless of batch size. A 1000-row import emits one cache eviction sweep, not
+1000 (story #1794).
+
+Per-row events and bulk events are alternatives, not complements — emit one or
+the other for the same set of rows, never both.
+
 ## Calendar view
 
 A calendar layout reads its rows from a dedicated range-query endpoint that the

--- a/src/Granit.Entities.EntityFrameworkCore/Extensions/EntitiesEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Entities.EntityFrameworkCore/Extensions/EntitiesEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -201,6 +201,11 @@ public static class EntitiesEntityFrameworkCoreServiceCollectionExtensions
             services.AddScoped(
                 typeof(ILocalEventHandler<>).MakeGenericType(typeof(EntityDeletedEvent<>).MakeGenericType(relatedType)),
                 closedInvalidatorType);
+            // Bulk event — same invalidator, opt-in payload for hosts that
+            // emit one bulk event instead of N per-row events (story #1794).
+            services.AddScoped(
+                typeof(ILocalEventHandler<>).MakeGenericType(typeof(EntityBulkUpdatedEvent<>).MakeGenericType(relatedType)),
+                closedInvalidatorType);
         }
 
         return services;

--- a/src/Granit.Entities.EntityFrameworkCore/Internal/RelationAggregateCacheInvalidator.cs
+++ b/src/Granit.Entities.EntityFrameworkCore/Internal/RelationAggregateCacheInvalidator.cs
@@ -33,7 +33,8 @@ internal sealed class RelationAggregateCacheInvalidator<TRelated>(
     RelationAggregateInvalidationTargets<TRelated> targets) :
     ILocalEventHandler<EntityCreatedEvent<TRelated>>,
     ILocalEventHandler<EntityUpdatedEvent<TRelated>>,
-    ILocalEventHandler<EntityDeletedEvent<TRelated>>
+    ILocalEventHandler<EntityDeletedEvent<TRelated>>,
+    ILocalEventHandler<EntityBulkUpdatedEvent<TRelated>>
     where TRelated : class, Granit.Domain.IEmitEntityLifecycleEvents
 {
     public Task HandleAsync(EntityCreatedEvent<TRelated> localEvent, CancellationToken cancellationToken = default) =>
@@ -44,6 +45,14 @@ internal sealed class RelationAggregateCacheInvalidator<TRelated>(
 
     public Task HandleAsync(EntityDeletedEvent<TRelated> localEvent, CancellationToken cancellationToken = default) =>
         EvictAsync(cancellationToken);
+
+    // One bulk event collapses to one eviction sweep — coarser tag granularity
+    // already groups per (source, relation), so the bulk event simply avoids the
+    // N-way fan-out cost when the host has a batch of writes (story #1794).
+    public Task HandleAsync(EntityBulkUpdatedEvent<TRelated> localEvent, CancellationToken cancellationToken = default) =>
+        localEvent.Entities.Count == 0
+            ? Task.CompletedTask
+            : EvictAsync(cancellationToken);
 
     private async Task EvictAsync(CancellationToken cancellationToken)
     {

--- a/src/Granit/Events/EntityBulkUpdatedEvent.cs
+++ b/src/Granit/Events/EntityBulkUpdatedEvent.cs
@@ -1,0 +1,32 @@
+using Granit.Domain;
+
+namespace Granit.Events;
+
+/// <summary>
+/// Domain event signalling that a batch of <typeparamref name="TEntity"/> rows
+/// was created, updated, or deleted in a single host operation (story #1794).
+/// Hosts emit this once per bulk operation instead of N per-row
+/// <see cref="EntityCreatedEvent{TEntity}"/> / <see cref="EntityUpdatedEvent{TEntity}"/> /
+/// <see cref="EntityDeletedEvent{TEntity}"/> events when the batch is large enough
+/// that fan-out invalidation would be wasteful (e.g. a 100-row archive emitting
+/// 100 cache eviction calls when one would suffice).
+/// </summary>
+/// <typeparam name="TEntity">The entity type. Must implement <see cref="IEmitEntityLifecycleEvents"/>.</typeparam>
+/// <param name="Entities">
+/// The affected rows (post-save state for create/update; pre-delete snapshot for
+/// delete). Empty list is allowed but a no-op for invalidation.
+/// </param>
+/// <remarks>
+/// <para>
+/// Consumed by <c>RelationAggregateCacheInvalidator&lt;TRelated&gt;</c> alongside
+/// the per-row events: a single bulk event drops the cached relation aggregates
+/// for every parent of the relation in one <c>RemoveByTagAsync</c> call.
+/// </para>
+/// <para>
+/// Hosts that emit this event SHOULD NOT also emit per-row events for the same
+/// rows — the consumer treats them as alternatives, not complements. Mixing
+/// causes duplicate invalidation work without correctness impact.
+/// </para>
+/// </remarks>
+public sealed record EntityBulkUpdatedEvent<TEntity>(IReadOnlyList<TEntity> Entities) : IDomainEvent
+    where TEntity : class, IEmitEntityLifecycleEvents;

--- a/tests/Granit.Entities.EntityFrameworkCore.Tests/RelationAggregateCacheInvalidatorTests.cs
+++ b/tests/Granit.Entities.EntityFrameworkCore.Tests/RelationAggregateCacheInvalidatorTests.cs
@@ -92,4 +92,46 @@ public sealed class RelationAggregateCacheInvalidatorTests
         RelationAggregateInvalidationTargets<SampleRelated> sut = new(["a", "b"]);
         sut.EvictionTags.ShouldBe(["a", "b"]);
     }
+
+    [Fact]
+    public async Task HandleAsync_Bulk_drops_each_tag_once_regardless_of_batch_size()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        RelationAggregateInvalidationTargets<SampleRelated> targets = new(
+            ["entity-relation:Granit.Parties.Party:invoices",
+             "entity-relation:Granit.Sales.Account:invoices"]);
+
+        RelationAggregateCacheInvalidator<SampleRelated> sut = new(cache, targets);
+
+        // 100-row batch must collapse to 2 RemoveByTagAsync calls (one per tag),
+        // not 200 — the whole point of EntityBulkUpdatedEvent.
+        IReadOnlyList<SampleRelated> batch = [.. Enumerable.Range(0, 100).Select(_ => new SampleRelated())];
+        await sut.HandleAsync(new EntityBulkUpdatedEvent<SampleRelated>(batch), TestContext.Current.CancellationToken);
+
+        await cache.Received(1).RemoveByTagAsync(
+            "entity-relation:Granit.Parties.Party:invoices",
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+        await cache.Received(1).RemoveByTagAsync(
+            "entity-relation:Granit.Sales.Account:invoices",
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_Bulk_empty_batch_is_a_no_op()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        RelationAggregateInvalidationTargets<SampleRelated> targets = new(
+            ["entity-relation:Granit.Parties.Party:invoices"]);
+
+        RelationAggregateCacheInvalidator<SampleRelated> sut = new(cache, targets);
+
+        await sut.HandleAsync(new EntityBulkUpdatedEvent<SampleRelated>([]), TestContext.Current.CancellationToken);
+
+        await cache.DidNotReceive().RemoveByTagAsync(
+            Arg.Any<string>(),
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Granit.Entities.EntityFrameworkCore.Tests/RelationAggregateInvalidationDiscoveryTests.cs
+++ b/tests/Granit.Entities.EntityFrameworkCore.Tests/RelationAggregateInvalidationDiscoveryTests.cs
@@ -87,10 +87,12 @@ public sealed class RelationAggregateInvalidationDiscoveryTests
         Type createdHandler = typeof(ILocalEventHandler<EntityCreatedEvent<Invoice>>);
         Type updatedHandler = typeof(ILocalEventHandler<EntityUpdatedEvent<Invoice>>);
         Type deletedHandler = typeof(ILocalEventHandler<EntityDeletedEvent<Invoice>>);
+        Type bulkHandler = typeof(ILocalEventHandler<EntityBulkUpdatedEvent<Invoice>>);
 
         services.Any(sd => sd.ServiceType == createdHandler).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == updatedHandler).ShouldBeTrue();
         services.Any(sd => sd.ServiceType == deletedHandler).ShouldBeTrue();
+        services.Any(sd => sd.ServiceType == bulkHandler).ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes [#1794](https://github.com/granit-fx/granit-dotnet/issues/1794) (Phase 2 Stream D, story D2 — scope reduced; full bulk endpoint carved into [#1822](https://github.com/granit-fx/granit-dotnet/issues/1822)).

Hosts that mutate many rows in one operation (CSV import, batch archive, mass re-assignment) now emit one `EntityBulkUpdatedEvent<TEntity>` instead of N per-row events. The same `RelationAggregateCacheInvalidator` from [#1793](https://github.com/granit-fx/granit-dotnet/issues/1793) collapses the eviction to one `RemoveByTagAsync` call per unique tag, regardless of batch size — a 1000-row import triggers one cache sweep instead of 1000.

## What ships

- **`EntityBulkUpdatedEvent<TEntity>(IReadOnlyList<TEntity> Entities)`** in `Granit/Events/`, sibling to the per-row `EntityCreated/Updated/DeletedEvent<TEntity>`
- **`RelationAggregateCacheInvalidator<TRelated>`** implements `ILocalEventHandler<EntityBulkUpdatedEvent<TRelated>>`; empty batch is a no-op
- **DI registration** extends the existing scan to include the bulk handler alongside the three per-row handlers — zero host configuration needed once `AddGranitEntitiesRelationAggregateInvalidation()` is called
- **Doc note** in `entity-definition.mdx` covers when to emit per-row vs bulk events (alternatives, never both for the same rows)

## Scope reduction — see issue comment

D2's story body envisioned a full `POST /api/entities/{name}/bulk/{action}` endpoint, which would require introducing an entire new framework concept — server-side action execution (`IEntityActionExecutor<TEntity>` + opt-in `IBulkActionExecutor<TEntity>`). The framework today has no executor surface; actions are purely declarative (URL + kind + permission), executed client-side.

Building that surface inline would have been 3-4× the story scope and warrants its own ADR (executor lifecycle, transactional semantics, side-effect contract). The deferred portion is now [#1822](https://github.com/granit-fx/granit-dotnet/issues/1822), unblocked by this PR. Full rationale on [#1794 comment](https://github.com/granit-fx/granit-dotnet/issues/1794#issuecomment-4363821326).

## Tests

- 2 new unit tests on `RelationAggregateCacheInvalidatorTests` — bulk drops one call per tag for any batch size (100 rows → 2 calls when 2 tags); empty batch no-op
- 1 line added to `RelationAggregateInvalidationDiscoveryTests` — verifies the bulk handler is registered alongside the 3 per-row handlers
- All 26/26 tests in `Granit.Entities.EntityFrameworkCore.Tests` green

## Test plan

- [x] `dotnet build .github/shard-filters/business.slnf` — 0 errors
- [x] `dotnet test .github/shard-filters/business.slnf --no-build` — clean (DocumentGenerator pre-existing failure resolved on develop, no longer present)
- [x] `dotnet build .github/shard-filters/architecture.slnf` + `dotnet test` — 209/209 pass
- [x] `dotnet test tests/Granit.Entities.EntityFrameworkCore.Tests` — 26/26 pass
- [x] `dotnet format` clean
- [x] `npx markdownlint-cli2` clean on the doc change
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles regenerated
