### PR TITLE
feat(documents): Folder aggregate root with IsTenantRoot invariant (F2.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18005,6 +18005,43 @@
       ]
     },
     {
+      "name": "Folder",
+      "fqn": "Granit.Documents.Domain.Folder",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/Folder.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Folder parent, string name, Guid ownerUserId)",
+          "returnType": "Folder"
+        },
+        {
+          "name": "Path",
+          "kind": "property",
+          "signature": "string Path",
+          "returnType": "string"
+        },
+        {
+          "name": "Rename",
+          "kind": "method",
+          "signature": "Rename(string newName)",
+          "returnType": "int Depth { get; private set; } public Guid OwnerUserId { get; private set; } public bool IsTenantRoot { get; private set; } public FolderStatus Status { get; private set; } public DateTimeOffset? TrashedAt { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "FolderStatus",
+      "fqn": "Granit.Documents.Domain.FolderStatus",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/FolderStatus.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Documents.EntityFrameworkCore.Extensions.DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -18026,7 +18063,7 @@
       "kind": "class",
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "ConfigureDocumentsModule",
@@ -18059,6 +18096,60 @@
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs",
       "line": 26,
+      "members": []
+    },
+    {
+      "name": "FolderCreatedEvent",
+      "fqn": "Granit.Documents.Events.FolderCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderCreatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "FolderMovedEvent",
+      "fqn": "Granit.Documents.Events.FolderMovedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderMovedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "FolderPathChangedEvent",
+      "fqn": "Granit.Documents.Events.FolderPathChangedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderPathChangedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "FolderRenamedEvent",
+      "fqn": "Granit.Documents.Events.FolderRenamedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderRenamedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FolderRestoredEvent",
+      "fqn": "Granit.Documents.Events.FolderRestoredEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderRestoredEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "FolderTrashedEvent",
+      "fqn": "Granit.Documents.Events.FolderTrashedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderTrashedEvent.cs",
+      "line": 8,
       "members": []
     },
     {

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Documents.EntityFrameworkCore.Extensions;
@@ -13,14 +14,10 @@ public static class DocumentsModelBuilderExtensions
     /// </summary>
     /// <param name="modelBuilder">The model builder.</param>
     /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
-    /// <remarks>
-    /// Phase-1 scaffolding: no entity configurations registered yet. Subsequent stories
-    /// (F2 <c>Folder</c>, F3 <c>Document</c>, …) will add their <c>IEntityTypeConfiguration</c>
-    /// classes here.
-    /// </remarks>
     public static ModelBuilder ConfigureDocumentsModule(this ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
+        modelBuilder.ApplyConfiguration(new FolderConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
@@ -1,4 +1,5 @@
 using Granit.DataFiltering;
+using Granit.Documents.Domain;
 using Granit.Documents.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -11,10 +12,9 @@ namespace Granit.Documents.EntityFrameworkCore.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Isolated from the host application's DbContext to avoid coupling. Phase-1 scaffolding:
-/// no <see cref="DbSet{TEntity}"/> declarations yet — aggregate roots arrive in subsequent
-/// stories (F2 <c>Folder</c>, F3 <c>Document</c>, …) along with their <c>IEntityTypeConfiguration</c>
-/// classes wired by <see cref="DocumentsModelBuilderExtensions.ConfigureDocumentsModule"/>.
+/// Isolated from the host application's DbContext to avoid coupling. Aggregate roots are
+/// added story-by-story along with their <c>IEntityTypeConfiguration</c> classes wired
+/// by <see cref="DocumentsModelBuilderExtensions.ConfigureDocumentsModule"/>.
 /// </para>
 /// <para>
 /// Compatible with SQL Server and PostgreSQL.
@@ -26,6 +26,9 @@ internal sealed class DocumentsDbContext(
     IDataFilter? dataFilter = null)
     : DbContext(options)
 {
+    /// <summary>Tenant-scoped folder hierarchy (one tenant-root row per tenant).</summary>
+    public DbSet<Folder> Folders { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/FolderConfiguration.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/FolderConfiguration.cs
@@ -1,0 +1,77 @@
+using Granit.Documents.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="Folder"/>.
+/// Table: <c>documents_folders</c>.
+/// </summary>
+internal sealed class FolderConfiguration : IEntityTypeConfiguration<Folder>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Folder> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitDocumentsDbProperties.DbTablePrefix + "folders",
+            GranitDocumentsDbProperties.DbSchema,
+            tb =>
+            {
+                // ParentFolderId is allowed to be NULL only for the tenant root.
+                tb.HasCheckConstraint(
+                    $"ck_{GranitDocumentsDbProperties.DbTablePrefix}folders_parent_only_root_null",
+                    "parent_folder_id IS NOT NULL OR is_tenant_root = TRUE");
+            });
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+
+        builder.Property(e => e.ParentFolderId);
+
+        builder.Property(e => e.Name)
+            .HasMaxLength(Folder.MaxNameLength)
+            .IsRequired();
+
+        builder.Property(e => e.Path)
+            .HasMaxLength(Folder.MaxPathLength)
+            .IsRequired();
+
+        builder.Property(e => e.Depth)
+            .IsRequired();
+
+        builder.Property(e => e.OwnerUserId)
+            .IsRequired();
+
+        builder.Property(e => e.IsTenantRoot)
+            .IsRequired();
+
+        // Store enum as string for readability and resilience to reordering.
+        builder.Property(e => e.Status)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.TrashedAt);
+
+        // Exactly one tenant-root row per tenant — partial unique index.
+        builder.HasIndex(e => e.TenantId)
+            .IsUnique()
+            .HasFilter("is_tenant_root = TRUE")
+            .HasDatabaseName($"ux_{GranitDocumentsDbProperties.DbTablePrefix}folders_one_root_per_tenant");
+
+        // Sibling-name uniqueness inside a parent. Per-tenant scoping is implicit because
+        // ParentFolderId is itself a tenant-scoped FK.
+        builder.HasIndex(e => new { e.TenantId, e.ParentFolderId, e.Name })
+            .IsUnique()
+            .HasDatabaseName($"ux_{GranitDocumentsDbProperties.DbTablePrefix}folders_sibling_name");
+
+        // Materialised-path index for ACL prefix scans (F6.2 will optionally promote this
+        // to text_pattern_ops on PostgreSQL when wiring the effective-permission resolver).
+        builder.HasIndex(e => new { e.TenantId, e.Path })
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}folders_tenant_path");
+    }
+}

--- a/src/Granit.Documents/Domain/Folder.cs
+++ b/src/Granit.Documents/Domain/Folder.cs
@@ -1,0 +1,334 @@
+using Granit.Documents.Events;
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Aggregate root representing a folder in a tenant's document tree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each tenant has exactly one invisible <b>tenant root</b> folder
+/// (<see cref="IsTenantRoot"/> = <c>true</c>, <see cref="ParentFolderId"/> = <c>null</c>,
+/// <see cref="Path"/> = <c>"/"</c>). All user-created folders descend from it; documents
+/// reference a folder (root included). The root unifies SQL: there is no
+/// <c>FolderId IS NULL</c> branch to handle, and tenant-wide permission grants are simply
+/// shares on the root folder.
+/// </para>
+/// <para>
+/// The root cannot be renamed, moved, trashed, or deleted (invariants enforced at the
+/// aggregate level). Bootstrap is handled by <c>IDocumentBootstrapService</c> in F2.2.
+/// </para>
+/// <para>
+/// The <see cref="Path"/> column is materialised so list/search and ACL resolution can
+/// run as a single non-recursive SQL query (see ADR-052 §Permission resolution model).
+/// </para>
+/// </remarks>
+public sealed class Folder : AggregateRoot, IMultiTenant
+{
+    /// <summary>Path separator used in the materialised <see cref="Path"/>.</summary>
+    public const string PathSeparator = "/";
+
+    /// <summary>The materialised <see cref="Path"/> of every tenant root.</summary>
+    public const string TenantRootPath = "/";
+
+    /// <summary>Maximum length, in characters, of a folder <see cref="Name"/>.</summary>
+    public const int MaxNameLength = 255;
+
+    /// <summary>Maximum length, in characters, of the materialised <see cref="Path"/>.</summary>
+    public const int MaxPathLength = 1024;
+
+    /// <summary>Parameterless constructor required by the EF Core materialiser.</summary>
+    private Folder() { }
+
+    /// <summary>
+    /// Creates a non-root folder under <paramref name="parent"/>.
+    /// </summary>
+    /// <param name="id">Unique identifier of the new folder.</param>
+    /// <param name="parent">The parent folder (the tenant root or any non-trashed folder).</param>
+    /// <param name="name">User-facing name (validated).</param>
+    /// <param name="ownerUserId">Identifier of the user who owns the folder.</param>
+    public static Folder Create(Guid id, Folder parent, string name, Guid ownerUserId)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+        ValidateName(name);
+        if (parent.Status != FolderStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Cannot create a folder under a non-active parent (parent {parent.Id} is {parent.Status}).");
+        }
+
+        string path = ComputeChildPath(parent.Path, name);
+        if (path.Length > MaxPathLength)
+        {
+            throw new ArgumentException(
+                $"Resulting folder path exceeds {MaxPathLength} characters.", nameof(name));
+        }
+
+        Folder folder = new()
+        {
+            Id = id,
+            TenantId = parent.TenantId,
+            ParentFolderId = parent.Id,
+            Name = name,
+            Path = path,
+            Depth = parent.Depth + 1,
+            OwnerUserId = ownerUserId,
+            IsTenantRoot = false,
+            Status = FolderStatus.Active,
+        };
+        folder.AddDomainEvent(new FolderCreatedEvent(
+            folder.Id, folder.TenantId, folder.ParentFolderId, folder.Name, folder.Path, IsTenantRoot: false));
+        return folder;
+    }
+
+    /// <summary>
+    /// Creates the unique tenant root folder. Internal: only called by the bootstrap service
+    /// (F2.2 <c>IDocumentBootstrapService.EnsureTenantRootAsync</c>).
+    /// </summary>
+    /// <param name="id">Unique identifier of the root.</param>
+    /// <param name="tenantId">Tenant the root belongs to.</param>
+    /// <param name="ownerUserId">Identifier of the user (or system principal) creating the tenant.</param>
+    internal static Folder CreateTenantRoot(Guid id, Guid? tenantId, Guid ownerUserId)
+    {
+        Folder folder = new()
+        {
+            Id = id,
+            TenantId = tenantId,
+            ParentFolderId = null,
+            Name = string.Empty,
+            Path = TenantRootPath,
+            Depth = 0,
+            OwnerUserId = ownerUserId,
+            IsTenantRoot = true,
+            Status = FolderStatus.Active,
+        };
+        folder.AddDomainEvent(new FolderCreatedEvent(
+            folder.Id, folder.TenantId, ParentFolderId: null, folder.Name, folder.Path, IsTenantRoot: true));
+        return folder;
+    }
+
+    /// <summary>Identifier of the tenant that owns this folder.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Explicit implementation preserves the <c>private set</c> DDD encapsulation on the
+    /// public property while satisfying the interface contract used by
+    /// <c>AuditedEntityInterceptor</c> for tenant-id injection.
+    /// </remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Parent folder identifier. <c>null</c> only when <see cref="IsTenantRoot"/> is true.</summary>
+    public Guid? ParentFolderId { get; private set; }
+
+    /// <summary>User-facing name of the folder.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>Materialised path: <c>"/"</c> for the root, <c>"/A/B/C"</c> otherwise.</summary>
+    public string Path { get; private set; } = TenantRootPath;
+
+    /// <summary>Depth in the tenant tree. <c>0</c> for the root, <c>1</c> for direct children, etc.</summary>
+    public int Depth { get; private set; }
+
+    /// <summary>Identifier of the user who owns the folder.</summary>
+    public Guid OwnerUserId { get; private set; }
+
+    /// <summary>
+    /// <c>true</c> for the unique invisible root of the tenant. Exactly one row per tenant
+    /// satisfies this (enforced by a partial unique index in
+    /// <c>FolderConfiguration</c>).
+    /// </summary>
+    public bool IsTenantRoot { get; private set; }
+
+    /// <summary>Lifecycle status. Trashed folders are eligible for permanent deletion via F8 / F9.2.</summary>
+    public FolderStatus Status { get; private set; }
+
+    /// <summary>UTC instant when the folder was trashed; <c>null</c> while <see cref="Status"/> is <see cref="FolderStatus.Active"/>.</summary>
+    public DateTimeOffset? TrashedAt { get; private set; }
+
+    /// <summary>
+    /// Renames the folder and recomputes its materialised <see cref="Path"/>. Descendants'
+    /// paths are NOT touched here — the service layer does that in a single SQL UPDATE
+    /// during the same transaction (F2.4 introduces the helper).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When this folder is the tenant root or trashed.</exception>
+    /// <exception cref="ArgumentException">When <paramref name="newName"/> is invalid.</exception>
+    public void Rename(string newName)
+    {
+        ThrowIfTenantRoot(nameof(Rename));
+        ThrowIfTrashed(nameof(Rename));
+        ValidateName(newName);
+
+        if (string.Equals(Name, newName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        string oldName = Name;
+        string oldPath = Path;
+        string parentPath = oldPath[..^(oldName.Length + PathSeparator.Length)];
+        // parentPath is the slice up to (and excluding) the trailing "/<oldName>"; for direct
+        // children of the root, parentPath collapses to the empty string, which we map back to "/".
+        if (parentPath.Length == 0)
+        {
+            parentPath = TenantRootPath;
+        }
+
+        string newPath = ComputeChildPath(parentPath, newName);
+        if (newPath.Length > MaxPathLength)
+        {
+            throw new ArgumentException(
+                $"Resulting folder path exceeds {MaxPathLength} characters.", nameof(newName));
+        }
+
+        Name = newName;
+        Path = newPath;
+
+        AddDomainEvent(new FolderRenamedEvent(Id, oldName, newName));
+        AddDomainEvent(new FolderPathChangedEvent(Id, TenantId, oldPath, newPath));
+    }
+
+    /// <summary>
+    /// Moves the folder under <paramref name="newParent"/>. Updates this folder's
+    /// <see cref="Path"/> and <see cref="Depth"/>; descendants are repointed by the service
+    /// layer in the same transaction (F2.4).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// When this folder is the tenant root, when this folder is trashed, when the target
+    /// parent is in a different tenant, when the target is this folder itself, when the
+    /// target is a descendant of this folder, or when the target is trashed.
+    /// </exception>
+    public void MoveTo(Folder newParent)
+    {
+        ArgumentNullException.ThrowIfNull(newParent);
+        ThrowIfTenantRoot(nameof(MoveTo));
+        ThrowIfTrashed(nameof(MoveTo));
+
+        if (newParent.Id == Id)
+        {
+            throw new InvalidOperationException("A folder cannot be moved under itself.");
+        }
+        if (newParent.TenantId != TenantId)
+        {
+            throw new InvalidOperationException("Cannot move a folder to a different tenant.");
+        }
+        if (newParent.Status != FolderStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Cannot move under a non-active parent (parent {newParent.Id} is {newParent.Status}).");
+        }
+        if (IsAncestorOf(newParent))
+        {
+            throw new InvalidOperationException(
+                "Cannot move a folder under one of its own descendants.");
+        }
+        if (newParent.Id == ParentFolderId)
+        {
+            return;
+        }
+
+        Guid? oldParentId = ParentFolderId;
+        string oldPath = Path;
+        string newPath = ComputeChildPath(newParent.Path, Name);
+        if (newPath.Length > MaxPathLength)
+        {
+            throw new InvalidOperationException(
+                $"Resulting folder path exceeds {MaxPathLength} characters.");
+        }
+
+        ParentFolderId = newParent.Id;
+        Path = newPath;
+        Depth = newParent.Depth + 1;
+
+        AddDomainEvent(new FolderMovedEvent(Id, oldParentId, newParent.Id));
+        AddDomainEvent(new FolderPathChangedEvent(Id, TenantId, oldPath, newPath));
+    }
+
+    /// <summary>
+    /// Sends the folder to the trash (soft-delete via domain status). Cascade trashing of
+    /// descendants is performed by the service layer (F8.1).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When this folder is the tenant root or already trashed.</exception>
+    public void Trash(DateTimeOffset trashedAt)
+    {
+        ThrowIfTenantRoot(nameof(Trash));
+        if (Status == FolderStatus.Trashed)
+        {
+            throw new InvalidOperationException($"Folder {Id} is already trashed.");
+        }
+
+        Status = FolderStatus.Trashed;
+        TrashedAt = trashedAt;
+        AddDomainEvent(new FolderTrashedEvent(Id, TenantId, trashedAt));
+    }
+
+    /// <summary>
+    /// Restores a trashed folder. Descendants stay trashed unless restored individually.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When this folder is the tenant root or already active.</exception>
+    public void Restore()
+    {
+        ThrowIfTenantRoot(nameof(Restore));
+        if (Status != FolderStatus.Trashed)
+        {
+            throw new InvalidOperationException($"Folder {Id} is not trashed.");
+        }
+
+        Status = FolderStatus.Active;
+        TrashedAt = null;
+        AddDomainEvent(new FolderRestoredEvent(Id, TenantId));
+    }
+
+    private bool IsAncestorOf(Folder candidate) =>
+        // Path-prefix check: ancestor.Path is "/" or ends with no separator; child paths begin
+        // with ancestor.Path + "/". The exact-equality check handles the candidate-is-self case
+        // already excluded above but kept here for symmetry with the SQL ancestor-match query.
+        candidate.Path == Path
+        || candidate.Path.StartsWith(Path == TenantRootPath ? TenantRootPath : Path + PathSeparator,
+            StringComparison.Ordinal);
+
+    private static string ComputeChildPath(string parentPath, string childName) =>
+        parentPath == TenantRootPath
+            ? TenantRootPath + childName
+            : parentPath + PathSeparator + childName;
+
+    private static void ValidateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (name.Length > MaxNameLength)
+        {
+            throw new ArgumentException(
+                $"Folder name exceeds {MaxNameLength} characters.", nameof(name));
+        }
+        if (name.Contains(PathSeparator, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Folder name must not contain the path separator '{PathSeparator}'.",
+                nameof(name));
+        }
+    }
+
+    private void ThrowIfTenantRoot(string operation)
+    {
+        if (IsTenantRoot)
+        {
+            throw new InvalidOperationException(
+                $"Operation '{operation}' is not allowed on the tenant root folder ({Id}).");
+        }
+    }
+
+    private void ThrowIfTrashed(string operation)
+    {
+        if (Status == FolderStatus.Trashed)
+        {
+            throw new InvalidOperationException(
+                $"Operation '{operation}' is not allowed on a trashed folder ({Id}).");
+        }
+    }
+}

--- a/src/Granit.Documents/Domain/FolderStatus.cs
+++ b/src/Granit.Documents/Domain/FolderStatus.cs
@@ -1,0 +1,17 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Lifecycle status of a <see cref="Folder"/>.
+/// </summary>
+/// <remarks>
+/// Trashed folders are retained for the duration of <c>DocumentsOptions.TrashRetentionDays</c>
+/// before permanent deletion by the empty-trash background job (F8 / F9.2).
+/// </remarks>
+public enum FolderStatus
+{
+    /// <summary>The folder is active and visible in browsing / search.</summary>
+    Active,
+
+    /// <summary>The folder has been moved to the trash; awaiting restore or permanent deletion.</summary>
+    Trashed,
+}

--- a/src/Granit.Documents/Events/FolderCreatedEvent.cs
+++ b/src/Granit.Documents/Events/FolderCreatedEvent.cs
@@ -1,0 +1,14 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Folder</c> aggregate is created (root or non-root).
+/// </summary>
+public sealed record FolderCreatedEvent(
+    Guid FolderId,
+    Guid? TenantId,
+    Guid? ParentFolderId,
+    string Name,
+    string Path,
+    bool IsTenantRoot) : IDomainEvent;

--- a/src/Granit.Documents/Events/FolderMovedEvent.cs
+++ b/src/Granit.Documents/Events/FolderMovedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Folder</c> is moved to a new parent. A
+/// <see cref="FolderPathChangedEvent"/> is emitted alongside since the
+/// materialised <c>Path</c> changes too.
+/// </summary>
+public sealed record FolderMovedEvent(
+    Guid FolderId,
+    Guid? OldParentFolderId,
+    Guid NewParentFolderId) : IDomainEvent;

--- a/src/Granit.Documents/Events/FolderPathChangedEvent.cs
+++ b/src/Granit.Documents/Events/FolderPathChangedEvent.cs
@@ -1,0 +1,14 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised whenever a <c>Folder</c>'s materialised <c>Path</c> changes — on rename
+/// or move. Consumers (F6.3 ACL cache invalidator, search index) use this event to
+/// invalidate or refresh derived state for the folder and all descendants.
+/// </summary>
+public sealed record FolderPathChangedEvent(
+    Guid FolderId,
+    Guid? TenantId,
+    string OldPath,
+    string NewPath) : IDomainEvent;

--- a/src/Granit.Documents/Events/FolderRenamedEvent.cs
+++ b/src/Granit.Documents/Events/FolderRenamedEvent.cs
@@ -1,0 +1,12 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Folder</c> is renamed. A <see cref="FolderPathChangedEvent"/>
+/// is emitted alongside since the materialised <c>Path</c> changes too.
+/// </summary>
+public sealed record FolderRenamedEvent(
+    Guid FolderId,
+    string OldName,
+    string NewName) : IDomainEvent;

--- a/src/Granit.Documents/Events/FolderRestoredEvent.cs
+++ b/src/Granit.Documents/Events/FolderRestoredEvent.cs
@@ -1,0 +1,10 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a trashed <c>Folder</c> is restored to active status.
+/// </summary>
+public sealed record FolderRestoredEvent(
+    Guid FolderId,
+    Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Documents/Events/FolderTrashedEvent.cs
+++ b/src/Granit.Documents/Events/FolderTrashedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Folder</c> is moved to the trash (soft-delete via domain status).
+/// </summary>
+public sealed record FolderTrashedEvent(
+    Guid FolderId,
+    Guid? TenantId,
+    DateTimeOffset TrashedAt) : IDomainEvent;

--- a/tests/Granit.Documents.Tests/Domain/FolderTests.cs
+++ b/tests/Granit.Documents.Tests/Domain/FolderTests.cs
@@ -1,0 +1,291 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Domain;
+
+public sealed class FolderTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    private static Folder NewRoot() =>
+        InvokeInternalCreateTenantRoot(Guid.NewGuid(), TenantId, OwnerId);
+
+    /// <summary>
+    /// <c>Folder.CreateTenantRoot</c> is internal; tests reside in
+    /// <c>Granit.Documents.Tests</c> which has <c>InternalsVisibleTo</c>, so the
+    /// member is reachable directly. This helper documents intent.
+    /// </summary>
+    private static Folder InvokeInternalCreateTenantRoot(Guid id, Guid? tenantId, Guid ownerId) =>
+        Folder.CreateTenantRoot(id, tenantId, ownerId);
+
+    [Fact]
+    public void CreateTenantRoot_Defaults_AreCorrect()
+    {
+        Folder root = NewRoot();
+
+        root.IsTenantRoot.ShouldBeTrue();
+        root.ParentFolderId.ShouldBeNull();
+        root.Path.ShouldBe("/");
+        root.Depth.ShouldBe(0);
+        root.Status.ShouldBe(FolderStatus.Active);
+        root.TrashedAt.ShouldBeNull();
+
+        FolderCreatedEvent created = root.DomainEvents.OfType<FolderCreatedEvent>().ShouldHaveSingleItem();
+        created.IsTenantRoot.ShouldBeTrue();
+        created.Path.ShouldBe("/");
+    }
+
+    [Fact]
+    public void Create_NonRoot_ComputesPathAndDepth()
+    {
+        Folder root = NewRoot();
+
+        var contracts = Folder.Create(Guid.NewGuid(), root, "Contracts", OwnerId);
+
+        contracts.IsTenantRoot.ShouldBeFalse();
+        contracts.ParentFolderId.ShouldBe(root.Id);
+        contracts.Path.ShouldBe("/Contracts");
+        contracts.Depth.ShouldBe(1);
+        contracts.TenantId.ShouldBe(TenantId);
+
+        var year = Folder.Create(Guid.NewGuid(), contracts, "2026", OwnerId);
+        year.Path.ShouldBe("/Contracts/2026");
+        year.Depth.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("a/b")]
+    public void Create_InvalidName_Throws(string name)
+    {
+        Folder root = NewRoot();
+
+        Should.Throw<ArgumentException>(() => Folder.Create(Guid.NewGuid(), root, name, OwnerId));
+    }
+
+    [Fact]
+    public void Create_NameTooLong_Throws()
+    {
+        Folder root = NewRoot();
+        string longName = new('a', Folder.MaxNameLength + 1);
+
+        Should.Throw<ArgumentException>(() => Folder.Create(Guid.NewGuid(), root, longName, OwnerId));
+    }
+
+    [Fact]
+    public void Create_UnderTrashedParent_Throws()
+    {
+        Folder root = NewRoot();
+        var parent = Folder.Create(Guid.NewGuid(), root, "Parent", OwnerId);
+        parent.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() =>
+            Folder.Create(Guid.NewGuid(), parent, "Child", OwnerId));
+    }
+
+    [Fact]
+    public void Rename_UpdatesNameAndPath_AndEmitsEvents()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "Old", OwnerId);
+
+        folder.Rename("New");
+
+        folder.Name.ShouldBe("New");
+        folder.Path.ShouldBe("/New");
+        folder.DomainEvents.OfType<FolderRenamedEvent>().ShouldHaveSingleItem();
+        FolderPathChangedEvent path = folder.DomainEvents.OfType<FolderPathChangedEvent>().ShouldHaveSingleItem();
+        path.OldPath.ShouldBe("/Old");
+        path.NewPath.ShouldBe("/New");
+    }
+
+    [Fact]
+    public void Rename_NestedFolder_RecomputesPathFromParent()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+        var b = Folder.Create(Guid.NewGuid(), a, "B", OwnerId);
+
+        b.Rename("BB");
+
+        b.Path.ShouldBe("/A/BB");
+    }
+
+    [Fact]
+    public void Rename_TenantRoot_Throws()
+    {
+        Folder root = NewRoot();
+
+        Should.Throw<InvalidOperationException>(() => root.Rename("Anything"));
+    }
+
+    [Fact]
+    public void Rename_TrashedFolder_Throws()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "F", OwnerId);
+        folder.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => folder.Rename("F2"));
+    }
+
+    [Fact]
+    public void Rename_SameName_IsNoOp()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "Same", OwnerId);
+
+        folder.Rename("Same");
+
+        folder.DomainEvents.OfType<FolderRenamedEvent>().ShouldBeEmpty();
+        folder.DomainEvents.OfType<FolderPathChangedEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MoveTo_DifferentParent_UpdatesPathDepthAndEmitsEvents()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+        var b = Folder.Create(Guid.NewGuid(), root, "B", OwnerId);
+        var leaf = Folder.Create(Guid.NewGuid(), a, "Leaf", OwnerId);
+
+        leaf.MoveTo(b);
+
+        leaf.ParentFolderId.ShouldBe(b.Id);
+        leaf.Path.ShouldBe("/B/Leaf");
+        leaf.Depth.ShouldBe(2);
+        leaf.DomainEvents.OfType<FolderMovedEvent>().ShouldHaveSingleItem();
+        leaf.DomainEvents.OfType<FolderPathChangedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void MoveTo_TenantRoot_Throws()
+    {
+        Folder root = NewRoot();
+        var somewhere = Folder.Create(Guid.NewGuid(), root, "X", OwnerId);
+
+        Should.Throw<InvalidOperationException>(() => root.MoveTo(somewhere));
+    }
+
+    [Fact]
+    public void MoveTo_Self_Throws()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+
+        Should.Throw<InvalidOperationException>(() => a.MoveTo(a));
+    }
+
+    [Fact]
+    public void MoveTo_DescendantOfSelf_Throws()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+        var b = Folder.Create(Guid.NewGuid(), a, "B", OwnerId);
+
+        Should.Throw<InvalidOperationException>(() => a.MoveTo(b));
+    }
+
+    [Fact]
+    public void MoveTo_DifferentTenant_Throws()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+
+        var otherRoot = Folder.CreateTenantRoot(Guid.NewGuid(), Guid.NewGuid(), OwnerId);
+        var otherFolder = Folder.Create(Guid.NewGuid(), otherRoot, "Other", OwnerId);
+
+        Should.Throw<InvalidOperationException>(() => a.MoveTo(otherFolder));
+    }
+
+    [Fact]
+    public void MoveTo_TrashedTarget_Throws()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+        var b = Folder.Create(Guid.NewGuid(), root, "B", OwnerId);
+        b.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => a.MoveTo(b));
+    }
+
+    [Fact]
+    public void MoveTo_SameParent_IsNoOp()
+    {
+        Folder root = NewRoot();
+        var a = Folder.Create(Guid.NewGuid(), root, "A", OwnerId);
+        var leaf = Folder.Create(Guid.NewGuid(), a, "Leaf", OwnerId);
+
+        leaf.MoveTo(a);
+
+        leaf.DomainEvents.OfType<FolderMovedEvent>().ShouldBeEmpty();
+        leaf.DomainEvents.OfType<FolderPathChangedEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Trash_SetsStatusAndTrashedAt_AndEmitsEvent()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "F", OwnerId);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        folder.Trash(now);
+
+        folder.Status.ShouldBe(FolderStatus.Trashed);
+        folder.TrashedAt.ShouldBe(now);
+        folder.DomainEvents.OfType<FolderTrashedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Trash_TenantRoot_Throws()
+    {
+        Folder root = NewRoot();
+
+        Should.Throw<InvalidOperationException>(() => root.Trash(DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Trash_AlreadyTrashed_Throws()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "F", OwnerId);
+        folder.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => folder.Trash(DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Restore_FromTrash_BecomesActive()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "F", OwnerId);
+        folder.Trash(DateTimeOffset.UtcNow);
+
+        folder.Restore();
+
+        folder.Status.ShouldBe(FolderStatus.Active);
+        folder.TrashedAt.ShouldBeNull();
+        folder.DomainEvents.OfType<FolderRestoredEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Restore_TenantRoot_Throws()
+    {
+        Folder root = NewRoot();
+
+        Should.Throw<InvalidOperationException>(() => root.Restore());
+    }
+
+    [Fact]
+    public void Restore_ActiveFolder_Throws()
+    {
+        Folder root = NewRoot();
+        var folder = Folder.Create(Guid.NewGuid(), root, "F", OwnerId);
+
+        Should.Throw<InvalidOperationException>(() => folder.Restore());
+    }
+}


### PR DESCRIPTION
## Summary

First domain aggregate of the `Granit.Documents` module per [ADR-052](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md) phase 1, F2 — Folder hierarchy + tenant root bootstrap.

- `Folder : AggregateRoot, IMultiTenant` with all properties from the ADR (private setters, materialised `Path`, `Depth`, `IsTenantRoot`, `Status`, `TrashedAt`).
- Public factory `Folder.Create(id, parent, name, ownerId)` for non-root folders; **internal** factory `Folder.CreateTenantRoot(id, tenantId, ownerId)` reserved for `IDocumentBootstrapService` (F2.2).
- Behaviour methods: `Rename`, `MoveTo` (with cycle / descendant / cross-tenant / trashed-target guards via path-prefix check), `Trash`, `Restore`. All reject mutation when `IsTenantRoot`. Rename + Move emit `FolderPathChangedEvent` alongside their main event so F6.3's ACL cache invalidator has a single hook.
- Six `IDomainEvent` records (`FolderCreatedEvent`, `FolderRenamedEvent`, `FolderMovedEvent`, `FolderPathChangedEvent`, `FolderTrashedEvent`, `FolderRestoredEvent`).
- `FolderConfiguration` adds the `documents_folders` table with three indexes:
  - `ux_documents_folders_one_root_per_tenant` — **partial unique** on `TenantId` `WHERE is_tenant_root = TRUE` (one root per tenant invariant).
  - `ux_documents_folders_sibling_name` — unique on `(TenantId, ParentFolderId, Name)` (no two siblings share a name).
  - `ix_documents_folders_tenant_path` — non-unique on `(TenantId, Path)` for ACL prefix scans (F6.2 may promote to `text_pattern_ops` on Postgres).
- CHECK constraint `ck_documents_folders_parent_only_root_null` enforces `parent_folder_id IS NOT NULL OR is_tenant_root = TRUE` at the DB level regardless of application code.
- `DocumentsDbContext` gains `DbSet<Folder> Folders`; `ConfigureDocumentsModule` applies the new configuration.
- **25 unit tests** on the Folder aggregate cover all factory paths, rename, move (incl. cycle / cross-tenant / descendant rejection), trash, restore, and root invariants.

## Tracking

- Story: #1727 (F2.1)
- Feature: #1726 (F2 — Folder hierarchy + tenant root bootstrap)
- Epic: #1721

## Test plan

- [x] `dotnet build src/Granit.Documents.EntityFrameworkCore` clean.
- [x] `dotnet test tests/Granit.Documents.Tests` — **40/40 passing** (15 prior + 25 new).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — **2/2 passing**.
- [x] `dotnet test tests/Granit.ArchitectureTests` — **209/209 passing**.
- [x] `dotnet format` clean (used `dotnet format style` to fix IDE0007 in tests).
- [ ] CI shards green.