### PR TITLE
feat(entities): optional GroupByField on GalleryLayoutDescriptor

### DIFF
--- a/src/Granit.Entities.Abstractions/Layouts/GalleryLayoutBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/GalleryLayoutBuilder.cs
@@ -18,6 +18,7 @@ public sealed class GalleryLayoutBuilder<TEntity>
     private string? _imagePropertyName;
     private string? _titlePropertyName;
     private string? _subtitlePropertyName;
+    private string? _groupByPropertyName;
     private GalleryCardSize _cardSize = GalleryCardSize.Medium;
     private bool _isDefault;
     private string? _requiresPermission;
@@ -60,6 +61,26 @@ public sealed class GalleryLayoutBuilder<TEntity>
     public GalleryLayoutBuilder<TEntity> SubtitleField<TProperty>(Expression<Func<TEntity, TProperty>> propertySelector)
     {
         _subtitlePropertyName = ReadPropertyName(propertySelector, "SubtitleField");
+        return this;
+    }
+
+    /// <summary>
+    /// Names the optional property the gallery groups cards by. When set,
+    /// the renderer paints one titled section per distinct value (cards
+    /// laid out in a grid inside each section) instead of a single flat
+    /// grid. Generic on <typeparamref name="TProperty"/> so any
+    /// discriminator type — enum, string, primitive, lookup id — works
+    /// without forcing a string projection on the entity. Optional: when
+    /// omitted, the renderer paints a flat grid.
+    /// </summary>
+    /// <remarks>
+    /// Unlike kanban's <c>GroupBy</c>, the gallery does not surface
+    /// per-bucket configuration (color, default state) — section headers
+    /// only carry a label, so a closed enum is not required.
+    /// </remarks>
+    public GalleryLayoutBuilder<TEntity> GroupByField<TProperty>(Expression<Func<TEntity, TProperty>> propertySelector)
+    {
+        _groupByPropertyName = ReadPropertyName(propertySelector, "GroupByField");
         return this;
     }
 
@@ -109,6 +130,7 @@ public sealed class GalleryLayoutBuilder<TEntity>
             ImagePropertyName = _imagePropertyName,
             TitlePropertyName = _titlePropertyName,
             SubtitlePropertyName = _subtitlePropertyName,
+            GroupByPropertyName = _groupByPropertyName,
             CardSize = _cardSize,
         };
     }

--- a/src/Granit.Entities.Abstractions/Layouts/GalleryLayoutDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Layouts/GalleryLayoutDescriptor.cs
@@ -26,6 +26,17 @@ public sealed record GalleryLayoutDescriptor : EntityListLayoutDescriptor
     /// <summary>Optional secondary line under the title (e.g. category, tag, status).</summary>
     public string? SubtitlePropertyName { get; init; }
 
+    /// <summary>
+    /// Optional grouping property — when set, the renderer paints one
+    /// titled section per distinct value (cards laid out in a grid inside
+    /// each section), instead of a single flat grid. Mirrors Kanban's
+    /// per-value column layout, except the per-bucket configuration
+    /// (color, default state) is not exposed: gallery sections only carry
+    /// a header label so the discriminator type doesn't need to be a
+    /// closed enum.
+    /// </summary>
+    public string? GroupByPropertyName { get; init; }
+
     /// <summary>Card size — controls grid track sizing in the renderer.</summary>
     public GalleryCardSize CardSize { get; init; } = GalleryCardSize.Medium;
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -76,11 +76,13 @@ public sealed record EntityCalendarLayoutManifest(
 /// <param name="ImagePropertyName">Entity property carrying the card image — typed <c>BlobReference</c> (or nullable). Required.</param>
 /// <param name="TitlePropertyName">Entity property used as the card headline, or <see langword="null"/> for the entity's <c>DisplayProperty</c> fallback.</param>
 /// <param name="SubtitlePropertyName">Optional secondary line under the title, or <see langword="null"/> for none.</param>
+/// <param name="GroupByPropertyName">Optional grouping property — when set, the renderer paints one titled section per distinct value instead of a flat grid. <see langword="null"/> for ungrouped flat layout.</param>
 /// <param name="CardSize">Card size — drives CSS-grid track sizing in the renderer.</param>
 public sealed record EntityGalleryLayoutManifest(
     string ImagePropertyName,
     string? TitlePropertyName,
     string? SubtitlePropertyName,
+    string? GroupByPropertyName,
     GalleryCardSize CardSize);
 
 /// <summary>Kanban-specific layout configuration carried in the manifest.</summary>

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -387,6 +387,7 @@ internal static class EntityManifestComposer
         new(descriptor.ImagePropertyName,
             descriptor.TitlePropertyName,
             descriptor.SubtitlePropertyName,
+            descriptor.GroupByPropertyName,
             descriptor.CardSize);
 
     private static EntityKanbanLayoutManifest? ComposeKanban(

--- a/tests/Granit.ArchitectureTests/GalleryFieldWhitelistPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/GalleryFieldWhitelistPairingTests.cs
@@ -56,6 +56,7 @@ public sealed class GalleryFieldWhitelistPairingTests
             CheckProperty(gallery.ImagePropertyName, "ImageField", required: true);
             CheckProperty(gallery.TitlePropertyName, "TitleField");
             CheckProperty(gallery.SubtitlePropertyName, "SubtitleField");
+            CheckProperty(gallery.GroupByPropertyName, "GroupByField");
 
             void CheckProperty(string? propertyName, string dslName, bool required = false)
             {

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -508,7 +508,35 @@ public sealed class EntityManifestComposerTests
         emitted.ImagePropertyName.ShouldBe("Cover");
         emitted.TitlePropertyName.ShouldBeNull();
         emitted.SubtitlePropertyName.ShouldBeNull();
+        emitted.GroupByPropertyName.ShouldBeNull();
         emitted.CardSize.ShouldBe(Granit.Entities.Layouts.GalleryCardSize.Medium);
+    }
+
+    [Fact]
+    public void Compose_emits_gallery_layout_with_GroupByPropertyName()
+    {
+        // Optional GroupByField — when set, the renderer paints titled
+        // sections instead of a flat grid. The manifest must surface the
+        // property name verbatim so the front-end can route the bucket
+        // header label and request the matching server-side groupBy
+        // parameter on the query endpoint.
+        Granit.Entities.Layouts.GalleryLayoutDescriptor gallery = new()
+        {
+            Kind = Granit.Entities.Layouts.EntityListLayoutKind.Gallery,
+            ImagePropertyName = "Cover",
+            GroupByPropertyName = "Status",
+        };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            BuildDescriptor(listLayouts: [gallery]),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntityGalleryLayoutManifest emitted = manifest.Collections!.ListLayouts
+            .ShouldHaveSingleItem().Gallery.ShouldNotBeNull();
+        emitted.GroupByPropertyName.ShouldBe("Status");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

**Track 2** of the *Gallery feature parity* chunk surfaced by the
showcase QA pass. Lets a gallery split into **titled sections**
(one per distinct value of a chosen property) instead of a single
flat grid, mirroring kanban's per-value column layout but without
per-bucket configuration. **Optional** — when omitted, the renderer
paints a flat grid as before.

## What ships

- **`GalleryLayoutDescriptor.GroupByPropertyName : string?`** — new
  optional slot.
- **`GalleryLayoutBuilder<TEntity>`**: new
  `GroupByField<TProperty>(Expression<Func<TEntity, TProperty>>)`
  method. Generic on `TProperty` so any discriminator type — enum,
  string, primitive, lookup id — works without forcing a string
  projection on the entity. Property name stored verbatim; the
  discriminator type isn't carried (gallery sections only need a
  header label, unlike kanban which surfaces per-bucket
  color / state).
- **`EntityGalleryLayoutManifest.GroupByPropertyName`** — routed via
  `EntityManifestComposer.ComposeGallery`.
- **`GalleryFieldWhitelistPairingTests`** extended: when
  `GroupByPropertyName` is set, it MUST appear in the matching
  `QueryDefinition.GetColumns()` whitelist — same shape as the
  existing `ImageField` / `TitleField` / `SubtitleField` checks. So a
  `.GroupByField(p => p.Status)` declared without a matching
  `.Column(p => p.Status)` fails at archi-test time.

## Tests

- 1 new `EntityManifestComposerTests` fact (group-by surfaces in the
  manifest payload).
- The minimal-gallery fact extended to assert
  `GroupByPropertyName` is `null` by default.

## Test plan

- [x] `dotnet build src/Granit.Entities.Abstractions` clean
- [x] `dotnet build src/Granit.Entities.Endpoints` clean
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 3 / 3 Gallery + existing
- [x] `dotnet test .github/shard-filters/business.slnf` — 0 failed assemblies
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 209 / 209
- [x] `dotnet format .github/shard-filters/business.slnf --verify-no-changes` clean

## Track 1 (granit-front, separate handoff)

Renderer fix: `<EntityGallery />`, `<EntityKanban />`,
`<EntityCalendar />` subscribe to the ambient `useQueryEndpoint`
state so `filter` / `sort` / `search` / `page` params reach the
server. Independent of this PR — Track 1 unblocks the existing flat
gallery / kanban / calendar; Track 2 (this PR) ships the future
grouped gallery. Both can land in any order.