### PR TITLE
feat(documents): folder move with descendant path re-materialisation (F2.4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18419,6 +18419,15 @@
       "members": []
     },
     {
+      "name": "MoveFolderRequest",
+      "fqn": "Granit.Documents.Endpoints.Folders.Dtos.MoveFolderRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Folders/Dtos/MoveFolderRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "RenameFolderRequest",
       "fqn": "Granit.Documents.Endpoints.Folders.Dtos.RenameFolderRequest",
       "kind": "record",
@@ -18588,6 +18597,15 @@
       "members": []
     },
     {
+      "name": "FolderTreePathChangedEvent",
+      "fqn": "Granit.Documents.Events.FolderTreePathChangedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/FolderTreePathChangedEvent.cs",
+      "line": 24,
+      "members": []
+    },
+    {
       "name": "DocumentsServiceCollectionExtensions",
       "fqn": "Granit.Documents.Extensions.DocumentsServiceCollectionExtensions",
       "kind": "class",
@@ -18664,6 +18682,12 @@
           "name": "RenameAsync",
           "kind": "method",
           "signature": "RenameAsync(Guid id, string newName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Folder?>"
+        },
+        {
+          "name": "MoveAsync",
+          "kind": "method",
+          "signature": "MoveAsync(Guid id, Guid? newParentFolderId, CancellationToken cancellationToken = default)",
           "returnType": "Task<Folder?>"
         },
         {

--- a/src/Granit.Documents.Endpoints/Folders/Dtos/MoveFolderRequest.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Dtos/MoveFolderRequest.cs
@@ -1,0 +1,10 @@
+namespace Granit.Documents.Endpoints.Folders.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /folders/{id}/move</c>.
+/// </summary>
+/// <param name="NewParentFolderId">
+/// New parent folder identifier. When <c>null</c>, the folder is moved directly under
+/// the invisible tenant root.
+/// </param>
+public sealed record MoveFolderRequest(Guid? NewParentFolderId);

--- a/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
@@ -83,6 +83,21 @@ internal static class FolderEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem();
 
+        folders.MapPost("/{id:guid}/move", MoveAsync)
+            .WithName("MoveFolder")
+            .WithSummary("Moves a folder under a new parent.")
+            .WithDescription(
+                "Moves the folder identified by `id` under `newParentFolderId` (or under the "
+                + "invisible tenant root when omitted). The materialised path and depth of the "
+                + "moved folder AND every descendant are re-materialised in a single SQL "
+                + "UPDATE within the same transaction. Cycles, cross-tenant moves, and moves "
+                + "under a trashed or descendant target are rejected. The tenant root cannot "
+                + "be moved.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .Produces<FolderResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
         folders.MapDelete("/{id:guid}", TrashAsync)
             .WithName("TrashFolder")
             .WithSummary("Sends a folder to the trash (soft-delete).")
@@ -179,6 +194,32 @@ internal static class FolderEndpoints
                 statusCode: StatusCodes.Status404NotFound);
         }
         return TypedResults.Ok(folder.ToResponse());
+    }
+
+    private static async Task<Results<Ok<FolderResponse>, ProblemHttpResult>> MoveAsync(
+        Guid id,
+        MoveFolderRequest request,
+        [FromServices] IFolderService folders,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Folder? folder = await folders
+                .MoveAsync(id, request.NewParentFolderId, cancellationToken)
+                .ConfigureAwait(false);
+            if (folder is null)
+            {
+                return TypedResults.Problem(
+                    $"Folder '{id}' was not found.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(folder.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Cycle, cross-tenant, descendant target, trashed target, or root invariant.
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
     }
 
     private static async Task<Results<Ok<FolderResponse>, ProblemHttpResult>> TrashAsync(

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/FolderService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/FolderService.cs
@@ -1,4 +1,6 @@
 using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Granit.Events;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timing;
@@ -14,7 +16,8 @@ internal sealed class FolderService(
     IDocumentBootstrapService bootstrap,
     ICurrentTenant currentTenant,
     IGuidGenerator guidGenerator,
-    IClock clock) : IFolderService
+    IClock clock,
+    ILocalEventBus localEventBus) : IFolderService
 {
     /// <inheritdoc />
     public async Task<Folder> CreateAsync(
@@ -149,6 +152,96 @@ internal sealed class FolderService(
 
         folder.Rename(newName);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return folder;
+    }
+
+    /// <inheritdoc />
+    public async Task<Folder?> MoveAsync(
+        Guid id,
+        Guid? newParentFolderId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? folder = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (folder is null)
+        {
+            return null;
+        }
+
+        // Resolve the effective new parent: tenant root when null is passed in.
+        Guid effectiveParentId = newParentFolderId ?? await bootstrap
+            .EnsureTenantRootAsync(folder.TenantId, folder.OwnerUserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? newParent = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == effectiveParentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (newParent is null)
+        {
+            throw new InvalidOperationException(
+                $"Target parent folder {effectiveParentId} was not found under the current tenant scope.");
+        }
+
+        string oldPath = folder.Path;
+        int oldDepth = folder.Depth;
+
+        // Aggregate-level validation + own-path update + per-aggregate events.
+        folder.MoveTo(newParent);
+
+        string newPath = folder.Path;
+        int newDepth = folder.Depth;
+        int affectedDescendants = 0;
+
+        // Re-materialise descendants in a single SQL UPDATE. Path is rewritten by replacing
+        // the old prefix with the new one; Depth is shifted by the difference between the
+        // moved folder's old and new depth — same delta applies to every descendant.
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            string descendantPrefix = oldPath + Folder.PathSeparator;
+            int depthDelta = newDepth - oldDepth;
+            int oldPrefixLength = oldPath.Length;
+
+            // CA1845 (Substring vs AsSpan) does not apply to EF Core expression trees:
+            // ExecuteUpdateAsync translates Substring() to SQL SUBSTRING; AsSpan has no SQL
+            // equivalent.
+#pragma warning disable CA1845
+            affectedDescendants = await context.Folders
+                .Where(f => f.TenantId == folder.TenantId
+                    && f.Id != folder.Id
+                    && f.Path.StartsWith(descendantPrefix))
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(f => f.Path, f => newPath + f.Path.Substring(oldPrefixLength))
+                    .SetProperty(f => f.Depth, f => f.Depth + depthDelta),
+                    cancellationToken)
+                .ConfigureAwait(false);
+#pragma warning restore CA1845
+        }
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            // Emit a single tree-level event so downstream consumers (F6.3 ACL cache,
+            // F19 search index) can issue prefix-based invalidation rather than N events.
+            // Service-emitted (local bus) — per the events convention, aggregate-internal
+            // events (FolderMovedEvent, FolderPathChangedEvent on the moved folder itself)
+            // are emitted by Folder.MoveTo while this aggregating event is owned by the
+            // service that performed the bulk operation.
+            await localEventBus.PublishAsync(
+                new FolderTreePathChangedEvent(
+                    folder.TenantId,
+                    folder.Id,
+                    oldPath,
+                    newPath,
+                    affectedDescendants),
+                cancellationToken).ConfigureAwait(false);
+        }
+
         return folder;
     }
 

--- a/src/Granit.Documents/Events/FolderTreePathChangedEvent.cs
+++ b/src/Granit.Documents/Events/FolderTreePathChangedEvent.cs
@@ -1,0 +1,29 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised once after a folder is moved (or, in future stories, after a high-level rename
+/// affecting many descendants) to notify consumers that every folder whose materialised
+/// path started with <see cref="OldPathPrefix"/> now starts with <see cref="NewPathPrefix"/>.
+/// </summary>
+/// <param name="TenantId">Tenant scope of the affected sub-tree.</param>
+/// <param name="MovedFolderId">The folder that was directly moved (the root of the affected sub-tree).</param>
+/// <param name="OldPathPrefix">Materialised path of the moved folder before the move (e.g. <c>/A/B</c>).</param>
+/// <param name="NewPathPrefix">Materialised path of the moved folder after the move (e.g. <c>/X/B</c>).</param>
+/// <param name="AffectedDescendantCount">Number of descendant folders whose path was rewritten in the bulk SQL update.</param>
+/// <remarks>
+/// <para>
+/// Per-folder <see cref="FolderPathChangedEvent"/> events are still emitted for the moved
+/// folder itself (by <see cref="Domain.Folder.MoveTo"/>); descendants are repointed by a
+/// single SQL <c>UPDATE</c> in the same transaction and announced collectively via this
+/// event so consumers (F6.3 ACL cache invalidator, F19 search index) can issue a
+/// prefix-based invalidation rather than N per-folder ones.
+/// </para>
+/// </remarks>
+public sealed record FolderTreePathChangedEvent(
+    Guid? TenantId,
+    Guid MovedFolderId,
+    string OldPathPrefix,
+    string NewPathPrefix,
+    int AffectedDescendantCount) : IDomainEvent;

--- a/src/Granit.Documents/IFolderService.cs
+++ b/src/Granit.Documents/IFolderService.cs
@@ -56,6 +56,31 @@ public interface IFolderService
     Task<Folder?> RenameAsync(Guid id, string newName, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Moves the folder identified by <paramref name="id"/> under the parent identified
+    /// by <paramref name="newParentFolderId"/> (or the tenant root when <c>null</c>) and
+    /// re-materialises the <c>Path</c> / <c>Depth</c> of every descendant folder in a
+    /// single SQL <c>UPDATE</c> within the same transaction.
+    /// </summary>
+    /// <returns>The updated moved folder, or <c>null</c> when the folder is not found.</returns>
+    /// <remarks>
+    /// <para>
+    /// Validation is performed by the <see cref="Folder.MoveTo"/> aggregate method
+    /// (cycle / descendant / cross-tenant / trashed-target rejection); invalid moves
+    /// surface as <see cref="InvalidOperationException"/> from the call site.
+    /// </para>
+    /// <para>
+    /// On success the moved folder emits a per-aggregate <see cref="Events.FolderMovedEvent"/>
+    /// + <see cref="Events.FolderPathChangedEvent"/>, and the service emits a single
+    /// <see cref="Events.FolderTreePathChangedEvent"/> aggregating the prefix change
+    /// for downstream consumers (cache invalidation, search index).
+    /// </para>
+    /// </remarks>
+    Task<Folder?> MoveAsync(
+        Guid id,
+        Guid? newParentFolderId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Trashes the folder with the given identifier. Returns the trashed folder, or
     /// <c>null</c> when the folder is not found or excluded by the tenant filter.
     /// </summary>

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/FolderServiceMovePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/FolderServiceMovePostgresTests.cs
@@ -1,0 +1,126 @@
+using Granit.Documents;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed verification of the bulk descendant path re-materialisation
+/// performed by <see cref="FolderService.MoveAsync"/>. Confirms that the
+/// <c>ExecuteUpdate</c> call translates to a single SQL <c>UPDATE</c> that updates
+/// every descendant correctly under realistic Postgres semantics (case-sensitive
+/// LIKE, materialised path index).
+/// </summary>
+public sealed class FolderServiceMovePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private FolderService _sut = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public FolderServiceMovePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_folders RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        ILocalEventBus localEventBus = Substitute.For<ILocalEventBus>();
+
+        _sut = new FolderService(_factory, bootstrap, currentTenant,
+            new SimpleGuidGenerator(), clock, localEventBus);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task MoveAsync_DeepSubtree_ReMaterialisesPathsViaSingleSqlUpdate()
+    {
+        // Build a 4-level subtree: A → B → C → D and a sibling A → B → E.
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, TestContext.Current.CancellationToken);
+        Folder c = await _sut.CreateAsync(b.Id, "C", OwnerId, TestContext.Current.CancellationToken);
+        Folder d = await _sut.CreateAsync(c.Id, "D", OwnerId, TestContext.Current.CancellationToken);
+        Folder e = await _sut.CreateAsync(b.Id, "E", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder x = await _sut.CreateAsync(null, "X", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder? movedB = await _sut.MoveAsync(b.Id, x.Id, TestContext.Current.CancellationToken);
+
+        movedB.ShouldNotBeNull();
+        movedB.Path.ShouldBe("/X/B");
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder cReloaded = await db.Folders.SingleAsync(f => f.Id == c.Id, TestContext.Current.CancellationToken);
+        Folder dReloaded = await db.Folders.SingleAsync(f => f.Id == d.Id, TestContext.Current.CancellationToken);
+        Folder eReloaded = await db.Folders.SingleAsync(f => f.Id == e.Id, TestContext.Current.CancellationToken);
+
+        cReloaded.Path.ShouldBe("/X/B/C");
+        cReloaded.Depth.ShouldBe(3);
+        dReloaded.Path.ShouldBe("/X/B/C/D");
+        dReloaded.Depth.ShouldBe(4);
+        eReloaded.Path.ShouldBe("/X/B/E");
+        eReloaded.Depth.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task MoveAsync_PrefixCollision_DoesNotAffectSiblingsWithSimilarNames()
+    {
+        // Postgres LIKE 'A/%' must not match a sibling "AB" — the trailing slash boundary
+        // is the safety check baked into MoveAsync's prefix.
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder ab = await _sut.CreateAsync(null, "AB", OwnerId, TestContext.Current.CancellationToken);
+        Folder aChild = await _sut.CreateAsync(a.Id, "Inner", OwnerId, TestContext.Current.CancellationToken);
+        Folder abChild = await _sut.CreateAsync(ab.Id, "Inner", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder x = await _sut.CreateAsync(null, "X", OwnerId, TestContext.Current.CancellationToken);
+
+        await _sut.MoveAsync(a.Id, x.Id, TestContext.Current.CancellationToken);
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder aChildReloaded = await db.Folders.SingleAsync(f => f.Id == aChild.Id, TestContext.Current.CancellationToken);
+        Folder abChildReloaded = await db.Folders.SingleAsync(f => f.Id == abChild.Id, TestContext.Current.CancellationToken);
+
+        aChildReloaded.Path.ShouldBe("/X/A/Inner");
+        abChildReloaded.Path.ShouldBe("/AB/Inner"); // unchanged
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/Granit.Documents.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/Granit.Documents.EntityFrameworkCore.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -41,6 +41,15 @@
           "Npgsql": "10.0.2"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.*, )",
@@ -79,6 +88,14 @@
         "type": "Transitive",
         "resolved": "2.6.2",
         "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -277,6 +294,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/FolderServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/FolderServiceSqliteTests.cs
@@ -1,6 +1,8 @@
 using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Events;
+using Granit.Events;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Timing;
@@ -23,6 +25,7 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
     private TestDbContextFactory _factory = null!;
     private DocumentBootstrapService _bootstrap = null!;
     private FolderService _sut = null!;
+    private CapturingLocalEventBus _localEventBus = null!;
 
     private static readonly Guid TenantId = Guid.NewGuid();
     private static readonly Guid OwnerId = Guid.NewGuid();
@@ -50,7 +53,10 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(DateTimeOffset.UtcNow);
 
-        _sut = new FolderService(_factory, _bootstrap, currentTenant, new SequentialGuidGenerator(), clock);
+        _localEventBus = new CapturingLocalEventBus();
+
+        _sut = new FolderService(
+            _factory, _bootstrap, currentTenant, new SequentialGuidGenerator(), clock, _localEventBus);
     }
 
     public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
@@ -158,6 +164,119 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
         trashed.TrashedAt.ShouldNotBeNull();
     }
 
+    // -------------------------------------------------------------------------
+    // F2.4 — MoveAsync + descendant path re-materialisation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task MoveAsync_ToDifferentParent_UpdatesMovedFolderPathAndDepth()
+    {
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder b = await _sut.CreateAsync(null, "B", OwnerId, TestContext.Current.CancellationToken);
+        Folder leaf = await _sut.CreateAsync(a.Id, "Leaf", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder? moved = await _sut.MoveAsync(leaf.Id, b.Id, TestContext.Current.CancellationToken);
+
+        moved.ShouldNotBeNull();
+        moved.ParentFolderId.ShouldBe(b.Id);
+        moved.Path.ShouldBe("/B/Leaf");
+        moved.Depth.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task MoveAsync_ThreeLevelSubtree_ReMaterialisesEveryDescendantPath()
+    {
+        // Build a 3-level subtree under "A": A/B/C/D and a parallel A/B/C/E plus
+        // an unrelated sibling "Other" that must not be touched.
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, TestContext.Current.CancellationToken);
+        Folder c = await _sut.CreateAsync(b.Id, "C", OwnerId, TestContext.Current.CancellationToken);
+        Folder d = await _sut.CreateAsync(c.Id, "D", OwnerId, TestContext.Current.CancellationToken);
+        Folder e = await _sut.CreateAsync(c.Id, "E", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder x = await _sut.CreateAsync(null, "X", OwnerId, TestContext.Current.CancellationToken);
+        Folder other = await _sut.CreateAsync(null, "Other", OwnerId, TestContext.Current.CancellationToken);
+
+        // Move B (and its subtree) under X — expected: /X/B, /X/B/C, /X/B/C/D, /X/B/C/E
+        Folder? movedB = await _sut.MoveAsync(b.Id, x.Id, TestContext.Current.CancellationToken);
+
+        movedB.ShouldNotBeNull();
+        movedB.Path.ShouldBe("/X/B");
+        movedB.Depth.ShouldBe(2);
+
+        // Reload descendants from a fresh context to verify the bulk SQL UPDATE landed.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder cReloaded = await db.Folders.SingleAsync(f => f.Id == c.Id, TestContext.Current.CancellationToken);
+        Folder dReloaded = await db.Folders.SingleAsync(f => f.Id == d.Id, TestContext.Current.CancellationToken);
+        Folder eReloaded = await db.Folders.SingleAsync(f => f.Id == e.Id, TestContext.Current.CancellationToken);
+        Folder otherReloaded = await db.Folders.SingleAsync(f => f.Id == other.Id, TestContext.Current.CancellationToken);
+
+        cReloaded.Path.ShouldBe("/X/B/C");
+        cReloaded.Depth.ShouldBe(3);
+        dReloaded.Path.ShouldBe("/X/B/C/D");
+        dReloaded.Depth.ShouldBe(4);
+        eReloaded.Path.ShouldBe("/X/B/C/E");
+        eReloaded.Depth.ShouldBe(4);
+
+        // Unrelated sibling untouched.
+        otherReloaded.Path.ShouldBe("/Other");
+        otherReloaded.Depth.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task MoveAsync_NullNewParent_PutsFolderUnderTenantRoot()
+    {
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder leaf = await _sut.CreateAsync(a.Id, "Leaf", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder? moved = await _sut.MoveAsync(leaf.Id, newParentFolderId: null, TestContext.Current.CancellationToken);
+
+        moved.ShouldNotBeNull();
+        moved.Path.ShouldBe("/Leaf");
+        moved.Depth.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task MoveAsync_DescendantTarget_Throws()
+    {
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await _sut.MoveAsync(a.Id, b.Id, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task MoveAsync_UnknownId_ReturnsNull()
+    {
+        Folder x = await _sut.CreateAsync(null, "X", OwnerId, TestContext.Current.CancellationToken);
+
+        Folder? result = await _sut.MoveAsync(Guid.NewGuid(), x.Id, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MoveAsync_PublishesTreePathChangedEvent_OnLocalBus()
+    {
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, TestContext.Current.CancellationToken);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, TestContext.Current.CancellationToken);
+        Folder x = await _sut.CreateAsync(null, "X", OwnerId, TestContext.Current.CancellationToken);
+
+        _localEventBus.Captured.Clear();
+
+        await _sut.MoveAsync(a.Id, x.Id, TestContext.Current.CancellationToken);
+
+        FolderTreePathChangedEvent treeEvent = _localEventBus.Captured
+            .OfType<FolderTreePathChangedEvent>()
+            .ShouldHaveSingleItem();
+
+        treeEvent.MovedFolderId.ShouldBe(a.Id);
+        treeEvent.OldPathPrefix.ShouldBe("/A");
+        treeEvent.NewPathPrefix.ShouldBe("/X/A");
+        treeEvent.AffectedDescendantCount.ShouldBe(1); // B
+    }
+
     [Fact]
     public async Task GetByIdAsync_TenantRoot_IsNotHidden_ButEndpointFiltersIt()
     {
@@ -184,5 +303,18 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
     private sealed class SequentialGuidGenerator : IGuidGenerator
     {
         public Guid Create() => Guid.NewGuid();
+    }
+
+    /// <summary>Captures every <c>PublishAsync</c> call so tests can assert event emission.</summary>
+    private sealed class CapturingLocalEventBus : ILocalEventBus
+    {
+        public List<object> Captured { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            Captured.Add(localEvent);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds `POST /folders/{id}/move` plus the `IFolderService.MoveAsync` orchestration backing it. Re-materialises the `Path` / `Depth` of every descendant folder in a single SQL `UPDATE` within the same transaction, then publishes one tree-level domain event for downstream consumers (F6.3 ACL cache invalidator, F19 search index). Closes Feature **F2 — Folder hierarchy + tenant root bootstrap**.

## Implementation

- **`FolderTreePathChangedEvent`** (NEW, `Granit.Documents.Events/`) — `IDomainEvent` carrying the old / new path prefixes, the moved folder id, and the affected descendant count. Sufficient for prefix-based cache invalidation; per-folder granularity stays available via the existing `FolderPathChangedEvent` emitted by `Folder.MoveTo` for the moved folder itself.
- **`FolderService.MoveAsync`** — calls `Folder.MoveTo` (aggregate validation: cycle, descendant target, cross-tenant, trashed target, root invariant — all reused from F2.1), then issues a single `ExecuteUpdateAsync`:
  ```csharp
  WHERE TenantId = @t AND Path StartsWith oldPath + "/"
  SET   Path = newPath + Path.Substring(oldPath.Length),
        Depth = Depth + (newDepth - oldDepth)
  ```
  CA1845 suppressed locally with a documented comment — `Substring` is the EF-translatable form; `AsSpan` has no SQL equivalent.
- `ILocalEventBus` dependency added to `FolderService` for the tree event; per-aggregate events stay on the `AggregateRoot` pipeline.
- **`POST /folders/{id}/move`** endpoint with `MoveFolderRequest` DTO. Aggregate-level invariant violations surface as **409 Conflict**; missing folder as **404 Not Found**.

## Tests

- **SQLite (`Granit.Documents.EntityFrameworkCore.Tests`)** — +6 tests covering moved folder's path/depth update, 3-level subtree's bulk re-materialisation, null parent → tenant root, descendant-target rejection, unknown id → null, and the `FolderTreePathChangedEvent` emission on the local event bus. **23/23 passing**.
- **Postgres (`Granit.Documents.EntityFrameworkCore.Tests.Integration`)** — +2 tests covering deep (4-level) subtree re-materialisation under real Postgres semantics and a **prefix-collision regression** (`"A"` must not match `"AB"` siblings — the trailing-slash boundary check in `MoveAsync`'s prefix). **5/5 passing**.
- ArchitectureTests **209/209**, format clean.

## Tracking

- Story: #1730 (F2.4 — Folder move with descendant path re-materialisation)
- Feature: #1726 (F2 — Folder hierarchy + tenant root bootstrap) — **closes the feature**
- Epic: #1721