### PR TITLE
feat(documents): Document aggregate root with optimistic concurrency (F3.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18611,6 +18611,37 @@
       ]
     },
     {
+      "name": "Document",
+      "fqn": "Granit.Documents.Domain.Document",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/Document.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Folder folder, Guid ownerUserId, string name, string? description = null)",
+          "returnType": "Document"
+        },
+        {
+          "name": "Rename",
+          "kind": "method",
+          "signature": "Rename(string newName)",
+          "returnType": "string? Description { get; private set; } public Guid? CurrentVersionId { get; private set; } public DocumentStatus Status { get; private set; } public DateTimeOffset? TrashedAt { get; private set; } public uint RowVersion { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "DocumentStatus",
+      "fqn": "Granit.Documents.Domain.DocumentStatus",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/DocumentStatus.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "Folder",
       "fqn": "Granit.Documents.Domain.Folder",
       "kind": "class",
@@ -18821,6 +18852,60 @@
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs",
       "line": 26,
+      "members": []
+    },
+    {
+      "name": "DocumentCreatedEvent",
+      "fqn": "Granit.Documents.Events.DocumentCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentCreatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DocumentCurrentVersionChangedEvent",
+      "fqn": "Granit.Documents.Events.DocumentCurrentVersionChangedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentCurrentVersionChangedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "DocumentMovedEvent",
+      "fqn": "Granit.Documents.Events.DocumentMovedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentMovedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DocumentRenamedEvent",
+      "fqn": "Granit.Documents.Events.DocumentRenamedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentRenamedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DocumentRestoredEvent",
+      "fqn": "Granit.Documents.Events.DocumentRestoredEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentRestoredEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DocumentTrashedEvent",
+      "fqn": "Granit.Documents.Events.DocumentTrashedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentTrashedEvent.cs",
+      "line": 8,
       "members": []
     },
     {

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class DocumentsModelBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfiguration(new FolderConfiguration());
+        modelBuilder.ApplyConfiguration(new DocumentConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentConfiguration.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentConfiguration.cs
@@ -1,0 +1,68 @@
+using Granit.Documents.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="Document"/>.
+/// Table: <c>documents_documents</c>.
+/// </summary>
+internal sealed class DocumentConfiguration : IEntityTypeConfiguration<Document>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Document> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitDocumentsDbProperties.DbTablePrefix + "documents",
+            GranitDocumentsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+
+        builder.Property(e => e.FolderId)
+            .IsRequired();
+
+        builder.Property(e => e.OwnerUserId)
+            .IsRequired();
+
+        builder.Property(e => e.Name)
+            .HasMaxLength(Document.MaxNameLength)
+            .IsRequired();
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(Document.MaxDescriptionLength);
+
+        builder.Property(e => e.CurrentVersionId);
+
+        // Store enum as string for readability and resilience to reordering.
+        builder.Property(e => e.Status)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.TrashedAt);
+
+        // Optimistic-concurrency token. uint maps to provider-native types
+        // (PostgreSQL bigint via npgsql, SQL Server int, SQLite INTEGER); IsConcurrencyToken
+        // makes EF compare it on UPDATE so concurrent writers surface as
+        // DbUpdateConcurrencyException.
+        builder.Property(e => e.RowVersion)
+            .IsRequired()
+            .IsConcurrencyToken();
+
+        // FK back to documents_folders (no navigation property — the aggregate boundary
+        // forbids cross-aggregate navigation, but the FK must exist for the planned
+        // F8 cascade-trash + F2.4 path-prefix queries to remain efficient).
+        builder.HasIndex(e => new { e.TenantId, e.FolderId })
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}documents_tenant_folder");
+
+        // Active-status index used by the trash listing (F8.2) and the empty-trash job
+        // (F9.2) to scan only the relevant rows.
+        builder.HasIndex(e => new { e.TenantId, e.Status })
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}documents_tenant_status");
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
@@ -29,6 +29,9 @@ internal sealed class DocumentsDbContext(
     /// <summary>Tenant-scoped folder hierarchy (one tenant-root row per tenant).</summary>
     public DbSet<Folder> Folders { get; set; } = null!;
 
+    /// <summary>Tenant-scoped documents — every row points at a folder via <see cref="Document.FolderId"/>.</summary>
+    public DbSet<Document> Documents { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Documents/Domain/Document.cs
+++ b/src/Granit.Documents/Domain/Document.cs
@@ -1,0 +1,279 @@
+using Granit.Documents.Events;
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Aggregate root representing a user-managed document — folder placement, ownership,
+/// description, lifecycle status, and the pointer to the currently published version.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per ADR-052 phase 1, every document lives in a folder (<see cref="FolderId"/> is
+/// non-nullable; the tenant root is the implicit fallback). Document content is stored
+/// in <c>Granit.BlobStorage</c>; this aggregate does not hold the bytes.
+/// </para>
+/// <para>
+/// <see cref="CurrentVersionId"/> points at the active <c>DocumentVersion</c> introduced
+/// in F4.1; phase 1 of this story (F3.1) leaves it unset for documents created via the
+/// scaffolding factory and is populated by <see cref="SetCurrentVersion"/> when the
+/// upload flow (F3.2) finalises the first version.
+/// </para>
+/// <para>
+/// <see cref="RowVersion"/> is a manually-incremented optimistic-concurrency token
+/// (portable across SQL Server, PostgreSQL, and SQLite). Every behavior method that
+/// mutates state increments it; EF Core's <c>IsConcurrencyToken</c> on the column
+/// detects concurrent overwrites and surfaces them as <c>DbUpdateConcurrencyException</c>.
+/// </para>
+/// </remarks>
+public sealed class Document : AggregateRoot, IMultiTenant
+{
+    /// <summary>Maximum length, in characters, of a document <see cref="Name"/>.</summary>
+    public const int MaxNameLength = 255;
+
+    /// <summary>Maximum length, in characters, of a document <see cref="Description"/>.</summary>
+    public const int MaxDescriptionLength = 2000;
+
+    /// <summary>Parameterless constructor required by the EF Core materialiser.</summary>
+    private Document() { }
+
+    /// <summary>
+    /// Creates a new document under <paramref name="folder"/>. The first
+    /// <c>DocumentVersion</c> is attached separately by the upload-finalize flow (F3.2)
+    /// via <see cref="SetCurrentVersion"/>.
+    /// </summary>
+    /// <param name="id">Unique identifier of the new document.</param>
+    /// <param name="folder">Folder the document is created under (must be active and same-tenant).</param>
+    /// <param name="ownerUserId">Identifier of the user who owns the document.</param>
+    /// <param name="name">User-facing name (validated).</param>
+    /// <param name="description">Optional free-text description.</param>
+    public static Document Create(
+        Guid id,
+        Folder folder,
+        Guid ownerUserId,
+        string name,
+        string? description = null)
+    {
+        ArgumentNullException.ThrowIfNull(folder);
+        ValidateName(name);
+        ValidateDescription(description);
+        if (folder.Status != FolderStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Cannot create a document under a non-active folder (folder {folder.Id} is {folder.Status}).");
+        }
+
+        Document document = new()
+        {
+            Id = id,
+            TenantId = folder.TenantId,
+            FolderId = folder.Id,
+            OwnerUserId = ownerUserId,
+            Name = name,
+            Description = description,
+            Status = DocumentStatus.Active,
+            RowVersion = 1u,
+        };
+        document.AddDomainEvent(new DocumentCreatedEvent(
+            document.Id, document.TenantId, document.FolderId, document.OwnerUserId, document.Name));
+        return document;
+    }
+
+    /// <summary>Identifier of the tenant that owns this document.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Explicit implementation preserves the <c>private set</c> DDD encapsulation on the
+    /// public property while satisfying the interface contract used by
+    /// <c>AuditedEntityInterceptor</c> for tenant-id injection.
+    /// </remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>The folder the document currently lives in. Never <c>null</c> — every document is in a folder.</summary>
+    public Guid FolderId { get; private set; }
+
+    /// <summary>Identifier of the user who owns the document.</summary>
+    public Guid OwnerUserId { get; private set; }
+
+    /// <summary>User-facing display name.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>Optional free-text description (rendered alongside the name in lists / detail views).</summary>
+    public string? Description { get; private set; }
+
+    /// <summary>
+    /// Identifier of the active <c>DocumentVersion</c>. <c>null</c> until the first version
+    /// has been finalised (F3.2 upload flow) or while a freshly-created document awaits
+    /// content.
+    /// </summary>
+    public Guid? CurrentVersionId { get; private set; }
+
+    /// <summary>Lifecycle status.</summary>
+    public DocumentStatus Status { get; private set; }
+
+    /// <summary>UTC instant the document was trashed; <c>null</c> while active.</summary>
+    public DateTimeOffset? TrashedAt { get; private set; }
+
+    /// <summary>
+    /// Optimistic-concurrency token. Manually incremented on each behavior method;
+    /// EF Core's <c>IsConcurrencyToken</c> mapping detects concurrent overwrites.
+    /// </summary>
+    public uint RowVersion { get; private set; }
+
+    /// <summary>
+    /// Renames the document.
+    /// </summary>
+    /// <exception cref="ArgumentException">When <paramref name="newName"/> is invalid.</exception>
+    /// <exception cref="InvalidOperationException">When the document is trashed or permanently deleted.</exception>
+    public void Rename(string newName)
+    {
+        ThrowIfNotActive(nameof(Rename));
+        ValidateName(newName);
+
+        if (string.Equals(Name, newName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        string oldName = Name;
+        Name = newName;
+        RowVersion++;
+        AddDomainEvent(new DocumentRenamedEvent(Id, oldName, newName));
+    }
+
+    /// <summary>Updates the optional description. Pass <c>null</c> to clear it.</summary>
+    public void UpdateDescription(string? newDescription)
+    {
+        ThrowIfNotActive(nameof(UpdateDescription));
+        ValidateDescription(newDescription);
+        if (string.Equals(Description ?? string.Empty, newDescription ?? string.Empty, StringComparison.Ordinal))
+        {
+            return;
+        }
+        Description = newDescription;
+        RowVersion++;
+    }
+
+    /// <summary>
+    /// Moves the document under <paramref name="newFolder"/>. The folder must be active
+    /// and same-tenant.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When the document is trashed, the target is trashed, or cross-tenant.</exception>
+    public void MoveTo(Folder newFolder)
+    {
+        ArgumentNullException.ThrowIfNull(newFolder);
+        ThrowIfNotActive(nameof(MoveTo));
+        if (newFolder.Status != FolderStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Cannot move a document under a non-active folder (folder {newFolder.Id} is {newFolder.Status}).");
+        }
+        if (newFolder.TenantId != TenantId)
+        {
+            throw new InvalidOperationException("Cannot move a document to a different tenant.");
+        }
+        if (newFolder.Id == FolderId)
+        {
+            return;
+        }
+
+        Guid oldFolderId = FolderId;
+        FolderId = newFolder.Id;
+        RowVersion++;
+        AddDomainEvent(new DocumentMovedEvent(Id, oldFolderId, newFolder.Id));
+    }
+
+    /// <summary>
+    /// Sets the document's current version. Called by F3.2's upload-finalise flow
+    /// when the first version lands, and by F4 when a new version is uploaded or
+    /// an older version is restored as current.
+    /// </summary>
+    /// <param name="newCurrentVersionId">Identifier of the <c>DocumentVersion</c> to mark as current.</param>
+    public void SetCurrentVersion(Guid newCurrentVersionId)
+    {
+        if (newCurrentVersionId == Guid.Empty)
+        {
+            throw new ArgumentException("Current version id cannot be empty.", nameof(newCurrentVersionId));
+        }
+        ThrowIfNotActive(nameof(SetCurrentVersion));
+
+        if (CurrentVersionId == newCurrentVersionId)
+        {
+            return;
+        }
+
+        Guid? oldVersionId = CurrentVersionId;
+        CurrentVersionId = newCurrentVersionId;
+        RowVersion++;
+        AddDomainEvent(new DocumentCurrentVersionChangedEvent(Id, oldVersionId, newCurrentVersionId));
+    }
+
+    /// <summary>
+    /// Sends the document to the trash (soft-delete via domain status). The empty-trash
+    /// background job (F8 / F9.2) promotes it to <see cref="DocumentStatus.PermanentlyDeleted"/>
+    /// after the configured retention period.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">When the document is already trashed or permanently deleted.</exception>
+    public void Trash(DateTimeOffset trashedAt)
+    {
+        if (Status != DocumentStatus.Active)
+        {
+            throw new InvalidOperationException($"Document {Id} is not active (status: {Status}).");
+        }
+
+        Status = DocumentStatus.Trashed;
+        TrashedAt = trashedAt;
+        RowVersion++;
+        AddDomainEvent(new DocumentTrashedEvent(Id, TenantId, trashedAt));
+    }
+
+    /// <summary>Restores a trashed document.</summary>
+    /// <exception cref="InvalidOperationException">When the document is not trashed.</exception>
+    public void Restore()
+    {
+        if (Status != DocumentStatus.Trashed)
+        {
+            throw new InvalidOperationException($"Document {Id} is not trashed (status: {Status}).");
+        }
+
+        Status = DocumentStatus.Active;
+        TrashedAt = null;
+        RowVersion++;
+        AddDomainEvent(new DocumentRestoredEvent(Id, TenantId));
+    }
+
+    private void ThrowIfNotActive(string operation)
+    {
+        if (Status != DocumentStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Operation '{operation}' is not allowed on a document with status {Status} ({Id}).");
+        }
+    }
+
+    private static void ValidateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (name.Length > MaxNameLength)
+        {
+            throw new ArgumentException(
+                $"Document name exceeds {MaxNameLength} characters.", nameof(name));
+        }
+    }
+
+    private static void ValidateDescription(string? description)
+    {
+        if (description is { Length: > MaxDescriptionLength })
+        {
+            throw new ArgumentException(
+                $"Document description exceeds {MaxDescriptionLength} characters.",
+                nameof(description));
+        }
+    }
+}

--- a/src/Granit.Documents/Domain/DocumentStatus.cs
+++ b/src/Granit.Documents/Domain/DocumentStatus.cs
@@ -1,0 +1,28 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Lifecycle status of a <see cref="Document"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Trashed"/> is a soft-delete via domain status — the row remains and is
+/// retained for the configured trash period before the empty-trash background job
+/// (F8 / F9.2) promotes it to <see cref="PermanentlyDeleted"/>.
+/// </para>
+/// <para>
+/// <see cref="PermanentlyDeleted"/> is a tombstone retained for the GDPR / ISO 27001
+/// audit trail (3 years per <c>BlobStorage</c>'s retention policy). The bytes have
+/// been removed from <c>Granit.BlobStorage</c>; only the audit row stays.
+/// </para>
+/// </remarks>
+public enum DocumentStatus
+{
+    /// <summary>The document is active and visible in browse / search.</summary>
+    Active,
+
+    /// <summary>The document has been moved to the trash; awaiting restore or permanent deletion.</summary>
+    Trashed,
+
+    /// <summary>Permanent-deletion tombstone — the underlying blobs are gone, the row remains for audit.</summary>
+    PermanentlyDeleted,
+}

--- a/src/Granit.Documents/Events/DocumentCreatedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentCreatedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Document</c> aggregate is created.
+/// </summary>
+public sealed record DocumentCreatedEvent(
+    Guid DocumentId,
+    Guid? TenantId,
+    Guid FolderId,
+    Guid OwnerUserId,
+    string Name) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentCurrentVersionChangedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentCurrentVersionChangedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Document</c>'s <c>CurrentVersionId</c> changes — either because a
+/// new <c>DocumentVersion</c> has been finalised (F4.1) or because an older version
+/// has been restored as current (F4.3).
+/// </summary>
+public sealed record DocumentCurrentVersionChangedEvent(
+    Guid DocumentId,
+    Guid? OldCurrentVersionId,
+    Guid NewCurrentVersionId) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentMovedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentMovedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Document</c> is moved to a different folder.
+/// </summary>
+public sealed record DocumentMovedEvent(
+    Guid DocumentId,
+    Guid OldFolderId,
+    Guid NewFolderId) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentRenamedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentRenamedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Document</c> is renamed.
+/// </summary>
+public sealed record DocumentRenamedEvent(
+    Guid DocumentId,
+    string OldName,
+    string NewName) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentRestoredEvent.cs
+++ b/src/Granit.Documents/Events/DocumentRestoredEvent.cs
@@ -1,0 +1,10 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a trashed <c>Document</c> is restored to active status.
+/// </summary>
+public sealed record DocumentRestoredEvent(
+    Guid DocumentId,
+    Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentTrashedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentTrashedEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <c>Document</c> is moved to the trash (soft-delete via domain status).
+/// </summary>
+public sealed record DocumentTrashedEvent(
+    Guid DocumentId,
+    Guid? TenantId,
+    DateTimeOffset TrashedAt) : IDomainEvent;

--- a/tests/Granit.Documents.Tests/Domain/DocumentTests.cs
+++ b/tests/Granit.Documents.Tests/Domain/DocumentTests.cs
@@ -1,0 +1,296 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Domain;
+
+public sealed class DocumentTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    private static Folder NewRoot() =>
+        Folder.CreateTenantRoot(Guid.NewGuid(), TenantId, OwnerId);
+
+    private static Folder NewFolder(Folder root, string name) =>
+        Folder.Create(Guid.NewGuid(), root, name, OwnerId);
+
+    [Fact]
+    public void Create_DefaultProperties_AreCorrect()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "Contracts");
+
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "Q1-2026.pdf", "Quarter 1 close");
+
+        doc.TenantId.ShouldBe(TenantId);
+        doc.FolderId.ShouldBe(folder.Id);
+        doc.OwnerUserId.ShouldBe(OwnerId);
+        doc.Name.ShouldBe("Q1-2026.pdf");
+        doc.Description.ShouldBe("Quarter 1 close");
+        doc.CurrentVersionId.ShouldBeNull();
+        doc.Status.ShouldBe(DocumentStatus.Active);
+        doc.TrashedAt.ShouldBeNull();
+        doc.RowVersion.ShouldBe(1u);
+        doc.DomainEvents.OfType<DocumentCreatedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_InvalidName_Throws(string name)
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+
+        Should.Throw<ArgumentException>(() => Document.Create(Guid.NewGuid(), folder, OwnerId, name));
+    }
+
+    [Fact]
+    public void Create_NameTooLong_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+
+        Should.Throw<ArgumentException>(
+            () => Document.Create(Guid.NewGuid(), folder, OwnerId, new string('a', Document.MaxNameLength + 1)));
+    }
+
+    [Fact]
+    public void Create_DescriptionTooLong_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        string desc = new('d', Document.MaxDescriptionLength + 1);
+
+        Should.Throw<ArgumentException>(
+            () => Document.Create(Guid.NewGuid(), folder, OwnerId, "name.pdf", desc));
+    }
+
+    [Fact]
+    public void Create_TrashedFolder_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        folder.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(
+            () => Document.Create(Guid.NewGuid(), folder, OwnerId, "x.pdf"));
+    }
+
+    [Fact]
+    public void Rename_UpdatesNameAndIncrementsRowVersion()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "Old.pdf");
+        uint before = doc.RowVersion;
+
+        doc.Rename("New.pdf");
+
+        doc.Name.ShouldBe("New.pdf");
+        doc.RowVersion.ShouldBeGreaterThan(before);
+        doc.DomainEvents.OfType<DocumentRenamedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Rename_SameName_IsNoOp()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "Same.pdf");
+        uint before = doc.RowVersion;
+
+        doc.Rename("Same.pdf");
+
+        doc.RowVersion.ShouldBe(before);
+        doc.DomainEvents.OfType<DocumentRenamedEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Rename_TrashedDocument_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        doc.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => doc.Rename("X.pdf"));
+    }
+
+    [Fact]
+    public void UpdateDescription_UpdatesAndIncrementsRowVersion()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf", "old");
+        uint before = doc.RowVersion;
+
+        doc.UpdateDescription("new");
+
+        doc.Description.ShouldBe("new");
+        doc.RowVersion.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public void UpdateDescription_SameValue_IsNoOp()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf", "same");
+        uint before = doc.RowVersion;
+
+        doc.UpdateDescription("same");
+
+        doc.RowVersion.ShouldBe(before);
+    }
+
+    [Fact]
+    public void MoveTo_DifferentFolder_UpdatesFolderIdAndEmitsEvent()
+    {
+        Folder root = NewRoot();
+        Folder a = NewFolder(root, "A");
+        Folder b = NewFolder(root, "B");
+        var doc = Document.Create(Guid.NewGuid(), a, OwnerId, "F.pdf");
+
+        doc.MoveTo(b);
+
+        doc.FolderId.ShouldBe(b.Id);
+        DocumentMovedEvent moved = doc.DomainEvents.OfType<DocumentMovedEvent>().ShouldHaveSingleItem();
+        moved.OldFolderId.ShouldBe(a.Id);
+        moved.NewFolderId.ShouldBe(b.Id);
+    }
+
+    [Fact]
+    public void MoveTo_SameFolder_IsNoOp()
+    {
+        Folder root = NewRoot();
+        Folder a = NewFolder(root, "A");
+        var doc = Document.Create(Guid.NewGuid(), a, OwnerId, "F.pdf");
+        uint before = doc.RowVersion;
+
+        doc.MoveTo(a);
+
+        doc.RowVersion.ShouldBe(before);
+        doc.DomainEvents.OfType<DocumentMovedEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MoveTo_DifferentTenant_Throws()
+    {
+        Folder rootA = NewRoot();
+        Folder folderA = NewFolder(rootA, "A");
+        var doc = Document.Create(Guid.NewGuid(), folderA, OwnerId, "F.pdf");
+
+        var rootB = Folder.CreateTenantRoot(Guid.NewGuid(), Guid.NewGuid(), OwnerId);
+        Folder folderB = NewFolder(rootB, "B");
+
+        Should.Throw<InvalidOperationException>(() => doc.MoveTo(folderB));
+    }
+
+    [Fact]
+    public void MoveTo_TrashedTarget_Throws()
+    {
+        Folder root = NewRoot();
+        Folder a = NewFolder(root, "A");
+        Folder b = NewFolder(root, "B");
+        b.Trash(DateTimeOffset.UtcNow);
+        var doc = Document.Create(Guid.NewGuid(), a, OwnerId, "F.pdf");
+
+        Should.Throw<InvalidOperationException>(() => doc.MoveTo(b));
+    }
+
+    [Fact]
+    public void SetCurrentVersion_UpdatesAndEmitsEvent()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        var versionId = Guid.NewGuid();
+
+        doc.SetCurrentVersion(versionId);
+
+        doc.CurrentVersionId.ShouldBe(versionId);
+        DocumentCurrentVersionChangedEvent ev = doc.DomainEvents
+            .OfType<DocumentCurrentVersionChangedEvent>().ShouldHaveSingleItem();
+        ev.OldCurrentVersionId.ShouldBeNull();
+        ev.NewCurrentVersionId.ShouldBe(versionId);
+    }
+
+    [Fact]
+    public void SetCurrentVersion_EmptyGuid_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+
+        Should.Throw<ArgumentException>(() => doc.SetCurrentVersion(Guid.Empty));
+    }
+
+    [Fact]
+    public void SetCurrentVersion_SameValue_IsNoOp()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        var versionId = Guid.NewGuid();
+        doc.SetCurrentVersion(versionId);
+        uint before = doc.RowVersion;
+
+        doc.SetCurrentVersion(versionId);
+
+        doc.RowVersion.ShouldBe(before);
+    }
+
+    [Fact]
+    public void Trash_SetsStatusAndTrashedAt_AndEmitsEvent()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        doc.Trash(now);
+
+        doc.Status.ShouldBe(DocumentStatus.Trashed);
+        doc.TrashedAt.ShouldBe(now);
+        doc.DomainEvents.OfType<DocumentTrashedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Trash_AlreadyTrashed_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        doc.Trash(DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => doc.Trash(DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Restore_FromTrash_BecomesActive()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        doc.Trash(DateTimeOffset.UtcNow);
+
+        doc.Restore();
+
+        doc.Status.ShouldBe(DocumentStatus.Active);
+        doc.TrashedAt.ShouldBeNull();
+        doc.DomainEvents.OfType<DocumentRestoredEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Restore_ActiveDocument_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+
+        Should.Throw<InvalidOperationException>(() => doc.Restore());
+    }
+}


### PR DESCRIPTION
## Summary

First domain aggregate of **Feature F3 (Document upload / download flow)**. Models user-managed documents — folder placement, ownership, description, lifecycle status, and the pointer to the currently-published version. Subsequent stories add the upload-finalise flow (F3.2), download endpoint (F3.3), versioning (F4), share ACL (F6), and tags (F5).

## Domain

- `DocumentStatus`: `Active | Trashed | PermanentlyDeleted` — the third value is the GDPR/ISO 27001 audit-trail tombstone retained after BlobStorage removes the bytes.
- `Document : AggregateRoot, IMultiTenant` with private setters and a `Document.Create(id, folder, ownerId, name, description?)` factory rejecting invalid names / descriptions and non-active parent folders.
- Behaviour methods: `Rename`, `UpdateDescription`, `MoveTo` (cross-tenant + trashed-target rejection), `SetCurrentVersion` (called by F3.2's finalise flow when the first `DocumentVersion` lands), `Trash`, `Restore`. Every mutation increments `RowVersion` and emits the corresponding domain event; same-value calls are no-ops with no event emission.
- Six `IDomainEvent` records: `DocumentCreatedEvent`, `DocumentRenamedEvent`, `DocumentMovedEvent`, `DocumentTrashedEvent`, `DocumentRestoredEvent`, `DocumentCurrentVersionChangedEvent`.
- **`RowVersion: uint`** as a manually-incremented optimistic-concurrency token (portable across SQL Server, PostgreSQL, SQLite — `[Timestamp]` is SQL-Server-specific). EF Core's `IsConcurrencyToken` mapping detects concurrent overwrites and surfaces them as `DbUpdateConcurrencyException`.

## Persistence

`DocumentConfiguration` adds the `documents_documents` table with two indexes:
- `ix_…_documents_tenant_folder` on `(TenantId, FolderId)` — folder-scoped listings.
- `ix_…_documents_tenant_status` on `(TenantId, Status)` — trash listings (F8.2) + empty-trash job (F9.2).

`DocumentsDbContext` gains `DbSet<Document>`; `ConfigureDocumentsModule` applies the new configuration.

## Tests

22 unit tests on the `Document` aggregate cover factory paths (valid + invalid name + invalid description + trashed-folder rejection), `Rename` / `UpdateDescription` / `MoveTo` / `SetCurrentVersion` / `Trash` / `Restore` behaviours including no-op detection and `RowVersion` increments, and cross-tenant + trashed-target rejection on `MoveTo`.

- `Granit.Documents.Tests`: **62/62** (40 Folder + 22 Document).
- `Granit.Documents.EntityFrameworkCore.Tests`: 23/23 (unchanged).
- `Granit.ArchitectureTests`: **209/209**.
- `dotnet format` clean.

## Tracking

- Story: #1732 (F3.1 — Document aggregate root)
- Feature: #1731 (F3 — Document aggregate + upload / download flow)
- Epic: #1721