### PR TITLE
feat(entities): EntityDefinition.Activities() opt-in + manifest exposure (#1800)

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -11,6 +11,7 @@
       "src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj",
       "src/Granit.AI.VectorData/Granit.AI.VectorData.csproj",
       "src/Granit.AI/Granit.AI.csproj",
+      "src/Granit.Activities.Abstractions/Granit.Activities.Abstractions.csproj",
       "src/Granit.Analytics.Abstractions/Granit.Analytics.Abstractions.csproj",
       "src/Granit.Analytics.Endpoints/Granit.Analytics.Endpoints.csproj",
       "src/Granit.Analytics.EntityFrameworkCore/Granit.Analytics.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -953,6 +953,7 @@
       "name": "Granit.Entities.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.Activities.Abstractions",
         "Granit.Caching",
         "Granit.Entities",
         "Granit.Http.ApiDocumentation",
@@ -20024,6 +20025,31 @@
       ]
     },
     {
+      "name": "ActivitiesDescriptor",
+      "fqn": "Granit.Entities.Activities.ActivitiesDescriptor",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Activities/ActivitiesDescriptor.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ActivitiesOptionsBuilder",
+      "fqn": "Granit.Entities.Activities.ActivitiesOptionsBuilder",
+      "kind": "class",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Activities/ActivitiesOptionsBuilder.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AllowedTypes",
+          "kind": "method",
+          "signature": "AllowedTypes(params string[] activityTypeNames)",
+          "returnType": "ActivitiesOptionsBuilder<TEntity>"
+        }
+      ]
+    },
+    {
       "name": "DetailBuilder",
       "fqn": "Granit.Entities.Details.DetailBuilder",
       "kind": "class",
@@ -20142,6 +20168,15 @@
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs",
       "line": 21,
+      "members": []
+    },
+    {
+      "name": "EntityActivitiesManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActivitiesManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActivitiesManifest.cs",
+      "line": 11,
       "members": []
     },
     {
@@ -20348,7 +20383,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs",
-      "line": 16,
+      "line": 17,
       "members": []
     },
     {
@@ -20533,7 +20568,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "DisplayKey",
@@ -20549,7 +20584,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "Name",

--- a/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-definition.mdx
@@ -161,6 +161,47 @@ regardless of batch size. A 1000-row import emits one cache eviction sweep, not
 Per-row events and bulk events are alternatives, not complements — emit one or
 the other for the same set of rows, never both.
 
+## Activities
+
+Opt an entity into hosting cross-entity to-dos (calls, meetings, follow-up
+tasks…) per [ADR-046](/dotnet/architecture/adr/046-activities-vs-timeline/) by
+calling `.Activities()` on the builder:
+
+```csharp
+public sealed class CustomerEntityDefinition : EntityDefinition<Customer>
+{
+    protected override void Configure(EntityDefinitionBuilder<Customer> b)
+    {
+        b.PermissionGroup("Customers");
+        b.Activities(a => a
+            .AllowedTypes("Call", "Meeting", "Email", "ToDo")
+            .DefaultAssignee(c => c.AccountManagerUserId));
+
+        b.Detail("default", d => d.SidePanel(p => p.Activities()));
+    }
+}
+```
+
+The manifest section `entity.activities` carries the resolved
+`allowedTypes` (filtered against the runtime `IActivityRegistry`) plus the
+optional `defaultAssignee` property name. Activity types listed in
+`AllowedTypes(...)` that are not registered with the framework are silently
+dropped from the manifest — entities can safely opt into types contributed by
+optional modules (e.g. `"Quote"` from `Granit.Sales`) without breaking when
+those modules are not loaded.
+
+The `activities` section is omitted entirely when:
+
+- the entity does not call `.Activities()`, or
+- the host has not loaded the `Granit.Activities` runtime
+  (`AddGranitActivities()`) — without it the registry is unavailable and the
+  catalog cannot be validated.
+
+`Detail.SidePanel.Activities()` is the standard side-panel hook that surfaces
+the React `<EntityActivitiesPanel />` component on the detail view; it works
+independently of the `.Activities()` opt-in (the panel renders an empty state
+when the entity does not own activities).
+
 ## Calendar view
 
 A calendar layout reads its rows from a dedicated range-query endpoint that the

--- a/src/Granit.Entities.Abstractions/Activities/ActivitiesDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Activities/ActivitiesDescriptor.cs
@@ -1,0 +1,13 @@
+namespace Granit.Entities.Activities;
+
+/// <summary>
+/// Immutable opt-in descriptor declaring that an
+/// <see cref="EntityDefinition{TEntity}"/> hosts cross-entity activities
+/// (ADR-046 §3). Built via
+/// <see cref="ActivitiesOptionsBuilder{TEntity}"/> on the fluent builder.
+/// </summary>
+/// <param name="AllowedTypeNames">Activity type names the entity restricts itself to (e.g. <c>["Call", "Meeting", "Email", "ToDo"]</c>). Empty list means "every type registered with the framework". Names that don't resolve in <c>IActivityRegistry</c> are silently dropped at manifest time per ADR-045 §3 — so an entity that opts into <c>"Quote"</c> simply does not surface that option when <c>Granit.Sales</c> is not loaded.</param>
+/// <param name="DefaultAssigneePropertyName">Optional property name (PascalCase) on the host entity that the React shell pre-fills as the assignee when creating an activity (e.g. <c>"AccountManagerUserId"</c>). The wire form is the property name, not the value — value resolution happens client-side from the loaded entity row.</param>
+public sealed record ActivitiesDescriptor(
+    IReadOnlyList<string> AllowedTypeNames,
+    string? DefaultAssigneePropertyName);

--- a/src/Granit.Entities.Abstractions/Activities/ActivitiesOptionsBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Activities/ActivitiesOptionsBuilder.cs
@@ -1,0 +1,67 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Granit.Entities.Activities;
+
+/// <summary>
+/// Fluent builder for <see cref="ActivitiesDescriptor"/>. Used inside the
+/// <c>EntityDefinitionBuilder&lt;T&gt;.Activities(b =&gt; ...)</c> opt-in
+/// (ADR-046 §3).
+/// </summary>
+/// <typeparam name="TEntity">The entity type that hosts activities.</typeparam>
+public sealed class ActivitiesOptionsBuilder<TEntity>
+    where TEntity : class
+{
+    private readonly List<string> _allowedTypeNames = [];
+    private string? _defaultAssigneePropertyName;
+
+    /// <summary>
+    /// Restricts the activity type catalog this entity offers to the listed
+    /// names. Names that don't resolve in <see cref="IActivityRegistry"/> at
+    /// manifest time are silently dropped (per ADR-045 §3) — call sites can
+    /// safely list types contributed by optional modules.
+    /// </summary>
+    /// <param name="activityTypeNames">Activity type names (e.g. <c>"Call"</c>, <c>"Quote"</c>). Empty argument list is rejected — call <see cref="ActivitiesOptionsBuilder{TEntity}"/>'s parameterless constructor pathway (i.e. omit <c>AllowedTypes</c>) to allow every registered type.</param>
+    public ActivitiesOptionsBuilder<TEntity> AllowedTypes(params string[] activityTypeNames)
+    {
+        ArgumentNullException.ThrowIfNull(activityTypeNames);
+        if (activityTypeNames.Length == 0)
+        {
+            throw new ArgumentException(
+                "AllowedTypes(...) must list at least one activity type name. Omit the call entirely to allow every registered type.",
+                nameof(activityTypeNames));
+        }
+        foreach (string name in activityTypeNames)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            _allowedTypeNames.Add(name);
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Names the host-entity property (PascalCase) that the React shell
+    /// pre-fills as the activity assignee when creating an activity from this
+    /// entity's detail page. Lambda must be a direct property access.
+    /// </summary>
+    public ActivitiesOptionsBuilder<TEntity> DefaultAssignee<TProperty>(Expression<Func<TEntity, TProperty>> propertySelector)
+    {
+        ArgumentNullException.ThrowIfNull(propertySelector);
+
+        if (propertySelector.Body is not MemberExpression member
+            || member.Member is not PropertyInfo property)
+        {
+            throw new ArgumentException(
+                "DefaultAssignee selector must be a direct property access expression (e.g. x => x.AccountManagerUserId).",
+                nameof(propertySelector));
+        }
+
+        _defaultAssigneePropertyName = property.Name;
+        return this;
+    }
+
+    internal ActivitiesDescriptor Build() =>
+        new(
+            AllowedTypeNames: _allowedTypeNames.AsReadOnly(),
+            DefaultAssigneePropertyName: _defaultAssigneePropertyName);
+}

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Granit.Entities.Actions;
+using Granit.Entities.Activities;
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
@@ -32,6 +33,8 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     private readonly List<RelationDescriptor> _relations = [];
     private readonly List<Func<EntityListLayoutDescriptor>> _layoutFactories = [];
     private readonly List<EntityActionDescriptor> _actions = [];
+
+    private ActivitiesDescriptor? _activities;
 
     /// <summary>Sets the i18n key for the entity's display name (singular).</summary>
     public EntityDefinitionBuilder<TEntity> DisplayKey(string displayKey)
@@ -306,6 +309,35 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         return this;
     }
 
+    /// <summary>
+    /// Opts the entity into hosting cross-entity activities (ADR-046 §3).
+    /// Surfaces the manifest's <c>activities</c> section so the React shell
+    /// can render the activity creation modal + side panel for this entity.
+    /// </summary>
+    /// <param name="configure">
+    /// Optional builder configuration — restrict the activity-type catalog via
+    /// <see cref="ActivitiesOptionsBuilder{TEntity}.AllowedTypes(string[])"/>
+    /// or pre-fill the assignee via
+    /// <see cref="ActivitiesOptionsBuilder{TEntity}.DefaultAssignee{TProperty}(System.Linq.Expressions.Expression{System.Func{TEntity, TProperty}})"/>.
+    /// Calling <c>.Activities()</c> with no configuration enables every
+    /// registered activity type with no default assignee.
+    /// </param>
+    /// <remarks>
+    /// Activity types named in <c>AllowedTypes(...)</c> that don't resolve in
+    /// <see cref="IActivityRegistry"/> at manifest time are silently dropped
+    /// (per ADR-045 §3) — call sites can safely list types contributed by
+    /// optional modules. The activity types registry itself is populated by
+    /// the host via <c>AddGranitActivities()</c>; without it, the
+    /// <c>activities</c> manifest section is omitted entirely.
+    /// </remarks>
+    public EntityDefinitionBuilder<TEntity> Activities(Action<ActivitiesOptionsBuilder<TEntity>>? configure = null)
+    {
+        ActivitiesOptionsBuilder<TEntity> builder = new();
+        configure?.Invoke(builder);
+        _activities = builder.Build();
+        return this;
+    }
+
     internal EntityDefinitionDescriptor Build(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -349,6 +381,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
             Relations = relations,
             ListLayouts = layouts,
             Actions = actions,
+            Activities = _activities,
         };
     }
 

--- a/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionDescriptor.cs
@@ -1,4 +1,5 @@
 using Granit.Entities.Actions;
+using Granit.Entities.Activities;
 using Granit.Entities.Details;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
@@ -118,4 +119,13 @@ public sealed record EntityDefinitionDescriptor
     /// precedence on conflicts (same <see cref="EntityActionDescriptor.Name"/>).
     /// </summary>
     public IReadOnlyList<EntityActionDescriptor> Actions { get; init; } = [];
+
+    /// <summary>
+    /// Activity opt-in (ADR-046 §3) — when non-<see langword="null"/>, the
+    /// entity hosts cross-entity activities; the manifest exposes
+    /// <c>activities.allowedTypes</c> and the optional default-assignee
+    /// property pointer. Set via
+    /// <see cref="EntityDefinitionBuilder{TEntity}.Activities(System.Action{ActivitiesOptionsBuilder{TEntity}})"/>.
+    /// </summary>
+    public ActivitiesDescriptor? Activities { get; init; }
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityActivitiesManifest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityActivitiesManifest.cs
@@ -1,0 +1,13 @@
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Activities opt-in section of the per-entity manifest (ADR-046 §3). Present
+/// only when the entity declared <c>.Activities()</c> on its
+/// <c>EntityDefinitionBuilder</c> AND the host loaded
+/// <c>Granit.Activities</c> runtime so the registry can validate type names.
+/// </summary>
+/// <param name="AllowedTypes">Activity type names the entity offers, after dropping any names absent from the runtime <c>IActivityRegistry</c> (per ADR-045 §3 silent-skip). Empty list = every registered type is allowed.</param>
+/// <param name="DefaultAssignee">Optional property name (PascalCase) on the host entity that the React shell pre-fills as the assignee when creating an activity (e.g. <c>"AccountManagerUserId"</c>). Value resolution happens client-side from the loaded entity row.</param>
+public sealed record EntityActivitiesManifest(
+    IReadOnlyList<string> AllowedTypes,
+    string? DefaultAssignee);

--- a/src/Granit.Entities.Endpoints/Dtos/EntityFacets.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityFacets.cs
@@ -41,6 +41,9 @@ public enum EntityFacets
     /// <summary>Actions exposed on the entity (intra-module + cross-module contributions per ADR-040).</summary>
     Actions = 1 << 9,
 
+    /// <summary>Activities opt-in (ADR-046) — allowed activity-type catalog + default-assignee property pointer. Section is omitted when the entity does not call <c>.Activities()</c>.</summary>
+    Activities = 1 << 10,
+
     /// <summary>All facets — the default when <c>?facets=</c> is absent.</summary>
-    All = Identity | Permissions | Forms | Details | Collections | Dashboards | Exports | Views | Relations | Actions,
+    All = Identity | Permissions | Forms | Details | Collections | Dashboards | Exports | Views | Relations | Actions | Activities,
 }

--- a/src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs
@@ -13,6 +13,7 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="Collections">Query / Export / Metric / Dashboard references + resolved default view.</param>
 /// <param name="Relations">Relations surfaced on the source entity (Tab / SmartButton / Sidebar / InlineChips per ADR-048). Already permission-filtered server-side.</param>
 /// <param name="Actions">Actions exposed on the entity (intra-module + cross-module contributions). Already permission-filtered server-side.</param>
+/// <param name="Activities">Activities opt-in section (ADR-046). Present only when the entity declared <c>.Activities()</c> AND the host loaded the <c>Granit.Activities</c> runtime.</param>
 public sealed record EntityManifestResponse(
     int SchemaVersion,
     EntityIdentitySection? Identity,
@@ -21,4 +22,5 @@ public sealed record EntityManifestResponse(
     IReadOnlyList<EntityDetailManifest>? Details,
     EntityCollectionsSection? Collections,
     IReadOnlyList<EntityRelationManifest>? Relations,
-    IReadOnlyList<EntityActionManifest>? Actions = null);
+    IReadOnlyList<EntityActionManifest>? Actions = null,
+    EntityActivitiesManifest? Activities = null);

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -125,7 +125,10 @@ internal static class EntitiesEndpoints
         [FromServices] IOptions<EntitiesEndpointsOptions> options,
         ClaimsPrincipal user,
         HttpContext httpContext,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        // Optional — null when the host has not loaded Granit.Activities runtime;
+        // the manifest then omits the activities section entirely (ADR-045 §3).
+        [FromServices] Granit.Activities.IActivityRegistry? activityRegistry = null)
     {
         IEntityDefinitionDescriptor? definitionRef = registry.GetByName(name);
         if (definitionRef is null)
@@ -161,7 +164,7 @@ internal static class EntitiesEndpoints
                 IReadOnlySet<string> grantedPermissions = await CollectGrantedPermissionsAsync(
                     permissionResolver, descriptor, ct).ConfigureAwait(false);
                 return EntityManifestComposer.Compose(
-                    descriptor, snapshot, grantedPermissions, selected, defaultViewId: null);
+                    descriptor, snapshot, grantedPermissions, selected, defaultViewId: null, activityRegistry);
             },
             new FusionCacheEntryOptions { Duration = options.Value.ManifestCacheTtl },
             token: cancellationToken)

--- a/src/Granit.Entities.Endpoints/Granit.Entities.Endpoints.csproj
+++ b/src/Granit.Entities.Endpoints/Granit.Entities.Endpoints.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Activities.Abstractions\Granit.Activities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Entities\Granit.Entities.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -1,3 +1,4 @@
+using Granit.Activities;
 using Granit.Entities.Actions;
 using Granit.Entities.Details;
 using Granit.Entities.Endpoints.Dtos;
@@ -24,7 +25,8 @@ internal static class EntityManifestComposer
         EntityPermissionSnapshot permissions,
         IReadOnlySet<string> grantedPermissions,
         EntityFacets facets,
-        Guid? defaultViewId)
+        Guid? defaultViewId,
+        IActivityRegistry? activityRegistry = null)
     {
         ArgumentNullException.ThrowIfNull(definition);
         ArgumentNullException.ThrowIfNull(permissions);
@@ -61,6 +63,10 @@ internal static class EntityManifestComposer
             ? ComposeActions(definition, grantedPermissions)
             : null;
 
+        EntityActivitiesManifest? activities = facets.HasFlag(EntityFacets.Activities)
+            ? ComposeActivities(definition, activityRegistry)
+            : null;
+
         return new EntityManifestResponse(
             SchemaVersion,
             identity,
@@ -69,7 +75,40 @@ internal static class EntityManifestComposer
             details,
             collections,
             relations,
-            actions);
+            actions,
+            activities);
+    }
+
+    /// <summary>
+    /// Projects the entity's <see cref="ActivitiesDescriptor"/> opt-in into the
+    /// wire-shape manifest section. Returns <see langword="null"/> when:
+    /// <list type="bullet">
+    ///   <item>The entity did not call <c>.Activities()</c> on its builder.</item>
+    ///   <item>The host did not load <c>Granit.Activities</c> runtime
+    ///         (<paramref name="activityRegistry"/> is <see langword="null"/>) — the
+    ///         catalog cannot be validated, so the section is omitted entirely
+    ///         per ADR-045 §3 silent-skip semantic.</item>
+    /// </list>
+    /// Allowed type names absent from the registry are silently dropped from the
+    /// manifest so that an entity opting into <c>"Quote"</c> simply does not
+    /// surface that option when <c>Granit.Sales</c> is not loaded.
+    /// </summary>
+    private static EntityActivitiesManifest? ComposeActivities(
+        EntityDefinitionDescriptor d,
+        IActivityRegistry? activityRegistry)
+    {
+        if (d.Activities is null || activityRegistry is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<string> filteredAllowed = d.Activities.AllowedTypeNames.Count == 0
+            ? activityRegistry.All.Keys.ToArray()
+            : [.. d.Activities.AllowedTypeNames.Where(name => activityRegistry.TryGet(name, out _))];
+
+        return new EntityActivitiesManifest(
+            AllowedTypes: filteredAllowed,
+            DefaultAssignee: d.Activities.DefaultAssigneePropertyName);
     }
 
     private static List<EntityActionManifest> ComposeActions(

--- a/src/Granit.Entities.Endpoints/packages.lock.json
+++ b/src/Granit.Entities.Endpoints/packages.lock.json
@@ -34,6 +34,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.activities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1442,6 +1442,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.activities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.ai": {
         "type": "Project",
         "dependencies": {
@@ -2292,6 +2298,7 @@
       "granit.entities.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Activities.Abstractions": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Entities": "[0.1.0-dev, )",

--- a/tests/Granit.Entities.Abstractions.Tests/Activities/ActivitiesOptionsBuilderTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Activities/ActivitiesOptionsBuilderTests.cs
@@ -1,0 +1,76 @@
+using Granit.Entities.Activities;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Activities;
+
+public sealed class ActivitiesOptionsBuilderTests
+{
+    private sealed class SampleEntity
+    {
+        public Guid AccountManagerUserId { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public void EntityDefinitionBuilder_Activities_with_no_configure_produces_empty_descriptor()
+    {
+        EntityDefinition<SampleEntity> def = new SampleEntityDefinition(b => b.Activities());
+        EntityDefinitionDescriptor descriptor = def.Descriptor;
+        descriptor.Activities.ShouldNotBeNull();
+        descriptor.Activities!.AllowedTypeNames.ShouldBeEmpty();
+        descriptor.Activities.DefaultAssigneePropertyName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void EntityDefinitionBuilder_Activities_AllowedTypes_captures_names_in_order()
+    {
+        EntityDefinition<SampleEntity> def = new SampleEntityDefinition(b =>
+            b.Activities(a => a.AllowedTypes("Call", "Meeting", "Email")));
+        EntityDefinitionDescriptor descriptor = def.Descriptor;
+        descriptor.Activities!.AllowedTypeNames.ShouldBe(["Call", "Meeting", "Email"]);
+    }
+
+    [Fact]
+    public void EntityDefinitionBuilder_Activities_DefaultAssignee_captures_property_name()
+    {
+        EntityDefinition<SampleEntity> def = new SampleEntityDefinition(b =>
+            b.Activities(a => a.DefaultAssignee(e => e.AccountManagerUserId)));
+        EntityDefinitionDescriptor descriptor = def.Descriptor;
+        descriptor.Activities!.DefaultAssigneePropertyName.ShouldBe("AccountManagerUserId");
+    }
+
+    [Fact]
+    public void Activities_descriptor_absent_when_builder_method_not_called()
+    {
+        EntityDefinition<SampleEntity> def = new SampleEntityDefinition(_ => { });
+        EntityDefinitionDescriptor descriptor = def.Descriptor;
+        descriptor.Activities.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AllowedTypes_with_no_arguments_throws()
+    {
+        ActivitiesOptionsBuilder<SampleEntity> sut = new();
+        Should.Throw<ArgumentException>(() => sut.AllowedTypes());
+    }
+
+    [Fact]
+    public void DefaultAssignee_with_non_property_lambda_throws()
+    {
+        ActivitiesOptionsBuilder<SampleEntity> sut = new();
+        Should.Throw<ArgumentException>(() => sut.DefaultAssignee(e => e.Name + "!"));
+    }
+
+    private sealed class SampleEntityDefinition(Action<EntityDefinitionBuilder<SampleEntity>> apply)
+        : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Test.SampleEntity";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> b)
+        {
+            b.PermissionGroup("Test.Samples");
+            apply(b);
+        }
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
@@ -1,0 +1,128 @@
+using Granit.Activities;
+using Granit.Entities.Activities;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Endpoints.Tests;
+
+public sealed class EntityActivitiesManifestTests
+{
+    private sealed class SampleEntity { }
+
+    private static EntityDefinitionDescriptor DescriptorWithActivities(ActivitiesDescriptor? activities) => new()
+    {
+        Name = "Test.Sample",
+        EntityType = typeof(SampleEntity),
+        DisplayKey = "Entity:Sample",
+        Icon = "box",
+        PermissionGroup = "Test.Samples",
+        DisplayProperty = "Name",
+        QueryDefinitionType = null,
+        ExportDefinitionType = null,
+        MetricDefinitionTypes = [],
+        DashboardDefinitionTypes = [],
+        WorkflowDefinitionType = null,
+        Forms = [],
+        Details = [],
+        Activities = activities,
+    };
+
+    private static IActivityRegistry RegistryWith(params string[] knownTypeNames)
+    {
+        IActivityRegistry registry = Substitute.For<IActivityRegistry>();
+        Dictionary<string, ActivityType> dict = knownTypeNames.ToDictionary(
+            name => name,
+            name => new ActivityType(name, "icon", $"Activity:{name}"),
+            StringComparer.Ordinal);
+        registry.All.Returns(dict);
+        foreach (string name in knownTypeNames)
+        {
+            ActivityType captured = dict[name];
+            registry.TryGet(name, out Arg.Any<ActivityType>()).Returns(call =>
+            {
+                call[1] = captured;
+                return true;
+            });
+        }
+        registry.TryGet(Arg.Is<string>(s => !knownTypeNames.Contains(s, StringComparer.Ordinal)), out Arg.Any<ActivityType>())
+            .Returns(false);
+        return registry;
+    }
+
+    [Fact]
+    public void Activities_section_omitted_when_descriptor_does_not_opt_in()
+    {
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            DescriptorWithActivities(activities: null),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.All,
+            defaultViewId: null,
+            activityRegistry: RegistryWith("ToDo"));
+
+        manifest.Activities.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Activities_section_omitted_when_registry_is_null_even_if_opted_in()
+    {
+        // Host did not load Granit.Activities runtime — silent-skip per ADR-045 §3.
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            DescriptorWithActivities(new ActivitiesDescriptor(["ToDo"], null)),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.All,
+            defaultViewId: null,
+            activityRegistry: null);
+
+        manifest.Activities.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Activities_section_returns_full_registry_catalog_when_no_AllowedTypes_specified()
+    {
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            DescriptorWithActivities(new ActivitiesDescriptor([], DefaultAssigneePropertyName: null)),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.All,
+            defaultViewId: null,
+            activityRegistry: RegistryWith("ToDo", "Call", "Meeting", "Email"));
+
+        manifest.Activities.ShouldNotBeNull();
+        manifest.Activities!.AllowedTypes.ShouldBe(["ToDo", "Call", "Meeting", "Email"], ignoreOrder: true);
+        manifest.Activities.DefaultAssignee.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Activities_section_silently_drops_AllowedTypes_absent_from_registry()
+    {
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            DescriptorWithActivities(new ActivitiesDescriptor(["Call", "Quote", "Demo"], "AccountManagerUserId")),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.All,
+            defaultViewId: null,
+            activityRegistry: RegistryWith("Call"));   // Quote and Demo not registered
+
+        manifest.Activities!.AllowedTypes.ShouldBe(["Call"]);
+        manifest.Activities.DefaultAssignee.ShouldBe("AccountManagerUserId");
+    }
+
+    [Fact]
+    public void Activities_section_omitted_when_facet_not_requested()
+    {
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            DescriptorWithActivities(new ActivitiesDescriptor(["ToDo"], null)),
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Identity,   // Activities flag NOT included
+            defaultViewId: null,
+            activityRegistry: RegistryWith("ToDo"));
+
+        manifest.Activities.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Entities.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Endpoints.Tests/packages.lock.json
@@ -308,6 +308,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.activities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -383,6 +389,7 @@
       "granit.entities.endpoints": {
         "type": "Project",
         "dependencies": {
+          "Granit.Activities.Abstractions": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Entities": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Closes [#1800](https://github.com/granit-fx/granit-dotnet/issues/1800) (Phase 2 Stream A, story A5).

Wires the [Granit.Activities](https://github.com/granit-fx/granit-dotnet/blob/develop/src/Granit.Activities/README.md) runtime into the entity manifest. Entities now opt into hosting cross-entity activities via `.Activities(...)` on the builder; the manifest's new `activities` section exposes the resolved `AllowedTypes` catalog + `DefaultAssignee` property pointer for the React shell to render the creation modal and side panel.

## Granit.Entities.Abstractions

- `ActivitiesDescriptor` record (`AllowedTypeNames` + `DefaultAssigneePropertyName`)
- `ActivitiesOptionsBuilder<T>` fluent builder with `.AllowedTypes(...)` + `.DefaultAssignee(lambda)`
- `EntityDefinitionBuilder<T>.Activities(configure?)` opt-in
- `Activities` field on `EntityDefinitionDescriptor` (nullable, default `null`)
- The `DefaultAssignee` selector requires a direct property access lambda (mirrors `DisplayProperty` / `SubtitleProperty` enforcement)

```csharp
b.Activities(a => a
    .AllowedTypes("Call", "Meeting", "Email", "ToDo")
    .DefaultAssignee(c => c.AccountManagerUserId));

b.Detail("default", d => d.SidePanel(p => p.Activities()));
```

## Granit.Entities.Endpoints

- New `ProjectReference` on `Granit.Activities.Abstractions` (lightweight contracts package)
- `EntityFacets.Activities` flag (`1 << 10`) + included in `.All`
- `EntityActivitiesManifest` DTO + `Activities` field on `EntityManifestResponse`
- `ComposeActivities()` in `EntityManifestComposer`:
  - Returns `null` when `descriptor.Activities is null`
  - Returns `null` when `activityRegistry is null` (host has not loaded `Granit.Activities`) — silent-skip per [ADR-045 §3](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/045-contributor-pattern.md)
  - Drops `AllowedTypes` absent from the registry (so optional-module types don't surface when the contributing module is absent)
  - Empty `AllowedTypes` means "every registered type"
- Endpoint handler injects `[FromServices] IActivityRegistry? = null` and threads it through `Compose`

## Pre-existing infrastructure leveraged

`SidePanelKind.Activities` and `SidePanel.Activities()` were already present from Phase 1 — the side-panel hook needed no work. The story body anticipated this; reused as-is.

## Tests

Both projects' suites green:
- 6 new `EntityActivitiesManifestTests` — descriptor null, registry null, no-AllowedTypes (full catalog), partial drop, facet not requested
- 6 new `ActivitiesOptionsBuilderTests` — empty configure, AllowedTypes order capture, DefaultAssignee property capture, descriptor absence, AllowedTypes() empty throws, non-property lambda throws
- All 80/80 abstractions + 78/78 endpoints tests pass (no regression)

## Test plan

- [x] `dotnet build src/Granit.Entities.Abstractions src/Granit.Entities.Endpoints` — 0 errors
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — 80/80 pass
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 78/78 pass
- [x] `dotnet build .github/shard-filters/architecture.slnf` + `dotnet test` — 209/209 pass
- [x] `dotnet format` clean across both src packages
- [x] `npx markdownlint-cli2` clean on the doc change
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles regenerated

## Out of scope (next stories)

- Cross-entity calendar (`GET /api/activities/calendar`) → A6 ([#1801](https://github.com/granit-fx/granit-dotnet/issues/1801))
- Notifications → A7 ([#1802](https://github.com/granit-fx/granit-dotnet/issues/1802))
- Background reminders / overdue scan → A8 ([#1803](https://github.com/granit-fx/granit-dotnet/issues/1803))
- Query/Export/Metric definitions → A9 ([#1804](https://github.com/granit-fx/granit-dotnet/issues/1804))
