### PR TITLE
feat(documents): upload-ticket + finalize flow with v1 DocumentVersion (F3.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18642,6 +18642,15 @@
       "members": []
     },
     {
+      "name": "DocumentVersion",
+      "fqn": "Granit.Documents.Domain.DocumentVersion",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/DocumentVersion.cs",
+      "line": 23,
+      "members": []
+    },
+    {
       "name": "Folder",
       "fqn": "Granit.Documents.Domain.Folder",
       "kind": "class",
@@ -18679,12 +18688,48 @@
       "members": []
     },
     {
+      "name": "DocumentResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.DocumentResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "FinalizeUploadRequest",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.FinalizeUploadRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/FinalizeUploadRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "UploadTicketRequest",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.UploadTicketRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketRequest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "UploadTicketResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.UploadTicketResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "DocumentsEndpointRouteBuilderExtensions",
       "fqn": "Granit.Documents.Endpoints.Extensions.DocumentsEndpointRouteBuilderExtensions",
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitDocuments",
@@ -18778,6 +18823,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "Documents",
+      "fqn": "Granit.Documents.Endpoints.Permissions.Documents",
+      "kind": "class",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
+      "line": 26,
+      "members": []
     },
     {
       "name": "DocumentsPermissions",
@@ -18909,6 +18963,15 @@
       "members": []
     },
     {
+      "name": "DocumentVersionAddedEvent",
+      "fqn": "Granit.Documents.Events.DocumentVersionAddedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentVersionAddedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "FolderCreatedEvent",
       "fqn": "Granit.Documents.Events.FolderCreatedEvent",
       "kind": "record",
@@ -19009,6 +19072,28 @@
           "kind": "method",
           "signature": "EnsureTenantRootAsync(Guid? tenantId, Guid ownerUserId, CancellationToken cancellationToken = default)",
           "returnType": "Task<Guid>"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentService",
+      "fqn": "Granit.Documents.IDocumentService",
+      "kind": "interface",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/IDocumentService.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "RequestUploadTicketAsync",
+          "kind": "method",
+          "signature": "RequestUploadTicketAsync(string fileName, string contentType, long maxAllowedBytes, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedUploadTicket>"
+        },
+        {
+          "name": "FinalizeUploadAsync",
+          "kind": "method",
+          "signature": "FinalizeUploadAsync(Guid blobId, Guid? folderId, Guid ownerUserId, string name, string? description = null, string? commitMessage = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document>"
         }
       ]
     },

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs
@@ -1,0 +1,20 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>Wire-shape representation of a document.</summary>
+/// <param name="Id">Unique identifier.</param>
+/// <param name="FolderId">Folder identifier the document currently lives in.</param>
+/// <param name="Name">User-facing display name.</param>
+/// <param name="Description">Optional free-text description.</param>
+/// <param name="OwnerUserId">Identifier of the user who owns the document.</param>
+/// <param name="CurrentVersionId">Identifier of the active <c>DocumentVersion</c>; <c>null</c> if none yet.</param>
+/// <param name="Status">Lifecycle status as a string (<c>Active</c> / <c>Trashed</c> / <c>PermanentlyDeleted</c>).</param>
+/// <param name="TrashedAt">UTC instant the document was trashed; <c>null</c> while active.</param>
+public sealed record DocumentResponse(
+    Guid Id,
+    Guid FolderId,
+    string Name,
+    string? Description,
+    Guid OwnerUserId,
+    Guid? CurrentVersionId,
+    string Status,
+    DateTimeOffset? TrashedAt);

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/FinalizeUploadRequest.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/FinalizeUploadRequest.cs
@@ -1,0 +1,16 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /documents/finalize</c>.
+/// </summary>
+/// <param name="BlobId">Identifier returned by <c>POST /documents/upload-ticket</c>.</param>
+/// <param name="FolderId">Target folder; <c>null</c> drops the document directly under the tenant root.</param>
+/// <param name="Name">User-facing document name.</param>
+/// <param name="Description">Optional free-text description.</param>
+/// <param name="CommitMessage">Optional changelog attached to the initial version.</param>
+public sealed record FinalizeUploadRequest(
+    Guid BlobId,
+    Guid? FolderId,
+    string Name,
+    string? Description,
+    string? CommitMessage);

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketRequest.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketRequest.cs
@@ -1,0 +1,9 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /documents/upload-ticket</c>.
+/// </summary>
+/// <param name="FileName">Original filename provided by the client (used for the blob's <c>OriginalFileName</c>).</param>
+/// <param name="ContentType">MIME type declared by the client. Re-verified post-upload via magic bytes.</param>
+/// <param name="MaxAllowedBytes">Maximum file size in bytes. Enforced post-upload by BlobStorage.</param>
+public sealed record UploadTicketRequest(string FileName, string ContentType, long MaxAllowedBytes);

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/UploadTicketResponse.cs
@@ -1,0 +1,16 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape response for <c>POST /documents/upload-ticket</c>.
+/// </summary>
+/// <param name="BlobId">Stable identifier the client passes back to <c>POST /documents/finalize</c>.</param>
+/// <param name="UploadUrl">Pre-signed PUT URL valid until <see cref="ExpiresAt"/>.</param>
+/// <param name="HttpMethod">HTTP method to use; always <c>"PUT"</c> for S3-compatible providers.</param>
+/// <param name="ExpiresAt">UTC expiry of the pre-signed URL.</param>
+/// <param name="RequiredHeaders">Headers the client must include verbatim in the PUT request (e.g. <c>Content-Type</c>).</param>
+public sealed record UploadTicketResponse(
+    Guid BlobId,
+    Uri UploadUrl,
+    string HttpMethod,
+    DateTimeOffset ExpiresAt,
+    IReadOnlyDictionary<string, string> RequiredHeaders);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -1,0 +1,123 @@
+using Granit.BlobStorage;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+using Granit.Documents.Endpoints.Documents.Mapping;
+using Granit.Documents.Endpoints.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Documents.Endpoints.Documents.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for the document upload flow (F3.2): presigned upload-ticket request
+/// and the post-upload finalise step that creates the Document + initial DocumentVersion.
+/// </summary>
+internal static class DocumentEndpoints
+{
+    private const string TagName = "Documents";
+
+    public static RouteGroupBuilder MapDocumentEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        RouteGroupBuilder documents = group.MapGroup("/documents").WithTags(TagName);
+
+        documents.MapPost("/upload-ticket", RequestUploadTicketAsync)
+            .WithName("RequestDocumentUploadTicket")
+            .WithSummary("Issues a presigned upload ticket for direct client-to-cloud transfer.")
+            .WithDescription(
+                "Issues a presigned PUT URL backed by Granit.BlobStorage. The client uploads the "
+                + "bytes directly to the configured cloud provider (no proxying through the API), "
+                + "then calls POST /documents/finalize with the returned blobId. Tickets expire "
+                + "after the BlobStorage-configured TTL (default 15 minutes).")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<UploadTicketResponse>()
+            .ProducesValidationProblem();
+
+        documents.MapPost("/finalize", FinalizeUploadAsync)
+            .WithName("FinalizeDocumentUpload")
+            .WithSummary("Confirms the upload and creates the Document + initial version.")
+            .WithDescription(
+                "Confirms with BlobStorage that the bytes have arrived and pass validation, "
+                + "then atomically creates the Document aggregate plus its initial v1 "
+                + "DocumentVersion under the requested folder (or the tenant root when "
+                + "folderId is omitted). Returns 422 when the blob fails validation, 404 when "
+                + "the target folder is missing.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<DocumentResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem();
+
+        return documents;
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Ok<UploadTicketResponse>> RequestUploadTicketAsync(
+        UploadTicketRequest request,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        PresignedUploadTicket ticket = await documents
+            .RequestUploadTicketAsync(request.FileName, request.ContentType, request.MaxAllowedBytes, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(ticket.ToResponse());
+    }
+
+    private static async Task<Results<Created<DocumentResponse>, ProblemHttpResult>> FinalizeUploadAsync(
+        FinalizeUploadRequest request,
+        [FromServices] IDocumentService documents,
+        [FromServices] IHttpContextAccessor accessor,
+        CancellationToken cancellationToken)
+    {
+        Guid ownerUserId = ResolveOwnerUserId(accessor.HttpContext);
+
+        try
+        {
+            Document document = await documents
+                .FinalizeUploadAsync(
+                    request.BlobId,
+                    request.FolderId,
+                    ownerUserId,
+                    request.Name,
+                    request.Description,
+                    request.CommitMessage,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Created($"/documents/{document.Id}", document.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Catches both validation failures (blob rejected) and missing-target-folder.
+            // Status code is the right granularity here: 422 fits both for v1; F7 will
+            // refine the quota path to 403.
+            return TypedResults.Problem(
+                ex.Message,
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static Guid ResolveOwnerUserId(HttpContext? httpContext)
+    {
+        if (httpContext is null)
+        {
+            return Guid.Empty;
+        }
+
+        // Mirrors FolderEndpoints.ResolveOwnerUserId — the User aggregate id (ADR-051) is
+        // exposed as ClaimTypes.NameIdentifier ("sub").
+        string? sub = httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out Guid id) ? id : Guid.Empty;
+    }
+}

--- a/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
@@ -1,0 +1,28 @@
+using Granit.BlobStorage;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+
+namespace Granit.Documents.Endpoints.Documents.Mapping;
+
+/// <summary>Maps the <see cref="Document"/> aggregate and BlobStorage tickets to wire-shape DTOs.</summary>
+internal static class DocumentMapper
+{
+    public static DocumentResponse ToResponse(this Document document) =>
+        new(
+            document.Id,
+            document.FolderId,
+            document.Name,
+            document.Description,
+            document.OwnerUserId,
+            document.CurrentVersionId,
+            document.Status.ToString(),
+            document.TrashedAt);
+
+    public static UploadTicketResponse ToResponse(this PresignedUploadTicket ticket) =>
+        new(
+            ticket.BlobId,
+            ticket.UploadUrl,
+            ticket.HttpMethod,
+            ticket.ExpiresAt,
+            ticket.RequiredHeaders);
+}

--- a/src/Granit.Documents.Endpoints/Documents/Validators/FinalizeUploadRequestValidator.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Validators/FinalizeUploadRequestValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+
+namespace Granit.Documents.Endpoints.Documents.Validators;
+
+/// <summary>
+/// Validator for <see cref="FinalizeUploadRequest"/>.
+/// </summary>
+internal sealed class FinalizeUploadRequestValidator : AbstractValidator<FinalizeUploadRequest>
+{
+    public FinalizeUploadRequestValidator()
+    {
+        RuleFor(x => x.BlobId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Document.MaxNameLength);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(Document.MaxDescriptionLength)
+            .When(x => x.Description is not null);
+
+        RuleFor(x => x.CommitMessage)
+            .MaximumLength(DocumentVersion.MaxCommitMessageLength)
+            .When(x => x.CommitMessage is not null);
+    }
+}

--- a/src/Granit.Documents.Endpoints/Documents/Validators/UploadTicketRequestValidator.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Validators/UploadTicketRequestValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using Granit.Documents.Endpoints.Documents.Dtos;
+
+namespace Granit.Documents.Endpoints.Documents.Validators;
+
+/// <summary>
+/// Validator for <see cref="UploadTicketRequest"/>.
+/// </summary>
+internal sealed class UploadTicketRequestValidator : AbstractValidator<UploadTicketRequest>
+{
+    /// <summary>Maximum upload ceiling enforced at the API edge — 10 GiB by default.</summary>
+    /// <remarks>
+    /// BlobStorage providers may enforce a tighter per-tenant ceiling; this is the absolute
+    /// maximum the API will issue tickets for.
+    /// </remarks>
+    public const long MaxAllowedBytesCeiling = 10L * 1024L * 1024L * 1024L;
+
+    public UploadTicketRequestValidator()
+    {
+        RuleFor(x => x.FileName)
+            .NotEmpty()
+            .MaximumLength(500);
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty()
+            .MaximumLength(127);
+
+        RuleFor(x => x.MaxAllowedBytes)
+            .GreaterThan(0)
+            .LessThanOrEqualTo(MaxAllowedBytesCeiling);
+    }
+}

--- a/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.Endpoints.Documents.Endpoints;
 using Granit.Documents.Endpoints.Folders.Endpoints;
 using Granit.Documents.Endpoints.Options;
 using Granit.Validation.AspNetCore;
@@ -38,6 +39,7 @@ public static class DocumentsEndpointRouteBuilderExtensions
         }
 
         group.MapFolderEndpoints();
+        group.MapDocumentEndpoints();
 
         return group;
     }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
@@ -1,6 +1,8 @@
 {
   "culture": "cs",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Nahrávat, přejmenovávat, přesouvat a odstraňovat dokumenty",
+    "Permission:Documents.Documents.Read": "Zobrazit a stáhnout dokumenty",
     "Permission:Documents.Folders.Manage": "Vytvářet, přejmenovávat, přesouvat a odstraňovat složky",
     "Permission:Documents.Folders.Read": "Zobrazit složky",
     "PermissionGroup:Documents": "Dokumenty"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
@@ -1,6 +1,8 @@
 {
   "culture": "de",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Dokumente hochladen, umbenennen, verschieben und in den Papierkorb legen",
+    "Permission:Documents.Documents.Read": "Dokumente anzeigen und herunterladen",
     "Permission:Documents.Folders.Manage": "Ordner erstellen, umbenennen, verschieben und in den Papierkorb legen",
     "Permission:Documents.Folders.Read": "Ordner anzeigen",
     "PermissionGroup:Documents": "Dokumente"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
@@ -1,6 +1,8 @@
 {
   "culture": "en",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Upload, rename, move, and trash documents",
+    "Permission:Documents.Documents.Read": "View and download documents",
     "Permission:Documents.Folders.Manage": "Create, rename, move, and trash folders",
     "Permission:Documents.Folders.Read": "View folders",
     "PermissionGroup:Documents": "Documents"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
@@ -1,6 +1,8 @@
 {
   "culture": "es",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Subir, renombrar, mover y enviar documentos a la papelera",
+    "Permission:Documents.Documents.Read": "Ver y descargar documentos",
     "Permission:Documents.Folders.Manage": "Crear, renombrar, mover y enviar carpetas a la papelera",
     "Permission:Documents.Folders.Read": "Ver carpetas",
     "PermissionGroup:Documents": "Documentos"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
@@ -1,6 +1,8 @@
 {
   "culture": "fr",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Téléverser, renommer, déplacer et corbeillir les documents",
+    "Permission:Documents.Documents.Read": "Consulter et télécharger les documents",
     "Permission:Documents.Folders.Manage": "Créer, renommer, déplacer et corbeillir des dossiers",
     "Permission:Documents.Folders.Read": "Consulter les dossiers",
     "PermissionGroup:Documents": "Documents"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
@@ -1,6 +1,8 @@
 {
   "culture": "hi",
   "texts": {
+    "Permission:Documents.Documents.Manage": "दस्तावेज़ अपलोड करें, नाम बदलें, स्थानांतरित करें और कूड़ेदान में डालें",
+    "Permission:Documents.Documents.Read": "दस्तावेज़ देखें और डाउनलोड करें",
     "Permission:Documents.Folders.Manage": "फ़ोल्डर बनाएँ, नाम बदलें, स्थानांतरित करें और कूड़ेदान में डालें",
     "Permission:Documents.Folders.Read": "फ़ोल्डर देखें",
     "PermissionGroup:Documents": "दस्तावेज़"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
@@ -1,6 +1,8 @@
 {
   "culture": "it",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Caricare, rinominare, spostare e cestinare documenti",
+    "Permission:Documents.Documents.Read": "Visualizzare e scaricare documenti",
     "Permission:Documents.Folders.Manage": "Creare, rinominare, spostare e cestinare cartelle",
     "Permission:Documents.Folders.Read": "Visualizzare le cartelle",
     "PermissionGroup:Documents": "Documenti"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
@@ -1,6 +1,8 @@
 {
   "culture": "ja",
   "texts": {
+    "Permission:Documents.Documents.Manage": "ドキュメントのアップロード、名前変更、移動、ゴミ箱への移動",
+    "Permission:Documents.Documents.Read": "ドキュメントの表示とダウンロード",
     "Permission:Documents.Folders.Manage": "フォルダーの作成、名前変更、移動、ゴミ箱への移動",
     "Permission:Documents.Folders.Read": "フォルダーを表示",
     "PermissionGroup:Documents": "ドキュメント"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
@@ -1,6 +1,8 @@
 {
   "culture": "ko",
   "texts": {
+    "Permission:Documents.Documents.Manage": "문서 업로드, 이름 바꾸기, 이동 및 휴지통으로 이동",
+    "Permission:Documents.Documents.Read": "문서 보기 및 다운로드",
     "Permission:Documents.Folders.Manage": "폴더 만들기, 이름 바꾸기, 이동 및 휴지통으로 이동",
     "Permission:Documents.Folders.Read": "폴더 보기",
     "PermissionGroup:Documents": "문서"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
@@ -1,6 +1,8 @@
 {
   "culture": "nl",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Documenten uploaden, hernoemen, verplaatsen en in de prullenbak gooien",
+    "Permission:Documents.Documents.Read": "Documenten bekijken en downloaden",
     "Permission:Documents.Folders.Manage": "Mappen aanmaken, hernoemen, verplaatsen en in de prullenbak gooien",
     "Permission:Documents.Folders.Read": "Mappen bekijken",
     "PermissionGroup:Documents": "Documenten"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
@@ -1,6 +1,8 @@
 {
   "culture": "pl",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Przesyłanie, zmiana nazwy, przenoszenie i przenoszenie do kosza dokumentów",
+    "Permission:Documents.Documents.Read": "Wyświetlanie i pobieranie dokumentów",
     "Permission:Documents.Folders.Manage": "Tworzenie, zmiana nazwy, przenoszenie i przenoszenie do kosza folderów",
     "Permission:Documents.Folders.Read": "Wyświetlanie folderów",
     "PermissionGroup:Documents": "Dokumenty"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt-BR.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Carregar, renomear, mover e enviar documentos para a lixeira",
     "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a lixeira"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
@@ -1,6 +1,8 @@
 {
   "culture": "pt",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Carregar, renomear, mover e enviar documentos para a reciclagem",
+    "Permission:Documents.Documents.Read": "Ver e transferir documentos",
     "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a reciclagem",
     "Permission:Documents.Folders.Read": "Ver pastas",
     "PermissionGroup:Documents": "Documentos"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
@@ -1,6 +1,8 @@
 {
   "culture": "sv",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Ladda upp, byta namn på, flytta och papperskorga dokument",
+    "Permission:Documents.Documents.Read": "Visa och ladda ner dokument",
     "Permission:Documents.Folders.Manage": "Skapa, byta namn på, flytta och papperskorga mappar",
     "Permission:Documents.Folders.Read": "Visa mappar",
     "PermissionGroup:Documents": "Dokument"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
@@ -1,6 +1,8 @@
 {
   "culture": "tr",
   "texts": {
+    "Permission:Documents.Documents.Manage": "Belgeleri yükleme, yeniden adlandırma, taşıma ve geri dönüşüm kutusuna gönderme",
+    "Permission:Documents.Documents.Read": "Belgeleri görüntüle ve indir",
     "Permission:Documents.Folders.Manage": "Klasörleri oluşturma, yeniden adlandırma, taşıma ve geri dönüşüm kutusuna gönderme",
     "Permission:Documents.Folders.Read": "Klasörleri görüntüle",
     "PermissionGroup:Documents": "Belgeler"

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
@@ -1,6 +1,8 @@
 {
   "culture": "zh",
   "texts": {
+    "Permission:Documents.Documents.Manage": "上传、重命名、移动和回收文档",
+    "Permission:Documents.Documents.Read": "查看和下载文档",
     "Permission:Documents.Folders.Manage": "创建、重命名、移动和回收文件夹",
     "Permission:Documents.Folders.Read": "查看文件夹",
     "PermissionGroup:Documents": "文档"

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
@@ -36,5 +36,17 @@ internal sealed class DocumentsPermissionDefinitionProvider : IPermissionDefinit
             LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
                 "Permission:Documents.Folders.Manage"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Documents.Read,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Documents.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Documents.Manage,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Documents.Manage"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
@@ -21,4 +21,14 @@ public static class DocumentsPermissions
         /// <summary>Manage folders (create, rename, move, trash, restore, permanent delete).</summary>
         public const string Manage = "Documents.Folders.Manage";
     }
+
+    /// <summary>Permissions on documents.</summary>
+    public static class Documents
+    {
+        /// <summary>Read documents (download, get metadata, list versions).</summary>
+        public const string Read = "Documents.Documents.Read";
+
+        /// <summary>Manage documents (upload, rename, move, trash, restore, permanent delete).</summary>
+        public const string Manage = "Documents.Documents.Manage";
+    }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -47,6 +47,11 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // Granit.Documents.Endpoints.
         builder.Services.AddScoped<IFolderService, FolderService>();
 
+        // Document service (F3.2): upload-ticket request + finalize flow that wraps
+        // BlobStorage's presigned upload pipeline and creates Document + initial
+        // DocumentVersion atomically.
+        builder.Services.AddScoped<IDocumentService, DocumentService>();
+
         return builder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
@@ -19,6 +19,7 @@ public static class DocumentsModelBuilderExtensions
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfiguration(new FolderConfiguration());
         modelBuilder.ApplyConfiguration(new DocumentConfiguration());
+        modelBuilder.ApplyConfiguration(new DocumentVersionConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -1,0 +1,144 @@
+using Granit.BlobStorage;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core / BlobStorage-backed implementation of <see cref="IDocumentService"/>.
+/// </summary>
+internal sealed class DocumentService(
+    IDbContextFactory<DocumentsDbContext> contextFactory,
+    IDocumentBootstrapService bootstrap,
+    IBlobStorage blobStorage,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IClock clock,
+    ILocalEventBus localEventBus,
+    DocumentsMetrics metrics) : IDocumentService
+{
+    /// <summary>
+    /// Container name used for every blob created by Granit.Documents. Hosts can layer
+    /// per-tenant prefixes via <c>IBlobKeyStrategy</c> in <c>BlobStorage</c>; the
+    /// container itself is constant.
+    /// </summary>
+    internal const string ContainerName = "documents";
+
+    /// <inheritdoc />
+    public async Task<PresignedUploadTicket> RequestUploadTicketAsync(
+        string fileName,
+        string contentType,
+        long maxAllowedBytes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+        if (maxAllowedBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxAllowedBytes), "Max allowed bytes must be strictly positive.");
+        }
+
+        BlobUploadRequest request = new(fileName, contentType, maxAllowedBytes);
+        return await blobStorage
+            .InitiateUploadAsync(ContainerName, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Document> FinalizeUploadAsync(
+        Guid blobId,
+        Guid? folderId,
+        Guid ownerUserId,
+        string name,
+        string? description = null,
+        string? commitMessage = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        // 1. Confirm the blob with BlobStorage — runs validators (size + magic-bytes), then
+        //    transitions Pending → Valid (or Rejected). Idempotent only across the
+        //    Pending → Uploading transition; subsequent calls on a Valid blob throw
+        //    BlobNotValidException with status Valid, which is the signal we want.
+        BlobConfirmationResult confirmation = await blobStorage
+            .ConfirmUploadAsync(ContainerName, blobId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!confirmation.IsValid)
+        {
+            metrics.RecordQuotaRejected(currentTenant.Id?.ToString());
+            throw new InvalidOperationException(
+                $"Blob {blobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+        }
+
+        long sizeBytes = confirmation.SizeBytes
+            ?? throw new InvalidOperationException(
+                $"Blob {blobId} validated successfully but BlobStorage returned no size.");
+        string contentType = confirmation.VerifiedContentType
+            ?? throw new InvalidOperationException(
+                $"Blob {blobId} validated successfully but BlobStorage returned no content type.");
+
+        // 2. Open a fresh DocumentsDbContext and resolve the target folder, defaulting to
+        //    the tenant root via the bootstrap service.
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid effectiveFolderId = folderId ?? await bootstrap
+            .EnsureTenantRootAsync(currentTenant.Id, ownerUserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? folder = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == effectiveFolderId, cancellationToken)
+            .ConfigureAwait(false);
+        if (folder is null)
+        {
+            throw new InvalidOperationException(
+                $"Target folder {effectiveFolderId} was not found under the current tenant scope.");
+        }
+
+        // 3. Create the Document aggregate + initial v1 DocumentVersion atomically.
+        var document = Document.Create(
+            guidGenerator.Create(), folder, ownerUserId, name, description);
+
+        var version = DocumentVersion.Create(
+            guidGenerator.Create(),
+            document,
+            versionNumber: 1,
+            blobDescriptorId: blobId,
+            sizeBytes: sizeBytes,
+            contentType: contentType,
+            contentHash: null,
+            uploadedByUserId: ownerUserId,
+            uploadedAt: clock.Now,
+            commitMessage: commitMessage);
+
+        document.SetCurrentVersion(version.Id);
+
+        context.Documents.Add(document);
+        context.DocumentVersions.Add(version);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 4. Emit the version-added event on the local bus (DocumentVersion is an entity,
+        //    not an aggregate root — service-level emission is the canonical pattern).
+        await localEventBus.PublishAsync(
+            new DocumentVersionAddedEvent(
+                document.Id,
+                document.TenantId,
+                version.Id,
+                version.VersionNumber,
+                version.BlobDescriptorId,
+                version.SizeBytes,
+                version.UploadedByUserId),
+            cancellationToken).ConfigureAwait(false);
+
+        metrics.RecordUpload(currentTenant.Id?.ToString());
+        return document;
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentVersionConfiguration.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentVersionConfiguration.cs
@@ -1,0 +1,65 @@
+using Granit.Documents.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="DocumentVersion"/>.
+/// Table: <c>documents_document_versions</c>.
+/// </summary>
+internal sealed class DocumentVersionConfiguration : IEntityTypeConfiguration<DocumentVersion>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<DocumentVersion> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitDocumentsDbProperties.DbTablePrefix + "document_versions",
+            GranitDocumentsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+
+        builder.Property(e => e.DocumentId)
+            .IsRequired();
+
+        builder.Property(e => e.VersionNumber)
+            .IsRequired();
+
+        builder.Property(e => e.BlobDescriptorId)
+            .IsRequired();
+
+        builder.Property(e => e.SizeBytes)
+            .IsRequired();
+
+        builder.Property(e => e.ContentType)
+            .HasMaxLength(127)
+            .IsRequired();
+
+        builder.Property(e => e.ContentHash)
+            .HasMaxLength(128);
+
+        builder.Property(e => e.UploadedByUserId)
+            .IsRequired();
+
+        builder.Property(e => e.UploadedAt)
+            .IsRequired();
+
+        builder.Property(e => e.CommitMessage)
+            .HasMaxLength(DocumentVersion.MaxCommitMessageLength);
+
+        // Monotonic-versioning invariant: at most one row per (DocumentId, VersionNumber)
+        // tuple. F4.1's "VersionNumber = max + 1" computation relies on this so
+        // concurrent re-uploads produce two distinct numbers, not the same number twice.
+        builder.HasIndex(e => new { e.DocumentId, e.VersionNumber })
+            .IsUnique()
+            .HasDatabaseName($"ux_{GranitDocumentsDbProperties.DbTablePrefix}document_versions_doc_number");
+
+        // Listing all versions of a document is the primary read path (F4.2).
+        builder.HasIndex(e => new { e.DocumentId, e.UploadedAt })
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}document_versions_doc_uploaded");
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
@@ -32,6 +32,9 @@ internal sealed class DocumentsDbContext(
     /// <summary>Tenant-scoped documents — every row points at a folder via <see cref="Document.FolderId"/>.</summary>
     public DbSet<Document> Documents { get; set; } = null!;
 
+    /// <summary>Append-only version history. The current pointer lives on <see cref="Document.CurrentVersionId"/>.</summary>
+    public DbSet<DocumentVersion> DocumentVersions { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Documents/Domain/DocumentVersion.cs
+++ b/src/Granit.Documents/Domain/DocumentVersion.cs
@@ -1,0 +1,122 @@
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Immutable version of a <see cref="Document"/>'s content. One row per upload (or per
+/// restore-from-history operation in F4.3); the bytes themselves live in
+/// <c>Granit.BlobStorage</c> under <see cref="BlobDescriptorId"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Versions are append-only. The <see cref="Document.CurrentVersionId"/> pointer moves
+/// to the newest version on each finalised upload (F3.2) or to a re-promoted older one
+/// on restore (F4.3) — the historical rows are never mutated.
+/// </para>
+/// <para>
+/// <see cref="VersionNumber"/> is monotonic per document, starting at <c>1</c>. F4.1
+/// computes <c>VersionNumber = max + 1</c> when finalising re-uploads; F3.2 always
+/// creates a v1 row when the parent document is brand-new.
+/// </para>
+/// </remarks>
+public sealed class DocumentVersion : Entity, IMultiTenant
+{
+    /// <summary>Maximum length, in characters, of an optional <see cref="CommitMessage"/>.</summary>
+    public const int MaxCommitMessageLength = 1000;
+
+    /// <summary>Parameterless constructor required by the EF Core materialiser.</summary>
+    private DocumentVersion() { }
+
+    /// <summary>
+    /// Creates a new version row. Internal: the only legitimate caller is
+    /// <c>FolderService</c> / <c>DocumentService</c> from <c>Granit.Documents.EntityFrameworkCore</c>;
+    /// HTTP and other consumers go through <see cref="Document"/>.
+    /// </summary>
+    internal static DocumentVersion Create(
+        Guid id,
+        Document document,
+        int versionNumber,
+        Guid blobDescriptorId,
+        long sizeBytes,
+        string contentType,
+        string? contentHash,
+        Guid uploadedByUserId,
+        DateTimeOffset uploadedAt,
+        string? commitMessage = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (versionNumber < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(versionNumber), "Version number must be 1 or greater.");
+        }
+        if (blobDescriptorId == Guid.Empty)
+        {
+            throw new ArgumentException("Blob descriptor id cannot be empty.", nameof(blobDescriptorId));
+        }
+        if (sizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sizeBytes), "Size must be non-negative.");
+        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+        if (commitMessage is { Length: > MaxCommitMessageLength })
+        {
+            throw new ArgumentException(
+                $"Commit message exceeds {MaxCommitMessageLength} characters.",
+                nameof(commitMessage));
+        }
+
+        return new DocumentVersion
+        {
+            Id = id,
+            TenantId = document.TenantId,
+            DocumentId = document.Id,
+            VersionNumber = versionNumber,
+            BlobDescriptorId = blobDescriptorId,
+            SizeBytes = sizeBytes,
+            ContentType = contentType,
+            ContentHash = contentHash,
+            UploadedByUserId = uploadedByUserId,
+            UploadedAt = uploadedAt,
+            CommitMessage = commitMessage,
+        };
+    }
+
+    /// <summary>Identifier of the tenant this version belongs to (mirrors the parent <see cref="Document.TenantId"/>).</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>Explicit interface implementation — see <see cref="Document"/> for rationale.</remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Parent document identifier.</summary>
+    public Guid DocumentId { get; private set; }
+
+    /// <summary>Monotonic version number within the parent document; starts at 1.</summary>
+    public int VersionNumber { get; private set; }
+
+    /// <summary>FK to <c>Granit.BlobStorage</c> — the actual content lives there.</summary>
+    public Guid BlobDescriptorId { get; private set; }
+
+    /// <summary>Verified size in bytes (from <c>BlobStorage</c>'s post-upload validation).</summary>
+    public long SizeBytes { get; private set; }
+
+    /// <summary>Verified content type (from <c>BlobStorage</c>'s magic-bytes check).</summary>
+    public string ContentType { get; private set; } = string.Empty;
+
+    /// <summary>Optional content hash for tamper detection / dedup awareness.</summary>
+    public string? ContentHash { get; private set; }
+
+    /// <summary>User who finalised this version.</summary>
+    public Guid UploadedByUserId { get; private set; }
+
+    /// <summary>UTC instant the version was finalised.</summary>
+    public DateTimeOffset UploadedAt { get; private set; }
+
+    /// <summary>Optional free-text changelog supplied by the uploader.</summary>
+    public string? CommitMessage { get; private set; }
+}

--- a/src/Granit.Documents/Events/DocumentVersionAddedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentVersionAddedEvent.cs
@@ -1,0 +1,17 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a new <c>DocumentVersion</c> is finalised and appended to the parent
+/// document's history. Emitted both for the initial v1 (F3.2 finalize flow) and for
+/// every subsequent re-upload (F4.1).
+/// </summary>
+public sealed record DocumentVersionAddedEvent(
+    Guid DocumentId,
+    Guid? TenantId,
+    Guid VersionId,
+    int VersionNumber,
+    Guid BlobDescriptorId,
+    long SizeBytes,
+    Guid UploadedByUserId) : IDomainEvent;

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -1,0 +1,49 @@
+using Granit.BlobStorage;
+using Granit.Documents.Domain;
+
+namespace Granit.Documents;
+
+/// <summary>
+/// Domain orchestration contract for document upload + read operations. The HTTP layer
+/// (<c>Granit.Documents.Endpoints</c>) consumes this interface; the EF Core / BlobStorage
+/// implementation lives in <c>Granit.Documents.EntityFrameworkCore</c>.
+/// </summary>
+public interface IDocumentService
+{
+    /// <summary>
+    /// Requests a presigned upload ticket from <c>Granit.BlobStorage</c>. The client uses
+    /// the returned <see cref="PresignedUploadTicket.UploadUrl"/> to PUT bytes directly to
+    /// the configured cloud provider, then calls <see cref="FinalizeUploadAsync"/> with
+    /// the resulting <see cref="PresignedUploadTicket.BlobId"/>.
+    /// </summary>
+    Task<PresignedUploadTicket> RequestUploadTicketAsync(
+        string fileName,
+        string contentType,
+        long maxAllowedBytes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Confirms the upload with <c>BlobStorage</c> (runs validators, transitions the blob
+    /// to <c>Valid</c> if it passes), then atomically creates the <see cref="Document"/>
+    /// aggregate and its initial <c>DocumentVersion</c> (<c>VersionNumber = 1</c>).
+    /// </summary>
+    /// <param name="blobId">Identifier returned by <see cref="RequestUploadTicketAsync"/>.</param>
+    /// <param name="folderId">Target folder; <c>null</c> drops the document directly under the tenant root.</param>
+    /// <param name="ownerUserId">Identifier of the user who owns the document (typically the caller).</param>
+    /// <param name="name">User-facing document name.</param>
+    /// <param name="description">Optional free-text description.</param>
+    /// <param name="commitMessage">Optional changelog attached to the initial version.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The created <see cref="Document"/> on success. Throws when the blob is missing,
+    /// the folder is missing or trashed, or the blob fails validation.
+    /// </returns>
+    Task<Document> FinalizeUploadAsync(
+        Guid blobId,
+        Guid? folderId,
+        Guid ownerUserId,
+        string name,
+        string? description = null,
+        string? commitMessage = null,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/FinalizeUploadRequestValidatorTests.cs
+++ b/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/FinalizeUploadRequestValidatorTests.cs
@@ -1,0 +1,91 @@
+using FluentValidation.Results;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+using Granit.Documents.Endpoints.Documents.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Endpoints.Tests.Documents.Validators;
+
+public sealed class FinalizeUploadRequestValidatorTests
+{
+    private readonly FinalizeUploadRequestValidator _validator = new();
+
+    [Fact]
+    public async Task ValidRequest_PassesValidation()
+    {
+        var request = new FinalizeUploadRequest(
+            BlobId: Guid.NewGuid(),
+            FolderId: null,
+            Name: "Q1-2026.pdf",
+            Description: "Quarter 1 close",
+            CommitMessage: "Initial upload");
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task EmptyBlobId_Fails()
+    {
+        var request = new FinalizeUploadRequest(Guid.Empty, null, "F.pdf", null, null);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task EmptyName_Fails(string name)
+    {
+        var request = new FinalizeUploadRequest(Guid.NewGuid(), null, name, null, null);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task NameTooLong_Fails()
+    {
+        var request = new FinalizeUploadRequest(
+            Guid.NewGuid(), null, new string('a', Document.MaxNameLength + 1), null, null);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DescriptionTooLong_Fails()
+    {
+        var request = new FinalizeUploadRequest(
+            Guid.NewGuid(),
+            null,
+            "F.pdf",
+            new string('d', Document.MaxDescriptionLength + 1),
+            null);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CommitMessageTooLong_Fails()
+    {
+        var request = new FinalizeUploadRequest(
+            Guid.NewGuid(),
+            null,
+            "F.pdf",
+            null,
+            new string('m', DocumentVersion.MaxCommitMessageLength + 1));
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/UploadTicketRequestValidatorTests.cs
+++ b/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/UploadTicketRequestValidatorTests.cs
@@ -1,0 +1,71 @@
+using FluentValidation.Results;
+using Granit.Documents.Endpoints.Documents.Dtos;
+using Granit.Documents.Endpoints.Documents.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Endpoints.Tests.Documents.Validators;
+
+public sealed class UploadTicketRequestValidatorTests
+{
+    private readonly UploadTicketRequestValidator _validator = new();
+
+    [Fact]
+    public async Task ValidRequest_PassesValidation()
+    {
+        var request = new UploadTicketRequest("contract.pdf", "application/pdf", 1024 * 1024);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task EmptyFileName_Fails(string fileName)
+    {
+        var request = new UploadTicketRequest(fileName, "application/pdf", 1024);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task EmptyContentType_Fails(string contentType)
+    {
+        var request = new UploadTicketRequest("a.pdf", contentType, 1024);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task NonPositiveMaxAllowedBytes_Fails(long maxBytes)
+    {
+        var request = new UploadTicketRequest("a.pdf", "application/pdf", maxBytes);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task MaxAllowedBytes_AboveCeiling_Fails()
+    {
+        var request = new UploadTicketRequest(
+            "a.pdf",
+            "application/pdf",
+            UploadTicketRequestValidator.MaxAllowedBytesCeiling + 1);
+
+        ValidationResult result = await _validator.ValidateAsync(request, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -1,0 +1,242 @@
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.Documents;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Events;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed integration tests for <see cref="DocumentService"/>. Exercises the
+/// upload-finalise flow by mocking <see cref="IBlobStorage"/> and asserting the
+/// persisted Document + initial v1 DocumentVersion + emitted events.
+/// </summary>
+public sealed class DocumentServiceSqliteTests : IAsyncLifetime
+{
+    private SqliteConnection _holdOpen = null!;
+    private TestDbContextFactory _factory = null!;
+    private DocumentBootstrapService _bootstrap = null!;
+    private IBlobStorage _blobStorage = null!;
+    private CapturingLocalEventBus _localEventBus = null!;
+    private DocumentService _sut = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public async ValueTask InitializeAsync()
+    {
+        string connectionString =
+            $"DataSource=file:f32-doc-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(connectionString);
+        await _holdOpen.OpenAsync();
+
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestDbContextFactory(options);
+        _bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        _blobStorage = Substitute.For<IBlobStorage>();
+        _localEventBus = new CapturingLocalEventBus();
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        _sut = new DocumentService(
+            _factory,
+            _bootstrap,
+            _blobStorage,
+            currentTenant,
+            new SimpleGuidGenerator(),
+            clock,
+            _localEventBus,
+            metrics);
+    }
+
+    public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
+
+    [Fact]
+    public async Task RequestUploadTicketAsync_DelegatesToBlobStorage()
+    {
+        var ticket = new PresignedUploadTicket(
+            BlobId: Guid.NewGuid(),
+            UploadUrl: new Uri("https://storage.test/blob/12345"),
+            HttpMethod: "PUT",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(15),
+            RequiredHeaders: new Dictionary<string, string> { ["Content-Type"] = "application/pdf" });
+        _blobStorage.InitiateUploadAsync(
+            DocumentService.ContainerName, Arg.Any<BlobUploadRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ticket);
+
+        PresignedUploadTicket result = await _sut.RequestUploadTicketAsync(
+            "contract.pdf", "application/pdf", 1_000_000, TestContext.Current.CancellationToken);
+
+        result.ShouldBeSameAs(ticket);
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_HappyPath_CreatesDocumentAndInitialVersion()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true,
+                Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf",
+                SizeBytes: 1_234_567,
+                RejectionReason: null));
+
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, folderId: null, OwnerId, "Q1-2026.pdf", "Quarter 1 close", "Initial",
+            TestContext.Current.CancellationToken);
+
+        doc.TenantId.ShouldBe(TenantId);
+        doc.Name.ShouldBe("Q1-2026.pdf");
+        doc.OwnerUserId.ShouldBe(OwnerId);
+        doc.Status.ShouldBe(DocumentStatus.Active);
+        doc.CurrentVersionId.ShouldNotBeNull();
+
+        // Verify the version row was inserted with VersionNumber = 1 and the verified
+        // BlobStorage metadata.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        DocumentVersion version = await db.DocumentVersions
+            .SingleAsync(v => v.DocumentId == doc.Id, TestContext.Current.CancellationToken);
+        version.VersionNumber.ShouldBe(1);
+        version.BlobDescriptorId.ShouldBe(blobId);
+        version.SizeBytes.ShouldBe(1_234_567);
+        version.ContentType.ShouldBe("application/pdf");
+        version.CommitMessage.ShouldBe("Initial");
+        version.Id.ShouldBe(doc.CurrentVersionId!.Value);
+
+        // DocumentVersionAddedEvent emitted on the local bus.
+        DocumentVersionAddedEvent ev = _localEventBus.Captured
+            .OfType<DocumentVersionAddedEvent>().ShouldHaveSingleItem();
+        ev.DocumentId.ShouldBe(doc.Id);
+        ev.VersionNumber.ShouldBe(1);
+        ev.BlobDescriptorId.ShouldBe(blobId);
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_BlobInvalid_Throws()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: false,
+                Status: BlobStatus.Rejected,
+                VerifiedContentType: null,
+                SizeBytes: null,
+                RejectionReason: "Magic-bytes mismatch"));
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await _sut.FinalizeUploadAsync(
+                blobId, null, OwnerId, "F.pdf", null, null, TestContext.Current.CancellationToken));
+
+        // No document row was created.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        (await db.Documents.AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_MissingFolder_Throws()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf", SizeBytes: 100, RejectionReason: null));
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await _sut.FinalizeUploadAsync(
+                blobId, folderId: Guid.NewGuid(), OwnerId, "F.pdf", null, null,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_TargetSpecificFolder_CreatesUnderIt()
+    {
+        // Create a folder via the bootstrap + folder service path.
+        Guid rootId = await _bootstrap.EnsureTenantRootAsync(TenantId, OwnerId,
+            TestContext.Current.CancellationToken);
+
+        await using (DocumentsDbContext seed = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            Folder root = await seed.Folders.SingleAsync(f => f.Id == rootId,
+                TestContext.Current.CancellationToken);
+            seed.Folders.Add(Folder.Create(Guid.NewGuid(), root, "Contracts", OwnerId));
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        Folder contracts;
+        await using (DocumentsDbContext q = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            contracts = await q.Folders.SingleAsync(f => f.Name == "Contracts",
+                TestContext.Current.CancellationToken);
+        }
+
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "text/plain", SizeBytes: 42, RejectionReason: null));
+
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, contracts.Id, OwnerId, "Note.txt", null, null,
+            TestContext.Current.CancellationToken);
+
+        doc.FolderId.ShouldBe(contracts.Id);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private sealed class CapturingLocalEventBus : ILocalEventBus
+    {
+        public List<object> Captured { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            Captured.Add(localEvent);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires the full document upload flow per [ADR-052](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md): presigned PUT URL via `Granit.BlobStorage`, post-upload validation, then atomic creation of the `Document` aggregate plus its initial v1 `DocumentVersion`.

## Endpoints

| Method | Route | Description |
| --- | --- | --- |
| `POST` | `/documents/upload-ticket` | Issues a presigned PUT URL backed by `BlobStorage`. Client uploads bytes directly to the cloud provider. |
| `POST` | `/documents/finalize` | Confirms the upload and atomically creates Document + initial v1 DocumentVersion under the requested folder (or tenant root). |

Both gated on `Documents.Documents.Manage`. 422 on validation failure / missing folder.

## Domain + persistence

- **`DocumentVersion`** entity — append-only history row carrying per-upload metadata (`VersionNumber`, `BlobDescriptorId`, `SizeBytes`, `ContentType`, `UploadedByUserId`, `UploadedAt`, optional `ContentHash` + `CommitMessage`). Internal factory; only the EF service constructs one.
- **Monotonic-versioning invariant** enforced at the DB level via `ux_documents_document_versions_doc_number` (`UNIQUE (DocumentId, VersionNumber)`) — concurrent re-uploads in F4.1 produce two distinct numbers, never the same number twice.
- **`DocumentVersionAddedEvent`** emitted on the local bus on every finalised version (initial v1 here, v2+ in F4.1).

## Service flow

1. `RequestUploadTicketAsync(fileName, contentType, maxBytes)` → wraps `IBlobStorage.InitiateUploadAsync` with the constant container `"documents"`.
2. `FinalizeUploadAsync(blobId, folderId?, ownerId, name, description?, commitMessage?)`:
   - Calls `IBlobStorage.ConfirmUploadAsync` to run validators (size + magic-bytes); throws on `IsValid: false`.
   - Resolves target folder (defaults to tenant root via `IDocumentBootstrapService` when `folderId` is null).
   - In a single `SaveChanges`: creates `Document`, creates v1 `DocumentVersion` with the verified BlobStorage metadata, calls `Document.SetCurrentVersion(version.Id)`, persists both rows.
   - Publishes `DocumentVersionAddedEvent` on `ILocalEventBus` after commit.

## Permissions

- `Documents.Documents.Read` (consumed by F3.3 download endpoint).
- `Documents.Documents.Manage` (the gate on both new endpoints).

Localised across **16 culture JSONs** (15 base + pt-BR override) — `PermissionLocalizationCompletenessTests` now covers 4 permissions × 15 cultures = 60 keys.

## Tests

- **Endpoints validators** (`Granit.Documents.Endpoints.Tests`): +13 → **28/28** total. Cover empty / too-long / non-positive-bytes / above-ceiling / missing-blobId paths.
- **Service SQLite** (`Granit.Documents.EntityFrameworkCore.Tests`): +5 → **28/28** total. NSubstitute-backed `IBlobStorage`. Cover ticket delegation, happy-path Document + v1 + event, blob-invalid rejection (no row inserted), missing-folder rejection, target-specific-folder placement.
- **ArchitectureTests**: 209/209.
- `dotnet format` clean.

## Deferred

- Permission check via the ACL resolver (depends on F6 — falls back to coarse permission claim for now).
- Quota check on upload (F7.2 — wire dependency, surface as 403).
- Showcase wiring (F13).

## Tracking

- Story: #1733 (F3.2 — Upload flow)
- Feature: #1731 (F3 — Document aggregate + upload / download flow)
- Epic: #1721