### PR TITLE
feat(documents): download endpoint with presigned URL + audit event (F3.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18698,6 +18698,15 @@
       "members": []
     },
     {
+      "name": "DownloadUrlResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.DownloadUrlResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/DownloadUrlResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "FinalizeUploadRequest",
       "fqn": "Granit.Documents.Endpoints.Documents.Dtos.FinalizeUploadRequest",
       "kind": "record",
@@ -18928,6 +18937,15 @@
       "members": []
     },
     {
+      "name": "DocumentDownloadedEvent",
+      "fqn": "Granit.Documents.Events.DocumentDownloadedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentDownloadedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "DocumentMovedEvent",
       "fqn": "Granit.Documents.Events.DocumentMovedEvent",
       "kind": "record",
@@ -19095,6 +19113,12 @@
           "kind": "method",
           "signature": "FinalizeUploadAsync(Guid blobId, Guid? folderId, Guid ownerUserId, string name, string? description = null, string? commitMessage = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<Document>"
+        },
+        {
+          "name": "RequestDownloadUrlAsync",
+          "kind": "method",
+          "signature": "RequestDownloadUrlAsync(Guid documentId, Guid? versionId, Guid requestedByUserId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedDownloadUrl?>"
         }
       ]
     },

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/DownloadUrlResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/DownloadUrlResponse.cs
@@ -1,0 +1,14 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape response for <c>GET /documents/{id}/download</c>.
+/// </summary>
+/// <param name="Url">Presigned download URL the client navigates to (or fetches).</param>
+/// <param name="ExpiresAt">UTC instant the URL expires.</param>
+/// <remarks>
+/// JSON over redirect: returning <c>{ url, expiresAt }</c> keeps the response
+/// SPA-friendly (the client can decide between <c>window.location</c>, an
+/// <c>&lt;a download&gt;</c>, or a fetch + Blob); a 302 redirect would constrain the
+/// client to the browser-native download UX.
+/// </remarks>
+public sealed record DownloadUrlResponse(Uri Url, DateTimeOffset ExpiresAt);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -55,6 +55,23 @@ internal static class DocumentEndpoints
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
 
+        documents.MapGet("/{id:guid}/download", DownloadAsync)
+            .WithName("RequestDocumentDownloadUrl")
+            .WithSummary("Issues a presigned download URL for a document version.")
+            .WithDescription(
+                "Returns a JSON response carrying a short-lived presigned URL the client can "
+                + "use to download the bytes directly from the configured cloud provider. "
+                + "Defaults to the document's CurrentVersionId; pass `?versionId={guid}` to "
+                + "download a specific historical version. Emits a DocumentDownloadedEvent for "
+                + "the ISO 27001 audit trail and increments granit.documents.download.count. "
+                + "Returns 404 when the document or version is not found, 409 when the document "
+                + "is trashed or has no current version yet.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Read))
+            .Produces<DownloadUrlResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
         return documents;
     }
 
@@ -105,6 +122,37 @@ internal static class DocumentEndpoints
             return TypedResults.Problem(
                 ex.Message,
                 statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static async Task<Results<Ok<DownloadUrlResponse>, ProblemHttpResult>> DownloadAsync(
+        Guid id,
+        [FromQuery] Guid? versionId,
+        [FromServices] IDocumentService documents,
+        [FromServices] IHttpContextAccessor accessor,
+        CancellationToken cancellationToken)
+    {
+        Guid requestedByUserId = ResolveOwnerUserId(accessor.HttpContext);
+
+        try
+        {
+            BlobStorage.PresignedDownloadUrl? url = await documents
+                .RequestDownloadUrlAsync(id, versionId, requestedByUserId, cancellationToken)
+                .ConfigureAwait(false);
+            if (url is null)
+            {
+                return TypedResults.Problem(
+                    versionId is null
+                        ? $"Document '{id}' was not found."
+                        : $"Document '{id}' or version '{versionId}' was not found.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(url.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Trashed / permanently-deleted document or no current version yet.
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }
 

--- a/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
@@ -25,4 +25,7 @@ internal static class DocumentMapper
             ticket.HttpMethod,
             ticket.ExpiresAt,
             ticket.RequiredHeaders);
+
+    public static DownloadUrlResponse ToResponse(this PresignedDownloadUrl url) =>
+        new(url.Url, url.ExpiresAt);
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -141,4 +141,64 @@ internal sealed class DocumentService(
         metrics.RecordUpload(currentTenant.Id?.ToString());
         return document;
     }
+
+    /// <inheritdoc />
+    public async Task<PresignedDownloadUrl?> RequestDownloadUrlAsync(
+        Guid documentId,
+        Guid? versionId,
+        Guid requestedByUserId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == documentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+        if (document.Status != DocumentStatus.Active)
+        {
+            throw new InvalidOperationException(
+                $"Document {documentId} is not active (status: {document.Status}).");
+        }
+
+        // Resolve target version: explicit override or the current pointer.
+        Guid targetVersionId = versionId ?? document.CurrentVersionId
+            ?? throw new InvalidOperationException(
+                $"Document {documentId} has no current version yet — finalize an upload first.");
+
+        DocumentVersion? version = await context.DocumentVersions
+            .FirstOrDefaultAsync(
+                v => v.Id == targetVersionId && v.DocumentId == document.Id,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (version is null)
+        {
+            return null;
+        }
+
+        // Issue the presigned URL via BlobStorage.
+        PresignedDownloadUrl url = await blobStorage
+            .CreateDownloadUrlAsync(ContainerName, version.BlobDescriptorId, options: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Audit + metrics. The DocumentDownloadedEvent flows through Granit.Auditing for
+        // the ISO 27001 A.12.4.1 trail.
+        await localEventBus.PublishAsync(
+            new DocumentDownloadedEvent(
+                document.Id,
+                version.Id,
+                document.TenantId,
+                requestedByUserId,
+                clock.Now,
+                url.ExpiresAt),
+            cancellationToken).ConfigureAwait(false);
+
+        metrics.RecordDownload(currentTenant.Id?.ToString());
+        return url;
+    }
 }

--- a/src/Granit.Documents/Events/DocumentDownloadedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentDownloadedEvent.cs
@@ -1,0 +1,21 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised every time a download URL is issued for a document version. Consumed by
+/// <c>Granit.Auditing</c> for the ISO 27001 A.12.4.1 "who downloaded what when" trail.
+/// </summary>
+/// <param name="DocumentId">Document the download targets.</param>
+/// <param name="VersionId">Version the download targets — current at time of request, or the explicitly-requested historical version.</param>
+/// <param name="TenantId">Tenant scope.</param>
+/// <param name="RequestedByUserId">User who requested the download.</param>
+/// <param name="RequestedAt">UTC instant the URL was issued.</param>
+/// <param name="UrlExpiresAt">UTC instant the issued URL expires (mirrors the BlobStorage TTL).</param>
+public sealed record DocumentDownloadedEvent(
+    Guid DocumentId,
+    Guid VersionId,
+    Guid? TenantId,
+    Guid RequestedByUserId,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset UrlExpiresAt) : IDomainEvent;

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -46,4 +46,24 @@ public interface IDocumentService
         string? description = null,
         string? commitMessage = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issues a presigned download URL for a document. Defaults to the document's
+    /// <see cref="Document.CurrentVersionId"/>; an explicit <paramref name="versionId"/>
+    /// fetches a specific historical version (F4.2 list endpoint surfaces them).
+    /// </summary>
+    /// <param name="documentId">Document to download.</param>
+    /// <param name="versionId">Optional specific version. <c>null</c> resolves to <see cref="Document.CurrentVersionId"/>.</param>
+    /// <param name="requestedByUserId">User issuing the request (recorded in the <c>DocumentDownloadedEvent</c> for audit).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The presigned download URL on success, or <c>null</c> when the document or version
+    /// is not found or excluded by the tenant filter. Throws on trashed / permanently-
+    /// deleted documents.
+    /// </returns>
+    Task<PresignedDownloadUrl?> RequestDownloadUrlAsync(
+        Guid documentId,
+        Guid? versionId,
+        Guid requestedByUserId,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -214,6 +214,126 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         doc.FolderId.ShouldBe(contracts.Id);
     }
 
+    // -------------------------------------------------------------------------
+    // F3.3 — RequestDownloadUrlAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RequestDownloadUrlAsync_HappyPath_ReturnsUrlAndEmitsAuditEvent()
+    {
+        // Seed a document via the upload flow.
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf", SizeBytes: 100, RejectionReason: null));
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, null, OwnerId, "F.pdf", null, null, TestContext.Current.CancellationToken);
+
+        // Stub the download URL.
+        DateTimeOffset expires = DateTimeOffset.UtcNow.AddMinutes(15);
+        var presigned = new PresignedDownloadUrl(new Uri("https://storage.test/dl/abc"), expires);
+        _blobStorage
+            .CreateDownloadUrlAsync(DocumentService.ContainerName, blobId, options: null, Arg.Any<CancellationToken>())
+            .Returns(presigned);
+
+        _localEventBus.Captured.Clear();
+        var requester = Guid.NewGuid();
+
+        PresignedDownloadUrl? url = await _sut.RequestDownloadUrlAsync(
+            doc.Id, versionId: null, requester, TestContext.Current.CancellationToken);
+
+        url.ShouldNotBeNull();
+        url.Url.ShouldBe(presigned.Url);
+        url.ExpiresAt.ShouldBe(expires);
+
+        DocumentDownloadedEvent ev = _localEventBus.Captured
+            .OfType<DocumentDownloadedEvent>().ShouldHaveSingleItem();
+        ev.DocumentId.ShouldBe(doc.Id);
+        ev.RequestedByUserId.ShouldBe(requester);
+        ev.UrlExpiresAt.ShouldBe(expires);
+        ev.VersionId.ShouldBe(doc.CurrentVersionId!.Value);
+    }
+
+    [Fact]
+    public async Task RequestDownloadUrlAsync_UnknownDocument_ReturnsNull()
+    {
+        PresignedDownloadUrl? url = await _sut.RequestDownloadUrlAsync(
+            Guid.NewGuid(), versionId: null, requestedByUserId: Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        url.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RequestDownloadUrlAsync_TrashedDocument_Throws()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf", SizeBytes: 100, RejectionReason: null));
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, null, OwnerId, "F.pdf", null, null, TestContext.Current.CancellationToken);
+
+        // Trash the document directly via the aggregate + DbContext.
+        await using (DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            Document tracked = await db.Documents.SingleAsync(d => d.Id == doc.Id,
+                TestContext.Current.CancellationToken);
+            tracked.Trash(DateTimeOffset.UtcNow);
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await _sut.RequestDownloadUrlAsync(doc.Id, null, Guid.NewGuid(),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RequestDownloadUrlAsync_SpecificVersion_ResolvesIt()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "text/plain", SizeBytes: 1, RejectionReason: null));
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, null, OwnerId, "F.txt", null, null, TestContext.Current.CancellationToken);
+
+        Guid versionId = doc.CurrentVersionId!.Value;
+        _blobStorage
+            .CreateDownloadUrlAsync(DocumentService.ContainerName, blobId, options: null, Arg.Any<CancellationToken>())
+            .Returns(new PresignedDownloadUrl(new Uri("https://storage.test/dl/v1"), DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        PresignedDownloadUrl? url = await _sut.RequestDownloadUrlAsync(
+            doc.Id, versionId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        url.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RequestDownloadUrlAsync_SpecificVersion_NotFound_ReturnsNull()
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "text/plain", SizeBytes: 1, RejectionReason: null));
+        Document doc = await _sut.FinalizeUploadAsync(
+            blobId, null, OwnerId, "F.txt", null, null, TestContext.Current.CancellationToken);
+
+        PresignedDownloadUrl? url = await _sut.RequestDownloadUrlAsync(
+            doc.Id, versionId: Guid.NewGuid(), Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        url.ShouldBeNull();
+    }
+
     private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
         : IDbContextFactory<DocumentsDbContext>
     {


### PR DESCRIPTION
## Summary

Adds `GET /documents/{id}/download` issuing a short-lived presigned URL via `Granit.BlobStorage`. Defaults to the document's `CurrentVersionId`; an optional `?versionId={guid}` query parameter targets a historical version (F4.2's list endpoint will surface them). Emits `DocumentDownloadedEvent` on the local bus for the ISO 27001 A.12.4.1 audit trail and increments `granit.documents.download.count`.

## Endpoint

`GET /documents/{id}/download[?versionId={guid}]` — gated on `Documents.Documents.Read`.

**Response shape**: JSON `{ url, expiresAt }` (per ADR-052 §F3.3 decision — keeps the response SPA-friendly; 302 redirect would constrain the client to the browser-native download UX).

**Status codes**:
- `200 OK` — happy path with the presigned URL.
- `404 Not Found` — document or specific version is missing or excluded by the tenant filter.
- `409 Conflict` — document is trashed / permanently-deleted, or has no current version yet (the latter hits before the F3.2 finalize flow has run on a brand-new aggregate).

## Service

`IDocumentService.RequestDownloadUrlAsync(documentId, versionId?, requestedByUserId, ct)` returns `PresignedDownloadUrl?`. Implementation: load Document, resolve target version (explicit override or `CurrentVersionId`), verify the version belongs to that document, call `IBlobStorage.CreateDownloadUrlAsync`, emit event, increment metric, return URL.

## Audit

`DocumentDownloadedEvent` (NEW) carries `DocumentId`, `VersionId`, `TenantId`, `RequestedByUserId`, `RequestedAt`, `UrlExpiresAt`. `Granit.Auditing`'s local handler picks it up automatically when both modules are loaded.

## Tests

- `DocumentServiceSqliteTests` +5 → **33/33** total. Covers happy path (URL + audit event + correct VersionId), unknown document → null, trashed document → throws, specific-version override, specific-version-not-found → null.
- ArchitectureTests **209/209**.
- Endpoints validators **28/28** (unchanged — no new validators).
- `dotnet format` clean.

## Tracking

- Story: #1734 (F3.3 — Download endpoint)
- Feature: #1731 (F3 — Document aggregate + upload / download flow)
- Epic: #1721