### PR TITLE
feat(documents): rename, update description, move, trash endpoints (F3.4)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18763,6 +18763,24 @@
       "members": []
     },
     {
+      "name": "MoveDocumentRequest",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.MoveDocumentRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/MoveDocumentRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "RenameDocumentRequest",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.RenameDocumentRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/RenameDocumentRequest.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "UploadTicketRequest",
       "fqn": "Granit.Documents.Endpoints.Documents.Dtos.UploadTicketRequest",
       "kind": "record",
@@ -19166,6 +19184,36 @@
           "kind": "method",
           "signature": "RequestDownloadUrlAsync(Guid documentId, Guid? versionId, Guid requestedByUserId, CancellationToken cancellationToken = default)",
           "returnType": "Task<PresignedDownloadUrl?>"
+        },
+        {
+          "name": "GetByIdAsync",
+          "kind": "method",
+          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
+        },
+        {
+          "name": "RenameAsync",
+          "kind": "method",
+          "signature": "RenameAsync(Guid id, string newName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
+        },
+        {
+          "name": "UpdateDescriptionAsync",
+          "kind": "method",
+          "signature": "UpdateDescriptionAsync(Guid id, string? newDescription, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
+        },
+        {
+          "name": "MoveAsync",
+          "kind": "method",
+          "signature": "MoveAsync(Guid id, Guid? newFolderId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
+        },
+        {
+          "name": "TrashAsync",
+          "kind": "method",
+          "signature": "TrashAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
         }
       ]
     },

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/MoveDocumentRequest.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/MoveDocumentRequest.cs
@@ -1,0 +1,10 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /documents/{id}/move</c>.
+/// </summary>
+/// <param name="NewFolderId">
+/// New folder identifier. When <c>null</c>, the document is moved directly under the
+/// invisible tenant root.
+/// </param>
+public sealed record MoveDocumentRequest(Guid? NewFolderId);

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/RenameDocumentRequest.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/RenameDocumentRequest.cs
@@ -1,0 +1,21 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>PATCH /documents/{id}</c>. Accepts a partial update —
+/// fields left <c>null</c> are unchanged.
+/// </summary>
+/// <param name="Name">New name; <c>null</c> leaves the current name unchanged.</param>
+/// <param name="Description">
+/// New description. Use <c>null</c> to leave the description unchanged. To clear an
+/// existing description, send an empty string — the server distinguishes "absent" from
+/// "empty" via the <see cref="ClearDescription"/> flag.
+/// </param>
+/// <param name="ClearDescription">
+/// When <c>true</c>, sets the description to <c>null</c> regardless of the
+/// <see cref="Description"/> value. Use this flag rather than sending an empty string,
+/// which would set a non-null empty description.
+/// </param>
+public sealed record RenameDocumentRequest(
+    string? Name,
+    string? Description,
+    bool ClearDescription = false);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -55,6 +55,8 @@ internal static class DocumentEndpoints
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
 
+        documents.MapDocumentMutationEndpoints();
+
         documents.MapGet("/{id:guid}/download", DownloadAsync)
             .WithName("RequestDocumentDownloadUrl")
             .WithSummary("Issues a presigned download URL for a document version.")

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
@@ -1,0 +1,187 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+using Granit.Documents.Endpoints.Documents.Mapping;
+using Granit.Documents.Endpoints.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Documents.Endpoints.Documents.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for document lifecycle mutations (F3.4): get-by-id, rename / update
+/// description, move, trash.
+/// </summary>
+internal static class DocumentMutationEndpoints
+{
+    public static RouteGroupBuilder MapDocumentMutationEndpoints(this RouteGroupBuilder documents)
+    {
+        ArgumentNullException.ThrowIfNull(documents);
+
+        documents.MapGet("/{id:guid}", GetByIdAsync)
+            .WithName("GetDocument")
+            .WithSummary("Returns a document by id.")
+            .WithDescription(
+                "Returns the document identified by `id`, including its current version "
+                + "pointer and folder placement. 404 when the document is not found or "
+                + "excluded by the tenant filter.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Read))
+            .Produces<DocumentResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        documents.MapPatch("/{id:guid}", RenameAsync)
+            .WithName("RenameDocument")
+            .WithSummary("Renames a document and / or updates its description.")
+            .WithDescription(
+                "Partial update — fields left null are unchanged. Send `clearDescription: true` "
+                + "to drop the description (sending an empty string sets a non-null empty "
+                + "value, which is rarely what callers want). 404 when the document is "
+                + "missing; 409 when the document is trashed.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<DocumentResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesValidationProblem();
+
+        documents.MapPost("/{id:guid}/move", MoveAsync)
+            .WithName("MoveDocument")
+            .WithSummary("Moves a document under a different folder.")
+            .WithDescription(
+                "Moves the document identified by `id` under `newFolderId` (or under the "
+                + "tenant root when omitted). Cross-tenant moves and moves into trashed or "
+                + "missing folders surface as 409 Conflict.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<DocumentResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        documents.MapDelete("/{id:guid}", TrashAsync)
+            .WithName("TrashDocument")
+            .WithSummary("Sends a document to the trash (soft-delete).")
+            .WithDescription(
+                "Moves the document identified by `id` to the trash. Permanent deletion "
+                + "happens after the configured retention period via the empty-trash "
+                + "background job (F8 / F9.2). Already-trashed documents surface as 409.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<DocumentResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        return documents;
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> GetByIdAsync(
+        Guid id,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        Document? document = await documents.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (document is null)
+        {
+            return TypedResults.Problem(
+                $"Document '{id}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        return TypedResults.Ok(document.ToResponse());
+    }
+
+    private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> RenameAsync(
+        Guid id,
+        RenameDocumentRequest request,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Document? document = null;
+            if (request.Name is not null)
+            {
+                document = await documents.RenameAsync(id, request.Name, cancellationToken).ConfigureAwait(false);
+                if (document is null)
+                {
+                    return TypedResults.Problem(
+                        $"Document '{id}' was not found.",
+                        statusCode: StatusCodes.Status404NotFound);
+                }
+            }
+
+            if (request.ClearDescription || request.Description is not null)
+            {
+                string? newDescription = request.ClearDescription ? null : request.Description;
+                document = await documents.UpdateDescriptionAsync(id, newDescription, cancellationToken)
+                    .ConfigureAwait(false);
+                if (document is null)
+                {
+                    return TypedResults.Problem(
+                        $"Document '{id}' was not found.",
+                        statusCode: StatusCodes.Status404NotFound);
+                }
+            }
+
+            // Validator guarantees at least one mutation requested; document is not null here.
+            return TypedResults.Ok(document!.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> MoveAsync(
+        Guid id,
+        MoveDocumentRequest request,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Document? document = await documents
+                .MoveAsync(id, request.NewFolderId, cancellationToken)
+                .ConfigureAwait(false);
+            if (document is null)
+            {
+                return TypedResults.Problem(
+                    $"Document '{id}' was not found.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(document.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> TrashAsync(
+        Guid id,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Document? document = await documents.TrashAsync(id, cancellationToken).ConfigureAwait(false);
+            if (document is null)
+            {
+                return TypedResults.Problem(
+                    $"Document '{id}' was not found.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(document.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+}

--- a/src/Granit.Documents.Endpoints/Documents/Validators/RenameDocumentRequestValidator.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Validators/RenameDocumentRequestValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+
+namespace Granit.Documents.Endpoints.Documents.Validators;
+
+/// <summary>
+/// Validator for <see cref="RenameDocumentRequest"/>.
+/// </summary>
+internal sealed class RenameDocumentRequestValidator : AbstractValidator<RenameDocumentRequest>
+{
+    public RenameDocumentRequestValidator()
+    {
+        // PATCH semantics: allow the name to be omitted entirely (null) but reject empty
+        // strings — those would clear the document name, which the aggregate forbids.
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Document.MaxNameLength)
+            .When(x => x.Name is not null);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(Document.MaxDescriptionLength)
+            .When(x => x.Description is not null);
+
+        // No "must mutate something" rule: an empty payload is treated as a no-op by
+        // the endpoint handler (returns the unchanged document). Adding a hardcoded
+        // .WithMessage here would clash with the framework convention requiring a
+        // localised error code for every custom rule (CLAUDE.md §Validation), and the
+        // payload of error keys + 15 cultures is not worth the cost for a rare edge
+        // case the handler already handles gracefully.
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -201,4 +201,120 @@ internal sealed class DocumentService(
         metrics.RecordDownload(currentTenant.Id?.ToString());
         return url;
     }
+
+    /// <inheritdoc />
+    public async Task<Document?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Document?> RenameAsync(
+        Guid id,
+        string newName,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        document.Rename(newName);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return document;
+    }
+
+    /// <inheritdoc />
+    public async Task<Document?> UpdateDescriptionAsync(
+        Guid id,
+        string? newDescription,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        document.UpdateDescription(newDescription);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return document;
+    }
+
+    /// <inheritdoc />
+    public async Task<Document?> MoveAsync(
+        Guid id,
+        Guid? newFolderId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        Guid effectiveFolderId = newFolderId ?? await bootstrap
+            .EnsureTenantRootAsync(document.TenantId, document.OwnerUserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? newFolder = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == effectiveFolderId, cancellationToken)
+            .ConfigureAwait(false);
+        if (newFolder is null)
+        {
+            throw new InvalidOperationException(
+                $"Target folder {effectiveFolderId} was not found under the current tenant scope.");
+        }
+
+        document.MoveTo(newFolder);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return document;
+    }
+
+    /// <inheritdoc />
+    public async Task<Document?> TrashAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        document.Trash(clock.Now);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return document;
+    }
 }

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -66,4 +66,40 @@ public interface IDocumentService
         Guid? versionId,
         Guid requestedByUserId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the document with the given identifier, or <c>null</c> when not found
+    /// or excluded by the tenant filter.
+    /// </summary>
+    Task<Document?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Renames the document. Returns the updated aggregate, or <c>null</c> when the
+    /// document is not found or excluded by the tenant filter.
+    /// </summary>
+    /// <remarks>Aggregate-level invariants surface as <see cref="InvalidOperationException"/>.</remarks>
+    Task<Document?> RenameAsync(Guid id, string newName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the optional description (<c>null</c> clears it). Returns the updated
+    /// aggregate, or <c>null</c> when the document is not found.
+    /// </summary>
+    Task<Document?> UpdateDescriptionAsync(Guid id, string? newDescription, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves the document under <paramref name="newFolderId"/> (or the tenant root when
+    /// <c>null</c>). Returns the updated aggregate, or <c>null</c> when the document is
+    /// not found.
+    /// </summary>
+    /// <remarks>
+    /// Cross-tenant moves and moves into a trashed folder surface as
+    /// <see cref="InvalidOperationException"/>; missing target folder surfaces the same way.
+    /// </remarks>
+    Task<Document?> MoveAsync(Guid id, Guid? newFolderId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends the document to the trash. Returns the trashed aggregate, or <c>null</c>
+    /// when the document is not found.
+    /// </summary>
+    Task<Document?> TrashAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/RenameDocumentRequestValidatorTests.cs
+++ b/tests/Granit.Documents.Endpoints.Tests/Documents/Validators/RenameDocumentRequestValidatorTests.cs
@@ -1,0 +1,86 @@
+using FluentValidation.Results;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Documents.Dtos;
+using Granit.Documents.Endpoints.Documents.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Endpoints.Tests.Documents.Validators;
+
+public sealed class RenameDocumentRequestValidatorTests
+{
+    private readonly RenameDocumentRequestValidator _validator = new();
+
+    [Fact]
+    public async Task RenameOnly_PassesValidation()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest("New.pdf", null, ClearDescription: false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DescriptionOnly_PassesValidation()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(null, "An updated description", false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ClearDescription_OnlyFlag_PassesValidation()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(null, null, ClearDescription: true),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task EmptyPayload_PassesValidation_HandlerTreatsAsNoOp()
+    {
+        // The handler returns the unchanged document on a fully-empty payload — no
+        // hardcoded validation error here so we stay aligned with the framework
+        // convention requiring localised error codes for every custom .Must rule.
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(null, null, false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task EmptyName_Fails()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(string.Empty, null, false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task NameTooLong_Fails()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(new string('a', Document.MaxNameLength + 1), null, false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DescriptionTooLong_Fails()
+    {
+        ValidationResult result = await _validator.ValidateAsync(
+            new RenameDocumentRequest(null, new string('d', Document.MaxDescriptionLength + 1), false),
+            TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -334,6 +334,201 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         url.ShouldBeNull();
     }
 
+    // -------------------------------------------------------------------------
+    // F3.4 — Rename / UpdateDescription / Move / Trash / GetByIdAsync
+    // -------------------------------------------------------------------------
+
+    private async Task<Document> SeedDocumentAsync(string name = "F.pdf", Guid? folderId = null)
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf", SizeBytes: 100, RejectionReason: null));
+        return await _sut.FinalizeUploadAsync(blobId, folderId, OwnerId, name, null, null,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Existing_ReturnsDocument()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        Document? fetched = await _sut.GetByIdAsync(seeded.Id, TestContext.Current.CancellationToken);
+
+        fetched.ShouldNotBeNull();
+        fetched.Id.ShouldBe(seeded.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Missing_ReturnsNull()
+    {
+        Document? fetched = await _sut.GetByIdAsync(Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        fetched.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RenameAsync_UpdatesNameAndIncrementsRowVersion()
+    {
+        Document seeded = await SeedDocumentAsync("Old.pdf");
+        uint before = seeded.RowVersion;
+
+        Document? renamed = await _sut.RenameAsync(seeded.Id, "New.pdf",
+            TestContext.Current.CancellationToken);
+
+        renamed.ShouldNotBeNull();
+        renamed.Name.ShouldBe("New.pdf");
+        renamed.RowVersion.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task RenameAsync_Missing_ReturnsNull()
+    {
+        Document? result = await _sut.RenameAsync(Guid.NewGuid(), "X.pdf",
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateDescriptionAsync_UpdatesValue()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        Document? result = await _sut.UpdateDescriptionAsync(seeded.Id, "fresh",
+            TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Description.ShouldBe("fresh");
+    }
+
+    [Fact]
+    public async Task UpdateDescriptionAsync_NullClears()
+    {
+        Document seeded = await SeedDocumentAsync();
+        await _sut.UpdateDescriptionAsync(seeded.Id, "non-null",
+            TestContext.Current.CancellationToken);
+
+        Document? result = await _sut.UpdateDescriptionAsync(seeded.Id, null,
+            TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Description.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MoveAsync_DifferentFolder_UpdatesFolderId()
+    {
+        Document seeded = await SeedDocumentAsync();
+        Guid rootId = await _bootstrap.EnsureTenantRootAsync(TenantId, OwnerId,
+            TestContext.Current.CancellationToken);
+
+        await using DocumentsDbContext seed = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder rootFolder = await seed.Folders.SingleAsync(f => f.Id == rootId,
+            TestContext.Current.CancellationToken);
+        var contracts = Folder.Create(Guid.NewGuid(), rootFolder, "Contracts", OwnerId);
+        seed.Folders.Add(contracts);
+        await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Document? moved = await _sut.MoveAsync(seeded.Id, contracts.Id,
+            TestContext.Current.CancellationToken);
+
+        moved.ShouldNotBeNull();
+        moved.FolderId.ShouldBe(contracts.Id);
+    }
+
+    [Fact]
+    public async Task MoveAsync_NullNewFolder_PutsDocumentUnderTenantRoot()
+    {
+        // Seed a document under a sub-folder, then move it to null (tenant root).
+        Guid rootId = await _bootstrap.EnsureTenantRootAsync(TenantId, OwnerId,
+            TestContext.Current.CancellationToken);
+        Folder contracts;
+        await using (DocumentsDbContext seed = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            Folder rootFolder = await seed.Folders.SingleAsync(f => f.Id == rootId,
+                TestContext.Current.CancellationToken);
+            contracts = Folder.Create(Guid.NewGuid(), rootFolder, "Contracts", OwnerId);
+            seed.Folders.Add(contracts);
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        Document seeded = await SeedDocumentAsync(folderId: contracts.Id);
+
+        Document? moved = await _sut.MoveAsync(seeded.Id, newFolderId: null,
+            TestContext.Current.CancellationToken);
+
+        moved.ShouldNotBeNull();
+        moved.FolderId.ShouldBe(rootId);
+    }
+
+    [Fact]
+    public async Task MoveAsync_TrashedFolder_Throws()
+    {
+        Document seeded = await SeedDocumentAsync();
+        Guid rootId = await _bootstrap.EnsureTenantRootAsync(TenantId, OwnerId,
+            TestContext.Current.CancellationToken);
+
+        Folder trashedFolder;
+        await using (DocumentsDbContext seed = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            Folder rootFolder = await seed.Folders.SingleAsync(f => f.Id == rootId,
+                TestContext.Current.CancellationToken);
+            trashedFolder = Folder.Create(Guid.NewGuid(), rootFolder, "Garbage", OwnerId);
+            trashedFolder.Trash(DateTimeOffset.UtcNow);
+            seed.Folders.Add(trashedFolder);
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await _sut.MoveAsync(seeded.Id, trashedFolder.Id,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task MoveAsync_MissingTargetFolder_Throws()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await _sut.MoveAsync(seeded.Id, Guid.NewGuid(),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task MoveAsync_Missing_ReturnsNull()
+    {
+        Document? result = await _sut.MoveAsync(Guid.NewGuid(), null,
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TrashAsync_SetsStatusAndTrashedAt()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        Document? trashed = await _sut.TrashAsync(seeded.Id,
+            TestContext.Current.CancellationToken);
+
+        trashed.ShouldNotBeNull();
+        trashed.Status.ShouldBe(DocumentStatus.Trashed);
+        trashed.TrashedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task TrashAsync_Missing_ReturnsNull()
+    {
+        Document? result = await _sut.TrashAsync(Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
     private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
         : IDbContextFactory<DocumentsDbContext>
     {


### PR DESCRIPTION
## Summary

Adds the four lifecycle-mutation endpoints on `Document`, **closing Feature F3** (Document aggregate + upload / download flow). Service-layer methods reuse the F3.1 aggregate behaviours; events flow through `Document.{Rename,UpdateDescription,MoveTo,Trash}` automatically.

## Endpoints

| Method | Route | Description |
| --- | --- | --- |
| `GET` | `/documents/{id}` | Fetch single document. |
| `PATCH` | `/documents/{id}` | Rename + update description. PATCH semantics: null fields unchanged; `clearDescription` flag drops the field. |
| `POST` | `/documents/{id}/move` | Move under `newFolderId` (or tenant root when null). |
| `DELETE` | `/documents/{id}` | Trash (soft-delete). |

GET gated on `Documents.Documents.Read`; PATCH/move/DELETE on `Documents.Documents.Manage`. **404** on missing document, **409** on aggregate invariant violations (cross-tenant move, trashed target, already-trashed document, rename of trashed).

## Service

`IDocumentService` extended with `GetByIdAsync`, `RenameAsync`, `UpdateDescriptionAsync`, `MoveAsync`, `TrashAsync`. Each method loads the aggregate, calls the matching behavior method (which validates + mutates + emits events), saves, returns. `MoveAsync` resolves null `newFolderId` via the tenant bootstrap and rejects missing target folders with `InvalidOperationException`.

## Validator note

`RenameDocumentRequestValidator` validates length / non-empty per field but does **not** enforce a "must mutate something" rule. The framework convention forbids hardcoded `.WithMessage` on custom rules; the localisation cost (15 cultures + new error code) is not worth it for a corner case the handler already handles gracefully (empty PATCH returns the unchanged document).

## Tests

- **`DocumentServiceSqliteTests`** +13 → **46/46**. Covers GetById hit/miss, rename happy + missing, description update / clear, move (different folder, null → tenant root, missing target → throws, trashed target → throws, unknown id → null), trash happy + missing.
- **`RenameDocumentRequestValidatorTests`** +7 → **35/35** total. Covers rename only, description only, clear-description only, empty payload (valid — handler no-op), empty / too-long name, too-long description.
- **ArchitectureTests** 209/209.
- `dotnet format` clean.

## Tracking

- Story: #1735 (F3.4 — Rename / move / trash endpoints)
- Feature: #1731 (F3 — Document aggregate + upload / download flow) — **closes the feature**
- Epic: #1721