### PR TITLE
feat(documents): versions list endpoint with paging + isCurrent flag (F4.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18964,6 +18964,15 @@
       ]
     },
     {
+      "name": "DocumentVersionPage",
+      "fqn": "Granit.Documents.DocumentVersionPage",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/DocumentVersionPage.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "Document",
       "fqn": "Granit.Documents.Domain.Document",
       "kind": "class",
@@ -19064,7 +19073,7 @@
       "kind": "record",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Documents/Dtos/DocumentVersionResponse.cs",
-      "line": 14,
+      "line": 20,
       "members": []
     },
     {
@@ -19083,6 +19092,15 @@
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Documents/Dtos/FinalizeUploadRequest.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "ListDocumentVersionsResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.ListDocumentVersionsResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/ListDocumentVersionsResponse.cs",
+      "line": 12,
       "members": []
     },
     {
@@ -19507,6 +19525,12 @@
           "kind": "method",
           "signature": "AppendVersionAsync(Guid documentId, Guid blobId, Guid uploadedByUserId, string? commitMessage = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<DocumentVersion?>"
+        },
+        {
+          "name": "ListVersionsAsync",
+          "kind": "method",
+          "signature": "ListVersionsAsync(Guid documentId, int skip, int take, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentVersionPage?>"
         },
         {
           "name": "RequestDownloadUrlAsync",

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentVersionResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentVersionResponse.cs
@@ -11,6 +11,12 @@ namespace Granit.Documents.Endpoints.Documents.Dtos;
 /// <param name="UploadedByUserId">User who finalised this version.</param>
 /// <param name="UploadedAt">UTC instant the version was finalised.</param>
 /// <param name="CommitMessage">Optional free-text changelog supplied by the uploader.</param>
+/// <param name="IsCurrent">
+/// <c>true</c> when this row matches the parent document's <c>CurrentVersionId</c>
+/// at the moment the page was rendered. The list endpoint computes it server-side;
+/// the append endpoint always returns <c>true</c> (a freshly-appended version is
+/// the new current).
+/// </param>
 public sealed record DocumentVersionResponse(
     Guid Id,
     Guid DocumentId,
@@ -21,4 +27,5 @@ public sealed record DocumentVersionResponse(
     string? ContentHash,
     Guid UploadedByUserId,
     DateTimeOffset UploadedAt,
-    string? CommitMessage);
+    string? CommitMessage,
+    bool IsCurrent);

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/ListDocumentVersionsResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/ListDocumentVersionsResponse.cs
@@ -1,0 +1,16 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>
+/// Wire-shape response for <c>GET /documents/{id}/versions</c>: a paged slice of the
+/// version history along with the total count so the frontend can render pagination
+/// controls.
+/// </summary>
+/// <param name="Versions">Page slice ordered by version number descending (latest first).</param>
+/// <param name="TotalCount">Total number of versions across all pages.</param>
+/// <param name="Skip">Number of versions skipped before this slice (echoes the request).</param>
+/// <param name="Take">Maximum number of versions returned (echoes the request).</param>
+public sealed record ListDocumentVersionsResponse(
+    IReadOnlyList<DocumentVersionResponse> Versions,
+    int TotalCount,
+    int Skip,
+    int Take);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -73,6 +73,20 @@ internal static class DocumentEndpoints
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
 
+        documents.MapGet("/{id:guid}/versions", ListVersionsAsync)
+            .WithName("ListDocumentVersions")
+            .WithSummary("Lists the version history of a document.")
+            .WithDescription(
+                "Returns a paged slice of the document's version history ordered by "
+                + "VersionNumber descending (latest first). The currently-active version "
+                + "is flagged via `isCurrent: true`. Use `?skip=` and `?take=` to page; "
+                + "defaults are skip=0, take=50 (max 200). Returns 404 when the document "
+                + "is missing or excluded by the tenant filter.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Read))
+            .Produces<ListDocumentVersionsResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         documents.MapDocumentMutationEndpoints();
 
         documents.MapGet("/{id:guid}/download", DownloadAsync)
@@ -167,7 +181,7 @@ internal static class DocumentEndpoints
             }
             return TypedResults.Created(
                 $"/documents/{id}/versions/{version.Id}",
-                version.ToResponse());
+                version.ToResponse(isCurrent: true));
         }
         catch (InvalidOperationException ex)
         {
@@ -176,6 +190,31 @@ internal static class DocumentEndpoints
                 ex.Message,
                 statusCode: StatusCodes.Status422UnprocessableEntity);
         }
+    }
+
+    private static async Task<Results<Ok<ListDocumentVersionsResponse>, ProblemHttpResult>> ListVersionsAsync(
+        Guid id,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken,
+        [FromQuery] int? skip = null,
+        [FromQuery] int? take = null)
+    {
+        const int DefaultTake = 50;
+        const int MaxTake = 200;
+
+        int effectiveSkip = Math.Max(0, skip ?? 0);
+        int effectiveTake = Math.Clamp(take ?? DefaultTake, 1, MaxTake);
+
+        DocumentVersionPage? page = await documents
+            .ListVersionsAsync(id, effectiveSkip, effectiveTake, cancellationToken)
+            .ConfigureAwait(false);
+        if (page is null)
+        {
+            return TypedResults.Problem(
+                $"Document '{id}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        return TypedResults.Ok(page.ToResponse(effectiveSkip, effectiveTake));
     }
 
     private static async Task<Results<Ok<DownloadUrlResponse>, ProblemHttpResult>> DownloadAsync(

--- a/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
@@ -7,6 +7,27 @@ namespace Granit.Documents.Endpoints.Documents.Mapping;
 /// <summary>Maps the <see cref="Document"/> aggregate and BlobStorage tickets to wire-shape DTOs.</summary>
 internal static class DocumentMapper
 {
+    public static DocumentVersionResponse ToResponse(this DocumentVersion version, bool isCurrent) =>
+        new(
+            version.Id,
+            version.DocumentId,
+            version.VersionNumber,
+            version.BlobDescriptorId,
+            version.SizeBytes,
+            version.ContentType,
+            version.ContentHash,
+            version.UploadedByUserId,
+            version.UploadedAt,
+            version.CommitMessage,
+            isCurrent);
+
+    public static ListDocumentVersionsResponse ToResponse(this DocumentVersionPage page, int skip, int take) =>
+        new(
+            [.. page.Versions.Select(v => v.ToResponse(isCurrent: v.Id == page.CurrentVersionId))],
+            page.TotalCount,
+            skip,
+            take);
+
     public static DocumentResponse ToResponse(this Document document) =>
         new(
             document.Id,
@@ -29,16 +50,4 @@ internal static class DocumentMapper
     public static DownloadUrlResponse ToResponse(this PresignedDownloadUrl url) =>
         new(url.Url, url.ExpiresAt);
 
-    public static DocumentVersionResponse ToResponse(this DocumentVersion version) =>
-        new(
-            version.Id,
-            version.DocumentId,
-            version.VersionNumber,
-            version.BlobDescriptorId,
-            version.SizeBytes,
-            version.ContentType,
-            version.ContentHash,
-            version.UploadedByUserId,
-            version.UploadedAt,
-            version.CommitMessage);
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -266,6 +266,55 @@ internal sealed class DocumentService(
     }
 
     /// <inheritdoc />
+    public async Task<DocumentVersionPage?> ListVersionsAsync(
+        Guid documentId,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default)
+    {
+        if (skip < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(skip), "skip must be non-negative.");
+        }
+        if (take <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(take), "take must be strictly positive.");
+        }
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Pull only the columns we need from Document — the version listing endpoint does
+        // not need the full aggregate, just the existence + current-version pointer.
+        var doc = await context.Documents
+            .Where(d => d.Id == documentId)
+            .Select(d => new { d.Id, d.CurrentVersionId })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (doc is null)
+        {
+            return null;
+        }
+
+        IQueryable<DocumentVersion> versionsQuery = context.DocumentVersions
+            .Where(v => v.DocumentId == documentId);
+
+        int totalCount = await versionsQuery
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<DocumentVersion> page = await versionsQuery
+            .OrderByDescending(v => v.VersionNumber)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new DocumentVersionPage(page, totalCount, doc.CurrentVersionId);
+    }
+
+    /// <inheritdoc />
     public async Task<PresignedDownloadUrl?> RequestDownloadUrlAsync(
         Guid documentId,
         Guid? versionId,

--- a/src/Granit.Documents/DocumentVersionPage.cs
+++ b/src/Granit.Documents/DocumentVersionPage.cs
@@ -1,0 +1,16 @@
+using Granit.Documents.Domain;
+
+namespace Granit.Documents;
+
+/// <summary>
+/// Paged slice of a document's version history along with the parent document's
+/// current-version pointer. The latter lets the HTTP mapper flag which row in the
+/// page is the active version without re-querying the document aggregate.
+/// </summary>
+/// <param name="Versions">Page slice ordered by <see cref="DocumentVersion.VersionNumber"/> descending.</param>
+/// <param name="TotalCount">Total number of versions for the parent document (across all pages).</param>
+/// <param name="CurrentVersionId">Identifier of the parent document's currently-active version.</param>
+public sealed record DocumentVersionPage(
+    IReadOnlyList<DocumentVersion> Versions,
+    int TotalCount,
+    Guid? CurrentVersionId);

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -74,9 +74,30 @@ public interface IDocumentService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns a paged slice of the document's version history, ordered by
+    /// <see cref="DocumentVersion.VersionNumber"/> descending (latest first), along with
+    /// the parent document's <see cref="Document.CurrentVersionId"/> so the HTTP mapper
+    /// can flag which row is the active version.
+    /// </summary>
+    /// <param name="documentId">Document whose history is requested.</param>
+    /// <param name="skip">Number of versions to skip (for pagination); must be ≥ 0.</param>
+    /// <param name="take">Maximum number of versions to return; must be &gt; 0.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The page on success, or <c>null</c> when the document is not found or excluded by
+    /// the tenant filter. An empty <c>Versions</c> list with <c>TotalCount = 0</c> is
+    /// possible only for a document that has not yet had its first version finalised.
+    /// </returns>
+    Task<DocumentVersionPage?> ListVersionsAsync(
+        Guid documentId,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Issues a presigned download URL for a document. Defaults to the document's
     /// <see cref="Document.CurrentVersionId"/>; an explicit <paramref name="versionId"/>
-    /// fetches a specific historical version (F4.2 list endpoint surfaces them).
+    /// fetches a specific historical version surfaced by <see cref="ListVersionsAsync"/>.
     /// </summary>
     /// <param name="documentId">Document to download.</param>
     /// <param name="versionId">Optional specific version. <c>null</c> resolves to <see cref="Document.CurrentVersionId"/>.</param>

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentVersionsListPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentVersionsListPostgresTests.cs
@@ -1,0 +1,136 @@
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.Documents;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed integration test for <see cref="DocumentService.ListVersionsAsync"/>.
+/// Confirms that the OFFSET / LIMIT translation produces correct paging under realistic
+/// Postgres semantics (the SQLite tests cover the same ordering, but Postgres is the
+/// production target and treats <c>ORDER BY ... DESC</c> + integer comparisons through
+/// a different planner path).
+/// </summary>
+public sealed class DocumentVersionsListPostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private DocumentService _sut = null!;
+    private IBlobStorage _blobStorage = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public DocumentVersionsListPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_document_versions, documents_documents, documents_folders RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        _blobStorage = Substitute.For<IBlobStorage>();
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        ILocalEventBus localEventBus = Substitute.For<ILocalEventBus>();
+
+        _sut = new DocumentService(
+            _factory, bootstrap, _blobStorage, currentTenant,
+            new SimpleGuidGenerator(), clock, localEventBus, metrics);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task ListVersionsAsync_AppendsThenPages_OrderedDescending_OnPostgres()
+    {
+        // Seed v1 via FinalizeUploadAsync, then append v2..v6.
+        Document seeded = await SeedDocumentAsync();
+        for (int i = 2; i <= 6; i++)
+        {
+            var blobId = Guid.NewGuid();
+            StubBlobConfirmation(blobId, sizeBytes: i * 100L);
+            DocumentVersion? appended = await _sut.AppendVersionAsync(
+                seeded.Id, blobId, OwnerId, $"v{i}", TestContext.Current.CancellationToken);
+            appended.ShouldNotBeNull();
+        }
+
+        // First page: latest 3.
+        DocumentVersionPage? firstPage = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 0, take: 3, TestContext.Current.CancellationToken);
+        firstPage.ShouldNotBeNull();
+        firstPage.TotalCount.ShouldBe(6);
+        firstPage.Versions.Select(v => v.VersionNumber).ShouldBe([6, 5, 4]);
+        firstPage.CurrentVersionId.ShouldBe(firstPage.Versions[0].Id);
+
+        // Second page: oldest 3.
+        DocumentVersionPage? secondPage = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 3, take: 3, TestContext.Current.CancellationToken);
+        secondPage.ShouldNotBeNull();
+        secondPage.TotalCount.ShouldBe(6);
+        secondPage.Versions.Select(v => v.VersionNumber).ShouldBe([3, 2, 1]);
+    }
+
+    private async Task<Document> SeedDocumentAsync()
+    {
+        var blobId = Guid.NewGuid();
+        StubBlobConfirmation(blobId);
+        return await _sut.FinalizeUploadAsync(
+            blobId, folderId: null, OwnerId, "F.pdf", null, "v1",
+            TestContext.Current.CancellationToken);
+    }
+
+    private void StubBlobConfirmation(Guid blobId, long sizeBytes = 100)
+    {
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf",
+                SizeBytes: sizeBytes, RejectionReason: null));
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -720,6 +720,101 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         persistedNumbers.Distinct().Count().ShouldBe(persistedNumbers.Count);
     }
 
+    // -------------------------------------------------------------------------
+    // F4.2 — ListVersionsAsync (paged history)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListVersionsAsync_AfterFinalize_ReturnsSingleV1_FlaggedAsCurrent()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        DocumentVersionPage? page = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 0, take: 50, TestContext.Current.CancellationToken);
+
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(1);
+        page.CurrentVersionId.ShouldBe(seeded.CurrentVersionId);
+        DocumentVersion only = page.Versions.ShouldHaveSingleItem();
+        only.VersionNumber.ShouldBe(1);
+        only.Id.ShouldBe(seeded.CurrentVersionId!.Value);
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_MultipleVersions_OrderedDescending()
+    {
+        Document seeded = await SeedDocumentAsync();
+        for (int i = 2; i <= 4; i++)
+        {
+            var blobId = Guid.NewGuid();
+            StubBlobConfirmation(blobId);
+            await _sut.AppendVersionAsync(seeded.Id, blobId, OwnerId, $"v{i}",
+                TestContext.Current.CancellationToken);
+        }
+
+        DocumentVersionPage? page = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 0, take: 50, TestContext.Current.CancellationToken);
+
+        page.ShouldNotBeNull();
+        page.TotalCount.ShouldBe(4);
+        int[] numbers = [.. page.Versions.Select(v => v.VersionNumber)];
+        numbers.ShouldBe([4, 3, 2, 1]);
+        // Latest version is the current pointer.
+        page.CurrentVersionId.ShouldBe(page.Versions[0].Id);
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_PagingSlicesResultSet()
+    {
+        Document seeded = await SeedDocumentAsync();
+        for (int i = 2; i <= 5; i++)
+        {
+            var blobId = Guid.NewGuid();
+            StubBlobConfirmation(blobId);
+            await _sut.AppendVersionAsync(seeded.Id, blobId, OwnerId, null,
+                TestContext.Current.CancellationToken);
+        }
+
+        DocumentVersionPage? firstPage = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 0, take: 2, TestContext.Current.CancellationToken);
+        DocumentVersionPage? secondPage = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 2, take: 2, TestContext.Current.CancellationToken);
+        DocumentVersionPage? thirdPage = await _sut.ListVersionsAsync(
+            seeded.Id, skip: 4, take: 2, TestContext.Current.CancellationToken);
+
+        firstPage.ShouldNotBeNull();
+        firstPage.TotalCount.ShouldBe(5);
+        firstPage.Versions.Select(v => v.VersionNumber).ShouldBe([5, 4]);
+
+        secondPage.ShouldNotBeNull();
+        secondPage.Versions.Select(v => v.VersionNumber).ShouldBe([3, 2]);
+
+        thirdPage.ShouldNotBeNull();
+        thirdPage.Versions.Select(v => v.VersionNumber).ShouldBe([1]);
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_MissingDocument_ReturnsNull()
+    {
+        DocumentVersionPage? page = await _sut.ListVersionsAsync(
+            Guid.NewGuid(), skip: 0, take: 50, TestContext.Current.CancellationToken);
+
+        page.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(0, 0)]
+    [InlineData(0, -1)]
+    public async Task ListVersionsAsync_InvalidPaging_Throws(int skip, int take)
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await _sut.ListVersionsAsync(seeded.Id, skip, take,
+                TestContext.Current.CancellationToken));
+    }
+
     private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
         : IDbContextFactory<DocumentsDbContext>
     {


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/documents/{id}/versions` — paged version history ordered by `VersionNumber DESC`, with an `isCurrent` flag computed from `Document.CurrentVersionId` so the frontend can render the active row without a second request.
- Default page size: 50; capped at 200; `?skip=` and `?take=` query parameters.
- `DocumentVersionResponse` gains an `IsCurrent` field (also returned `true` from the F4.1 append endpoint, since a freshly-appended version is always the new current).
- Domain layer ships `DocumentVersionPage(Versions, TotalCount, CurrentVersionId)` so the HTTP mapper does not re-query the document aggregate to flag the active row.
- Permission gate: `Documents.Documents.Read` (per the story acceptance criteria).

## Test plan

- [x] `dotnet test tests/Granit.Documents.Tests` — 62 passed
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 59 passed (7 new F4.2 service tests: empty post-finalize, multi-version DESC ordering, paging across slices, missing document, invalid skip/take)
- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 39 passed
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration --filter ListVersions` — 1 passed (Postgres OFFSET/LIMIT translation)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 209 passed
- [x] `dotnet format style --verify-no-changes` on each touched project — clean

Closes #1738. Feature: #1736. Epic: #1721.
