### PR TITLE
feat(activities): Activity Query/Export/Metric definitions — closes Stream A 9/9

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -83,7 +83,10 @@
       "deps": [
         "Granit",
         "Granit.Activities.Abstractions",
-        "Granit.Localization"
+        "Granit.Analytics",
+        "Granit.DataExchange.Abstractions",
+        "Granit.Localization",
+        "Granit.QueryEngine.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -5018,12 +5021,28 @@
       "members": []
     },
     {
+      "name": "ActivityExportDefinition",
+      "fqn": "Granit.Activities.Exports.ActivityExportDefinition",
+      "kind": "class",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Exports/ActivityExportDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "ActivitiesServiceCollectionExtensions",
       "fqn": "Granit.Activities.Extensions.ActivitiesServiceCollectionExtensions",
       "kind": "class",
       "project": "Granit.Activities",
       "file": "src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitActivities",
@@ -5089,6 +5108,110 @@
           "kind": "method",
           "signature": "Provide()",
           "returnType": "IEnumerable<ActivityType>"
+        }
+      ]
+    },
+    {
+      "name": "OpenActivityCountMetricDefinition",
+      "fqn": "Granit.Activities.Metrics.OpenActivityCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Metrics/OpenActivityCountMetricDefinition.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, int?>>? Selector",
+          "returnType": "Expression<Func<Activity, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Activity, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Activity, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "OverdueActivityCountMetricDefinition",
+      "fqn": "Granit.Activities.Metrics.OverdueActivityCountMetricDefinition",
+      "kind": "class",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Metrics/OverdueActivityCountMetricDefinition.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ValueKind",
+          "kind": "property",
+          "signature": "MetricValueKind ValueKind",
+          "returnType": "MetricValueKind"
+        },
+        {
+          "name": "Aggregation",
+          "kind": "property",
+          "signature": "AggregateFunction Aggregation",
+          "returnType": "AggregateFunction"
+        },
+        {
+          "name": "Selector",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, int?>>? Selector",
+          "returnType": "Expression<Func<Activity, int?>>?"
+        },
+        {
+          "name": "BaseFilter",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, bool>>? BaseFilter",
+          "returnType": "Expression<Func<Activity, bool>>?"
+        },
+        {
+          "name": "PeriodSelector",
+          "kind": "property",
+          "signature": "Expression<Func<Activity, DateTimeOffset>>? PeriodSelector",
+          "returnType": "Expression<Func<Activity, DateTimeOffset>>?"
+        },
+        {
+          "name": "IsHigherBetter",
+          "kind": "property",
+          "signature": "bool IsHigherBetter",
+          "returnType": "bool"
         }
       ]
     },
@@ -5245,6 +5368,28 @@
       "file": "src/Granit.Activities.Notifications/Handlers/ActivityReminderHandler.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "ActivityQueryDefinition",
+      "fqn": "Granit.Activities.Queries.ActivityQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Queries/ActivityQueryDefinition.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(ActivitiesLocalizationResource)",
+          "returnType": "Type? LocalizationResourceType =>"
+        }
+      ]
     },
     {
       "name": "StandardActivityTypeProvider",

--- a/src/Granit.Activities.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Activities.BackgroundJobs/packages.lock.json
@@ -60,13 +60,41 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.backgroundjobs": {
@@ -100,6 +128,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -110,6 +157,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -145,6 +203,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Cronos": {

--- a/src/Granit.Activities.Endpoints/packages.lock.json
+++ b/src/Granit.Activities.Endpoints/packages.lock.json
@@ -39,13 +39,26 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.abstractions": {
@@ -72,6 +85,16 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.dashboards.abstractions": {

--- a/src/Granit.Activities.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Activities.EntityFrameworkCore/packages.lock.json
@@ -105,13 +105,41 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {
@@ -131,6 +159,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -141,6 +188,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -203,6 +261,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/src/Granit.Activities.Notifications/packages.lock.json
+++ b/src/Granit.Activities.Notifications/packages.lock.json
@@ -43,13 +43,41 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {
@@ -69,6 +97,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -79,6 +126,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {

--- a/src/Granit.Activities/Exports/ActivityExportDefinition.cs
+++ b/src/Granit.Activities/Exports/ActivityExportDefinition.cs
@@ -1,0 +1,37 @@
+using Granit.Activities.Domain;
+using Granit.DataExchange.Export;
+
+namespace Granit.Activities.Exports;
+
+/// <summary>
+/// Export definition for activities — whitelists the columns produced by
+/// CSV / XLSX exports of the activities admin grid.
+/// </summary>
+public sealed class ActivityExportDefinition : ExportDefinition<Activity>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Activities.ActivityExport";
+
+    /// <inheritdoc/>
+    protected override void Configure(ExportDefinitionBuilder<Activity> builder)
+    {
+        builder
+            .IncludeId()
+            .Field(a => a.TenantId)
+            .Field(a => a.EntityType)
+            .Field(a => a.EntityId)
+            .Field(a => a.Type)
+            .Field(a => a.Status)
+            .Field(a => a.AssignedToUserId)
+            .Field(a => a.CreatedByUserId)
+            .Field(a => a.CompletedByUserId)
+            .Field(a => a.DueAt, f => f.Format("O"))
+            .Field(a => a.CompletedAt, f => f.Format("O"))
+            .Field(a => a.OverdueNotifiedAt, f => f.Format("O"))
+            .Field(a => a.Description)
+            .Field(a => a.CreatedAt, f => f.Format("O"))
+            .Field(a => a.CreatedBy)
+            .Field(a => a.ModifiedAt, f => f.Format("O"))
+            .Field(a => a.ModifiedBy);
+    }
+}

--- a/src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs
+++ b/src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs
@@ -1,5 +1,12 @@
+using Granit.Activities.Domain;
+using Granit.Activities.Exports;
 using Granit.Activities.Extensions;
 using Granit.Activities.Internal;
+using Granit.Activities.Metrics;
+using Granit.Activities.Queries;
+using Granit.Analytics.Extensions;
+using Granit.DataExchange.Extensions;
+using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Activities.Extensions;
@@ -11,7 +18,9 @@ public static class ActivitiesServiceCollectionExtensions
 {
     /// <summary>
     /// Registers the runtime <see cref="IActivityRegistry"/> plus the framework's
-    /// <see cref="StandardActivityTypeProvider"/> (ToDo / Call / Meeting / Email).
+    /// <see cref="StandardActivityTypeProvider"/> (ToDo / Call / Meeting / Email),
+    /// the <see cref="ActivityQueryDefinition"/> / <see cref="ActivityExportDefinition"/>
+    /// pairing for the admin grid, and the open / overdue activity-count metrics.
     /// Hosts that want a strictly custom catalog can call this and then remove
     /// the standard provider before <c>BuildServiceProvider</c>.
     /// </summary>
@@ -21,6 +30,10 @@ public static class ActivitiesServiceCollectionExtensions
 
         services.AddActivityTypeProvider<StandardActivityTypeProvider>();
         services.AddSingleton<IActivityRegistry, ActivityRegistry>();
+        services.AddQueryDefinition<Activity, ActivityQueryDefinition>();
+        services.AddExportDefinition<Activity, ActivityExportDefinition>();
+        services.AddMetricDefinition<Activity, int, OpenActivityCountMetricDefinition>();
+        services.AddMetricDefinition<Activity, int, OverdueActivityCountMetricDefinition>();
         return services;
     }
 }

--- a/src/Granit.Activities/Granit.Activities.csproj
+++ b/src/Granit.Activities/Granit.Activities.csproj
@@ -22,7 +22,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Activities.Abstractions\Granit.Activities.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
+    <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Activities/Localization/Activities/cs.json
+++ b/src/Granit.Activities/Localization/Activities/cs.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Úkol",
     "Activity:Call": "Hovor",
     "Activity:Meeting": "Schůzka",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Otevřené aktivity",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Aktivity po termínu",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Hostitelská entita",
+    "Activities.Columns.EntityId": "Id hostitele",
+    "Activities.Columns.Type": "Typ",
+    "Activities.Columns.Status": "Stav",
+    "Activities.Columns.AssignedToUserId": "Přiřazeno",
+    "Activities.Columns.CreatedByUserId": "Vytvořil",
+    "Activities.Columns.CompletedByUserId": "Uzavřel",
+    "Activities.Columns.DueAt": "Termín",
+    "Activities.Columns.CompletedAt": "Uzavřeno",
+    "Activities.Columns.OverdueNotifiedAt": "Oznámeno po termínu",
+    "Activities.Columns.Description": "Popis"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/de.json
+++ b/src/Granit.Activities/Localization/Activities/de.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Aufgabe",
     "Activity:Call": "Anruf",
     "Activity:Meeting": "Besprechung",
-    "Activity:Email": "E-Mail"
+    "Activity:Email": "E-Mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Offene Aktivitäten",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Überfällige Aktivitäten",
+
+    "Activities.Columns.Tenant": "Mandant",
+    "Activities.Columns.EntityType": "Host-Entität",
+    "Activities.Columns.EntityId": "Host-ID",
+    "Activities.Columns.Type": "Typ",
+    "Activities.Columns.Status": "Status",
+    "Activities.Columns.AssignedToUserId": "Zugewiesen an",
+    "Activities.Columns.CreatedByUserId": "Erstellt von",
+    "Activities.Columns.CompletedByUserId": "Abgeschlossen von",
+    "Activities.Columns.DueAt": "Fällig am",
+    "Activities.Columns.CompletedAt": "Abgeschlossen am",
+    "Activities.Columns.OverdueNotifiedAt": "Überfälligkeit gemeldet am",
+    "Activities.Columns.Description": "Beschreibung"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/en.json
+++ b/src/Granit.Activities/Localization/Activities/en.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "To-do",
     "Activity:Call": "Call",
     "Activity:Meeting": "Meeting",
-    "Activity:Email": "Email"
+    "Activity:Email": "Email",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Open activities",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Overdue activities",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Host entity",
+    "Activities.Columns.EntityId": "Host id",
+    "Activities.Columns.Type": "Type",
+    "Activities.Columns.Status": "Status",
+    "Activities.Columns.AssignedToUserId": "Assigned to",
+    "Activities.Columns.CreatedByUserId": "Created by",
+    "Activities.Columns.CompletedByUserId": "Completed by",
+    "Activities.Columns.DueAt": "Due at",
+    "Activities.Columns.CompletedAt": "Completed at",
+    "Activities.Columns.OverdueNotifiedAt": "Overdue notified at",
+    "Activities.Columns.Description": "Description"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/es.json
+++ b/src/Granit.Activities/Localization/Activities/es.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Tarea",
     "Activity:Call": "Llamada",
     "Activity:Meeting": "Reunión",
-    "Activity:Email": "Correo electrónico"
+    "Activity:Email": "Correo electrónico",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Actividades abiertas",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Actividades vencidas",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Entidad anfitriona",
+    "Activities.Columns.EntityId": "Id anfitrión",
+    "Activities.Columns.Type": "Tipo",
+    "Activities.Columns.Status": "Estado",
+    "Activities.Columns.AssignedToUserId": "Asignada a",
+    "Activities.Columns.CreatedByUserId": "Creada por",
+    "Activities.Columns.CompletedByUserId": "Cerrada por",
+    "Activities.Columns.DueAt": "Vencimiento",
+    "Activities.Columns.CompletedAt": "Cerrada el",
+    "Activities.Columns.OverdueNotifiedAt": "Notificada como vencida el",
+    "Activities.Columns.Description": "Descripción"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/fr.json
+++ b/src/Granit.Activities/Localization/Activities/fr.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "À faire",
     "Activity:Call": "Appel",
     "Activity:Meeting": "Réunion",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Activités ouvertes",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Activités en retard",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Entité hôte",
+    "Activities.Columns.EntityId": "Id hôte",
+    "Activities.Columns.Type": "Type",
+    "Activities.Columns.Status": "Statut",
+    "Activities.Columns.AssignedToUserId": "Assignée à",
+    "Activities.Columns.CreatedByUserId": "Créée par",
+    "Activities.Columns.CompletedByUserId": "Clôturée par",
+    "Activities.Columns.DueAt": "Échéance",
+    "Activities.Columns.CompletedAt": "Clôturée le",
+    "Activities.Columns.OverdueNotifiedAt": "Notifiée en retard le",
+    "Activities.Columns.Description": "Description"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/hi.json
+++ b/src/Granit.Activities/Localization/Activities/hi.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "कार्य",
     "Activity:Call": "कॉल",
     "Activity:Meeting": "मीटिंग",
-    "Activity:Email": "ईमेल"
+    "Activity:Email": "ईमेल",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "खुली गतिविधियाँ",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "विलंबित गतिविधियाँ",
+
+    "Activities.Columns.Tenant": "टेनेंट",
+    "Activities.Columns.EntityType": "होस्ट इकाई",
+    "Activities.Columns.EntityId": "होस्ट आईडी",
+    "Activities.Columns.Type": "प्रकार",
+    "Activities.Columns.Status": "स्थिति",
+    "Activities.Columns.AssignedToUserId": "सौंपी गई",
+    "Activities.Columns.CreatedByUserId": "बनाई गई द्वारा",
+    "Activities.Columns.CompletedByUserId": "पूर्ण द्वारा",
+    "Activities.Columns.DueAt": "नियत तिथि",
+    "Activities.Columns.CompletedAt": "पूर्ण होने का समय",
+    "Activities.Columns.OverdueNotifiedAt": "विलंब अधिसूचित समय",
+    "Activities.Columns.Description": "विवरण"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/it.json
+++ b/src/Granit.Activities/Localization/Activities/it.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Da fare",
     "Activity:Call": "Chiamata",
     "Activity:Meeting": "Riunione",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Attività aperte",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Attività in ritardo",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Entità host",
+    "Activities.Columns.EntityId": "Id host",
+    "Activities.Columns.Type": "Tipo",
+    "Activities.Columns.Status": "Stato",
+    "Activities.Columns.AssignedToUserId": "Assegnata a",
+    "Activities.Columns.CreatedByUserId": "Creata da",
+    "Activities.Columns.CompletedByUserId": "Chiusa da",
+    "Activities.Columns.DueAt": "Scadenza",
+    "Activities.Columns.CompletedAt": "Chiusa il",
+    "Activities.Columns.OverdueNotifiedAt": "Notificata in ritardo il",
+    "Activities.Columns.Description": "Descrizione"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/ja.json
+++ b/src/Granit.Activities/Localization/Activities/ja.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "ToDo",
     "Activity:Call": "通話",
     "Activity:Meeting": "会議",
-    "Activity:Email": "メール"
+    "Activity:Email": "メール",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "未完了アクティビティ",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "期限切れアクティビティ",
+
+    "Activities.Columns.Tenant": "テナント",
+    "Activities.Columns.EntityType": "ホストエンティティ",
+    "Activities.Columns.EntityId": "ホスト ID",
+    "Activities.Columns.Type": "タイプ",
+    "Activities.Columns.Status": "ステータス",
+    "Activities.Columns.AssignedToUserId": "担当者",
+    "Activities.Columns.CreatedByUserId": "作成者",
+    "Activities.Columns.CompletedByUserId": "完了者",
+    "Activities.Columns.DueAt": "期限",
+    "Activities.Columns.CompletedAt": "完了日時",
+    "Activities.Columns.OverdueNotifiedAt": "期限切れ通知日時",
+    "Activities.Columns.Description": "説明"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/ko.json
+++ b/src/Granit.Activities/Localization/Activities/ko.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "할 일",
     "Activity:Call": "통화",
     "Activity:Meeting": "회의",
-    "Activity:Email": "이메일"
+    "Activity:Email": "이메일",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "미완료 활동",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "기한 초과 활동",
+
+    "Activities.Columns.Tenant": "테넌트",
+    "Activities.Columns.EntityType": "호스트 엔티티",
+    "Activities.Columns.EntityId": "호스트 ID",
+    "Activities.Columns.Type": "유형",
+    "Activities.Columns.Status": "상태",
+    "Activities.Columns.AssignedToUserId": "담당자",
+    "Activities.Columns.CreatedByUserId": "작성자",
+    "Activities.Columns.CompletedByUserId": "완료자",
+    "Activities.Columns.DueAt": "기한",
+    "Activities.Columns.CompletedAt": "완료 일시",
+    "Activities.Columns.OverdueNotifiedAt": "기한 초과 알림 일시",
+    "Activities.Columns.Description": "설명"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/nl.json
+++ b/src/Granit.Activities/Localization/Activities/nl.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Te doen",
     "Activity:Call": "Oproep",
     "Activity:Meeting": "Vergadering",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Openstaande activiteiten",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Achterstallige activiteiten",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Hoofdentiteit",
+    "Activities.Columns.EntityId": "Hoofd-id",
+    "Activities.Columns.Type": "Type",
+    "Activities.Columns.Status": "Status",
+    "Activities.Columns.AssignedToUserId": "Toegewezen aan",
+    "Activities.Columns.CreatedByUserId": "Aangemaakt door",
+    "Activities.Columns.CompletedByUserId": "Afgesloten door",
+    "Activities.Columns.DueAt": "Vervaldatum",
+    "Activities.Columns.CompletedAt": "Afgesloten op",
+    "Activities.Columns.OverdueNotifiedAt": "Achterstallig gemeld op",
+    "Activities.Columns.Description": "Beschrijving"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/pl.json
+++ b/src/Granit.Activities/Localization/Activities/pl.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Do zrobienia",
     "Activity:Call": "Połączenie",
     "Activity:Meeting": "Spotkanie",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Otwarte aktywności",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Zaległe aktywności",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Encja nadrzędna",
+    "Activities.Columns.EntityId": "Id nadrzędne",
+    "Activities.Columns.Type": "Typ",
+    "Activities.Columns.Status": "Status",
+    "Activities.Columns.AssignedToUserId": "Przypisana do",
+    "Activities.Columns.CreatedByUserId": "Utworzona przez",
+    "Activities.Columns.CompletedByUserId": "Zamknięta przez",
+    "Activities.Columns.DueAt": "Termin",
+    "Activities.Columns.CompletedAt": "Zamknięta dnia",
+    "Activities.Columns.OverdueNotifiedAt": "Zgłoszona jako zaległa dnia",
+    "Activities.Columns.Description": "Opis"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/pt.json
+++ b/src/Granit.Activities/Localization/Activities/pt.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "A fazer",
     "Activity:Call": "Chamada",
     "Activity:Meeting": "Reunião",
-    "Activity:Email": "E-mail"
+    "Activity:Email": "E-mail",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Atividades em aberto",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Atividades em atraso",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Entidade anfitriã",
+    "Activities.Columns.EntityId": "Id anfitrião",
+    "Activities.Columns.Type": "Tipo",
+    "Activities.Columns.Status": "Estado",
+    "Activities.Columns.AssignedToUserId": "Atribuída a",
+    "Activities.Columns.CreatedByUserId": "Criada por",
+    "Activities.Columns.CompletedByUserId": "Concluída por",
+    "Activities.Columns.DueAt": "Prazo",
+    "Activities.Columns.CompletedAt": "Concluída em",
+    "Activities.Columns.OverdueNotifiedAt": "Notificada em atraso em",
+    "Activities.Columns.Description": "Descrição"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/sv.json
+++ b/src/Granit.Activities/Localization/Activities/sv.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Att göra",
     "Activity:Call": "Samtal",
     "Activity:Meeting": "Möte",
-    "Activity:Email": "E-post"
+    "Activity:Email": "E-post",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Öppna aktiviteter",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Försenade aktiviteter",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Värdentitet",
+    "Activities.Columns.EntityId": "Värd-id",
+    "Activities.Columns.Type": "Typ",
+    "Activities.Columns.Status": "Status",
+    "Activities.Columns.AssignedToUserId": "Tilldelad till",
+    "Activities.Columns.CreatedByUserId": "Skapad av",
+    "Activities.Columns.CompletedByUserId": "Avslutad av",
+    "Activities.Columns.DueAt": "Förfallodatum",
+    "Activities.Columns.CompletedAt": "Avslutad",
+    "Activities.Columns.OverdueNotifiedAt": "Försenad notifierad",
+    "Activities.Columns.Description": "Beskrivning"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/tr.json
+++ b/src/Granit.Activities/Localization/Activities/tr.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "Yapılacak",
     "Activity:Call": "Arama",
     "Activity:Meeting": "Toplantı",
-    "Activity:Email": "E-posta"
+    "Activity:Email": "E-posta",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "Açık aktiviteler",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "Gecikmiş aktiviteler",
+
+    "Activities.Columns.Tenant": "Tenant",
+    "Activities.Columns.EntityType": "Ana varlık",
+    "Activities.Columns.EntityId": "Ana id",
+    "Activities.Columns.Type": "Tür",
+    "Activities.Columns.Status": "Durum",
+    "Activities.Columns.AssignedToUserId": "Atanan",
+    "Activities.Columns.CreatedByUserId": "Oluşturan",
+    "Activities.Columns.CompletedByUserId": "Kapatan",
+    "Activities.Columns.DueAt": "Son tarih",
+    "Activities.Columns.CompletedAt": "Kapatılma tarihi",
+    "Activities.Columns.OverdueNotifiedAt": "Gecikme bildirim tarihi",
+    "Activities.Columns.Description": "Açıklama"
   }
 }

--- a/src/Granit.Activities/Localization/Activities/zh.json
+++ b/src/Granit.Activities/Localization/Activities/zh.json
@@ -4,6 +4,22 @@
     "Activity:ToDo": "待办事项",
     "Activity:Call": "通话",
     "Activity:Meeting": "会议",
-    "Activity:Email": "电子邮件"
+    "Activity:Email": "电子邮件",
+
+    "Metric:Granit.Activities.OpenActivityCountMetric": "未完成活动",
+    "Metric:Granit.Activities.OverdueActivityCountMetric": "逾期活动",
+
+    "Activities.Columns.Tenant": "租户",
+    "Activities.Columns.EntityType": "宿主实体",
+    "Activities.Columns.EntityId": "宿主 ID",
+    "Activities.Columns.Type": "类型",
+    "Activities.Columns.Status": "状态",
+    "Activities.Columns.AssignedToUserId": "指派给",
+    "Activities.Columns.CreatedByUserId": "创建人",
+    "Activities.Columns.CompletedByUserId": "完成人",
+    "Activities.Columns.DueAt": "截止时间",
+    "Activities.Columns.CompletedAt": "完成时间",
+    "Activities.Columns.OverdueNotifiedAt": "逾期通知时间",
+    "Activities.Columns.Description": "描述"
   }
 }

--- a/src/Granit.Activities/Metrics/OpenActivityCountMetricDefinition.cs
+++ b/src/Granit.Activities/Metrics/OpenActivityCountMetricDefinition.cs
@@ -1,0 +1,51 @@
+using System.Linq.Expressions;
+using Granit.Activities.Domain;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Activities.Metrics;
+
+/// <summary>
+/// Number of activities currently in <see cref="ActivityStatus.Open"/> — the
+/// outstanding-work KPI for the activities admin dashboard. Done and Cancelled
+/// activities are excluded by design: they would inflate the KPI with
+/// already-closed work.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Period selector is <see cref="Activity.DueAt"/>. With <c>?period=last_7d</c>
+/// the count is restricted to open activities due in that window
+/// ("how many open items are due in the next 7 days?" when paired with a
+/// forward-looking token, "how many open items were due in the last 7 days?"
+/// otherwise). Without a period parameter, returns the all-time open count.
+/// </para>
+/// <para>
+/// <c>IsHigherBetter</c> is <c>false</c> — fewer open activities is favourable,
+/// so the delta arrow renders red when the value goes up.
+/// </para>
+/// </remarks>
+public sealed class OpenActivityCountMetricDefinition : MetricDefinition<Activity, int>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Activities.OpenActivityCountMetric";
+
+    /// <inheritdoc/>
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc/>
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, int?>>? Selector => null;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, bool>>? BaseFilter
+        => a => a.Status == ActivityStatus.Open;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, DateTimeOffset>>? PeriodSelector
+        => a => a.DueAt;
+
+    /// <inheritdoc/>
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Activities/Metrics/OverdueActivityCountMetricDefinition.cs
+++ b/src/Granit.Activities/Metrics/OverdueActivityCountMetricDefinition.cs
@@ -1,0 +1,56 @@
+using System.Linq.Expressions;
+using Granit.Activities.Domain;
+using Granit.Analytics.Metrics;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Activities.Metrics;
+
+/// <summary>
+/// Number of activities still in <see cref="ActivityStatus.Open"/> that the
+/// overdue background job (story A8) has already flagged as past due — i.e.
+/// rows whose <see cref="Activity.OverdueNotifiedAt"/> stamp is set. This is
+/// the "currently-known overdue" count that pairs with the assignee
+/// notifications shipped in A7.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The overdue determination relies on the BG-job-stamped column rather than
+/// an in-expression <c>UtcNow</c> comparison (forbidden by CLAUDE.md): the
+/// stamp is the framework's atomic, server-controlled signal that the row has
+/// crossed the deadline.
+/// </para>
+/// <para>
+/// Period selector is <see cref="Activity.DueAt"/>; <c>?period=mtd</c> answers
+/// "overdue items due so far this month". Without a period parameter, returns
+/// the all-time backlog of currently-flagged overdue items.
+/// </para>
+/// <para>
+/// <c>IsHigherBetter</c> is <c>false</c> — fewer overdue activities is
+/// favourable.
+/// </para>
+/// </remarks>
+public sealed class OverdueActivityCountMetricDefinition : MetricDefinition<Activity, int>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Activities.OverdueActivityCountMetric";
+
+    /// <inheritdoc/>
+    public override MetricValueKind ValueKind => MetricValueKind.Count;
+
+    /// <inheritdoc/>
+    public override AggregateFunction Aggregation => AggregateFunction.Count;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, int?>>? Selector => null;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, bool>>? BaseFilter
+        => a => a.Status == ActivityStatus.Open && a.OverdueNotifiedAt != null;
+
+    /// <inheritdoc/>
+    public override Expression<Func<Activity, DateTimeOffset>>? PeriodSelector
+        => a => a.DueAt;
+
+    /// <inheritdoc/>
+    public override bool IsHigherBetter => false;
+}

--- a/src/Granit.Activities/Queries/ActivityQueryDefinition.cs
+++ b/src/Granit.Activities/Queries/ActivityQueryDefinition.cs
@@ -1,0 +1,46 @@
+using Granit.Activities.Domain;
+using Granit.Activities.Internal;
+using Granit.QueryEngine;
+
+namespace Granit.Activities.Queries;
+
+/// <summary>
+/// Query definition for activities — declares the columns, filters, sorting,
+/// and search exposed by the admin grid endpoint backing the cross-entity
+/// activities list.
+/// </summary>
+public sealed class ActivityQueryDefinition : QueryDefinition<Activity>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Activities.ActivityQuery";
+
+    /// <inheritdoc/>
+    public override Type? LocalizationResourceType => typeof(ActivitiesLocalizationResource);
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<Activity> builder)
+    {
+        builder
+            // ── Tenant + polymorphic host ────────────────────────────────────
+            .Column(a => a.TenantId, c => c.Label("Tenant").LabelKey("Activities.Columns.Tenant").Filterable().Sortable())
+            .Column(a => a.EntityType, c => c.Label("Host Entity").LabelKey("Activities.Columns.EntityType").Filterable().Sortable())
+            .Column(a => a.EntityId, c => c.Label("Host Id").LabelKey("Activities.Columns.EntityId").Filterable())
+            // ── Type + lifecycle ─────────────────────────────────────────────
+            .Column(a => a.Type, c => c.Label("Type").LabelKey("Activities.Columns.Type").Filterable().Sortable())
+            .Column(a => a.Status, c => c.Label("Status").LabelKey("Activities.Columns.Status").Filterable().Sortable())
+            // ── Assignment ───────────────────────────────────────────────────
+            .Column(a => a.AssignedToUserId, c => c.Label("Assigned To").LabelKey("Activities.Columns.AssignedToUserId").Filterable())
+            .Column(a => a.CreatedByUserId, c => c.Label("Created By").LabelKey("Activities.Columns.CreatedByUserId").Filterable())
+            .Column(a => a.CompletedByUserId, c => c.Label("Completed By").LabelKey("Activities.Columns.CompletedByUserId").Filterable())
+            // ── Time ─────────────────────────────────────────────────────────
+            .Column(a => a.DueAt, c => c.Label("Due At").LabelKey("Activities.Columns.DueAt").Sortable())
+            .Column(a => a.CompletedAt, c => c.Label("Completed At").LabelKey("Activities.Columns.CompletedAt").Sortable())
+            .Column(a => a.OverdueNotifiedAt, c => c.Label("Overdue Notified At").LabelKey("Activities.Columns.OverdueNotifiedAt").Sortable())
+            // ── Free text ────────────────────────────────────────────────────
+            .Column(a => a.Description, c => c.Label("Description").LabelKey("Activities.Columns.Description").Filterable())
+            .GlobalSearch(a => a.Description)
+            .DateFilter(a => a.DueAt)
+            .DefaultSort("-dueAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Activities/packages.lock.json
+++ b/src/Granit.Activities/packages.lock.json
@@ -44,6 +44,31 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -61,6 +86,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -71,6 +115,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -98,6 +153,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Activities.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Activities.BackgroundJobs.Tests/packages.lock.json
@@ -292,7 +292,10 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
@@ -306,6 +309,31 @@
         "dependencies": {
           "Granit.Activities": "[0.1.0-dev, )",
           "Granit.BackgroundJobs": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.backgroundjobs": {
@@ -339,6 +367,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -349,6 +396,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -384,6 +442,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Cronos": {

--- a/tests/Granit.Activities.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Activities.Endpoints.Tests/packages.lock.json
@@ -302,7 +302,10 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
@@ -319,6 +322,16 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "granit.analytics.abstractions": {
@@ -351,6 +364,17 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
         }
       },
       "granit.dashboards.abstractions": {

--- a/tests/Granit.Activities.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Activities.EntityFrameworkCore.Tests/packages.lock.json
@@ -336,7 +336,10 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
@@ -351,6 +354,31 @@
           "Granit.Activities": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {
@@ -370,6 +398,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -380,6 +427,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -442,6 +500,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Activities.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Activities.Notifications.Tests/packages.lock.json
@@ -275,7 +275,10 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
@@ -290,6 +293,31 @@
           "Granit.Activities": "[0.1.0-dev, )",
           "Granit.Notifications.Abstractions": "[0.1.0-dev, )",
           "Granit.Templating": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {
@@ -309,6 +337,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -319,6 +366,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {

--- a/tests/Granit.Activities.Tests/packages.lock.json
+++ b/tests/Granit.Activities.Tests/packages.lock.json
@@ -281,13 +281,41 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Activities.Abstractions": "[0.1.0-dev, )",
-          "Granit.Localization": "[0.1.0-dev, )"
+          "Granit.Analytics": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.activities.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.analytics.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.caching": {
@@ -307,6 +335,25 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.dashboards": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.dashboards.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -317,6 +364,17 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Analytics.Abstractions": "[0.1.0-dev, )",
+          "Granit.Dashboards.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Workflow.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -344,6 +402,12 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {


### PR DESCRIPTION
## Summary

Closes [#1804](https://github.com/granit-fx/granit-dotnet/issues/1804) — last story of Phase 2 Stream A. Closes Stream A (9/9).

Ships the three declarative primitives for the `Activity` aggregate so it joins the admin pairing trio (browse / export / measure) enforced by the architecture tests.

## Definitions

| File | Wire identifier | Purpose |
| ---- | --------------- | ------- |
| `Queries/ActivityQueryDefinition.cs` | `Granit.Activities.ActivityQuery` | Admin grid columns + DueAt date filter + free-text search on Description, default sort `-dueAt` |
| `Exports/ActivityExportDefinition.cs` | `Granit.Activities.ActivityExport` | CSV/XLSX whitelist over the same column set + audit fields |
| `Metrics/OpenActivityCountMetricDefinition.cs` | `Granit.Activities.OpenActivityCountMetric` | `Status == Open`, period selector `DueAt`, `IsHigherBetter = false` |
| `Metrics/OverdueActivityCountMetricDefinition.cs` | `Granit.Activities.OverdueActivityCountMetric` | `Status == Open && OverdueNotifiedAt != null`, period selector `DueAt`, `IsHigherBetter = false` |

The overdue metric leans on the `OverdueNotifiedAt` column stamped by the A8 background job rather than an in-expression `UtcNow` comparison (forbidden by CLAUDE.md). Same trick the BG job already uses for idempotency — re-used here as the metric's "currently-known overdue" predicate.

## Localization

`Metric:Granit.Activities.OpenActivityCountMetric`, `Metric:Granit.Activities.OverdueActivityCountMetric`, and 12 `Activities.Columns.*` keys added in all 15 base cultures (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi). Regional variants (en-GB, fr-CA, pt-BR) inherit.

## DI

`AddGranitActivities` now registers the four definitions in addition to the registry — single call, hosts get the full pairing trio for free.

`Granit.Activities.csproj` picks up three new project references (`Granit.Analytics`, `Granit.DataExchange.Abstractions`, `Granit.QueryEngine.Abstractions`) — all lightweight abstraction packages, zero new transitive runtime weight.

## Test plan

- [x] `dotnet build src/Granit.Activities` — 0 errors / 0 warnings
- [x] `dotnet build .github/shard-filters/architecture.slnf` + `dotnet test --no-build` — 209/209 pass (incl. `QueryExportPairingTests`, `QueryMetricPairingTests`, `MetricLocalizationCompletenessTests`)
- [x] `dotnet test tests/Granit.Activities.Tests` — 20/20 pass
- [x] `dotnet format src/Granit.Activities --verify-no-changes` — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles regenerated

## Stream A is now closed (9/9)

A1 #1788 · A2 #1789 · A3 #1790 · A4 #1791 · A5 #1792 · A6 #1793 · A7 #1802 · A8 #1803 · **A9 #1804**

Phase 2 next: Stream B (Customization L1, 5 stories) and Stream C (Reactions Timeline, 3 stories).
