### PR TITLE
feat(entities-customization): manifest composer Layer 1 + provenance — closes Stream B 5/5 (closes #1810)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -987,6 +987,7 @@
         "Granit.Entities",
         "Granit.Entities.Abstractions",
         "Granit.Entities.Customization",
+        "Granit.Entities.Endpoints",
         "Granit.Guids",
         "Granit.Http.ApiDocumentation",
         "Granit.Validation"
@@ -20990,7 +20991,7 @@
       "kind": "class",
       "project": "Granit.Entities.Customization.Endpoints",
       "file": "src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs",
-      "line": 28,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21407,7 +21408,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 39,
+      "line": 53,
       "members": []
     },
     {
@@ -21416,7 +21417,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 9,
+      "line": 16,
       "members": []
     },
     {
@@ -21425,7 +21426,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 56,
+      "line": 71,
       "members": []
     },
     {
@@ -21434,7 +21435,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 21,
+      "line": 29,
       "members": []
     },
     {
@@ -21555,6 +21556,24 @@
       "members": []
     },
     {
+      "name": "EntityProvenance",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenance",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntityProvenanceLayers",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenanceLayers",
+      "kind": "class",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
+      "line": 21,
+      "members": []
+    },
+    {
       "name": "EntityRelationAggregateManifest",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityRelationAggregateManifest",
       "kind": "record",
@@ -21644,6 +21663,22 @@
           "kind": "method",
           "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
           "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
+        }
+      ]
+    },
+    {
+      "name": "IManifestCustomizationApplier",
+      "fqn": "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier",
+      "kind": "interface",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Internal/IManifestCustomizationApplier.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ApplyAsync",
+          "kind": "method",
+          "signature": "ApplyAsync(string entityName, EntityManifestResponse composedManifest, CancellationToken cancellationToken = default)",
+          "returnType": "Task<EntityManifestResponse>"
         }
       ]
     },

--- a/src/Granit.Entities.Customization.Endpoints/Endpoints/EntityCustomizationEndpoints.cs
+++ b/src/Granit.Entities.Customization.Endpoints/Endpoints/EntityCustomizationEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Entities.Customization.Domain.Deltas;
 using Granit.Entities.Customization.Endpoints.Dtos;
 using Granit.Entities.Customization.Endpoints.Internal;
 using Granit.Entities.Customization.Endpoints.Permissions;
+using Granit.Entities.Endpoints.Internal;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Builder;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace Granit.Entities.Customization.Endpoints.Endpoints;
 
@@ -78,6 +80,7 @@ internal static class EntityCustomizationEndpoints
         [FromServices] EntityCustomizationAuditWriter auditWriter,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IFusionCache cache,
         CancellationToken cancellationToken)
     {
         ValidationResult validation = descriptorValidator.Validate(entityName, layoutKind, request.Deltas);
@@ -104,6 +107,9 @@ internal static class EntityCustomizationEndpoints
 
         await writer.UpsertAsync(toPersist, cancellationToken).ConfigureAwait(false);
         await auditWriter.WriteUpsertAsync(toPersist, previousDeltas, cancellationToken).ConfigureAwait(false);
+        await cache.RemoveByTagAsync(
+            EntityCacheKey.EvictionTagForManifest(entityName), token: cancellationToken)
+            .ConfigureAwait(false);
 
         EntityCustomization? saved = await reader.GetAsync(entityName, layoutKind, tenantId, cancellationToken)
             .ConfigureAwait(false);
@@ -117,6 +123,7 @@ internal static class EntityCustomizationEndpoints
         [FromServices] IEntityCustomizationWriter writer,
         [FromServices] EntityCustomizationAuditWriter auditWriter,
         [FromServices] ICurrentTenant currentTenant,
+        [FromServices] IFusionCache cache,
         CancellationToken cancellationToken)
     {
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
@@ -130,6 +137,9 @@ internal static class EntityCustomizationEndpoints
 
         await writer.DeleteAsync(existing.Id, cancellationToken).ConfigureAwait(false);
         await auditWriter.WriteDeleteAsync(existing, cancellationToken).ConfigureAwait(false);
+        await cache.RemoveByTagAsync(
+            EntityCacheKey.EvictionTagForManifest(entityName), token: cancellationToken)
+            .ConfigureAwait(false);
         return TypedResults.NoContent();
     }
 

--- a/src/Granit.Entities.Customization.Endpoints/Granit.Entities.Customization.Endpoints.csproj
+++ b/src/Granit.Entities.Customization.Endpoints/Granit.Entities.Customization.Endpoints.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Granit.Entities\Granit.Entities.csproj" />
     <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Entities.Customization\Granit.Entities.Customization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Endpoints\Granit.Entities.Endpoints.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs
+++ b/src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs
@@ -1,6 +1,8 @@
 using Granit.Auditing;
 using Granit.Authorization;
 using Granit.Entities.Customization.Endpoints.Internal;
+using Granit.Entities.Endpoints;
+using Granit.Entities.Endpoints.Internal;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
@@ -11,7 +13,11 @@ namespace Granit.Entities.Customization.Endpoints;
 
 /// <summary>
 /// Granit module for the entities-customization HTTP endpoints — exposes the
-/// per-tenant Layer 1 GET / PUT / DELETE per ADR-053.
+/// per-tenant Layer 1 GET / PUT / DELETE per ADR-053. Loading this module also
+/// replaces the manifest endpoint's no-op
+/// <see cref="IManifestCustomizationApplier"/> with the real
+/// <see cref="EntityCustomizationManifestApplier"/> so subsequent manifest
+/// reads honour the tenant's customization deltas (B4).
 /// </summary>
 /// <remarks>
 /// Map endpoints in your application:
@@ -22,6 +28,7 @@ namespace Granit.Entities.Customization.Endpoints;
     typeof(GranitAuditingModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitEntitiesCustomizationModule),
+    typeof(GranitEntitiesEndpointsModule),
     typeof(GranitEntitiesModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitValidationModule))]
@@ -32,5 +39,7 @@ public sealed class GranitEntitiesCustomizationEndpointsModule : GranitModule
     {
         context.Services.TryAddScoped<DescriptorDeltaValidator>();
         context.Services.TryAddScoped<EntityCustomizationAuditWriter>();
+        context.Services.Replace(
+            ServiceDescriptor.Scoped<IManifestCustomizationApplier, EntityCustomizationManifestApplier>());
     }
 }

--- a/src/Granit.Entities.Customization.Endpoints/Internal/EntityCustomizationManifestApplier.cs
+++ b/src/Granit.Entities.Customization.Endpoints/Internal/EntityCustomizationManifestApplier.cs
@@ -1,0 +1,182 @@
+using Granit.Entities.Customization.Domain;
+using Granit.Entities.Customization.Domain.Deltas;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using Granit.MultiTenancy;
+
+namespace Granit.Entities.Customization.Endpoints.Internal;
+
+/// <summary>
+/// Real <see cref="IManifestCustomizationApplier"/> — applies the active
+/// <see cref="EntityCustomization"/> for the current tenant on top of the
+/// composed manifest, mutating the form layout and tagging affected fields
+/// with <see cref="EntityProvenance"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Targets <see cref="LayoutKind.FormDefault"/> in v1: only the default form
+/// variant is customizable through the manifest pipeline. Other layout kinds
+/// (List / Calendar / Gallery / DetailDefault) load their layout descriptors
+/// from separate composition paths — those will gain customization in
+/// follow-up stories without touching this applier.
+/// </para>
+/// <para>
+/// Applies in declaration order — same as the persisted delta order. Reorder
+/// targets the within-section position; cross-section moves are expressed as
+/// <see cref="RegroupDelta"/>. Hidden fields are dropped from the section
+/// they belong to and accumulated into <see cref="EntityFormManifest.HiddenByOverride"/>
+/// so the dev-mode field-inspector overlay can render the "hidden by tenant"
+/// badge.
+/// </para>
+/// </remarks>
+internal sealed class EntityCustomizationManifestApplier(
+    IEntityCustomizationReader reader,
+    ICurrentTenant currentTenant) : IManifestCustomizationApplier
+{
+    public async Task<EntityManifestResponse> ApplyAsync(
+        string entityName,
+        EntityManifestResponse composedManifest,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityName);
+        ArgumentNullException.ThrowIfNull(composedManifest);
+
+        if (composedManifest.Forms is null || composedManifest.Forms.Count == 0)
+        {
+            return composedManifest;
+        }
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        EntityCustomization? customization = await reader.GetAsync(
+            entityName, LayoutKind.FormDefault, tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (customization is null || customization.Deltas.Count == 0)
+        {
+            return composedManifest;
+        }
+
+        // Only the first form variant ("default") is customized in v1.
+        EntityFormManifest defaultForm = composedManifest.Forms[0];
+        EntityFormManifest customizedForm = ApplyToForm(defaultForm, customization);
+
+        List<EntityFormManifest> newForms = [.. composedManifest.Forms];
+        newForms[0] = customizedForm;
+
+        return composedManifest with { Forms = newForms };
+    }
+
+    private static EntityFormManifest ApplyToForm(EntityFormManifest form, EntityCustomization customization)
+    {
+        // Mutable working state — section key → ordered field list.
+        var bySection =
+            form.Sections.ToDictionary(s => s.Key, s => s.Fields.ToList(), StringComparer.Ordinal);
+        HashSet<string> hidden = new(StringComparer.Ordinal);
+
+        EntityProvenance provenance = new(
+            EntityProvenanceLayers.TenantCustomization, customization.Id);
+
+        foreach (LayoutDelta delta in customization.Deltas)
+        {
+            (string sectionKey, int index, EntityFormFieldManifest field)? located = LocateField(bySection, delta.FieldName);
+            if (located is null)
+            {
+                // Dangling reference — silently drop per ADR-053 §6 (composer is
+                // the authoritative validator; B3 endpoint validates new writes
+                // but historic deltas may reference a since-removed field).
+                continue;
+            }
+
+            (string fromSection, int fromIndex, EntityFormFieldManifest target) = located.Value;
+
+            switch (delta)
+            {
+                case HideDelta:
+                    bySection[fromSection].RemoveAt(fromIndex);
+                    hidden.Add(target.PropertyName);
+                    break;
+
+                case RegroupDelta regroup:
+                    if (!bySection.TryGetValue(regroup.GroupKey, out List<EntityFormFieldManifest>? targetSection))
+                    {
+                        // Unknown target group — drop silently (defense in depth).
+                        continue;
+                    }
+                    bySection[fromSection].RemoveAt(fromIndex);
+                    targetSection.Add(target with { Provenance = provenance });
+                    break;
+
+                case ReorderDelta reorder:
+                    bySection[fromSection].RemoveAt(fromIndex);
+                    int newIndex = ResolveAnchorIndex(bySection[fromSection], reorder);
+                    bySection[fromSection].Insert(newIndex, target with { Provenance = provenance });
+                    break;
+            }
+        }
+
+        List<EntityFormSectionManifest> newSections = new(form.Sections.Count);
+        foreach (EntityFormSectionManifest section in form.Sections)
+        {
+            List<EntityFormFieldManifest> fields = bySection[section.Key];
+            if (fields.Count == 0 && section.OwnedCollection is null)
+            {
+                // Section emptied by hides — drop to keep parity with the
+                // existing "no surviving field → drop section" behaviour.
+                continue;
+            }
+            newSections.Add(section with { Fields = fields });
+        }
+
+        return form with
+        {
+            Sections = newSections,
+            HiddenByOverride = hidden.Count == 0 ? null : [.. hidden],
+        };
+    }
+
+    private static (string sectionKey, int index, EntityFormFieldManifest field)? LocateField(
+        Dictionary<string, List<EntityFormFieldManifest>> bySection,
+        string fieldName)
+    {
+        foreach ((string sectionKey, List<EntityFormFieldManifest> fields) in bySection)
+        {
+            for (int i = 0; i < fields.Count; i++)
+            {
+                if (string.Equals(fields[i].PropertyName, fieldName, StringComparison.Ordinal))
+                {
+                    return (sectionKey, i, fields[i]);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static int ResolveAnchorIndex(List<EntityFormFieldManifest> fields, ReorderDelta reorder)
+    {
+        if (reorder.BeforeFieldName is { } before)
+        {
+            for (int i = 0; i < fields.Count; i++)
+            {
+                if (string.Equals(fields[i].PropertyName, before, StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+            return fields.Count;
+        }
+
+        if (reorder.AfterFieldName is { } after)
+        {
+            for (int i = 0; i < fields.Count; i++)
+            {
+                if (string.Equals(fields[i].PropertyName, after, StringComparison.Ordinal))
+                {
+                    return i + 1;
+                }
+            }
+            return fields.Count;
+        }
+
+        return fields.Count;
+    }
+}

--- a/src/Granit.Entities.Customization.Endpoints/packages.lock.json
+++ b/src/Granit.Entities.Customization.Endpoints/packages.lock.json
@@ -34,6 +34,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.activities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -112,6 +118,18 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Activities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {

--- a/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs
@@ -6,10 +6,18 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="Name">Variant name, unique per entity (e.g. <c>"default"</c>).</param>
 /// <param name="Customizable">When <see langword="true"/>, tenant admins may reorder/regroup/hide fields (Tier B Layer 1).</param>
 /// <param name="Sections">Sections in declaration order.</param>
+/// <param name="HiddenByOverride">
+/// Field property names hidden by an active Layer 1 customization (ADR-053).
+/// Surfaced for the field-inspector dev tooling so the React shell can render
+/// a "hidden by tenant" badge — the fields themselves are absent from
+/// <see cref="EntityFormSectionManifest.Fields"/>.
+/// <see langword="null"/> when no customization is active or no field is hidden.
+/// </param>
 public sealed record EntityFormManifest(
     string Name,
     bool Customizable,
-    IReadOnlyList<EntityFormSectionManifest> Sections);
+    IReadOnlyList<EntityFormSectionManifest> Sections,
+    IReadOnlyList<string>? HiddenByOverride = null);
 
 /// <summary>One form section.</summary>
 /// <param name="Key">Stable section key (e.g. <c>"identity"</c>).</param>
@@ -36,6 +44,12 @@ public sealed record EntityFormSectionManifest(
 /// <param name="Order">Display order within the section.</param>
 /// <param name="ReadOnly">Read-only in the form context.</param>
 /// <param name="VisibleIf">Closed-DSL conditional-visibility rule (ADR-040), or <see langword="null"/>.</param>
+/// <param name="Provenance">
+/// Per-field source attribution (ADR-053 §6). <see langword="null"/> means
+/// compiled defaults; a non-null value (typically <c>tenant-customization</c>)
+/// signals the field was reordered or regrouped by an active Layer 1
+/// customization.
+/// </param>
 public sealed record EntityFormFieldManifest(
     string PropertyName,
     string ClrTypeName,
@@ -45,7 +59,8 @@ public sealed record EntityFormFieldManifest(
     string? HelpKey,
     int Order,
     bool ReadOnly,
-    VisibilityCondition? VisibleIf);
+    VisibilityCondition? VisibleIf,
+    EntityProvenance? Provenance = null);
 
 /// <summary>An owned-collection sub-section (rendered as a list of items per ADR-040).</summary>
 /// <param name="PropertyName">Owner-side property exposing the collection (e.g. <c>"Addresses"</c>).</param>

--- a/src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs
@@ -1,0 +1,28 @@
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Per-field attribution token added by the manifest composer (ADR-053 §6).
+/// The dev-mode field-inspector overlay in the React shell renders a small
+/// badge per field that resolves to this token, so a developer can answer
+/// "where does this field come from?" without grepping the codebase.
+/// </summary>
+/// <param name="Layer">
+/// The source layer; one of <see cref="EntityProvenanceLayers.Compiled"/> or
+/// <see cref="EntityProvenanceLayers.TenantCustomization"/>. (URL state, saved
+/// view, and workspace preset layers — when they ship — also slot in here.)
+/// </param>
+/// <param name="OverrideId">
+/// Identifier of the customization row that produced this provenance, when
+/// applicable. <see langword="null"/> for the compiled layer.
+/// </param>
+public sealed record EntityProvenance(string Layer, Guid? OverrideId);
+
+/// <summary>Stable wire identifiers for <see cref="EntityProvenance.Layer"/>.</summary>
+public static class EntityProvenanceLayers
+{
+    /// <summary>Compiled defaults — the field comes straight from <c>EntityDefinition&lt;T&gt;</c>.</summary>
+    public const string Compiled = "compiled";
+
+    /// <summary>Layer 1 tenant customization (ADR-053).</summary>
+    public const string TenantCustomization = "tenant-customization";
+}

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -123,6 +123,7 @@ internal static class EntitiesEndpoints
         [FromServices] EntityPermissionResolver permissionResolver,
         [FromServices] IFusionCache cache,
         [FromServices] IOptions<EntitiesEndpointsOptions> options,
+        [FromServices] IManifestCustomizationApplier customizationApplier,
         ClaimsPrincipal user,
         HttpContext httpContext,
         CancellationToken cancellationToken,
@@ -163,10 +164,15 @@ internal static class EntitiesEndpoints
             {
                 IReadOnlySet<string> grantedPermissions = await CollectGrantedPermissionsAsync(
                     permissionResolver, descriptor, ct).ConfigureAwait(false);
-                return EntityManifestComposer.Compose(
+                EntityManifestResponse composed = EntityManifestComposer.Compose(
                     descriptor, snapshot, grantedPermissions, selected, defaultViewId: null, activityRegistry);
+                // Layer 4 (ADR-053): apply tenant customization deltas + provenance.
+                // Default impl is a no-op; replaced by Granit.Entities.Customization.Endpoints
+                // when that package is loaded.
+                return await customizationApplier.ApplyAsync(name, composed, ct).ConfigureAwait(false);
             },
             new FusionCacheEntryOptions { Duration = options.Value.ManifestCacheTtl },
+            tags: [EntityCacheKey.EvictionTagForManifest(name)],
             token: cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
@@ -69,6 +69,9 @@ public static class EntitiesEndpointRouteBuilderExtensions
         // concrete ICalendarRangeService BEFORE calling AddGranitEntitiesEndpoints,
         // or by calling Replace afterwards.
         services.TryAddSingleton<ICalendarRangeService, NullCalendarRangeService>();
+        // Layer 1 customization (ADR-053): default no-op applier. Replaced by
+        // Granit.Entities.Customization.Endpoints when that package is loaded.
+        services.TryAddScoped<IManifestCustomizationApplier, NullManifestCustomizationApplier>();
         services.AddOptions<EntitiesEndpointsOptions>();
         Granit.Diagnostics.GranitActivitySourceRegistry.Register(EntityActivitySource.Name);
         return services;

--- a/src/Granit.Entities.Endpoints/Granit.Entities.Endpoints.csproj
+++ b/src/Granit.Entities.Endpoints/Granit.Entities.Endpoints.csproj
@@ -10,6 +10,8 @@
     <InternalsVisibleTo Include="Granit.Entities.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Entities.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.Entities.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization.Endpoints.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Entities.Endpoints/Internal/EntityCacheKey.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityCacheKey.cs
@@ -86,6 +86,18 @@ internal static class EntityCacheKey
     }
 
     /// <summary>
+    /// FusionCache eviction tag covering every cached manifest entry for one
+    /// entity (across permission hashes, cultures, and facet selections). Used
+    /// by the Layer 1 customization PUT / DELETE handlers (ADR-053) to evict
+    /// the manifest cache after a tenant changes the entity's customization.
+    /// </summary>
+    public static string EvictionTagForManifest(string entityName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityName);
+        return $"{ManifestPrefix}:{entityName}";
+    }
+
+    /// <summary>
     /// SHA-256 over the sorted role + permission claim values. 16 hex chars is
     /// enough — collisions on this surface only mean a stale entry is served
     /// up to the next TTL boundary; security gating runs separately on every

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -17,8 +17,12 @@ namespace Granit.Entities.Endpoints.Internal;
 /// </summary>
 internal static class EntityManifestComposer
 {
-    /// <summary>Manifest schema version. Bump on breaking shape changes.</summary>
-    public const int SchemaVersion = 1;
+    /// <summary>
+    /// Manifest schema version. Bump on breaking shape changes.
+    /// v2 adds per-field <c>Provenance</c> + per-form <c>HiddenByOverride</c>
+    /// for the Layer 1 customization field-inspector dev tooling (ADR-053 §6).
+    /// </summary>
+    public const int SchemaVersion = 2;
 
     public static EntityManifestResponse Compose(
         EntityDefinitionDescriptor definition,

--- a/src/Granit.Entities.Endpoints/Internal/IManifestCustomizationApplier.cs
+++ b/src/Granit.Entities.Endpoints/Internal/IManifestCustomizationApplier.cs
@@ -1,0 +1,38 @@
+using Granit.Entities.Endpoints.Dtos;
+
+namespace Granit.Entities.Endpoints.Internal;
+
+/// <summary>
+/// Layer 4 of the manifest resolution hierarchy (ADR-053 §5) — the per-tenant
+/// customization step. The composer (steps 5 → compiled defaults) runs first;
+/// this applier mutates the resulting payload to apply the tenant's
+/// <c>EntityCustomization</c> deltas (reorder / regroup / hide) and tag
+/// affected fields with <see cref="EntityProvenance"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default registration is the <see cref="NullManifestCustomizationApplier"/>
+/// no-op — hosts that do not load <c>Granit.Entities.Customization.Endpoints</c>
+/// see the compiled manifest unchanged. The customization endpoints package
+/// replaces the registration via <c>services.Replace</c> with the real
+/// implementation.
+/// </para>
+/// <para>
+/// Applies INSIDE the manifest cache miss path so the customized payload is
+/// the cached value — re-applying on every read would defeat the cache. PUT /
+/// DELETE on the customization endpoint evict the per-entity cache via the
+/// <see cref="EntityCacheKey.EvictionTagForManifest"/> tag.
+/// </para>
+/// </remarks>
+public interface IManifestCustomizationApplier
+{
+    /// <summary>
+    /// Returns a customized copy of <paramref name="composedManifest"/> with
+    /// the active per-tenant deltas applied, or the input unchanged when no
+    /// customization exists.
+    /// </summary>
+    Task<EntityManifestResponse> ApplyAsync(
+        string entityName,
+        EntityManifestResponse composedManifest,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Entities.Endpoints/Internal/NullManifestCustomizationApplier.cs
+++ b/src/Granit.Entities.Endpoints/Internal/NullManifestCustomizationApplier.cs
@@ -1,0 +1,19 @@
+using Granit.Entities.Endpoints.Dtos;
+
+namespace Granit.Entities.Endpoints.Internal;
+
+/// <summary>
+/// Default no-op <see cref="IManifestCustomizationApplier"/> registered by
+/// <c>GranitEntitiesEndpointsModule</c>. Hosts that omit
+/// <c>Granit.Entities.Customization.Endpoints</c> see the compiled manifest
+/// unchanged — every field's <c>Provenance</c> is the implicit
+/// <see cref="EntityProvenanceLayers.Compiled"/>.
+/// </summary>
+internal sealed class NullManifestCustomizationApplier : IManifestCustomizationApplier
+{
+    public Task<EntityManifestResponse> ApplyAsync(
+        string entityName,
+        EntityManifestResponse composedManifest,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(composedManifest);
+}

--- a/tests/Granit.Entities.Customization.Endpoints.Tests/Internal/EntityCustomizationManifestApplierTests.cs
+++ b/tests/Granit.Entities.Customization.Endpoints.Tests/Internal/EntityCustomizationManifestApplierTests.cs
@@ -1,0 +1,189 @@
+using Granit.Entities.Customization.Domain;
+using Granit.Entities.Customization.Domain.Deltas;
+using Granit.Entities.Customization.Endpoints.Internal;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Customization.Endpoints.Tests.Internal;
+
+public sealed class EntityCustomizationManifestApplierTests
+{
+    private const string EntityName = "Granit.Parties.Party";
+
+    [Fact]
+    public async Task No_customization_returns_input_unchanged()
+    {
+        EntityManifestResponse manifest = ManifestWith(BuildSection("identity", "FirstName", "LastName"));
+        EntityCustomizationManifestApplier sut = SutFor(customization: null);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        result.ShouldBeSameAs(manifest);
+    }
+
+    [Fact]
+    public async Task Empty_delta_list_returns_input_unchanged()
+    {
+        EntityManifestResponse manifest = ManifestWith(BuildSection("identity", "FirstName", "LastName"));
+        var customization = EntityCustomization.Create(
+            id: Guid.NewGuid(),
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: []);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        result.ShouldBeSameAs(manifest);
+    }
+
+    [Fact]
+    public async Task Hide_drops_field_and_records_HiddenByOverride()
+    {
+        EntityManifestResponse manifest = ManifestWith(BuildSection("identity", "FirstName", "LastName"));
+        var overrideId = Guid.NewGuid();
+        var customization = EntityCustomization.Create(
+            id: overrideId,
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: [new HideDelta("LastName")]);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        EntityFormManifest form = result.Forms!.ShouldHaveSingleItem();
+        EntityFormSectionManifest section = form.Sections.ShouldHaveSingleItem();
+        section.Fields.Select(f => f.PropertyName).ShouldBe(["FirstName"]);
+        form.HiddenByOverride.ShouldNotBeNull();
+        form.HiddenByOverride.ShouldBe(["LastName"]);
+    }
+
+    [Fact]
+    public async Task Section_with_all_fields_hidden_is_dropped()
+    {
+        EntityManifestResponse manifest = ManifestWith(BuildSection("identity", "FirstName"));
+        var customization = EntityCustomization.Create(
+            id: Guid.NewGuid(),
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: [new HideDelta("FirstName")]);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        result.Forms!.ShouldHaveSingleItem().Sections.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Reorder_with_Before_anchor_repositions_within_section()
+    {
+        EntityManifestResponse manifest = ManifestWith(
+            BuildSection("identity", "FirstName", "LastName", "Email"));
+        var overrideId = Guid.NewGuid();
+        var customization = EntityCustomization.Create(
+            id: overrideId,
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: [new ReorderDelta("Email", BeforeFieldName: "FirstName", AfterFieldName: null)]);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        EntityFormSectionManifest section = result.Forms!.ShouldHaveSingleItem().Sections.ShouldHaveSingleItem();
+        section.Fields.Select(f => f.PropertyName).ShouldBe(["Email", "FirstName", "LastName"]);
+        EntityFormFieldManifest moved = section.Fields[0];
+        moved.Provenance.ShouldNotBeNull();
+        moved.Provenance.Layer.ShouldBe(EntityProvenanceLayers.TenantCustomization);
+        moved.Provenance.OverrideId.ShouldBe(overrideId);
+    }
+
+    [Fact]
+    public async Task Regroup_moves_field_across_sections_with_provenance()
+    {
+        EntityManifestResponse manifest = ManifestWith(
+            BuildSection("identity", "FirstName"),
+            BuildSection("contact", "Email"));
+        var overrideId = Guid.NewGuid();
+        var customization = EntityCustomization.Create(
+            id: overrideId,
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: [new RegroupDelta("Email", "identity")]);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        IReadOnlyList<EntityFormSectionManifest> sections = result.Forms!.ShouldHaveSingleItem().Sections;
+        EntityFormSectionManifest identitySection = sections.First(s => s.Key == "identity");
+        identitySection.Fields.Select(f => f.PropertyName).ShouldBe(["FirstName", "Email"]);
+        EntityFormFieldManifest moved = identitySection.Fields[1];
+        moved.Provenance!.Layer.ShouldBe(EntityProvenanceLayers.TenantCustomization);
+        moved.Provenance.OverrideId.ShouldBe(overrideId);
+        // contact is now empty — section is dropped per the same rule that drops sections
+        // emptied by Hide deltas (no surviving fields → drop the empty header).
+        sections.ShouldNotContain(s => s.Key == "contact");
+    }
+
+    [Fact]
+    public async Task Dangling_field_reference_is_silently_dropped()
+    {
+        EntityManifestResponse manifest = ManifestWith(BuildSection("identity", "FirstName"));
+        var customization = EntityCustomization.Create(
+            id: Guid.NewGuid(),
+            entityName: EntityName,
+            layoutKind: LayoutKind.FormDefault,
+            deltas: [new HideDelta("Phantom")]);
+        EntityCustomizationManifestApplier sut = SutFor(customization);
+
+        EntityManifestResponse result = await sut.ApplyAsync(EntityName, manifest, TestContext.Current.CancellationToken);
+
+        EntityFormManifest form = result.Forms!.ShouldHaveSingleItem();
+        form.HiddenByOverride.ShouldBeNull();
+        form.Sections.ShouldHaveSingleItem().Fields.Select(f => f.PropertyName).ShouldBe(["FirstName"]);
+    }
+
+    private static EntityCustomizationManifestApplier SutFor(EntityCustomization? customization)
+    {
+        IEntityCustomizationReader reader = Substitute.For<IEntityCustomizationReader>();
+        reader.GetAsync(EntityName, LayoutKind.FormDefault, Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(customization);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Guid.NewGuid());
+
+        return new EntityCustomizationManifestApplier(reader, tenant);
+    }
+
+    private static EntityManifestResponse ManifestWith(params EntityFormSectionManifest[] sections) =>
+        new(
+            SchemaVersion: 2,
+            Identity: null,
+            Permissions: null,
+            Forms: [new EntityFormManifest("default", Customizable: true, sections)],
+            Details: null,
+            Collections: null,
+            Relations: null,
+            Actions: null,
+            Activities: null);
+
+    private static EntityFormSectionManifest BuildSection(string key, params string[] fieldNames) =>
+        new(
+            Key: key,
+            LabelKey: null,
+            Order: 0,
+            CollapsedByDefault: false,
+            Fields: [.. fieldNames.Select(n => new EntityFormFieldManifest(
+                PropertyName: n,
+                ClrTypeName: "String",
+                Component: "text",
+                Config: null,
+                LabelKey: null,
+                HelpKey: null,
+                Order: 0,
+                ReadOnly: false,
+                VisibleIf: null))]);
+}

--- a/tests/Granit.Entities.Customization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Customization.Endpoints.Tests/packages.lock.json
@@ -308,6 +308,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.activities.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.analytics.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -408,8 +414,21 @@
           "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Entities.Customization": "[0.1.0-dev, )",
+          "Granit.Entities.Endpoints": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.entities.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Activities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },


### PR DESCRIPTION
## Summary

Closes [#1810](https://github.com/granit-fx/granit-dotnet/issues/1810) — final story of Phase 2 Stream B (Customization L1). **Stream B closed 5/5** (B0 [#1849](https://github.com/granit-fx/granit-dotnet/pull/1849), B1 [#1851](https://github.com/granit-fx/granit-dotnet/pull/1851), B2 [#1853](https://github.com/granit-fx/granit-dotnet/pull/1853), B3 [#1873](https://github.com/granit-fx/granit-dotnet/pull/1873), **B4 this PR**).

Wires per-tenant Layer 1 customization into the manifest pipeline per [ADR-053](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/053-entities-customization-layer-1.md) §5 (resolution hierarchy) + §6 (field inspector).

## `Granit.Entities.Endpoints` changes

| File | Change |
| ---- | ------ |
| `Dtos/EntityProvenance.cs` | NEW — `EntityProvenance(Layer, OverrideId)` + `EntityProvenanceLayers` constants (`compiled`, `tenant-customization`) |
| `Dtos/EntityFormManifest.cs` | `EntityFormFieldManifest` gains optional `Provenance` (null = compiled). `EntityFormManifest` gains optional `HiddenByOverride: IReadOnlyList<string>?` powering the field-inspector "hidden by tenant" badge |
| `Internal/IManifestCustomizationApplier.cs` | NEW — interface that the manifest endpoint calls inside the cache-miss path to apply layer-4 deltas |
| `Internal/NullManifestCustomizationApplier.cs` | NEW — default no-op registered via `TryAddScoped`; hosts that omit the Customization package see the compiled manifest unchanged |
| `Internal/EntityCacheKey.cs` | `EvictionTagForManifest(entityName)` returns `entity-meta:{entityName}` so PUT/DELETE on customization can flush in O(1) |
| `Internal/EntityManifestComposer.cs` | `SchemaVersion` bumped 1 → 2 to signal the new shape |
| `Endpoints/EntitiesEndpoints.cs` | `ManifestAsync` injects the applier, calls it inside the cache factory, tags the cached entry with the eviction tag |
| `Extensions/EntitiesEndpointRouteBuilderExtensions.cs` | Wires the `Null` applier in `AddGranitEntitiesEndpoints` |
| `Granit.Entities.Endpoints.csproj` | `InternalsVisibleTo` extended to the Customization.Endpoints package + its tests for cache-key access |

## `Granit.Entities.Customization.Endpoints` changes

| File | Change |
| ---- | ------ |
| `Internal/EntityCustomizationManifestApplier.cs` | NEW — real `IManifestCustomizationApplier` impl. Reads the `EntityCustomization` for `(current tenant, entity, FormDefault)`, applies `Reorder`/`Regroup`/`Hide` deltas in declaration order, tags moved fields with `TenantCustomization` provenance, accumulates hidden field names. **Dangling references silently dropped** — historic deltas may reference a since-removed field, and the composer is the authoritative validator (B3 endpoint validates new writes only) |
| `GranitEntitiesCustomizationEndpointsModule.cs` | `services.Replace` swaps the `Null` applier for the real impl. `DependsOn` extended with `GranitEntitiesEndpointsModule` |
| `Endpoints/EntityCustomizationEndpoints.cs` | PUT and DELETE inject `IFusionCache` and call `RemoveByTagAsync(EvictionTagForManifest(entityName))` after the write so subsequent manifest reads see the change immediately |
| `Granit.Entities.Customization.Endpoints.csproj` | Adds `<ProjectReference>` to `Granit.Entities.Endpoints` |

## Resolution hierarchy realised

ADR-053 §5 — the manifest pipeline now executes layers 5 → 4 server-side:

1. ~~URL state~~ (client)
2. ~~Saved Entity View~~ (client)
3. ~~Workspace preset~~ (client)
4. **Tenant customization (Layer 1) — this PR**
5. **Compiled defaults — `EntityManifestComposer.Compose`**

Hidden fields are dropped before the manifest leaves the server: layers 1-3 (client-side) cannot resurrect a field hidden at layer 4 — the floor that ADR-053 promises.

## Cache invariants

- Manifest cache key continues to embed `(entityName, userPermsHash, culture, facets)` — per-tenant segregation comes for free via the perms hash.
- Customization is baked INTO the cached manifest (apply runs inside the `GetOrSet` factory) — re-applying on every read would defeat the cache.
- PUT/DELETE on the customization endpoint emits `cache.RemoveByTagAsync` against the entity's manifest tag — within-tenant invalidation is O(1).

## Test plan

- [x] `dotnet build src/Granit.Entities.Endpoints src/Granit.Entities.Customization.Endpoints` — 0 errors / 0 warnings
- [x] `dotnet test tests/Granit.Entities.Customization.Endpoints.Tests` — **20/20 pass** (7 new applier scenarios + 13 existing B3 tests, no regression):
  - No-customization passthrough returns input unchanged
  - Empty deltas passthrough returns input unchanged
  - Hide drops field + records `HiddenByOverride`
  - All-fields-hidden drops the section (parity with permission-filtering)
  - Reorder with `Before` anchor repositions + tags provenance
  - Regroup moves across sections + drops emptied source section + tags provenance
  - Dangling field reference silently dropped (no `HiddenByOverride` entry)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — **83/83 pass** (no regression on the manifest pipeline despite the schema bump + applier injection)
- [x] `dotnet format --verify-no-changes` on src + tests — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles regenerated

## ADR alignment notes

- The B4 issue mentions a `WorkspaceManifestComposer` integration. Workspace presets remain layer 3 (additive-only, [ADR-044](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/044-workspace-navigation.md)) per ADR-053 — they are not customization deltas. Out of scope for B4 (and for Stream B as a whole).
- Layout kinds beyond `FormDefault` (Detail / List / Calendar / Gallery) load their layout descriptors from separate composition paths; those will gain customization in follow-up stories without touching this applier. The manifest cache invalidation tag covers them transparently.

## Stream B is now closed (5/5)

| Story | PR | Scope |
| ----- | -- | ----- |
| B0 | [#1849](https://github.com/granit-fx/granit-dotnet/pull/1849) | ADR-053 published |
| B1 | [#1851](https://github.com/granit-fx/granit-dotnet/pull/1851) | `Granit.Entities.Customization` core (aggregate + delta vocabulary + repository contracts) |
| B2 | [#1853](https://github.com/granit-fx/granit-dotnet/pull/1853) | `.EntityFrameworkCore` (JSON delta column + EF reader/writer) |
| B3 | [#1873](https://github.com/granit-fx/granit-dotnet/pull/1873) | `.Endpoints` (GET/PUT/DELETE + audit trail + descriptor validation) |
| **B4** | **this PR** | Manifest composer integration + per-field provenance |

Phase 2 next: **Stream C — Reactions Timeline** (3 stories: C1 aggregate, C2 toggle endpoint, C3 catalog policy).
