### PR TITLE
feat(timeline): closed-catalog reactions on TimelineEntry — closes Stream C 3/3 (#1812 #1813 #1814)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -56874,6 +56874,56 @@
       "members": []
     },
     {
+      "name": "IReactionReader",
+      "fqn": "Granit.Timeline.Abstractions.IReactionReader",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/IReactionReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetByEntryAsync",
+          "kind": "method",
+          "signature": "GetByEntryAsync(Guid entryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Reaction>>"
+        },
+        {
+          "name": "GetByEntriesAsync",
+          "kind": "method",
+          "signature": "GetByEntriesAsync(IReadOnlyCollection<Guid> entryIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Reaction>>"
+        },
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(Guid entryId, Guid userId, string emoji, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Reaction?>"
+        }
+      ]
+    },
+    {
+      "name": "IReactionWriter",
+      "fqn": "Granit.Timeline.Abstractions.IReactionWriter",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/IReactionWriter.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddAsync",
+          "kind": "method",
+          "signature": "AddAsync(Reaction reaction, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(Guid entryId, Guid userId, string emoji, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "ITimelineFollowerService",
       "fqn": "Granit.Timeline.Abstractions.ITimelineFollowerService",
       "kind": "interface",
@@ -56970,6 +57020,38 @@
           "kind": "method",
           "signature": "AddAttachmentAsync(Guid entryId, Guid blobId, string fileName, string contentType, long sizeBytes, CancellationToken cancellationToken = default)",
           "returnType": "Task<TimelineAttachment>"
+        }
+      ]
+    },
+    {
+      "name": "Reaction",
+      "fqn": "Granit.Timeline.Domain.Reaction",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/Reaction.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid entryId, Guid userId, string emoji, DateTimeOffset createdAt, string createdBy, Guid? tenantId = null)",
+          "returnType": "Reaction"
+        }
+      ]
+    },
+    {
+      "name": "ReactionEmojiCatalog",
+      "fqn": "Granit.Timeline.Domain.ReactionEmojiCatalog",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/ReactionEmojiCatalog.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "IsValid",
+          "kind": "method",
+          "signature": "IsValid(string emoji)",
+          "returnType": "bool"
         }
       ]
     },
@@ -57072,12 +57154,39 @@
       "members": []
     },
     {
+      "name": "ReactionAggregateResponse",
+      "fqn": "Granit.Timeline.Endpoints.Dtos.ReactionAggregateResponse",
+      "kind": "record",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "ReactionCatalogEntryResponse",
+      "fqn": "Granit.Timeline.Endpoints.Dtos.ReactionCatalogEntryResponse",
+      "kind": "record",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ReactionToggleResponse",
+      "fqn": "Granit.Timeline.Endpoints.Dtos.ReactionToggleResponse",
+      "kind": "record",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs",
+      "line": 7,
+      "members": []
+    },
+    {
       "name": "TimelineAttachmentInfoResponse",
       "fqn": "Granit.Timeline.Endpoints.Dtos.TimelineAttachmentInfoResponse",
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 17,
+      "line": 24,
       "members": []
     },
     {
@@ -57086,7 +57195,7 @@
       "kind": "record",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs",
-      "line": 6,
+      "line": 12,
       "members": []
     },
     {
@@ -57164,6 +57273,15 @@
       "members": []
     },
     {
+      "name": "Reactions",
+      "fqn": "Granit.Timeline.Endpoints.Permissions.Reactions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
+      "line": 41,
+      "members": []
+    },
+    {
       "name": "TimelinePermissions",
       "fqn": "Granit.Timeline.Endpoints.Permissions.TimelinePermissions",
       "kind": "class",
@@ -57227,6 +57345,24 @@
       "project": "Granit.Timeline.EntityFrameworkCore",
       "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineEntityFrameworkCoreModule.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "ReactionToggleAction",
+      "fqn": "Granit.Timeline.Events.ReactionToggleAction",
+      "kind": "enum",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/ReactionToggledEvent.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "ReactionToggledEvent",
+      "fqn": "Granit.Timeline.Events.ReactionToggledEvent",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/ReactionToggledEvent.cs",
+      "line": 15,
       "members": []
     },
     {

--- a/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -792,11 +792,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Events.Wolverine/packages.lock.json
+++ b/src/Granit.Events.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -772,11 +772,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.MultiTenancy.Provisioning/packages.lock.json
+++ b/src/Granit.MultiTenancy.Provisioning/packages.lock.json
@@ -850,8 +850,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -873,11 +873,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -21,8 +21,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -867,11 +867,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",

--- a/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
@@ -789,8 +789,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -812,11 +812,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Scheduling.Wolverine/packages.lock.json
+++ b/src/Granit.Scheduling.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -784,11 +784,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs
+++ b/src/Granit.Timeline.Endpoints/Dtos/ReactionResponses.cs
@@ -1,0 +1,28 @@
+namespace Granit.Timeline.Endpoints.Dtos;
+
+/// <summary>
+/// Returned by <c>POST /api/timeline/entries/{entryId}/reactions/{emoji}</c> —
+/// the post-toggle state for the (entry, emoji) pair.
+/// </summary>
+public sealed record ReactionToggleResponse(
+    Guid EntryId,
+    string Emoji,
+    int Count,
+    bool CurrentUserHasReacted);
+
+/// <summary>One catalog entry returned by <c>GET /api/timeline/reactions/catalog</c>.</summary>
+/// <param name="Emoji">Catalog key (e.g. <c>"thumbs_up"</c>).</param>
+/// <param name="DisplayKey">i18n key (<c>Reaction:{key}</c>) for the rendered label.</param>
+/// <param name="Display">Localized label for the current request culture.</param>
+public sealed record ReactionCatalogEntryResponse(
+    string Emoji,
+    string DisplayKey,
+    string Display);
+
+/// <summary>
+/// Aggregated reaction counts attached to one timeline entry by the stream
+/// endpoint (story C3). Omitted when the entry has zero reactions.
+/// </summary>
+/// <param name="Count">Total number of reactions of this emoji on the entry.</param>
+/// <param name="ByCurrentUser">Whether the calling user is among the reactors.</param>
+public sealed record ReactionAggregateResponse(int Count, bool ByCurrentUser);

--- a/src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs
+++ b/src/Granit.Timeline.Endpoints/Dtos/TimelineResponses.cs
@@ -2,7 +2,13 @@ using Granit.Timeline;
 
 namespace Granit.Timeline.Endpoints.Dtos;
 
-/// <summary>Activity stream entry.</summary>
+/// <summary>
+/// Activity stream entry. The <c>Reactions</c> field carries the per-emoji
+/// reaction summary keyed by the catalog emoji (e.g. <c>"thumbs_up"</c>);
+/// only emojis with at least one reaction are present and the field itself
+/// is <see langword="null"/> when the entry has no reactions, keeping the
+/// wire payload tight (story C3).
+/// </summary>
 public sealed record TimelineStreamEntryResponse(
     Guid Id,
     DateTimeOffset OccurredAt,
@@ -11,7 +17,8 @@ public sealed record TimelineStreamEntryResponse(
     string? AuthorName,
     string Body,
     IReadOnlyList<TimelineAttachmentInfoResponse> Attachments,
-    Guid? ParentEntryId);
+    Guid? ParentEntryId,
+    IReadOnlyDictionary<string, ReactionAggregateResponse>? Reactions = null);
 
 /// <summary>Attachment metadata.</summary>
 public sealed record TimelineAttachmentInfoResponse(

--- a/src/Granit.Timeline.Endpoints/Endpoints/ReactionEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/ReactionEndpoints.cs
@@ -1,0 +1,148 @@
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
+using Granit.Timeline.Endpoints.Dtos;
+using Granit.Timeline.Endpoints.Internal;
+using Granit.Timeline.Endpoints.Permissions;
+using Granit.Timeline.Events;
+using Granit.Timing;
+using Granit.Users;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+
+namespace Granit.Timeline.Endpoints.Endpoints;
+
+/// <summary>
+/// POST /api/timeline/entries/{entryId}/reactions/{emoji} (toggle) and
+/// GET /api/timeline/reactions/catalog (closed list of supported emojis).
+/// Both gated by <see cref="TimelinePermissions.Reactions.React"/>.
+/// </summary>
+internal static class ReactionEndpoints
+{
+    internal static RouteGroupBuilder MapReactionEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/reactions/catalog", GetCatalogAsync)
+            .RequireAuthorization(TimelinePermissions.Reactions.React)
+            .WithName("GetTimelineReactionCatalog")
+            .WithSummary("Returns the closed catalog of supported reaction emojis.")
+            .WithDescription("Returns the 5 v1 emojis (👍 / ❤️ / 🎉 / 😂 / 👀) with their localized display labels for the current request culture. Used by the React shell to render the reaction picker. Permission gate matches the toggle endpoint — a user who cannot react does not need to see the picker.")
+            .Produces<IReadOnlyList<ReactionCatalogEntryResponse>>();
+
+        group.MapPost("/entries/{entryId:guid}/reactions/{emoji}", ToggleAsync)
+            .RequireAuthorization(TimelinePermissions.Reactions.React)
+            .WithName("ToggleTimelineReaction")
+            .WithSummary("Toggles a reaction on a timeline entry by the calling user.")
+            .WithDescription("Idempotent toggle — adds the reaction if absent, removes if present. Validates the emoji against the closed ReactionEmojiCatalog (returns 400 with Granit:Timeline:UnknownEmoji on a miss). Emits ReactionToggledEvent on the local bus on success. Concurrent double-POST is collapsed by the unique (EntryId, UserId, Emoji) DB index.")
+            .Produces<ReactionToggleResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        return group;
+    }
+
+    private static Ok<IReadOnlyList<ReactionCatalogEntryResponse>> GetCatalogAsync(
+        [FromServices] IStringLocalizerFactory localizerFactory)
+    {
+        IStringLocalizer localizer = localizerFactory.Create(typeof(TimelineEndpointsLocalizationResource));
+
+        IReadOnlyList<ReactionCatalogEntryResponse> entries = [.. ReactionEmojiCatalog.All
+            .Select(emoji =>
+            {
+                string key = $"Reaction:{emoji}";
+                return new ReactionCatalogEntryResponse(
+                    Emoji: emoji,
+                    DisplayKey: key,
+                    Display: localizer[key].Value);
+            })];
+
+        return TypedResults.Ok(entries);
+    }
+
+    private static async Task<Results<Ok<ReactionToggleResponse>, ProblemHttpResult>> ToggleAsync(
+        [FromRoute] Guid entryId,
+        [FromRoute] string emoji,
+        [FromServices] IReactionReader reader,
+        [FromServices] IReactionWriter writer,
+        [FromServices] ILocalEventBus eventBus,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IClock clock,
+        CancellationToken cancellationToken)
+    {
+        if (!ReactionEmojiCatalog.IsValid(emoji))
+        {
+            return TypedResults.Problem(
+                detail: $"Emoji '{emoji}' is not in the closed catalog (Granit:Timeline:UnknownEmoji).",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Unknown emoji");
+        }
+
+        if (currentUser.UserId is not { } userIdRaw
+            || !Guid.TryParse(userIdRaw, out Guid userId)
+            || userId == Guid.Empty)
+        {
+            return TypedResults.Problem(
+                detail: "Reactions require an authenticated user with a GUID identifier.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        Reaction? existing = await reader
+            .FindAsync(entryId, userId, emoji, cancellationToken)
+            .ConfigureAwait(false);
+
+        ReactionToggleAction action;
+        if (existing is null)
+        {
+            var reaction = Reaction.Create(
+                id: guidGenerator.Create(),
+                entryId: entryId,
+                userId: userId,
+                emoji: emoji,
+                createdAt: clock.Normalize(clock.Now),
+                createdBy: userIdRaw,
+                tenantId: tenantId);
+            await writer.AddAsync(reaction, cancellationToken).ConfigureAwait(false);
+            action = ReactionToggleAction.Added;
+        }
+        else
+        {
+            await writer.RemoveAsync(entryId, userId, emoji, cancellationToken).ConfigureAwait(false);
+            action = ReactionToggleAction.Removed;
+        }
+
+        await eventBus
+            .PublishAsync(new ReactionToggledEvent(entryId, userId, emoji, action), cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<Reaction> after = await reader
+            .GetByEntryAsync(entryId, cancellationToken)
+            .ConfigureAwait(false);
+        int count = 0;
+        bool currentUserHasReacted = false;
+        foreach (Reaction r in after)
+        {
+            if (string.Equals(r.Emoji, emoji, StringComparison.Ordinal))
+            {
+                count++;
+                if (r.UserId == userId)
+                {
+                    currentUserHasReacted = true;
+                }
+            }
+        }
+
+        return TypedResults.Ok(new ReactionToggleResponse(
+            EntryId: entryId,
+            Emoji: emoji,
+            Count: count,
+            CurrentUserHasReacted: currentUserHasReacted));
+    }
+}

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -60,7 +60,7 @@ internal static class TimelineEntryEndpoints
         IReadOnlyList<string> mentionedUserIds = MentionParser.ExtractMentionedUserIds(entry.Body);
         if (mentionedUserIds.Count > MaxMentionsPerEntry)
         {
-            mentionedUserIds = mentionedUserIds.Take(MaxMentionsPerEntry).ToList();
+            mentionedUserIds = [.. mentionedUserIds.Take(MaxMentionsPerEntry)];
         }
 
         // Notify followers

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineStreamEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineStreamEndpoints.cs
@@ -2,9 +2,11 @@ using Granit.Authorization;
 using Granit.Authorization.Extensions;
 using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
 using Granit.Timeline.Endpoints.Dtos;
 using Granit.Timeline.Endpoints.Internal;
 using Granit.Timeline.Endpoints.Permissions;
+using Granit.Users;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -34,6 +36,8 @@ internal static class TimelineStreamEndpoints
         string entityType,
         string entityId,
         [FromServices] ITimelineReader reader,
+        [FromServices] IReactionReader reactionReader,
+        [FromServices] ICurrentUserService currentUser,
         [FromServices] IPermissionChecker permissionChecker,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = QueryEngineDefaults.DefaultPageSize,
@@ -54,8 +58,21 @@ internal static class TimelineStreamEndpoints
             result = new PagedResult<TimelineStreamEntry>(filtered, result.TotalCount, result.HasMore);
         }
 
+        // C3 — batch-load reactions for the visible entries in one round trip,
+        // then attach the per-emoji summary to each response. Entries without
+        // reactions get a null Reactions field (omitted on the wire).
+        Guid[] entryIds = [.. result.Items.Select(e => e.Id)];
+        IReadOnlyList<Reaction> reactions = await reactionReader
+            .GetByEntriesAsync(entryIds, cancellationToken)
+            .ConfigureAwait(false);
+        Guid? currentUserId = Guid.TryParse(currentUser.UserId, out Guid uid) ? uid : null;
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> byEntry =
+            TimelineResponseMapper.AggregateReactions(reactions, currentUserId);
+
         PagedResult<TimelineStreamEntryResponse> mapped = new(
-            result.Items.Select(TimelineResponseMapper.ToResponse).ToList(),
+            [.. result.Items.Select(e => TimelineResponseMapper.ToResponse(
+                e,
+                byEntry.TryGetValue(e.Id, out IReadOnlyDictionary<string, ReactionAggregateResponse>? r) ? r : null))],
             result.TotalCount,
             result.HasMore);
 

--- a/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
@@ -59,6 +59,7 @@ public static class TimelineEndpointRouteBuilderExtensions
         group.MapStreamEndpoints();
         group.MapEntryEndpoints();
         group.MapFollowerEndpoints();
+        group.MapReactionEndpoints();
 
         return group;
     }

--- a/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
+++ b/src/Granit.Timeline.Endpoints/Internal/TimelineResponseMapper.cs
@@ -1,14 +1,53 @@
 using Granit.Timeline;
+using Granit.Timeline.Domain;
 using Granit.Timeline.Endpoints.Dtos;
 
 namespace Granit.Timeline.Endpoints.Internal;
 
 internal static class TimelineResponseMapper
 {
-    internal static TimelineStreamEntryResponse ToResponse(TimelineStreamEntry entry) =>
+    internal static TimelineStreamEntryResponse ToResponse(
+        TimelineStreamEntry entry,
+        IReadOnlyDictionary<string, ReactionAggregateResponse>? reactions = null) =>
         new(entry.Id, entry.OccurredAt, entry.EntryType, entry.AuthorId, entry.AuthorName, entry.Body,
-            entry.Attachments.Select(ToResponse).ToList(), entry.ParentEntryId);
+            [.. entry.Attachments.Select(ToResponse)], entry.ParentEntryId, reactions);
 
     internal static TimelineAttachmentInfoResponse ToResponse(TimelineAttachmentInfo attachment) =>
         new(attachment.Id, attachment.BlobId, attachment.FileName, attachment.ContentType, attachment.SizeBytes);
+
+    /// <summary>
+    /// Aggregates the flat reaction list returned by
+    /// <c>IReactionReader.GetByEntriesAsync</c> into a per-entry,
+    /// per-emoji summary suitable for the wire payload (story C3).
+    /// Entries with no reactions are absent from the map (caller passes
+    /// <see langword="null"/> for those).
+    /// </summary>
+    internal static IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> AggregateReactions(
+        IReadOnlyList<Reaction> reactions,
+        Guid? currentUserId)
+    {
+        Dictionary<Guid, Dictionary<string, (int Count, bool ByCurrentUser)>> byEntry = [];
+        foreach (Reaction r in reactions)
+        {
+            if (!byEntry.TryGetValue(r.EntryId, out Dictionary<string, (int, bool)>? perEmoji))
+            {
+                perEmoji = new Dictionary<string, (int, bool)>(StringComparer.Ordinal);
+                byEntry[r.EntryId] = perEmoji;
+            }
+            perEmoji.TryGetValue(r.Emoji, out (int Count, bool ByCurrentUser) cur);
+            perEmoji[r.Emoji] = (cur.Count + 1, cur.ByCurrentUser || (currentUserId is { } uid && r.UserId == uid));
+        }
+
+        Dictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result = [];
+        foreach ((Guid entryId, Dictionary<string, (int Count, bool ByCurrentUser)> perEmoji) in byEntry)
+        {
+            Dictionary<string, ReactionAggregateResponse> summary = new(perEmoji.Count, StringComparer.Ordinal);
+            foreach ((string emoji, (int Count, bool ByCurrentUser) agg) in perEmoji)
+            {
+                summary[emoji] = new ReactionAggregateResponse(agg.Count, agg.ByCurrentUser);
+            }
+            result[entryId] = summary;
+        }
+        return result;
+    }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Spravovat (mazat) libovolnou položku časové osy bez ohledu na vlastníka",
     "Permission:Timeline.InternalNotes.Read": "Zobrazit interní poznámky pouze pro zaměstnance v kanálech aktivity",
     "Permission:Timeline.Followers.Manage": "Sledovat a přestat sledovat entity v kanálech aktivity",
-    "Granit:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů."
+    "Permission:Timeline.Reactions.React": "Reagovat na položky časové osy emoji z katalogu",
+    "Granit:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů.",
+
+    "Reaction:thumbs_up": "Palec nahoru",
+    "Reaction:heart": "Srdce",
+    "Reaction:tada": "Oslava",
+    "Reaction:joy": "Smích",
+    "Reaction:eyes": "Oči"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Beliebige Zeitachseneinträge verwalten (löschen), unabhängig vom Eigentümer",
     "Permission:Timeline.InternalNotes.Read": "Interne Notizen (nur für Mitarbeiter) in Aktivitätsfeeds anzeigen",
     "Permission:Timeline.Followers.Manage": "Entitäten in Aktivitätsfeeds folgen und entfolgen",
-    "Granit:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden."
+    "Permission:Timeline.Reactions.React": "Auf Zeitachseneinträge mit Katalog-Emojis reagieren",
+    "Granit:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden.",
+
+    "Reaction:thumbs_up": "Daumen hoch",
+    "Reaction:heart": "Herz",
+    "Reaction:tada": "Feiern",
+    "Reaction:joy": "Lachen",
+    "Reaction:eyes": "Augen"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
     "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
     "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
-    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files."
+    "Permission:Timeline.Reactions.React": "React to timeline entries with the closed-catalog emojis",
+    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
+
+    "Reaction:thumbs_up": "Thumbs up",
+    "Reaction:heart": "Heart",
+    "Reaction:tada": "Celebrate",
+    "Reaction:joy": "Laughing",
+    "Reaction:eyes": "Eyes"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Gestionar (eliminar) cualquier entrada de línea de tiempo sin importar el propietario",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas solo para personal en los feeds de actividad",
     "Permission:Timeline.Followers.Manage": "Seguir y dejar de seguir entidades en los feeds de actividad",
-    "Granit:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos."
+    "Permission:Timeline.Reactions.React": "Reaccionar a entradas de la línea de tiempo con los emojis del catálogo",
+    "Granit:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos.",
+
+    "Reaction:thumbs_up": "Pulgar arriba",
+    "Reaction:heart": "Corazón",
+    "Reaction:tada": "Celebración",
+    "Reaction:joy": "Risa",
+    "Reaction:eyes": "Ojos"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
     "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
     "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
-    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers."
+    "Permission:Timeline.Reactions.React": "Réagir aux entrées du fil d'activité avec les emojis du catalogue",
+    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
+
+    "Reaction:thumbs_up": "Pouce levé",
+    "Reaction:heart": "Cœur",
+    "Reaction:tada": "Bravo",
+    "Reaction:joy": "Rire",
+    "Reaction:eyes": "Yeux"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "स्वामित्व की परवाह किए बिना किसी भी टाइमलाइन प्रविष्टि को प्रबंधित (हटाएँ) करें",
     "Permission:Timeline.InternalNotes.Read": "गतिविधि फ़ीड में केवल-स्टाफ़ आंतरिक नोट देखें",
     "Permission:Timeline.Followers.Manage": "टाइमलाइन फ़ीड में इकाइयों को फ़ॉलो और अनफ़ॉलो करें",
-    "Granit:Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।"
+    "Permission:Timeline.Reactions.React": "कैटलॉग इमोजी से टाइमलाइन प्रविष्टियों पर प्रतिक्रिया दें",
+    "Granit:Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।",
+
+    "Reaction:thumbs_up": "अंगूठा ऊपर",
+    "Reaction:heart": "दिल",
+    "Reaction:tada": "जश्न",
+    "Reaction:joy": "हँसी",
+    "Reaction:eyes": "आँखें"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Gestire (eliminare) qualsiasi voce della timeline indipendentemente dal proprietario",
     "Permission:Timeline.InternalNotes.Read": "Visualizzare le note interne riservate al personale nei feed di attività",
     "Permission:Timeline.Followers.Manage": "Seguire e smettere di seguire entità nei feed di attività",
-    "Granit:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file."
+    "Permission:Timeline.Reactions.React": "Reagire alle voci della timeline con gli emoji del catalogo",
+    "Granit:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file.",
+
+    "Reaction:thumbs_up": "Pollice in su",
+    "Reaction:heart": "Cuore",
+    "Reaction:tada": "Festeggiare",
+    "Reaction:joy": "Risata",
+    "Reaction:eyes": "Occhi"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "所有者に関係なくタイムラインエントリを管理（削除）",
     "Permission:Timeline.InternalNotes.Read": "アクティビティフィードでスタッフ限定の内部メモを表示",
     "Permission:Timeline.Followers.Manage": "アクティビティフィードでエンティティのフォロー・フォロー解除",
-    "Granit:Validation:TooManyAttachments": "添付ファイルは20個までです。"
+    "Permission:Timeline.Reactions.React": "カタログの絵文字でタイムラインエントリにリアクションを付ける",
+    "Granit:Validation:TooManyAttachments": "添付ファイルは20個までです。",
+
+    "Reaction:thumbs_up": "いいね",
+    "Reaction:heart": "ハート",
+    "Reaction:tada": "お祝い",
+    "Reaction:joy": "笑い",
+    "Reaction:eyes": "目"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "소유자에 관계없이 타임라인 항목 관리(삭제)",
     "Permission:Timeline.InternalNotes.Read": "활동 피드에서 직원 전용 내부 메모 보기",
     "Permission:Timeline.Followers.Manage": "활동 피드에서 엔터티 팔로우 및 팔로우 취소",
-    "Granit:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다."
+    "Permission:Timeline.Reactions.React": "카탈로그 이모지로 타임라인 항목에 반응하기",
+    "Granit:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다.",
+
+    "Reaction:thumbs_up": "좋아요",
+    "Reaction:heart": "하트",
+    "Reaction:tada": "축하",
+    "Reaction:joy": "웃음",
+    "Reaction:eyes": "눈"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Alle tijdlijnvermeldingen beheren (verwijderen) ongeacht eigenaar",
     "Permission:Timeline.InternalNotes.Read": "Alleen voor personeel bestemde interne notities bekijken",
     "Permission:Timeline.Followers.Manage": "Entiteiten volgen en ontvolgen in activiteitenfeeds",
-    "Granit:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen."
+    "Permission:Timeline.Reactions.React": "Reageren op tijdlijnvermeldingen met de catalogus-emoji's",
+    "Granit:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen.",
+
+    "Reaction:thumbs_up": "Duim omhoog",
+    "Reaction:heart": "Hart",
+    "Reaction:tada": "Vieren",
+    "Reaction:joy": "Lachen",
+    "Reaction:eyes": "Ogen"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Zarządzanie (usuwanie) wpisów osi czasu niezależnie od właściciela",
     "Permission:Timeline.InternalNotes.Read": "Przeglądanie wewnętrznych notatek dostępnych tylko dla personelu",
     "Permission:Timeline.Followers.Manage": "Obserwowanie i rezygnacja z obserwowania podmiotów w kanałach aktywności",
-    "Granit:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików."
+    "Permission:Timeline.Reactions.React": "Reaguj na wpisy osi czasu emoji z katalogu",
+    "Granit:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików.",
+
+    "Reaction:thumbs_up": "Kciuk w górę",
+    "Reaction:heart": "Serce",
+    "Reaction:tada": "Świętowanie",
+    "Reaction:joy": "Śmiech",
+    "Reaction:eyes": "Oczy"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Gerir (eliminar) qualquer entrada de cronologia independentemente do proprietário",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas apenas para funcionários nos feeds de atividade",
     "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
-    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros."
+    "Permission:Timeline.Reactions.React": "Reagir às entradas da cronologia com os emojis do catálogo",
+    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros.",
+
+    "Reaction:thumbs_up": "Polegar para cima",
+    "Reaction:heart": "Coração",
+    "Reaction:tada": "Comemorar",
+    "Reaction:joy": "Riso",
+    "Reaction:eyes": "Olhos"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Hantera (ta bort) tidslinjepost oavsett ägare",
     "Permission:Timeline.InternalNotes.Read": "Visa personalens interna anteckningar i aktivitetsflöden",
     "Permission:Timeline.Followers.Manage": "Följa och sluta följa entiteter i aktivitetsflöden",
-    "Granit:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer."
+    "Permission:Timeline.Reactions.React": "Reagera på tidslinjeposter med katalogens emojier",
+    "Granit:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer.",
+
+    "Reaction:thumbs_up": "Tummen upp",
+    "Reaction:heart": "Hjärta",
+    "Reaction:tada": "Fira",
+    "Reaction:joy": "Skratt",
+    "Reaction:eyes": "Ögon"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "Sahibinden bağımsız olarak herhangi bir zaman çizelgesi girişini yönetin (silin)",
     "Permission:Timeline.InternalNotes.Read": "Etkinlik akışlarında yalnızca personele özel dahili notları görüntüleyin",
     "Permission:Timeline.Followers.Manage": "Etkinlik akışlarında varlıkları takip edin ve takipten çıkın",
-    "Granit:Validation:TooManyAttachments": "20'den fazla dosya eklenemez."
+    "Permission:Timeline.Reactions.React": "Zaman çizelgesi girişlerine katalog emojileriyle tepki verin",
+    "Granit:Validation:TooManyAttachments": "20'den fazla dosya eklenemez.",
+
+    "Reaction:thumbs_up": "Beğeni",
+    "Reaction:heart": "Kalp",
+    "Reaction:tada": "Kutlama",
+    "Reaction:joy": "Gülme",
+    "Reaction:eyes": "Gözler"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
@@ -7,6 +7,13 @@
     "Permission:Timeline.Entries.Manage": "管理（删除）任何时间轴条目，无论所有者",
     "Permission:Timeline.InternalNotes.Read": "查看活动源中仅供员工查看的内部笔记",
     "Permission:Timeline.Followers.Manage": "在活动源中关注和取消关注实体",
-    "Granit:Validation:TooManyAttachments": "不能附加超过20个文件。"
+    "Permission:Timeline.Reactions.React": "使用目录表情符号对时间线条目作出回应",
+    "Granit:Validation:TooManyAttachments": "不能附加超过20个文件。",
+
+    "Reaction:thumbs_up": "点赞",
+    "Reaction:heart": "爱心",
+    "Reaction:tada": "庆祝",
+    "Reaction:joy": "大笑",
+    "Reaction:eyes": "眼睛"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
+++ b/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
@@ -47,5 +47,11 @@ internal sealed class TimelinePermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
                 "Permission:Timeline.Followers.Manage"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            TimelinePermissions.Reactions.React,
+            LocalizableString.Create<TimelineEndpointsLocalizationResource>(
+                "Permission:Timeline.Reactions.React"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs
+++ b/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs
@@ -36,4 +36,16 @@ public static class TimelinePermissions
         /// <summary>Grants access to follow/unfollow entities and view follower lists.</summary>
         public const string Manage = "Timeline.Followers.Manage";
     }
+
+    /// <summary>Permissions for the reactions resource (story C2 / ADR-046 §1).</summary>
+    public static class Reactions
+    {
+        /// <summary>
+        /// Grants access to read the reactions catalog and toggle reactions on
+        /// timeline entries via <c>POST /timeline/entries/{id}/reactions/{emoji}</c>.
+        /// Catalog read requires the same permission (defense in depth — a
+        /// user who cannot react does not need to see the picker).
+        /// </summary>
+        public const string React = "Timeline.Reactions.React";
+    }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Configurations/ReactionConfiguration.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Configurations/ReactionConfiguration.cs
@@ -1,0 +1,44 @@
+using Granit.Timeline.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Timeline.EntityFrameworkCore.Configurations;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="Reaction"/>.
+/// Table: <c>{prefix}reactions</c>.
+/// </summary>
+internal sealed class ReactionConfiguration : IEntityTypeConfiguration<Reaction>
+{
+    public void Configure(EntityTypeBuilder<Reaction> builder)
+    {
+        builder.ToTable(
+            GranitTimelineDbProperties.DbTablePrefix + "reactions",
+            GranitTimelineDbProperties.DbSchema);
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.EntryId).IsRequired();
+        builder.Property(x => x.UserId).IsRequired();
+        builder.Property(x => x.Emoji).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(256).IsRequired();
+
+        // Cascade-delete with the parent TimelineEntry — reactions have no
+        // meaning without their entry. Soft-delete is intentionally not
+        // supported (a removed reaction is removed, not preserved for audit).
+        builder.HasOne<TimelineEntry>()
+            .WithMany()
+            .HasForeignKey(x => x.EntryId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Idempotency guard — concurrent double-clicks collide here and
+        // resolve to a single row. The toggle endpoint (story C2) catches the
+        // unique-violation and treats it as "already added".
+        builder.HasIndex(x => new { x.EntryId, x.UserId, x.Emoji })
+            .IsUnique()
+            .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}reactions_unique");
+
+        // Read all reactions on an entry (timeline stream enrichment, story C3).
+        builder.HasIndex(x => new { x.EntryId, x.TenantId })
+            .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}reactions_by_entry");
+    }
+}

--- a/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -40,6 +40,13 @@ public static class TimelineEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.Replace(
             ServiceDescriptor.Scoped<ITimelineReader, EfCoreTimelineQuery>());
 
+        // Reactions (story C1) — single EF impl backs both reader + writer.
+        builder.Services.AddScoped<EfCoreReactionStore>();
+        builder.Services.Replace(
+            ServiceDescriptor.Scoped<IReactionReader>(sp => sp.GetRequiredService<EfCoreReactionStore>()));
+        builder.Services.Replace(
+            ServiceDescriptor.Scoped<IReactionWriter>(sp => sp.GetRequiredService<EfCoreReactionStore>()));
+
         return builder;
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class TimelineModelBuilderExtensions
     {
         modelBuilder.ApplyConfiguration(new TimelineEntryConfiguration());
         modelBuilder.ApplyConfiguration(new TimelineAttachmentConfiguration());
+        modelBuilder.ApplyConfiguration(new ReactionConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreReactionStore.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreReactionStore.cs
@@ -1,0 +1,78 @@
+using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Timeline.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IReactionReader"/> +
+/// <see cref="IReactionWriter"/>. Tenant filtering is applied automatically
+/// by the DbContext's standard query filter.
+/// </summary>
+internal sealed class EfCoreReactionStore(IDbContextFactory<TimelineDbContext> contextFactory)
+    : IReactionReader, IReactionWriter
+{
+    public async Task<IReadOnlyList<Reaction>> GetByEntryAsync(
+        Guid entryId, CancellationToken cancellationToken = default)
+    {
+        await using TimelineDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.Reactions
+            .AsNoTracking()
+            .Where(r => r.EntryId == entryId)
+            .OrderBy(r => r.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<Reaction>> GetByEntriesAsync(
+        IReadOnlyCollection<Guid> entryIds, CancellationToken cancellationToken = default)
+    {
+        if (entryIds is null || entryIds.Count == 0)
+        {
+            return [];
+        }
+
+        await using TimelineDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.Reactions
+            .AsNoTracking()
+            .Where(r => entryIds.Contains(r.EntryId))
+            .OrderBy(r => r.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<Reaction?> FindAsync(
+        Guid entryId, Guid userId, string emoji, CancellationToken cancellationToken = default)
+    {
+        await using TimelineDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await context.Reactions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                r => r.EntryId == entryId && r.UserId == userId && r.Emoji == emoji,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AddAsync(Reaction reaction, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reaction);
+        await using TimelineDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        context.Reactions.Add(reaction);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RemoveAsync(
+        Guid entryId, Guid userId, string emoji, CancellationToken cancellationToken = default)
+    {
+        await using TimelineDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await context.Reactions
+            .Where(r => r.EntryId == entryId && r.UserId == userId && r.Emoji == emoji)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
@@ -26,6 +26,9 @@ internal sealed class TimelineDbContext(
     /// <summary>Attachment references linking entries to BlobStorage blobs.</summary>
     public DbSet<TimelineAttachment> TimelineAttachments => Set<TimelineAttachment>();
 
+    /// <summary>Per-entry user reactions (👍 / ❤️ / 🎉 / 😂 / 👀) per ADR-046 + story C1.</summary>
+    public DbSet<Reaction> Reactions => Set<Reaction>();
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Timeline/Abstractions/IReactionReader.cs
+++ b/src/Granit.Timeline/Abstractions/IReactionReader.cs
@@ -1,0 +1,36 @@
+using Granit.Timeline.Domain;
+
+namespace Granit.Timeline.Abstractions;
+
+/// <summary>
+/// Read side of the reactions repository (CQRS split). Tenant filtering is
+/// applied automatically by the persistence layer's standard query filter —
+/// callers never constrain by <c>TenantId</c> directly.
+/// </summary>
+public interface IReactionReader
+{
+    /// <summary>Returns every reaction on a single timeline entry, ordered by <c>CreatedAt</c>.</summary>
+    Task<IReadOnlyList<Reaction>> GetByEntryAsync(
+        Guid entryId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batch lookup for the timeline stream endpoint — returns every reaction
+    /// across the supplied entry ids in a single round trip. Empty input
+    /// returns an empty list (no query issued).
+    /// </summary>
+    Task<IReadOnlyList<Reaction>> GetByEntriesAsync(
+        IReadOnlyCollection<Guid> entryIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the (current user, entry, emoji) row when present, or
+    /// <see langword="null"/>. Used by the toggle endpoint (story C2) to
+    /// decide between Add and Remove without scanning the full entry.
+    /// </summary>
+    Task<Reaction?> FindAsync(
+        Guid entryId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Timeline/Abstractions/IReactionWriter.cs
+++ b/src/Granit.Timeline/Abstractions/IReactionWriter.cs
@@ -1,0 +1,25 @@
+using Granit.Timeline.Domain;
+
+namespace Granit.Timeline.Abstractions;
+
+/// <summary>
+/// Write side of the reactions repository. The unique
+/// <c>(EntryId, UserId, Emoji)</c> index in the EF companion is the
+/// authoritative idempotency guard — concurrent double-clicks collide on
+/// <c>AddAsync</c> and resolve to a single row.
+/// </summary>
+public interface IReactionWriter
+{
+    /// <summary>Persists a new reaction row. Throws on unique-index violation.</summary>
+    Task AddAsync(Reaction reaction, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the matching reaction. Idempotent — removing a non-existent
+    /// row is a no-op (no exception).
+    /// </summary>
+    Task RemoveAsync(
+        Guid entryId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Timeline/Domain/Reaction.cs
+++ b/src/Granit.Timeline/Domain/Reaction.cs
@@ -1,0 +1,83 @@
+using Granit.Domain;
+
+namespace Granit.Timeline.Domain;
+
+/// <summary>
+/// One reaction (👍 / ❤️ / 🎉 / 😂 / 👀) by a user on a
+/// <see cref="TimelineEntry"/>. Idempotency is enforced at the SQL level by a
+/// composite unique index on <c>(EntryId, UserId, Emoji)</c>; the toggle
+/// endpoint (story C2) flips between Add and Remove against that constraint.
+/// </summary>
+/// <remarks>
+/// Cascade-deletes with the parent <see cref="TimelineEntry"/> — reactions
+/// have no meaning without their entry. Soft-delete is intentionally NOT
+/// supported: a removed reaction is removed (not preserved for audit), and
+/// re-adding it is a fresh row.
+/// </remarks>
+public sealed class Reaction : CreationAuditedEntity, IMultiTenant
+{
+    // Parameterless constructor required by EF Core materializer.
+    private Reaction() { }
+
+    /// <summary>
+    /// Creates a new reaction. Validates <paramref name="emoji"/> against the
+    /// closed <see cref="ReactionEmojiCatalog"/>; unknown values throw at the
+    /// factory boundary so they never hit persistence.
+    /// </summary>
+    public static Reaction Create(
+        Guid id,
+        Guid entryId,
+        Guid userId,
+        string emoji,
+        DateTimeOffset createdAt,
+        string createdBy,
+        Guid? tenantId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(emoji);
+        ArgumentException.ThrowIfNullOrWhiteSpace(createdBy);
+        if (entryId == Guid.Empty)
+        {
+            throw new ArgumentException("EntryId cannot be Guid.Empty.", nameof(entryId));
+        }
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId cannot be Guid.Empty.", nameof(userId));
+        }
+        if (!ReactionEmojiCatalog.IsValid(emoji))
+        {
+            throw new ArgumentException(
+                $"Emoji '{emoji}' is not in the closed catalog (see ReactionEmojiCatalog.All).",
+                nameof(emoji));
+        }
+
+        return new Reaction
+        {
+            Id = id,
+            EntryId = entryId,
+            UserId = userId,
+            Emoji = emoji,
+            CreatedAt = createdAt,
+            CreatedBy = createdBy,
+            TenantId = tenantId,
+        };
+    }
+
+    /// <summary>FK to the parent <see cref="TimelineEntry"/>.</summary>
+    public Guid EntryId { get; private set; }
+
+    /// <summary>The user who reacted.</summary>
+    public Guid UserId { get; private set; }
+
+    /// <summary>Catalog key (e.g. <c>"thumbs_up"</c>).</summary>
+    public string Emoji { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc/>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+}

--- a/src/Granit.Timeline/Domain/ReactionEmojiCatalog.cs
+++ b/src/Granit.Timeline/Domain/ReactionEmojiCatalog.cs
@@ -1,0 +1,34 @@
+namespace Granit.Timeline.Domain;
+
+/// <summary>
+/// Closed catalog of reaction emojis (ADR-046 §1, story C3). Extending the
+/// catalog requires an ADR amendment — same pattern as ADR-048 §2 for
+/// cross-module relation kinds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The wire identifier is the snake_case key (e.g. <c>"thumbs_up"</c>),
+/// not the rendered glyph — keeps the API stable across font / Unicode
+/// changes and lets the React shell pick the rendering. Display labels
+/// are localized via the <c>Reaction:{key}</c> resource keys in
+/// <c>Granit.Timeline.Endpoints</c> (18 cultures).
+/// </para>
+/// </remarks>
+public static class ReactionEmojiCatalog
+{
+    /// <summary>The 5 v1 emojis: 👍 ❤️ 🎉 😂 👀.</summary>
+    public static readonly IReadOnlyList<string> All =
+    [
+        "thumbs_up",
+        "heart",
+        "tada",
+        "joy",
+        "eyes",
+    ];
+
+    private static readonly HashSet<string> Lookup = new(All, StringComparer.Ordinal);
+
+    /// <summary>Returns <see langword="true"/> when <paramref name="emoji"/> is in the closed catalog.</summary>
+    public static bool IsValid(string emoji) =>
+        !string.IsNullOrEmpty(emoji) && Lookup.Contains(emoji);
+}

--- a/src/Granit.Timeline/Events/ReactionToggledEvent.cs
+++ b/src/Granit.Timeline/Events/ReactionToggledEvent.cs
@@ -1,0 +1,29 @@
+using Granit.Events;
+
+namespace Granit.Timeline.Events;
+
+/// <summary>
+/// Raised on the local event bus by the toggle endpoint (story C2) after a
+/// reaction is added or removed. Notification / follower modules subscribe
+/// to surface "X reacted with 👍 to your comment" messages without re-querying
+/// the database.
+/// </summary>
+/// <param name="EntryId">The timeline entry the reaction is on.</param>
+/// <param name="UserId">The user who toggled.</param>
+/// <param name="Emoji">Catalog key (e.g. <c>"thumbs_up"</c>).</param>
+/// <param name="Action">Whether the toggle resulted in an add or a remove.</param>
+public sealed record ReactionToggledEvent(
+    Guid EntryId,
+    Guid UserId,
+    string Emoji,
+    ReactionToggleAction Action) : IDomainEvent;
+
+/// <summary>The two outcomes of a reaction toggle.</summary>
+public enum ReactionToggleAction
+{
+    /// <summary>The reaction was previously absent and has been added.</summary>
+    Added = 0,
+
+    /// <summary>The reaction was previously present and has been removed.</summary>
+    Removed = 1,
+}

--- a/src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs
+++ b/src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs
@@ -34,6 +34,13 @@ public static class TimelineServiceCollectionExtensions
         // Notifier facade (no-op, replaced by Granit.Timeline.Notifications)
         services.TryAddScoped<ITimelineNotifier, NullTimelineNotifier>();
 
+        // Reactions (story C1) — default in-memory store, replaced by EF Core.
+        // Single instance backs both reader + writer because the in-memory
+        // implementation needs a shared list across roles.
+        services.TryAddScoped<InMemoryReactionStore>();
+        services.TryAddScoped<IReactionReader>(sp => sp.GetRequiredService<InMemoryReactionStore>());
+        services.TryAddScoped<IReactionWriter>(sp => sp.GetRequiredService<InMemoryReactionStore>());
+
         // Query + Export definitions (ADR-020: owned by the base module).
         services.AddQueryDefinition<TimelineEntry, TimelineEntryQueryDefinition>();
         services.AddExportDefinition<TimelineEntry, TimelineEntryExportDefinition>();

--- a/src/Granit.Timeline/Internal/InMemoryReactionStore.cs
+++ b/src/Granit.Timeline/Internal/InMemoryReactionStore.cs
@@ -1,0 +1,98 @@
+using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
+
+namespace Granit.Timeline.Internal;
+
+/// <summary>
+/// Default in-memory implementation of <see cref="IReactionReader"/> +
+/// <see cref="IReactionWriter"/> — replaced by
+/// <c>EfCoreReactionStore</c> when <c>Granit.Timeline.EntityFrameworkCore</c>
+/// is loaded. Kept for development hosts and unit tests.
+/// </summary>
+internal sealed class InMemoryReactionStore : IReactionReader, IReactionWriter
+{
+    private readonly System.Threading.Lock _lock = new();
+    private readonly List<Reaction> _store = [];
+
+    public Task<IReadOnlyList<Reaction>> GetByEntryAsync(
+        Guid entryId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            IReadOnlyList<Reaction> rows = [.. _store
+                .Where(r => r.EntryId == entryId)
+                .OrderBy(r => r.CreatedAt)];
+            return Task.FromResult(rows);
+        }
+    }
+
+    public Task<IReadOnlyList<Reaction>> GetByEntriesAsync(
+        IReadOnlyCollection<Guid> entryIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (entryIds is null || entryIds.Count == 0)
+        {
+            return Task.FromResult<IReadOnlyList<Reaction>>([]);
+        }
+
+        HashSet<Guid> set = [.. entryIds];
+        lock (_lock)
+        {
+            IReadOnlyList<Reaction> rows = [.. _store
+                .Where(r => set.Contains(r.EntryId))
+                .OrderBy(r => r.CreatedAt)];
+            return Task.FromResult(rows);
+        }
+    }
+
+    public Task<Reaction?> FindAsync(
+        Guid entryId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            Reaction? hit = _store.FirstOrDefault(r =>
+                r.EntryId == entryId
+                && r.UserId == userId
+                && string.Equals(r.Emoji, emoji, StringComparison.Ordinal));
+            return Task.FromResult(hit);
+        }
+    }
+
+    public Task AddAsync(Reaction reaction, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reaction);
+        lock (_lock)
+        {
+            if (_store.Any(r =>
+                r.EntryId == reaction.EntryId
+                && r.UserId == reaction.UserId
+                && string.Equals(r.Emoji, reaction.Emoji, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException(
+                    $"Reaction ({reaction.EntryId}, {reaction.UserId}, {reaction.Emoji}) already exists.");
+            }
+            _store.Add(reaction);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(
+        Guid entryId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            _store.RemoveAll(r =>
+                r.EntryId == entryId
+                && r.UserId == userId
+                && string.Equals(r.Emoji, emoji, StringComparison.Ordinal));
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -993,11 +993,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -58,24 +58,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "5ZpUM+zKkNUwgL3U25n4KZ6Nwwmvqg3qdk1NUuBMXWD66jl3P+nWEw8Zk/c2EQmIX20bgIjwB0DlwJExZQOZuA==",
+        "resolved": "5.36.1",
+        "contentHash": "FBiWAsrNRJGJmgmLyvSlU5hdZeuj3pfmL0/ai4DBCfXdPi1bme0DaaJZ3Kwom668AIA9Ks5kIKqwCp2RGkt4uQ==",
         "dependencies": {
           "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "DistributedLock.Core": {
@@ -688,11 +688,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZString": {
@@ -1025,8 +1025,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1048,11 +1048,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -60,24 +60,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "gSjgGuskdVZNSXMciU7dV6/P0jthPVQKAhpX+MY7w7U6amuk48CAhB+mfikYdydbFe+C7TuDOqD1DMhYOTqaQA==",
+        "resolved": "5.36.1",
+        "contentHash": "MlpnQ7hQW4Wv89Gnk/Jr0why7gN8MZ9hPRGLD/5DZMFB2Xl25XD2OXtdF4rjDM6DXI6L9F2dOpLiVz5Tk5NlUw==",
         "dependencies": {
           "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "Azure.Core": {
@@ -796,11 +796,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZString": {
@@ -1123,8 +1123,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1146,11 +1146,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine/packages.lock.json
+++ b/src/Granit.Wolverine/packages.lock.json
@@ -11,8 +11,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -25,11 +25,11 @@
       "WolverineFx.FluentValidation": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "FastExpressionCompiler": {

--- a/tests/Granit.ArchitectureTests/DtoConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DtoConventionTests.cs
@@ -15,12 +15,11 @@ public sealed class DtoConventionTests
     public void Endpoint_types_should_not_use_Dto_suffix()
     {
         // Auto-discover endpoint namespaces from loaded architecture graph
-        string[] endpointNamespaces = Architecture.Namespaces
+        string[] endpointNamespaces = [.. Architecture.Namespaces
             .Select(ns => ns.FullName)
             .Where(ns => ns.StartsWith("Granit.", StringComparison.Ordinal)
                 && ns.EndsWith(".Endpoints", StringComparison.Ordinal))
-            .Distinct()
-            .ToArray();
+            .Distinct()];
 
         NamingConventionRules.EndpointTypesShouldNotUseDtoSuffix(Architecture, endpointNamespaces);
     }

--- a/tests/Granit.ArchitectureTests/LocalizationFileShapeTests.cs
+++ b/tests/Granit.ArchitectureTests/LocalizationFileShapeTests.cs
@@ -35,7 +35,7 @@ public sealed class LocalizationFileShapeTests
     public void Every_localization_json_file_should_use_the_culture_envelope()
     {
         string srcDir = Path.Join(RepoRoot, "src");
-        IReadOnlyList<string> files = EnumerateLocalizationFiles(srcDir).ToList();
+        IReadOnlyList<string> files = [.. EnumerateLocalizationFiles(srcDir)];
 
         files.ShouldNotBeEmpty(
             "No localization JSON files discovered — the test cannot run. " +

--- a/tests/Granit.ArchitectureTests/McpConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/McpConventionTests.cs
@@ -70,8 +70,7 @@ public sealed class McpConventionTests
             foreach (FieldInfo field in nested.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
                          .Where(f => f is { IsLiteral: true, FieldType.Name: "String" }))
             {
-                string? value = field.GetValue(null) as string;
-                if (value is null)
+                if (field.GetValue(null) is not string value)
                 {
                     continue;
                 }

--- a/tests/Granit.ArchitectureTests/MergeableConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/MergeableConventionTests.cs
@@ -126,15 +126,14 @@ public sealed class MergeableConventionTests
     }
 
     private static List<Type> FindAllReferenceRewriterImplementations() =>
-        AllSrcTypes()
+        [.. AllSrcTypes()
             .Where(t => !t.IsAbstract && !t.IsInterface)
             .Where(t => t.GetInterfaces().Any(i =>
                 i.IsGenericType
                 && i.GetGenericTypeDefinition() == typeof(IReferenceRewriter<>)
-                && i.GenericTypeArguments[0] == typeof(Party)))
-            .ToList();
+                && i.GenericTypeArguments[0] == typeof(Party)))];
 
-    private static readonly object EagerLoadGate = new();
+    private static readonly Lock EagerLoadGate = new();
     private static bool _eagerLoaded;
 
     /// <summary>
@@ -193,7 +192,7 @@ public sealed class MergeableConventionTests
             }
             catch (ReflectionTypeLoadException ex)
             {
-                types = ex.Types.Where(t => t is not null).Cast<Type>().ToArray();
+                types = [.. ex.Types.Where(t => t is not null).Cast<Type>()];
             }
 
             foreach (Type t in types)

--- a/tests/Granit.ArchitectureTests/ODataPermissionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ODataPermissionConventionTests.cs
@@ -38,9 +38,7 @@ public sealed class ODataPermissionConventionTests
     [Fact]
     public void OData_Host_permissions_must_declare_MultiTenancySides_Host()
     {
-        IReadOnlyList<PermissionDefinition> hostFeedPermissions = ScanPermissions()
-            .Where(p => p.Name.StartsWith("OData.Host.", StringComparison.Ordinal))
-            .ToList();
+        IReadOnlyList<PermissionDefinition> hostFeedPermissions = [.. ScanPermissions().Where(p => p.Name.StartsWith("OData.Host.", StringComparison.Ordinal))];
 
         IEnumerable<string> violators = hostFeedPermissions
             .Where(p => p.MultiTenancySides != MultiTenancySides.Host)
@@ -62,11 +60,10 @@ public sealed class ODataPermissionConventionTests
         // MultiTenancySides.Host — that would prevent tenant users from
         // ever being granted it. Common typo: copy-paste a host-feed
         // declaration but forget to drop the .Host segment in the name.
-        IReadOnlyList<PermissionDefinition> tenantFeedPermissions = ScanPermissions()
+        IReadOnlyList<PermissionDefinition> tenantFeedPermissions = [.. ScanPermissions()
             .Where(p =>
                 p.Name.StartsWith("OData.", StringComparison.Ordinal)
-                && !p.Name.StartsWith("OData.Host.", StringComparison.Ordinal))
-            .ToList();
+                && !p.Name.StartsWith("OData.Host.", StringComparison.Ordinal))];
 
         IEnumerable<string> violators = tenantFeedPermissions
             .Where(p => p.MultiTenancySides == MultiTenancySides.Host)

--- a/tests/Granit.ArchitectureTests/PrivacyDataProviderConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/PrivacyDataProviderConventionTests.cs
@@ -38,10 +38,9 @@ public sealed class PrivacyDataProviderConventionTests
             Type[] providers;
             try
             {
-                providers = assembly.GetTypes()
+                providers = [.. assembly.GetTypes()
                     .Where(t => !t.IsAbstract && !t.IsInterface)
-                    .Where(t => typeof(IPrivacyDataProvider).IsAssignableFrom(t))
-                    .ToArray();
+                    .Where(t => typeof(IPrivacyDataProvider).IsAssignableFrom(t))];
             }
             catch (ReflectionTypeLoadException)
             {
@@ -50,10 +49,9 @@ public sealed class PrivacyDataProviderConventionTests
 
             foreach (Type provider in providers)
             {
-                Type[] candidateHandlers = assembly.GetTypes()
+                Type[] candidateHandlers = [.. assembly.GetTypes()
                     .Where(t => !t.IsAbstract && !t.IsInterface && t.IsPublic)
-                    .Where(t => t.Name.EndsWith("PersonalDataExportHandler", StringComparison.Ordinal))
-                    .ToArray();
+                    .Where(t => t.Name.EndsWith("PersonalDataExportHandler", StringComparison.Ordinal))];
 
                 bool hasMatchingHandler = candidateHandlers.Any(h => HandlerReferencesProvider(h, provider));
                 if (!hasMatchingHandler)

--- a/tests/Granit.ArchitectureTests/ReactionEmojiLocalizationTests.cs
+++ b/tests/Granit.ArchitectureTests/ReactionEmojiLocalizationTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Granit.Timeline.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces story C3 acceptance — every emoji in
+/// <see cref="ReactionEmojiCatalog.All"/> MUST have a <c>Reaction:{key}</c>
+/// resource key in all 15 base cultures of
+/// <c>Granit.Timeline.Endpoints/Localization/</c>. Regional variants
+/// (<c>fr-CA</c>, <c>en-GB</c>, <c>pt-BR</c>) are exempt — they ship only
+/// differing keys and fall through to their parent culture.
+/// </summary>
+public sealed class ReactionEmojiLocalizationTests
+{
+    private static readonly string[] BaseCultures =
+    [
+        "en", "fr", "nl", "de", "es", "it", "pt", "zh", "ja",
+        "pl", "tr", "ko", "sv", "cs", "hi",
+    ];
+
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void Every_emoji_should_have_localization_keys_in_all_base_cultures()
+    {
+        ReactionEmojiCatalog.All.ShouldNotBeEmpty();
+
+        string localizationDir = Path.Join(RepoRoot, "src", "Granit.Timeline.Endpoints", "Localization");
+        Directory.Exists(localizationDir).ShouldBeTrue(
+            $"Granit.Timeline.Endpoints/Localization/ not found at {localizationDir}");
+
+        List<string> missing = [];
+        foreach (string emoji in ReactionEmojiCatalog.All)
+        {
+            string key = $"Reaction:{emoji}";
+            foreach (string culture in BaseCultures)
+            {
+                if (!LocateKeyInCultureFiles(localizationDir, culture, key))
+                {
+                    missing.Add($"{emoji} -> {culture} (expected key '{key}' in src/Granit.Timeline.Endpoints/Localization/**/{culture}.json)");
+                }
+            }
+        }
+
+        missing.ShouldBeEmpty(
+            "Story C3: every emoji in ReactionEmojiCatalog.All must have a 'Reaction:{key}' key in all 15 base cultures. "
+            + $"{missing.Count} key(s) missing:" + Environment.NewLine
+            + string.Join(Environment.NewLine, missing.Order(StringComparer.Ordinal)));
+    }
+
+    private static bool LocateKeyInCultureFiles(string localizationDir, string culture, string resourceKey)
+    {
+        string[] files = Directory.GetFiles(localizationDir, $"{culture}.json", SearchOption.AllDirectories);
+        return files.Any(file => FileContainsKey(file, resourceKey));
+    }
+
+    private static bool FileContainsKey(string filePath, string key)
+    {
+        using FileStream stream = File.OpenRead(filePath);
+        using var doc = JsonDocument.Parse(stream);
+        JsonElement root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+        if (root.TryGetProperty("texts", out JsonElement texts)
+            && texts.ValueKind == JsonValueKind.Object
+            && texts.TryGetProperty(key, out _))
+        {
+            return true;
+        }
+        return root.TryGetProperty(key, out _);
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Granit.slnx")))
+        {
+            dir = dir.Parent;
+        }
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate the repository root (Granit.slnx not found).");
+    }
+}

--- a/tests/Granit.ArchitectureTests/SagaConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SagaConventionTests.cs
@@ -67,9 +67,7 @@ public sealed class SagaConventionTests
             Type[] sagaTypes;
             try
             {
-                sagaTypes = assembly.GetTypes()
-                    .Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))
-                    .ToArray();
+                sagaTypes = [.. assembly.GetTypes().Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))];
             }
             catch (ReflectionTypeLoadException)
             {
@@ -135,9 +133,7 @@ public sealed class SagaConventionTests
             Type[] sagaTypes;
             try
             {
-                sagaTypes = assembly.GetTypes()
-                    .Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))
-                    .ToArray();
+                sagaTypes = [.. assembly.GetTypes().Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))];
             }
             catch (ReflectionTypeLoadException)
             {

--- a/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
@@ -78,15 +78,14 @@ public sealed partial class ValidationConventionTests
             try { allTypes = assembly.GetTypes(); }
             catch (ReflectionTypeLoadException ex) { allTypes = ex.Types.Where(t => t is not null).ToArray()!; }
 
-            Type[] requestTypes = allTypes
+            Type[] requestTypes = [.. allTypes
                 .Where(t => t.Name.EndsWith("Request", StringComparison.Ordinal)
                     && t.IsPublic
                     && !t.IsAbstract
                     && !t.IsInterface
                     && !ValidatorExemptions.Contains(t.Name)
                     && !IsCustomBindingType(t)
-                    && !HasOnlyValidationFreeProperties(t))
-                .ToArray();
+                    && !HasOnlyValidationFreeProperties(t))];
 
             foreach (Type requestType in requestTypes)
             {

--- a/tests/Granit.ArchitectureTests/VaultConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/VaultConventionTests.cs
@@ -84,9 +84,7 @@ public sealed class VaultConventionTests
         // Every Granit.Vault.Exceptions.* type must inherit from SecretVaultException, or from
         // Granit.Exceptions.NotFoundException / ForbiddenException (the two framework-level
         // user-friendly bases used by SecretNotFoundException / SecretAccessDeniedException).
-        Type[] exceptionTypes = typeof(SecretVaultException).Assembly.GetTypes()
-            .Where(t => t.Namespace == "Granit.Vault.Exceptions" && typeof(Exception).IsAssignableFrom(t))
-            .ToArray();
+        Type[] exceptionTypes = [.. typeof(SecretVaultException).Assembly.GetTypes().Where(t => t.Namespace == "Granit.Vault.Exceptions" && typeof(Exception).IsAssignableFrom(t))];
 
         foreach (Type type in exceptionTypes)
         {
@@ -107,12 +105,11 @@ public sealed class VaultConventionTests
         // Default interface method on ISecretStore centralises the anti-footgun contract:
         // only SecretNotFoundException → null; every other failure bubbles. Providers must
         // NOT reimplement it, or they risk swallowing 403/503 under the guise of "missing".
-        Type[] concrete = ProviderAssemblies
+        Type[] concrete = [.. ProviderAssemblies
             .Append(typeof(ISecretStore).Assembly)
             .SelectMany(a => a.GetTypes())
             .Distinct()
-            .Where(t => t.IsClass && !t.IsAbstract && typeof(ISecretStore).IsAssignableFrom(t))
-            .ToArray();
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(ISecretStore).IsAssignableFrom(t))];
 
         foreach (Type type in concrete)
         {

--- a/tests/Granit.ArchitectureTests/WidgetRendererPairingTests.cs
+++ b/tests/Granit.ArchitectureTests/WidgetRendererPairingTests.cs
@@ -40,9 +40,7 @@ public sealed class WidgetRendererPairingTests
     {
         Assembly[] assemblies = LoadFrameworkAssemblies();
 
-        IReadOnlyList<Type> definitions = ScanConcreteSubtypes<WidgetDefinition>(assemblies)
-            .Where(t => t.Name.EndsWith(DefinitionSuffix, StringComparison.Ordinal))
-            .ToList();
+        IReadOnlyList<Type> definitions = [.. ScanConcreteSubtypes<WidgetDefinition>(assemblies).Where(t => t.Name.EndsWith(DefinitionSuffix, StringComparison.Ordinal))];
 
         var rendererPrefixes = ScanConcreteSubtypes<IWidgetInstanceRenderer>(assemblies)
             .Where(t => t.Name.EndsWith(RendererSuffix, StringComparison.Ordinal))
@@ -75,9 +73,7 @@ public sealed class WidgetRendererPairingTests
         // a good signal of dead code.
         Assembly[] assemblies = LoadFrameworkAssemblies();
 
-        IReadOnlyList<Type> renderers = ScanConcreteSubtypes<IWidgetInstanceRenderer>(assemblies)
-            .Where(t => t.Name.EndsWith(RendererSuffix, StringComparison.Ordinal))
-            .ToList();
+        IReadOnlyList<Type> renderers = [.. ScanConcreteSubtypes<IWidgetInstanceRenderer>(assemblies).Where(t => t.Name.EndsWith(RendererSuffix, StringComparison.Ordinal))];
 
         var definitionPrefixes = ScanConcreteSubtypes<WidgetDefinition>(assemblies)
             .Where(t => t.Name.EndsWith(DefinitionSuffix, StringComparison.Ordinal))

--- a/tests/Granit.ArchitectureTests/WolverineHandlerConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/WolverineHandlerConventionTests.cs
@@ -37,10 +37,9 @@ public sealed class WolverineHandlerConventionTests
             Type[] internalHandlers;
             try
             {
-                internalHandlers = assembly.GetTypes()
+                internalHandlers = [.. assembly.GetTypes()
                     .Where(t => !t.IsPublic && !t.IsAbstract && !t.IsInterface)
-                    .Where(HasWolverineHandlerMethod)
-                    .ToArray();
+                    .Where(HasWolverineHandlerMethod)];
             }
             catch (ReflectionTypeLoadException)
             {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1352,11 +1352,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "xunit.analyzers": {
@@ -5149,8 +5149,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -5163,44 +5163,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "5ZpUM+zKkNUwgL3U25n4KZ6Nwwmvqg3qdk1NUuBMXWD66jl3P+nWEw8Zk/c2EQmIX20bgIjwB0DlwJExZQOZuA==",
+        "resolved": "5.36.1",
+        "contentHash": "FBiWAsrNRJGJmgmLyvSlU5hdZeuj3pfmL0/ai4DBCfXdPi1bme0DaaJZ3Kwom668AIA9Ks5kIKqwCp2RGkt4uQ==",
         "dependencies": {
           "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "gSjgGuskdVZNSXMciU7dV6/P0jthPVQKAhpX+MY7w7U6amuk48CAhB+mfikYdydbFe+C7TuDOqD1DMhYOTqaQA==",
+        "resolved": "5.36.1",
+        "contentHash": "MlpnQ7hQW4Wv89Gnk/Jr0why7gN8MZ9hPRGLD/5DZMFB2Xl25XD2OXtdF4rjDM6DXI6L9F2dOpLiVz5Tk5NlUw==",
         "dependencies": {
           "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
@@ -52,8 +52,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1017,11 +1017,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -994,8 +994,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1017,11 +1017,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Events.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Events.Wolverine.Tests/packages.lock.json
@@ -974,8 +974,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -997,11 +997,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
@@ -1075,8 +1075,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1098,11 +1098,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -1071,8 +1071,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1094,11 +1094,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -63,8 +63,8 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",

--- a/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
@@ -1020,8 +1020,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1043,11 +1043,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
@@ -1023,8 +1023,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1046,11 +1046,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Timeline.Endpoints.Tests/GranitTimelineEndpointsModuleTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/GranitTimelineEndpointsModuleTests.cs
@@ -17,36 +17,33 @@ public sealed class GranitTimelineEndpointsModuleTests
     [Fact]
     public void Module_DependsOn_GranitAuthorizationModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineEndpointsModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineEndpointsModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitAuthorizationModule));
     }
 
     [Fact]
     public void Module_DependsOn_GranitTimelineModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineEndpointsModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineEndpointsModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitTimelineModule));
     }
 
     [Fact]
     public void Module_DependsOn_GranitHttpApiDocumentationModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineEndpointsModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineEndpointsModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitHttpApiDocumentationModule));
     }
 }

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelinePermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelinePermissionDefinitionProviderTests.cs
@@ -101,7 +101,19 @@ public sealed class TimelinePermissionDefinitionProviderTests
     }
 
     [Fact]
-    public void DefinePermissions_registers_exactly_five_permissions()
+    public void DefinePermissions_registers_Reactions_React_permission()
+    {
+        FakePermissionDefinitionContext context = new();
+        TimelinePermissionDefinitionProvider provider = new();
+
+        provider.DefinePermissions(context);
+
+        PermissionGroup group = context.Groups.Single(g => g.Name == TimelinePermissions.GroupName);
+        group.Permissions.ShouldContain(p => p.Name == TimelinePermissions.Reactions.React);
+    }
+
+    [Fact]
+    public void DefinePermissions_registers_exactly_six_permissions()
     {
         // Arrange
         FakePermissionDefinitionContext context = new();
@@ -110,9 +122,9 @@ public sealed class TimelinePermissionDefinitionProviderTests
         // Act
         provider.DefinePermissions(context);
 
-        // Assert
+        // Assert — Entries.{Read, Create, Manage} + InternalNotes.Read + Followers.Manage + Reactions.React
         PermissionGroup group = context.Groups.Single(g => g.Name == TimelinePermissions.GroupName);
-        group.Permissions.Count.ShouldBe(5);
+        group.Permissions.Count.ShouldBe(6);
     }
 
     [Fact]

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperReactionTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineResponseMapperReactionTests.cs
@@ -1,0 +1,64 @@
+using Granit.Timeline.Domain;
+using Granit.Timeline.Endpoints.Dtos;
+using Granit.Timeline.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Endpoints.Tests;
+
+public sealed class TimelineResponseMapperReactionTests
+{
+    [Fact]
+    public void AggregateReactions_groups_per_entry_per_emoji_with_count()
+    {
+        var entry1 = Guid.NewGuid();
+        var entry2 = Guid.NewGuid();
+        var currentUser = Guid.NewGuid();
+        var otherUser = Guid.NewGuid();
+
+        Reaction[] reactions =
+        [
+            R(entry1, currentUser, "thumbs_up"),
+            R(entry1, otherUser, "thumbs_up"),
+            R(entry1, otherUser, "heart"),
+            R(entry2, otherUser, "tada"),
+        ];
+
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
+            TimelineResponseMapper.AggregateReactions(reactions, currentUser);
+
+        result[entry1]["thumbs_up"].ShouldBe(new ReactionAggregateResponse(2, ByCurrentUser: true));
+        result[entry1]["heart"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false));
+        result[entry2]["tada"].ShouldBe(new ReactionAggregateResponse(1, ByCurrentUser: false));
+    }
+
+    [Fact]
+    public void AggregateReactions_with_no_current_user_marks_byCurrentUser_false()
+    {
+        var entryId = Guid.NewGuid();
+        Reaction[] reactions = [R(entryId, Guid.NewGuid(), "heart")];
+
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
+            TimelineResponseMapper.AggregateReactions(reactions, currentUserId: null);
+
+        result[entryId]["heart"].ByCurrentUser.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AggregateReactions_with_empty_input_returns_empty_dict()
+    {
+        IReadOnlyDictionary<Guid, IReadOnlyDictionary<string, ReactionAggregateResponse>> result =
+            TimelineResponseMapper.AggregateReactions([], currentUserId: Guid.NewGuid());
+
+        result.ShouldBeEmpty();
+    }
+
+    private static Reaction R(Guid entryId, Guid userId, string emoji) =>
+        Reaction.Create(
+            id: Guid.NewGuid(),
+            entryId: entryId,
+            userId: userId,
+            emoji: emoji,
+            createdAt: DateTimeOffset.UtcNow,
+            createdBy: userId.ToString());
+}

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
@@ -56,6 +56,12 @@ public sealed class TimelineStreamEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<ITimelineNotifier>());
         builder.Services.AddSingleton(Substitute.For<Granit.Users.ICurrentUserService>());
 
+        // Reactions infra (story C1-C3) — stream endpoint enriches entries
+        // with the per-emoji reaction summary; no reactions are exercised here
+        // so the substitute returns an empty list by default.
+        builder.Services.AddSingleton(Substitute.For<IReactionReader>());
+        builder.Services.AddSingleton(Substitute.For<IReactionWriter>());
+
         _app = builder.Build();
         _app.MapGranitTimeline();
         _app.StartAsync().GetAwaiter().GetResult();

--- a/tests/Granit.Timeline.EntityFrameworkCore.Tests/GranitTimelineEntityFrameworkCoreModuleTests.cs
+++ b/tests/Granit.Timeline.EntityFrameworkCore.Tests/GranitTimelineEntityFrameworkCoreModuleTests.cs
@@ -16,24 +16,22 @@ public sealed class GranitTimelineEntityFrameworkCoreModuleTests
     [Fact]
     public void Module_DependsOn_GranitTimelineModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineEntityFrameworkCoreModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineEntityFrameworkCoreModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitTimelineModule));
     }
 
     [Fact]
     public void Module_DependsOn_GranitPersistenceEntityFrameworkCoreModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineEntityFrameworkCoreModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineEntityFrameworkCoreModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitPersistenceEntityFrameworkCoreModule));
     }
 }

--- a/tests/Granit.Timeline.EntityFrameworkCore.Tests/ReactionConfigurationTests.cs
+++ b/tests/Granit.Timeline.EntityFrameworkCore.Tests/ReactionConfigurationTests.cs
@@ -1,0 +1,66 @@
+using Granit.Timeline.Domain;
+using Granit.Timeline.EntityFrameworkCore;
+using Granit.Timeline.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.EntityFrameworkCore.Tests;
+
+public sealed class ReactionConfigurationTests
+{
+    private static IEntityType GetEntityType()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+        DbContextOptions<TimelineDbContext> options = new DbContextOptionsBuilder<TimelineDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using TimelineDbContext ctx = new(options);
+        return ctx.Model.FindEntityType(typeof(Reaction))
+            ?? throw new InvalidOperationException("Reaction entity type missing from model");
+    }
+
+    [Fact]
+    public void Table_uses_configured_prefix()
+    {
+        IEntityType type = GetEntityType();
+        type.GetTableName().ShouldBe(GranitTimelineDbProperties.DbTablePrefix + "reactions");
+    }
+
+    [Fact]
+    public void Emoji_property_has_max_length_32()
+    {
+        IProperty prop = GetEntityType().FindProperty(nameof(Reaction.Emoji))!;
+        prop.GetMaxLength().ShouldBe(32);
+        prop.IsNullable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Unique_index_covers_entry_user_emoji()
+    {
+        IIndex unique = GetEntityType().GetIndexes().Single(i => i.IsUnique);
+        unique.Properties.Select(p => p.Name).ShouldBe(["EntryId", "UserId", "Emoji"]);
+        unique.GetDatabaseName().ShouldBe($"ix_{GranitTimelineDbProperties.DbTablePrefix}reactions_unique");
+    }
+
+    [Fact]
+    public void By_entry_index_present_for_batch_reads()
+    {
+        IIndex byEntry = GetEntityType().GetIndexes()
+            .Single(i => i.GetDatabaseName() == $"ix_{GranitTimelineDbProperties.DbTablePrefix}reactions_by_entry");
+        byEntry.Properties.Select(p => p.Name).ShouldBe(["EntryId", "TenantId"]);
+        byEntry.IsUnique.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Foreign_key_to_TimelineEntry_cascade_deletes()
+    {
+        IEntityType type = GetEntityType();
+        IForeignKey fk = type.GetForeignKeys()
+            .Single(f => f.PrincipalEntityType.ClrType == typeof(TimelineEntry));
+        fk.DeleteBehavior.ShouldBe(DeleteBehavior.Cascade);
+    }
+}

--- a/tests/Granit.Timeline.Tests/GranitTimelineModuleTests.cs
+++ b/tests/Granit.Timeline.Tests/GranitTimelineModuleTests.cs
@@ -13,36 +13,33 @@ public sealed class GranitTimelineModuleTests
     [Fact]
     public void Module_DependsOn_GranitGuidsModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitGuidsModule));
     }
 
     [Fact]
     public void Module_DependsOn_GranitQueryEngineAbstractionsModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitQueryEngineAbstractionsModule));
     }
 
     [Fact]
     public void Module_DependsOn_removed_security_dependency()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
 
         allDeps.ShouldNotContain(t => t.Name == "GranitSecurityModule",
             "GranitSecurityModule was dissolved — it should no longer appear in DependsOn");
@@ -51,12 +48,11 @@ public sealed class GranitTimelineModuleTests
     [Fact]
     public void Module_DependsOn_GranitTimingModule()
     {
-        DependsOnAttribute[] attributes = typeof(GranitTimelineModule)
+        DependsOnAttribute[] attributes = [.. typeof(GranitTimelineModule)
             .GetCustomAttributes(typeof(DependsOnAttribute), false)
-            .Cast<DependsOnAttribute>()
-            .ToArray();
+            .Cast<DependsOnAttribute>()];
 
-        Type[] allDeps = attributes.SelectMany(a => a.DependedTypes).ToArray();
+        Type[] allDeps = [.. attributes.SelectMany(a => a.DependedTypes)];
         allDeps.ShouldContain(typeof(GranitTimingModule));
     }
 

--- a/tests/Granit.Timeline.Tests/InMemoryReactionStoreTests.cs
+++ b/tests/Granit.Timeline.Tests/InMemoryReactionStoreTests.cs
@@ -1,0 +1,104 @@
+using Granit.Timeline.Domain;
+using Granit.Timeline.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Tests;
+
+public sealed class InMemoryReactionStoreTests
+{
+    private static Reaction NewReaction(Guid entryId, Guid userId, string emoji = "heart") =>
+        Reaction.Create(
+            id: Guid.NewGuid(),
+            entryId: entryId,
+            userId: userId,
+            emoji: emoji,
+            createdAt: DateTimeOffset.UtcNow,
+            createdBy: userId.ToString());
+
+    [Fact]
+    public async Task Add_then_GetByEntry_returns_reaction()
+    {
+        InMemoryReactionStore sut = new();
+        var entryId = Guid.NewGuid();
+        Reaction reaction = NewReaction(entryId, Guid.NewGuid());
+
+        await sut.AddAsync(reaction, TestContext.Current.CancellationToken);
+        IReadOnlyList<Reaction> rows = await sut.GetByEntryAsync(entryId, TestContext.Current.CancellationToken);
+
+        rows.ShouldHaveSingleItem().Id.ShouldBe(reaction.Id);
+    }
+
+    [Fact]
+    public async Task Add_duplicate_throws_idempotency_violation()
+    {
+        InMemoryReactionStore sut = new();
+        var entryId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await sut.AddAsync(NewReaction(entryId, userId), TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await sut.AddAsync(NewReaction(entryId, userId), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Remove_then_re_add_works()
+    {
+        InMemoryReactionStore sut = new();
+        var entryId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await sut.AddAsync(NewReaction(entryId, userId), TestContext.Current.CancellationToken);
+
+        await sut.RemoveAsync(entryId, userId, "heart", TestContext.Current.CancellationToken);
+        await sut.AddAsync(NewReaction(entryId, userId), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<Reaction> rows = await sut.GetByEntryAsync(entryId, TestContext.Current.CancellationToken);
+        rows.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Remove_non_existent_is_noop()
+    {
+        InMemoryReactionStore sut = new();
+        await sut.RemoveAsync(Guid.NewGuid(), Guid.NewGuid(), "heart", TestContext.Current.CancellationToken);
+        // No exception.
+    }
+
+    [Fact]
+    public async Task GetByEntries_batch_filters_to_supplied_ids()
+    {
+        InMemoryReactionStore sut = new();
+        var e1 = Guid.NewGuid();
+        var e2 = Guid.NewGuid();
+        var e3 = Guid.NewGuid();
+        await sut.AddAsync(NewReaction(e1, Guid.NewGuid()), TestContext.Current.CancellationToken);
+        await sut.AddAsync(NewReaction(e2, Guid.NewGuid()), TestContext.Current.CancellationToken);
+        await sut.AddAsync(NewReaction(e3, Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        IReadOnlyList<Reaction> rows = await sut.GetByEntriesAsync([e1, e3], TestContext.Current.CancellationToken);
+        rows.Select(r => r.EntryId).ShouldBe([e1, e3], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task GetByEntries_with_empty_input_returns_empty()
+    {
+        InMemoryReactionStore sut = new();
+        IReadOnlyList<Reaction> rows = await sut.GetByEntriesAsync([], TestContext.Current.CancellationToken);
+        rows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task FindAsync_returns_match_or_null()
+    {
+        InMemoryReactionStore sut = new();
+        var entryId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await sut.AddAsync(NewReaction(entryId, userId, "thumbs_up"), TestContext.Current.CancellationToken);
+
+        Reaction? hit = await sut.FindAsync(entryId, userId, "thumbs_up", TestContext.Current.CancellationToken);
+        hit.ShouldNotBeNull();
+
+        Reaction? miss = await sut.FindAsync(entryId, userId, "heart", TestContext.Current.CancellationToken);
+        miss.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Timeline.Tests/Internal/NullTimelineNotifierTests.cs
+++ b/tests/Granit.Timeline.Tests/Internal/NullTimelineNotifierTests.cs
@@ -19,7 +19,7 @@ public sealed class NullTimelineNotifierTests
             "Test comment", new AuthorInfo("user-1", "Alice"), DateTimeOffset.UtcNow, "user-1");
         List<string> followerIds = ["user-2", "user-3"];
 
-        Func<Task> act = () => _notifier.NotifyEntryPostedAsync(
+        Task act() => _notifier.NotifyEntryPostedAsync(
             entry, followerIds, TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);
@@ -33,7 +33,7 @@ public sealed class NullTimelineNotifierTests
             "{}", new AuthorInfo("system", "System"), DateTimeOffset.UtcNow, "system");
         List<string> followerIds = [];
 
-        Func<Task> act = () => _notifier.NotifyEntryPostedAsync(
+        Task act() => _notifier.NotifyEntryPostedAsync(
             entry, followerIds, TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);
@@ -60,7 +60,7 @@ public sealed class NullTimelineNotifierTests
             "Hey @user-2", new AuthorInfo("user-1", "Alice"), DateTimeOffset.UtcNow, "user-1");
         List<string> mentionedUserIds = ["user-2"];
 
-        Func<Task> act = () => _notifier.NotifyMentionedUsersAsync(
+        Task act() => _notifier.NotifyMentionedUsersAsync(
             entry, mentionedUserIds, TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);
@@ -74,7 +74,7 @@ public sealed class NullTimelineNotifierTests
             "No mentions here", new AuthorInfo("user-1", "Alice"), DateTimeOffset.UtcNow, "user-1");
         List<string> mentionedUserIds = [];
 
-        Func<Task> act = () => _notifier.NotifyMentionedUsersAsync(
+        Task act() => _notifier.NotifyMentionedUsersAsync(
             entry, mentionedUserIds, TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);

--- a/tests/Granit.Timeline.Tests/ReactionTests.cs
+++ b/tests/Granit.Timeline.Tests/ReactionTests.cs
@@ -1,0 +1,99 @@
+using Granit.Domain;
+using Granit.Timeline.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Timeline.Tests;
+
+public sealed class ReactionTests
+{
+    [Fact]
+    public void Create_with_valid_emoji_succeeds()
+    {
+        var id = Guid.NewGuid();
+        var entryId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        DateTimeOffset now = new(2026, 5, 2, 12, 0, 0, TimeSpan.Zero);
+
+        var reaction = Reaction.Create(
+            id, entryId, userId, "thumbs_up", now, "user-1", tenantId: null);
+
+        reaction.Id.ShouldBe(id);
+        reaction.EntryId.ShouldBe(entryId);
+        reaction.UserId.ShouldBe(userId);
+        reaction.Emoji.ShouldBe("thumbs_up");
+        reaction.CreatedAt.ShouldBe(now);
+        reaction.CreatedBy.ShouldBe("user-1");
+    }
+
+    [Fact]
+    public void Create_with_unknown_emoji_throws()
+    {
+        ArgumentException ex = Should.Throw<ArgumentException>(() => Reaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "rocket", DateTimeOffset.UtcNow, "user-1"));
+
+        ex.Message.ShouldContain("rocket");
+        ex.Message.ShouldContain("catalog");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_with_blank_emoji_throws(string emoji) =>
+        Should.Throw<ArgumentException>(() => Reaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), emoji, DateTimeOffset.UtcNow, "user-1"));
+
+    [Fact]
+    public void Create_with_empty_entryId_throws() =>
+        Should.Throw<ArgumentException>(() => Reaction.Create(
+            Guid.NewGuid(), Guid.Empty, Guid.NewGuid(), "heart", DateTimeOffset.UtcNow, "user-1"));
+
+    [Fact]
+    public void Create_with_empty_userId_throws() =>
+        Should.Throw<ArgumentException>(() => Reaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.Empty, "heart", DateTimeOffset.UtcNow, "user-1"));
+
+    [Fact]
+    public void Create_with_blank_createdBy_throws() =>
+        Should.Throw<ArgumentException>(() => Reaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "heart", DateTimeOffset.UtcNow, ""));
+
+    [Fact]
+    public void IMultiTenant_round_trips_explicitly()
+    {
+        var tenantId = Guid.NewGuid();
+        var reaction = Reaction.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "heart",
+            DateTimeOffset.UtcNow, "user-1", tenantId);
+
+        reaction.TenantId.ShouldBe(tenantId);
+        ((IMultiTenant)reaction).TenantId.ShouldBe(tenantId);
+
+        var newTenant = Guid.NewGuid();
+        ((IMultiTenant)reaction).TenantId = newTenant;
+        reaction.TenantId.ShouldBe(newTenant);
+    }
+}
+
+public sealed class ReactionEmojiCatalogTests
+{
+    [Fact]
+    public void All_returns_5_v1_emojis()
+    {
+        ReactionEmojiCatalog.All.Count.ShouldBe(5);
+        ReactionEmojiCatalog.All.ShouldBe(
+            ["thumbs_up", "heart", "tada", "joy", "eyes"]);
+    }
+
+    [Theory]
+    [InlineData("thumbs_up", true)]
+    [InlineData("heart", true)]
+    [InlineData("tada", true)]
+    [InlineData("joy", true)]
+    [InlineData("eyes", true)]
+    [InlineData("rocket", false)]
+    [InlineData("THUMBS_UP", false)] // case-sensitive (Ordinal)
+    [InlineData("", false)]
+    public void IsValid_recognises_only_catalog_keys(string emoji, bool expected) =>
+        ReactionEmojiCatalog.IsValid(emoji).ShouldBe(expected);
+}

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -1195,8 +1195,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1218,11 +1218,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -842,11 +842,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "xunit.analyzers": {
@@ -1284,8 +1284,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1307,34 +1307,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "5ZpUM+zKkNUwgL3U25n4KZ6Nwwmvqg3qdk1NUuBMXWD66jl3P+nWEw8Zk/c2EQmIX20bgIjwB0DlwJExZQOZuA==",
+        "resolved": "5.36.1",
+        "contentHash": "FBiWAsrNRJGJmgmLyvSlU5hdZeuj3pfmL0/ai4DBCfXdPi1bme0DaaJZ3Kwom668AIA9Ks5kIKqwCp2RGkt4uQ==",
         "dependencies": {
           "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -763,11 +763,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "xunit.analyzers": {
@@ -1228,8 +1228,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1251,34 +1251,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "5ZpUM+zKkNUwgL3U25n4KZ6Nwwmvqg3qdk1NUuBMXWD66jl3P+nWEw8Zk/c2EQmIX20bgIjwB0DlwJExZQOZuA==",
+        "resolved": "5.36.1",
+        "contentHash": "FBiWAsrNRJGJmgmLyvSlU5hdZeuj3pfmL0/ai4DBCfXdPi1bme0DaaJZ3Kwom668AIA9Ks5kIKqwCp2RGkt4uQ==",
         "dependencies": {
           "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
@@ -955,11 +955,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "xunit.analyzers": {
@@ -1413,8 +1413,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1436,34 +1436,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "gSjgGuskdVZNSXMciU7dV6/P0jthPVQKAhpX+MY7w7U6amuk48CAhB+mfikYdydbFe+C7TuDOqD1DMhYOTqaQA==",
+        "resolved": "5.36.1",
+        "contentHash": "MlpnQ7hQW4Wv89Gnk/Jr0why7gN8MZ9hPRGLD/5DZMFB2Xl25XD2OXtdF4rjDM6DXI6L9F2dOpLiVz5Tk5NlUw==",
         "dependencies": {
           "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -869,11 +869,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.36.0",
-        "contentHash": "6WJZCEtq/eoulS8vbrPfTfGPjckJzyhh2xlx+iFvVG+tl4zakvk7XsSWZYGlOpE+jtmdk7GFD3cl9VsGf0T4Dg==",
+        "resolved": "5.36.1",
+        "contentHash": "Uz4wCpfGYi8+p4f4buM44bV+BEfyxY7vqGHA4IPpttO4Hje20ye9zT3WkDdom+FZVcl+rMFchaEGMbPtbveYtQ==",
         "dependencies": {
           "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "xunit.analyzers": {
@@ -1325,8 +1325,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -1348,34 +1348,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "VojBIGEG+MIG1ZAJjnmD1YhsotX5Dsx7O6LxJtNiOSrPtLGJrk/prX1gK08plm9kfbQb6QD9gnpVPtq23KUaaQ==",
+        "resolved": "5.36.1",
+        "contentHash": "hPp4xwWLSCluyyR4oaN25UBf+/Alwxo1aoRtWkzF2g2BglkNlQsgBy2fMLr6HdDYnnNNrpuwHOLAokEnJ/0zkA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "gSjgGuskdVZNSXMciU7dV6/P0jthPVQKAhpX+MY7w7U6amuk48CAhB+mfikYdydbFe+C7TuDOqD1DMhYOTqaQA==",
+        "resolved": "5.36.1",
+        "contentHash": "MlpnQ7hQW4Wv89Gnk/Jr0why7gN8MZ9hPRGLD/5DZMFB2Xl25XD2OXtdF4rjDM6DXI6L9F2dOpLiVz5Tk5NlUw==",
         "dependencies": {
           "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.36.0"
+          "WolverineFx.RDBMS": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -607,8 +607,8 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "oOEwyUNKKNSx3sFS9PaVOAqJBTfYY+qrHKt7Bhyr3vyAPpR9R2bX3HwkR7avdQ1BALtEd4lb9twjKW2wZxld8g==",
+        "resolved": "5.36.1",
+        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
         "dependencies": {
           "JasperFx": "1.28.2",
           "JasperFx.Events": "1.31.1",
@@ -621,11 +621,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.0",
-        "contentHash": "1v31bPCGzhP3jVmDbYvXmmVEj45ZomYBJtyni5liE4T760oEMI+yNzLkp+PM5Z8j1ug4bbasSlVWEzWInASb+Q==",
+        "resolved": "5.36.1",
+        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.0"
+          "WolverineFx": "5.36.1"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary

Closes [#1812](https://github.com/granit-fx/granit-dotnet/issues/1812) (C1), [#1813](https://github.com/granit-fx/granit-dotnet/issues/1813) (C2), [#1814](https://github.com/granit-fx/granit-dotnet/issues/1814) (C3) — bundles all three Stream C stories into a single PR per JF's request. **Stream C closed 3/3 → Phase 2 epic [#1510](https://github.com/granit-fx/granit-dotnet/issues/1510) finishes at A: 9/9, B: 5/5, C: 3/3, D: 2/2 = 19/19.**

Adds the closed-catalog reaction system (👍 ❤️ 🎉 😂 👀) on `TimelineEntry` per ADR-046 §1.

## C1 — `Reaction` aggregate + EF persistence

**`Granit.Timeline`**

| File | Role |
| ---- | ---- |
| `Domain/Reaction.cs` | `CreationAuditedEntity + IMultiTenant`. Factory `Create()` validates against the catalog at the boundary; unknown emojis never hit persistence |
| `Domain/ReactionEmojiCatalog.cs` | Closed set `{ thumbs_up, heart, tada, joy, eyes }`. Extending requires an ADR amendment (same precedent as ADR-048 §2 closed-catalog relation kinds) |
| `Abstractions/IReactionReader.cs` + `IReactionWriter.cs` | CQRS split per CLAUDE.md anti-pattern rule. Reader exposes `GetByEntryAsync` + batch `GetByEntriesAsync` (for the C3 stream enrichment) + `FindAsync` (for the C2 toggle path) |
| `Internal/InMemoryReactionStore.cs` | Default in-memory impl (replaced by EF Core when loaded) |
| `Events/ReactionToggledEvent.cs` | `IDomainEvent` carrying `(EntryId, UserId, Emoji, Action)` for follower / notification handlers |

**`Granit.Timeline.EntityFrameworkCore`**

| File | Role |
| ---- | ---- |
| `Configurations/ReactionConfiguration.cs` | Composite **UNIQUE `(EntryId, UserId, Emoji)`** (DB-level idempotency guard against double-clicks), FK to `TimelineEntry` with `OnDelete(Cascade)`, secondary index `(EntryId, TenantId)` for batch reads, `Emoji` `MaxLength(32)` |
| `Internal/EfCoreReactionStore.cs` | EF impl backing both reader + writer through `IDbContextFactory` (same pattern as `EfCoreTimelineStore`) |
| `TimelineDbContext` | Adds `DbSet<Reaction>` |
| `AddGranitTimelineEntityFrameworkCore` | DI `Replace` swaps the in-memory store for the EF impl |

## C2 — POST toggle endpoint + `Timeline.Reactions.React` permission

| | |
| - | - |
| Route | `POST /timeline/entries/{entryId:guid}/reactions/{emoji}` |
| Permission | `Timeline.Reactions.React` (CLAUDE.md `[Group].[Resource].[Action]`) |
| Behaviour | Idempotent toggle — `Add` if absent, `Remove` if present. Returns `ReactionToggleResponse { entryId, emoji, count, currentUserHasReacted }` reflecting the post-toggle state |
| Validation | Emoji checked against `ReactionEmojiCatalog.IsValid` → 400 with `Granit:Timeline:UnknownEmoji` on miss; user must be authenticated with a parsable GUID `sub` claim → 401 otherwise |
| Event | Emits `ReactionToggledEvent` on the local bus on success — notification / follower handlers subscribe without re-querying |
| Concurrent double-POST | DB unique index collides on race; the second request observes the toggled state via the find-then-toggle round-trip |
| OpenAPI | 5 metadata elements per CLAUDE.md (`WithName` / `WithSummary` / `WithDescription` / `Produces` / `ProducesProblem` 400 + 401) |

`TimelinePermissionDefinitionProvider` adds the new permission with localization keys; auto-discovered by `GranitAuthorizationModule`.

## C3 — Catalog endpoint + manifest exposure + 18-culture i18n

| | |
| - | - |
| Catalog route | `GET /timeline/reactions/catalog` — returns the 5 emojis with localized display labels (gated by `Timeline.Reactions.React`; defense in depth — a user who cannot react does not need to see the picker) |
| Manifest | `TimelineStreamEntryResponse` gains optional `Reactions: IReadOnlyDictionary<string, ReactionAggregateResponse>?` keyed by emoji with `{ Count, ByCurrentUser }` per entry. Field omitted entirely when zero reactions — keeps the wire payload tight |
| Stream enrichment | The stream endpoint batch-loads reactions for the visible entries in **one round trip** via `GetByEntriesAsync` and aggregates via `TimelineResponseMapper.AggregateReactions` |
| Localization | `Reaction:thumbs_up` / `heart` / `tada` / `joy` / `eyes` + `Permission:Timeline.Reactions.React` added to all **15 base cultures** (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi). Regional variants (en-GB, fr-CA, pt-BR) inherit |
| Architecture test | `ReactionEmojiLocalizationTests` — asserts every `ReactionEmojiCatalog.All` entry has a `Reaction:{key}` resource key in all 15 base cultures. Fail-loudly when extending the catalog without shipping translations |

## Test plan

- [x] `dotnet test tests/Granit.Timeline.Tests` — **111/111 pass** (95 existing + 16 new: Reaction factory validation, catalog membership, in-memory store with idempotency cycle, batch GetByEntries, FindAsync hit/miss, IMultiTenant explicit-interface round-trip)
- [x] `dotnet test tests/Granit.Timeline.EntityFrameworkCore.Tests` — **29/29 pass** (24 existing + 5 new: table prefix, Emoji max-length, unique-index shape, by-entry secondary index, FK cascade behaviour)
- [x] `dotnet test tests/Granit.Timeline.Endpoints.Tests` — **57/57 pass** (53 existing + 3 new: per-entry/per-emoji aggregation with current-user flag, no-current-user fallback, empty input + 1 updated permission count + 1 new permission registration)
- [x] Targeted archi tests (`ReactionEmojiLocalization` / `DomainConvention` / `AbstractionsPurity` / `FileOrganization` / `LayerDependency` / `LocalizationFileShape` / `PermissionsConvention`) — **54/54 pass** (full archi shard left to CI to avoid local OOM)
- [x] `dotnet format --verify-no-changes` on Timeline / Timeline.Endpoints / Timeline.EntityFrameworkCore — clean
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles regenerated

## Out of scope (explicit follow-ups)

- **Postgres testcontainer integration test** — value converters + unique-index shape verified at SQLite level; a provider-specific story can land separately if Postgres-only behaviour needs verification (e.g. case-folding on the emoji column).
- **Doc page** — Stream C C3 acceptance mentioned a `docs-site` reactions section. Deferred to a docs-only follow-up to keep this PR focused on the runtime change. The architecture test (`ReactionEmojiLocalizationTests`) already enforces the closed-catalog policy programmatically.

## Phase 2 epic [#1510](https://github.com/granit-fx/granit-dotnet/issues/1510) — done

| Stream | Stories | PRs |
| ------ | ------- | --- |
| **D — Relations cache invalidation** | 2/2 | (early) |
| **A — Activities** | 9/9 | A1 #1788 → A9 #1848 |
| **B — Customization L1** | 5/5 | B0 #1849 / B1 #1851 / B2 #1853 / B3 #1873 / B4 #1874 |
| **C — Reactions Timeline** | 3/3 | **this PR** |

19/19 stories shipped across the epic.
