### PR TITLE
feat(entities-actions): RouteBase + verb shortcuts (closes #1845)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20790,7 +20790,38 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs",
       "line": 12,
-      "members": []
+      "members": [
+        {
+          "name": "Put",
+          "kind": "method",
+          "signature": "Put(string? path = null)",
+          "returnType": "EntityActionBuilder<TEntity>"
+        },
+        {
+          "name": "Delete",
+          "kind": "method",
+          "signature": "Delete(string? path = null)",
+          "returnType": "EntityActionBuilder<TEntity>"
+        },
+        {
+          "name": "Patch",
+          "kind": "method",
+          "signature": "Patch(string? path = null)",
+          "returnType": "EntityActionBuilder<TEntity>"
+        },
+        {
+          "name": "Get",
+          "kind": "method",
+          "signature": "Get(string? path = null)",
+          "returnType": "EntityActionBuilder<TEntity>"
+        },
+        {
+          "name": "AbsolutePath",
+          "kind": "method",
+          "signature": "AbsolutePath(string urlTemplate)",
+          "returnType": "EntityActionBuilder<TEntity>"
+        }
+      ]
     },
     {
       "name": "EntityActionContributionContext",

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
@@ -14,6 +14,7 @@ public sealed class EntityActionBuilder<TEntity>
 {
     private readonly string _name;
     private readonly string? _contributorAssemblyName;
+    private readonly string? _routeBase;
 
     private EntityActionKind _kind = EntityActionKind.ApiCall;
     private string? _displayKey;
@@ -29,17 +30,29 @@ public sealed class EntityActionBuilder<TEntity>
     private bool _showOnCalendarTile;
     private bool _showOnListHeader;
 
-    internal EntityActionBuilder(string name, string? contributorAssemblyName = null)
+    // RouteBase composition state — populated by verb shortcuts (Post / Put / Delete /
+    // Patch / Get / Download). At Build() time, if no explicit URL was supplied via
+    // ApiCall(method, fullUrl) or AbsolutePath(...), the URL is composed as
+    // {routeBase}/{id?}/{pathSegment ?? actionName}. {id} segment is omitted when
+    // the action is pinned via OnListHeader().
+    private bool _useRouteBase;
+    private string? _pathSegment;
+    private string? _absolutePath;
+
+    internal EntityActionBuilder(string name, string? contributorAssemblyName = null, string? routeBase = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _name = name;
         _contributorAssemblyName = contributorAssemblyName;
+        _routeBase = routeBase;
     }
 
     /// <summary>
     /// Configures the action as an HTTP write call (POST / PUT / DELETE) against
-    /// <paramref name="urlTemplate"/>. The template can reference <c>{id}</c> for
-    /// the entity primary key; the renderer resolves it at click time.
+    /// the explicit <paramref name="urlTemplate"/>. The template can reference
+    /// <c>{id}</c> for the entity primary key; the renderer resolves it at click
+    /// time. Escape hatch — prefer <see cref="Post"/> / <see cref="Put"/> /
+    /// <see cref="Delete"/> when the entity has a <c>RouteBase</c>.
     /// </summary>
     public EntityActionBuilder<TEntity> ApiCall(string method, string urlTemplate)
     {
@@ -49,25 +62,31 @@ public sealed class EntityActionBuilder<TEntity>
         _kind = EntityActionKind.ApiCall;
         _httpMethod = method.ToUpperInvariant();
         _urlTemplate = urlTemplate;
+        _useRouteBase = false;
+        _pathSegment = null;
         return this;
     }
 
     /// <summary>
-    /// Configures the action as a binary download (HTTP GET) against
-    /// <paramref name="urlTemplate"/>. The renderer triggers a browser download.
+    /// Configures the action as a binary download (HTTP GET). When the entity declares
+    /// a <c>RouteBase</c>, the URL is composed as
+    /// <c>{RouteBase}/{id}/{path ?? actionName}</c> (no <c>{id}</c> for header
+    /// actions). When <c>RouteBase</c> is absent, <paramref name="path"/> is treated
+    /// as the full URL (legacy behaviour — kept for backwards compatibility).
     /// </summary>
-    public EntityActionBuilder<TEntity> Download(string urlTemplate)
+    public EntityActionBuilder<TEntity> Download(string? path = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(urlTemplate);
-
         _kind = EntityActionKind.Download;
         _httpMethod = null;
-        _urlTemplate = urlTemplate;
+        _useRouteBase = true;
+        _pathSegment = path;
+        _urlTemplate = null;
         return this;
     }
 
     /// <summary>
     /// Configures the action as a client-side navigation (route or external URL).
+    /// SPA URLs never compose from <c>RouteBase</c> — pass the full SPA path here.
     /// </summary>
     public EntityActionBuilder<TEntity> Navigate(string urlTemplate)
     {
@@ -76,6 +95,69 @@ public sealed class EntityActionBuilder<TEntity>
         _kind = EntityActionKind.Navigate;
         _httpMethod = null;
         _urlTemplate = urlTemplate;
+        _useRouteBase = false;
+        _pathSegment = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Verb shortcut: composes the URL as <c>POST {RouteBase}/{id}/{path ?? actionName}</c>
+    /// (no <c>{id}</c> when the action is pinned on the list header).
+    /// Requires the entity to declare a <c>RouteBase</c>.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Post(string? path = null) => SetVerbShortcut(EntityActionKind.ApiCall, "POST", path);
+
+    /// <summary>
+    /// Verb shortcut: composes the URL as <c>PUT {RouteBase}/{id}/{path ?? actionName}</c>
+    /// (no <c>{id}</c> when the action is pinned on the list header).
+    /// Requires the entity to declare a <c>RouteBase</c>.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Put(string? path = null) => SetVerbShortcut(EntityActionKind.ApiCall, "PUT", path);
+
+    /// <summary>
+    /// Verb shortcut: composes the URL as <c>DELETE {RouteBase}/{id}/{path ?? actionName}</c>
+    /// (no <c>{id}</c> when the action is pinned on the list header).
+    /// Requires the entity to declare a <c>RouteBase</c>.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Delete(string? path = null) => SetVerbShortcut(EntityActionKind.ApiCall, "DELETE", path);
+
+    /// <summary>
+    /// Verb shortcut: composes the URL as <c>PATCH {RouteBase}/{id}/{path ?? actionName}</c>
+    /// (no <c>{id}</c> when the action is pinned on the list header).
+    /// Requires the entity to declare a <c>RouteBase</c>.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Patch(string? path = null) => SetVerbShortcut(EntityActionKind.ApiCall, "PATCH", path);
+
+    /// <summary>
+    /// Verb shortcut: composes the URL as <c>GET {RouteBase}/{id}/{path ?? actionName}</c>
+    /// (no <c>{id}</c> when the action is pinned on the list header).
+    /// Requires the entity to declare a <c>RouteBase</c>. Returns JSON
+    /// (<see cref="EntityActionKind.ApiCall"/>); use <see cref="Download"/> for
+    /// binary streams.
+    /// </summary>
+    public EntityActionBuilder<TEntity> Get(string? path = null) => SetVerbShortcut(EntityActionKind.ApiCall, "GET", path);
+
+    /// <summary>
+    /// Bypasses <c>RouteBase</c> composition and forces an absolute URL after a
+    /// verb shortcut has been applied. Useful when an action lives outside the
+    /// entity's primary route prefix but still benefits from the verb shortcut's
+    /// kind / method / confirmation chain. Equivalent in effect to using
+    /// <see cref="ApiCall"/> with the same method and full URL.
+    /// </summary>
+    public EntityActionBuilder<TEntity> AbsolutePath(string urlTemplate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(urlTemplate);
+        _absolutePath = urlTemplate;
+        return this;
+    }
+
+    private EntityActionBuilder<TEntity> SetVerbShortcut(EntityActionKind kind, string? method, string? path)
+    {
+        _kind = kind;
+        _httpMethod = method;
+        _useRouteBase = true;
+        _pathSegment = path;
+        _urlTemplate = null;
         return this;
     }
 
@@ -227,18 +309,21 @@ public sealed class EntityActionBuilder<TEntity>
 
     internal EntityActionDescriptor Build()
     {
+        string? resolvedUrl = ResolveUrl();
+
         // Kind-specific guards: invariants the fluent shortcuts can't catch on
         // their own (e.g. someone configures DisplayKey + Order without ever
         // calling ApiCall/Download/Navigate/WorkflowTransition/OpenDrawer/OpenModal).
         // OpenDrawer / OpenModal are pure-frontend kinds — a null URL is valid
         // (the renderer falls back to the entity's default detail / form layout).
-        if (_urlTemplate is null
+        if (resolvedUrl is null
             && _kind is not EntityActionKind.WorkflowTransition
             && _kind is not EntityActionKind.OpenDrawer
             && _kind is not EntityActionKind.OpenModal)
         {
             throw new InvalidOperationException(
                 $"Action '{_name}' must declare a URL via ApiCall(...) / Download(...) / Navigate(...), "
+                + "a verb shortcut (Post/Put/Delete/Patch/Get) combined with .RouteBase(...), "
                 + "be a WorkflowTransition, or use OpenDrawer() / OpenModal(). Bare actions are not allowed.");
         }
 
@@ -246,7 +331,7 @@ public sealed class EntityActionBuilder<TEntity>
         // expand to nothing useful since no row is selected when the
         // header bar fires. Catch the misconfiguration at build time
         // (host startup) instead of letting it ship a broken URL.
-        if (_showOnListHeader && _urlTemplate is { } template && template.Contains("{id}", StringComparison.Ordinal))
+        if (_showOnListHeader && resolvedUrl is { } template && template.Contains("{id}", StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 $"Action '{_name}' is pinned on the list header (OnListHeader) but its URL template contains '{{id}}'. "
@@ -260,7 +345,7 @@ public sealed class EntityActionBuilder<TEntity>
             Icon: _icon,
             Order: _order,
             RequiresPermission: _requiresPermission,
-            UrlTemplate: _urlTemplate,
+            UrlTemplate: resolvedUrl,
             HttpMethod: _httpMethod,
             ConfirmationKey: _confirmationKey,
             WorkflowTransitionName: _workflowTransitionName,
@@ -269,5 +354,43 @@ public sealed class EntityActionBuilder<TEntity>
             ShowOnGalleryCard: _showOnGalleryCard,
             ShowOnCalendarTile: _showOnCalendarTile,
             ShowOnListHeader: _showOnListHeader);
+    }
+
+    private string? ResolveUrl()
+    {
+        // Precedence:
+        //   1. .AbsolutePath(...)              → bypass everything
+        //   2. .ApiCall(method, fullUrl)       → directly sets _urlTemplate
+        //   3. Verb shortcut (Post / Get / …) → compose from RouteBase
+        //   4. Legacy Download(fullUrl)        → arg is the full URL
+        if (_absolutePath is not null)
+        {
+            return _absolutePath;
+        }
+
+        if (!_useRouteBase)
+        {
+            return _urlTemplate;
+        }
+
+        if (_routeBase is null)
+        {
+            // Legacy back-compat: pre-RouteBase callers wrote
+            // .Download("/api/orders/{id}/pdf") with the full URL inline. Honour
+            // that when no RouteBase is declared and a path was supplied.
+            if (_kind == EntityActionKind.Download && _pathSegment is not null)
+            {
+                return _pathSegment;
+            }
+
+            throw new InvalidOperationException(
+                $"Action '{_name}' uses a verb shortcut (Post/Put/Delete/Patch/Get/Download) but the entity declares no RouteBase. "
+                + "Either declare .RouteBase(\"/api/...\") at the entity level or use .ApiCall(method, fullUrl) / .AbsolutePath(...) for this action.");
+        }
+
+        string trailing = _pathSegment ?? _name;
+        string idSegment = _showOnListHeader ? string.Empty : "/{id}";
+        string prefix = _routeBase.TrimEnd('/');
+        return $"{prefix}{idSegment}/{trailing}";
     }
 }

--- a/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/EntityDefinitionBuilder.cs
@@ -21,6 +21,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
     private string? _permissionGroup;
     private string? _displayProperty;
     private string? _subtitleProperty;
+    private string? _routeBase;
 
     private Type? _queryDefinitionType;
     private Type? _exportDefinitionType;
@@ -148,6 +149,28 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         where TWorkflowDefinition : class
     {
         _workflowDefinitionType = typeof(TWorkflowDefinition);
+        return this;
+    }
+
+    /// <summary>
+    /// Declares the entity's API route prefix (e.g. <c>"/api/parties"</c>). Once set,
+    /// action verb shortcuts (<see cref="EntityActionBuilder{TEntity}.Post"/>,
+    /// <see cref="EntityActionBuilder{TEntity}.Get"/>,
+    /// <see cref="EntityActionBuilder{TEntity}.Download"/>, …) compose URLs as
+    /// <c>{RouteBase}/{id}/{actionName}</c> (or <c>{RouteBase}/{actionName}</c> for
+    /// <see cref="EntityActionBuilder{TEntity}.OnListHeader"/> actions). Eliminates
+    /// the need to repeat the same prefix on every action declaration.
+    /// </summary>
+    /// <remarks>
+    /// Optional. Hosts can keep using the verbose escape hatches
+    /// (<see cref="EntityActionBuilder{TEntity}.ApiCall"/> with a full URL, or
+    /// <see cref="EntityActionBuilder{TEntity}.AbsolutePath"/>) when an action lives
+    /// outside the entity's primary route prefix.
+    /// </remarks>
+    public EntityDefinitionBuilder<TEntity> RouteBase(string routeBase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(routeBase);
+        _routeBase = routeBase;
         return this;
     }
 
@@ -303,7 +326,7 @@ public sealed class EntityDefinitionBuilder<TEntity> where TEntity : class
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(configure);
 
-        EntityActionBuilder<TEntity> builder = new(name);
+        EntityActionBuilder<TEntity> builder = new(name, routeBase: _routeBase);
         configure(builder);
         _actions.Add(builder.Build());
         return this;

--- a/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionRouteBaseTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionRouteBaseTests.cs
@@ -1,0 +1,185 @@
+using Granit.Entities.Actions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Abstractions.Tests.Actions;
+
+public sealed class EntityActionRouteBaseTests
+{
+    [Fact]
+    public void Post_with_route_base_no_path_uses_action_name_segment()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor archive = d.Actions.Single(a => a.Name == "archive");
+        archive.Kind.ShouldBe(EntityActionKind.ApiCall);
+        archive.HttpMethod.ShouldBe("POST");
+        archive.UrlTemplate.ShouldBe("/api/parties/{id}/archive");
+    }
+
+    [Fact]
+    public void Post_with_route_base_explicit_path_uses_provided_segment()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor custom = d.Actions.Single(a => a.Name == "custom");
+        custom.HttpMethod.ShouldBe("POST");
+        custom.UrlTemplate.ShouldBe("/api/parties/{id}/custom-segment");
+    }
+
+    [Fact]
+    public void Put_delete_patch_emit_correct_methods()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        d.Actions.Single(a => a.Name == "rename").HttpMethod.ShouldBe("PUT");
+        d.Actions.Single(a => a.Name == "remove").HttpMethod.ShouldBe("DELETE");
+        d.Actions.Single(a => a.Name == "patch-status").HttpMethod.ShouldBe("PATCH");
+    }
+
+    [Fact]
+    public void Get_uses_apicall_kind_with_GET_method()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor stats = d.Actions.Single(a => a.Name == "stats");
+        stats.Kind.ShouldBe(EntityActionKind.ApiCall);
+        stats.HttpMethod.ShouldBe("GET");
+        stats.UrlTemplate.ShouldBe("/api/parties/{id}/stats");
+    }
+
+    [Fact]
+    public void Download_with_route_base_uses_download_kind_and_no_method()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor export = d.Actions.Single(a => a.Name == "export");
+        export.Kind.ShouldBe(EntityActionKind.Download);
+        export.HttpMethod.ShouldBeNull();
+        export.UrlTemplate.ShouldBe("/api/parties/{id}/export");
+    }
+
+    [Fact]
+    public void OnListHeader_with_verb_shortcut_omits_id_segment()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor import = d.Actions.Single(a => a.Name == "import");
+        import.HttpMethod.ShouldBe("POST");
+        import.ShowOnListHeader.ShouldBeTrue();
+        import.UrlTemplate.ShouldBe("/api/parties/import");
+    }
+
+    [Fact]
+    public void Navigate_does_not_compose_from_route_base()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor merge = d.Actions.Single(a => a.Name == "merge");
+        merge.Kind.ShouldBe(EntityActionKind.Navigate);
+        merge.UrlTemplate.ShouldBe("/w/parties/{id}/merge");
+    }
+
+    [Fact]
+    public void AbsolutePath_overrides_route_base_composition()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor offsite = d.Actions.Single(a => a.Name == "offsite");
+        offsite.Kind.ShouldBe(EntityActionKind.ApiCall);
+        offsite.HttpMethod.ShouldBe("POST");
+        offsite.UrlTemplate.ShouldBe("/legacy/offsite/path");
+    }
+
+    [Fact]
+    public void ApiCall_full_url_is_unaffected_by_route_base()
+    {
+        EntityDefinitionDescriptor d = new RouteBaseDefinition().Descriptor;
+
+        EntityActionDescriptor legacy = d.Actions.Single(a => a.Name == "legacy");
+        legacy.HttpMethod.ShouldBe("POST");
+        legacy.UrlTemplate.ShouldBe("/raw/url/{id}");
+    }
+
+    [Fact]
+    public void Verb_shortcut_without_route_base_throws_clear_error()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new MissingRouteBaseDefinition().Descriptor);
+
+        ex.Message.ShouldContain("RouteBase");
+        ex.Message.ShouldContain("orphan");
+    }
+
+    [Fact]
+    public void Download_legacy_full_url_still_works_without_route_base()
+    {
+        EntityDefinitionDescriptor d = new LegacyDownloadDefinition().Descriptor;
+
+        EntityActionDescriptor pdf = d.Actions.Single(a => a.Name == "download-pdf");
+        pdf.Kind.ShouldBe(EntityActionKind.Download);
+        pdf.UrlTemplate.ShouldBe("/api/v1/orders/{id}/pdf");
+    }
+
+    [Fact]
+    public void Route_base_trims_trailing_slash()
+    {
+        EntityDefinitionDescriptor d = new TrailingSlashRouteBaseDefinition().Descriptor;
+
+        d.Actions.Single(a => a.Name == "archive").UrlTemplate.ShouldBe("/api/parties/{id}/archive");
+    }
+
+    private sealed class SampleEntity;
+
+    private sealed class RouteBaseDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.RouteBase";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .RouteBase("/api/parties")
+                .Action("archive", a => a.Post().Order(10))
+                .Action("custom", a => a.Post("custom-segment").Order(20))
+                .Action("rename", a => a.Put().Order(30))
+                .Action("remove", a => a.Delete().Order(40))
+                .Action("patch-status", a => a.Patch().Order(50))
+                .Action("stats", a => a.Get().Order(60))
+                .Action("export", a => a.Download().Order(70))
+                .Action("import", a => a.Post().OnListHeader().Order(80))
+                .Action("merge", a => a.Navigate("/w/parties/{id}/merge").Order(90))
+                .Action("offsite", a => a.Post().AbsolutePath("/legacy/offsite/path").Order(100))
+                .Action("legacy", a => a.ApiCall("POST", "/raw/url/{id}").Order(110));
+    }
+
+    private sealed class MissingRouteBaseDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.OrphanShortcut";
+
+        // Sentinel name "orphan" appears in the error message so the test can
+        // assert on the diagnostic text without rebinding to the verb-shortcut
+        // wording, which may evolve.
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.Action("orphan", a => a.Post());
+    }
+
+    private sealed class LegacyDownloadDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.LegacyDownload";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder.Action("download-pdf", a => a
+                .Download("/api/v1/orders/{id}/pdf")
+                .DisplayKey("Orders:Action.Pdf")
+                .Icon("file-down"));
+    }
+
+    private sealed class TrailingSlashRouteBaseDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.TrailingSlash";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .RouteBase("/api/parties/")
+                .Action("archive", a => a.Post());
+    }
+}


### PR DESCRIPTION
## Summary

Eliminates the URL DRY violation on action declarations. Hosts no longer repeat `/api/parties/{id}/...` on every action — the path prefix, verb and trailing segment are derivable by convention once `RouteBase` is declared at the entity level.

**PR B** of the EntityDefinition action-DSL series (epic #1843). Sequencing: A merged → B (this) → C (`OnSelection`, #1846).

## DSL before / after

```csharp
// Before
.Action("archive", a => a.ApiCall("POST", "/api/parties/{id}/archive"))
.Action("export",  a => a.Download("/api/parties/{id}/export"))
.Action("import",  a => a.ApiCall("POST", "/api/parties/import").OnListHeader())

// After
.RouteBase("/api/parties")
.Action("archive", a => a.Post())                          // POST /api/parties/{id}/archive
.Action("export",  a => a.Download())                      // GET  /api/parties/{id}/export
.Action("custom",  a => a.Post("custom-segment"))          // POST /api/parties/{id}/custom-segment
.Action("import",  a => a.Post().OnListHeader())           // POST /api/parties/import (no {id})
.Action("offsite", a => a.Post().AbsolutePath("/x"))       // POST /x (bypasses RouteBase)
.Action("legacy",  a => a.ApiCall("POST", "/raw/url/{id}")) // escape hatch unchanged
```

URL convention: `{verb} {RouteBase}/{id}/{path ?? actionName}`. `{id}` segment is omitted when the action is pinned via `OnListHeader()`. `.AbsolutePath(...)` overrides the composition; `ApiCall(method, fullUrl)` remains the verbose escape hatch.

## Surface

- New on `EntityDefinitionBuilder<TEntity>`:
  - `.RouteBase(string)` — once per entity, optional.
- New on `EntityActionBuilder<TEntity>`:
  - `.Post(path?)`, `.Put(path?)`, `.Delete(path?)`, `.Patch(path?)`, `.Get(path?)` — verb shortcuts requiring `RouteBase` (else clear error at host startup).
  - `.AbsolutePath(string)` — modifier overriding the verb-shortcut URL composition.
- Modified signatures (source-compatible):
  - `.Download(string? path = null)` (was `Download(string urlTemplate)`). Without `RouteBase`, the arg is still treated as the full URL (legacy back-compat).
  - `Navigate` keeps full-URL semantics — SPA URLs never compose from a backend `RouteBase`.

## Test plan

- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — **98 tests** green (12 new in `EntityActionRouteBaseTests`)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 83 tests green
- [x] `dotnet test tests/Granit.Entities.Tests` — 16 tests green
- [x] `dotnet test tests/Granit.Invoicing.Tests` — 72 tests green (existing `Download("/api/v1/invoices/{id}/pdf")` legacy path verified)
- [x] `dotnet format --verify-no-changes` clean on touched projects
- [x] Architecture shard — 208 / 210 green; the 2 failures (`Granit.Taxonomy` README, `IManifestCustomizationApplier` visibility) **pre-exist on develop** and are unrelated to this PR

## Out of scope

- Rewriting existing `.ApiCall(...)` callsites in showcase modules to use the shortcuts (Invoicing keeps full URLs — the current tests pin those exact strings).
- `OnSelection()` URL convention — covered in PR C (#1846); the `_showOnSelection` branch in `ResolveUrl()` will be added there.
