### PR TITLE
feat(entities-actions): OnSelection — selection-bar bulk surface (closes #1846)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20845,7 +20845,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs",
-      "line": 24,
+      "line": 25,
       "members": []
     },
     {
@@ -21348,7 +21348,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 84,
+      "line": 107,
       "members": []
     },
     {
@@ -21357,7 +21357,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 99,
+      "line": 122,
       "members": []
     },
     {
@@ -21366,7 +21366,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 51,
+      "line": 74,
       "members": []
     },
     {
@@ -21375,7 +21375,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -21483,7 +21483,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 134,
+      "line": 157,
       "members": []
     },
     {
@@ -21492,7 +21492,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 118,
+      "line": 141,
       "members": []
     },
     {
@@ -21501,7 +21501,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 39,
+      "line": 41,
       "members": []
     },
     {
@@ -21519,7 +21519,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 193,
+      "line": 216,
       "members": []
     },
     {
@@ -21528,7 +21528,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 161,
+      "line": 184,
       "members": []
     },
     {
@@ -21537,7 +21537,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 177,
+      "line": 200,
       "members": []
     },
     {
@@ -21546,7 +21546,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 203,
+      "line": 226,
       "members": []
     },
     {
@@ -21555,7 +21555,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 145,
+      "line": 168,
       "members": []
     },
     {
@@ -21564,7 +21564,7 @@
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 66,
+      "line": 89,
       "members": []
     },
     {
@@ -21628,6 +21628,15 @@
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityRelationsSection.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntitySelectionActionManifest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.EntitySelectionActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
+      "line": 61,
       "members": []
     },
     {

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
@@ -29,6 +29,7 @@ public sealed class EntityActionBuilder<TEntity>
     private bool _showOnGalleryCard;
     private bool _showOnCalendarTile;
     private bool _showOnListHeader;
+    private bool _showOnSelection;
 
     // RouteBase composition state — populated by verb shortcuts (Post / Put / Delete /
     // Patch / Get / Download). At Build() time, if no explicit URL was supplied via
@@ -307,6 +308,22 @@ public sealed class EntityActionBuilder<TEntity>
         return this;
     }
 
+    /// <summary>
+    /// Exposes this action on the selection-bar dropdown that appears above
+    /// the list when one or more rows are selected (Odoo's "Action ▼"). The
+    /// renderer reuses the same row URL as the per-row action and fires
+    /// N parallel requests, substituting <c>{id}</c> per selected row
+    /// (concurrency-capped client-side). One declaration, dual surface —
+    /// no separate bulk endpoint and no DRY violation. Mutually exclusive
+    /// with <see cref="OnListHeader"/>: header actions are entity-scope and
+    /// cannot also be selection-scope.
+    /// </summary>
+    public EntityActionBuilder<TEntity> OnSelection()
+    {
+        _showOnSelection = true;
+        return this;
+    }
+
     internal EntityActionDescriptor Build()
     {
         string? resolvedUrl = ResolveUrl();
@@ -338,6 +355,17 @@ public sealed class EntityActionBuilder<TEntity>
                 + "Header actions are entity-scope; remove the placeholder or surface this action on rows / cards instead.");
         }
 
+        // OnListHeader fires once on the entity (no row context); OnSelection
+        // fires per selected row (substitutes {id} per request). Combining
+        // them is contradictory — guard at host startup so the manifest
+        // doesn't ship a nonsensical dual flag.
+        if (_showOnListHeader && _showOnSelection)
+        {
+            throw new InvalidOperationException(
+                $"Action '{_name}' opts into both OnListHeader and OnSelection — these surfaces are mutually exclusive. "
+                + "OnListHeader is entity-scope (no row context); OnSelection fires per selected row. Pick one.");
+        }
+
         return new EntityActionDescriptor(
             Name: _name,
             Kind: _kind,
@@ -353,7 +381,8 @@ public sealed class EntityActionBuilder<TEntity>
             ShowOnKanbanCard: _showOnKanbanCard,
             ShowOnGalleryCard: _showOnGalleryCard,
             ShowOnCalendarTile: _showOnCalendarTile,
-            ShowOnListHeader: _showOnListHeader);
+            ShowOnListHeader: _showOnListHeader,
+            ShowOnSelection: _showOnSelection);
     }
 
     private string? ResolveUrl()

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
@@ -21,6 +21,7 @@ namespace Granit.Entities.Actions;
 /// <param name="ShowOnGalleryCard">When <see langword="true"/>, the action also appears as a compact icon-button on the source entity's gallery card. Off by default — same surface-budget rationale as <see cref="ShowOnKanbanCard"/>.</param>
 /// <param name="ShowOnCalendarTile">When <see langword="true"/>, the action also appears as a compact icon-button on the source entity's calendar tile. Off by default — calendar tiles are smaller than kanban cards so curate carefully.</param>
 /// <param name="ShowOnListHeader">When <see langword="true"/>, the action is pinned on the list-page header (above the list / kanban / gallery / calendar tabs), not on individual rows. Use for entity-scope actions like <c>Import</c>, <c>Export</c>, <c>BulkArchive</c> — the URL template must NOT carry a <c>{id}</c> placeholder since no row is selected. Mirrors Odoo's top-of-list action bar.</param>
+/// <param name="ShowOnSelection">When <see langword="true"/>, the action is exposed on the selection-bar dropdown that appears above the list when at least one row is selected (Odoo's "Action ▼"). Same row URL as the per-row action — the renderer fires N parallel requests, substituting <c>{id}</c> per selected row (concurrency-capped client-side). Mutually exclusive with <see cref="ShowOnListHeader"/>: header actions are entity-scope and cannot also be selection-scope.</param>
 public sealed record EntityActionDescriptor(
     string Name,
     EntityActionKind Kind,
@@ -36,4 +37,5 @@ public sealed record EntityActionDescriptor(
     bool ShowOnKanbanCard = false,
     bool ShowOnGalleryCard = false,
     bool ShowOnCalendarTile = false,
-    bool ShowOnListHeader = false);
+    bool ShowOnListHeader = false,
+    bool ShowOnSelection = false);

--- a/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs
@@ -15,6 +15,7 @@ namespace Granit.Entities.Endpoints.Dtos;
 /// <param name="DefaultViewId">Resolved default <c>EntityView</c> id per ADR-049's 5-tier resolver, or <see langword="null"/> when none applies.</param>
 /// <param name="ListLayouts">Alternative list-view layouts (kanban, …) the entity exposes — drives the EntityListViewSwitcher tabs.</param>
 /// <param name="HeaderActions">Compact references to actions the entity opted into the list-page header via <c>OnListHeader()</c>. Pinned above the layout tabs (Odoo-style action bar) — entity-scope, no <c>{id}</c> placeholder. Already permission-filtered.</param>
+/// <param name="SelectionActions">Compact references to actions the entity opted into the selection-bar dropdown via <c>OnSelection()</c>. Surfaced when one or more rows are selected (Odoo's "Action ▼"). The renderer fires the action's row URL N times in parallel, substituting <c>{id}</c> per selected row. Already permission-filtered.</param>
 public sealed record EntityCollectionsSection(
     EntityCollectionReference? Query,
     EntityCollectionReference? Export,
@@ -22,7 +23,8 @@ public sealed record EntityCollectionsSection(
     IReadOnlyList<EntityCollectionReference> Dashboards,
     Guid? DefaultViewId,
     IReadOnlyList<EntityListLayoutManifest> ListLayouts,
-    IReadOnlyList<EntityHeaderActionManifest> HeaderActions);
+    IReadOnlyList<EntityHeaderActionManifest> HeaderActions,
+    IReadOnlyList<EntitySelectionActionManifest> SelectionActions);
 
 /// <summary>
 /// Compact reference to one action pinned on the list-page header
@@ -40,6 +42,27 @@ public sealed record EntityHeaderActionManifest(
     string Name,
     string? DisplayKey,
     string? Icon,
+    string? ContributorAssemblyName);
+
+/// <summary>
+/// Compact reference to one action surfaced on the selection-bar dropdown
+/// (rendered above the list once at least one row is selected — Odoo's
+/// "Action ▼"). The renderer iterates the selected ids and fires N parallel
+/// requests against the action's row URL with <c>{id}</c> substituted.
+/// <see cref="ConfirmationKey"/> is carried inline (rather than looked up in
+/// the entity's <c>Actions</c> facet) because confirmation on a multi-row
+/// destructive operation is a UX-critical fast path.
+/// </summary>
+/// <param name="Name">Stable action name — matches the entry in the entity's <c>Actions</c> facet.</param>
+/// <param name="DisplayKey">i18n key for the dropdown item label.</param>
+/// <param name="Icon">Icon name from the catalog.</param>
+/// <param name="ConfirmationKey">i18n key for the confirmation prompt shown before firing the bulk fan-out, or <see langword="null"/> for no confirmation.</param>
+/// <param name="ContributorAssemblyName">Contributing assembly. <see langword="null"/> for intra-module declarations.</param>
+public sealed record EntitySelectionActionManifest(
+    string Name,
+    string? DisplayKey,
+    string? Icon,
+    string? ConfirmationKey,
     string? ContributorAssemblyName);
 
 /// <summary>

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -372,7 +372,13 @@ internal static class EntityManifestComposer
             .Select(a => new EntityHeaderActionManifest(
                 a.Name, a.DisplayKey, a.Icon, a.ContributorAssemblyName))];
 
-        return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId, layouts, headerActions);
+        IReadOnlyList<EntitySelectionActionManifest> selectionActions = [.. d.Actions
+            .Where(a => a.ShowOnSelection && (a.RequiresPermission is null || granted.Contains(a.RequiresPermission)))
+            .OrderBy(a => a.Order)
+            .Select(a => new EntitySelectionActionManifest(
+                a.Name, a.DisplayKey, a.Icon, a.ConfirmationKey, a.ContributorAssemblyName))];
+
+        return new EntityCollectionsSection(query, export, metrics, dashboards, defaultViewId, layouts, headerActions, selectionActions);
     }
 
     private static List<EntityListLayoutManifest> ComposeListLayouts(

--- a/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
+++ b/tests/Granit.Entities.Abstractions.Tests/Actions/EntityActionTests.cs
@@ -305,4 +305,68 @@ public sealed class EntityActionTests
                 .Icon("upload")
                 .OnListHeader());
     }
+
+    [Fact]
+    public void OnSelection_defaults_false_and_opt_in_sets_flag()
+    {
+        EntityDefinitionDescriptor d = new SampleDefinition().Descriptor;
+
+        d.Actions.Single(a => a.Name == "finalize").ShowOnSelection.ShouldBeFalse();
+
+        EntityDefinitionDescriptor pinned = new SelectionPinnedDefinition().Descriptor;
+        pinned.Actions.Single(a => a.Name == "archive").ShowOnSelection.ShouldBeTrue();
+        pinned.Actions.Single(a => a.Name == "void").ShowOnSelection.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OnSelection_keeps_id_placeholder_in_url_for_per_row_fanout()
+    {
+        // OnSelection actions reuse the per-row URL — the renderer fires N
+        // parallel requests substituting {id} per selected row. So the URL
+        // template MUST keep its {id}, unlike OnListHeader which strips it.
+        EntityDefinitionDescriptor d = new SelectionPinnedDefinition().Descriptor;
+
+        EntityActionDescriptor archive = d.Actions.Single(a => a.Name == "archive");
+        archive.UrlTemplate.ShouldBe("/api/parties/{id}/archive");
+    }
+
+    [Fact]
+    public void OnSelection_combined_with_OnListHeader_throws()
+    {
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() =>
+            _ = new SelectionAndHeaderDefinition().Descriptor);
+
+        ex.Message.ShouldContain("OnListHeader");
+        ex.Message.ShouldContain("OnSelection");
+        ex.Message.ShouldContain("mutually exclusive");
+    }
+
+    private sealed class SelectionPinnedDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.SelectionPinned";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .RouteBase("/api/parties")
+                .Action("archive", a => a
+                    .Post()
+                    .Icon("archive")
+                    .OnSelection())
+                .Action("void", a => a
+                    .Post()
+                    .Icon("ban"));
+    }
+
+    private sealed class SelectionAndHeaderDefinition : EntityDefinition<SampleEntity>
+    {
+        public override string Name => "Granit.Sample.SelectionAndHeader";
+
+        protected override void Configure(EntityDefinitionBuilder<SampleEntity> builder) =>
+            builder
+                .RouteBase("/api/parties")
+                .Action("contradiction", a => a
+                    .Post()
+                    .OnListHeader()
+                    .OnSelection());
+    }
 }

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -1052,4 +1052,105 @@ public sealed class EntityManifestComposerTests
 
         manifest.Collections!.HeaderActions.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void Compose_emits_SelectionActions_for_actions_pinned_via_OnSelection()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor archive = new(
+            Name: "archive",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: "Parties:Action.Archive",
+            Icon: "archive",
+            Order: 10,
+            RequiresPermission: null,
+            UrlTemplate: "/api/parties/{id}/archive",
+            HttpMethod: "POST",
+            ConfirmationKey: "Parties:Action.Archive.Confirm",
+            WorkflowTransitionName: null,
+            ContributorAssemblyName: null,
+            ShowOnSelection: true);
+
+        Granit.Entities.Actions.EntityActionDescriptor rowOnly = archive with
+        {
+            Name = "void",
+            ShowOnSelection = false,
+            ConfirmationKey = null,
+        };
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor() with
+        { Actions = [archive, rowOnly] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        EntitySelectionActionManifest only = manifest.Collections!
+            .SelectionActions.ShouldHaveSingleItem();
+        only.Name.ShouldBe("archive");
+        only.Icon.ShouldBe("archive");
+        only.DisplayKey.ShouldBe("Parties:Action.Archive");
+        only.ConfirmationKey.ShouldBe("Parties:Action.Archive.Confirm");
+    }
+
+    [Fact]
+    public void Compose_SelectionActions_drops_pinned_action_when_RequiresPermission_not_granted()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor gated = new(
+            Name: "bulk-archive",
+            Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: null, Icon: "archive", Order: 0,
+            RequiresPermission: "Parties.Manage",
+            UrlTemplate: "/api/parties/{id}/archive", HttpMethod: "POST",
+            ConfirmationKey: null, WorkflowTransitionName: null,
+            ContributorAssemblyName: null,
+            ShowOnSelection: true);
+
+        EntityDefinitionDescriptor descriptor = BuildDescriptor() with
+        { Actions = [gated] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.SelectionActions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Compose_SelectionActions_preserves_ascending_Order()
+    {
+        Granit.Entities.Actions.EntityActionDescriptor late = new(
+            Name: "delete-many", Kind: Granit.Entities.Actions.EntityActionKind.ApiCall,
+            DisplayKey: null, Icon: null, Order: 40,
+            RequiresPermission: null,
+            UrlTemplate: "/api/parties/{id}/delete", HttpMethod: "DELETE",
+            ConfirmationKey: null, WorkflowTransitionName: null,
+            ContributorAssemblyName: null, ShowOnSelection: true);
+
+        Granit.Entities.Actions.EntityActionDescriptor middle = late with
+        { Name = "tag", Order = 20 };
+
+        Granit.Entities.Actions.EntityActionDescriptor early = late with
+        { Name = "archive", Order = 10 };
+
+        // Pass them in reverse Order to verify the composer sorts.
+        EntityDefinitionDescriptor descriptor = BuildDescriptor() with
+        { Actions = [late, middle, early] };
+
+        EntityManifestResponse manifest = EntityManifestComposer.Compose(
+            descriptor,
+            EntityPermissionSnapshot.AllPublic,
+            grantedPermissions: new HashSet<string>(StringComparer.Ordinal),
+            EntityFacets.Collections,
+            defaultViewId: null);
+
+        manifest.Collections!.SelectionActions
+            .Select(a => a.Name)
+            .ShouldBe(["archive", "tag", "delete-many"]);
+    }
 }


### PR DESCRIPTION
## Summary

Adds the selection-aware bulk surface to `EntityDefinition` actions — Odoo's "Action ▼" dropdown that appears above the list when at least one row is selected.

**PR C** of the EntityDefinition action-DSL series (epic #1843). PRs A (#1880) and B (#1881) merged.

**One declaration, dual surface:**

```csharp
.RouteBase("/api/parties")
.Action("archive", a => a.Post().OnSelection())
```

Surfaces the same action both as a row-level button **and** as a "Action ▼" dropdown entry. The renderer takes the row URL, substitutes `{id}` per selected row, and fires N parallel requests (concurrency-capped client-side). Per-id success/failure handled with a toast recap.

## Why "loop on row URL" instead of a new bulk endpoint

| Pro | Con |
| --- | --- |
| Zero new server endpoint | N round-trips for N selections |
| Same descriptor, no DRY violation | No transactional all-or-nothing |
| Permission/idempotency natural per-id | Slow on huge selections (>1000 ids) |

Transactional / perf-critical bulk endpoints can ship later as an opt-in `.BulkUrl(...)` modifier — out of scope here.

## Surface

- `EntityActionDescriptor.ShowOnSelection : bool = false` (parallel to `ShowOnListHeader`)
- `EntityActionBuilder<TEntity>.OnSelection()` builder method
- `EntityCollectionsSection.SelectionActions : IReadOnlyList<EntitySelectionActionManifest>` (top-level, parallel to `HeaderActions`)
- `EntitySelectionActionManifest(Name, DisplayKey, Icon, ConfirmationKey, ContributorAssemblyName)` — `ConfirmationKey` is inlined (rather than looked up via Name → canonical Actions facet) because confirmation on a multi-row destructive op is a UX-critical fast path
- Composer `ComposeCollections` collects them: opt-in, permission-filtered, ordered
- Build-time guard: `OnListHeader() + OnSelection()` throws (mutually exclusive — header is entity-scope, selection fires per row)

## Test plan

- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests` — **101 tests** green (3 new: default-false / opt-in, URL keeps `{id}`, mutex with OnListHeader)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — **86 tests** green (3 new: composer emits SelectionActions, drops on missing permission, sorts by Order)
- [x] `dotnet format --verify-no-changes` clean on touched projects (4 src + 2 tests)

## Out of scope

- Frontend renderer wiring of the selection bar — granit-front #353
- Transactional bulk endpoints (`.BulkUrl(...)`) — deferred per issue's Pro/Con table
