### PR TITLE
[T1.3] feat(taxonomy): TaxonomyMetrics + TaxonomyActivitySource

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55510,6 +55510,22 @@
       "members": []
     },
     {
+      "name": "TaxonomyMetrics",
+      "fqn": "Granit.Taxonomy.Diagnostics.TaxonomyMetrics",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecordTagDeleted",
+          "kind": "method",
+          "signature": "RecordTagDeleted(string? tenantId, string scope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "Tag",
       "fqn": "Granit.Taxonomy.Domain.Tag",
       "kind": "class",
@@ -55651,7 +55667,7 @@
       "kind": "class",
       "project": "Granit.Taxonomy",
       "file": "src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitTaxonomy",

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagService.cs
@@ -1,5 +1,6 @@
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
 using Granit.Taxonomy.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,7 +20,8 @@ namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
 internal sealed class TagService(
     IDbContextFactory<TaxonomyDbContext> contextFactory,
     ICurrentTenant currentTenant,
-    IGuidGenerator guidGenerator) : ITagService
+    IGuidGenerator guidGenerator,
+    TaxonomyMetrics metrics) : ITagService
 {
     /// <inheritdoc />
     public async Task<Tag> CreateAsync(
@@ -57,6 +59,7 @@ internal sealed class TagService(
 
         context.Tags.Add(tag);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        metrics.RecordTagCreated(tenantId?.ToString(), scope);
         return tag;
     }
 
@@ -148,6 +151,7 @@ internal sealed class TagService(
         tag.MarkDeleted();
         context.Tags.Remove(tag);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        metrics.RecordTagDeleted(tag.TenantId?.ToString(), tag.Scope);
         return true;
     }
 

--- a/src/Granit.Taxonomy/Diagnostics/TaxonomyActivitySource.cs
+++ b/src/Granit.Taxonomy/Diagnostics/TaxonomyActivitySource.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace Granit.Taxonomy.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Taxonomy distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class TaxonomyActivitySource
+{
+    /// <summary>The name of the Granit.Taxonomy <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Taxonomy";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    // ──── Operation names ────────────────────────────────────────────────────
+    // Operations populate as the corresponding stories land.
+    internal const string TagCreate = "taxonomy.tag.create";
+    internal const string TagDelete = "taxonomy.tag.delete";
+    internal const string TagList = "taxonomy.tag.list";
+}

--- a/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
+++ b/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Taxonomy.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the Granit.Taxonomy module.
+/// Meter: <c>Granit.Taxonomy</c>.
+/// </summary>
+/// <remarks>
+/// T1.3 baseline counters cover the tag lifecycle. Assignment counters
+/// (<c>granit.taxonomy.assignment.created</c> / <c>...assignment.deleted</c>) are
+/// added in T2.2 alongside the polymorphic <c>TagAssignment</c> table and the
+/// <c>ITagAssignmentService</c>.
+/// </remarks>
+public sealed class TaxonomyMetrics
+{
+    /// <summary>Meter name — <c>Granit.Taxonomy</c>.</summary>
+    public const string MeterName = "Granit.Taxonomy";
+
+    private const string TagTenantId = "tenant_id";
+    private const string TagScope = "scope";
+    private const string DefaultTenant = "global";
+
+    private readonly Counter<long> _tagsCreated;
+    private readonly Counter<long> _tagsDeleted;
+
+    /// <summary>Initialises the meter and counters.</summary>
+    public TaxonomyMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _tagsCreated = meter.CreateCounter<long>(
+            "granit.taxonomy.tag.created",
+            description: "Number of tags created.");
+
+        _tagsDeleted = meter.CreateCounter<long>(
+            "granit.taxonomy.tag.deleted",
+            description: "Number of tags deleted.");
+    }
+
+    /// <summary>Records a tag-creation event in <paramref name="scope"/> for <paramref name="tenantId"/>.</summary>
+    public void RecordTagCreated(string? tenantId, string scope) =>
+        _tagsCreated.Add(1, CreateTags(tenantId, scope));
+
+    /// <summary>Records a tag-deletion event.</summary>
+    public void RecordTagDeleted(string? tenantId, string scope) =>
+        _tagsDeleted.Add(1, CreateTags(tenantId, scope));
+
+    private static TagList CreateTags(string? tenantId, string scope) => new()
+    {
+        { TagTenantId, tenantId ?? DefaultTenant },
+        { TagScope, scope },
+    };
+}

--- a/src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs
+++ b/src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
+using Granit.Diagnostics;
+using Granit.Taxonomy.Diagnostics;
 using Granit.Taxonomy.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Taxonomy.Extensions;
@@ -18,14 +21,20 @@ public static class TaxonomyServiceCollectionExtensions
     /// When omitted, options are bound from the <c>"Taxonomy"</c> configuration section.
     /// </param>
     /// <remarks>
-    /// Phase T1 — no-op beyond options binding. Tag and category services are wired
-    /// by <c>Granit.Taxonomy.EntityFrameworkCore</c> in story T1.2.
+    /// Registers options binding plus diagnostics
+    /// (<see cref="TaxonomyMetrics"/> meter and <c>Granit.Taxonomy</c>
+    /// <see cref="System.Diagnostics.ActivitySource"/>). Tag persistence and CRUD
+    /// services are wired by <c>Granit.Taxonomy.EntityFrameworkCore</c>
+    /// (<c>AddGranitTaxonomyEntityFrameworkCore</c>).
     /// </remarks>
     public static IServiceCollection AddGranitTaxonomy(
         this IServiceCollection services,
         Action<TaxonomyOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        GranitActivitySourceRegistry.Register(TaxonomyActivitySource.Name);
+        services.TryAddSingleton<TaxonomyMetrics>();
 
         OptionsBuilder<TaxonomyOptions> optionsBuilder = services
             .AddOptions<TaxonomyOptions>()

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagPostgresUniquenessTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagPostgresUniquenessTests.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.Metrics;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
 using Granit.Taxonomy.Domain;
 using Granit.Taxonomy.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using NSubstitute;
 using Shouldly;
@@ -45,7 +48,12 @@ public sealed class TagPostgresUniquenessTests :
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns(TenantId);
 
-        _sut = new TagService(_factory, currentTenant, new SimpleGuidGenerator());
+        ServiceCollection services = new();
+        services.AddMetrics();
+        var metrics = new TaxonomyMetrics(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        _sut = new TagService(_factory, currentTenant, new SimpleGuidGenerator(), metrics);
     }
 
     public ValueTask DisposeAsync() => default;

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagServiceSqliteTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagServiceSqliteTests.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.Metrics;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
 using Granit.Taxonomy.Domain;
 using Granit.Taxonomy.EntityFrameworkCore.Internal;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -43,7 +46,12 @@ public sealed class TagServiceSqliteTests : IAsyncLifetime
         currentTenant.IsAvailable.Returns(true);
         currentTenant.Id.Returns(TenantId);
 
-        _sut = new TagService(_factory, currentTenant, new SimpleGuidGenerator());
+        ServiceCollection services = new();
+        services.AddMetrics();
+        var metrics = new TaxonomyMetrics(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        _sut = new TagService(_factory, currentTenant, new SimpleGuidGenerator(), metrics);
     }
 
     public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();

--- a/tests/Granit.Taxonomy.Tests/Diagnostics/TaxonomyMetricsTests.cs
+++ b/tests/Granit.Taxonomy.Tests/Diagnostics/TaxonomyMetricsTests.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.Metrics;
+using Granit.Taxonomy.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Tests.Diagnostics;
+
+public sealed class TaxonomyMetricsTests : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly TaxonomyMetrics _metrics;
+
+    public TaxonomyMetricsTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new TaxonomyMetrics(_meterFactory);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    [Fact]
+    public void RecordTagCreated_IncrementsWithTenantAndScopeTags()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, TaxonomyMetrics.MeterName, "granit.taxonomy.tag.created");
+
+        _metrics.RecordTagCreated("tenant-123", "documents");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["tenant_id"].ShouldBe("tenant-123");
+        snapshot[0].Tags["scope"].ShouldBe("documents");
+    }
+
+    [Fact]
+    public void RecordTagCreated_NullTenant_UsesGlobal()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, TaxonomyMetrics.MeterName, "granit.taxonomy.tag.created");
+
+        _metrics.RecordTagCreated(null, "global");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["tenant_id"].ShouldBe("global");
+        snapshot[0].Tags["scope"].ShouldBe("global");
+    }
+
+    [Fact]
+    public void RecordTagDeleted_Increments()
+    {
+        using MetricCollector<long> collector = new(
+            _meterFactory, TaxonomyMetrics.MeterName, "granit.taxonomy.tag.deleted");
+
+        _metrics.RecordTagDeleted("tenant-1", "parties");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["scope"].ShouldBe("parties");
+    }
+
+    [Fact]
+    public void Constructor_NullMeterFactory_Throws() =>
+        Should.Throw<ArgumentNullException>(() => new TaxonomyMetrics(null!));
+}

--- a/tests/Granit.Taxonomy.Tests/Granit.Taxonomy.Tests.csproj
+++ b/tests/Granit.Taxonomy.Tests/Granit.Taxonomy.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Taxonomy.Tests/packages.lock.json
+++ b/tests/Granit.Taxonomy.Tests/packages.lock.json
@@ -20,6 +20,17 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Diagnostics.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.5.0",
+        "contentHash": "EiERK24AmaxMa7hkgV5UqdfIlrMxg3n+7XdkaV3FWLoyEzca6gvGiaRZofl6KzAtvMBJoZvb5a+EyYqq+M9CoQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.5.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -100,6 +111,71 @@
         "type": "Transitive",
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.5.0",
+        "contentHash": "xbWZji13Vb2jDJNtwVrKpI09jd8x3n3fL+GzhiLK+8O5Wc2A+GyqCZalST2fV46Pf0QfCwkXf83y+3/rDkCd7A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.ObjectPool": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "2Jafd4fdxxiwiQ08mcF+Lf3vqikkQZusGVThOKZNSmPDceGk4IwkjeHL7OEb9Ov8q9ICY5wofL98CS153K5VvQ=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.5.0",
+        "contentHash": "VmU7e6xHqoubWKl7y9MtWyQAjlDpvbds3gY8ZKMS/1GxY2+U1/aMNnMj09aOXAa3p5qhHSSkBzDJvyokCjVkPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.ObjectPool": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -254,6 +330,54 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Persistence": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds the diagnostics layer for `Granit.Taxonomy` per framework conventions:

- **`TaxonomyMetrics`** — sealed class with `IMeterFactory` ctor, meter `Granit.Taxonomy`, counters `granit.taxonomy.tag.created` / `granit.taxonomy.tag.deleted`, tags `tenant_id` (coalesced to `"global"`) + `scope`
- **`TaxonomyActivitySource`** — internal static, name `Granit.Taxonomy`, reserved operation names (`taxonomy.tag.create`, `taxonomy.tag.delete`, `taxonomy.tag.list`)
- **`AddGranitTaxonomy()`** — wires `GranitActivitySourceRegistry.Register("Granit.Taxonomy")` and `TryAddSingleton<TaxonomyMetrics>()`
- **`TagService`** — injects `TaxonomyMetrics` and records on the create / delete success paths
- **`Microsoft.Extensions.Diagnostics.Testing`** PackageReference added to `Granit.Taxonomy.Tests` for `MetricCollector<>`

## Test plan

- [x] `dotnet test tests/Granit.Taxonomy.Tests` — **37 / 37** passed (4 new metrics tests + 33 Tag domain + module tests)
- [x] `dotnet test tests/Granit.Taxonomy.EntityFrameworkCore.Tests` — **15 / 15** passed (TagService SQLite tests, metrics injected)
- [x] `dotnet build tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration` — clean (Postgres tests, run by CI)
- [x] `dotnet format` — clean across all 5 projects
- [x] Lock file regenerated for `Granit.Taxonomy.Tests` (new package reference)

## Out of scope

- Assignment counters (`granit.taxonomy.assignment.created` / `.deleted`) ship in T2.2 (#1865)
- `*ActivitySource.StartActivity(...)` call sites populate as endpoints land in T2.1 (#1864)

## Related

Closes #1863
Parent feature: #1855 (T1 — Module scaffolding)
Epic: #1854
ADR: [ADR-054 — Granit.Taxonomy module](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/054-taxonomy-module.md)
