### PR TITLE
chore(archi): exclude IManifestCustomizationApplier from internal-ns rule

### DIFF
--- a/tests/Granit.ArchitectureTests/ClassDesignTests.cs
+++ b/tests/Granit.ArchitectureTests/ClassDesignTests.cs
@@ -44,7 +44,13 @@ public sealed class ClassDesignTests
             Architecture, "Granit.",
             // Wolverine requires middleware constructor parameters to be public,
             // even when the interface is an internal implementation detail.
-            "Granit.Wolverine.Internal.IWolverineUserContextSetter");
+            "Granit.Wolverine.Internal.IWolverineUserContextSetter",
+            // ADR-053 §5 layer-4 extension point: Granit.Entities.Customization.Endpoints
+            // replaces the default no-op via services.Replace, which requires the
+            // interface to be visible across assemblies. The framework keeps the
+            // applier name in the Internal namespace because callers should never
+            // resolve it directly — only the composer pipeline does.
+            "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier");
 
     [Fact]
     public void Concrete_exception_classes_should_be_sealed() =>


### PR DESCRIPTION
## Summary

Excludes \`Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier\` from the \`Public_types_should_not_reside_in_Internal_namespaces\` archi check.

The interface is the **ADR-053 §5 layer-4 manifest extension point**: \`Granit.Entities.Customization.Endpoints\` replaces the default no-op via \`services.Replace\`, which requires cross-assembly visibility. The \`Internal\` namespace stays because callers should never resolve it directly — only the composer pipeline does. Same pattern as the existing \`IWolverineUserContextSetter\` exclusion (with rationale comment in the code).

## History

This PR originally bundled a missing \`Granit.Taxonomy/README.md\` to clear a second archi failure. That README was independently added on develop while this PR was open (commit 0820349 or similar — see develop's history). Rebase dropped the hunk; the README on develop is more accurate (real \`Tag\` aggregate description, correct ADR filename), so keeping it is the right outcome.

## Test plan

- [x] \`dotnet test tests/Granit.ArchitectureTests\` — **210 / 210** green (was 208/210 on develop)
- [x] \`dotnet format --verify-no-changes\` clean