### PR TITLE
[T2.2] feat(taxonomy): TagAssignment polymorphic table + idempotent assignment endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55520,6 +55520,38 @@
       "members": []
     },
     {
+      "name": "AllowAllTaggablePermissionResolver",
+      "fqn": "Granit.Taxonomy.Authorization.AllowAllTaggablePermissionResolver",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Authorization/ITaggablePermissionResolver.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "IsAuthorizedAsync",
+          "kind": "method",
+          "signature": "IsAuthorizedAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ITaggablePermissionResolver",
+      "fqn": "Granit.Taxonomy.Authorization.ITaggablePermissionResolver",
+      "kind": "interface",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Authorization/ITaggablePermissionResolver.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "IsAuthorizedAsync",
+          "kind": "method",
+          "signature": "IsAuthorizedAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
       "name": "TaxonomyMetrics",
       "fqn": "Granit.Taxonomy.Diagnostics.TaxonomyMetrics",
       "kind": "class",
@@ -55531,6 +55563,18 @@
           "name": "RecordTagDeleted",
           "kind": "method",
           "signature": "RecordTagDeleted(string? tenantId, string scope)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordAssignmentCreated",
+          "kind": "method",
+          "signature": "RecordAssignmentCreated(string? tenantId, string targetType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordAssignmentDeleted",
+          "kind": "method",
+          "signature": "RecordAssignmentDeleted(string? tenantId, string targetType)",
           "returnType": "void"
         }
       ]
@@ -55566,6 +55610,28 @@
           "kind": "method",
           "signature": "Rename(string newName)",
           "returnType": "bool HideOnEntityCard { get; private set; } public uint RowVersion { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "TagAssignment",
+      "fqn": "Granit.Taxonomy.Domain.TagAssignment",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Domain/TagAssignment.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid? tenantId, Guid tagId, string targetType, Guid targetId, Guid assignedByUserId, DateTimeOffset assignedAt)",
+          "returnType": "TagAssignment"
+        },
+        {
+          "name": "ValidateTargetType",
+          "kind": "method",
+          "signature": "ValidateTargetType(string targetType)",
+          "returnType": "Guid TargetId { get; private set; } public DateTimeOffset AssignedAt { get; private set; } public Guid AssignedByUserId { get; private set; } private void"
         }
       ]
     },
@@ -55635,6 +55701,15 @@
       "members": []
     },
     {
+      "name": "AssignTagRequest",
+      "fqn": "Granit.Taxonomy.Endpoints.Tags.Dtos.AssignTagRequest",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Tags/Dtos/AssignTagRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "CreateTagRequest",
       "fqn": "Granit.Taxonomy.Endpoints.Tags.Dtos.CreateTagRequest",
       "kind": "record",
@@ -55649,6 +55724,15 @@
       "kind": "record",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Tags/Dtos/ListTagsResponse.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "TagAssignmentResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Tags.Dtos.TagAssignmentResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Tags/Dtos/TagAssignmentResponse.cs",
       "line": 4,
       "members": []
     },
@@ -55778,7 +55862,7 @@
       "kind": "class",
       "project": "Granit.Taxonomy",
       "file": "src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitTaxonomy",
@@ -55796,6 +55880,34 @@
       "file": "src/Granit.Taxonomy/GranitTaxonomyModule.cs",
       "line": 23,
       "members": []
+    },
+    {
+      "name": "ITagAssignmentService",
+      "fqn": "Granit.Taxonomy.ITagAssignmentService",
+      "kind": "interface",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ITagAssignmentService.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UnassignAsync",
+          "kind": "method",
+          "signature": "UnassignAsync(Guid tagId, string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "ListForTargetAsync",
+          "kind": "method",
+          "signature": "ListForTargetAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Tag>>"
+        },
+        {
+          "name": "RemoveAllAssignmentsAsync",
+          "kind": "method",
+          "signature": "RemoveAllAssignmentsAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
     },
     {
       "name": "ITagService",
@@ -55857,6 +55969,34 @@
       "file": "src/Granit.Taxonomy/Options/TaxonomyOptions.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "TaggableTypeRegistry",
+      "fqn": "Granit.Taxonomy.Registration.TaggableTypeRegistry",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Registration/TaggableTypeRegistration.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string targetType, string scope)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetScope",
+          "kind": "method",
+          "signature": "GetScope(string targetType)",
+          "returnType": "string?"
+        },
+        {
+          "name": "ToArray",
+          "kind": "method",
+          "signature": "ToArray()",
+          "returnType": "IReadOnlyDictionary<string, string> Snapshot => _typeToScope."
+        }
+      ]
     },
     {
       "name": "AITemplateDataEnricher",

--- a/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
@@ -35,6 +35,7 @@ public static class TaxonomyEndpointRouteBuilderExtensions
         }
 
         group.MapTagEndpoints();
+        group.MapTagAssignmentEndpoints();
 
         return group;
     }

--- a/src/Granit.Taxonomy.Endpoints/Tags/Dtos/AssignTagRequest.cs
+++ b/src/Granit.Taxonomy.Endpoints/Tags/Dtos/AssignTagRequest.cs
@@ -1,0 +1,8 @@
+namespace Granit.Taxonomy.Endpoints.Tags.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /api/v1/taxonomy/tags/{id}/assign</c>.
+/// </summary>
+/// <param name="TargetType">Polymorphic discriminator (assembly-qualified type name of the target aggregate).</param>
+/// <param name="TargetId">Identifier of the target aggregate row.</param>
+public sealed record AssignTagRequest(string TargetType, Guid TargetId);

--- a/src/Granit.Taxonomy.Endpoints/Tags/Dtos/TagAssignmentResponse.cs
+++ b/src/Granit.Taxonomy.Endpoints/Tags/Dtos/TagAssignmentResponse.cs
@@ -1,0 +1,11 @@
+namespace Granit.Taxonomy.Endpoints.Tags.Dtos;
+
+/// <summary>Wire-shape response for a <c>TagAssignment</c> row.</summary>
+public sealed record TagAssignmentResponse(
+    Guid Id,
+    Guid? TenantId,
+    Guid TagId,
+    string TargetType,
+    Guid TargetId,
+    DateTimeOffset AssignedAt,
+    Guid AssignedByUserId);

--- a/src/Granit.Taxonomy.Endpoints/Tags/Endpoints/TagAssignmentEndpoints.cs
+++ b/src/Granit.Taxonomy.Endpoints/Tags/Endpoints/TagAssignmentEndpoints.cs
@@ -1,0 +1,165 @@
+using System.Security.Claims;
+using Granit.Taxonomy.Authorization;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Permissions;
+using Granit.Taxonomy.Endpoints.Tags.Dtos;
+using Granit.Taxonomy.Endpoints.Tags.Mapping;
+using Granit.Taxonomy.Registration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Taxonomy.Endpoints.Tags.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for the polymorphic <c>TagAssignment</c> table introduced by ADR-054
+/// (T2.2): idempotent assignment, idempotent unassignment, and per-target listing.
+/// </summary>
+internal static class TagAssignmentEndpoints
+{
+    private const string TagName = "Taxonomy";
+
+    public static RouteGroupBuilder MapTagAssignmentEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        // Assign / unassign live under /tags/{id}/...
+        RouteGroupBuilder tags = group.MapGroup("/tags/{id:guid}/assign").WithTags(TagName);
+
+        tags.MapPost("/", AssignAsync)
+            .WithName("AssignTaxonomyTag")
+            .WithSummary("Idempotently assigns a tag to a target aggregate.")
+            .WithDescription(
+                "Creates a new TagAssignment row for the given (TagId, TargetType, "
+                + "TargetId) triplet. When the row already exists, the existing row is "
+                + "returned with status 200 instead of 201 — the operation is "
+                + "idempotent. Returns 422 when targetType is not a registered "
+                + "taggable aggregate; 403 when the per-target permission check fails.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Tags.Manage))
+            .Produces<TagAssignmentResponse>(StatusCodes.Status201Created)
+            .Produces<TagAssignmentResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem();
+
+        tags.MapDelete("/{targetType}/{targetId:guid}", UnassignAsync)
+            .WithName("UnassignTaxonomyTag")
+            .WithSummary("Removes a tag assignment.")
+            .WithDescription(
+                "Deletes the TagAssignment row matching the (TagId, TargetType, "
+                + "TargetId) triplet. Returns 204 on success, 404 when no matching "
+                + "row exists, 403 when the per-target permission check fails.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Tags.Manage))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        // /assignments — per-target listing
+        RouteGroupBuilder assignments = group.MapGroup("/assignments").WithTags(TagName);
+
+        assignments.MapGet("/", ListForTargetAsync)
+            .WithName("ListTaxonomyAssignments")
+            .WithSummary("Lists tags currently assigned to a target.")
+            .WithDescription(
+                "Returns every Tag assigned to (targetType, targetId), ordered by tag "
+                + "name. Both query parameters are mandatory.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Tags.Read))
+            .Produces<ListTagsResponse>()
+            .ProducesValidationProblem();
+
+        return group;
+    }
+
+    private static async Task<Results<Created<TagAssignmentResponse>, Ok<TagAssignmentResponse>, ProblemHttpResult, ForbidHttpResult>> AssignAsync(
+        Guid id,
+        AssignTagRequest request,
+        [FromServices] ITagAssignmentService service,
+        [FromServices] TaggableTypeRegistry registry,
+        [FromServices] ITaggablePermissionResolver permissionResolver,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        if (!registry.IsRegistered(request.TargetType))
+        {
+            return TypedResults.Problem(
+                $"Target type '{request.TargetType}' is not a registered taggable aggregate.",
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+
+        bool authorized = await permissionResolver
+            .IsAuthorizedAsync(request.TargetType, request.TargetId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!authorized)
+        {
+            return TypedResults.Forbid();
+        }
+
+        Guid userId = ExtractUserId(user);
+
+        (TagAssignment assignment, bool created) = await service
+            .AssignAsync(id, request.TargetType, request.TargetId, userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        TagAssignmentResponse response = assignment.ToResponse();
+        return created
+            ? TypedResults.Created($"/api/v1/taxonomy/tags/{id}/assign/{request.TargetType}/{request.TargetId}", response)
+            : TypedResults.Ok(response);
+    }
+
+    private static async Task<Results<NoContent, NotFound, ForbidHttpResult>> UnassignAsync(
+        Guid id,
+        string targetType,
+        Guid targetId,
+        [FromServices] ITagAssignmentService service,
+        [FromServices] ITaggablePermissionResolver permissionResolver,
+        CancellationToken cancellationToken)
+    {
+        bool authorized = await permissionResolver
+            .IsAuthorizedAsync(targetType, targetId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!authorized)
+        {
+            return TypedResults.Forbid();
+        }
+
+        bool deleted = await service
+            .UnassignAsync(id, targetType, targetId, cancellationToken)
+            .ConfigureAwait(false);
+        return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
+    }
+
+    private static async Task<Results<Ok<ListTagsResponse>, ValidationProblem>> ListForTargetAsync(
+        [FromQuery] string targetType,
+        [FromQuery] Guid targetId,
+        [FromServices] ITagAssignmentService service,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<string, string[]> errors = new();
+        if (string.IsNullOrWhiteSpace(targetType))
+        {
+            errors[nameof(targetType)] = ["targetType is required."];
+        }
+        if (targetId == Guid.Empty)
+        {
+            errors[nameof(targetId)] = ["targetId is required."];
+        }
+        if (errors.Count > 0)
+        {
+            return TypedResults.ValidationProblem(errors);
+        }
+
+        IReadOnlyList<Tag> tags = await service
+            .ListForTargetAsync(targetType, targetId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new ListTagsResponse([.. tags.Select(t => t.ToResponse())]));
+    }
+
+    private static Guid ExtractUserId(ClaimsPrincipal user)
+    {
+        string? sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub");
+        return Guid.TryParse(sub, out Guid id) ? id : Guid.Empty;
+    }
+}

--- a/src/Granit.Taxonomy.Endpoints/Tags/Mapping/TagMapper.cs
+++ b/src/Granit.Taxonomy.Endpoints/Tags/Mapping/TagMapper.cs
@@ -7,4 +7,14 @@ internal static class TagMapper
 {
     public static TagResponse ToResponse(this Tag tag) =>
         new(tag.Id, tag.TenantId, tag.Scope, tag.Name, tag.Color, tag.HideOnEntityCard, tag.RowVersion);
+
+    public static TagAssignmentResponse ToResponse(this TagAssignment assignment) =>
+        new(
+            assignment.Id,
+            assignment.TenantId,
+            assignment.TagId,
+            assignment.TargetType,
+            assignment.TargetId,
+            assignment.AssignedAt,
+            assignment.AssignedByUserId);
 }

--- a/src/Granit.Taxonomy.Endpoints/Tags/Validators/AssignTagRequestValidator.cs
+++ b/src/Granit.Taxonomy.Endpoints/Tags/Validators/AssignTagRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Tags.Dtos;
+
+namespace Granit.Taxonomy.Endpoints.Tags.Validators;
+
+/// <summary>Validator for <see cref="AssignTagRequest"/>.</summary>
+internal sealed class AssignTagRequestValidator : AbstractValidator<AssignTagRequest>
+{
+    public AssignTagRequestValidator()
+    {
+        RuleFor(x => x.TargetType)
+            .NotEmpty()
+            .MaximumLength(TagAssignment.MaxTargetTypeLength);
+
+        RuleFor(x => x.TargetId)
+            .NotEqual(Guid.Empty);
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -29,6 +29,7 @@ public static class TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions
 
         builder.Services.AddGranitDbContext<TaxonomyDbContext>(configure);
         builder.Services.AddScoped<ITagService, TagService>();
+        builder.Services.AddScoped<ITagAssignmentService, TagAssignmentService>();
 
         return builder;
     }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyModelBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyModelBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class TaxonomyModelBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfiguration(new TagConfiguration());
+        modelBuilder.ApplyConfiguration(new TagAssignmentConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagAssignmentConfiguration.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagAssignmentConfiguration.cs
@@ -1,0 +1,53 @@
+using Granit.Taxonomy.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="TagAssignment"/>.
+/// Table: <c>taxonomy_tag_assignments</c>.
+/// </summary>
+internal sealed class TagAssignmentConfiguration : IEntityTypeConfiguration<TagAssignment>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<TagAssignment> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitTaxonomyDbProperties.DbTablePrefix + "tag_assignments",
+            GranitTaxonomyDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+        builder.Property(e => e.TagId).IsRequired();
+
+        builder.Property(e => e.TargetType)
+            .HasMaxLength(TagAssignment.MaxTargetTypeLength)
+            .IsRequired();
+
+        builder.Property(e => e.TargetId).IsRequired();
+        builder.Property(e => e.AssignedAt).IsRequired();
+        builder.Property(e => e.AssignedByUserId).IsRequired();
+
+        // ADR-054 invariant: a tag is assigned to a target at most once per tenant.
+        builder.HasIndex(e => new { e.TenantId, e.TagId, e.TargetType, e.TargetId })
+            .IsUnique()
+            .HasDatabaseName(
+                $"ux_{GranitTaxonomyDbProperties.DbTablePrefix}tag_assignments_tenant_tag_target");
+
+        // "Tags of entity X" lookup — used by the per-target list endpoint and the
+        // T5.1 cleanup handler when the target is hard-deleted.
+        builder.HasIndex(e => new { e.TenantId, e.TargetType, e.TargetId })
+            .HasDatabaseName(
+                $"ix_{GranitTaxonomyDbProperties.DbTablePrefix}tag_assignments_tenant_target");
+
+        // "Things tagged X" lookup — used by the cross-entity search endpoint (T3.1)
+        // and orphan-cleanup when a tag is deleted.
+        builder.HasIndex(e => new { e.TenantId, e.TagId })
+            .HasDatabaseName(
+                $"ix_{GranitTaxonomyDbProperties.DbTablePrefix}tag_assignments_tenant_tag");
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagAssignmentService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagAssignmentService.cs
@@ -1,0 +1,173 @@
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ITagAssignmentService"/>. Idempotent
+/// assignment: a duplicate <c>(TenantId, TagId, TargetType, TargetId)</c> insert
+/// returns the existing row instead of throwing.
+/// </summary>
+internal sealed class TagAssignmentService(
+    IDbContextFactory<TaxonomyDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IClock clock,
+    TaxonomyMetrics metrics) : ITagAssignmentService
+{
+    /// <inheritdoc />
+    public async Task<(TagAssignment Assignment, bool Created)> AssignAsync(
+        Guid tagId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        TagAssignment? existing = await context.TagAssignments
+            .FirstOrDefaultAsync(
+                a => a.TenantId == tenantId &&
+                     a.TagId == tagId &&
+                     a.TargetType == targetType &&
+                     a.TargetId == targetId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return (existing, Created: false);
+        }
+
+        var assignment = TagAssignment.Create(
+            guidGenerator.Create(),
+            tenantId,
+            tagId,
+            targetType,
+            targetId,
+            assignedByUserId,
+            clock.Now);
+
+        context.TagAssignments.Add(assignment);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException)
+        {
+            // Concurrent insert won the race — re-read the row and return idempotently.
+            await using TaxonomyDbContext rereadContext = await contextFactory
+                .CreateDbContextAsync(cancellationToken)
+                .ConfigureAwait(false);
+            TagAssignment? winner = await rereadContext.TagAssignments
+                .FirstOrDefaultAsync(
+                    a => a.TenantId == tenantId &&
+                         a.TagId == tagId &&
+                         a.TargetType == targetType &&
+                         a.TargetId == targetId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (winner is not null)
+            {
+                return (winner, Created: false);
+            }
+            throw;
+        }
+
+        metrics.RecordAssignmentCreated(tenantId?.ToString(), targetType);
+        return (assignment, Created: true);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UnassignAsync(
+        Guid tagId,
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        TagAssignment? assignment = await context.TagAssignments
+            .FirstOrDefaultAsync(
+                a => a.TagId == tagId && a.TargetType == targetType && a.TargetId == targetId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (assignment is null)
+        {
+            return false;
+        }
+
+        context.TagAssignments.Remove(assignment);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        metrics.RecordAssignmentDeleted(assignment.TenantId?.ToString(), assignment.TargetType);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Tag>> ListForTargetAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.TagAssignments
+            .AsNoTracking()
+            .Where(a => a.TargetType == targetType && a.TargetId == targetId)
+            .Join(
+                context.Tags.AsNoTracking(),
+                assignment => assignment.TagId,
+                tag => tag.Id,
+                (_, tag) => tag)
+            .OrderBy(t => t.Name)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> RemoveAllAssignmentsAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<TagAssignment> rows = await context.TagAssignments
+            .Where(a => a.TargetType == targetType && a.TargetId == targetId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        context.TagAssignments.RemoveRange(rows);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        foreach (TagAssignment row in rows)
+        {
+            metrics.RecordAssignmentDeleted(row.TenantId?.ToString(), row.TargetType);
+        }
+        return rows.Count;
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TaxonomyDbContext.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TaxonomyDbContext.cs
@@ -23,6 +23,13 @@ internal sealed class TaxonomyDbContext(
     /// <summary>Tenant-scoped tags. Uniqueness enforced on <c>(TenantId, Scope, Name)</c>.</summary>
     public DbSet<Tag> Tags { get; set; } = null!;
 
+    /// <summary>
+    /// Polymorphic tag assignments — links tags to target aggregates via
+    /// <c>(TargetType, TargetId)</c>. Uniqueness enforced on
+    /// <c>(TenantId, TagId, TargetType, TargetId)</c>.
+    /// </summary>
+    public DbSet<TagAssignment> TagAssignments { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Taxonomy/Authorization/ITaggablePermissionResolver.cs
+++ b/src/Granit.Taxonomy/Authorization/ITaggablePermissionResolver.cs
@@ -1,0 +1,39 @@
+namespace Granit.Taxonomy.Authorization;
+
+/// <summary>
+/// Composite permission gate for tag-assignment operations. Resolves the
+/// per-target permission required to assign or unassign a tag on
+/// <c>(targetType, targetId)</c> in addition to the base
+/// <c>Taxonomy.Tags.Manage</c> permission.
+/// </summary>
+/// <remarks>
+/// Phase T2.2 ships a no-op default. T6.1 tightens the gate for
+/// <c>Granit.Documents</c> by requiring <c>Documents.Documents.Manage</c> on the
+/// target document. Hosts that taggable other aggregates register their own
+/// resolver via DI.
+/// </remarks>
+public interface ITaggablePermissionResolver
+{
+    /// <summary>
+    /// Returns <c>true</c> when the calling principal is authorised to assign or
+    /// unassign tags on the target. The default implementation accepts every call.
+    /// </summary>
+    Task<bool> IsAuthorizedAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Default no-op resolver — allows every tag-assignment call to pass through. Hosts
+/// can replace this in DI to tighten the gate per target type.
+/// </summary>
+public sealed class AllowAllTaggablePermissionResolver : ITaggablePermissionResolver
+{
+    /// <inheritdoc />
+    public Task<bool> IsAuthorizedAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(true);
+}

--- a/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
+++ b/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
@@ -8,10 +8,10 @@ namespace Granit.Taxonomy.Diagnostics;
 /// Meter: <c>Granit.Taxonomy</c>.
 /// </summary>
 /// <remarks>
-/// T1.3 baseline counters cover the tag lifecycle. Assignment counters
-/// (<c>granit.taxonomy.assignment.created</c> / <c>...assignment.deleted</c>) are
-/// added in T2.2 alongside the polymorphic <c>TagAssignment</c> table and the
-/// <c>ITagAssignmentService</c>.
+/// Counters cover the Tag lifecycle (<c>granit.taxonomy.tag.created</c> /
+/// <c>...deleted</c>) and the assignment lifecycle
+/// (<c>granit.taxonomy.assignment.created</c> / <c>...deleted</c>) introduced by
+/// T2.2 alongside the polymorphic <c>TagAssignment</c> table.
 /// </remarks>
 public sealed class TaxonomyMetrics
 {
@@ -20,10 +20,13 @@ public sealed class TaxonomyMetrics
 
     private const string TagTenantId = "tenant_id";
     private const string TagScope = "scope";
+    private const string TagTargetType = "target_type";
     private const string DefaultTenant = "global";
 
     private readonly Counter<long> _tagsCreated;
     private readonly Counter<long> _tagsDeleted;
+    private readonly Counter<long> _assignmentsCreated;
+    private readonly Counter<long> _assignmentsDeleted;
 
     /// <summary>Initialises the meter and counters.</summary>
     public TaxonomyMetrics(IMeterFactory meterFactory)
@@ -39,19 +42,41 @@ public sealed class TaxonomyMetrics
         _tagsDeleted = meter.CreateCounter<long>(
             "granit.taxonomy.tag.deleted",
             description: "Number of tags deleted.");
+
+        _assignmentsCreated = meter.CreateCounter<long>(
+            "granit.taxonomy.assignment.created",
+            description: "Number of tag assignments created (excludes idempotent no-ops on already-assigned rows).");
+
+        _assignmentsDeleted = meter.CreateCounter<long>(
+            "granit.taxonomy.assignment.deleted",
+            description: "Number of tag assignments removed (includes orphan-cleanup deletions).");
     }
 
     /// <summary>Records a tag-creation event in <paramref name="scope"/> for <paramref name="tenantId"/>.</summary>
     public void RecordTagCreated(string? tenantId, string scope) =>
-        _tagsCreated.Add(1, CreateTags(tenantId, scope));
+        _tagsCreated.Add(1, CreateTagTags(tenantId, scope));
 
     /// <summary>Records a tag-deletion event.</summary>
     public void RecordTagDeleted(string? tenantId, string scope) =>
-        _tagsDeleted.Add(1, CreateTags(tenantId, scope));
+        _tagsDeleted.Add(1, CreateTagTags(tenantId, scope));
 
-    private static TagList CreateTags(string? tenantId, string scope) => new()
+    /// <summary>Records a new tag-assignment row creation.</summary>
+    public void RecordAssignmentCreated(string? tenantId, string targetType) =>
+        _assignmentsCreated.Add(1, CreateAssignmentTags(tenantId, targetType));
+
+    /// <summary>Records a tag-assignment row deletion.</summary>
+    public void RecordAssignmentDeleted(string? tenantId, string targetType) =>
+        _assignmentsDeleted.Add(1, CreateAssignmentTags(tenantId, targetType));
+
+    private static TagList CreateTagTags(string? tenantId, string scope) => new()
     {
         { TagTenantId, tenantId ?? DefaultTenant },
         { TagScope, scope },
+    };
+
+    private static TagList CreateAssignmentTags(string? tenantId, string targetType) => new()
+    {
+        { TagTenantId, tenantId ?? DefaultTenant },
+        { TagTargetType, targetType },
     };
 }

--- a/src/Granit.Taxonomy/Domain/TagAssignment.cs
+++ b/src/Granit.Taxonomy/Domain/TagAssignment.cs
@@ -1,0 +1,94 @@
+using Granit.Domain;
+
+namespace Granit.Taxonomy.Domain;
+
+/// <summary>
+/// Polymorphic link between a <see cref="Tag"/> and a target aggregate root, identified
+/// by its assembly-qualified type name (<see cref="TargetType"/>) and identifier
+/// (<see cref="TargetId"/>) per ADR-054.
+/// </summary>
+/// <remarks>
+/// <para>
+/// There is no DB-level FK on <see cref="TargetId"/>: the target table varies per
+/// consumer module (Documents, Parties, Activities, …). Orphan rows left after a
+/// hard-delete of the target are cleaned up by the
+/// <c>EntityDeletedEto</c> listener (T5.1) and a nightly sweep job (T5.2).
+/// </para>
+/// <para>
+/// Uniqueness is enforced on <c>(TenantId, TagId, TargetType, TargetId)</c>; the
+/// supporting indexes <c>(TenantId, TargetType, TargetId)</c> and
+/// <c>(TenantId, TagId)</c> serve the "tags of entity X" and "things tagged X"
+/// lookups respectively.
+/// </para>
+/// </remarks>
+public sealed class TagAssignment : Entity, IMultiTenant
+{
+    /// <summary>Maximum length, in characters, of the polymorphic <see cref="TargetType"/> discriminator.</summary>
+    public const int MaxTargetTypeLength = 256;
+
+    private TagAssignment() { }
+
+    /// <summary>Creates a new tag assignment.</summary>
+    public static TagAssignment Create(
+        Guid id,
+        Guid? tenantId,
+        Guid tagId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        DateTimeOffset assignedAt)
+    {
+        ValidateTargetType(targetType);
+        if (targetId == Guid.Empty)
+        {
+            throw new ArgumentException("Target id cannot be empty.", nameof(targetId));
+        }
+
+        return new TagAssignment
+        {
+            Id = id,
+            TenantId = tenantId,
+            TagId = tagId,
+            TargetType = targetType,
+            TargetId = targetId,
+            AssignedByUserId = assignedByUserId,
+            AssignedAt = assignedAt,
+        };
+    }
+
+    /// <summary>Identifier of the tenant that owns this assignment; <c>null</c> for host-global tags.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Identifier of the assigned <see cref="Tag"/>.</summary>
+    public Guid TagId { get; private set; }
+
+    /// <summary>Polymorphic discriminator (assembly-qualified type name of the target aggregate).</summary>
+    public string TargetType { get; private set; } = string.Empty;
+
+    /// <summary>Identifier of the target aggregate row.</summary>
+    public Guid TargetId { get; private set; }
+
+    /// <summary>UTC instant of assignment.</summary>
+    public DateTimeOffset AssignedAt { get; private set; }
+
+    /// <summary>Identifier of the user who created the assignment.</summary>
+    public Guid AssignedByUserId { get; private set; }
+
+    private static void ValidateTargetType(string targetType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+        if (targetType.Length > MaxTargetTypeLength)
+        {
+            throw new ArgumentException(
+                $"TargetType discriminator exceeds {MaxTargetTypeLength} characters.",
+                nameof(targetType));
+        }
+    }
+}

--- a/src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs
+++ b/src/Granit.Taxonomy/Extensions/TaxonomyServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.Diagnostics;
+using Granit.Taxonomy.Authorization;
 using Granit.Taxonomy.Diagnostics;
 using Granit.Taxonomy.Options;
+using Granit.Taxonomy.Registration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -35,6 +37,16 @@ public static class TaxonomyServiceCollectionExtensions
 
         GranitActivitySourceRegistry.Register(TaxonomyActivitySource.Name);
         services.TryAddSingleton<TaxonomyMetrics>();
+        services.TryAddSingleton<TaggableTypeRegistry>(static sp =>
+        {
+            TaggableTypeRegistry registry = new();
+            foreach (ITaggableRegistration reg in sp.GetServices<ITaggableRegistration>())
+            {
+                registry.Register(reg.TargetType, reg.Scope);
+            }
+            return registry;
+        });
+        services.TryAddSingleton<ITaggablePermissionResolver, AllowAllTaggablePermissionResolver>();
 
         OptionsBuilder<TaxonomyOptions> optionsBuilder = services
             .AddOptions<TaxonomyOptions>()
@@ -47,4 +59,43 @@ public static class TaxonomyServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Registers <typeparamref name="TAggregate"/> as a taggable target under
+    /// <paramref name="scope"/>. The full type name is used as the polymorphic
+    /// <c>TargetType</c> discriminator on <c>TagAssignment</c> rows.
+    /// </summary>
+    /// <typeparam name="TAggregate">Aggregate root type to taggable.</typeparam>
+    /// <param name="services">The DI service collection.</param>
+    /// <param name="scope">Tag scope under which tags applied to this aggregate are managed (e.g. <c>"documents"</c>).</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddTaggableEntity<TAggregate>(
+        this IServiceCollection services,
+        string scope)
+        where TAggregate : class
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+
+        // The registry is a singleton — register a startup callback that mutates it
+        // on first resolution. Eager registration during DI configuration would race
+        // with potentially multiple AddTaggableEntity calls in different module
+        // ConfigureServices methods.
+        services.AddSingleton<ITaggableRegistration>(
+            new TaggableRegistration(typeof(TAggregate).FullName ?? typeof(TAggregate).Name, scope));
+        return services;
+    }
 }
+
+/// <summary>
+/// Marker captured by DI for each <c>AddTaggableEntity&lt;T&gt;</c> call. Resolved into
+/// the singleton <see cref="TaggableTypeRegistry"/> when the registry is first created.
+/// </summary>
+internal interface ITaggableRegistration
+{
+    string TargetType { get; }
+    string Scope { get; }
+}
+
+internal sealed record TaggableRegistration(string TargetType, string Scope) : ITaggableRegistration;
+

--- a/src/Granit.Taxonomy/ITagAssignmentService.cs
+++ b/src/Granit.Taxonomy/ITagAssignmentService.cs
@@ -1,0 +1,49 @@
+using Granit.Taxonomy.Domain;
+
+namespace Granit.Taxonomy;
+
+/// <summary>
+/// Service for assigning <see cref="Tag"/>s to target aggregate roots through the
+/// polymorphic <c>TagAssignment</c> table introduced by ADR-054 (T2.2).
+/// </summary>
+public interface ITagAssignmentService
+{
+    /// <summary>
+    /// Idempotent assignment. If <c>(TenantId, TagId, TargetType, TargetId)</c> already
+    /// exists, the existing row is returned. Otherwise a new <see cref="TagAssignment"/>
+    /// is created.
+    /// </summary>
+    /// <returns>A tuple of the assignment and a flag indicating whether the row was newly created.</returns>
+    Task<(TagAssignment Assignment, bool Created)> AssignAsync(
+        Guid tagId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the assignment row matching the given triplet.
+    /// </summary>
+    /// <returns><c>true</c> when a row was deleted; <c>false</c> when none matched.</returns>
+    Task<bool> UnassignAsync(
+        Guid tagId,
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists every <see cref="Tag"/> currently assigned to the target.</summary>
+    Task<IReadOnlyList<Tag>> ListForTargetAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes every assignment row for the given target. Called by the T5.1
+    /// <c>EntityDeletedEto</c> cleanup handler when a target aggregate is hard-deleted.
+    /// </summary>
+    /// <returns>The number of rows removed.</returns>
+    Task<int> RemoveAllAssignmentsAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Taxonomy/Registration/TaggableTypeRegistration.cs
+++ b/src/Granit.Taxonomy/Registration/TaggableTypeRegistration.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+
+namespace Granit.Taxonomy.Registration;
+
+/// <summary>
+/// Singleton registry mapping a <c>TargetType</c> discriminator to the scope under
+/// which tags applied to that aggregate are managed.
+/// </summary>
+/// <remarks>
+/// Each consumer module registers its taggable aggregates via
+/// <c>services.AddTaggableEntity&lt;TAggregate&gt;(scope: "...")</c>. The assignment
+/// endpoints validate the incoming <c>targetType</c> against this registry.
+/// </remarks>
+public sealed class TaggableTypeRegistry
+{
+    private readonly ConcurrentDictionary<string, string> _typeToScope = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers <paramref name="targetType"/> under <paramref name="scope"/>. Throws
+    /// when a different scope is already registered for the same target type, to keep
+    /// the (TargetType → Scope) mapping unambiguous.
+    /// </summary>
+    public void Register(string targetType, string scope)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+
+        _typeToScope.AddOrUpdate(
+            targetType,
+            scope,
+            (_, existing) =>
+            {
+                if (!string.Equals(existing, scope, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Target type '{targetType}' is already registered under scope '{existing}'; " +
+                        $"cannot re-register under '{scope}'.");
+                }
+                return existing;
+            });
+    }
+
+    /// <summary>Returns <c>true</c> when <paramref name="targetType"/> is a registered taggable aggregate.</summary>
+    public bool IsRegistered(string targetType) => _typeToScope.ContainsKey(targetType);
+
+    /// <summary>Returns the scope registered for <paramref name="targetType"/>, or <c>null</c> when unregistered.</summary>
+    public string? GetScope(string targetType) =>
+        _typeToScope.TryGetValue(targetType, out string? scope) ? scope : null;
+
+    /// <summary>Snapshot of the currently registered (targetType, scope) pairs.</summary>
+    public IReadOnlyDictionary<string, string> Snapshot => _typeToScope.ToArray()
+        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal);
+}

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Tags/Validators/AssignTagRequestValidatorTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Tags/Validators/AssignTagRequestValidatorTests.cs
@@ -1,0 +1,44 @@
+using FluentValidation.Results;
+using Granit.Taxonomy.Endpoints.Tags.Dtos;
+using Granit.Taxonomy.Endpoints.Tags.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Endpoints.Tests.Tags.Validators;
+
+public sealed class AssignTagRequestValidatorTests
+{
+    private readonly AssignTagRequestValidator _sut = new();
+
+    [Fact]
+    public void Valid_Request_Passes()
+    {
+        ValidationResult result = _sut.Validate(new AssignTagRequest(
+            "Granit.Documents.Domain.Document", Guid.NewGuid()));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyTargetType_Fails(string targetType)
+    {
+        ValidationResult result = _sut.Validate(new AssignTagRequest(targetType, Guid.NewGuid()));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TargetTypeTooLong_Fails()
+    {
+        string tooLong = new('x', 257);
+        ValidationResult result = _sut.Validate(new AssignTagRequest(tooLong, Guid.NewGuid()));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EmptyTargetId_Fails()
+    {
+        ValidationResult result = _sut.Validate(new AssignTagRequest("X", Guid.Empty));
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagAssignmentConcurrentPostgresTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagAssignmentConcurrentPostgresTests.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics.Metrics;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed tests for <c>TagAssignmentService</c> idempotency under
+/// contention — the load-bearing invariant of T2.2: when multiple callers race
+/// to assign the same <c>(TenantId, TagId, TargetType, TargetId)</c> triplet,
+/// exactly one row exists at the end and every call returns the same id.
+/// </summary>
+public sealed class TagAssignmentConcurrentPostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private DbContextOptions<TaxonomyDbContext> _options = null!;
+    private TestDbContextFactory _factory = null!;
+    private TagService _tagService = null!;
+    private TaxonomyMetrics _metrics = null!;
+    private ICurrentTenant _currentTenant = null!;
+    private IClock _clock = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string TargetType = "Granit.Documents.Domain.Document";
+
+    public TagAssignmentConcurrentPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        _options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(_options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE taxonomy_tag_assignments, taxonomy_tags RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(_options);
+
+        _currentTenant = Substitute.For<ICurrentTenant>();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _metrics = new TaxonomyMetrics(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        _clock = Substitute.For<IClock>();
+        _clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _tagService = new TagService(_factory, _currentTenant, new SimpleGuidGenerator(), _metrics);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task AssignAsync_HighConcurrency_ProducesSingleRowAndIdempotentResults()
+    {
+        Tag tag = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        const int parallelism = 16;
+        TagAssignmentService[] services = Enumerable
+            .Range(0, parallelism)
+            .Select(_ => new TagAssignmentService(_factory, _currentTenant, new SimpleGuidGenerator(), _clock, _metrics))
+            .ToArray();
+
+        Task<(TagAssignment Assignment, bool Created)>[] tasks = services
+            .Select(s => Task.Run(() => s.AssignAsync(
+                tag.Id, TargetType, targetId, userId, TestContext.Current.CancellationToken)))
+            .ToArray();
+
+        (TagAssignment Assignment, bool Created)[] results = await Task.WhenAll(tasks);
+
+        // Every call returns the same row id.
+        results.Select(r => r.Assignment.Id).Distinct().ShouldHaveSingleItem();
+
+        // Exactly one of them succeeded as "created"; the rest are idempotent reads.
+        results.Count(r => r.Created).ShouldBe(1);
+
+        // The DB has exactly one row.
+        await using TaxonomyDbContext verify = await _factory.CreateDbContextAsync(
+            TestContext.Current.CancellationToken);
+        int rowCount = await verify.TagAssignments
+            .CountAsync(a => a.TagId == tag.Id && a.TargetId == targetId,
+                TestContext.Current.CancellationToken);
+        rowCount.ShouldBe(1);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagAssignmentServiceSqliteTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagAssignmentServiceSqliteTests.cs
@@ -1,0 +1,188 @@
+using System.Diagnostics.Metrics;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Internal;
+
+public sealed class TagAssignmentServiceSqliteTests : IAsyncLifetime
+{
+    private SqliteConnection _holdOpen = null!;
+    private TestDbContextFactory _factory = null!;
+    private TagService _tagService = null!;
+    private TagAssignmentService _sut = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string TargetType = "Granit.Documents.Domain.Document";
+
+    public async ValueTask InitializeAsync()
+    {
+        string connectionString =
+            $"DataSource=file:taxonomy-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(connectionString);
+        await _holdOpen.OpenAsync();
+
+        DbContextOptions<TaxonomyDbContext> options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestDbContextFactory(options);
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        TaxonomyMetrics metrics = new(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _tagService = new TagService(_factory, currentTenant, new SimpleGuidGenerator(), metrics);
+        _sut = new TagAssignmentService(_factory, currentTenant, new SimpleGuidGenerator(), clock, metrics);
+    }
+
+    public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
+
+    [Fact]
+    public async Task AssignAsync_FirstCall_CreatesRow()
+    {
+        Tag tag = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+
+        (TagAssignment assignment, bool created) = await _sut.AssignAsync(
+            tag.Id, TargetType, targetId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        created.ShouldBeTrue();
+        assignment.TagId.ShouldBe(tag.Id);
+        assignment.TargetType.ShouldBe(TargetType);
+        assignment.TargetId.ShouldBe(targetId);
+    }
+
+    [Fact]
+    public async Task AssignAsync_SameTriplet_Idempotent()
+    {
+        Tag tag = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        (TagAssignment first, bool firstCreated) = await _sut.AssignAsync(
+            tag.Id, TargetType, targetId, userId, TestContext.Current.CancellationToken);
+        (TagAssignment second, bool secondCreated) = await _sut.AssignAsync(
+            tag.Id, TargetType, targetId, userId, TestContext.Current.CancellationToken);
+
+        firstCreated.ShouldBeTrue();
+        secondCreated.ShouldBeFalse();
+        second.Id.ShouldBe(first.Id);
+    }
+
+    [Fact]
+    public async Task UnassignAsync_RemovesRow()
+    {
+        Tag tag = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+        await _sut.AssignAsync(tag.Id, TargetType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        bool deleted = await _sut.UnassignAsync(tag.Id, TargetType, targetId,
+            TestContext.Current.CancellationToken);
+
+        deleted.ShouldBeTrue();
+        IReadOnlyList<Tag> remaining = await _sut.ListForTargetAsync(TargetType, targetId,
+            TestContext.Current.CancellationToken);
+        remaining.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task UnassignAsync_UnknownTriplet_ReturnsFalse()
+    {
+        bool deleted = await _sut.UnassignAsync(Guid.NewGuid(), TargetType, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        deleted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ListForTargetAsync_ReturnsAssignedTags_OrderedByName()
+    {
+        Tag urgent = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Tag review = await _tagService.CreateAsync("documents", "review", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _tagService.CreateAsync("documents", "archived", "#0000FF",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var targetId = Guid.NewGuid();
+        await _sut.AssignAsync(urgent.Id, TargetType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _sut.AssignAsync(review.Id, TargetType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        IReadOnlyList<Tag> tags = await _sut.ListForTargetAsync(TargetType, targetId,
+            TestContext.Current.CancellationToken);
+
+        tags.Count.ShouldBe(2);
+        tags.Select(t => t.Name).ShouldBe(["review", "urgent"]);
+    }
+
+    [Fact]
+    public async Task RemoveAllAssignmentsAsync_RemovesEveryRowForTarget()
+    {
+        Tag tag1 = await _tagService.CreateAsync("documents", "t1", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Tag tag2 = await _tagService.CreateAsync("documents", "t2", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var targetId = Guid.NewGuid();
+        await _sut.AssignAsync(tag1.Id, TargetType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _sut.AssignAsync(tag2.Id, TargetType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        int removed = await _sut.RemoveAllAssignmentsAsync(TargetType, targetId,
+            TestContext.Current.CancellationToken);
+
+        removed.ShouldBe(2);
+        IReadOnlyList<Tag> remaining = await _sut.ListForTargetAsync(TargetType, targetId,
+            TestContext.Current.CancellationToken);
+        remaining.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveAllAssignmentsAsync_UnknownTarget_ReturnsZero()
+    {
+        int removed = await _sut.RemoveAllAssignmentsAsync(TargetType, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        removed.ShouldBe(0);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Taxonomy.Tests/Domain/TagAssignmentTests.cs
+++ b/tests/Granit.Taxonomy.Tests/Domain/TagAssignmentTests.cs
@@ -1,0 +1,105 @@
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Registration;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Tests.Domain;
+
+public sealed class TagAssignmentTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid TagId = Guid.NewGuid();
+    private static readonly Guid TargetId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    [Fact]
+    public void Create_PopulatesAllProperties()
+    {
+        var assignment = TagAssignment.Create(
+            Guid.NewGuid(), TenantId, TagId, "Granit.Documents.Domain.Document", TargetId, UserId, Now);
+
+        assignment.TenantId.ShouldBe(TenantId);
+        assignment.TagId.ShouldBe(TagId);
+        assignment.TargetType.ShouldBe("Granit.Documents.Domain.Document");
+        assignment.TargetId.ShouldBe(TargetId);
+        assignment.AssignedByUserId.ShouldBe(UserId);
+        assignment.AssignedAt.ShouldBe(Now);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_BlankTargetType_Throws(string targetType) =>
+        Should.Throw<ArgumentException>(() =>
+            TagAssignment.Create(Guid.NewGuid(), TenantId, TagId, targetType, TargetId, UserId, Now));
+
+    [Fact]
+    public void Create_TargetTypeTooLong_Throws()
+    {
+        string tooLong = new('x', TagAssignment.MaxTargetTypeLength + 1);
+        Should.Throw<ArgumentException>(() =>
+            TagAssignment.Create(Guid.NewGuid(), TenantId, TagId, tooLong, TargetId, UserId, Now));
+    }
+
+    [Fact]
+    public void Create_EmptyTargetId_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            TagAssignment.Create(Guid.NewGuid(), TenantId, TagId, "X", Guid.Empty, UserId, Now));
+}
+
+public sealed class TaggableTypeRegistryTests
+{
+    [Fact]
+    public void Register_NewType_StoresScope()
+    {
+        TaggableTypeRegistry registry = new();
+        registry.Register("Granit.Documents.Domain.Document", "documents");
+
+        registry.IsRegistered("Granit.Documents.Domain.Document").ShouldBeTrue();
+        registry.GetScope("Granit.Documents.Domain.Document").ShouldBe("documents");
+    }
+
+    [Fact]
+    public void Register_SameTypeSameScope_NoOp()
+    {
+        TaggableTypeRegistry registry = new();
+        registry.Register("X", "documents");
+        Should.NotThrow(() => registry.Register("X", "documents"));
+    }
+
+    [Fact]
+    public void Register_SameTypeDifferentScope_Throws()
+    {
+        TaggableTypeRegistry registry = new();
+        registry.Register("X", "documents");
+        Should.Throw<InvalidOperationException>(() => registry.Register("X", "parties"));
+    }
+
+    [Fact]
+    public void Snapshot_ReturnsAllRegistrations()
+    {
+        TaggableTypeRegistry registry = new();
+        registry.Register("X", "documents");
+        registry.Register("Y", "parties");
+
+        IReadOnlyDictionary<string, string> snapshot = registry.Snapshot;
+        snapshot.Count.ShouldBe(2);
+        snapshot["X"].ShouldBe("documents");
+        snapshot["Y"].ShouldBe("parties");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Register_BlankTargetType_Throws(string targetType) =>
+        Should.Throw<ArgumentException>(() =>
+            new TaggableTypeRegistry().Register(targetType, "documents"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Register_BlankScope_Throws(string scope) =>
+        Should.Throw<ArgumentException>(() =>
+            new TaggableTypeRegistry().Register("X", scope));
+}

--- a/tests/Granit.Taxonomy.Tests/Extensions/AddTaggableEntityTests.cs
+++ b/tests/Granit.Taxonomy.Tests/Extensions/AddTaggableEntityTests.cs
@@ -1,0 +1,61 @@
+using Granit.Taxonomy.Extensions;
+using Granit.Taxonomy.Registration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Tests.Extensions;
+
+public sealed class AddTaggableEntityTests
+{
+    private sealed class FakeAggregateA;
+    private sealed class FakeAggregateB;
+
+    [Fact]
+    public void AddTaggableEntity_RegistersAggregate_TypeFullNameIsTargetType()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddGranitTaxonomy();
+        services.AddTaggableEntity<FakeAggregateA>("documents");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        TaggableTypeRegistry registry = sp.GetRequiredService<TaggableTypeRegistry>();
+
+        registry.IsRegistered(typeof(FakeAggregateA).FullName!).ShouldBeTrue();
+        registry.GetScope(typeof(FakeAggregateA).FullName!).ShouldBe("documents");
+    }
+
+    [Fact]
+    public void AddTaggableEntity_DifferentTypes_BothRegistered()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddGranitTaxonomy();
+        services.AddTaggableEntity<FakeAggregateA>("documents");
+        services.AddTaggableEntity<FakeAggregateB>("parties");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        TaggableTypeRegistry registry = sp.GetRequiredService<TaggableTypeRegistry>();
+
+        registry.GetScope(typeof(FakeAggregateA).FullName!).ShouldBe("documents");
+        registry.GetScope(typeof(FakeAggregateB).FullName!).ShouldBe("parties");
+    }
+
+    [Fact]
+    public void AddTaggableEntity_SameTypeDifferentScope_RegistryFactoryThrows()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddGranitTaxonomy();
+        services.AddTaggableEntity<FakeAggregateA>("documents");
+        services.AddTaggableEntity<FakeAggregateA>("parties");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // The registry factory invokes Register() per markers; the second one with a
+        // different scope must throw to prevent ambiguous (TargetType -> Scope) state.
+        Should.Throw<InvalidOperationException>(() => sp.GetRequiredService<TaggableTypeRegistry>());
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the **polymorphic FK pattern** locked by ADR-054 — Tags can be assigned to any aggregate root through a single shared `TagAssignment` table with a `(TargetType, TargetId)` discriminator pair. Idempotent assign endpoint, per-target permission gate, and the `TaggableTypeRegistry` consumer modules use to opt their aggregates in.

| Verb     | Route                                                                | Permission                                          |
| -------- | -------------------------------------------------------------------- | --------------------------------------------------- |
| `POST`   | `/api/v1/taxonomy/tags/{id}/assign`                                  | `Taxonomy.Tags.Manage` + `ITaggablePermissionResolver` |
| `DELETE` | `/api/v1/taxonomy/tags/{id}/assign/{targetType}/{targetId}`          | `Taxonomy.Tags.Manage` + `ITaggablePermissionResolver` |
| `GET`    | `/api/v1/taxonomy/assignments?targetType=&targetId=`                 | `Taxonomy.Tags.Read`                                |

- **Idempotency** — `POST` returns `201` on first assign and `200` with the existing row on subsequent calls; concurrent races are absorbed by re-reading after `DbUpdateException` 23505.
- **Composite permission gate** — base `Taxonomy.Tags.Manage` claim plus a per-target check via `ITaggablePermissionResolver`. Default `AllowAllTaggablePermissionResolver` is a no-op; T6.1 will wire a `Documents.Documents.Manage` resolver for `Document` targets.
- **`TaggableTypeRegistry`** — singleton populated by `services.AddTaggableEntity<TAggregate>(scope: "...")`. Conflicting re-registration throws.
- **`TagAssignment` table** — unique index `ux_taxonomy_tag_assignments_tenant_tag_target` plus supporting indexes for "tags of entity X" and "things tagged X" lookups.
- **Counters** — `granit.taxonomy.assignment.created` / `.deleted` with `target_type` tag added to `TaxonomyMetrics`.

## Test plan

- [x] `dotnet test tests/Granit.Taxonomy.Tests` — **53 / 53** passed (Tag domain, TagAssignment domain, TaggableTypeRegistry, AddTaggableEntity DI factory)
- [x] `dotnet test tests/Granit.Taxonomy.EntityFrameworkCore.Tests` — **22 / 22** SQLite passed (TagAssignment CRUD: idempotent, unassign, list, remove-all)
- [x] `dotnet test tests/Granit.Taxonomy.Endpoints.Tests` — **61 / 61** passed (validator + permission + localization theory + new AssignTagRequest validator)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "Validation|Domain|Permission"` — **22 / 22** passed
- [x] `dotnet build tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration` — clean (16-way concurrent idempotency test, run by CI integration shard)
- [x] `dotnet format` — clean across all 7 projects

## Out of scope

- Cross-entity search endpoint with `scope=*` (T3.1 — #1866)
- Categories (T4 — #1867 / #1868)
- T5.1 cleanup handler (`EntityDeletedEto` listener uses the new `RemoveAllAssignmentsAsync` method introduced here)
- T6.1 Documents wire-up (will register `Document` as taggable + ship a stricter `ITaggablePermissionResolver` that consults `Documents.Documents.Manage`)

## Related

Closes #1865
Parent feature: #1856 (T2 — Tag endpoints)
Epic: #1854
ADR: [ADR-054 — Granit.Taxonomy module](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/054-taxonomy-module.md)
