### PR TITLE
[T3.1] feat(taxonomy): cross-entity tag search endpoint

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55641,7 +55641,7 @@
       "kind": "class",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitTaxonomy",
@@ -55683,12 +55683,21 @@
       ]
     },
     {
+      "name": "Search",
+      "fqn": "Granit.Taxonomy.Endpoints.Permissions.Search",
+      "kind": "class",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs",
+      "line": 33,
+      "members": []
+    },
+    {
       "name": "Tags",
       "fqn": "Granit.Taxonomy.Endpoints.Permissions.Tags",
       "kind": "class",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs",
-      "line": 18,
+      "line": 17,
       "members": []
     },
     {
@@ -55697,7 +55706,34 @@
       "kind": "class",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "SearchHit",
+      "fqn": "Granit.Taxonomy.Endpoints.Search.Dtos.SearchHit",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Search/Dtos/SearchResponse.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "SearchResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Search.Dtos.SearchResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Search/Dtos/SearchResponse.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "SearchTagItem",
+      "fqn": "Granit.Taxonomy.Endpoints.Search.Dtos.SearchTagItem",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Search/Dtos/SearchResponse.cs",
+      "line": 20,
       "members": []
     },
     {
@@ -55910,6 +55946,22 @@
       ]
     },
     {
+      "name": "ITagSearchService",
+      "fqn": "Granit.Taxonomy.ITagSearchService",
+      "kind": "interface",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ITagSearchService.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(string query, string scope, int skip = 0, int take = 50, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TagSearchResult>"
+        }
+      ]
+    },
+    {
       "name": "ITagService",
       "fqn": "Granit.Taxonomy.ITagService",
       "kind": "interface",
@@ -55997,6 +56049,33 @@
           "returnType": "IReadOnlyDictionary<string, string> Snapshot => _typeToScope."
         }
       ]
+    },
+    {
+      "name": "TagSearchHit",
+      "fqn": "Granit.Taxonomy.TagSearchHit",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ITagSearchService.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "TagSearchResult",
+      "fqn": "Granit.Taxonomy.TagSearchResult",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ITagSearchService.cs",
+      "line": 42,
+      "members": []
+    },
+    {
+      "name": "TagSearchTag",
+      "fqn": "Granit.Taxonomy.TagSearchTag",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ITagSearchService.cs",
+      "line": 50,
+      "members": []
     },
     {
       "name": "AITemplateDataEnricher",

--- a/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Taxonomy.Endpoints.Options;
+using Granit.Taxonomy.Endpoints.Search.Endpoints;
 using Granit.Taxonomy.Endpoints.Tags.Endpoints;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -36,6 +37,7 @@ public static class TaxonomyEndpointRouteBuilderExtensions
 
         group.MapTagEndpoints();
         group.MapTagAssignmentEndpoints();
+        group.MapTagSearchEndpoints();
 
         return group;
     }

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/cs.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/cs.json
@@ -1,6 +1,7 @@
 {
   "culture": "cs",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Vyhledávat tagy napříč všemi entitami",
     "Permission:Taxonomy.Tags.Manage": "Vytvářet, přejmenovávat, přebarvovat a odstraňovat tagy",
     "Permission:Taxonomy.Tags.Read": "Zobrazit tagy",
     "PermissionGroup:Taxonomy": "Taxonomie"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/de.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/de.json
@@ -1,6 +1,7 @@
 {
   "culture": "de",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Tags entitätsübergreifend suchen",
     "Permission:Taxonomy.Tags.Manage": "Tags erstellen, umbenennen, neu einfärben und löschen",
     "Permission:Taxonomy.Tags.Read": "Tags anzeigen",
     "PermissionGroup:Taxonomy": "Taxonomie"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/en.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/en.json
@@ -1,6 +1,7 @@
 {
   "culture": "en",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Search tags across every entity",
     "Permission:Taxonomy.Tags.Manage": "Create, rename, recolour, and delete tags",
     "Permission:Taxonomy.Tags.Read": "View tags",
     "PermissionGroup:Taxonomy": "Taxonomy"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/es.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/es.json
@@ -1,6 +1,7 @@
 {
   "culture": "es",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Buscar etiquetas en todas las entidades",
     "Permission:Taxonomy.Tags.Manage": "Crear, renombrar, recolorear y eliminar etiquetas",
     "Permission:Taxonomy.Tags.Read": "Ver etiquetas",
     "PermissionGroup:Taxonomy": "Taxonomía"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/fr.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/fr.json
@@ -1,6 +1,7 @@
 {
   "culture": "fr",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Rechercher les tags à travers toutes les entités",
     "Permission:Taxonomy.Tags.Manage": "Créer, renommer, recolorer et supprimer les tags",
     "Permission:Taxonomy.Tags.Read": "Consulter les tags",
     "PermissionGroup:Taxonomy": "Taxonomie"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/hi.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/hi.json
@@ -1,6 +1,7 @@
 {
   "culture": "hi",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "सभी एंटिटीज़ में टैग खोजें",
     "Permission:Taxonomy.Tags.Manage": "टैग बनाएँ, नाम बदलें, रंग बदलें और हटाएँ",
     "Permission:Taxonomy.Tags.Read": "टैग देखें",
     "PermissionGroup:Taxonomy": "वर्गीकरण"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/it.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/it.json
@@ -1,6 +1,7 @@
 {
   "culture": "it",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Cercare i tag su tutte le entità",
     "Permission:Taxonomy.Tags.Manage": "Creare, rinominare, ricolorare ed eliminare i tag",
     "Permission:Taxonomy.Tags.Read": "Visualizzare i tag",
     "PermissionGroup:Taxonomy": "Tassonomia"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ja.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ja.json
@@ -1,6 +1,7 @@
 {
   "culture": "ja",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "すべてのエンティティでタグを検索",
     "Permission:Taxonomy.Tags.Manage": "タグの作成、名前変更、色変更、削除",
     "Permission:Taxonomy.Tags.Read": "タグを表示",
     "PermissionGroup:Taxonomy": "タクソノミー"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ko.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ko.json
@@ -1,6 +1,7 @@
 {
   "culture": "ko",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "모든 엔터티에서 태그 검색",
     "Permission:Taxonomy.Tags.Manage": "태그 생성, 이름 변경, 색상 변경, 삭제",
     "Permission:Taxonomy.Tags.Read": "태그 보기",
     "PermissionGroup:Taxonomy": "분류 체계"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/nl.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/nl.json
@@ -1,6 +1,7 @@
 {
   "culture": "nl",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Tags zoeken in alle entiteiten",
     "Permission:Taxonomy.Tags.Manage": "Tags maken, hernoemen, herkleuren en verwijderen",
     "Permission:Taxonomy.Tags.Read": "Tags bekijken",
     "PermissionGroup:Taxonomy": "Taxonomie"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pl.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pl.json
@@ -1,6 +1,7 @@
 {
   "culture": "pl",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Wyszukaj tagi we wszystkich encjach",
     "Permission:Taxonomy.Tags.Manage": "Twórz, zmieniaj nazwy, zmieniaj kolory i usuwaj tagi",
     "Permission:Taxonomy.Tags.Read": "Wyświetl tagi",
     "PermissionGroup:Taxonomy": "Taksonomia"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pt.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pt.json
@@ -1,6 +1,7 @@
 {
   "culture": "pt",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Pesquisar tags em todas as entidades",
     "Permission:Taxonomy.Tags.Manage": "Criar, renomear, recolorir e excluir tags",
     "Permission:Taxonomy.Tags.Read": "Ver tags",
     "PermissionGroup:Taxonomy": "Taxonomia"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/sv.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/sv.json
@@ -1,6 +1,7 @@
 {
   "culture": "sv",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Sök taggar över alla entiteter",
     "Permission:Taxonomy.Tags.Manage": "Skapa, byt namn, färgändra och ta bort taggar",
     "Permission:Taxonomy.Tags.Read": "Visa taggar",
     "PermissionGroup:Taxonomy": "Taxonomi"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/tr.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/tr.json
@@ -1,6 +1,7 @@
 {
   "culture": "tr",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "Tüm varlıklarda etiket ara",
     "Permission:Taxonomy.Tags.Manage": "Etiketleri oluştur, yeniden adlandır, yeniden renklendir ve sil",
     "Permission:Taxonomy.Tags.Read": "Etiketleri görüntüle",
     "PermissionGroup:Taxonomy": "Taksonomi"

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/zh.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/zh.json
@@ -1,6 +1,7 @@
 {
   "culture": "zh",
   "texts": {
+    "Permission:Taxonomy.Search.Read": "跨所有实体搜索标签",
     "Permission:Taxonomy.Tags.Manage": "创建、重命名、重新着色和删除标签",
     "Permission:Taxonomy.Tags.Read": "查看标签",
     "PermissionGroup:Taxonomy": "分类法"

--- a/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissionDefinitionProvider.cs
+++ b/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissionDefinitionProvider.cs
@@ -32,5 +32,11 @@ internal sealed class TaxonomyPermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<TaxonomyEndpointsLocalizationResource>(
                 "Permission:Taxonomy.Tags.Manage"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            TaxonomyPermissions.Search.Read,
+            LocalizableString.Create<TaxonomyEndpointsLocalizationResource>(
+                "Permission:Taxonomy.Search.Read"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs
+++ b/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs
@@ -4,10 +4,9 @@ namespace Granit.Taxonomy.Endpoints.Permissions;
 /// Permission constants exposed by <c>Granit.Taxonomy.Endpoints</c>.
 /// </summary>
 /// <remarks>
-/// T2.1 ships only the Tag permissions. Category permissions
-/// (<c>Taxonomy.Categories.Read</c> / <c>...Manage</c>) and the cross-entity
-/// search permission (<c>Taxonomy.Search.Read</c>) arrive with their respective
-/// stories (T4 and T3).
+/// Tag permissions ship in T2.1, the cross-entity search permission lands in T3.1.
+/// Category permissions (<c>Taxonomy.Categories.Read</c> / <c>...Manage</c>) arrive
+/// with story T4.
 /// </remarks>
 public static class TaxonomyPermissions
 {
@@ -22,5 +21,18 @@ public static class TaxonomyPermissions
 
         /// <summary>Manage tags (create, rename, recolour, hide, delete).</summary>
         public const string Manage = "Taxonomy.Tags.Manage";
+    }
+
+    /// <summary>Permissions on the cross-entity search endpoint.</summary>
+    /// <remarks>
+    /// Separate from <see cref="Tags.Read"/> because the search results expose
+    /// <c>TargetId</c>s the caller may not have per-entity read on. Hosts that
+    /// grant <c>Taxonomy.Search.Read</c> MUST combine the result with their
+    /// own per-entity ACL when rendering.
+    /// </remarks>
+    public static class Search
+    {
+        /// <summary>Run cross-entity tag searches that expose target ids across modules.</summary>
+        public const string Read = "Taxonomy.Search.Read";
     }
 }

--- a/src/Granit.Taxonomy.Endpoints/Search/Dtos/SearchResponse.cs
+++ b/src/Granit.Taxonomy.Endpoints/Search/Dtos/SearchResponse.cs
@@ -1,0 +1,23 @@
+namespace Granit.Taxonomy.Endpoints.Search.Dtos;
+
+/// <summary>Wire-shape response for <c>GET /api/v1/taxonomy/search</c>.</summary>
+/// <param name="Tags">Tags whose name matched the query (paged).</param>
+/// <param name="Hits">
+/// Assignments grouped by <c>TargetType</c>. Each entry is a list of target hits
+/// — the <c>TargetId</c> plus the ids of the matching tags applied to it.
+/// </param>
+/// <param name="TotalCount">Total number of matching tags before pagination.</param>
+/// <param name="Skip">Pagination offset applied.</param>
+/// <param name="Take">Pagination page size applied.</param>
+public sealed record SearchResponse(
+    IReadOnlyList<SearchTagItem> Tags,
+    IReadOnlyDictionary<string, IReadOnlyList<SearchHit>> Hits,
+    int TotalCount,
+    int Skip,
+    int Take);
+
+/// <summary>A tag in the <see cref="SearchResponse.Tags"/> list.</summary>
+public sealed record SearchTagItem(Guid Id, string Name, string Color, string Scope);
+
+/// <summary>One target hit grouped under <see cref="SearchResponse.Hits"/>.</summary>
+public sealed record SearchHit(Guid TargetId, IReadOnlyList<Guid> TagIds);

--- a/src/Granit.Taxonomy.Endpoints/Search/Endpoints/TagSearchEndpoints.cs
+++ b/src/Granit.Taxonomy.Endpoints/Search/Endpoints/TagSearchEndpoints.cs
@@ -1,0 +1,77 @@
+using Granit.Taxonomy.Endpoints.Permissions;
+using Granit.Taxonomy.Endpoints.Search.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Taxonomy.Endpoints.Search.Endpoints;
+
+/// <summary>
+/// HTTP endpoint for the cross-entity tag search introduced by ADR-054 (T3.1):
+/// answers "show me everything tagged X" with results grouped by <c>TargetType</c>.
+/// </summary>
+internal static class TagSearchEndpoints
+{
+    private const string TagName = "Taxonomy";
+
+    public static RouteGroupBuilder MapTagSearchEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        RouteGroupBuilder search = group.MapGroup("/search").WithTags(TagName);
+
+        search.MapGet("/", SearchAsync)
+            .WithName("SearchTaxonomy")
+            .WithSummary("Cross-entity tag search grouped by target type.")
+            .WithDescription(
+                "Returns tags whose Name prefix-matches q (case-insensitive) along "
+                + "with the assignments grouped by TargetType so the frontend can "
+                + "dispatch to the matching rendering pipeline. Pass scope=* for "
+                + "cross-scope, otherwise the search is restricted to the matching "
+                + "Tag.Scope. SECURITY: results expose TargetIds the caller may not "
+                + "have per-entity read on — hosts MUST combine with their own "
+                + "per-entity ACL when rendering.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Search.Read))
+            .Produces<SearchResponse>()
+            .ProducesValidationProblem();
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<SearchResponse>, ValidationProblem>> SearchAsync(
+        [FromQuery] string q,
+        [FromQuery] string? scope,
+        [FromQuery] int? skip,
+        [FromQuery] int? take,
+        [FromServices] ITagSearchService service,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<string, string[]> errors = new();
+        if (string.IsNullOrWhiteSpace(q))
+        {
+            errors[nameof(q)] = ["q is required."];
+        }
+        if (errors.Count > 0)
+        {
+            return TypedResults.ValidationProblem(errors);
+        }
+
+        TagSearchResult result = await service
+            .SearchAsync(q, scope ?? "*", skip ?? 0, take ?? 50, cancellationToken)
+            .ConfigureAwait(false);
+
+        SearchResponse response = new(
+            [.. result.Tags.Select(t => new SearchTagItem(t.Id, t.Name, t.Color, t.Scope))],
+            result.HitsByTargetType.ToDictionary(
+                kvp => kvp.Key,
+                kvp => (IReadOnlyList<SearchHit>)[.. kvp.Value.Select(h => new SearchHit(h.TargetId, h.TagIds))],
+                StringComparer.Ordinal),
+            result.TotalCount,
+            result.Skip,
+            result.Take);
+
+        return TypedResults.Ok(response);
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -30,6 +30,7 @@ public static class TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddGranitDbContext<TaxonomyDbContext>(configure);
         builder.Services.AddScoped<ITagService, TagService>();
         builder.Services.AddScoped<ITagAssignmentService, TagAssignmentService>();
+        builder.Services.AddScoped<ITagSearchService, TagSearchService>();
 
         return builder;
     }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagSearchService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TagSearchService.cs
@@ -1,0 +1,98 @@
+using Granit.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ITagSearchService"/>. Single-query
+/// cross-entity search per ADR-054 — joins tags + assignments and groups by
+/// <c>TargetType</c>.
+/// </summary>
+internal sealed class TagSearchService(
+    IDbContextFactory<TaxonomyDbContext> contextFactory,
+    ICurrentTenant currentTenant) : ITagSearchService
+{
+    /// <inheritdoc />
+    public async Task<TagSearchResult> SearchAsync(
+        string query,
+        string scope,
+        int skip = 0,
+        int take = 50,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        if (skip < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(skip), "Skip must be non-negative.");
+        }
+        if (take is <= 0 or > 500)
+        {
+            throw new ArgumentOutOfRangeException(nameof(take), "Take must be in (0, 500].");
+        }
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        string prefix = query.Trim() + "%";
+        bool crossScope = string.Equals(scope, "*", StringComparison.Ordinal);
+
+        IQueryable<Domain.Tag> tagQuery = context.Tags
+            .AsNoTracking()
+            .Where(t => t.TenantId == tenantId)
+            .Where(t => EF.Functions.Like(t.Name, prefix));
+        if (!crossScope)
+        {
+            tagQuery = tagQuery.Where(t => t.Scope == scope);
+        }
+
+        int totalCount = await tagQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        List<TagSearchTag> matchingTags = await tagQuery
+            .OrderBy(t => t.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(t => new TagSearchTag(t.Id, t.Name, t.Color, t.Scope))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (matchingTags.Count == 0)
+        {
+            return new TagSearchResult(
+                matchingTags,
+                new Dictionary<string, IReadOnlyList<TagSearchHit>>(StringComparer.Ordinal),
+                totalCount,
+                skip,
+                take);
+        }
+
+        Guid[] tagIds = [.. matchingTags.Select(t => t.Id)];
+
+        // Single query for every assignment of the matching tags. Grouping happens
+        // server-side by (TargetType, TargetId) so the wire shape carries the tag
+        // ids per target without N+1 round-trips.
+        var rawHits = await context.TagAssignments
+            .AsNoTracking()
+            .Where(a => a.TenantId == tenantId && tagIds.Contains(a.TagId))
+            .Select(a => new { a.TargetType, a.TargetId, a.TagId })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var grouped = rawHits
+            .GroupBy(r => r.TargetType, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<TagSearchHit>)g
+                    .GroupBy(r => r.TargetId)
+                    .Select(targetGroup => new TagSearchHit(
+                        targetGroup.Key,
+                        [.. targetGroup.Select(r => r.TagId)]))
+                    .OrderBy(h => h.TargetId)
+                    .ToList(),
+                StringComparer.Ordinal);
+
+        return new TagSearchResult(matchingTags, grouped, totalCount, skip, take);
+    }
+}

--- a/src/Granit.Taxonomy/ITagSearchService.cs
+++ b/src/Granit.Taxonomy/ITagSearchService.cs
@@ -1,0 +1,53 @@
+namespace Granit.Taxonomy;
+
+/// <summary>
+/// Cross-entity tag search — answers "show me everything tagged X" with results
+/// grouped by <c>TargetType</c> per ADR-054.
+/// </summary>
+/// <remarks>
+/// The search returns the <c>TargetId</c> of every assignment matching the query.
+/// Hosts that render the result MUST combine these ids with their own per-entity
+/// ACL: a tag-assignment row leaks the existence of an entity even when the
+/// caller has no per-entity read permission.
+/// </remarks>
+public interface ITagSearchService
+{
+    /// <summary>
+    /// Returns tags whose <c>Name</c> matches <paramref name="query"/> (case-insensitive
+    /// prefix) along with the assignments grouped by <c>TargetType</c>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="query"/> is matched as a case-insensitive prefix against
+    /// <c>Tag.Name</c>. Pass <paramref name="scope"/> = <c>"*"</c> for cross-scope.
+    /// Pagination via <paramref name="skip"/> (default 0) and <paramref name="take"/>
+    /// (default 50, max 500).
+    /// </remarks>
+    Task<TagSearchResult> SearchAsync(
+        string query,
+        string scope,
+        int skip = 0,
+        int take = 50,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Aggregate result of a cross-entity tag search.</summary>
+/// <param name="Tags">Tags whose name matched the query (paged).</param>
+/// <param name="HitsByTargetType">
+/// Assignments grouped by <c>TargetType</c>. Each hit carries the matching
+/// <c>TargetId</c> and the ids of the matching tags applied to it.
+/// </param>
+/// <param name="TotalCount">Total number of matching tags before pagination.</param>
+/// <param name="Skip">Pagination offset applied.</param>
+/// <param name="Take">Pagination page size applied.</param>
+public sealed record TagSearchResult(
+    IReadOnlyList<TagSearchTag> Tags,
+    IReadOnlyDictionary<string, IReadOnlyList<TagSearchHit>> HitsByTargetType,
+    int TotalCount,
+    int Skip,
+    int Take);
+
+/// <summary>A tag returned by <see cref="ITagSearchService.SearchAsync"/>.</summary>
+public sealed record TagSearchTag(Guid Id, string Name, string Color, string Scope);
+
+/// <summary>One target hit — the entity that carries one or more matching tags.</summary>
+public sealed record TagSearchHit(Guid TargetId, IReadOnlyList<Guid> TagIds);

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Localization/LocalizationFileTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Localization/LocalizationFileTests.cs
@@ -44,6 +44,7 @@ public sealed class LocalizationFileTests
         content.ShouldContain("\"PermissionGroup:Taxonomy\"");
         content.ShouldContain("\"Permission:Taxonomy.Tags.Read\"");
         content.ShouldContain("\"Permission:Taxonomy.Tags.Manage\"");
+        content.ShouldContain("\"Permission:Taxonomy.Search.Read\"");
     }
 
     public static TheoryData<string> AllCultures()

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Search/TaxonomySearchPermissionTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Search/TaxonomySearchPermissionTests.cs
@@ -1,0 +1,12 @@
+using Granit.Taxonomy.Endpoints.Permissions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Endpoints.Tests.Search;
+
+public sealed class TaxonomySearchPermissionTests
+{
+    [Fact]
+    public void SearchPermissionConstant_FollowsGranitFormat() =>
+        TaxonomyPermissions.Search.Read.ShouldBe("Taxonomy.Search.Read");
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagSearchPostgresTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/TagSearchPostgresTests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.Metrics;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres test for the cross-entity search invariant required by T3.1: the same
+/// query <c>q=urgent</c> with <c>scope=*</c> finds hits across two different
+/// <c>TargetType</c>s and groups them under their respective discriminator.
+/// </summary>
+public sealed class TagSearchPostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private DbContextOptions<TaxonomyDbContext> _options = null!;
+    private TestDbContextFactory _factory = null!;
+    private TagService _tagService = null!;
+    private TagAssignmentService _assignmentService = null!;
+    private TagSearchService _sut = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string DocumentType = "Granit.Documents.Domain.Document";
+    private const string PartyType = "Granit.Parties.Domain.Party";
+
+    public TagSearchPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        _options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(_options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE taxonomy_tag_assignments, taxonomy_tags RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(_options);
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        TaxonomyMetrics metrics = new(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _tagService = new TagService(_factory, currentTenant, new SimpleGuidGenerator(), metrics);
+        _assignmentService = new TagAssignmentService(_factory, currentTenant, new SimpleGuidGenerator(), clock, metrics);
+        _sut = new TagSearchService(_factory, currentTenant);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task SearchAsync_CrossScope_FindsHitsAcrossTwoTargetTypes()
+    {
+        Tag urgentDoc = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Tag urgentParty = await _tagService.CreateAsync("parties", "urgentVip", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var doc = Guid.NewGuid();
+        var party = Guid.NewGuid();
+        await _assignmentService.AssignAsync(urgentDoc.Id, DocumentType, doc, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _assignmentService.AssignAsync(urgentParty.Id, PartyType, party, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        TagSearchResult result = await _sut.SearchAsync("urg", "*",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.Count.ShouldBe(2);
+        result.HitsByTargetType.Count.ShouldBe(2);
+        result.HitsByTargetType[DocumentType].ShouldHaveSingleItem().TargetId.ShouldBe(doc);
+        result.HitsByTargetType[PartyType].ShouldHaveSingleItem().TargetId.ShouldBe(party);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagSearchServiceSqliteTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/TagSearchServiceSqliteTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics.Metrics;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Internal;
+
+public sealed class TagSearchServiceSqliteTests : IAsyncLifetime
+{
+    private SqliteConnection _holdOpen = null!;
+    private TestDbContextFactory _factory = null!;
+    private TagService _tagService = null!;
+    private TagAssignmentService _assignmentService = null!;
+    private TagSearchService _sut = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string DocumentType = "Granit.Documents.Domain.Document";
+    private const string PartyType = "Granit.Parties.Domain.Party";
+
+    public async ValueTask InitializeAsync()
+    {
+        string connectionString =
+            $"DataSource=file:taxonomy-search-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(connectionString);
+        await _holdOpen.OpenAsync();
+
+        DbContextOptions<TaxonomyDbContext> options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestDbContextFactory(options);
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        TaxonomyMetrics metrics = new(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _tagService = new TagService(_factory, currentTenant, new SimpleGuidGenerator(), metrics);
+        _assignmentService = new TagAssignmentService(_factory, currentTenant, new SimpleGuidGenerator(), clock, metrics);
+        _sut = new TagSearchService(_factory, currentTenant);
+    }
+
+    public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
+
+    [Fact]
+    public async Task SearchAsync_NoMatchingTags_ReturnsEmptyResult()
+    {
+        TagSearchResult result = await _sut.SearchAsync("xyz", "*",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.ShouldBeEmpty();
+        result.HitsByTargetType.ShouldBeEmpty();
+        result.TotalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task SearchAsync_PrefixMatch_ReturnsTagsWithoutAssignmentsWhenNoneExist()
+    {
+        await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _tagService.CreateAsync("parties", "urgentVip", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _tagService.CreateAsync("documents", "review", "#0000FF",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        TagSearchResult result = await _sut.SearchAsync("urg", "*",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.Count.ShouldBe(2); // urgent + urgentVip
+        result.HitsByTargetType.ShouldBeEmpty(); // no assignments
+    }
+
+    [Fact]
+    public async Task SearchAsync_ScopeFilter_RestrictsToScope()
+    {
+        await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _tagService.CreateAsync("parties", "urgentVip", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        TagSearchResult result = await _sut.SearchAsync("urg", "documents",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.Count.ShouldBe(1);
+        result.Tags[0].Name.ShouldBe("urgent");
+    }
+
+    [Fact]
+    public async Task SearchAsync_CrossTargetType_GroupsHitsByTargetType()
+    {
+        Tag urgent = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var doc1 = Guid.NewGuid();
+        var doc2 = Guid.NewGuid();
+        var party1 = Guid.NewGuid();
+
+        await _assignmentService.AssignAsync(urgent.Id, DocumentType, doc1, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _assignmentService.AssignAsync(urgent.Id, DocumentType, doc2, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _assignmentService.AssignAsync(urgent.Id, PartyType, party1, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        TagSearchResult result = await _sut.SearchAsync("urgent", "*",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.Count.ShouldBe(1);
+        result.HitsByTargetType.Count.ShouldBe(2);
+        result.HitsByTargetType[DocumentType].Count.ShouldBe(2);
+        result.HitsByTargetType[DocumentType].Select(h => h.TargetId).OrderBy(g => g)
+            .ShouldBe(new[] { doc1, doc2 }.OrderBy(g => g));
+        result.HitsByTargetType[PartyType].Count.ShouldBe(1);
+        result.HitsByTargetType[PartyType][0].TargetId.ShouldBe(party1);
+    }
+
+    [Fact]
+    public async Task SearchAsync_MultipleTagsOnSameTarget_TagIdsAggregated()
+    {
+        Tag urgent = await _tagService.CreateAsync("documents", "urgent", "#FF0000",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Tag urgent2 = await _tagService.CreateAsync("documents", "urgentBis", "#00FF00",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var doc = Guid.NewGuid();
+        await _assignmentService.AssignAsync(urgent.Id, DocumentType, doc, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+        await _assignmentService.AssignAsync(urgent2.Id, DocumentType, doc, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        TagSearchResult result = await _sut.SearchAsync("urgent", "*",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.HitsByTargetType[DocumentType].Count.ShouldBe(1);
+        result.HitsByTargetType[DocumentType][0].TargetId.ShouldBe(doc);
+        result.HitsByTargetType[DocumentType][0].TagIds.OrderBy(g => g)
+            .ShouldBe(new[] { urgent.Id, urgent2.Id }.OrderBy(g => g));
+    }
+
+    [Fact]
+    public async Task SearchAsync_Pagination_AppliedToTagsOnly()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            await _tagService.CreateAsync("documents", $"urgent-{i}", "#FF0000",
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TagSearchResult result = await _sut.SearchAsync("urgent", "*", skip: 1, take: 2,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Tags.Count.ShouldBe(2);
+        result.TotalCount.ShouldBe(5);
+        result.Skip.ShouldBe(1);
+        result.Take.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchAsync_BlankQuery_Throws(string query) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.SearchAsync(query, "*", cancellationToken: TestContext.Current.CancellationToken));
+
+    [Fact]
+    public async Task SearchAsync_InvalidTake_Throws() =>
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            _sut.SearchAsync("x", "*", take: 0,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the cross-entity tag search endpoint per ADR-054 — answers "show me everything tagged X" with results grouped by `TargetType` so the frontend can dispatch to the matching rendering pipeline.

| Verb  | Route                                                | Permission              |
| ----- | ---------------------------------------------------- | ----------------------- |
| `GET` | `/api/v1/taxonomy/search?q=&scope=&skip=&take=`     | `Taxonomy.Search.Read`  |

**Response shape** matches the issue:

```json
{
  "tags": [{ "id": "...", "name": "urgent", "color": "#FF0000", "scope": "documents" }],
  "hits": {
    "Granit.Documents.Domain.Document": [{ "targetId": "...", "tagIds": ["..."] }],
    "Granit.Parties.Domain.Party": [{ "targetId": "...", "tagIds": ["..."] }]
  },
  "totalCount": 5,
  "skip": 0,
  "take": 50
}
```

- **Single-query implementation** in `TagSearchService`: one paged tag query + one assignment query joined by tag id, grouped server-side by `TargetType` — no N+1 round-trips.
- **`Taxonomy.Search.Read` permission** is **separate from `Taxonomy.Tags.Read`** by design (ADR-054). Search results expose `TargetId`s the caller may not have per-entity read on — hosts MUST combine with their own per-entity ACL when rendering. Documented in the OpenAPI description and the permission XML doc.
- **18-culture localization** updated for the new `Permission:Taxonomy.Search.Read` key.

## Test plan

- [x] `dotnet test tests/Granit.Taxonomy.EntityFrameworkCore.Tests` — **31 / 31** SQLite passed (9 new search tests: no-match, prefix-match, scope filter, cross-TargetType grouping, multi-tag-on-same-target aggregation, pagination, blank-query / invalid-take guards)
- [x] `dotnet test tests/Granit.Taxonomy.Endpoints.Tests` — **62 / 62** passed (new permission constant + extended localization-coverage theory)
- [x] `dotnet build tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration` — clean (cross-TargetType Postgres test, run by CI integration shard)
- [x] `dotnet format` — clean across all 6 projects
- [x] Lock files refreshed

## Out of scope

- Categories (T4 — #1867 / #1868)
- Cleanup handler (T5.1 — #1869) and nightly orphan sweep (T5.2 — #1870)
- Documents wire-up (T6.1 — #1871) — registers `Document` as taggable + ships a stricter `ITaggablePermissionResolver`

## Related

Closes #1866
Parent feature: #1857 (T3 — Cross-entity search)
Epic: #1854
ADR: [ADR-054 — Granit.Taxonomy module](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/054-taxonomy-module.md)
