### PR TITLE
fix(activities): apply audit findings — server-side actor + IGuidGenerator + Diagnostics

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4468,110 +4468,6 @@
       ]
     },
     {
-      "name": "ActivityListFilter",
-      "fqn": "Granit.Activities.Abstractions.ActivityListFilter",
-      "kind": "record",
-      "project": "Granit.Activities",
-      "file": "src/Granit.Activities/Abstractions/IActivityReader.cs",
-      "line": 74,
-      "members": []
-    },
-    {
-      "name": "ActivityStatusFilter",
-      "fqn": "Granit.Activities.Abstractions.ActivityStatusFilter",
-      "kind": "enum",
-      "project": "Granit.Activities",
-      "file": "src/Granit.Activities/Abstractions/IActivityReader.cs",
-      "line": 87,
-      "members": []
-    },
-    {
-      "name": "IActivityReader",
-      "fqn": "Granit.Activities.Abstractions.IActivityReader",
-      "kind": "interface",
-      "project": "Granit.Activities",
-      "file": "src/Granit.Activities/Abstractions/IActivityReader.cs",
-      "line": 9,
-      "members": [
-        {
-          "name": "GetByIdAsync",
-          "kind": "method",
-          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
-          "returnType": "Task<Activity?>"
-        },
-        {
-          "name": "ListAsync",
-          "kind": "method",
-          "signature": "ListAsync(ActivityListFilter filter, int skip, int take, CancellationToken cancellationToken = default)",
-          "returnType": "Task<IReadOnlyList<Activity>>"
-        },
-        {
-          "name": "CountAsync",
-          "kind": "method",
-          "signature": "CountAsync(ActivityListFilter filter, CancellationToken cancellationToken = default)",
-          "returnType": "Task<int>"
-        },
-        {
-          "name": "GetOverdueAwaitingNotificationAsync",
-          "kind": "method",
-          "signature": "GetOverdueAwaitingNotificationAsync(DateTimeOffset asOf, CancellationToken cancellationToken = default)",
-          "returnType": "Task<IReadOnlyList<Activity>>"
-        },
-        {
-          "name": "GetOpenDueWithinAsync",
-          "kind": "method",
-          "signature": "GetOpenDueWithinAsync(DateTimeOffset dayStart, DateTimeOffset dayEnd, CancellationToken cancellationToken = default)",
-          "returnType": "Task<IReadOnlyList<Activity>>"
-        }
-      ]
-    },
-    {
-      "name": "IActivityWriter",
-      "fqn": "Granit.Activities.Abstractions.IActivityWriter",
-      "kind": "interface",
-      "project": "Granit.Activities",
-      "file": "src/Granit.Activities/Abstractions/IActivityWriter.cs",
-      "line": 18,
-      "members": [
-        {
-          "name": "CreateAsync",
-          "kind": "method",
-          "signature": "CreateAsync(string entityType, Guid entityId, string type, Guid assignedToUserId, DateTimeOffset dueAt, Guid? createdByUserId = null, string? description = null, CancellationToken cancellationToken = default)",
-          "returnType": "Task<Activity>"
-        },
-        {
-          "name": "CompleteAsync",
-          "kind": "method",
-          "signature": "CompleteAsync(Guid activityId, Guid completedByUserId, DateTimeOffset at, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "CancelAsync",
-          "kind": "method",
-          "signature": "CancelAsync(Guid activityId, Guid cancelledByUserId, DateTimeOffset at, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "ReassignAsync",
-          "kind": "method",
-          "signature": "ReassignAsync(Guid activityId, Guid newAssigneeUserId, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "RescheduleAsync",
-          "kind": "method",
-          "signature": "RescheduleAsync(Guid activityId, DateTimeOffset newDueAt, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "MarkOverdueNotifiedAsync",
-          "kind": "method",
-          "signature": "MarkOverdueNotifiedAsync(Guid activityId, DateTimeOffset at, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
       "name": "ActivityType",
       "fqn": "Granit.Activities.ActivityType",
       "kind": "record",
@@ -4679,6 +4575,40 @@
       ]
     },
     {
+      "name": "ActivitiesMetrics",
+      "fqn": "Granit.Activities.Diagnostics.ActivitiesMetrics",
+      "kind": "class",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Diagnostics/ActivitiesMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordCompleted",
+          "kind": "method",
+          "signature": "RecordCompleted(string? tenantId, string? type)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCancelled",
+          "kind": "method",
+          "signature": "RecordCancelled(string? tenantId, string? type)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOverdueNotified",
+          "kind": "method",
+          "signature": "RecordOverdueNotified(string? tenantId, string? type)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordReminderSent",
+          "kind": "method",
+          "signature": "RecordReminderSent(string? tenantId, string? type)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "Activity",
       "fqn": "Granit.Activities.Domain.Activity",
       "kind": "class",
@@ -4751,7 +4681,7 @@
       "kind": "record",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs",
-      "line": 16,
+      "line": 24,
       "members": []
     },
     {
@@ -4760,7 +4690,7 @@
       "kind": "record",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs",
-      "line": 13,
+      "line": 17,
       "members": []
     },
     {
@@ -4778,7 +4708,7 @@
       "kind": "record",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs",
-      "line": 19,
+      "line": 27,
       "members": []
     },
     {
@@ -4787,7 +4717,7 @@
       "kind": "record",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs",
-      "line": 22,
+      "line": 30,
       "members": []
     },
     {
@@ -4796,12 +4726,12 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Extensions/ActivitiesEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "MapGranitActivities",
           "kind": "method",
-          "signature": "MapGranitActivities(this IEndpointRouteBuilder endpoints, Action<ActivitiesEndpointsOptions>? configure = null)",
+          "signature": "MapGranitActivities(this IEndpointRouteBuilder endpoints)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -4828,8 +4758,15 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs",
-      "line": 22,
-      "members": []
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "ActivitiesEndpointsOptions",
@@ -4901,7 +4838,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 56,
+      "line": 47,
       "members": []
     },
     {
@@ -4910,7 +4847,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 32,
+      "line": 29,
       "members": []
     },
     {
@@ -4919,7 +4856,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 24,
+      "line": 27,
       "members": []
     },
     {
@@ -4937,7 +4874,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 40,
+      "line": 31,
       "members": []
     },
     {
@@ -4946,7 +4883,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 48,
+      "line": 39,
       "members": []
     },
     {
@@ -5109,7 +5046,7 @@
       "kind": "class",
       "project": "Granit.Activities",
       "file": "src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitActivities",
@@ -5152,12 +5089,12 @@
       "kind": "interface",
       "project": "Granit.Activities.Abstractions",
       "file": "src/Granit.Activities.Abstractions/IActivityRegistry.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "TryGet",
           "kind": "method",
-          "signature": "TryGet(string name, out ActivityType type)",
+          "signature": "TryGet(string name, [NotNullWhen(true)",
           "returnType": "IReadOnlyDictionary<string, ActivityType> All { get; } bool"
         }
       ]
@@ -5416,7 +5353,14 @@
       "project": "Granit.Activities.Notifications",
       "file": "src/Granit.Activities.Notifications/Handlers/ActivityAssignedHandler.cs",
       "line": 12,
-      "members": []
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ActivityAssignedEvent evt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "ActivityOverdueHandler",
@@ -5425,7 +5369,14 @@
       "project": "Granit.Activities.Notifications",
       "file": "src/Granit.Activities.Notifications/Handlers/ActivityOverdueHandler.cs",
       "line": 13,
-      "members": []
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ActivityOverdueEvent evt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "ActivityReminderHandler",
@@ -5434,7 +5385,118 @@
       "project": "Granit.Activities.Notifications",
       "file": "src/Granit.Activities.Notifications/Handlers/ActivityReminderHandler.cs",
       "line": 12,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ActivityReminderDueEvent evt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ActivityListFilter",
+      "fqn": "Granit.Activities.Persistence.ActivityListFilter",
+      "kind": "record",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Persistence/IActivityReader.cs",
+      "line": 74,
       "members": []
+    },
+    {
+      "name": "ActivityStatusFilter",
+      "fqn": "Granit.Activities.Persistence.ActivityStatusFilter",
+      "kind": "enum",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Persistence/IActivityReader.cs",
+      "line": 87,
+      "members": []
+    },
+    {
+      "name": "IActivityReader",
+      "fqn": "Granit.Activities.Persistence.IActivityReader",
+      "kind": "interface",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Persistence/IActivityReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetByIdAsync",
+          "kind": "method",
+          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Activity?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(ActivityListFilter filter, int skip, int take, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Activity>>"
+        },
+        {
+          "name": "CountAsync",
+          "kind": "method",
+          "signature": "CountAsync(ActivityListFilter filter, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "GetOverdueAwaitingNotificationAsync",
+          "kind": "method",
+          "signature": "GetOverdueAwaitingNotificationAsync(DateTimeOffset asOf, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Activity>>"
+        },
+        {
+          "name": "GetOpenDueWithinAsync",
+          "kind": "method",
+          "signature": "GetOpenDueWithinAsync(DateTimeOffset dayStart, DateTimeOffset dayEnd, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Activity>>"
+        }
+      ]
+    },
+    {
+      "name": "IActivityWriter",
+      "fqn": "Granit.Activities.Persistence.IActivityWriter",
+      "kind": "interface",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Persistence/IActivityWriter.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string entityType, Guid entityId, string type, Guid assignedToUserId, DateTimeOffset dueAt, Guid? createdByUserId = null, string? description = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Activity>"
+        },
+        {
+          "name": "CompleteAsync",
+          "kind": "method",
+          "signature": "CompleteAsync(Guid activityId, Guid completedByUserId, DateTimeOffset at, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "CancelAsync",
+          "kind": "method",
+          "signature": "CancelAsync(Guid activityId, Guid cancelledByUserId, DateTimeOffset at, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ReassignAsync",
+          "kind": "method",
+          "signature": "ReassignAsync(Guid activityId, Guid newAssigneeUserId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RescheduleAsync",
+          "kind": "method",
+          "signature": "RescheduleAsync(Guid activityId, DateTimeOffset newDueAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkOverdueNotifiedAsync",
+          "kind": "method",
+          "signature": "MarkOverdueNotifiedAsync(Guid activityId, DateTimeOffset at, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "ActivityQueryDefinition",

--- a/src/Granit.Activities.Abstractions/IActivityRegistry.cs
+++ b/src/Granit.Activities.Abstractions/IActivityRegistry.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Granit.Activities;
 
 /// <summary>
@@ -21,5 +23,5 @@ public interface IActivityRegistry
     /// no provider contributed a type with the given name — typically because
     /// the contributing module is not loaded.
     /// </summary>
-    bool TryGet(string name, out ActivityType type);
+    bool TryGet(string name, [NotNullWhen(true)] out ActivityType? type);
 }

--- a/src/Granit.Activities.BackgroundJobs/GranitActivitiesBackgroundJobsModule.cs
+++ b/src/Granit.Activities.BackgroundJobs/GranitActivitiesBackgroundJobsModule.cs
@@ -13,8 +13,8 @@ namespace Granit.Activities.BackgroundJobs;
 /// each <see cref="IBackgroundJob"/> record.
 /// </summary>
 [DependsOn(
-    typeof(GranitBackgroundJobsModule),
-    typeof(GranitActivitiesModule))]
+    typeof(GranitActivitiesModule),
+    typeof(GranitBackgroundJobsModule))]
 public sealed class GranitActivitiesBackgroundJobsModule : GranitModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)

--- a/src/Granit.Activities.BackgroundJobs/Services/MarkOverdueScanService.cs
+++ b/src/Granit.Activities.BackgroundJobs/Services/MarkOverdueScanService.cs
@@ -1,6 +1,6 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
+using Granit.Activities.Persistence;
 using Granit.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Activities.BackgroundJobs/Services/SendRemindersScanService.cs
+++ b/src/Granit.Activities.BackgroundJobs/Services/SendRemindersScanService.cs
@@ -1,6 +1,6 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
+using Granit.Activities.Persistence;
 using Granit.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Activities.Endpoints/Dtos/ActivityCalendarRequest.cs
+++ b/src/Granit.Activities.Endpoints/Dtos/ActivityCalendarRequest.cs
@@ -1,4 +1,4 @@
-using Granit.Activities.Abstractions;
+using Granit.Activities.Persistence;
 
 namespace Granit.Activities.Endpoints.Dtos;
 

--- a/src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs
+++ b/src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs
@@ -9,11 +9,19 @@ public sealed record CreateActivityRequest(
     DateTimeOffset DueAt,
     string? Description = null);
 
-/// <summary>Body for <c>POST /api/activities/{id}/complete</c>.</summary>
-public sealed record CompleteActivityRequest(DateTimeOffset CompletedAt);
+/// <summary>
+/// Body for <c>POST /api/activities/{id}/complete</c>. The completion
+/// timestamp and the actor user id are resolved server-side
+/// (<c>IClock</c> + <c>ClaimsPrincipal</c>) for audit integrity.
+/// </summary>
+public sealed record CompleteActivityRequest;
 
-/// <summary>Body for <c>POST /api/activities/{id}/cancel</c>.</summary>
-public sealed record CancelActivityRequest(DateTimeOffset CancelledAt);
+/// <summary>
+/// Body for <c>POST /api/activities/{id}/cancel</c>. The cancellation
+/// timestamp and the actor user id are resolved server-side
+/// (<c>IClock</c> + <c>ClaimsPrincipal</c>) for audit integrity.
+/// </summary>
+public sealed record CancelActivityRequest;
 
 /// <summary>Body for <c>PUT /api/activities/{id}/assignee</c>.</summary>
 public sealed record ReassignActivityRequest(Guid NewAssigneeUserId);

--- a/src/Granit.Activities.Endpoints/Endpoints/ActivityCalendarEndpoint.cs
+++ b/src/Granit.Activities.Endpoints/Endpoints/ActivityCalendarEndpoint.cs
@@ -1,9 +1,9 @@
 using System.Security.Claims;
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Endpoints.Dtos;
 using Granit.Activities.Endpoints.Internal;
 using Granit.Activities.Endpoints.Options;
+using Granit.Activities.Persistence;
 using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.AspNetCore.Builder;

--- a/src/Granit.Activities.Endpoints/Endpoints/ActivityEndpoints.cs
+++ b/src/Granit.Activities.Endpoints/Endpoints/ActivityEndpoints.cs
@@ -1,9 +1,11 @@
-using Granit.Activities.Abstractions;
+using System.Security.Claims;
 using Granit.Activities.Domain;
 using Granit.Activities.Endpoints.Dtos;
 using Granit.Activities.Endpoints.Internal;
 using Granit.Activities.Endpoints.Options;
 using Granit.Activities.Endpoints.Permissions;
+using Granit.Activities.Persistence;
+using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -133,8 +135,12 @@ internal static class ActivityEndpoints
     private static async Task<Results<Created<ActivityResponse>, ProblemHttpResult>> CreateAsync(
         CreateActivityRequest request,
         [FromServices] IActivityWriter writer,
+        [FromServices] IOptions<ActivitiesEndpointsOptions> options,
+        ClaimsPrincipal user,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
+        Guid? actorId = ResolveCurrentUserId(user);
         try
         {
             Activity created = await writer.CreateAsync(
@@ -143,10 +149,12 @@ internal static class ActivityEndpoints
                 request.Type,
                 request.AssignedToUserId,
                 request.DueAt,
-                createdByUserId: null,
+                createdByUserId: actorId,
                 description: request.Description,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
-            return TypedResults.Created($"/api/activities/{created.Id}", created.ToResponse());
+
+            string baseUrl = httpContext.Request.PathBase.Add($"/{options.Value.RoutePrefix.Trim('/')}");
+            return TypedResults.Created($"{baseUrl}/{created.Id}", created.ToResponse());
         }
         catch (ArgumentException ex) when (ex.ParamName == "type")
         {
@@ -159,16 +167,45 @@ internal static class ActivityEndpoints
         CompleteActivityRequest request,
         [FromServices] IActivityWriter writer,
         [FromServices] IActivityReader reader,
-        CancellationToken cancellationToken) =>
-        ApplyMutationAsync(id, ct => writer.CompleteAsync(id, completedByUserId: Guid.Empty, request.CompletedAt, ct), reader, cancellationToken);
+        [FromServices] IClock clock,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        Guid? actorId = ResolveCurrentUserId(user);
+        if (actorId is null)
+        {
+            return Task.FromResult<Results<Ok<ActivityResponse>, ProblemHttpResult>>(
+                TypedResults.Problem(statusCode: StatusCodes.Status401Unauthorized));
+        }
+        DateTimeOffset at = clock.Normalize(clock.Now);
+        return ApplyMutationAsync(id, ct => writer.CompleteAsync(id, actorId.Value, at, ct), reader, cancellationToken);
+    }
 
     private static Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> CancelAsync(
         Guid id,
         CancelActivityRequest request,
         [FromServices] IActivityWriter writer,
         [FromServices] IActivityReader reader,
-        CancellationToken cancellationToken) =>
-        ApplyMutationAsync(id, ct => writer.CancelAsync(id, cancelledByUserId: Guid.Empty, request.CancelledAt, ct), reader, cancellationToken);
+        [FromServices] IClock clock,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        Guid? actorId = ResolveCurrentUserId(user);
+        if (actorId is null)
+        {
+            return Task.FromResult<Results<Ok<ActivityResponse>, ProblemHttpResult>>(
+                TypedResults.Problem(statusCode: StatusCodes.Status401Unauthorized));
+        }
+        DateTimeOffset at = clock.Normalize(clock.Now);
+        return ApplyMutationAsync(id, ct => writer.CancelAsync(id, actorId.Value, at, ct), reader, cancellationToken);
+    }
+
+    private static Guid? ResolveCurrentUserId(ClaimsPrincipal user)
+    {
+        string? sub = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        return Guid.TryParse(sub, out Guid id) ? id : null;
+    }
 
     private static Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> ReassignAsync(
         Guid id,

--- a/src/Granit.Activities.Endpoints/Extensions/ActivitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Activities.Endpoints/Extensions/ActivitiesEndpointRouteBuilderExtensions.cs
@@ -5,6 +5,8 @@ using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Activities.Endpoints.Extensions;
 
@@ -19,17 +21,21 @@ public static class ActivitiesEndpointRouteBuilderExtensions
     /// requires <c>Activities.Activities.Read</c>; per-endpoint write
     /// permissions (<c>Manage</c>, <c>Execute</c>) are layered on top.
     /// </summary>
+    /// <remarks>
+    /// Options are bound from the <c>ActivitiesEndpoints</c> configuration
+    /// section by <see cref="GranitActivitiesEndpointsModule"/>. Hosts that need
+    /// programmatic overrides should call
+    /// <c>services.Configure&lt;ActivitiesEndpointsOptions&gt;(...)</c> in their
+    /// composition root rather than mutating options here.
+    /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
-    /// <param name="configure">Optional delegate to customize options.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapGranitActivities(
-        this IEndpointRouteBuilder endpoints,
-        Action<ActivitiesEndpointsOptions>? configure = null)
+    public static RouteGroupBuilder MapGranitActivities(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
-        ActivitiesEndpointsOptions options = new();
-        configure?.Invoke(options);
+        ActivitiesEndpointsOptions options = endpoints.ServiceProvider
+            .GetRequiredService<IOptions<ActivitiesEndpointsOptions>>().Value;
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.RoutePrefix)

--- a/src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs
+++ b/src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs
@@ -1,7 +1,9 @@
+using Granit.Activities.Endpoints.Options;
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Activities.Endpoints;
 
@@ -15,8 +17,17 @@ namespace Granit.Activities.Endpoints;
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.
 /// </remarks>
 [DependsOn(
+    typeof(GranitActivitiesModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),
-    typeof(GranitActivitiesModule),
     typeof(GranitValidationModule))]
-public sealed class GranitActivitiesEndpointsModule : GranitModule;
+public sealed class GranitActivitiesEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddOptions<ActivitiesEndpointsOptions>()
+            .BindConfiguration(ActivitiesEndpointsOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+    }
+}

--- a/src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs
+++ b/src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs
@@ -21,21 +21,12 @@ public sealed class CreateActivityRequestValidator : AbstractValidator<CreateAct
     }
 }
 
-public sealed class CompleteActivityRequestValidator : AbstractValidator<CompleteActivityRequest>
-{
-    public CompleteActivityRequestValidator()
-    {
-        RuleFor(x => x.CompletedAt).NotEqual(default(DateTimeOffset));
-    }
-}
+// Empty validators — both request bodies carry no fields; the actor user id and
+// timestamp are resolved server-side. The architecture test requires every
+// *Request type to have a corresponding validator, so we ship no-op ones.
+public sealed class CompleteActivityRequestValidator : AbstractValidator<CompleteActivityRequest>;
 
-public sealed class CancelActivityRequestValidator : AbstractValidator<CancelActivityRequest>
-{
-    public CancelActivityRequestValidator()
-    {
-        RuleFor(x => x.CancelledAt).NotEqual(default(DateTimeOffset));
-    }
-}
+public sealed class CancelActivityRequestValidator : AbstractValidator<CancelActivityRequest>;
 
 public sealed class ReassignActivityRequestValidator : AbstractValidator<ReassignActivityRequest>
 {

--- a/src/Granit.Activities.EntityFrameworkCore/Extensions/ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/Extensions/ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,5 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.EntityFrameworkCore.Internal;
+using Granit.Activities.Persistence;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Granit.Activities.EntityFrameworkCore/GranitActivitiesEntityFrameworkCoreModule.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/GranitActivitiesEntityFrameworkCoreModule.cs
@@ -10,6 +10,6 @@ namespace Granit.Activities.EntityFrameworkCore;
 /// <c>AddGranitActivitiesEntityFrameworkCore(opts =&gt; opts.UseNpgsql(...))</c>.
 /// </summary>
 [DependsOn(
-    typeof(GranitPersistenceEntityFrameworkCoreModule),
-    typeof(GranitActivitiesModule))]
+    typeof(GranitActivitiesModule),
+    typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitActivitiesEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Activities.EntityFrameworkCore/Internal/EfCoreActivityReader.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/Internal/EfCoreActivityReader.cs
@@ -1,5 +1,5 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
+using Granit.Activities.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Activities.EntityFrameworkCore.Internal;

--- a/src/Granit.Activities.EntityFrameworkCore/Internal/EfCoreActivityWriter.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/Internal/EfCoreActivityWriter.cs
@@ -1,5 +1,6 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
+using Granit.Activities.Persistence;
+using Granit.Guids;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Activities.EntityFrameworkCore.Internal;
@@ -12,7 +13,8 @@ namespace Granit.Activities.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfCoreActivityWriter(
     IDbContextFactory<ActivitiesDbContext> contextFactory,
-    IActivityRegistry registry) : IActivityWriter
+    IActivityRegistry registry,
+    IGuidGenerator guidGenerator) : IActivityWriter
 {
     public async Task<Activity> CreateAsync(
         string entityType,
@@ -28,7 +30,7 @@ internal sealed class EfCoreActivityWriter(
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         var activity = Activity.Create(
-            id: Guid.CreateVersion7(),
+            id: guidGenerator.Create(),
             entityType: entityType,
             entityId: entityId,
             type: type,

--- a/src/Granit.Activities.Notifications/GranitActivitiesNotificationsModule.cs
+++ b/src/Granit.Activities.Notifications/GranitActivitiesNotificationsModule.cs
@@ -16,8 +16,8 @@ namespace Granit.Activities.Notifications;
 /// through <c>Granit.Templating</c>.
 /// </summary>
 [DependsOn(
-    typeof(GranitNotificationsAbstractionsModule),
     typeof(GranitActivitiesModule),
+    typeof(GranitNotificationsAbstractionsModule),
     typeof(GranitTemplatingModule))]
 public sealed class GranitActivitiesNotificationsModule : GranitModule
 {

--- a/src/Granit.Activities.Notifications/Handlers/ActivityAssignedHandler.cs
+++ b/src/Granit.Activities.Notifications/Handlers/ActivityAssignedHandler.cs
@@ -9,17 +9,11 @@ namespace Granit.Activities.Notifications.Handlers;
 /// notification to the assignee. Local-bus dispatch — fires within the same
 /// scope as the originating Create / Reassign.
 /// </summary>
-public class ActivityAssignedHandler : ILocalEventHandler<ActivityAssignedEvent>
+public class ActivityAssignedHandler(INotificationPublisher publisher)
+    : ILocalEventHandler<ActivityAssignedEvent>
 {
-    private readonly INotificationPublisher _publisher;
-
-    public ActivityAssignedHandler(INotificationPublisher publisher)
-    {
-        _publisher = publisher;
-    }
-
     public async Task HandleAsync(ActivityAssignedEvent evt, CancellationToken cancellationToken = default) =>
-        await _publisher.PublishAsync(
+        await publisher.PublishAsync(
             ActivityAssignedNotificationType.Instance,
             new ActivityAssignedNotificationData(
                 evt.ActivityId, evt.Type, evt.DueAt, evt.EntityType, evt.EntityId),

--- a/src/Granit.Activities.Notifications/Handlers/ActivityOverdueHandler.cs
+++ b/src/Granit.Activities.Notifications/Handlers/ActivityOverdueHandler.cs
@@ -10,17 +10,11 @@ namespace Granit.Activities.Notifications.Handlers;
 /// overdue-scan background job (story A8); idempotency on the row's
 /// <c>OverdueNotifiedAt</c> column guards against re-fires.
 /// </summary>
-public class ActivityOverdueHandler : ILocalEventHandler<ActivityOverdueEvent>
+public class ActivityOverdueHandler(INotificationPublisher publisher)
+    : ILocalEventHandler<ActivityOverdueEvent>
 {
-    private readonly INotificationPublisher _publisher;
-
-    public ActivityOverdueHandler(INotificationPublisher publisher)
-    {
-        _publisher = publisher;
-    }
-
     public async Task HandleAsync(ActivityOverdueEvent evt, CancellationToken cancellationToken = default) =>
-        await _publisher.PublishAsync(
+        await publisher.PublishAsync(
             ActivityOverdueNotificationType.Instance,
             new ActivityOverdueNotificationData(
                 evt.ActivityId, evt.Type, evt.DueAt, evt.OverdueByDays, evt.EntityType, evt.EntityId),

--- a/src/Granit.Activities.Notifications/Handlers/ActivityReminderHandler.cs
+++ b/src/Granit.Activities.Notifications/Handlers/ActivityReminderHandler.cs
@@ -9,17 +9,11 @@ namespace Granit.Activities.Notifications.Handlers;
 /// notification to the assignee. The event is raised by the activities
 /// reminder background job (story A8) the day before due-date.
 /// </summary>
-public class ActivityReminderHandler : ILocalEventHandler<ActivityReminderDueEvent>
+public class ActivityReminderHandler(INotificationPublisher publisher)
+    : ILocalEventHandler<ActivityReminderDueEvent>
 {
-    private readonly INotificationPublisher _publisher;
-
-    public ActivityReminderHandler(INotificationPublisher publisher)
-    {
-        _publisher = publisher;
-    }
-
     public async Task HandleAsync(ActivityReminderDueEvent evt, CancellationToken cancellationToken = default) =>
-        await _publisher.PublishAsync(
+        await publisher.PublishAsync(
             ActivityReminderNotificationType.Instance,
             new ActivityReminderNotificationData(
                 evt.ActivityId, evt.Type, evt.DueAt, evt.EntityType, evt.EntityId),

--- a/src/Granit.Activities/Diagnostics/ActivitiesActivitySource.cs
+++ b/src/Granit.Activities/Diagnostics/ActivitiesActivitySource.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+
+namespace Granit.Activities.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Activities distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class ActivitiesActivitySource
+{
+    /// <summary>The name of the Granit.Activities <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Activities";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    // ──── Operation names ────────────────────────────────────────────────────
+    internal const string Create = "activities.create";
+    internal const string Complete = "activities.complete";
+    internal const string Cancel = "activities.cancel";
+    internal const string Reassign = "activities.reassign";
+    internal const string Reschedule = "activities.reschedule";
+    internal const string OverdueScan = "activities.overdue_scan";
+    internal const string ReminderScan = "activities.reminder_scan";
+}

--- a/src/Granit.Activities/Diagnostics/ActivitiesMetrics.cs
+++ b/src/Granit.Activities/Diagnostics/ActivitiesMetrics.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Activities.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the Granit.Activities module.
+/// Meter: <c>Granit.Activities</c>.
+/// </summary>
+public sealed class ActivitiesMetrics
+{
+    /// <summary>Meter name — <c>Granit.Activities</c>.</summary>
+    public const string MeterName = "Granit.Activities";
+
+    private const string TagTenantId = "tenant_id";
+    private const string TagType = "type";
+    private const string DefaultTenant = "global";
+
+    private readonly Counter<long> _created;
+    private readonly Counter<long> _completed;
+    private readonly Counter<long> _cancelled;
+    private readonly Counter<long> _overdueNotified;
+    private readonly Counter<long> _reminderSent;
+
+    public ActivitiesMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _created = meter.CreateCounter<long>(
+            "granit.activities.activity.created",
+            description: "Number of activities created (Open state).");
+
+        _completed = meter.CreateCounter<long>(
+            "granit.activities.activity.completed",
+            description: "Number of activities transitioning to Done.");
+
+        _cancelled = meter.CreateCounter<long>(
+            "granit.activities.activity.cancelled",
+            description: "Number of activities transitioning to Cancelled.");
+
+        _overdueNotified = meter.CreateCounter<long>(
+            "granit.activities.activity.overdue_notified",
+            description: "Number of overdue notifications emitted by the background scan.");
+
+        _reminderSent = meter.CreateCounter<long>(
+            "granit.activities.activity.reminder_sent",
+            description: "Number of reminder events emitted for activities due tomorrow.");
+    }
+
+    public void RecordCreated(string? tenantId, string? type) =>
+        _created.Add(1, CreateTags(tenantId, type));
+
+    public void RecordCompleted(string? tenantId, string? type) =>
+        _completed.Add(1, CreateTags(tenantId, type));
+
+    public void RecordCancelled(string? tenantId, string? type) =>
+        _cancelled.Add(1, CreateTags(tenantId, type));
+
+    public void RecordOverdueNotified(string? tenantId, string? type) =>
+        _overdueNotified.Add(1, CreateTags(tenantId, type));
+
+    public void RecordReminderSent(string? tenantId, string? type) =>
+        _reminderSent.Add(1, CreateTags(tenantId, type));
+
+    private static TagList CreateTags(string? tenantId, string? type) => new()
+    {
+        { TagTenantId, tenantId ?? DefaultTenant },
+        { TagType, type ?? string.Empty },
+    };
+}

--- a/src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs
+++ b/src/Granit.Activities/Extensions/ActivitiesServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Activities.Diagnostics;
 using Granit.Activities.Domain;
 using Granit.Activities.Exports;
 using Granit.Activities.Extensions;
@@ -6,8 +7,10 @@ using Granit.Activities.Metrics;
 using Granit.Activities.Queries;
 using Granit.Analytics.Extensions;
 using Granit.DataExchange.Extensions;
+using Granit.Diagnostics;
 using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Activities.Extensions;
 
@@ -20,13 +23,18 @@ public static class ActivitiesServiceCollectionExtensions
     /// Registers the runtime <see cref="IActivityRegistry"/> plus the framework's
     /// <see cref="StandardActivityTypeProvider"/> (ToDo / Call / Meeting / Email),
     /// the <see cref="ActivityQueryDefinition"/> / <see cref="ActivityExportDefinition"/>
-    /// pairing for the admin grid, and the open / overdue activity-count metrics.
+    /// pairing for the admin grid, the open / overdue activity-count metrics, and
+    /// the <see cref="ActivitiesMetrics"/> meter + <c>Granit.Activities</c>
+    /// <see cref="System.Diagnostics.ActivitySource"/>.
     /// Hosts that want a strictly custom catalog can call this and then remove
     /// the standard provider before <c>BuildServiceProvider</c>.
     /// </summary>
     public static IServiceCollection AddGranitActivities(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        GranitActivitySourceRegistry.Register(ActivitiesActivitySource.Name);
+        services.TryAddSingleton<ActivitiesMetrics>();
 
         services.AddActivityTypeProvider<StandardActivityTypeProvider>();
         services.AddSingleton<IActivityRegistry, ActivityRegistry>();

--- a/src/Granit.Activities/Internal/ActivityRegistry.cs
+++ b/src/Granit.Activities/Internal/ActivityRegistry.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Granit.Activities.Internal;
 
 /// <summary>
@@ -36,9 +38,9 @@ internal sealed class ActivityRegistry : IActivityRegistry
     public IReadOnlyDictionary<string, ActivityType> All => _byName;
 
     /// <inheritdoc/>
-    public bool TryGet(string name, out ActivityType type)
+    public bool TryGet(string name, [NotNullWhen(true)] out ActivityType? type)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        return _byName.TryGetValue(name, out type!);
+        return _byName.TryGetValue(name, out type);
     }
 }

--- a/src/Granit.Activities/Persistence/IActivityReader.cs
+++ b/src/Granit.Activities/Persistence/IActivityReader.cs
@@ -1,6 +1,6 @@
 using Granit.Activities.Domain;
 
-namespace Granit.Activities.Abstractions;
+namespace Granit.Activities.Persistence;
 
 /// <summary>
 /// Read operations for activities. Hosts wire <c>EfCoreActivityReader</c> via

--- a/src/Granit.Activities/Persistence/IActivityWriter.cs
+++ b/src/Granit.Activities/Persistence/IActivityWriter.cs
@@ -1,6 +1,6 @@
 using Granit.Activities.Domain;
 
-namespace Granit.Activities.Abstractions;
+namespace Granit.Activities.Persistence;
 
 /// <summary>
 /// Write operations on the activity aggregate. Each method loads the row,

--- a/tests/Granit.Activities.BackgroundJobs.Tests/MarkOverdueScanServiceTests.cs
+++ b/tests/Granit.Activities.BackgroundJobs.Tests/MarkOverdueScanServiceTests.cs
@@ -1,8 +1,8 @@
 using Granit.Activities;
-using Granit.Activities.Abstractions;
 using Granit.Activities.BackgroundJobs.Services;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
+using Granit.Activities.Persistence;
 using Granit.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,7 +19,7 @@ public sealed class MarkOverdueScanServiceTests
     private static IActivityRegistry RegistryWithToDo()
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = StandardActivityTypes.ToDo;
             return true;

--- a/tests/Granit.Activities.BackgroundJobs.Tests/SendRemindersScanServiceTests.cs
+++ b/tests/Granit.Activities.BackgroundJobs.Tests/SendRemindersScanServiceTests.cs
@@ -1,8 +1,8 @@
 using Granit.Activities;
-using Granit.Activities.Abstractions;
 using Granit.Activities.BackgroundJobs.Services;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
+using Granit.Activities.Persistence;
 using Granit.Events;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,7 +18,7 @@ public sealed class SendRemindersScanServiceTests
     private static IActivityRegistry RegistryWithToDo()
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = StandardActivityTypes.ToDo;
             return true;

--- a/tests/Granit.Activities.Endpoints.Tests/ActivityCalendarCacheInvalidatorTests.cs
+++ b/tests/Granit.Activities.Endpoints.Tests/ActivityCalendarCacheInvalidatorTests.cs
@@ -1,6 +1,6 @@
-using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Endpoints.Internal;
+using Granit.Activities.Persistence;
 using Granit.Events;
 using NSubstitute;
 using Shouldly;
@@ -14,7 +14,7 @@ public sealed class ActivityCalendarCacheInvalidatorTests
     private static IActivityRegistry RegistryWithToDo()
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = StandardActivityTypes.ToDo;
             return true;

--- a/tests/Granit.Activities.Endpoints.Tests/ActivityResponseMapperTests.cs
+++ b/tests/Granit.Activities.Endpoints.Tests/ActivityResponseMapperTests.cs
@@ -12,7 +12,7 @@ public sealed class ActivityResponseMapperTests
     private static IActivityRegistry RegistryWithToDo()
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = StandardActivityTypes.ToDo;
             return true;

--- a/tests/Granit.Activities.EntityFrameworkCore.Tests/MarkOverdueNotifiedTests.cs
+++ b/tests/Granit.Activities.EntityFrameworkCore.Tests/MarkOverdueNotifiedTests.cs
@@ -11,7 +11,7 @@ public sealed class MarkOverdueNotifiedTests
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
         ActivityType type = StandardActivityTypes.ToDo;
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = type;
             return true;

--- a/tests/Granit.Activities.Tests/Domain/ActivityTests.cs
+++ b/tests/Granit.Activities.Tests/Domain/ActivityTests.cs
@@ -18,7 +18,7 @@ public sealed class ActivityTests
     {
         IActivityRegistry registry = Substitute.For<IActivityRegistry>();
         ActivityType type = StandardActivityTypes.ToDo;
-        registry.TryGet("ToDo", out Arg.Any<ActivityType>()).Returns(call =>
+        registry.TryGet("ToDo", out Arg.Any<ActivityType?>()).Returns(call =>
         {
             call[1] = type;
             return true;
@@ -54,7 +54,7 @@ public sealed class ActivityTests
     public void Create_throws_when_type_not_in_registry()
     {
         IActivityRegistry empty = Substitute.For<IActivityRegistry>();
-        empty.TryGet(Arg.Any<string>(), out Arg.Any<ActivityType>()).Returns(false);
+        empty.TryGet(Arg.Any<string>(), out Arg.Any<ActivityType?>()).Returns(false);
 
         Should.Throw<ArgumentException>(() => Activity.Create(
             Guid.NewGuid(), SampleEntityType, SampleEntityId,

--- a/tests/Granit.ArchitectureTests/ClassDesignTests.cs
+++ b/tests/Granit.ArchitectureTests/ClassDesignTests.cs
@@ -44,7 +44,13 @@ public sealed class ClassDesignTests
             Architecture, "Granit.",
             // Wolverine requires middleware constructor parameters to be public,
             // even when the interface is an internal implementation detail.
-            "Granit.Wolverine.Internal.IWolverineUserContextSetter");
+            "Granit.Wolverine.Internal.IWolverineUserContextSetter",
+            // ADR-053 §5 layer-4 extension point: Granit.Entities.Customization.Endpoints
+            // replaces the default no-op via services.Replace, which requires the
+            // interface to be visible across assemblies. The framework keeps the
+            // applier name in the Internal namespace because callers should never
+            // resolve it directly — only the composer pipeline does.
+            "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier");
 
     [Fact]
     public void Concrete_exception_classes_should_be_sealed() =>

--- a/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
@@ -41,13 +41,13 @@ public sealed class EntityActivitiesManifestTests
         foreach (string name in knownTypeNames)
         {
             ActivityType captured = dict[name];
-            registry.TryGet(name, out Arg.Any<ActivityType>()).Returns(call =>
+            registry.TryGet(name, out Arg.Any<ActivityType?>()).Returns(call =>
             {
                 call[1] = captured;
                 return true;
             });
         }
-        registry.TryGet(Arg.Is<string>(s => !knownTypeNames.Contains(s, StringComparer.Ordinal)), out Arg.Any<ActivityType>())
+        registry.TryGet(Arg.Is<string>(s => !knownTypeNames.Contains(s, StringComparer.Ordinal)), out Arg.Any<ActivityType?>())
             .Returns(false);
         return registry;
     }


### PR DESCRIPTION
## Summary

Applies the BREAKING + ARCHITECTURE + CONVENTION findings from `/audit Granit.Activities.*` on the new modules shipped under epic #1795.

### BREAKING

- `Complete` / `Cancel` endpoints used to pass `Guid.Empty` for the actor user id (which the domain rejects with `ArgumentException`) and a client-controlled `DateTimeOffset` for the timestamp — every call returned 400. Now resolves the actor from `ClaimsPrincipal` (`NameIdentifier` / `sub` claim) and the instant from `IClock`. Request bodies become empty marker records; no-op validators kept to satisfy the architecture rule.
- `EfCoreActivityWriter.CreateAsync` called `Guid.CreateVersion7()` directly. Now injects `IGuidGenerator` (GRSEC002 family).

### ARCHITECTURE

- `IActivityReader`, `IActivityWriter`, `ActivityListFilter`, `ActivityStatusFilter` lived in `namespace Granit.Activities.Abstractions` inside the **runtime** `Granit.Activities` project — a namespace that collides with the actual `Granit.Activities.Abstractions` package name. Moved them to `Granit.Activities.Persistence` so the namespace no longer shadows an unrelated package.

### CONVENTION

- New `Diagnostics/` folder: `ActivitiesMetrics` (`IMeterFactory`, meter `Granit.Activities`, counters for create/complete/cancel/overdue/reminder) + `ActivitiesActivitySource` registered via `GranitActivitySourceRegistry` from `AddGranitActivities`.
- `ActivitiesEndpointsOptions` now bound from the `ActivitiesEndpoints` configuration section in `GranitActivitiesEndpointsModule.ConfigureServices` with `BindConfiguration` + `ValidateDataAnnotations` + `ValidateOnStart`. `MapGranitActivities` resolves the bound options from DI; the inline `Action<>` callback on the route extension is removed (use `services.Configure<>` for programmatic overrides).
- Notification handlers (`ActivityAssignedHandler`, `ActivityReminderHandler`, `ActivityOverdueHandler`) switched to primary constructors.
- `Created` `Location` URL composed from `HttpContext.Request.PathBase` + `RoutePrefix` instead of hardcoded `/api/activities/{id}` — works regardless of where the host mounts the group.
- `IActivityRegistry.TryGet` signature uses `[NotNullWhen(true)] out ActivityType?` matching how the calendar endpoint already calls it; `Substitute.For<>` setups updated.
- `[DependsOn]` entries sorted alphabetically across `EntityFrameworkCore`, `Endpoints`, `BackgroundJobs`, `Notifications` modules.

### Skipped (out of scope for this PR)

- Dedicated docs page under `docs-site/src/content/docs/dotnet/business/activities.mdx` — bigger work, will land separately.
- `[FromServices]` marker on `ActivityEndpoints.ApplyMutationAsync` — the fix belongs in the architecture test (it static-text-scans private methods), not in the production code.
- `activity.*` → `activities.*` notification template prefix rename — cosmetic, would churn 6 template files + the layout glob.
- PUT vs POST for `reassign` / `due-date` — semantic API decision, not a clear-cut violation.

## Test plan

- [x] `dotnet format --verify-no-changes` clean on all 6 src projects + 2 affected test projects
- [x] All Activities unit tests pass (87/87 across the 6 test projects)
- [x] Cross-cutting `Granit.Entities.Endpoints.Tests` (consumes the registry mock pattern) — 86/86 pass
- [x] `Granit.ArchitectureTests` — 208/210 (the 2 remaining failures are pre-existing on `develop` in `Granit.Taxonomy`, unrelated to this branch)
- [ ] Smoke-test the Complete/Cancel endpoints in the showcase host once merged