### PR TITLE
[T4.1] feat(taxonomy): Category aggregate + tree-path materialisation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55576,6 +55576,80 @@
           "kind": "method",
           "signature": "RecordAssignmentDeleted(string? tenantId, string targetType)",
           "returnType": "void"
+        },
+        {
+          "name": "RecordCategoryCreated",
+          "kind": "method",
+          "signature": "RecordCategoryCreated(string? tenantId, string scope)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCategoryDeleted",
+          "kind": "method",
+          "signature": "RecordCategoryDeleted(string? tenantId, string scope)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCategoryAssignmentChanged",
+          "kind": "method",
+          "signature": "RecordCategoryAssignmentChanged(string? tenantId, string targetType)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "Category",
+      "fqn": "Granit.Taxonomy.Domain.Category",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Domain/Category.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "CreateRoot",
+          "kind": "method",
+          "signature": "CreateRoot(Guid id, Guid? tenantId, string scope, string name, string? iconName = null, bool hideOnEntityCard = false)",
+          "returnType": "Category"
+        },
+        {
+          "name": "ParentId",
+          "kind": "property",
+          "signature": "Guid? ParentId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "Path",
+          "kind": "property",
+          "signature": "string Path",
+          "returnType": "string"
+        },
+        {
+          "name": "Rename",
+          "kind": "method",
+          "signature": "Rename(string newName)",
+          "returnType": "int Depth { get; private set; } public string? IconName { get; private set; } public bool HideOnEntityCard { get; private set; } public uint RowVersion { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "CategoryAssignment",
+      "fqn": "Granit.Taxonomy.Domain.CategoryAssignment",
+      "kind": "class",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Domain/CategoryAssignment.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid? tenantId, Guid categoryId, string targetType, Guid targetId, Guid assignedByUserId, DateTimeOffset assignedAt)",
+          "returnType": "CategoryAssignment"
+        },
+        {
+          "name": "ValidateTargetType",
+          "kind": "method",
+          "signature": "ValidateTargetType(string targetType)",
+          "returnType": "Guid TargetId { get; private set; } public DateTimeOffset AssignedAt { get; private set; } public Guid AssignedByUserId { get; private set; } private void"
         }
       ]
     },
@@ -55848,6 +55922,60 @@
       "members": []
     },
     {
+      "name": "CategoryAssignmentChangedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryAssignmentChangedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryAssignmentChangedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CategoryCreatedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryCreatedEvent.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CategoryDeletedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryDeletedEvent.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CategoryMovedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryMovedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryMovedEvent.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CategoryRenamedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryRenamedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryRenamedEvent.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CategoryTreePathChangedEvent",
+      "fqn": "Granit.Taxonomy.Events.CategoryTreePathChangedEvent",
+      "kind": "record",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/Events/CategoryTreePathChangedEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "TagCreatedEvent",
       "fqn": "Granit.Taxonomy.Events.TagCreatedEvent",
       "kind": "record",
@@ -55916,6 +56044,98 @@
       "file": "src/Granit.Taxonomy/GranitTaxonomyModule.cs",
       "line": 23,
       "members": []
+    },
+    {
+      "name": "ICategoryAssignmentService",
+      "fqn": "Granit.Taxonomy.ICategoryAssignmentService",
+      "kind": "interface",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ICategoryAssignmentService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AssignAsync",
+          "kind": "method",
+          "signature": "AssignAsync(Guid categoryId, string targetType, Guid targetId, Guid assignedByUserId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<CategoryAssignment>"
+        },
+        {
+          "name": "UnassignAsync",
+          "kind": "method",
+          "signature": "UnassignAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetForTargetAsync",
+          "kind": "method",
+          "signature": "GetForTargetAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "RemoveAllAssignmentsAsync",
+          "kind": "method",
+          "signature": "RemoveAllAssignmentsAsync(string targetType, Guid targetId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "ICategoryService",
+      "fqn": "Granit.Taxonomy.ICategoryService",
+      "kind": "interface",
+      "project": "Granit.Taxonomy",
+      "file": "src/Granit.Taxonomy/ICategoryService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string scope, Guid? parentId, string name, string? iconName = null, bool hideOnEntityCard = false, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category>"
+        },
+        {
+          "name": "RenameAsync",
+          "kind": "method",
+          "signature": "RenameAsync(Guid id, string newName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "MoveAsync",
+          "kind": "method",
+          "signature": "MoveAsync(Guid id, Guid? newParentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "SetIconAsync",
+          "kind": "method",
+          "signature": "SetIconAsync(Guid id, string? iconName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "ToggleHideAsync",
+          "kind": "method",
+          "signature": "ToggleHideAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetByIdAsync",
+          "kind": "method",
+          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Category?>"
+        },
+        {
+          "name": "ListByScopeAsync",
+          "kind": "method",
+          "signature": "ListByScopeAsync(string scope, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Category>>"
+        }
+      ]
     },
     {
       "name": "ITagAssignmentService",

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -31,6 +31,8 @@ public static class TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddScoped<ITagService, TagService>();
         builder.Services.AddScoped<ITagAssignmentService, TagAssignmentService>();
         builder.Services.AddScoped<ITagSearchService, TagSearchService>();
+        builder.Services.AddScoped<ICategoryService, CategoryService>();
+        builder.Services.AddScoped<ICategoryAssignmentService, CategoryAssignmentService>();
 
         return builder;
     }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyModelBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyModelBuilderExtensions.cs
@@ -17,6 +17,8 @@ public static class TaxonomyModelBuilderExtensions
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfiguration(new TagConfiguration());
         modelBuilder.ApplyConfiguration(new TagAssignmentConfiguration());
+        modelBuilder.ApplyConfiguration(new CategoryConfiguration());
+        modelBuilder.ApplyConfiguration(new CategoryAssignmentConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryAssignmentConfiguration.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryAssignmentConfiguration.cs
@@ -1,0 +1,44 @@
+using Granit.Taxonomy.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="CategoryAssignment"/>.
+/// Table: <c>taxonomy_category_assignments</c>.
+/// </summary>
+internal sealed class CategoryAssignmentConfiguration : IEntityTypeConfiguration<CategoryAssignment>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<CategoryAssignment> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitTaxonomyDbProperties.DbTablePrefix + "category_assignments",
+            GranitTaxonomyDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+        builder.Property(e => e.CategoryId).IsRequired();
+        builder.Property(e => e.TargetType)
+            .HasMaxLength(CategoryAssignment.MaxTargetTypeLength)
+            .IsRequired();
+        builder.Property(e => e.TargetId).IsRequired();
+        builder.Property(e => e.AssignedAt).IsRequired();
+        builder.Property(e => e.AssignedByUserId).IsRequired();
+
+        // Single-category-per-target invariant (ADR-054, opposite of TagAssignment).
+        builder.HasIndex(e => new { e.TenantId, e.TargetType, e.TargetId })
+            .IsUnique()
+            .HasDatabaseName(
+                $"ux_{GranitTaxonomyDbProperties.DbTablePrefix}category_assignments_tenant_target");
+
+        // "Things classified under category X" lookup.
+        builder.HasIndex(e => new { e.TenantId, e.CategoryId })
+            .HasDatabaseName(
+                $"ix_{GranitTaxonomyDbProperties.DbTablePrefix}category_assignments_tenant_category");
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryAssignmentService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryAssignmentService.cs
@@ -1,0 +1,171 @@
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Events;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ICategoryAssignmentService"/>. A
+/// target carries at most one category — re-assigning the same target updates the
+/// existing row instead of creating a duplicate (enforced by the unique index on
+/// <c>(TenantId, TargetType, TargetId)</c>).
+/// </summary>
+internal sealed class CategoryAssignmentService(
+    IDbContextFactory<TaxonomyDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IClock clock,
+    ILocalEventBus localEventBus,
+    TaxonomyMetrics metrics) : ICategoryAssignmentService
+{
+    /// <inheritdoc />
+    public async Task<CategoryAssignment> AssignAsync(
+        Guid categoryId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+
+        CategoryAssignment? existing = await context.CategoryAssignments
+            .FirstOrDefaultAsync(
+                a => a.TenantId == tenantId && a.TargetType == targetType && a.TargetId == targetId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? oldCategoryId = existing?.CategoryId;
+
+        if (existing is not null)
+        {
+            existing.ChangeCategory(categoryId, assignedByUserId, clock.Now);
+        }
+        else
+        {
+            existing = CategoryAssignment.Create(
+                guidGenerator.Create(),
+                tenantId,
+                categoryId,
+                targetType,
+                targetId,
+                assignedByUserId,
+                clock.Now);
+            context.CategoryAssignments.Add(existing);
+        }
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (oldCategoryId != categoryId)
+        {
+            metrics.RecordCategoryAssignmentChanged(tenantId?.ToString(), targetType);
+            await localEventBus.PublishAsync(
+                new CategoryAssignmentChangedEvent(
+                    tenantId, targetType, targetId, oldCategoryId, categoryId),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return existing;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UnassignAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        CategoryAssignment? assignment = await context.CategoryAssignments
+            .FirstOrDefaultAsync(
+                a => a.TargetType == targetType && a.TargetId == targetId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (assignment is null)
+        {
+            return false;
+        }
+
+        Guid removedCategoryId = assignment.CategoryId;
+        Guid? tenantId = assignment.TenantId;
+
+        context.CategoryAssignments.Remove(assignment);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        metrics.RecordCategoryAssignmentChanged(tenantId?.ToString(), targetType);
+        await localEventBus.PublishAsync(
+            new CategoryAssignmentChangedEvent(
+                tenantId, targetType, targetId, removedCategoryId, NewCategoryId: null),
+            cancellationToken).ConfigureAwait(false);
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> GetForTargetAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.CategoryAssignments
+            .AsNoTracking()
+            .Where(a => a.TargetType == targetType && a.TargetId == targetId)
+            .Join(
+                context.Categories.AsNoTracking(),
+                assignment => assignment.CategoryId,
+                category => category.Id,
+                (_, category) => category)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> RemoveAllAssignmentsAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<CategoryAssignment> rows = await context.CategoryAssignments
+            .Where(a => a.TargetType == targetType && a.TargetId == targetId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (rows.Count == 0)
+        {
+            return 0;
+        }
+
+        context.CategoryAssignments.RemoveRange(rows);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        foreach (CategoryAssignment row in rows)
+        {
+            metrics.RecordCategoryAssignmentChanged(row.TenantId?.ToString(), row.TargetType);
+        }
+        return rows.Count;
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryConfiguration.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryConfiguration.cs
@@ -1,0 +1,55 @@
+using Granit.Taxonomy.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="Category"/>.
+/// Table: <c>taxonomy_categories</c>.
+/// </summary>
+internal sealed class CategoryConfiguration : IEntityTypeConfiguration<Category>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Category> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitTaxonomyDbProperties.DbTablePrefix + "categories",
+            GranitTaxonomyDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+        builder.Property(e => e.Scope)
+            .HasMaxLength(Category.MaxScopeLength)
+            .IsRequired();
+        builder.Property(e => e.ParentId);
+        builder.Property(e => e.Name)
+            .HasMaxLength(Category.MaxNameLength)
+            .IsRequired();
+        builder.Property(e => e.Path)
+            .HasMaxLength(Category.MaxPathLength)
+            .IsRequired();
+        builder.Property(e => e.Depth).IsRequired();
+        builder.Property(e => e.IconName).HasMaxLength(Category.MaxIconNameLength);
+        builder.Property(e => e.HideOnEntityCard).IsRequired();
+
+        builder.Property(e => e.RowVersion)
+            .IsRequired()
+            .IsConcurrencyToken();
+
+        // Sibling-name uniqueness within scope: two children of the same parent
+        // cannot share a name (mirrors UX_documents_folders_sibling_name).
+        builder.HasIndex(e => new { e.TenantId, e.Scope, e.ParentId, e.Name })
+            .IsUnique()
+            .HasDatabaseName(
+                $"ux_{GranitTaxonomyDbProperties.DbTablePrefix}categories_sibling_name");
+
+        // Subtree prefix scans (move re-materialisation, descendant queries).
+        builder.HasIndex(e => new { e.TenantId, e.Path })
+            .HasDatabaseName(
+                $"ix_{GranitTaxonomyDbProperties.DbTablePrefix}categories_tenant_path");
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryService.cs
@@ -1,0 +1,316 @@
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Events;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ICategoryService"/>. <see cref="MoveAsync"/>
+/// re-materialises descendant paths in a single <c>ExecuteUpdate</c>, mirroring
+/// <c>FolderService.MoveAsync</c> from <c>Granit.Documents</c>.
+/// </summary>
+internal sealed class CategoryService(
+    IDbContextFactory<TaxonomyDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    ILocalEventBus localEventBus,
+    TaxonomyMetrics metrics) : ICategoryService
+{
+    /// <inheritdoc />
+    public async Task<Category> CreateAsync(
+        string scope,
+        Guid? parentId,
+        string name,
+        string? iconName = null,
+        bool hideOnEntityCard = false,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        Category category;
+
+        if (parentId is { } parentGuid)
+        {
+            Category? parent = await context.Categories
+                .FirstOrDefaultAsync(c => c.Id == parentGuid, cancellationToken)
+                .ConfigureAwait(false);
+            if (parent is null)
+            {
+                throw new InvalidOperationException(
+                    $"Parent category {parentGuid} was not found.");
+            }
+            if (!string.Equals(parent.Scope, scope, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Parent category {parentGuid} is in scope '{parent.Scope}', not '{scope}'.");
+            }
+            category = Category.Create(
+                guidGenerator.Create(), parent, name, iconName, hideOnEntityCard);
+        }
+        else
+        {
+            category = Category.CreateRoot(
+                guidGenerator.Create(), tenantId, scope, name, iconName, hideOnEntityCard);
+        }
+
+        context.Categories.Add(category);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        metrics.RecordCategoryCreated(tenantId?.ToString(), scope);
+        return category;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> RenameAsync(
+        Guid id,
+        string newName,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? category = await context.Categories
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (category is null)
+        {
+            return null;
+        }
+
+        string oldPath = category.Path;
+        category.Rename(newName);
+        string newPath = category.Path;
+        int affectedDescendants = 0;
+
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            affectedDescendants = await ReMaterialiseDescendantsAsync(
+                context, category, oldPath, newPath, depthDelta: 0, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            await localEventBus.PublishAsync(
+                new CategoryTreePathChangedEvent(
+                    category.Id, category.TenantId, oldPath, newPath, affectedDescendants),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return category;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> MoveAsync(
+        Guid id,
+        Guid? newParentId,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? category = await context.Categories
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (category is null)
+        {
+            return null;
+        }
+
+        Category? newParent = null;
+        if (newParentId is { } parentGuid)
+        {
+            newParent = await context.Categories
+                .FirstOrDefaultAsync(c => c.Id == parentGuid, cancellationToken)
+                .ConfigureAwait(false);
+            if (newParent is null)
+            {
+                throw new InvalidOperationException(
+                    $"Target parent category {parentGuid} was not found.");
+            }
+        }
+
+        string oldPath = category.Path;
+        int oldDepth = category.Depth;
+
+        category.MoveTo(newParent);
+
+        string newPath = category.Path;
+        int newDepth = category.Depth;
+        int affectedDescendants = 0;
+
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            int depthDelta = newDepth - oldDepth;
+            affectedDescendants = await ReMaterialiseDescendantsAsync(
+                context, category, oldPath, newPath, depthDelta, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!string.Equals(oldPath, newPath, StringComparison.Ordinal))
+        {
+            await localEventBus.PublishAsync(
+                new CategoryTreePathChangedEvent(
+                    category.Id, category.TenantId, oldPath, newPath, affectedDescendants),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return category;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> SetIconAsync(
+        Guid id,
+        string? iconName,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? category = await context.Categories
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (category is null)
+        {
+            return null;
+        }
+
+        category.SetIcon(iconName);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return category;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> ToggleHideAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? category = await context.Categories
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (category is null)
+        {
+            return null;
+        }
+
+        category.ToggleHideOnEntityCard();
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return category;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? category = await context.Categories
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (category is null)
+        {
+            return false;
+        }
+
+        bool hasChildren = await context.Categories
+            .AnyAsync(c => c.ParentId == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (hasChildren)
+        {
+            throw new InvalidOperationException(
+                $"Category {id} has descendants. Move or delete them first.");
+        }
+
+        category.MarkDeleted();
+        context.Categories.Remove(category);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        metrics.RecordCategoryDeleted(category.TenantId?.ToString(), category.Scope);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<Category?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.Categories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Category>> ListByScopeAsync(
+        string scope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.Categories
+            .AsNoTracking()
+            .Where(c => c.Scope == scope)
+            .OrderBy(c => c.Path)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Bulk-updates every descendant of <paramref name="category"/>: rewrites
+    /// <c>Path</c> by replacing the old prefix with the new one and shifts
+    /// <c>Depth</c> by <paramref name="depthDelta"/>. Single SQL <c>UPDATE</c>.
+    /// </summary>
+    private static async Task<int> ReMaterialiseDescendantsAsync(
+        TaxonomyDbContext context,
+        Category category,
+        string oldPath,
+        string newPath,
+        int depthDelta,
+        CancellationToken cancellationToken)
+    {
+        string descendantPrefix = oldPath + Category.PathSeparator;
+        int oldPrefixLength = oldPath.Length;
+
+        // CA1845 (Substring vs AsSpan) does not apply to EF Core expression trees:
+        // ExecuteUpdateAsync translates Substring() to SQL SUBSTRING; AsSpan has no
+        // SQL equivalent.
+#pragma warning disable CA1845
+        return await context.Categories
+            .Where(c => c.TenantId == category.TenantId
+                && c.Id != category.Id
+                && c.Path.StartsWith(descendantPrefix))
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(c => c.Path, c => newPath + c.Path.Substring(oldPrefixLength))
+                .SetProperty(c => c.Depth, c => c.Depth + depthDelta),
+                cancellationToken)
+            .ConfigureAwait(false);
+#pragma warning restore CA1845
+    }
+}

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TaxonomyDbContext.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/TaxonomyDbContext.cs
@@ -30,6 +30,15 @@ internal sealed class TaxonomyDbContext(
     /// </summary>
     public DbSet<TagAssignment> TagAssignments { get; set; } = null!;
 
+    /// <summary>Hierarchical categories — single-assignment classification (ADR-054 / T4.1).</summary>
+    public DbSet<Category> Categories { get; set; } = null!;
+
+    /// <summary>
+    /// Polymorphic category assignments — links a single <see cref="Category"/> to a
+    /// target aggregate. Uniqueness enforced on <c>(TenantId, TargetType, TargetId)</c>.
+    /// </summary>
+    public DbSet<CategoryAssignment> CategoryAssignments { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
+++ b/src/Granit.Taxonomy/Diagnostics/TaxonomyMetrics.cs
@@ -27,6 +27,9 @@ public sealed class TaxonomyMetrics
     private readonly Counter<long> _tagsDeleted;
     private readonly Counter<long> _assignmentsCreated;
     private readonly Counter<long> _assignmentsDeleted;
+    private readonly Counter<long> _categoriesCreated;
+    private readonly Counter<long> _categoriesDeleted;
+    private readonly Counter<long> _categoryAssignmentsChanged;
 
     /// <summary>Initialises the meter and counters.</summary>
     public TaxonomyMetrics(IMeterFactory meterFactory)
@@ -50,6 +53,18 @@ public sealed class TaxonomyMetrics
         _assignmentsDeleted = meter.CreateCounter<long>(
             "granit.taxonomy.assignment.deleted",
             description: "Number of tag assignments removed (includes orphan-cleanup deletions).");
+
+        _categoriesCreated = meter.CreateCounter<long>(
+            "granit.taxonomy.category.created",
+            description: "Number of categories created.");
+
+        _categoriesDeleted = meter.CreateCounter<long>(
+            "granit.taxonomy.category.deleted",
+            description: "Number of categories deleted.");
+
+        _categoryAssignmentsChanged = meter.CreateCounter<long>(
+            "granit.taxonomy.category_assignment.changed",
+            description: "Number of category assignment changes (initial assign, re-assign, unassign).");
     }
 
     /// <summary>Records a tag-creation event in <paramref name="scope"/> for <paramref name="tenantId"/>.</summary>
@@ -67,6 +82,18 @@ public sealed class TaxonomyMetrics
     /// <summary>Records a tag-assignment row deletion.</summary>
     public void RecordAssignmentDeleted(string? tenantId, string targetType) =>
         _assignmentsDeleted.Add(1, CreateAssignmentTags(tenantId, targetType));
+
+    /// <summary>Records a category-creation event in <paramref name="scope"/>.</summary>
+    public void RecordCategoryCreated(string? tenantId, string scope) =>
+        _categoriesCreated.Add(1, CreateTagTags(tenantId, scope));
+
+    /// <summary>Records a category-deletion event.</summary>
+    public void RecordCategoryDeleted(string? tenantId, string scope) =>
+        _categoriesDeleted.Add(1, CreateTagTags(tenantId, scope));
+
+    /// <summary>Records a category-assignment change (assign / re-assign / unassign).</summary>
+    public void RecordCategoryAssignmentChanged(string? tenantId, string targetType) =>
+        _categoryAssignmentsChanged.Add(1, CreateAssignmentTags(tenantId, targetType));
 
     private static TagList CreateTagTags(string? tenantId, string scope) => new()
     {

--- a/src/Granit.Taxonomy/Domain/Category.cs
+++ b/src/Granit.Taxonomy/Domain/Category.cs
@@ -1,0 +1,301 @@
+using Granit.Domain;
+using Granit.Taxonomy.Events;
+
+namespace Granit.Taxonomy.Domain;
+
+/// <summary>
+/// Hierarchical category aggregate root — single-assignment classification per
+/// ADR-054. Mirrors the <c>Folder</c> pattern from ADR-052: parent / child tree
+/// with materialised path for fast subtree queries (e.g. "every category under
+/// /electronics").
+/// </summary>
+/// <remarks>
+/// Path convention: every category — root or child — has a <see cref="Path"/>
+/// that starts with <c>"/"</c>, e.g. <c>"/electronics"</c> for a root and
+/// <c>"/electronics/laptops"</c> for a child. Re-materialisation on move is
+/// performed by <c>CategoryService.MoveAsync</c> with a single
+/// <c>ExecuteUpdate</c>.
+/// </remarks>
+public sealed class Category : AggregateRoot, IMultiTenant
+{
+    /// <summary>Path component separator.</summary>
+    public const string PathSeparator = "/";
+
+    /// <summary>Maximum length, in characters, of <see cref="Path"/>.</summary>
+    public const int MaxPathLength = 1024;
+
+    /// <summary>Maximum length, in characters, of <see cref="Name"/>.</summary>
+    public const int MaxNameLength = 100;
+
+    /// <summary>Maximum length, in characters, of <see cref="Scope"/>.</summary>
+    public const int MaxScopeLength = 64;
+
+    /// <summary>Maximum length, in characters, of <see cref="IconName"/> (Lucide identifier).</summary>
+    public const int MaxIconNameLength = 100;
+
+    private Category() { }
+
+    /// <summary>Creates a root category in <paramref name="scope"/>.</summary>
+    public static Category CreateRoot(
+        Guid id,
+        Guid? tenantId,
+        string scope,
+        string name,
+        string? iconName = null,
+        bool hideOnEntityCard = false)
+    {
+        ValidateScope(scope);
+        ValidateName(name);
+        ValidateIconName(iconName);
+
+        string path = PathSeparator + name;
+        ValidatePathLength(path);
+
+        var category = new Category
+        {
+            Id = id,
+            TenantId = tenantId,
+            Scope = scope,
+            ParentId = null,
+            Name = name,
+            Path = path,
+            Depth = 0,
+            IconName = iconName,
+            HideOnEntityCard = hideOnEntityCard,
+            RowVersion = 1u,
+        };
+        category.AddDomainEvent(new CategoryCreatedEvent(
+            category.Id, category.TenantId, category.Scope, category.ParentId,
+            category.Name, category.Path, category.Depth));
+        return category;
+    }
+
+    /// <summary>Creates a child category under <paramref name="parent"/>.</summary>
+    public static Category Create(
+        Guid id,
+        Category parent,
+        string name,
+        string? iconName = null,
+        bool hideOnEntityCard = false)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+        ValidateName(name);
+        ValidateIconName(iconName);
+
+        string path = ComputeChildPath(parent.Path, name);
+        ValidatePathLength(path);
+
+        var category = new Category
+        {
+            Id = id,
+            TenantId = parent.TenantId,
+            Scope = parent.Scope,
+            ParentId = parent.Id,
+            Name = name,
+            Path = path,
+            Depth = parent.Depth + 1,
+            IconName = iconName,
+            HideOnEntityCard = hideOnEntityCard,
+            RowVersion = 1u,
+        };
+        category.AddDomainEvent(new CategoryCreatedEvent(
+            category.Id, category.TenantId, category.Scope, category.ParentId,
+            category.Name, category.Path, category.Depth));
+        return category;
+    }
+
+    /// <summary>Identifier of the tenant that owns this category; <c>null</c> for host-global.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Domain scope (e.g. <c>"products"</c>, <c>"documents"</c>).</summary>
+    public string Scope { get; private set; } = string.Empty;
+
+    /// <summary>Identifier of the parent category, or <c>null</c> for a root.</summary>
+    public Guid? ParentId { get; private set; }
+
+    /// <summary>User-facing label.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Materialised path (<c>"/electronics/laptops"</c>). Always starts with
+    /// <see cref="PathSeparator"/>; descendants of this category share the
+    /// <c>Path + "/"</c> prefix.
+    /// </summary>
+    public string Path { get; private set; } = PathSeparator;
+
+    /// <summary>Depth in the tree — 0 for roots, parent.Depth + 1 for children.</summary>
+    public int Depth { get; private set; }
+
+    /// <summary>Optional icon identifier (e.g. Lucide name).</summary>
+    public string? IconName { get; private set; }
+
+    /// <summary>When <c>true</c>, hides the category on entity cards while keeping it admin-visible.</summary>
+    public bool HideOnEntityCard { get; private set; }
+
+    /// <summary>Optimistic-concurrency token. Bumped on every state-mutating behavior.</summary>
+    public uint RowVersion { get; private set; }
+
+    /// <summary>Renames the category. Descendant paths are re-materialised by the service layer.</summary>
+    public void Rename(string newName)
+    {
+        ValidateName(newName);
+        if (string.Equals(Name, newName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        string oldPath = Path;
+        string oldName = Name;
+
+        // Rebuild own path under the same parent.
+        string parentPath = oldPath[..^(oldName.Length + PathSeparator.Length)];
+        if (parentPath.Length == 0)
+        {
+            parentPath = string.Empty; // root: "/electronics" → after strip → "" → child path is "/{newName}".
+        }
+
+        string newPath = parentPath.Length == 0
+            ? PathSeparator + newName
+            : ComputeChildPath(parentPath, newName);
+        ValidatePathLength(newPath);
+
+        Name = newName;
+        Path = newPath;
+        RowVersion++;
+        AddDomainEvent(new CategoryRenamedEvent(Id, oldName, newName));
+        AddDomainEvent(new CategoryTreePathChangedEvent(Id, TenantId, oldPath, newPath));
+    }
+
+    /// <summary>
+    /// Moves the category under <paramref name="newParent"/>, or to root when
+    /// <paramref name="newParent"/> is <c>null</c>. Same-tenant, same-scope, no-cycle
+    /// validation is enforced; descendant paths are re-materialised by the service
+    /// layer.
+    /// </summary>
+    public void MoveTo(Category? newParent)
+    {
+        if (newParent is not null)
+        {
+            if (newParent.TenantId != TenantId)
+            {
+                throw new InvalidOperationException("Cannot move a category to a different tenant.");
+            }
+            if (!string.Equals(newParent.Scope, Scope, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Cannot move a category to a different scope.");
+            }
+            if (newParent.Id == Id)
+            {
+                throw new InvalidOperationException("Cannot move a category under itself.");
+            }
+            if (IsAncestorOf(newParent))
+            {
+                throw new InvalidOperationException(
+                    "Cannot move a category under one of its descendants (cycle).");
+            }
+            if (newParent.Id == ParentId)
+            {
+                return; // no-op
+            }
+        }
+        else if (ParentId is null)
+        {
+            return; // already root, no-op
+        }
+
+        string oldPath = Path;
+        int oldDepth = Depth;
+        Guid? oldParentId = ParentId;
+
+        ParentId = newParent?.Id;
+        Path = newParent is null
+            ? PathSeparator + Name
+            : ComputeChildPath(newParent.Path, Name);
+        Depth = (newParent?.Depth ?? -1) + 1;
+        ValidatePathLength(Path);
+
+        RowVersion++;
+        AddDomainEvent(new CategoryMovedEvent(Id, oldParentId, ParentId));
+        AddDomainEvent(new CategoryTreePathChangedEvent(Id, TenantId, oldPath, Path));
+    }
+
+    /// <summary>Replaces the icon. Pass <c>null</c> to clear it.</summary>
+    public void SetIcon(string? iconName)
+    {
+        ValidateIconName(iconName);
+        if (string.Equals(IconName ?? string.Empty, iconName ?? string.Empty, StringComparison.Ordinal))
+        {
+            return;
+        }
+        IconName = iconName;
+        RowVersion++;
+    }
+
+    /// <summary>Flips the <see cref="HideOnEntityCard"/> flag.</summary>
+    public void ToggleHideOnEntityCard()
+    {
+        HideOnEntityCard = !HideOnEntityCard;
+        RowVersion++;
+    }
+
+    /// <summary>Marks the category as deleted by raising <see cref="CategoryDeletedEvent"/>.</summary>
+    public void MarkDeleted() =>
+        AddDomainEvent(new CategoryDeletedEvent(Id, TenantId, Scope, Path));
+
+    private bool IsAncestorOf(Category candidate) =>
+        candidate.Path == Path
+        || candidate.Path.StartsWith(Path + PathSeparator, StringComparison.Ordinal);
+
+    private static string ComputeChildPath(string parentPath, string childName) =>
+        parentPath + PathSeparator + childName;
+
+    private static void ValidateScope(string scope)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        if (scope.Length > MaxScopeLength)
+        {
+            throw new ArgumentException(
+                $"Category scope exceeds {MaxScopeLength} characters.", nameof(scope));
+        }
+    }
+
+    private static void ValidateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (name.Length > MaxNameLength)
+        {
+            throw new ArgumentException(
+                $"Category name exceeds {MaxNameLength} characters.", nameof(name));
+        }
+        if (name.Contains(PathSeparator, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Category name cannot contain the path separator '{PathSeparator}'.", nameof(name));
+        }
+    }
+
+    private static void ValidateIconName(string? iconName)
+    {
+        if (iconName is { Length: > MaxIconNameLength })
+        {
+            throw new ArgumentException(
+                $"Category icon name exceeds {MaxIconNameLength} characters.", nameof(iconName));
+        }
+    }
+
+    private static void ValidatePathLength(string path)
+    {
+        if (path.Length > MaxPathLength)
+        {
+            throw new ArgumentException(
+                $"Resulting category path exceeds {MaxPathLength} characters.");
+        }
+    }
+}

--- a/src/Granit.Taxonomy/Domain/CategoryAssignment.cs
+++ b/src/Granit.Taxonomy/Domain/CategoryAssignment.cs
@@ -1,0 +1,92 @@
+using Granit.Domain;
+
+namespace Granit.Taxonomy.Domain;
+
+/// <summary>
+/// Polymorphic link between a <see cref="Category"/> and a target aggregate root —
+/// single-assignment per ADR-054 (one category per <c>(TargetType, TargetId)</c>,
+/// opposite of <see cref="TagAssignment"/> which is many-to-many).
+/// </summary>
+public sealed class CategoryAssignment : Entity, IMultiTenant
+{
+    /// <summary>Maximum length, in characters, of the polymorphic <see cref="TargetType"/> discriminator.</summary>
+    public const int MaxTargetTypeLength = 256;
+
+    private CategoryAssignment() { }
+
+    /// <summary>Creates a new category assignment.</summary>
+    public static CategoryAssignment Create(
+        Guid id,
+        Guid? tenantId,
+        Guid categoryId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        DateTimeOffset assignedAt)
+    {
+        ValidateTargetType(targetType);
+        if (targetId == Guid.Empty)
+        {
+            throw new ArgumentException("Target id cannot be empty.", nameof(targetId));
+        }
+
+        return new CategoryAssignment
+        {
+            Id = id,
+            TenantId = tenantId,
+            CategoryId = categoryId,
+            TargetType = targetType,
+            TargetId = targetId,
+            AssignedByUserId = assignedByUserId,
+            AssignedAt = assignedAt,
+        };
+    }
+
+    /// <summary>Replaces the assigned category. Bumps timestamp + assigning user.</summary>
+    public void ChangeCategory(Guid newCategoryId, Guid assignedByUserId, DateTimeOffset assignedAt)
+    {
+        if (newCategoryId == Guid.Empty)
+        {
+            throw new ArgumentException("Category id cannot be empty.", nameof(newCategoryId));
+        }
+        CategoryId = newCategoryId;
+        AssignedByUserId = assignedByUserId;
+        AssignedAt = assignedAt;
+    }
+
+    /// <summary>Identifier of the tenant that owns this assignment; <c>null</c> for host-global.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Identifier of the assigned <see cref="Category"/>.</summary>
+    public Guid CategoryId { get; private set; }
+
+    /// <summary>Polymorphic discriminator (assembly-qualified type name of the target aggregate).</summary>
+    public string TargetType { get; private set; } = string.Empty;
+
+    /// <summary>Identifier of the target aggregate row.</summary>
+    public Guid TargetId { get; private set; }
+
+    /// <summary>UTC instant of assignment / re-assignment.</summary>
+    public DateTimeOffset AssignedAt { get; private set; }
+
+    /// <summary>Identifier of the user who created or last changed the assignment.</summary>
+    public Guid AssignedByUserId { get; private set; }
+
+    private static void ValidateTargetType(string targetType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+        if (targetType.Length > MaxTargetTypeLength)
+        {
+            throw new ArgumentException(
+                $"TargetType discriminator exceeds {MaxTargetTypeLength} characters.",
+                nameof(targetType));
+        }
+    }
+}

--- a/src/Granit.Taxonomy/Events/CategoryAssignmentChangedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryAssignmentChangedEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>
+/// Raised when a target's assigned category changes. Covers initial assignment
+/// (<see cref="OldCategoryId"/> == <c>null</c>), re-assignment to a different
+/// category, and unassignment (<see cref="NewCategoryId"/> == <c>null</c>).
+/// </summary>
+public sealed record CategoryAssignmentChangedEvent(
+    Guid? TenantId,
+    string TargetType,
+    Guid TargetId,
+    Guid? OldCategoryId,
+    Guid? NewCategoryId) : IDomainEvent;

--- a/src/Granit.Taxonomy/Events/CategoryCreatedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryCreatedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>Raised when a new category is created.</summary>
+public sealed record CategoryCreatedEvent(
+    Guid CategoryId,
+    Guid? TenantId,
+    string Scope,
+    Guid? ParentId,
+    string Name,
+    string Path,
+    int Depth) : IDomainEvent;

--- a/src/Granit.Taxonomy/Events/CategoryDeletedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryDeletedEvent.cs
@@ -1,0 +1,10 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>Raised when a category is deleted.</summary>
+public sealed record CategoryDeletedEvent(
+    Guid CategoryId,
+    Guid? TenantId,
+    string Scope,
+    string Path) : IDomainEvent;

--- a/src/Granit.Taxonomy/Events/CategoryMovedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryMovedEvent.cs
@@ -1,0 +1,9 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>Raised when a category's parent changes.</summary>
+public sealed record CategoryMovedEvent(
+    Guid CategoryId,
+    Guid? OldParentId,
+    Guid? NewParentId) : IDomainEvent;

--- a/src/Granit.Taxonomy/Events/CategoryRenamedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryRenamedEvent.cs
@@ -1,0 +1,9 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>Raised when a category is renamed.</summary>
+public sealed record CategoryRenamedEvent(
+    Guid CategoryId,
+    string OldName,
+    string NewName) : IDomainEvent;

--- a/src/Granit.Taxonomy/Events/CategoryTreePathChangedEvent.cs
+++ b/src/Granit.Taxonomy/Events/CategoryTreePathChangedEvent.cs
@@ -1,0 +1,16 @@
+using Granit.Events;
+
+namespace Granit.Taxonomy.Events;
+
+/// <summary>
+/// Raised by both the moved aggregate and the service after a bulk descendant
+/// re-materialisation. The service-emitted variant carries the count of affected
+/// descendant rows so downstream consumers can issue prefix-based cache invalidations
+/// rather than N point invalidations.
+/// </summary>
+public sealed record CategoryTreePathChangedEvent(
+    Guid CategoryId,
+    Guid? TenantId,
+    string OldPath,
+    string NewPath,
+    int AffectedDescendantCount = 0) : IDomainEvent;

--- a/src/Granit.Taxonomy/ICategoryAssignmentService.cs
+++ b/src/Granit.Taxonomy/ICategoryAssignmentService.cs
@@ -1,0 +1,45 @@
+using Granit.Taxonomy.Domain;
+
+namespace Granit.Taxonomy;
+
+/// <summary>
+/// Service for assigning a single <see cref="Category"/> to a target aggregate
+/// per ADR-054 (one category per <c>(TenantId, TargetType, TargetId)</c>,
+/// opposite of <see cref="TagAssignment"/> which is many-to-many).
+/// </summary>
+public interface ICategoryAssignmentService
+{
+    /// <summary>
+    /// Sets the category for <paramref name="targetType"/>/<paramref name="targetId"/>.
+    /// If a previous assignment exists for the same target, the row is updated to
+    /// point at <paramref name="categoryId"/> instead of creating a duplicate.
+    /// </summary>
+    /// <returns>The persisted assignment row.</returns>
+    Task<CategoryAssignment> AssignAsync(
+        Guid categoryId,
+        string targetType,
+        Guid targetId,
+        Guid assignedByUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Removes the category assignment for the target. Returns <c>false</c> if no row matched.</summary>
+    Task<bool> UnassignAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Loads the (single) category assigned to the target, or <c>null</c>.</summary>
+    Task<Category?> GetForTargetAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the assignment for the given target. Called by the T5.1
+    /// <c>EntityDeletedEto</c> cleanup handler when the target aggregate is hard-deleted.
+    /// </summary>
+    Task<int> RemoveAllAssignmentsAsync(
+        string targetType,
+        Guid targetId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Taxonomy/ICategoryService.cs
+++ b/src/Granit.Taxonomy/ICategoryService.cs
@@ -1,0 +1,61 @@
+using Granit.Taxonomy.Domain;
+
+namespace Granit.Taxonomy;
+
+/// <summary>CRUD service for the hierarchical <see cref="Category"/> aggregate.</summary>
+public interface ICategoryService
+{
+    /// <summary>Creates a new category. Pass <paramref name="parentId"/> = <c>null</c> for a root.</summary>
+    Task<Category> CreateAsync(
+        string scope,
+        Guid? parentId,
+        string name,
+        string? iconName = null,
+        bool hideOnEntityCard = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Renames a category. Descendant paths are re-materialised in a single SQL UPDATE.</summary>
+    Task<Category?> RenameAsync(
+        Guid id,
+        string newName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves a category under <paramref name="newParentId"/>, or to root when
+    /// <c>null</c>. Descendant paths and depths are re-materialised in a single
+    /// SQL UPDATE.
+    /// </summary>
+    Task<Category?> MoveAsync(
+        Guid id,
+        Guid? newParentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Sets or clears the icon.</summary>
+    Task<Category?> SetIconAsync(
+        Guid id,
+        string? iconName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Toggles the <c>HideOnEntityCard</c> flag.</summary>
+    Task<Category?> ToggleHideAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Hard-deletes a category. Throws when descendants exist — callers must move /
+    /// delete descendants first, or use a future <c>DeleteSubtreeAsync</c> overload.
+    /// </summary>
+    Task<bool> DeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Loads a category by id.</summary>
+    Task<Category?> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists every category in <paramref name="scope"/>, ordered by path.</summary>
+    Task<IReadOnlyList<Category>> ListByScopeAsync(
+        string scope,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/CategoryServiceMovePostgresTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration/CategoryServiceMovePostgresTests.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.Metrics;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres-backed verification of the move re-materialisation invariant locked by
+/// T4.1: a deep subtree move under a different parent rewrites every descendant's
+/// path and depth in a single SQL UPDATE, and prefix collisions on similarly-named
+/// siblings are not accidentally affected.
+/// </summary>
+public sealed class CategoryServiceMovePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private DbContextOptions<TaxonomyDbContext> _options = null!;
+    private TestDbContextFactory _factory = null!;
+    private CategoryService _sut = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    public CategoryServiceMovePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        _options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(_options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE taxonomy_category_assignments, taxonomy_categories RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(_options);
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        TaxonomyMetrics metrics = new(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        ILocalEventBus eventBus = Substitute.For<ILocalEventBus>();
+
+        _sut = new CategoryService(_factory, currentTenant, new SimpleGuidGenerator(), eventBus, metrics);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task MoveAsync_DeepSubtree_ReMaterialisesDescendantsViaSingleSqlUpdate()
+    {
+        // Build: /a/b/c/d, /a/b/e, and target /x
+        Category a = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category b = await _sut.CreateAsync("products", a.Id, "b",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category c = await _sut.CreateAsync("products", b.Id, "c",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category d = await _sut.CreateAsync("products", c.Id, "d",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category e = await _sut.CreateAsync("products", b.Id, "e",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category x = await _sut.CreateAsync("products", null, "x",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await _sut.MoveAsync(b.Id, x.Id, TestContext.Current.CancellationToken);
+
+        Category? reloadedB = await _sut.GetByIdAsync(b.Id, TestContext.Current.CancellationToken);
+        reloadedB!.Path.ShouldBe("/x/b");
+        reloadedB.Depth.ShouldBe(1);
+
+        Category? reloadedC = await _sut.GetByIdAsync(c.Id, TestContext.Current.CancellationToken);
+        reloadedC!.Path.ShouldBe("/x/b/c");
+        reloadedC.Depth.ShouldBe(2);
+
+        Category? reloadedD = await _sut.GetByIdAsync(d.Id, TestContext.Current.CancellationToken);
+        reloadedD!.Path.ShouldBe("/x/b/c/d");
+        reloadedD.Depth.ShouldBe(3);
+
+        Category? reloadedE = await _sut.GetByIdAsync(e.Id, TestContext.Current.CancellationToken);
+        reloadedE!.Path.ShouldBe("/x/b/e");
+        reloadedE.Depth.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task MoveAsync_PrefixCollision_DoesNotAffectSiblingsWithSimilarNames()
+    {
+        Category a = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category ab = await _sut.CreateAsync("products", null, "ab",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category aInner = await _sut.CreateAsync("products", a.Id, "inner",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category abInner = await _sut.CreateAsync("products", ab.Id, "inner",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category x = await _sut.CreateAsync("products", null, "x",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await _sut.MoveAsync(a.Id, x.Id, TestContext.Current.CancellationToken);
+
+        Category? reloadedAInner = await _sut.GetByIdAsync(aInner.Id, TestContext.Current.CancellationToken);
+        reloadedAInner!.Path.ShouldBe("/x/a/inner");
+
+        Category? reloadedAbInner = await _sut.GetByIdAsync(abInner.Id, TestContext.Current.CancellationToken);
+        reloadedAbInner!.Path.ShouldBe("/ab/inner"); // unchanged — prefix boundary
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/CategoryServiceSqliteTests.cs
+++ b/tests/Granit.Taxonomy.EntityFrameworkCore.Tests/Internal/CategoryServiceSqliteTests.cs
@@ -1,0 +1,312 @@
+using System.Diagnostics.Metrics;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Taxonomy.Diagnostics;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.EntityFrameworkCore.Tests.Internal;
+
+public sealed class CategoryServiceSqliteTests : IAsyncLifetime
+{
+    private SqliteConnection _holdOpen = null!;
+    private TestDbContextFactory _factory = null!;
+    private CategoryService _sut = null!;
+    private CategoryAssignmentService _assignmentSut = null!;
+    private CapturingLocalEventBus _localBus = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string DocumentType = "Granit.Documents.Domain.Document";
+
+    public async ValueTask InitializeAsync()
+    {
+        string connectionString =
+            $"DataSource=file:taxonomy-cat-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        _holdOpen = new SqliteConnection(connectionString);
+        await _holdOpen.OpenAsync();
+
+        DbContextOptions<TaxonomyDbContext> options = new DbContextOptionsBuilder<TaxonomyDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+
+        await using TaxonomyDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestDbContextFactory(options);
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        TaxonomyMetrics metrics = new(
+            services.BuildServiceProvider().GetRequiredService<IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _localBus = new CapturingLocalEventBus();
+
+        _sut = new CategoryService(_factory, currentTenant, new SimpleGuidGenerator(), _localBus, metrics);
+        _assignmentSut = new CategoryAssignmentService(
+            _factory, currentTenant, new SimpleGuidGenerator(), clock, _localBus, metrics);
+    }
+
+    public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
+
+    // -------------------------------------------------------------------------
+    // CategoryService — CRUD
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateAsync_RootAndChild_PersistsTree()
+    {
+        Category root = await _sut.CreateAsync("products", parentId: null, name: "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category child = await _sut.CreateAsync("products", parentId: root.Id, name: "laptops",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        root.Path.ShouldBe("/electronics");
+        child.Path.ShouldBe("/electronics/laptops");
+        child.Depth.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ParentInDifferentScope_Throws()
+    {
+        Category root = await _sut.CreateAsync("products", parentId: null, name: "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            _sut.CreateAsync("documents", parentId: root.Id, name: "child",
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RenameAsync_RootWithChildren_ReMaterialisesDescendants()
+    {
+        Category root = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category child = await _sut.CreateAsync("products", root.Id, "laptops",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category grandchild = await _sut.CreateAsync("products", child.Id, "gaming",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Category? renamed = await _sut.RenameAsync(root.Id, "hardware",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        renamed.ShouldNotBeNull();
+        renamed.Path.ShouldBe("/hardware");
+
+        Category? reloadedChild = await _sut.GetByIdAsync(child.Id, TestContext.Current.CancellationToken);
+        reloadedChild!.Path.ShouldBe("/hardware/laptops");
+
+        Category? reloadedGrandchild = await _sut.GetByIdAsync(grandchild.Id, TestContext.Current.CancellationToken);
+        reloadedGrandchild!.Path.ShouldBe("/hardware/laptops/gaming");
+    }
+
+    [Fact]
+    public async Task MoveAsync_DeepSubtree_ReMaterialisesDescendantPathsAndDepths()
+    {
+        // Build: /a/b/c/d   /a/b/e   and target /x
+        Category a = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category b = await _sut.CreateAsync("products", a.Id, "b",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category c = await _sut.CreateAsync("products", b.Id, "c",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category d = await _sut.CreateAsync("products", c.Id, "d",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category e = await _sut.CreateAsync("products", b.Id, "e",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category x = await _sut.CreateAsync("products", null, "x",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Move b under x
+        Category? moved = await _sut.MoveAsync(b.Id, x.Id, TestContext.Current.CancellationToken);
+        moved.ShouldNotBeNull();
+        moved.Path.ShouldBe("/x/b");
+        moved.Depth.ShouldBe(1);
+
+        Category? reloadedC = await _sut.GetByIdAsync(c.Id, TestContext.Current.CancellationToken);
+        reloadedC!.Path.ShouldBe("/x/b/c");
+        reloadedC.Depth.ShouldBe(2);
+
+        Category? reloadedD = await _sut.GetByIdAsync(d.Id, TestContext.Current.CancellationToken);
+        reloadedD!.Path.ShouldBe("/x/b/c/d");
+        reloadedD.Depth.ShouldBe(3);
+
+        Category? reloadedE = await _sut.GetByIdAsync(e.Id, TestContext.Current.CancellationToken);
+        reloadedE!.Path.ShouldBe("/x/b/e");
+        reloadedE.Depth.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task MoveAsync_PrefixCollision_DoesNotAffectSimilarlyNamedSiblings()
+    {
+        // Build: /a/inner   /ab/inner
+        Category a = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category ab = await _sut.CreateAsync("products", null, "ab",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category aInner = await _sut.CreateAsync("products", a.Id, "inner",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category abInner = await _sut.CreateAsync("products", ab.Id, "inner",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category x = await _sut.CreateAsync("products", null, "x",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await _sut.MoveAsync(a.Id, x.Id, TestContext.Current.CancellationToken);
+
+        Category? reloadedA = await _sut.GetByIdAsync(aInner.Id, TestContext.Current.CancellationToken);
+        reloadedA!.Path.ShouldBe("/x/a/inner");
+        Category? reloadedAb = await _sut.GetByIdAsync(abInner.Id, TestContext.Current.CancellationToken);
+        reloadedAb!.Path.ShouldBe("/ab/inner"); // unchanged — '/' boundary prevents collision
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithDescendants_Throws()
+    {
+        Category root = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _sut.CreateAsync("products", root.Id, "laptops",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            _sut.DeleteAsync(root.Id, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_LeafCategory_RemovesRow()
+    {
+        Category root = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        bool deleted = await _sut.DeleteAsync(root.Id, TestContext.Current.CancellationToken);
+        deleted.ShouldBeTrue();
+
+        Category? reloaded = await _sut.GetByIdAsync(root.Id, TestContext.Current.CancellationToken);
+        reloaded.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListByScopeAsync_OrdersByPath()
+    {
+        Category a = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _sut.CreateAsync("products", a.Id, "child",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _sut.CreateAsync("products", null, "b",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        IReadOnlyList<Category> list = await _sut.ListByScopeAsync("products",
+            TestContext.Current.CancellationToken);
+
+        list.Count.ShouldBe(3);
+        list.Select(c => c.Path).ShouldBe(["/a", "/a/child", "/b"]);
+    }
+
+    // -------------------------------------------------------------------------
+    // CategoryAssignmentService — single-assignment semantics
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Assign_FirstCall_CreatesRow()
+    {
+        Category cat = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+
+        CategoryAssignment assignment = await _assignmentSut.AssignAsync(
+            cat.Id, DocumentType, targetId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        assignment.CategoryId.ShouldBe(cat.Id);
+    }
+
+    [Fact]
+    public async Task Assign_SameTarget_DifferentCategory_ReplacesAssignment()
+    {
+        Category catA = await _sut.CreateAsync("products", null, "a",
+            cancellationToken: TestContext.Current.CancellationToken);
+        Category catB = await _sut.CreateAsync("products", null, "b",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+
+        CategoryAssignment first = await _assignmentSut.AssignAsync(
+            catA.Id, DocumentType, targetId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+        CategoryAssignment second = await _assignmentSut.AssignAsync(
+            catB.Id, DocumentType, targetId, Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        first.Id.ShouldBe(second.Id); // same row, updated in place
+        second.CategoryId.ShouldBe(catB.Id);
+    }
+
+    [Fact]
+    public async Task GetForTarget_ReturnsAssignedCategory()
+    {
+        Category cat = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+        await _assignmentSut.AssignAsync(cat.Id, DocumentType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        Category? got = await _assignmentSut.GetForTargetAsync(DocumentType, targetId,
+            TestContext.Current.CancellationToken);
+
+        got.ShouldNotBeNull();
+        got.Id.ShouldBe(cat.Id);
+    }
+
+    [Fact]
+    public async Task UnassignAsync_RemovesRow()
+    {
+        Category cat = await _sut.CreateAsync("products", null, "electronics",
+            cancellationToken: TestContext.Current.CancellationToken);
+        var targetId = Guid.NewGuid();
+        await _assignmentSut.AssignAsync(cat.Id, DocumentType, targetId, Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        bool removed = await _assignmentSut.UnassignAsync(DocumentType, targetId,
+            TestContext.Current.CancellationToken);
+        removed.ShouldBeTrue();
+
+        Category? got = await _assignmentSut.GetForTargetAsync(DocumentType, targetId,
+            TestContext.Current.CancellationToken);
+        got.ShouldBeNull();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<TaxonomyDbContext> options)
+        : IDbContextFactory<TaxonomyDbContext>
+    {
+        public TaxonomyDbContext CreateDbContext() => new(options);
+
+        public Task<TaxonomyDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<TaxonomyDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private sealed class CapturingLocalEventBus : ILocalEventBus
+    {
+        public List<object> Captured { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            Captured.Add(localEvent);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Granit.Taxonomy.Tests/Domain/CategoryTests.cs
+++ b/tests/Granit.Taxonomy.Tests/Domain/CategoryTests.cs
@@ -1,0 +1,189 @@
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Tests.Domain;
+
+public sealed class CategoryTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    [Fact]
+    public void CreateRoot_PopulatesPathAndEmitsEvent()
+    {
+        var root = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+
+        root.ParentId.ShouldBeNull();
+        root.Path.ShouldBe("/electronics");
+        root.Depth.ShouldBe(0);
+        root.Scope.ShouldBe("products");
+        root.DomainEvents.OfType<CategoryCreatedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Create_UnderParent_ComposesPathAndDepth()
+    {
+        var parent = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var child = Category.Create(Guid.NewGuid(), parent, "laptops");
+
+        child.ParentId.ShouldBe(parent.Id);
+        child.Path.ShouldBe("/electronics/laptops");
+        child.Depth.ShouldBe(1);
+        child.Scope.ShouldBe("products");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("has/slash")]
+    public void CreateRoot_InvalidName_Throws(string name) =>
+        Should.Throw<ArgumentException>(() =>
+            Category.CreateRoot(Guid.NewGuid(), TenantId, "products", name));
+
+    [Fact]
+    public void Rename_RootCategory_UpdatesPath()
+    {
+        var root = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        root.ClearDomainEvents();
+
+        root.Rename("hardware");
+
+        root.Path.ShouldBe("/hardware");
+        root.RowVersion.ShouldBe(2u);
+        root.DomainEvents.OfType<CategoryRenamedEvent>().ShouldHaveSingleItem();
+        root.DomainEvents.OfType<CategoryTreePathChangedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Rename_ChildCategory_UpdatesPathPreservingParent()
+    {
+        var parent = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var child = Category.Create(Guid.NewGuid(), parent, "laptops");
+        child.ClearDomainEvents();
+
+        child.Rename("notebooks");
+
+        child.Path.ShouldBe("/electronics/notebooks");
+    }
+
+    [Fact]
+    public void Rename_SameName_NoOp()
+    {
+        var root = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        root.ClearDomainEvents();
+
+        root.Rename("electronics");
+
+        root.RowVersion.ShouldBe(1u);
+        root.DomainEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MoveTo_NewParent_RecomputesPathAndDepth()
+    {
+        var parent1 = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var parent2 = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "hardware");
+        var child = Category.Create(Guid.NewGuid(), parent1, "laptops");
+        child.ClearDomainEvents();
+
+        child.MoveTo(parent2);
+
+        child.ParentId.ShouldBe(parent2.Id);
+        child.Path.ShouldBe("/hardware/laptops");
+        child.Depth.ShouldBe(1);
+        child.DomainEvents.OfType<CategoryMovedEvent>().ShouldHaveSingleItem();
+        child.DomainEvents.OfType<CategoryTreePathChangedEvent>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void MoveTo_Root_ConvertsToRoot()
+    {
+        var parent = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var child = Category.Create(Guid.NewGuid(), parent, "laptops");
+
+        child.MoveTo(null);
+
+        child.ParentId.ShouldBeNull();
+        child.Path.ShouldBe("/laptops");
+        child.Depth.ShouldBe(0);
+    }
+
+    [Fact]
+    public void MoveTo_DifferentScope_Throws()
+    {
+        var parent1 = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var parent2 = Category.CreateRoot(Guid.NewGuid(), TenantId, "documents", "shared");
+        var child = Category.Create(Guid.NewGuid(), parent1, "laptops");
+
+        Should.Throw<InvalidOperationException>(() => child.MoveTo(parent2));
+    }
+
+    [Fact]
+    public void MoveTo_DifferentTenant_Throws()
+    {
+        var parent1 = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var parent2 = Category.CreateRoot(Guid.NewGuid(), Guid.NewGuid(), "products", "electronics");
+        var child = Category.Create(Guid.NewGuid(), parent1, "laptops");
+
+        Should.Throw<InvalidOperationException>(() => child.MoveTo(parent2));
+    }
+
+    [Fact]
+    public void MoveTo_OwnDescendant_ThrowsCycle()
+    {
+        var root = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        var child = Category.Create(Guid.NewGuid(), root, "laptops");
+
+        Should.Throw<InvalidOperationException>(() => root.MoveTo(child));
+    }
+
+    [Fact]
+    public void MarkDeleted_EmitsDeletedEvent()
+    {
+        var root = Category.CreateRoot(Guid.NewGuid(), TenantId, "products", "electronics");
+        root.ClearDomainEvents();
+
+        root.MarkDeleted();
+
+        root.DomainEvents.OfType<CategoryDeletedEvent>().ShouldHaveSingleItem();
+    }
+}
+
+public sealed class CategoryAssignmentTests
+{
+    [Fact]
+    public void Create_PopulatesAllProperties()
+    {
+        var assignment = CategoryAssignment.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            "Granit.Documents.Domain.Document", Guid.NewGuid(),
+            Guid.NewGuid(), DateTimeOffset.UtcNow);
+
+        assignment.TargetType.ShouldBe("Granit.Documents.Domain.Document");
+    }
+
+    [Fact]
+    public void ChangeCategory_UpdatesIdAndAuditFields()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var assignment = CategoryAssignment.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "X", Guid.NewGuid(), Guid.NewGuid(), now);
+
+        var newCategoryId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        DateTimeOffset newTime = now.AddMinutes(5);
+        assignment.ChangeCategory(newCategoryId, newUserId, newTime);
+
+        assignment.CategoryId.ShouldBe(newCategoryId);
+        assignment.AssignedByUserId.ShouldBe(newUserId);
+        assignment.AssignedAt.ShouldBe(newTime);
+    }
+
+    [Fact]
+    public void Create_EmptyTargetId_Throws() =>
+        Should.Throw<ArgumentException>(() =>
+            CategoryAssignment.Create(
+                Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+                "X", Guid.Empty, Guid.NewGuid(), DateTimeOffset.UtcNow));
+}


### PR DESCRIPTION
## Summary

Adds the hierarchical `Category` aggregate per ADR-054, mirroring ADR-052's `Folder` pattern (materialised path, depth, parent/child tree, single-`ExecuteUpdate` re-materialisation on move). `CategoryAssignment` is **single-assignment** (one category per `(TenantId, TargetType, TargetId)`) — opposite of the many-to-many `TagAssignment`.

| Layer | What |
|-------|------|
| Domain | `Category` (sealed AggregateRoot), `CategoryAssignment` (Entity), 6 events, `ICategoryService` + `ICategoryAssignmentService` |
| EF Core | `taxonomy_categories` (sibling-name unique index, tenant+path prefix index), `taxonomy_category_assignments` (unique on `(TenantId, TargetType, TargetId)`), `CategoryService.MoveAsync` does single-`ExecuteUpdate` descendant path + depth re-materialisation |
| Diagnostics | `granit.taxonomy.category.created` / `.deleted` and `granit.taxonomy.category_assignment.changed` counters |

## Test plan

- [x] `dotnet test tests/Granit.Taxonomy.Tests` — **70 / 70** passed (15 new Category + CategoryAssignment domain tests)
- [x] `dotnet test tests/Granit.Taxonomy.EntityFrameworkCore.Tests` — **43 / 43** SQLite passed (12 new tests covering CRUD + deep-subtree move re-materialisation + prefix-collision boundary + single-assignment-per-target replacement)
- [x] `dotnet build tests/Granit.Taxonomy.EntityFrameworkCore.Tests.Integration` — clean (Postgres re-materialisation tests, run by CI integration shard)
- [x] `dotnet format` — clean across all 5 projects

## Out of scope

- Endpoints (T4.2 — #1868)
- Cleanup handler (T5.1 — #1869) — reuses the new `RemoveAllAssignmentsAsync` method
- Documents wire-up (T6.1 — #1871)

## Related

Closes #1867
Parent feature: #1858 (T4 — Category aggregate)
Epic: #1854
ADR: [ADR-054 — Granit.Taxonomy module](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/054-taxonomy-module.md)
