### PR TITLE
[T4.2] feat(taxonomy-endpoints): Category CRUD + assignment + autocomplete endpoints

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -55772,12 +55772,84 @@
       ]
     },
     {
+      "name": "AssignCategoryRequest",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.AssignCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/AssignCategoryRequest.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "CategoryAssignmentResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.CategoryAssignmentResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "CategoryDetailResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.CategoryDetailResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "CategoryResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.CategoryResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "CreateCategoryRequest",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.CreateCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/CreateCategoryRequest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ListCategoriesResponse",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.ListCategoriesResponse",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "MoveCategoryRequest",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.MoveCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/MoveCategoryRequest.cs",
+      "line": 5,
+      "members": []
+    },
+    {
+      "name": "UpdateCategoryRequest",
+      "fqn": "Granit.Taxonomy.Endpoints.Categories.Dtos.UpdateCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Categories/Dtos/UpdateCategoryRequest.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "TaxonomyEndpointRouteBuilderExtensions",
       "fqn": "Granit.Taxonomy.Endpoints.Extensions.TaxonomyEndpointRouteBuilderExtensions",
       "kind": "class",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitTaxonomy",
@@ -55819,12 +55891,21 @@
       ]
     },
     {
+      "name": "Categories",
+      "fqn": "Granit.Taxonomy.Endpoints.Permissions.Categories",
+      "kind": "class",
+      "project": "Granit.Taxonomy.Endpoints",
+      "file": "src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs",
+      "line": 27,
+      "members": []
+    },
+    {
       "name": "Search",
       "fqn": "Granit.Taxonomy.Endpoints.Permissions.Search",
       "kind": "class",
       "project": "Granit.Taxonomy.Endpoints",
       "file": "src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs",
-      "line": 33,
+      "line": 43,
       "members": []
     },
     {
@@ -56190,6 +56271,18 @@
           "kind": "method",
           "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Category?>"
+        },
+        {
+          "name": "GetBreadcrumbAsync",
+          "kind": "method",
+          "signature": "GetBreadcrumbAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Category>>"
+        },
+        {
+          "name": "ListChildrenAsync",
+          "kind": "method",
+          "signature": "ListChildrenAsync(string scope, Guid? parentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Category>>"
         },
         {
           "name": "ListByScopeAsync",

--- a/src/Granit.Taxonomy.Endpoints/Categories/Dtos/AssignCategoryRequest.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Dtos/AssignCategoryRequest.cs
@@ -1,0 +1,4 @@
+namespace Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+/// <summary>Wire-shape request for <c>POST /api/v1/taxonomy/categories/{id}/assign</c>.</summary>
+public sealed record AssignCategoryRequest(string TargetType, Guid TargetId);

--- a/src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Dtos/CategoryResponse.cs
@@ -1,0 +1,32 @@
+namespace Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+/// <summary>Wire-shape response carrying a single <c>Category</c>.</summary>
+public sealed record CategoryResponse(
+    Guid Id,
+    Guid? TenantId,
+    string Scope,
+    Guid? ParentId,
+    string Name,
+    string Path,
+    int Depth,
+    string? IconName,
+    bool HideOnEntityCard,
+    uint RowVersion);
+
+/// <summary>Wire-shape response for the per-parent listing.</summary>
+public sealed record ListCategoriesResponse(IReadOnlyList<CategoryResponse> Items);
+
+/// <summary>Wire-shape response combining a category with its breadcrumb chain.</summary>
+public sealed record CategoryDetailResponse(
+    CategoryResponse Category,
+    IReadOnlyList<CategoryResponse> Breadcrumb);
+
+/// <summary>Wire-shape response for a <c>CategoryAssignment</c> row.</summary>
+public sealed record CategoryAssignmentResponse(
+    Guid Id,
+    Guid? TenantId,
+    Guid CategoryId,
+    string TargetType,
+    Guid TargetId,
+    DateTimeOffset AssignedAt,
+    Guid AssignedByUserId);

--- a/src/Granit.Taxonomy.Endpoints/Categories/Dtos/CreateCategoryRequest.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Dtos/CreateCategoryRequest.cs
@@ -1,0 +1,14 @@
+namespace Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+/// <summary>Wire-shape request for <c>POST /api/v1/taxonomy/categories</c>.</summary>
+/// <param name="Scope">Domain scope (e.g. <c>"products"</c>).</param>
+/// <param name="ParentId">Identifier of the parent category, or <c>null</c> for a root.</param>
+/// <param name="Name">User-facing label (max 100 chars; cannot contain '/').</param>
+/// <param name="IconName">Optional icon identifier (e.g. Lucide name).</param>
+/// <param name="HideOnEntityCard">When <c>true</c>, hides the category from entity surfaces.</param>
+public sealed record CreateCategoryRequest(
+    string Scope,
+    Guid? ParentId,
+    string Name,
+    string? IconName,
+    bool? HideOnEntityCard);

--- a/src/Granit.Taxonomy.Endpoints/Categories/Dtos/MoveCategoryRequest.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Dtos/MoveCategoryRequest.cs
@@ -1,0 +1,5 @@
+namespace Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+/// <summary>Wire-shape request for <c>POST /api/v1/taxonomy/categories/{id}/move</c>.</summary>
+/// <param name="NewParentId">New parent id, or <c>null</c> to convert to a root category.</param>
+public sealed record MoveCategoryRequest(Guid? NewParentId);

--- a/src/Granit.Taxonomy.Endpoints/Categories/Dtos/UpdateCategoryRequest.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Dtos/UpdateCategoryRequest.cs
@@ -1,0 +1,7 @@
+namespace Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+/// <summary>Partial-update request for <c>PATCH /api/v1/taxonomy/categories/{id}</c>.</summary>
+public sealed record UpdateCategoryRequest(
+    string? Name,
+    string? IconName,
+    bool? HideOnEntityCard);

--- a/src/Granit.Taxonomy.Endpoints/Categories/Endpoints/CategoryEndpoints.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Endpoints/CategoryEndpoints.cs
@@ -1,0 +1,307 @@
+using System.Security.Claims;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+using Granit.Taxonomy.Endpoints.Categories.Mapping;
+using Granit.Taxonomy.Endpoints.Permissions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Taxonomy.Endpoints.Categories.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for the hierarchical <see cref="Category"/> aggregate (T4.2):
+/// CRUD, breadcrumb, move, and single-assignment endpoints.
+/// </summary>
+internal static class CategoryEndpoints
+{
+    private const string TagName = "Taxonomy";
+
+    public static RouteGroupBuilder MapCategoryEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        RouteGroupBuilder categories = group.MapGroup("/categories").WithTags(TagName);
+
+        categories.MapGet("/", ListAsync)
+            .WithName("ListTaxonomyCategories")
+            .WithSummary("Lists categories under a parent (or roots) within a scope.")
+            .WithDescription(
+                "Returns the direct children of parentId in the given scope, ordered "
+                + "by name. When parentId is omitted, returns the root categories of "
+                + "the scope. Use GET /categories/{id} to fetch a single category "
+                + "with its breadcrumb chain.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Read))
+            .Produces<ListCategoriesResponse>()
+            .ProducesValidationProblem();
+
+        categories.MapGet("/{id:guid}", GetAsync)
+            .WithName("GetTaxonomyCategory")
+            .WithSummary("Returns a category with its breadcrumb chain.")
+            .WithDescription(
+                "Returns the category and its breadcrumb (root → leaf). Returns 404 "
+                + "when the category is missing or excluded by the tenant filter.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Read))
+            .Produces<CategoryDetailResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        categories.MapPost("/", CreateAsync)
+            .WithName("CreateTaxonomyCategory")
+            .WithSummary("Creates a new category — root or under an existing parent.")
+            .WithDescription(
+                "Creates a new category in the supplied scope. When parentId is "
+                + "supplied the new category is placed under it (must share scope). "
+                + "Returns 422 when the parent does not exist or is in a different "
+                + "scope, or when sibling-name uniqueness is violated.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces<CategoryResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem();
+
+        categories.MapPatch("/{id:guid}", UpdateAsync)
+            .WithName("UpdateTaxonomyCategory")
+            .WithSummary("Partially updates a category (rename / icon / hide).")
+            .WithDescription(
+                "Applies the supplied facets in turn. Renaming a category re-"
+                + "materialises descendant paths via a single SQL UPDATE. Returns "
+                + "404 when the category is missing.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces<CategoryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem();
+
+        categories.MapPost("/{id:guid}/move", MoveAsync)
+            .WithName("MoveTaxonomyCategory")
+            .WithSummary("Moves a category under a new parent (or to root).")
+            .WithDescription(
+                "Re-parents the category and re-materialises descendant paths and "
+                + "depths in a single SQL UPDATE. Returns 422 on cycle / cross-scope "
+                + "violations, 404 when the category or target parent is missing.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces<CategoryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem();
+
+        categories.MapDelete("/{id:guid}", DeleteAsync)
+            .WithName("DeleteTaxonomyCategory")
+            .WithSummary("Hard-deletes a leaf category with no active assignments.")
+            .WithDescription(
+                "Returns 422 when the category has descendants OR when one or more "
+                + "CategoryAssignment rows still reference it — callers must move / "
+                + "delete descendants and reassign / unassign targets first.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+
+        categories.MapPost("/{id:guid}/assign", AssignAsync)
+            .WithName("AssignTaxonomyCategory")
+            .WithSummary("Sets the category for a target. Replaces any existing assignment.")
+            .WithDescription(
+                "Single-assignment per target: if a previous assignment exists for "
+                + "(targetType, targetId), it is updated in place to point at the "
+                + "supplied category. Returns 200 on update, 201 on first assignment.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces<CategoryAssignmentResponse>(StatusCodes.Status200OK)
+            .Produces<CategoryAssignmentResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem();
+
+        categories.MapDelete("/assign/{targetType}/{targetId:guid}", UnassignAsync)
+            .WithName("UnassignTaxonomyCategory")
+            .WithSummary("Clears the category assignment for a target.")
+            .WithDescription(
+                "Removes the CategoryAssignment row for (targetType, targetId). "
+                + "Returns 204 on success, 404 when no assignment matches.")
+            .RequireAuthorization(p => p.RequireClaim("permission", TaxonomyPermissions.Categories.Manage))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<ListCategoriesResponse>, ValidationProblem>> ListAsync(
+        [FromQuery] string scope,
+        [FromQuery] Guid? parentId,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                [nameof(scope)] = ["scope is required."],
+            });
+        }
+
+        IReadOnlyList<Category> children = await service
+            .ListChildrenAsync(scope, parentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new ListCategoriesResponse(
+            [.. children.Select(c => c.ToResponse())]));
+    }
+
+    private static async Task<Results<Ok<CategoryDetailResponse>, NotFound>> GetAsync(
+        Guid id,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        Category? category = await service.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (category is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        IReadOnlyList<Category> chain = await service
+            .GetBreadcrumbAsync(id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new CategoryDetailResponse(
+            category.ToResponse(),
+            [.. chain.Select(c => c.ToResponse())]));
+    }
+
+    private static async Task<Results<Created<CategoryResponse>, ProblemHttpResult>> CreateAsync(
+        CreateCategoryRequest request,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Category category = await service
+                .CreateAsync(
+                    request.Scope,
+                    request.ParentId,
+                    request.Name,
+                    request.IconName,
+                    request.HideOnEntityCard ?? false,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return TypedResults.Created($"/api/v1/taxonomy/categories/{category.Id}", category.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static async Task<Results<Ok<CategoryResponse>, NotFound, ProblemHttpResult>> UpdateAsync(
+        Guid id,
+        UpdateCategoryRequest request,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        Category? category = await service.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (category is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        try
+        {
+            if (request.Name is not null)
+            {
+                category = await service.RenameAsync(id, request.Name, cancellationToken).ConfigureAwait(false);
+            }
+            if (request.IconName is not null && category is not null)
+            {
+                category = await service.SetIconAsync(id, request.IconName, cancellationToken).ConfigureAwait(false);
+            }
+            if (request.HideOnEntityCard is { } target && category is not null && category.HideOnEntityCard != target)
+            {
+                category = await service.ToggleHideAsync(id, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+
+        return category is null ? TypedResults.NotFound() : TypedResults.Ok(category.ToResponse());
+    }
+
+    private static async Task<Results<Ok<CategoryResponse>, NotFound, ProblemHttpResult>> MoveAsync(
+        Guid id,
+        MoveCategoryRequest request,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Category? moved = await service
+                .MoveAsync(id, request.NewParentId, cancellationToken)
+                .ConfigureAwait(false);
+            return moved is null ? TypedResults.NotFound() : TypedResults.Ok(moved.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteAsync(
+        Guid id,
+        [FromServices] ICategoryService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            bool deleted = await service.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static async Task<Results<Ok<CategoryAssignmentResponse>, Created<CategoryAssignmentResponse>>> AssignAsync(
+        Guid id,
+        AssignCategoryRequest request,
+        [FromServices] ICategoryAssignmentService service,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        Guid userId = ExtractUserId(user);
+
+        // Probe for an existing row to distinguish 200 vs 201.
+        Category? before = await service
+            .GetForTargetAsync(request.TargetType, request.TargetId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Domain.CategoryAssignment assignment = await service
+            .AssignAsync(id, request.TargetType, request.TargetId, userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return before is null
+            ? TypedResults.Created(
+                $"/api/v1/taxonomy/categories/assign/{request.TargetType}/{request.TargetId}",
+                assignment.ToResponse())
+            : TypedResults.Ok(assignment.ToResponse());
+    }
+
+    private static async Task<Results<NoContent, NotFound>> UnassignAsync(
+        string targetType,
+        Guid targetId,
+        [FromServices] ICategoryAssignmentService service,
+        CancellationToken cancellationToken)
+    {
+        bool removed = await service
+            .UnassignAsync(targetType, targetId, cancellationToken)
+            .ConfigureAwait(false);
+        return removed ? TypedResults.NoContent() : TypedResults.NotFound();
+    }
+
+    private static Guid ExtractUserId(ClaimsPrincipal user)
+    {
+        string? sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub");
+        return Guid.TryParse(sub, out Guid id) ? id : Guid.Empty;
+    }
+}

--- a/src/Granit.Taxonomy.Endpoints/Categories/Mapping/CategoryMapper.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Mapping/CategoryMapper.cs
@@ -1,0 +1,17 @@
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+namespace Granit.Taxonomy.Endpoints.Categories.Mapping;
+
+internal static class CategoryMapper
+{
+    public static CategoryResponse ToResponse(this Category category) =>
+        new(category.Id, category.TenantId, category.Scope, category.ParentId,
+            category.Name, category.Path, category.Depth, category.IconName,
+            category.HideOnEntityCard, category.RowVersion);
+
+    public static CategoryAssignmentResponse ToResponse(this CategoryAssignment assignment) =>
+        new(assignment.Id, assignment.TenantId, assignment.CategoryId,
+            assignment.TargetType, assignment.TargetId,
+            assignment.AssignedAt, assignment.AssignedByUserId);
+}

--- a/src/Granit.Taxonomy.Endpoints/Categories/Validators/AssignCategoryRequestValidator.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Validators/AssignCategoryRequestValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+namespace Granit.Taxonomy.Endpoints.Categories.Validators;
+
+internal sealed class AssignCategoryRequestValidator : AbstractValidator<AssignCategoryRequest>
+{
+    public AssignCategoryRequestValidator()
+    {
+        RuleFor(x => x.TargetType)
+            .NotEmpty()
+            .MaximumLength(CategoryAssignment.MaxTargetTypeLength);
+
+        RuleFor(x => x.TargetId).NotEqual(Guid.Empty);
+    }
+}

--- a/src/Granit.Taxonomy.Endpoints/Categories/Validators/CreateCategoryRequestValidator.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Validators/CreateCategoryRequestValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+namespace Granit.Taxonomy.Endpoints.Categories.Validators;
+
+internal sealed class CreateCategoryRequestValidator : AbstractValidator<CreateCategoryRequest>
+{
+    public CreateCategoryRequestValidator()
+    {
+        RuleFor(x => x.Scope)
+            .NotEmpty()
+            .MaximumLength(Category.MaxScopeLength);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Category.MaxNameLength)
+            .Matches("^[^/]+$");
+
+        RuleFor(x => x.IconName)
+            .MaximumLength(Category.MaxIconNameLength)
+            .When(x => x.IconName is not null);
+    }
+}

--- a/src/Granit.Taxonomy.Endpoints/Categories/Validators/UpdateCategoryRequestValidator.cs
+++ b/src/Granit.Taxonomy.Endpoints/Categories/Validators/UpdateCategoryRequestValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using Granit.Taxonomy.Domain;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+
+namespace Granit.Taxonomy.Endpoints.Categories.Validators;
+
+internal sealed class UpdateCategoryRequestValidator : AbstractValidator<UpdateCategoryRequest>
+{
+    public UpdateCategoryRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Category.MaxNameLength)
+            .Matches("^[^/]+$")
+            .When(x => x.Name is not null);
+
+        RuleFor(x => x.IconName)
+            .MaximumLength(Category.MaxIconNameLength)
+            .When(x => x.IconName is not null);
+    }
+}

--- a/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.Endpoints/Extensions/TaxonomyEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Taxonomy.Endpoints.Categories.Endpoints;
 using Granit.Taxonomy.Endpoints.Options;
 using Granit.Taxonomy.Endpoints.Search.Endpoints;
 using Granit.Taxonomy.Endpoints.Tags.Endpoints;
@@ -38,6 +39,7 @@ public static class TaxonomyEndpointRouteBuilderExtensions
         group.MapTagEndpoints();
         group.MapTagAssignmentEndpoints();
         group.MapTagSearchEndpoints();
+        group.MapCategoryEndpoints();
 
         return group;
     }

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/cs.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/cs.json
@@ -1,6 +1,8 @@
 {
   "culture": "cs",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Vytvářet, přejmenovávat, přesouvat, skrývat a odstraňovat kategorie",
+    "Permission:Taxonomy.Categories.Read": "Zobrazit kategorie",
     "Permission:Taxonomy.Search.Read": "Vyhledávat tagy napříč všemi entitami",
     "Permission:Taxonomy.Tags.Manage": "Vytvářet, přejmenovávat, přebarvovat a odstraňovat tagy",
     "Permission:Taxonomy.Tags.Read": "Zobrazit tagy",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/de.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/de.json
@@ -1,6 +1,8 @@
 {
   "culture": "de",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Kategorien erstellen, umbenennen, verschieben, ausblenden und löschen",
+    "Permission:Taxonomy.Categories.Read": "Kategorien anzeigen",
     "Permission:Taxonomy.Search.Read": "Tags entitätsübergreifend suchen",
     "Permission:Taxonomy.Tags.Manage": "Tags erstellen, umbenennen, neu einfärben und löschen",
     "Permission:Taxonomy.Tags.Read": "Tags anzeigen",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/en.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/en.json
@@ -1,6 +1,8 @@
 {
   "culture": "en",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Create, rename, move, hide, and delete categories",
+    "Permission:Taxonomy.Categories.Read": "View categories",
     "Permission:Taxonomy.Search.Read": "Search tags across every entity",
     "Permission:Taxonomy.Tags.Manage": "Create, rename, recolour, and delete tags",
     "Permission:Taxonomy.Tags.Read": "View tags",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/es.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/es.json
@@ -1,6 +1,8 @@
 {
   "culture": "es",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Crear, renombrar, mover, ocultar y eliminar categorías",
+    "Permission:Taxonomy.Categories.Read": "Ver categorías",
     "Permission:Taxonomy.Search.Read": "Buscar etiquetas en todas las entidades",
     "Permission:Taxonomy.Tags.Manage": "Crear, renombrar, recolorear y eliminar etiquetas",
     "Permission:Taxonomy.Tags.Read": "Ver etiquetas",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/fr.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/fr.json
@@ -1,6 +1,8 @@
 {
   "culture": "fr",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Créer, renommer, déplacer, masquer et supprimer les catégories",
+    "Permission:Taxonomy.Categories.Read": "Consulter les catégories",
     "Permission:Taxonomy.Search.Read": "Rechercher les tags à travers toutes les entités",
     "Permission:Taxonomy.Tags.Manage": "Créer, renommer, recolorer et supprimer les tags",
     "Permission:Taxonomy.Tags.Read": "Consulter les tags",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/hi.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/hi.json
@@ -1,6 +1,8 @@
 {
   "culture": "hi",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "श्रेणियाँ बनाएँ, नाम बदलें, स्थानांतरित करें, छिपाएँ और हटाएँ",
+    "Permission:Taxonomy.Categories.Read": "श्रेणियाँ देखें",
     "Permission:Taxonomy.Search.Read": "सभी एंटिटीज़ में टैग खोजें",
     "Permission:Taxonomy.Tags.Manage": "टैग बनाएँ, नाम बदलें, रंग बदलें और हटाएँ",
     "Permission:Taxonomy.Tags.Read": "टैग देखें",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/it.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/it.json
@@ -1,6 +1,8 @@
 {
   "culture": "it",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Creare, rinominare, spostare, nascondere ed eliminare le categorie",
+    "Permission:Taxonomy.Categories.Read": "Visualizzare le categorie",
     "Permission:Taxonomy.Search.Read": "Cercare i tag su tutte le entità",
     "Permission:Taxonomy.Tags.Manage": "Creare, rinominare, ricolorare ed eliminare i tag",
     "Permission:Taxonomy.Tags.Read": "Visualizzare i tag",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ja.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ja.json
@@ -1,6 +1,8 @@
 {
   "culture": "ja",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "カテゴリの作成、名前変更、移動、非表示、削除",
+    "Permission:Taxonomy.Categories.Read": "カテゴリを表示",
     "Permission:Taxonomy.Search.Read": "すべてのエンティティでタグを検索",
     "Permission:Taxonomy.Tags.Manage": "タグの作成、名前変更、色変更、削除",
     "Permission:Taxonomy.Tags.Read": "タグを表示",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ko.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/ko.json
@@ -1,6 +1,8 @@
 {
   "culture": "ko",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "카테고리 생성, 이름 변경, 이동, 숨김, 삭제",
+    "Permission:Taxonomy.Categories.Read": "카테고리 보기",
     "Permission:Taxonomy.Search.Read": "모든 엔터티에서 태그 검색",
     "Permission:Taxonomy.Tags.Manage": "태그 생성, 이름 변경, 색상 변경, 삭제",
     "Permission:Taxonomy.Tags.Read": "태그 보기",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/nl.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/nl.json
@@ -1,6 +1,8 @@
 {
   "culture": "nl",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Categorieën maken, hernoemen, verplaatsen, verbergen en verwijderen",
+    "Permission:Taxonomy.Categories.Read": "Categorieën bekijken",
     "Permission:Taxonomy.Search.Read": "Tags zoeken in alle entiteiten",
     "Permission:Taxonomy.Tags.Manage": "Tags maken, hernoemen, herkleuren en verwijderen",
     "Permission:Taxonomy.Tags.Read": "Tags bekijken",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pl.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pl.json
@@ -1,6 +1,8 @@
 {
   "culture": "pl",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Twórz, zmieniaj nazwy, przenoś, ukrywaj i usuwaj kategorie",
+    "Permission:Taxonomy.Categories.Read": "Wyświetl kategorie",
     "Permission:Taxonomy.Search.Read": "Wyszukaj tagi we wszystkich encjach",
     "Permission:Taxonomy.Tags.Manage": "Twórz, zmieniaj nazwy, zmieniaj kolory i usuwaj tagi",
     "Permission:Taxonomy.Tags.Read": "Wyświetl tagi",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pt.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/pt.json
@@ -1,6 +1,8 @@
 {
   "culture": "pt",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Criar, renomear, mover, ocultar e excluir categorias",
+    "Permission:Taxonomy.Categories.Read": "Ver categorias",
     "Permission:Taxonomy.Search.Read": "Pesquisar tags em todas as entidades",
     "Permission:Taxonomy.Tags.Manage": "Criar, renomear, recolorir e excluir tags",
     "Permission:Taxonomy.Tags.Read": "Ver tags",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/sv.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/sv.json
@@ -1,6 +1,8 @@
 {
   "culture": "sv",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Skapa, byt namn, flytta, dölj och ta bort kategorier",
+    "Permission:Taxonomy.Categories.Read": "Visa kategorier",
     "Permission:Taxonomy.Search.Read": "Sök taggar över alla entiteter",
     "Permission:Taxonomy.Tags.Manage": "Skapa, byt namn, färgändra och ta bort taggar",
     "Permission:Taxonomy.Tags.Read": "Visa taggar",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/tr.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/tr.json
@@ -1,6 +1,8 @@
 {
   "culture": "tr",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "Kategorileri oluştur, yeniden adlandır, taşı, gizle ve sil",
+    "Permission:Taxonomy.Categories.Read": "Kategorileri görüntüle",
     "Permission:Taxonomy.Search.Read": "Tüm varlıklarda etiket ara",
     "Permission:Taxonomy.Tags.Manage": "Etiketleri oluştur, yeniden adlandır, yeniden renklendir ve sil",
     "Permission:Taxonomy.Tags.Read": "Etiketleri görüntüle",

--- a/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/zh.json
+++ b/src/Granit.Taxonomy.Endpoints/Localization/TaxonomyEndpoints/zh.json
@@ -1,6 +1,8 @@
 {
   "culture": "zh",
   "texts": {
+    "Permission:Taxonomy.Categories.Manage": "创建、重命名、移动、隐藏和删除分类",
+    "Permission:Taxonomy.Categories.Read": "查看分类",
     "Permission:Taxonomy.Search.Read": "跨所有实体搜索标签",
     "Permission:Taxonomy.Tags.Manage": "创建、重命名、重新着色和删除标签",
     "Permission:Taxonomy.Tags.Read": "查看标签",

--- a/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissionDefinitionProvider.cs
+++ b/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissionDefinitionProvider.cs
@@ -38,5 +38,17 @@ internal sealed class TaxonomyPermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<TaxonomyEndpointsLocalizationResource>(
                 "Permission:Taxonomy.Search.Read"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            TaxonomyPermissions.Categories.Read,
+            LocalizableString.Create<TaxonomyEndpointsLocalizationResource>(
+                "Permission:Taxonomy.Categories.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            TaxonomyPermissions.Categories.Manage,
+            LocalizableString.Create<TaxonomyEndpointsLocalizationResource>(
+                "Permission:Taxonomy.Categories.Manage"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs
+++ b/src/Granit.Taxonomy.Endpoints/Permissions/TaxonomyPermissions.cs
@@ -23,6 +23,16 @@ public static class TaxonomyPermissions
         public const string Manage = "Taxonomy.Tags.Manage";
     }
 
+    /// <summary>Permissions on hierarchical categories.</summary>
+    public static class Categories
+    {
+        /// <summary>Read categories (get, list, breadcrumb).</summary>
+        public const string Read = "Taxonomy.Categories.Read";
+
+        /// <summary>Manage categories (create, rename, move, hide, delete, assign / unassign on targets).</summary>
+        public const string Manage = "Taxonomy.Categories.Manage";
+    }
+
     /// <summary>Permissions on the cross-entity search endpoint.</summary>
     /// <remarks>
     /// Separate from <see cref="Tags.Read"/> because the search results expose

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryService.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Internal/CategoryService.cs
@@ -241,6 +241,15 @@ internal sealed class CategoryService(
                 $"Category {id} has descendants. Move or delete them first.");
         }
 
+        bool hasAssignments = await context.CategoryAssignments
+            .AnyAsync(a => a.CategoryId == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (hasAssignments)
+        {
+            throw new InvalidOperationException(
+                $"Category {id} is still assigned to one or more targets. Reassign or unassign first.");
+        }
+
         category.MarkDeleted();
         context.Categories.Remove(category);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -260,6 +269,67 @@ internal sealed class CategoryService(
         return await context.Categories
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Category>> GetBreadcrumbAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Category? leaf = await context.Categories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (leaf is null)
+        {
+            return [];
+        }
+
+        // Walk the parent chain; the tree is bounded by MaxPathLength so the depth
+        // is small in practice. A single SQL query that materialises the chain via
+        // path-prefix matching would also work — kept simple here.
+        List<Category> chain = [leaf];
+        Category current = leaf;
+        while (current.ParentId is { } parentId)
+        {
+            Category? parent = await context.Categories
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == parentId, cancellationToken)
+                .ConfigureAwait(false);
+            if (parent is null)
+            {
+                break;
+            }
+            chain.Add(parent);
+            current = parent;
+        }
+
+        chain.Reverse(); // root first
+        return chain;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Category>> ListChildrenAsync(
+        string scope,
+        Guid? parentId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+
+        await using TaxonomyDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await context.Categories
+            .AsNoTracking()
+            .Where(c => c.Scope == scope && c.ParentId == parentId)
+            .OrderBy(c => c.Name)
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Granit.Taxonomy/ICategoryService.cs
+++ b/src/Granit.Taxonomy/ICategoryService.cs
@@ -42,8 +42,9 @@ public interface ICategoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Hard-deletes a category. Throws when descendants exist — callers must move /
-    /// delete descendants first, or use a future <c>DeleteSubtreeAsync</c> overload.
+    /// Hard-deletes a category. Throws when descendants exist OR when one or more
+    /// <c>CategoryAssignment</c> rows still reference it — callers must move /
+    /// delete descendants and reassign / unassign targets first.
     /// </summary>
     Task<bool> DeleteAsync(
         Guid id,
@@ -52,6 +53,26 @@ public interface ICategoryService
     /// <summary>Loads a category by id.</summary>
     Task<Category?> GetByIdAsync(
         Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the breadcrumb chain for <paramref name="id"/>: the category itself
+    /// plus every ancestor up to (and including) the root, ordered root → leaf.
+    /// Returns an empty list when the category does not exist.
+    /// </summary>
+    Task<IReadOnlyList<Category>> GetBreadcrumbAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists categories in <paramref name="scope"/>. When
+    /// <paramref name="parentId"/> is supplied, returns only the direct children of
+    /// that parent. When <paramref name="parentId"/> is <c>null</c>, returns root
+    /// categories. Ordered by name.
+    /// </summary>
+    Task<IReadOnlyList<Category>> ListChildrenAsync(
+        string scope,
+        Guid? parentId,
         CancellationToken cancellationToken = default);
 
     /// <summary>Lists every category in <paramref name="scope"/>, ordered by path.</summary>

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/AssignCategoryRequestValidatorTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/AssignCategoryRequestValidatorTests.cs
@@ -1,0 +1,33 @@
+using FluentValidation.Results;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+using Granit.Taxonomy.Endpoints.Categories.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Endpoints.Tests.Categories.Validators;
+
+public sealed class AssignCategoryRequestValidatorTests
+{
+    private readonly AssignCategoryRequestValidator _sut = new();
+
+    [Fact]
+    public void Valid_Passes()
+    {
+        ValidationResult result = _sut.Validate(new AssignCategoryRequest("Granit.Documents.Domain.Document", Guid.NewGuid()));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EmptyTargetType_Fails()
+    {
+        ValidationResult result = _sut.Validate(new AssignCategoryRequest("", Guid.NewGuid()));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EmptyTargetId_Fails()
+    {
+        ValidationResult result = _sut.Validate(new AssignCategoryRequest("X", Guid.Empty));
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/CreateCategoryRequestValidatorTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/CreateCategoryRequestValidatorTests.cs
@@ -1,0 +1,58 @@
+using FluentValidation.Results;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+using Granit.Taxonomy.Endpoints.Categories.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Endpoints.Tests.Categories.Validators;
+
+public sealed class CreateCategoryRequestValidatorTests
+{
+    private readonly CreateCategoryRequestValidator _sut = new();
+
+    [Fact]
+    public void Valid_RootCategory_Passes()
+    {
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest("products", null, "electronics", null, null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Valid_ChildCategory_Passes()
+    {
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest("products", Guid.NewGuid(), "laptops", "laptop", true));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyScope_Fails(string scope)
+    {
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest(scope, null, "x", null, null));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NameWithSlash_Fails()
+    {
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest("products", null, "a/b", null, null));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NameTooLong_Fails()
+    {
+        string tooLong = new('x', 101);
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest("products", null, tooLong, null, null));
+        result.IsValid.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IconTooLong_Fails()
+    {
+        string tooLong = new('x', 101);
+        ValidationResult result = _sut.Validate(new CreateCategoryRequest("products", null, "x", tooLong, null));
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/UpdateCategoryRequestValidatorTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Categories/Validators/UpdateCategoryRequestValidatorTests.cs
@@ -1,0 +1,33 @@
+using FluentValidation.Results;
+using Granit.Taxonomy.Endpoints.Categories.Dtos;
+using Granit.Taxonomy.Endpoints.Categories.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Taxonomy.Endpoints.Tests.Categories.Validators;
+
+public sealed class UpdateCategoryRequestValidatorTests
+{
+    private readonly UpdateCategoryRequestValidator _sut = new();
+
+    [Fact]
+    public void EmptyRequest_Passes_NoOpHandledByEndpoint()
+    {
+        ValidationResult result = _sut.Validate(new UpdateCategoryRequest(null, null, null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OnlyName_Passes()
+    {
+        ValidationResult result = _sut.Validate(new UpdateCategoryRequest("hardware", null, null));
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NameWithSlash_Fails()
+    {
+        ValidationResult result = _sut.Validate(new UpdateCategoryRequest("a/b", null, null));
+        result.IsValid.ShouldBeFalse();
+    }
+}

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Localization/LocalizationFileTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Localization/LocalizationFileTests.cs
@@ -45,6 +45,8 @@ public sealed class LocalizationFileTests
         content.ShouldContain("\"Permission:Taxonomy.Tags.Read\"");
         content.ShouldContain("\"Permission:Taxonomy.Tags.Manage\"");
         content.ShouldContain("\"Permission:Taxonomy.Search.Read\"");
+        content.ShouldContain("\"Permission:Taxonomy.Categories.Read\"");
+        content.ShouldContain("\"Permission:Taxonomy.Categories.Manage\"");
     }
 
     public static TheoryData<string> AllCultures()

--- a/tests/Granit.Taxonomy.Endpoints.Tests/Permissions/TaxonomyPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Taxonomy.Endpoints.Tests/Permissions/TaxonomyPermissionDefinitionProviderTests.cs
@@ -11,6 +11,8 @@ public sealed class TaxonomyPermissionDefinitionProviderTests
     {
         TaxonomyPermissions.Tags.Read.ShouldBe("Taxonomy.Tags.Read");
         TaxonomyPermissions.Tags.Manage.ShouldBe("Taxonomy.Tags.Manage");
+        TaxonomyPermissions.Categories.Read.ShouldBe("Taxonomy.Categories.Read");
+        TaxonomyPermissions.Categories.Manage.ShouldBe("Taxonomy.Categories.Manage");
         TaxonomyPermissions.GroupName.ShouldBe("Taxonomy");
     }
 


### PR DESCRIPTION
## Summary

Adds the `Category` HTTP surface per ADR-054 — CRUD + breadcrumb + move + single-assignment endpoints. Hosts can now create / rename / move / delete categories and apply a single category to any taggable target.

| Verb     | Route                                                  | Permission                  |
| -------- | ------------------------------------------------------ | --------------------------- |
| `GET`    | `/api/v1/taxonomy/categories?scope=&parentId=`         | `Taxonomy.Categories.Read`   |
| `GET`    | `/api/v1/taxonomy/categories/{id}`                     | `Taxonomy.Categories.Read`   |
| `POST`   | `/api/v1/taxonomy/categories`                          | `Taxonomy.Categories.Manage` |
| `PATCH`  | `/api/v1/taxonomy/categories/{id}`                     | `Taxonomy.Categories.Manage` |
| `POST`   | `/api/v1/taxonomy/categories/{id}/move`                | `Taxonomy.Categories.Manage` |
| `DELETE` | `/api/v1/taxonomy/categories/{id}`                     | `Taxonomy.Categories.Manage` |
| `POST`   | `/api/v1/taxonomy/categories/{id}/assign`              | `Taxonomy.Categories.Manage` |
| `DELETE` | `/api/v1/taxonomy/categories/assign/{targetType}/{id}` | `Taxonomy.Categories.Manage` |

- `GET /{id}` returns a `CategoryDetailResponse` carrying both the category and its **breadcrumb chain** (root → leaf), mirroring `Folder` from ADR-052.
- `DELETE /{id}` returns **422** when the category has descendants OR when one or more `CategoryAssignment` rows still reference it (per the issue's strict guard).
- `POST /{id}/assign` returns **200** on an in-place re-assignment (target already had a category) and **201** on the first assignment, matching the single-assignment-per-target invariant.
- `POST /{id}/move` re-parents the category and re-materialises descendant `Path` + `Depth` via `CategoryService.MoveAsync`'s single `ExecuteUpdate`.
- New `Taxonomy.Categories.Read` / `Taxonomy.Categories.Manage` permissions registered + **18-culture localization** updated.
- `ICategoryService` extended with `GetBreadcrumbAsync` and `ListChildrenAsync`; `CategoryService.DeleteAsync` now blocks on outstanding assignments.

## Test plan

- [x] `dotnet test tests/Granit.Taxonomy.Endpoints.Tests` — **75 / 75** passed (12 new validator tests + extended permission-constants + extended localization-coverage theory)
- [x] `dotnet test tests/Granit.Taxonomy.EntityFrameworkCore.Tests` — **43 / 43** SQLite passed (existing CategoryServiceSqliteTests still green after adding the assignment-blocking delete check)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "Validation|Permission|Domain"` — **22 / 22** passed
- [x] `dotnet format` — clean across all 4 projects
- [x] Lock files refreshed

## Out of scope

- Cleanup handler (T5.1 — #1869) — uses `RemoveAllAssignmentsAsync` shipped in T2.2 / T4.1
- Documents wire-up (T6.1 — #1871)

## Related

Closes #1868
Parent feature: #1858 (T4 — Category aggregate)
Epic: #1854
ADR: [ADR-054 — Granit.Taxonomy module](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/054-taxonomy-module.md)
