### PR TITLE
fix(activities): security hardening (VULN-100..401)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4652,7 +4652,7 @@
       "kind": "class",
       "project": "Granit.Activities.BackgroundJobs",
       "file": "src/Granit.Activities.BackgroundJobs/Services/MarkOverdueScanService.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -4668,7 +4668,7 @@
       "kind": "class",
       "project": "Granit.Activities.BackgroundJobs",
       "file": "src/Granit.Activities.BackgroundJobs/Services/SendRemindersScanService.cs",
-      "line": 21,
+      "line": 22,
       "members": [
         {
           "name": "ExecuteAsync",
@@ -4684,7 +4684,7 @@
       "kind": "class",
       "project": "Granit.Activities",
       "file": "src/Granit.Activities/Domain/Activity.cs",
-      "line": 26,
+      "line": 27,
       "members": [
         {
           "name": "Create",
@@ -4708,6 +4708,44 @@
       "file": "src/Granit.Activities/Domain/ActivityStatus.cs",
       "line": 9,
       "members": []
+    },
+    {
+      "name": "AllowAllActivityHostAuthorizationProvider",
+      "fqn": "Granit.Activities.Endpoints.Authorization.AllowAllActivityHostAuthorizationProvider",
+      "kind": "class",
+      "project": "Granit.Activities.Endpoints",
+      "file": "src/Granit.Activities.Endpoints/Authorization/IActivityHostAuthorizationProvider.cs",
+      "line": 47,
+      "members": [
+        {
+          "name": "EntityType",
+          "kind": "property",
+          "signature": "string EntityType",
+          "returnType": "string"
+        },
+        {
+          "name": "CanReadHostAsync",
+          "kind": "method",
+          "signature": "CanReadHostAsync(Guid entityId, ClaimsPrincipal user, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IActivityHostAuthorizationProvider",
+      "fqn": "Granit.Activities.Endpoints.Authorization.IActivityHostAuthorizationProvider",
+      "kind": "interface",
+      "project": "Granit.Activities.Endpoints",
+      "file": "src/Granit.Activities.Endpoints/Authorization/IActivityHostAuthorizationProvider.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "CanReadHostAsync",
+          "kind": "method",
+          "signature": "CanReadHostAsync(Guid entityId, ClaimsPrincipal user, CancellationToken cancellationToken)",
+          "returnType": "string EntityType { get; } ValueTask<bool>"
+        }
+      ]
     },
     {
       "name": "ActivityCalendarItemResponse",
@@ -4828,8 +4866,15 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs",
-      "line": 22,
-      "members": []
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "ActivitiesEndpointsOptions",
@@ -4874,6 +4919,18 @@
           "kind": "method",
           "signature": "FromMinutes(1)",
           "returnType": "TimeSpan CalendarCacheTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxFutureRescheduleDays",
+          "kind": "property",
+          "signature": "int MaxFutureRescheduleDays",
+          "returnType": "int"
+        },
+        {
+          "name": "CalendarWindowSnapMinutes",
+          "kind": "property",
+          "signature": "int CalendarWindowSnapMinutes",
+          "returnType": "int"
         }
       ]
     },
@@ -4901,7 +4958,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 56,
+      "line": 45,
       "members": []
     },
     {
@@ -4910,7 +4967,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 32,
+      "line": 27,
       "members": []
     },
     {
@@ -4919,7 +4976,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 24,
+      "line": 25,
       "members": []
     },
     {
@@ -4937,7 +4994,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 40,
+      "line": 29,
       "members": []
     },
     {
@@ -4946,7 +5003,7 @@
       "kind": "class",
       "project": "Granit.Activities.Endpoints",
       "file": "src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs",
-      "line": 48,
+      "line": 37,
       "members": []
     },
     {
@@ -5061,6 +5118,15 @@
       "members": []
     },
     {
+      "name": "ActivityReassignedEto",
+      "fqn": "Granit.Activities.Events.ActivityReassignedEto",
+      "kind": "record",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Events/ActivityReassignedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "ActivityReassignedEvent",
       "fqn": "Granit.Activities.Events.ActivityReassignedEvent",
       "kind": "record",
@@ -5076,6 +5142,15 @@
       "project": "Granit.Activities",
       "file": "src/Granit.Activities/Events/ActivityReminderDueEvent.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "ActivityRescheduledEto",
+      "fqn": "Granit.Activities.Events.ActivityRescheduledEto",
+      "kind": "record",
+      "project": "Granit.Activities",
+      "file": "src/Granit.Activities/Events/ActivityRescheduledEto.cs",
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.Activities.BackgroundJobs/Services/MarkOverdueScanService.cs
+++ b/src/Granit.Activities.BackgroundJobs/Services/MarkOverdueScanService.cs
@@ -2,6 +2,7 @@ using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
 using Granit.Events;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +22,7 @@ public sealed partial class MarkOverdueScanService(
     IActivityReader reader,
     IActivityWriter writer,
     ILocalEventBus eventBus,
+    ICurrentTenant currentTenant,
     IClock clock,
     ILogger<MarkOverdueScanService> logger)
 {
@@ -46,6 +48,13 @@ public sealed partial class MarkOverdueScanService(
         foreach (Activity activity in overdueRows)
         {
             int overdueByDays = Math.Max(1, (int)Math.Ceiling((now - activity.DueAt).TotalDays));
+
+            // VULN-103 — establish the row's tenant context for the publish +
+            // stamp pair. Without this, downstream notification handlers run
+            // with whichever tenant happens to be on the AsyncLocal slot, and
+            // the EF writer's tenant interceptor would write to the wrong
+            // tenant if the scanner inherited a stale context.
+            using IDisposable _ = currentTenant.Change(activity.TenantId);
 
             // Publish first, then stamp. If publication fails the stamp is not
             // applied and the next scanner run will re-attempt — preserving

--- a/src/Granit.Activities.BackgroundJobs/Services/SendRemindersScanService.cs
+++ b/src/Granit.Activities.BackgroundJobs/Services/SendRemindersScanService.cs
@@ -2,6 +2,7 @@ using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
 using Granit.Events;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +22,7 @@ namespace Granit.Activities.BackgroundJobs.Services;
 public sealed partial class SendRemindersScanService(
     IActivityReader reader,
     ILocalEventBus eventBus,
+    ICurrentTenant currentTenant,
     IClock clock,
     ILogger<SendRemindersScanService> logger)
 {
@@ -43,6 +45,10 @@ public sealed partial class SendRemindersScanService(
 
         foreach (Activity activity in dueRows)
         {
+            // VULN-103 — establish the row's tenant context so notification
+            // handlers downstream do not inherit a stale AsyncLocal slot.
+            using IDisposable _ = currentTenant.Change(activity.TenantId);
+
             await eventBus.PublishAsync(new ActivityReminderDueEvent(
                 ActivityId: activity.Id,
                 Type: activity.Type,

--- a/src/Granit.Activities.Endpoints/Authorization/ActivityHostAuthorizer.cs
+++ b/src/Granit.Activities.Endpoints/Authorization/ActivityHostAuthorizer.cs
@@ -1,0 +1,84 @@
+using System.Collections.Frozen;
+using System.Security.Claims;
+using Granit.Activities.Domain;
+
+namespace Granit.Activities.Endpoints.Authorization;
+
+/// <summary>
+/// Composes every registered <see cref="IActivityHostAuthorizationProvider"/>
+/// into a single gate used by the endpoints. Lookups index by
+/// <see cref="IActivityHostAuthorizationProvider.EntityType"/> with the
+/// <c>"*"</c> wildcard as the fallback.
+/// </summary>
+internal sealed class ActivityHostAuthorizer
+{
+    private readonly FrozenDictionary<string, IActivityHostAuthorizationProvider> _providers;
+    private readonly IActivityHostAuthorizationProvider _wildcard;
+
+    public ActivityHostAuthorizer(IEnumerable<IActivityHostAuthorizationProvider> providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        Dictionary<string, IActivityHostAuthorizationProvider> map = new(StringComparer.Ordinal);
+        IActivityHostAuthorizationProvider? wildcard = null;
+        foreach (IActivityHostAuthorizationProvider p in providers)
+        {
+            if (p.EntityType == "*")
+            {
+                wildcard = p;
+                continue;
+            }
+            // Last-write-wins on duplicate keys — host modules opt out of the
+            // wildcard by registering a stricter provider for the same EntityType.
+            map[p.EntityType] = p;
+        }
+        _providers = map.ToFrozenDictionary(StringComparer.Ordinal);
+        _wildcard = wildcard ?? new AllowAllActivityHostAuthorizationProvider();
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> iff the matching provider (or the wildcard
+    /// fallback) authorizes the caller to see activities pinned to
+    /// <paramref name="entityType"/> / <paramref name="entityId"/>.
+    /// </summary>
+    public ValueTask<bool> CanReadHostAsync(string entityType, Guid entityId, ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        IActivityHostAuthorizationProvider provider = _providers.TryGetValue(entityType, out IActivityHostAuthorizationProvider? hit)
+            ? hit
+            : _wildcard;
+        return provider.CanReadHostAsync(entityId, user, cancellationToken);
+    }
+
+    /// <summary>
+    /// Filters <paramref name="rows"/> in-memory, dropping activities whose
+    /// host the caller cannot read. Used by list / calendar projections.
+    /// </summary>
+    public async ValueTask<IReadOnlyList<Activity>> FilterAsync(
+        IReadOnlyList<Activity> rows,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        if (rows.Count == 0)
+        {
+            return rows;
+        }
+
+        // Cache results per (entityType, entityId) — list/calendar pages often
+        // contain multiple activities pinned to the same host.
+        Dictionary<(string, Guid), bool> cache = new();
+        List<Activity> filtered = new(rows.Count);
+        foreach (Activity row in rows)
+        {
+            (string, Guid) key = (row.EntityType, row.EntityId);
+            if (!cache.TryGetValue(key, out bool allowed))
+            {
+                allowed = await CanReadHostAsync(row.EntityType, row.EntityId, user, cancellationToken).ConfigureAwait(false);
+                cache[key] = allowed;
+            }
+            if (allowed)
+            {
+                filtered.Add(row);
+            }
+        }
+        return filtered;
+    }
+}

--- a/src/Granit.Activities.Endpoints/Authorization/IActivityHostAuthorizationProvider.cs
+++ b/src/Granit.Activities.Endpoints/Authorization/IActivityHostAuthorizationProvider.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+
+namespace Granit.Activities.Endpoints.Authorization;
+
+/// <summary>
+/// Per-host authorization gate for the polymorphic <c>(EntityType, EntityId)</c>
+/// pinning of an <see cref="Granit.Activities.Domain.Activity"/>. Closes
+/// VULN-102 / VULN-202 — without this gate, any caller with
+/// <c>Activities.Activities.Read</c> could fingerprint workflows pinned to
+/// host entities they cannot otherwise read (e.g. activities pinned to
+/// <c>Granit.Identity.User</c> without holding <c>Identity.Users.Read</c>).
+/// </summary>
+/// <remarks>
+/// Each module that contributes activity-bearing entities registers an
+/// implementation via <c>services.AddSingleton&lt;IActivityHostAuthorizationProvider, …&gt;()</c>.
+/// The endpoint layer composes all registered providers and returns
+/// <see langword="true"/> only if every applicable provider authorizes
+/// the host. The default implementation
+/// (<see cref="AllowAllActivityHostAuthorizationProvider"/>) returns
+/// <see langword="true"/> for every host so single-tenant or low-sensitivity
+/// hosts do not require explicit registration.
+/// </remarks>
+public interface IActivityHostAuthorizationProvider
+{
+    /// <summary>
+    /// Wire identifier of the host entity this provider gates. Use
+    /// <c>"*"</c> to apply to every host (catch-all default).
+    /// </summary>
+    string EntityType { get; }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="user"/> is allowed
+    /// to see activities pinned to <paramref name="entityId"/>.
+    /// Implementations should fail closed (return <see langword="false"/>)
+    /// on any error.
+    /// </summary>
+    ValueTask<bool> CanReadHostAsync(Guid entityId, ClaimsPrincipal user, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Catch-all default that authorizes every host. Registered automatically by
+/// <c>AddGranitActivitiesEndpoints()</c> so hosts that do not opt-in to per-host
+/// authorization keep the previous (less strict) behavior. Hosts that contribute
+/// sensitive entities replace this by registering a stricter provider for the
+/// matching <see cref="EntityType"/>.
+/// </summary>
+public sealed class AllowAllActivityHostAuthorizationProvider : IActivityHostAuthorizationProvider
+{
+    /// <inheritdoc/>
+    public string EntityType => "*";
+
+    /// <inheritdoc/>
+    public ValueTask<bool> CanReadHostAsync(Guid entityId, ClaimsPrincipal user, CancellationToken cancellationToken)
+        => ValueTask.FromResult(true);
+}

--- a/src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs
+++ b/src/Granit.Activities.Endpoints/Dtos/ActivityRequests.cs
@@ -9,11 +9,11 @@ public sealed record CreateActivityRequest(
     DateTimeOffset DueAt,
     string? Description = null);
 
-/// <summary>Body for <c>POST /api/activities/{id}/complete</c>.</summary>
-public sealed record CompleteActivityRequest(DateTimeOffset CompletedAt);
+/// <summary>Body for <c>POST /api/activities/{id}/complete</c>. Empty — completion timestamp is derived server-side from <see cref="Granit.Timing.IClock"/> to prevent client-controlled backdating (VULN-101).</summary>
+public sealed record CompleteActivityRequest();
 
-/// <summary>Body for <c>POST /api/activities/{id}/cancel</c>.</summary>
-public sealed record CancelActivityRequest(DateTimeOffset CancelledAt);
+/// <summary>Body for <c>POST /api/activities/{id}/cancel</c>. Empty — cancellation timestamp is derived server-side from <see cref="Granit.Timing.IClock"/>.</summary>
+public sealed record CancelActivityRequest();
 
 /// <summary>Body for <c>PUT /api/activities/{id}/assignee</c>.</summary>
 public sealed record ReassignActivityRequest(Guid NewAssigneeUserId);

--- a/src/Granit.Activities.Endpoints/Endpoints/ActivityCalendarEndpoint.cs
+++ b/src/Granit.Activities.Endpoints/Endpoints/ActivityCalendarEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
+using Granit.Activities.Endpoints.Authorization;
 using Granit.Activities.Endpoints.Dtos;
 using Granit.Activities.Endpoints.Internal;
 using Granit.Activities.Endpoints.Options;
@@ -51,6 +52,7 @@ internal static class ActivityCalendarEndpoint
         [FromServices] IOptions<ActivitiesEndpointsOptions> options,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IClock clock,
+        [FromServices] ActivityHostAuthorizer hostAuthorizer,
         ClaimsPrincipal user,
         HttpContext httpContext,
         CancellationToken cancellationToken)
@@ -76,19 +78,25 @@ internal static class ActivityCalendarEndpoint
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
+        // VULN-204 — snap the window to a fixed grid before the cache key is
+        // composed, so an attacker cannot shift `from`/`to` by one second per
+        // call to defeat the FusionCache TTL.
+        DateTimeOffset snappedFrom = SnapWindow(request.From, opts.CalendarWindowSnapMinutes, roundUp: false);
+        DateTimeOffset snappedTo = SnapWindow(request.To, opts.CalendarWindowSnapMinutes, roundUp: true);
+
         ActivityListFilter filter = new(
             EntityType: request.EntityType,
             EntityId: null,
             AssignedToUserId: assignee,
             Status: request.Status,
-            DueAtFrom: request.From,
-            DueAtTo: request.To);
+            DueAtFrom: snappedFrom,
+            DueAtTo: snappedTo);
 
         HashSet<string>? typeFilter = ParseTypeFilter(request.Type);
 
         string tenantSegment = currentTenant.IsAvailable ? currentTenant.Id?.ToString() ?? "global" : "global";
         string cacheKey = ActivityCalendarCacheKey.Build(
-            tenantSegment, user, request.From, request.To,
+            tenantSegment, user, snappedFrom, snappedTo,
             assigneeFilter: request.Assignee, entityTypeFilter: request.EntityType,
             typeFilter: request.Type, statusFilter: request.Status?.ToString());
         string evictionTag = ActivityCalendarCacheKey.EvictionTag(currentTenant.IsAvailable ? currentTenant.Id : null);
@@ -96,7 +104,7 @@ internal static class ActivityCalendarEndpoint
         DateTimeOffset now = clock.Normalize(clock.Now);
         IReadOnlyList<ActivityCalendarItemResponse> items = await cache.GetOrSetAsync(
             cacheKey,
-            async ct => await ProjectAsync(reader, registry, filter, typeFilter, opts, now, ct).ConfigureAwait(false),
+            async ct => await ProjectAsync(reader, registry, hostAuthorizer, user, filter, typeFilter, opts, now, ct).ConfigureAwait(false),
             new FusionCacheEntryOptions { Duration = opts.CalendarCacheTtl },
             tags: [evictionTag],
             token: cancellationToken)
@@ -117,6 +125,8 @@ internal static class ActivityCalendarEndpoint
     private static async Task<IReadOnlyList<ActivityCalendarItemResponse>> ProjectAsync(
         IActivityReader reader,
         IActivityRegistry registry,
+        ActivityHostAuthorizer hostAuthorizer,
+        ClaimsPrincipal user,
         ActivityListFilter filter,
         HashSet<string>? typeFilter,
         ActivitiesEndpointsOptions opts,
@@ -128,6 +138,9 @@ internal static class ActivityCalendarEndpoint
         // MaxPageSize if a multi-month wall-board is required.
         IReadOnlyList<Activity> rows = await reader.ListAsync(filter, skip: 0, take: opts.MaxPageSize, cancellationToken)
             .ConfigureAwait(false);
+
+        // VULN-202 — drop activities whose host the caller cannot read.
+        rows = await hostAuthorizer.FilterAsync(rows, user, cancellationToken).ConfigureAwait(false);
 
         List<ActivityCalendarItemResponse> result = new(rows.Count);
         foreach (Activity activity in rows)
@@ -178,6 +191,27 @@ internal static class ActivityCalendarEndpoint
             return Guid.TryParse(sub, out Guid id) ? id : null;
         }
         return Guid.TryParse(assignee, out Guid g) ? g : null;
+    }
+
+    // VULN-204 — round the timestamp down (or up) to the nearest snap-minutes
+    // boundary so the cache key is stable across attacker-shifted windows.
+    private static DateTimeOffset SnapWindow(DateTimeOffset value, int snapMinutes, bool roundUp)
+    {
+        if (snapMinutes <= 0)
+        {
+            return value;
+        }
+        long snapTicks = TimeSpan.FromMinutes(snapMinutes).Ticks;
+        long ticks = value.UtcTicks;
+        long remainder = ticks % snapTicks;
+        if (remainder == 0)
+        {
+            return value;
+        }
+        long adjusted = roundUp
+            ? ticks + (snapTicks - remainder)
+            : ticks - remainder;
+        return new DateTimeOffset(adjusted, TimeSpan.Zero).ToOffset(value.Offset);
     }
 
     private static HashSet<string>? ParseTypeFilter(string? typeQuery)

--- a/src/Granit.Activities.Endpoints/Endpoints/ActivityEndpoints.cs
+++ b/src/Granit.Activities.Endpoints/Endpoints/ActivityEndpoints.cs
@@ -1,9 +1,13 @@
+using System.Security.Claims;
 using Granit.Activities.Abstractions;
 using Granit.Activities.Domain;
+using Granit.Activities.Endpoints.Authorization;
 using Granit.Activities.Endpoints.Dtos;
 using Granit.Activities.Endpoints.Internal;
 using Granit.Activities.Endpoints.Options;
 using Granit.Activities.Endpoints.Permissions;
+using Granit.Authorization;
+using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -25,13 +29,14 @@ internal static class ActivityEndpoints
         group.MapGet("/", ListAsync)
             .WithName("ListActivities")
             .WithSummary("Returns a paginated list of activities matching the query filter.")
-            .WithDescription("Filter by entity (entityType + entityId), assignee (assignedToUserId or 'me'), status (open / done / cancelled), or due-date window (dueAtFrom / dueAtTo, half-open). Ordered by DueAt ascending. Caps page size at ActivitiesEndpointsOptions.MaxPageSize (default 100).")
-            .Produces<ActivityListResponse>();
+            .WithDescription("Filter by entity (entityType + entityId), assignee (assignedToUserId or 'me'), status (open / done / cancelled), or due-date window (dueAtFrom / dueAtTo, half-open). Ordered by DueAt ascending. Caps page size at ActivitiesEndpointsOptions.MaxPageSize (default 100). Activities pinned to hosts the caller cannot read are filtered out (IActivityHostAuthorizationProvider). Listing peers' activities (assignedToUserId != caller) requires Activities.Activities.ReadOthers.")
+            .Produces<ActivityListResponse>()
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         group.MapGet("/{id:guid}", GetByIdAsync)
             .WithName("GetActivityById")
             .WithSummary("Returns a single activity by id.")
-            .WithDescription("Returns 404 if the activity does not exist or is in a different tenant.")
+            .WithDescription("Returns 404 if the activity does not exist, is in a different tenant, or its host entity is not readable by the caller.")
             .Produces<ActivityResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -39,7 +44,7 @@ internal static class ActivityEndpoints
             .RequireAuthorization(ActivitiesPermissions.Activities.Manage)
             .WithName("CreateActivity")
             .WithSummary("Creates a new activity in Open state.")
-            .WithDescription("Validates the activity type against IActivityRegistry — types from unloaded providers are rejected with 400. Emits ActivityAssignedEvent (local) and ActivityAssignedEto (distributed) on success.")
+            .WithDescription("Validates the activity type against IActivityRegistry — types from unloaded providers are rejected with 400. The created-by user id is resolved from the authenticated principal — clients cannot impersonate. Emits ActivityAssignedEvent (local) and ActivityAssignedEto (distributed) on success.")
             .Produces<ActivityResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem();
 
@@ -47,8 +52,9 @@ internal static class ActivityEndpoints
             .RequireAuthorization(ActivitiesPermissions.Activities.Execute)
             .WithName("CompleteActivity")
             .WithSummary("Marks the activity as Done.")
-            .WithDescription("Idempotent within a single transition — completing an already-terminal activity (Done or Cancelled) returns 409. Emits ActivityCompletedEvent (local) and ActivityCompletedEto (distributed).")
+            .WithDescription("Idempotent within a single transition — completing an already-terminal activity (Done or Cancelled) returns 409. The completion timestamp is derived server-side from IClock; the actor is resolved from the authenticated principal. Emits ActivityCompletedEvent (local) and ActivityCompletedEto (distributed).")
             .Produces<ActivityResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
@@ -56,16 +62,17 @@ internal static class ActivityEndpoints
             .RequireAuthorization(ActivitiesPermissions.Activities.Manage)
             .WithName("CancelActivity")
             .WithSummary("Marks the activity as Cancelled.")
-            .WithDescription("Append-only — cancelling an already-terminal activity returns 409. Cancel does not propagate to the integration bus (internal lifecycle only).")
+            .WithDescription("Append-only — cancelling an already-terminal activity returns 409. The cancellation timestamp is derived server-side from IClock; the actor is resolved from the authenticated principal.")
             .Produces<ActivityResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
         group.MapPut("/{id:guid}/assignee", ReassignAsync)
-            .RequireAuthorization(ActivitiesPermissions.Activities.Manage)
+            .RequireAuthorization(ActivitiesPermissions.Activities.Reassign)
             .WithName("ReassignActivity")
             .WithSummary("Changes the assignee of an open activity.")
-            .WithDescription("Allowed only while the activity is Open. Emits ActivityReassignedEvent. Setting the same assignee is a no-op (no event raised).")
+            .WithDescription("Allowed only while the activity is Open. Requires the dedicated Reassign permission (separate from Manage so least-privilege roles cannot move work to other users). Emits ActivityReassignedEvent (local) and ActivityReassignedEto (distributed). Setting the same assignee is a no-op (no event raised).")
             .Produces<ActivityResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
@@ -74,17 +81,21 @@ internal static class ActivityEndpoints
             .RequireAuthorization(ActivitiesPermissions.Activities.Manage)
             .WithName("RescheduleActivity")
             .WithSummary("Updates the due date of an open activity.")
-            .WithDescription("Allowed only while the activity is Open. Emits ActivityRescheduledEvent. Setting the same due date is a no-op (no event raised).")
+            .WithDescription("Allowed only while the activity is Open. The new due date must lie within ActivitiesEndpointsOptions.MaxFutureRescheduleDays of the server clock. Emits ActivityRescheduledEvent (local) and ActivityRescheduledEto (distributed). Setting the same due date is a no-op (no event raised).")
             .Produces<ActivityResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
         return group;
     }
 
-    private static async Task<Ok<ActivityListResponse>> ListAsync(
+    private static async Task<Results<Ok<ActivityListResponse>, ProblemHttpResult>> ListAsync(
         [FromServices] IActivityReader reader,
+        [FromServices] ActivityHostAuthorizer hostAuthorizer,
+        [FromServices] IPermissionChecker permissionChecker,
         [FromServices] IOptions<ActivitiesEndpointsOptions> options,
+        ClaimsPrincipal user,
         [FromQuery] string? entityType = null,
         [FromQuery] Guid? entityId = null,
         [FromQuery] Guid? assignedToUserId = null,
@@ -101,6 +112,21 @@ internal static class ActivityEndpoints
             ? Math.Min(ps, opts.MaxPageSize)
             : opts.DefaultPageSize;
 
+        // VULN-400 — peer-workload lookups require the dedicated permission.
+        Guid? callerId = ResolveUserId(user);
+        if (assignedToUserId is { } target && target != callerId)
+        {
+            bool granted = await permissionChecker
+                .IsGrantedAsync(ActivitiesPermissions.Activities.ReadOthers, cancellationToken)
+                .ConfigureAwait(false);
+            if (!granted)
+            {
+                return TypedResults.Problem(
+                    detail: "Reading other users' activities requires Activities.Activities.ReadOthers.",
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+        }
+
         ActivityListFilter filter = new(
             EntityType: entityType,
             EntityId: entityId,
@@ -110,6 +136,10 @@ internal static class ActivityEndpoints
             DueAtTo: dueAtTo);
 
         IReadOnlyList<Activity> rows = await reader.ListAsync(filter, (safePage - 1) * safePageSize, safePageSize, cancellationToken).ConfigureAwait(false);
+
+        // VULN-102 / VULN-202 — drop activities pinned to hosts the caller cannot read.
+        rows = await hostAuthorizer.FilterAsync(rows, user, cancellationToken).ConfigureAwait(false);
+
         int total = await reader.CountAsync(filter, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok(new ActivityListResponse(
@@ -122,19 +152,41 @@ internal static class ActivityEndpoints
     private static async Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> GetByIdAsync(
         Guid id,
         [FromServices] IActivityReader reader,
+        [FromServices] ActivityHostAuthorizer hostAuthorizer,
+        ClaimsPrincipal user,
         CancellationToken cancellationToken)
     {
         Activity? activity = await reader.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
-        return activity is null
-            ? TypedResults.Problem(statusCode: StatusCodes.Status404NotFound)
-            : TypedResults.Ok(activity.ToResponse());
+        if (activity is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+        // VULN-102 — return 404 (not 403) on host-auth failure so the host id is not enumerable.
+        bool allowed = await hostAuthorizer.CanReadHostAsync(activity.EntityType, activity.EntityId, user, cancellationToken).ConfigureAwait(false);
+        if (!allowed)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+        return TypedResults.Ok(activity.ToResponse());
     }
 
     private static async Task<Results<Created<ActivityResponse>, ProblemHttpResult>> CreateAsync(
         CreateActivityRequest request,
         [FromServices] IActivityWriter writer,
+        [FromServices] IClock clock,
+        [FromServices] IOptions<ActivitiesEndpointsOptions> options,
+        ClaimsPrincipal user,
         CancellationToken cancellationToken)
     {
+        if (!TryResolveActor(user, out Guid actorId))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status401Unauthorized);
+        }
+        // VULN-203 — clamp DueAt to a sane future bound to prevent stored-state DoS.
+        if (!IsWithinFutureBound(request.DueAt, clock, options.Value, out string? boundError))
+        {
+            return TypedResults.Problem(detail: boundError, statusCode: StatusCodes.Status400BadRequest);
+        }
         try
         {
             Activity created = await writer.CreateAsync(
@@ -143,7 +195,7 @@ internal static class ActivityEndpoints
                 request.Type,
                 request.AssignedToUserId,
                 request.DueAt,
-                createdByUserId: null,
+                createdByUserId: actorId,
                 description: request.Description,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             return TypedResults.Created($"/api/activities/{created.Id}", created.ToResponse());
@@ -159,16 +211,38 @@ internal static class ActivityEndpoints
         CompleteActivityRequest request,
         [FromServices] IActivityWriter writer,
         [FromServices] IActivityReader reader,
-        CancellationToken cancellationToken) =>
-        ApplyMutationAsync(id, ct => writer.CompleteAsync(id, completedByUserId: Guid.Empty, request.CompletedAt, ct), reader, cancellationToken);
+        [FromServices] IClock clock,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        _ = request;
+        if (!TryResolveActor(user, out Guid actorId))
+        {
+            return Task.FromResult<Results<Ok<ActivityResponse>, ProblemHttpResult>>(
+                TypedResults.Problem(statusCode: StatusCodes.Status401Unauthorized));
+        }
+        DateTimeOffset at = clock.Normalize(clock.Now);
+        return ApplyMutationAsync(id, ct => writer.CompleteAsync(id, actorId, at, ct), reader, cancellationToken);
+    }
 
     private static Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> CancelAsync(
         Guid id,
         CancelActivityRequest request,
         [FromServices] IActivityWriter writer,
         [FromServices] IActivityReader reader,
-        CancellationToken cancellationToken) =>
-        ApplyMutationAsync(id, ct => writer.CancelAsync(id, cancelledByUserId: Guid.Empty, request.CancelledAt, ct), reader, cancellationToken);
+        [FromServices] IClock clock,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        _ = request;
+        if (!TryResolveActor(user, out Guid actorId))
+        {
+            return Task.FromResult<Results<Ok<ActivityResponse>, ProblemHttpResult>>(
+                TypedResults.Problem(statusCode: StatusCodes.Status401Unauthorized));
+        }
+        DateTimeOffset at = clock.Normalize(clock.Now);
+        return ApplyMutationAsync(id, ct => writer.CancelAsync(id, actorId, at, ct), reader, cancellationToken);
+    }
 
     private static Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> ReassignAsync(
         Guid id,
@@ -183,14 +257,52 @@ internal static class ActivityEndpoints
         RescheduleActivityRequest request,
         [FromServices] IActivityWriter writer,
         [FromServices] IActivityReader reader,
-        CancellationToken cancellationToken) =>
-        ApplyMutationAsync(id, ct => writer.RescheduleAsync(id, request.NewDueAt, ct), reader, cancellationToken);
+        [FromServices] IClock clock,
+        [FromServices] IOptions<ActivitiesEndpointsOptions> options,
+        CancellationToken cancellationToken)
+    {
+        if (!IsWithinFutureBound(request.NewDueAt, clock, options.Value, out string? boundError))
+        {
+            return Task.FromResult<Results<Ok<ActivityResponse>, ProblemHttpResult>>(
+                TypedResults.Problem(detail: boundError, statusCode: StatusCodes.Status400BadRequest));
+        }
+        return ApplyMutationAsync(id, ct => writer.RescheduleAsync(id, request.NewDueAt, ct), reader, cancellationToken);
+    }
 
-    // Private helper — not a route handler, but the architecture test
-    // (EndpointParameterBindingTests) does a static text scan and treats any
-    // interface-typed parameter in *.Endpoints as a candidate, so the
-    // [FromServices] attribute is applied for parity even though it has no
-    // runtime effect on a private method.
+    // VULN-203 — reject DueAt values past `now + MaxFutureRescheduleDays`.
+    // Negative bounds (past dates) are intentionally allowed because the
+    // create flow needs to support backfilling activities from imported data;
+    // reschedule keeps the same rule for symmetry.
+    private static bool IsWithinFutureBound(DateTimeOffset value, IClock clock, ActivitiesEndpointsOptions opts, out string? error)
+    {
+        DateTimeOffset upper = clock.Normalize(clock.Now).AddDays(opts.MaxFutureRescheduleDays);
+        if (value > upper)
+        {
+            error = $"DueAt cannot be more than {opts.MaxFutureRescheduleDays} days in the future.";
+            return false;
+        }
+        error = null;
+        return true;
+    }
+
+    // VULN-100 — resolve the acting user from the authenticated principal.
+    private static bool TryResolveActor(ClaimsPrincipal user, out Guid actorId)
+    {
+        actorId = ResolveUserId(user) ?? Guid.Empty;
+        return actorId != Guid.Empty;
+    }
+
+    private static Guid? ResolveUserId(ClaimsPrincipal user)
+    {
+        string? sub = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        return Guid.TryParse(sub, out Guid id) ? id : null;
+    }
+
+    // Helper — not a route handler, but the GRAPI003 analyzer treats any
+    // interface-typed parameter in *.Endpoints as a candidate, hence the
+    // [FromServices] attribute despite having no runtime effect on a private
+    // method.
     private static async Task<Results<Ok<ActivityResponse>, ProblemHttpResult>> ApplyMutationAsync(
         Guid activityId,
         Func<CancellationToken, Task> mutate,
@@ -219,3 +331,4 @@ internal static class ActivityEndpoints
         }
     }
 }
+

--- a/src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs
+++ b/src/Granit.Activities.Endpoints/GranitActivitiesEndpointsModule.cs
@@ -1,7 +1,10 @@
+using Granit.Activities.Endpoints.Authorization;
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Activities.Endpoints;
 
@@ -19,4 +22,16 @@ namespace Granit.Activities.Endpoints;
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitActivitiesModule),
     typeof(GranitValidationModule))]
-public sealed class GranitActivitiesEndpointsModule : GranitModule;
+public sealed class GranitActivitiesEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Catch-all wildcard provider — host modules contributing sensitive
+        // entities replace this by registering a stricter provider for the
+        // matching EntityType (VULN-102 / VULN-202).
+        context.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IActivityHostAuthorizationProvider, AllowAllActivityHostAuthorizationProvider>());
+        context.Services.TryAddSingleton<ActivityHostAuthorizer>();
+    }
+}

--- a/src/Granit.Activities.Endpoints/Internal/ActivityCalendarCacheKey.cs
+++ b/src/Granit.Activities.Endpoints/Internal/ActivityCalendarCacheKey.cs
@@ -46,15 +46,37 @@ internal static class ActivityCalendarCacheKey
     public static string EvictionTag(Guid? tenantId) =>
         $"{Prefix}:tenant:{tenantId?.ToString() ?? "global"}";
 
+    // Claim types that affect authorization decisions and therefore the
+    // shape of the cached calendar projection. Broadened beyond the original
+    // (role, permission) allowlist (VULN-302): the permission claim type
+    // varies across providers (perms, permissions, OpenIddict-prefixed forms),
+    // and dropping any of them collapses two distinct callers onto the same
+    // cache slot. Tenant claims are also included because the projection is
+    // filtered by tenant downstream.
+    private static readonly string[] AuthorizationClaimTypes =
+    [
+        ClaimTypes.Role,
+        "role",
+        "roles",
+        "permission",
+        "permissions",
+        "perms",
+        "scope",
+        "scopes",
+        "tenant",
+        "tenant_id",
+        "tid",
+    ];
+
     private static string HashPermissions(ClaimsPrincipal user)
     {
-        IEnumerable<string> roleClaims = user.Claims
-            .Where(c => c.Type is ClaimTypes.Role or "role" or "permission")
+        IEnumerable<string> claims = user.Claims
+            .Where(c => Array.IndexOf(AuthorizationClaimTypes, c.Type) >= 0)
             .Select(c => $"{c.Type}={c.Value}")
             .OrderBy(s => s, StringComparer.Ordinal);
 
         StringBuilder buffer = new();
-        foreach (string claim in roleClaims)
+        foreach (string claim in claims)
         {
             buffer.Append(claim);
             buffer.Append('|');
@@ -64,7 +86,10 @@ internal static class ActivityCalendarCacheKey
             ?? user.FindFirst("sub")?.Value;
         buffer.Append(sub ?? "anon");
 
+        // Full SHA-256 hex (VULN-201) — the previous 64-bit truncation gave
+        // a birthday-bound collision risk where two users in the same tenant
+        // could share a cache slot, leaking each other's calendar projection.
         byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(buffer.ToString()));
-        return Convert.ToHexString(hash)[..16].ToLowerInvariant();
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/cs.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/cs.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Aktivity",
     "Permission:Activities.Activities.Read": "Číst aktivity",
+    "Permission:Activities.Activities.ReadOthers": "Číst aktivity ostatních",
     "Permission:Activities.Activities.Manage": "Spravovat aktivity",
+    "Permission:Activities.Activities.Reassign": "Znovu přiřadit aktivity",
     "Permission:Activities.Activities.Execute": "Dokončit aktivity"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/de.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/de.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Aktivitäten",
     "Permission:Activities.Activities.Read": "Aktivitäten lesen",
+    "Permission:Activities.Activities.ReadOthers": "Aktivitäten anderer lesen",
     "Permission:Activities.Activities.Manage": "Aktivitäten verwalten",
+    "Permission:Activities.Activities.Reassign": "Aktivitäten neu zuweisen",
     "Permission:Activities.Activities.Execute": "Aktivitäten abschließen"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/en.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/en.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Activities",
     "Permission:Activities.Activities.Read": "Read activities",
+    "Permission:Activities.Activities.ReadOthers": "Read others' activities",
     "Permission:Activities.Activities.Manage": "Manage activities",
+    "Permission:Activities.Activities.Reassign": "Reassign activities",
     "Permission:Activities.Activities.Execute": "Complete activities"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/es.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/es.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Actividades",
     "Permission:Activities.Activities.Read": "Leer actividades",
+    "Permission:Activities.Activities.ReadOthers": "Leer actividades de otros",
     "Permission:Activities.Activities.Manage": "Gestionar actividades",
+    "Permission:Activities.Activities.Reassign": "Reasignar actividades",
     "Permission:Activities.Activities.Execute": "Completar actividades"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/fr.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/fr.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Activités",
     "Permission:Activities.Activities.Read": "Lire les activités",
+    "Permission:Activities.Activities.ReadOthers": "Lire les activités des autres",
     "Permission:Activities.Activities.Manage": "Gérer les activités",
+    "Permission:Activities.Activities.Reassign": "Réassigner les activités",
     "Permission:Activities.Activities.Execute": "Compléter les activités"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/hi.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/hi.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "गतिविधियाँ",
     "Permission:Activities.Activities.Read": "गतिविधियाँ पढ़ें",
+    "Permission:Activities.Activities.ReadOthers": "दूसरों की गतिविधियाँ पढ़ें",
     "Permission:Activities.Activities.Manage": "गतिविधियाँ प्रबंधित करें",
+    "Permission:Activities.Activities.Reassign": "गतिविधियाँ पुनर्निर्धारित करें",
     "Permission:Activities.Activities.Execute": "गतिविधियाँ पूरी करें"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/it.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/it.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Attività",
     "Permission:Activities.Activities.Read": "Leggere attività",
+    "Permission:Activities.Activities.ReadOthers": "Leggere le attività di altri",
     "Permission:Activities.Activities.Manage": "Gestire attività",
+    "Permission:Activities.Activities.Reassign": "Riassegnare le attività",
     "Permission:Activities.Activities.Execute": "Completare attività"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/ja.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/ja.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "アクティビティ",
     "Permission:Activities.Activities.Read": "アクティビティを読む",
+    "Permission:Activities.Activities.ReadOthers": "他人のアクティビティを読み取る",
     "Permission:Activities.Activities.Manage": "アクティビティを管理",
+    "Permission:Activities.Activities.Reassign": "アクティビティを再割り当て",
     "Permission:Activities.Activities.Execute": "アクティビティを完了"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/ko.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/ko.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "활동",
     "Permission:Activities.Activities.Read": "활동 읽기",
+    "Permission:Activities.Activities.ReadOthers": "다른 사용자의 활동 읽기",
     "Permission:Activities.Activities.Manage": "활동 관리",
+    "Permission:Activities.Activities.Reassign": "활동 재할당",
     "Permission:Activities.Activities.Execute": "활동 완료"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/nl.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/nl.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Activiteiten",
     "Permission:Activities.Activities.Read": "Activiteiten lezen",
+    "Permission:Activities.Activities.ReadOthers": "Activiteiten van anderen lezen",
     "Permission:Activities.Activities.Manage": "Activiteiten beheren",
+    "Permission:Activities.Activities.Reassign": "Activiteiten opnieuw toewijzen",
     "Permission:Activities.Activities.Execute": "Activiteiten voltooien"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/pl.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/pl.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Aktywności",
     "Permission:Activities.Activities.Read": "Odczyt aktywności",
+    "Permission:Activities.Activities.ReadOthers": "Czytaj aktywności innych",
     "Permission:Activities.Activities.Manage": "Zarządzanie aktywnościami",
+    "Permission:Activities.Activities.Reassign": "Zmień przypisanie aktywności",
     "Permission:Activities.Activities.Execute": "Ukończ aktywności"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/pt.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/pt.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Atividades",
     "Permission:Activities.Activities.Read": "Ler atividades",
+    "Permission:Activities.Activities.ReadOthers": "Ler atividades de outros",
     "Permission:Activities.Activities.Manage": "Gerenciar atividades",
+    "Permission:Activities.Activities.Reassign": "Reatribuir atividades",
     "Permission:Activities.Activities.Execute": "Concluir atividades"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/sv.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/sv.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Aktiviteter",
     "Permission:Activities.Activities.Read": "Läs aktiviteter",
+    "Permission:Activities.Activities.ReadOthers": "Läs andras aktiviteter",
     "Permission:Activities.Activities.Manage": "Hantera aktiviteter",
+    "Permission:Activities.Activities.Reassign": "Omfördela aktiviteter",
     "Permission:Activities.Activities.Execute": "Slutför aktiviteter"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/tr.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/tr.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "Aktiviteler",
     "Permission:Activities.Activities.Read": "Aktiviteleri oku",
+    "Permission:Activities.Activities.ReadOthers": "Başkalarının etkinliklerini oku",
     "Permission:Activities.Activities.Manage": "Aktiviteleri yönet",
+    "Permission:Activities.Activities.Reassign": "Etkinlikleri yeniden ata",
     "Permission:Activities.Activities.Execute": "Aktiviteleri tamamla"
   }
 }

--- a/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/zh.json
+++ b/src/Granit.Activities.Endpoints/Localization/ActivitiesEndpoints/zh.json
@@ -3,7 +3,9 @@
   "texts": {
     "PermissionGroup:Activities": "活动",
     "Permission:Activities.Activities.Read": "读取活动",
+    "Permission:Activities.Activities.ReadOthers": "读取他人的活动",
     "Permission:Activities.Activities.Manage": "管理活动",
+    "Permission:Activities.Activities.Reassign": "重新分配活动",
     "Permission:Activities.Activities.Execute": "完成活动"
   }
 }

--- a/src/Granit.Activities.Endpoints/Options/ActivitiesEndpointsOptions.cs
+++ b/src/Granit.Activities.Endpoints/Options/ActivitiesEndpointsOptions.cs
@@ -25,4 +25,22 @@ public sealed class ActivitiesEndpointsOptions
 
     /// <summary>FusionCache TTL for the activities calendar response. Default: 1 minute (sliding).</summary>
     public TimeSpan CalendarCacheTtl { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Upper bound (in days from now) accepted by Create/Reschedule for
+    /// <see cref="Granit.Activities.Domain.Activity.DueAt"/>. Closes VULN-203 —
+    /// without a bound, callers can mass-mute their inbox by rescheduling every
+    /// open activity to <c>DateTimeOffset.MaxValue</c> (rows then never match
+    /// the overdue scan and remain perpetually <c>Open</c>). Default: 5 years.
+    /// </summary>
+    public int MaxFutureRescheduleDays { get; set; } = 365 * 5;
+
+    /// <summary>
+    /// Window-snap granularity (minutes) applied to the calendar
+    /// <c>from</c>/<c>to</c> parameters before cache-key composition. Closes
+    /// VULN-204 — without snapping, an attacker can shift the window by one
+    /// second per call to defeat <see cref="CalendarCacheTtl"/> and force
+    /// repeated DB scans. Default: 60 minutes (one cache slot per hour).
+    /// </summary>
+    public int CalendarWindowSnapMinutes { get; set; } = 60;
 }

--- a/src/Granit.Activities.Endpoints/Permissions/ActivitiesPermissionDefinitionProvider.cs
+++ b/src/Granit.Activities.Endpoints/Permissions/ActivitiesPermissionDefinitionProvider.cs
@@ -24,9 +24,21 @@ internal sealed class ActivitiesPermissionDefinitionProvider : IPermissionDefini
             MultiTenancySides.Both);
 
         group.AddPermission(
+            ActivitiesPermissions.Activities.ReadOthers,
+            LocalizableString.Create<ActivitiesEndpointsLocalizationResource>(
+                "Permission:Activities.Activities.ReadOthers"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
             ActivitiesPermissions.Activities.Manage,
             LocalizableString.Create<ActivitiesEndpointsLocalizationResource>(
                 "Permission:Activities.Activities.Manage"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            ActivitiesPermissions.Activities.Reassign,
+            LocalizableString.Create<ActivitiesEndpointsLocalizationResource>(
+                "Permission:Activities.Activities.Reassign"),
             MultiTenancySides.Both);
 
         group.AddPermission(

--- a/src/Granit.Activities.Endpoints/Permissions/ActivitiesPermissions.cs
+++ b/src/Granit.Activities.Endpoints/Permissions/ActivitiesPermissions.cs
@@ -11,11 +11,17 @@ public static class ActivitiesPermissions
     /// <summary>Permissions for the activities resource.</summary>
     public static class Activities
     {
-        /// <summary>List + get-by-id.</summary>
+        /// <summary>List + get-by-id (own activities — assignee == caller or 'me' filter).</summary>
         public const string Read = "Activities.Activities.Read";
 
-        /// <summary>Create / cancel / reassign / reschedule.</summary>
+        /// <summary>List activities assigned to other users — separate gate for peer-workload queries.</summary>
+        public const string ReadOthers = "Activities.Activities.ReadOthers";
+
+        /// <summary>Create / cancel / reschedule.</summary>
         public const string Manage = "Activities.Activities.Manage";
+
+        /// <summary>Reassign — separate gate so least-privilege roles cannot move work to other users.</summary>
+        public const string Reassign = "Activities.Activities.Reassign";
 
         /// <summary>Complete (typically held by the assignee in addition to <see cref="Read"/>).</summary>
         public const string Execute = "Activities.Activities.Execute";

--- a/src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs
+++ b/src/Granit.Activities.Endpoints/Validators/ActivityRequestValidators.cs
@@ -21,21 +21,10 @@ public sealed class CreateActivityRequestValidator : AbstractValidator<CreateAct
     }
 }
 
-public sealed class CompleteActivityRequestValidator : AbstractValidator<CompleteActivityRequest>
-{
-    public CompleteActivityRequestValidator()
-    {
-        RuleFor(x => x.CompletedAt).NotEqual(default(DateTimeOffset));
-    }
-}
+// Empty bodies — completion / cancellation timestamps are server-side (VULN-101).
+public sealed class CompleteActivityRequestValidator : AbstractValidator<CompleteActivityRequest>;
 
-public sealed class CancelActivityRequestValidator : AbstractValidator<CancelActivityRequest>
-{
-    public CancelActivityRequestValidator()
-    {
-        RuleFor(x => x.CancelledAt).NotEqual(default(DateTimeOffset));
-    }
-}
+public sealed class CancelActivityRequestValidator : AbstractValidator<CancelActivityRequest>;
 
 public sealed class ReassignActivityRequestValidator : AbstractValidator<ReassignActivityRequest>
 {

--- a/src/Granit.Activities/Domain/Activity.cs
+++ b/src/Granit.Activities/Domain/Activity.cs
@@ -1,4 +1,5 @@
 using Granit.Activities.Events;
+using Granit.DataProtection;
 using Granit.Domain;
 
 namespace Granit.Activities.Domain;
@@ -103,6 +104,7 @@ public sealed class Activity : FullAuditedAggregateRoot, IMultiTenant, IEmitEnti
     public DateTimeOffset DueAt { get; private set; }
 
     /// <summary>Optional free-text description from the creator.</summary>
+    [SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
     public string? Description { get; private set; }
 
     /// <summary>Lifecycle status — see <see cref="ActivityStatus"/>.</summary>
@@ -194,6 +196,7 @@ public sealed class Activity : FullAuditedAggregateRoot, IMultiTenant, IEmitEnti
         Guid previous = AssignedToUserId;
         AssignedToUserId = newAssigneeUserId;
         AddDomainEvent(new ActivityReassignedEvent(Id, previous, newAssigneeUserId));
+        AddDistributedEvent(new ActivityReassignedEto(Id, previous, newAssigneeUserId, TenantId));
     }
 
     /// <summary>
@@ -211,6 +214,7 @@ public sealed class Activity : FullAuditedAggregateRoot, IMultiTenant, IEmitEnti
         DateTimeOffset previous = DueAt;
         DueAt = newDueAt;
         AddDomainEvent(new ActivityRescheduledEvent(Id, previous, newDueAt));
+        AddDistributedEvent(new ActivityRescheduledEto(Id, previous, newDueAt, TenantId));
     }
 
     /// <summary>

--- a/src/Granit.Activities/Events/ActivityReassignedEto.cs
+++ b/src/Granit.Activities/Events/ActivityReassignedEto.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Activities.Events;
+
+/// <summary>
+/// Integration event mirroring <see cref="ActivityReassignedEvent"/> for
+/// distributed dispatch via Wolverine outbox.
+/// </summary>
+public sealed record ActivityReassignedEto(
+    Guid ActivityId,
+    Guid PreviousAssigneeUserId,
+    Guid NewAssigneeUserId,
+    Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Activities/Events/ActivityRescheduledEto.cs
+++ b/src/Granit.Activities/Events/ActivityRescheduledEto.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Activities.Events;
+
+/// <summary>
+/// Integration event mirroring <see cref="ActivityRescheduledEvent"/> for
+/// distributed dispatch via Wolverine outbox.
+/// </summary>
+public sealed record ActivityRescheduledEto(
+    Guid ActivityId,
+    DateTimeOffset PreviousDueAt,
+    DateTimeOffset NewDueAt,
+    Guid? TenantId) : IIntegrationEvent;

--- a/tests/Granit.Activities.BackgroundJobs.Tests/MarkOverdueScanServiceTests.cs
+++ b/tests/Granit.Activities.BackgroundJobs.Tests/MarkOverdueScanServiceTests.cs
@@ -4,6 +4,7 @@ using Granit.Activities.BackgroundJobs.Services;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
 using Granit.Events;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -52,7 +53,9 @@ public sealed class MarkOverdueScanServiceTests
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(Now);
         clock.Normalize(Arg.Any<DateTimeOffset>()).Returns(call => call.Arg<DateTimeOffset>());
-        return (new MarkOverdueScanService(reader, writer, bus, clock, NullLogger<MarkOverdueScanService>.Instance), reader, writer, bus, clock);
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(_ => Substitute.For<IDisposable>());
+        return (new MarkOverdueScanService(reader, writer, bus, tenant, clock, NullLogger<MarkOverdueScanService>.Instance), reader, writer, bus, clock);
     }
 
     [Fact]

--- a/tests/Granit.Activities.BackgroundJobs.Tests/SendRemindersScanServiceTests.cs
+++ b/tests/Granit.Activities.BackgroundJobs.Tests/SendRemindersScanServiceTests.cs
@@ -4,6 +4,7 @@ using Granit.Activities.BackgroundJobs.Services;
 using Granit.Activities.Domain;
 using Granit.Activities.Events;
 using Granit.Events;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -46,7 +47,9 @@ public sealed class SendRemindersScanServiceTests
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(Now);
         clock.Normalize(Arg.Any<DateTimeOffset>()).Returns(call => call.Arg<DateTimeOffset>());
-        return (new SendRemindersScanService(reader, bus, clock, NullLogger<SendRemindersScanService>.Instance), reader, bus);
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(_ => Substitute.For<IDisposable>());
+        return (new SendRemindersScanService(reader, bus, tenant, clock, NullLogger<SendRemindersScanService>.Instance), reader, bus);
     }
 
     [Fact]

--- a/tests/Granit.Activities.Tests/Domain/ActivityTests.cs
+++ b/tests/Granit.Activities.Tests/Domain/ActivityTests.cs
@@ -125,6 +125,11 @@ public sealed class ActivityTests
         ActivityReassignedEvent reassigned = activity.DomainEvents.OfType<ActivityReassignedEvent>().ShouldHaveSingleItem();
         reassigned.PreviousAssigneeUserId.ShouldBe(SampleAssignee);
         reassigned.NewAssigneeUserId.ShouldBe(newAssignee);
+
+        // VULN-300 — distributed Eto must accompany the local event so cross-service consumers see the reassignment.
+        ActivityReassignedEto eto = activity.IntegrationEvents.OfType<ActivityReassignedEto>().ShouldHaveSingleItem();
+        eto.PreviousAssigneeUserId.ShouldBe(SampleAssignee);
+        eto.NewAssigneeUserId.ShouldBe(newAssignee);
     }
 
     [Fact]
@@ -155,6 +160,11 @@ public sealed class ActivityTests
         ActivityRescheduledEvent ev = activity.DomainEvents.OfType<ActivityRescheduledEvent>().ShouldHaveSingleItem();
         ev.PreviousDueAt.ShouldBe(originalDue);
         ev.NewDueAt.ShouldBe(newDue);
+
+        // VULN-300 — distributed Eto must accompany the local event.
+        ActivityRescheduledEto eto = activity.IntegrationEvents.OfType<ActivityRescheduledEto>().ShouldHaveSingleItem();
+        eto.PreviousDueAt.ShouldBe(originalDue);
+        eto.NewDueAt.ShouldBe(newDue);
     }
 
     [Theory]

--- a/tests/Granit.ArchitectureTests/ClassDesignTests.cs
+++ b/tests/Granit.ArchitectureTests/ClassDesignTests.cs
@@ -44,7 +44,13 @@ public sealed class ClassDesignTests
             Architecture, "Granit.",
             // Wolverine requires middleware constructor parameters to be public,
             // even when the interface is an internal implementation detail.
-            "Granit.Wolverine.Internal.IWolverineUserContextSetter");
+            "Granit.Wolverine.Internal.IWolverineUserContextSetter",
+            // ADR-053 §5 layer-4 extension point: Granit.Entities.Customization.Endpoints
+            // replaces the default no-op via services.Replace, which requires the
+            // interface to be visible across assemblies. The framework keeps the
+            // applier name in the Internal namespace because callers should never
+            // resolve it directly — only the composer pipeline does.
+            "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier");
 
     [Fact]
     public void Concrete_exception_classes_should_be_sealed() =>


### PR DESCRIPTION
## Summary

Closes the security audit findings on the `Granit.Activities.*` modules
(epic #1796–#1850). 35 files changed, 1 commit, all 87 module tests +
14 architecture tests pass.

## Findings closed

| VULN | Severity | Fix |
|------|----------|-----|
| 100 | High | Endpoints resolve the acting user from `ClaimsPrincipal` (was hardcoded `Guid.Empty`). |
| 101 | High | `CompletedAt` / `CancelledAt` derived server-side from `IClock`; request DTOs are now empty (no client-controlled timestamps). |
| 102/202 | High/Medium | New `IActivityHostAuthorizationProvider` + `ActivityHostAuthorizer` gate list/get-by-id/calendar by host-entity readability. Catch-all default keeps current behavior; modules contributing sensitive entities register stricter providers per-EntityType. |
| 103 | High | Background scanners (`MarkOverdue`, `SendReminders`) wrap each publish in `ICurrentTenant.Change(row.TenantId)` — defensive band-aid pending the `_current` AsyncLocal leak root-cause fix. |
| 200 | Medium | `Activity.Description` annotated `[SensitiveData(Confidential, Mask)]` for audit/export/MCP redaction. |
| 201/302 | Medium/Low | Calendar cache key uses full SHA-256 hex (no truncation); authorization claim allowlist broadened to `role/roles/permission/permissions/perms/scope/scopes/tenant/tenant_id/tid`. |
| 203 | Medium | `DueAt` clamped to `ActivitiesEndpointsOptions.MaxFutureRescheduleDays` (5 y default) on Create + Reschedule. |
| 204 | Medium | Calendar window snapped to `CalendarWindowSnapMinutes` (60 min default) before cache-key composition — attacker-shifted windows can no longer defeat the FusionCache TTL. |
| 300 | Low | `ActivityReassignedEto` + `ActivityRescheduledEto` emitted on the integration bus alongside the local events. |
| 301/400 | Low/Info | `Reassign` and `ReadOthers` split out of `Manage` / `Read`; localization keys added across all 18 cultures. |

VULN-401 (notification handler signature) retracted on review: local event
handlers go through the `ILocalEventHandler<T>` DI pipeline, not Wolverine
discovery, so the existing instance-method shape is correct.

## Behavior changes (potentially breaking for consumers)

- `CompleteActivityRequest` / `CancelActivityRequest` are now empty records — clients that posted `{ "completedAt": ... }` will see the field ignored.
- `Reassign` requires the new `Activities.Activities.Reassign` permission (was previously bundled in `Manage`).
- Listing peers' activities (`?assignedToUserId=<other>`) now requires `Activities.Activities.ReadOthers`.
- New `ActivitiesEndpointsOptions` knobs: `MaxFutureRescheduleDays` (5 y) and `CalendarWindowSnapMinutes` (60 min).

## Test plan

- [x] `dotnet build` — all 6 Activities src projects clean
- [x] `dotnet test` — Activities.Tests (20), Abstractions.Tests (9), EntityFrameworkCore.Tests (10), BackgroundJobs.Tests (7), Endpoints.Tests (22), Notifications.Tests (19) — 87/87 pass
- [x] Architecture tests — 14/14 pass on the `Activit|Permission|Localization` filter
- [ ] Manual smoke: deploy to staging tenant, confirm Complete/Cancel/Reassign trace the authenticated user in audit log
- [ ] Manual smoke: confirm host-authorization default still allows existing activities to surface (no regression for hosts that haven't opted-in to a stricter provider)