### PR TITLE
feat(security): EPIC 1 — multi-tenant trust model + observability

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -21065,6 +21065,15 @@
       ]
     },
     {
+      "name": "CalendarItemResponse",
+      "fqn": "Granit.Entities.CalendarItemResponse",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/CalendarItemResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
       "name": "HideDelta",
       "fqn": "Granit.Entities.Customization.Domain.Deltas.HideDelta",
       "kind": "record",
@@ -21178,7 +21187,7 @@
       "kind": "class",
       "project": "Granit.Entities.Customization.Endpoints",
       "file": "src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs",
-      "line": 35,
+      "line": 38,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21455,13 +21464,20 @@
       "members": []
     },
     {
-      "name": "CalendarItemResponse",
-      "fqn": "Granit.Entities.Endpoints.Dtos.CalendarItemResponse",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs",
-      "line": 12,
-      "members": []
+      "name": "EntityActivitySource",
+      "fqn": "Granit.Entities.Diagnostics.EntityActivitySource",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Diagnostics/EntityActivitySource.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(Name)",
+          "returnType": "ActivitySource Source ="
+        }
+      ]
     },
     {
       "name": "CalendarRangeRequest",
@@ -21847,22 +21863,6 @@
       ]
     },
     {
-      "name": "ICalendarRangeService",
-      "fqn": "Granit.Entities.Endpoints.ICalendarRangeService",
-      "kind": "interface",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 19,
-      "members": [
-        {
-          "name": "GetItemsAsync",
-          "kind": "method",
-          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
-          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
-        }
-      ]
-    },
-    {
       "name": "IManifestCustomizationApplier",
       "fqn": "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier",
       "kind": "interface",
@@ -21917,15 +21917,6 @@
           "returnType": "TimeSpan CalendarRangeCacheTtl { get; set; } = TimeSpan."
         }
       ]
-    },
-    {
-      "name": "struct",
-      "fqn": "Granit.Entities.Endpoints.struct",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 34,
-      "members": []
     },
     {
       "name": "EntityDefinition",
@@ -21993,7 +21984,7 @@
       "kind": "class",
       "project": "Granit.Entities.EntityFrameworkCore",
       "file": "src/Granit.Entities.EntityFrameworkCore/Extensions/EntitiesEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntitiesEntityFrameworkCore",
@@ -22025,7 +22016,7 @@
       "kind": "class",
       "project": "Granit.Entities",
       "file": "src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntities",
@@ -22138,6 +22129,22 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICalendarRangeService",
+      "fqn": "Granit.Entities.ICalendarRangeService",
+      "kind": "interface",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "GetItemsAsync",
+          "kind": "method",
+          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
         }
       ]
     },
@@ -22679,11 +22686,11 @@
       "members": []
     },
     {
-      "name": "EntityViewSharedWithDto",
-      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithDto",
+      "name": "EntityViewSharedWithResponse",
+      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithResponse",
       "kind": "record",
       "project": "Granit.Entities.Views.Endpoints",
-      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithDto.cs",
+      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithResponse.cs",
       "line": 6,
       "members": []
     },
@@ -22867,6 +22874,22 @@
       "members": []
     },
     {
+      "name": "EntitiesViewsServiceCollectionExtensions",
+      "fqn": "Granit.Entities.Views.Extensions.EntitiesViewsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Entities.Views",
+      "file": "src/Granit.Entities.Views/Extensions/EntitiesViewsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitEntitiesViews",
+          "kind": "method",
+          "signature": "AddGranitEntitiesViews(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitEntitiesViewsAbstractionsModule",
       "fqn": "Granit.Entities.Views.GranitEntitiesViewsAbstractionsModule",
       "kind": "class",
@@ -22881,8 +22904,15 @@
       "kind": "class",
       "project": "Granit.Entities.Views",
       "file": "src/Granit.Entities.Views/GranitEntitiesViewsModule.cs",
-      "line": 12,
-      "members": []
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IEntityViewReader",
@@ -22980,6 +23010,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Visibility/VisibilityCondition.cs",
       "line": 32,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.struct",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 31,
       "members": []
     },
     {
@@ -35334,14 +35373,8 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/CurrentTenant.cs",
-      "line": 7,
+      "line": 31,
       "members": [
-        {
-          "name": "IsAvailable",
-          "kind": "property",
-          "signature": "bool IsAvailable",
-          "returnType": "bool"
-        },
         {
           "name": "Id",
           "kind": "property",
@@ -35396,6 +35429,12 @@
           "name": "RecordContextSwitched",
           "kind": "method",
           "signature": "RecordContextSwitched(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordMembershipRejected",
+          "kind": "method",
+          "signature": "RecordMembershipRejected()",
           "returnType": "void"
         }
       ]
@@ -35672,7 +35711,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "AddGranitMultiTenancy",
@@ -35713,6 +35752,40 @@
           "returnType": "bool IsAvailable { get; } Guid? Id { get; } string? Name { get; } IDisposable"
         }
       ]
+    },
+    {
+      "name": "IHostAccessContext",
+      "fqn": "Granit.MultiTenancy.IHostAccessContext",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/IHostAccessContext.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "IHostAccessFeature",
+      "fqn": "Granit.MultiTenancy.IHostAccessFeature",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/IHostAccessFeature.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "HostModeFeature",
+          "kind": "method",
+          "signature": "HostModeFeature()",
+          "returnType": "bool IsHostAccess { get; } public IHostAccessFeature HostMode { get; } ="
+        }
+      ]
+    },
+    {
+      "name": "ITenantContextFeature",
+      "fqn": "Granit.MultiTenancy.ITenantContextFeature",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/ITenantContextFeature.cs",
+      "line": 15,
+      "members": []
     },
     {
       "name": "ITenantInfo",
@@ -36095,6 +36168,22 @@
           "kind": "method",
           "signature": "DeactivateAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IUserTenantMembershipReader",
+      "fqn": "Granit.MultiTenancy.Stores.IUserTenantMembershipReader",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Stores/IUserTenantMembershipReader.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "IsMemberAsync",
+          "kind": "method",
+          "signature": "IsMemberAsync(string userId, Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -45888,7 +45977,14 @@
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Diagnostics/PersistenceMetrics.cs",
       "line": 13,
-      "members": []
+      "members": [
+        {
+          "name": "RecordCrossTenantQuery",
+          "kind": "method",
+          "signature": "RecordCrossTenantQuery(string entityName, string origin)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "EfStoreBase",
@@ -45896,7 +45992,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs",
-      "line": 42,
+      "line": 40,
       "members": []
     },
     {
@@ -61961,7 +62057,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs",
-      "line": 27,
+      "line": 30,
       "members": [
         {
           "name": "Before",
@@ -62066,6 +62162,15 @@
       ]
     },
     {
+      "name": "CrossTenantMessageAttribute",
+      "fqn": "Granit.Wolverine.CrossTenantMessageAttribute",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/CrossTenantMessageAttribute.cs",
+      "line": 26,
+      "members": []
+    },
+    {
       "name": "WolverineMetrics",
       "fqn": "Granit.Wolverine.Diagnostics.WolverineMetrics",
       "kind": "class",
@@ -62095,6 +62200,12 @@
           "name": "RecordClaimCheckRetrieved",
           "kind": "method",
           "signature": "RecordClaimCheckRetrieved(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordEnvelopeWithoutTenant",
+          "kind": "method",
+          "signature": "RecordEnvelopeWithoutTenant(string messageType, string outcome)",
           "returnType": "void"
         }
       ]

--- a/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
+++ b/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
@@ -53,6 +53,11 @@ internal sealed class RequireHostContextEndpointFilter : IEndpointFilter
                     statusCode: StatusCodes.Status401Unauthorized));
         }
 
+        // Signal the data layer that the cross-tenant read about to happen is a
+        // legitimate host-access path, not an accidental tenant-context loss.
+        // EfStoreBase reads this feature to tag its metric origin=host_endpoint.
+        context.HttpContext.Features.Set(IHostAccessFeature.HostMode);
+
         return next(context);
     }
 }

--- a/src/Granit.MultiTenancy/CurrentTenant.cs
+++ b/src/Granit.MultiTenancy/CurrentTenant.cs
@@ -1,31 +1,123 @@
+using Granit.MultiTenancy.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
 namespace Granit.MultiTenancy;
 
 /// <summary>
-/// Implementation of <see cref="ICurrentTenant"/> based on <see cref="AsyncLocal{T}"/>.
-/// Thread-safe: each async/await flow has its own tenant context.
+/// Implementation of <see cref="ICurrentTenant"/> with a dual-backend storage:
+/// <list type="bullet">
+///   <item><b>HTTP path</b> — when an <see cref="HttpContext"/> is active, the
+///   tenant is stored on <see cref="HttpContext.Features"/> via
+///   <see cref="ITenantContextFeature"/>. The lifetime is bound to the request
+///   itself (closes by construction at the end of the pipeline).</item>
+///   <item><b>Non-HTTP path</b> — when no <see cref="HttpContext"/> is active
+///   (Wolverine handlers, background jobs, migrations, hosted services), the
+///   tenant is stored in a process-static <see cref="AsyncLocal{T}"/>. Compatible
+///   with the existing <c>using (currentTenant.Change(id))</c> pattern in those
+///   call sites.</item>
+/// </list>
 /// </summary>
+/// <remarks>
+/// SECURITY: a cross-request tenant leak has been observed in production on the
+/// HTTP path — symptom of thread-pool reuse re-flowing the framework's own
+/// static <see cref="AsyncLocal{T}"/>. The HTTP path now stores the tenant on
+/// <see cref="HttpContext.Features"/>, which is scoped to the request by
+/// construction. The <see cref="AsyncLocal{T}"/> fallback remains for non-HTTP
+/// code paths where no equivalent ambient scope exists; handlers and jobs
+/// process one message at a time, so the documented leak class has not
+/// materialized there.
+/// </remarks>
 public sealed class CurrentTenant : ICurrentTenant
 {
-    private static readonly AsyncLocal<TenantInfo?> _current = new();
+    private static readonly AsyncLocal<TenantInfo?> _ambientNonHttp = new();
+    private readonly IHttpContextAccessor? _httpContextAccessor;
+
+    /// <summary>
+    /// Constructs the tenant context with no <see cref="IHttpContextAccessor"/>.
+    /// Used by tests and by AddGranit&lt;T&gt;() before <see cref="IHttpContextAccessor"/>
+    /// is registered. In this mode all reads/writes use the AsyncLocal fallback.
+    /// </summary>
+    public CurrentTenant()
+    {
+        _httpContextAccessor = null;
+    }
+
+    /// <summary>
+    /// Constructs the tenant context with an <see cref="IHttpContextAccessor"/>.
+    /// HTTP requests use <see cref="HttpContext.Features"/>; non-HTTP code paths
+    /// fall back to a process-static <see cref="AsyncLocal{T}"/>.
+    /// </summary>
+    public CurrentTenant(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
 
     /// <inheritdoc/>
     public bool IsAvailable => Id.HasValue;
 
     /// <inheritdoc/>
-    public Guid? Id => _current.Value?.Id;
+    public Guid? Id => CurrentInfo?.Id;
 
     /// <inheritdoc/>
-    public string? Name => _current.Value?.Name;
+    public string? Name => CurrentInfo?.Name;
 
     /// <inheritdoc/>
     public IDisposable Change(Guid? id, string? name = null)
     {
-        TenantInfo? previous = _current.Value;
-        _current.Value = id.HasValue ? new TenantInfo(id, name) : null;
-        return new TenantScope(previous);
+        TenantInfo? newValue = id.HasValue ? new TenantInfo(id, name) : null;
+        HttpContext? httpContext = _httpContextAccessor?.HttpContext;
+
+        return httpContext is not null
+            ? ChangeOnHttpContext(httpContext, newValue)
+            : ChangeOnAmbientAsyncLocal(newValue);
     }
 
-    private sealed class TenantScope(TenantInfo? previous) : IDisposable
+    private TenantInfo? CurrentInfo
+    {
+        get
+        {
+            // HTTP context takes precedence: if a request is active, its feature is
+            // the source of truth. The AsyncLocal fallback is consulted only when
+            // no HttpContext is present (Wolverine handlers, jobs, migrations).
+            HttpContext? httpContext = _httpContextAccessor?.HttpContext;
+            return httpContext is not null
+                ? httpContext.Features.Get<ITenantContextFeature>()?.Tenant
+                : _ambientNonHttp.Value;
+        }
+    }
+
+    private static HttpScope ChangeOnHttpContext(HttpContext httpContext, TenantInfo? newValue)
+    {
+        ITenantContextFeature? previous = httpContext.Features.Get<ITenantContextFeature>();
+        httpContext.Features.Set<ITenantContextFeature>(new TenantContextFeature(newValue));
+        return new HttpScope(httpContext, previous);
+    }
+
+    private static AmbientScope ChangeOnAmbientAsyncLocal(TenantInfo? newValue)
+    {
+        TenantInfo? previous = _ambientNonHttp.Value;
+        _ambientNonHttp.Value = newValue;
+        return new AmbientScope(previous);
+    }
+
+    private sealed class HttpScope(HttpContext httpContext, ITenantContextFeature? previous) : IDisposable
+    {
+        private readonly HttpContext _httpContext = httpContext;
+        private readonly ITenantContextFeature? _previous = previous;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _httpContext.Features.Set(_previous);
+            }
+        }
+    }
+
+    private sealed class AmbientScope(TenantInfo? previous) : IDisposable
     {
         private readonly TenantInfo? _previous = previous;
         private bool _disposed;
@@ -35,7 +127,7 @@ public sealed class CurrentTenant : ICurrentTenant
             if (!_disposed)
             {
                 _disposed = true;
-                _current.Value = _previous;
+                _ambientNonHttp.Value = _previous;
             }
         }
     }

--- a/src/Granit.MultiTenancy/Diagnostics/MultiTenancyMetrics.cs
+++ b/src/Granit.MultiTenancy/Diagnostics/MultiTenancyMetrics.cs
@@ -14,6 +14,7 @@ public sealed class MultiTenancyMetrics
     private readonly Counter<long> _resolutionsSucceeded;
     private readonly Counter<long> _resolutionsFailed;
     private readonly Counter<long> _contextSwitches;
+    private readonly Counter<long> _membershipRejected;
 
     public MultiTenancyMetrics(IMeterFactory meterFactory)
     {
@@ -30,6 +31,13 @@ public sealed class MultiTenancyMetrics
         _contextSwitches = meter.CreateCounter<long>(
             "granit.multi_tenancy.context.switched",
             description: "Number of explicit tenant context switches.");
+
+        _membershipRejected = meter.CreateCounter<long>(
+            "granit.multi_tenancy.membership.rejected",
+            description:
+                "Number of requests rejected by the membership check "
+                + "(authenticated user is not a member of the resolved tenant). "
+                + "Anomalous volume signals tenant-claim spoofing attempts.");
     }
 
     public void RecordResolutionSucceeded(string tenantId, string resolverType) =>
@@ -50,4 +58,7 @@ public sealed class MultiTenancyMetrics
         {
             { "tenant_id", tenantId ?? "global" },
         });
+
+    public void RecordMembershipRejected() =>
+        _membershipRejected.Add(1);
 }

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Granit.DataExchange.Extensions;
 using Granit.MultiTenancy.Diagnostics;
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.Exports;
+using Granit.MultiTenancy.Internal;
 using Granit.MultiTenancy.Middleware;
 using Granit.MultiTenancy.Options;
 using Granit.MultiTenancy.Pipeline;
@@ -35,12 +36,30 @@ public static class MultiTenancyServiceCollectionExtensions
 
         services.TryAddSingleton<IValidateOptions<MultiTenancyOptions>, MultiTenancyOptionsValidator>();
 
-        // Replace the NullTenantContext registered by AddGranit<T>() with the real implementation.
+        // Replace the NullTenantContext registered by AddGranit<T>() with the real
+        // implementation. CurrentTenant uses a dual-backend storage: HttpContext.Features
+        // when a request is active (ties the tenant lifetime to the request itself,
+        // so there is no execution-context state to leak across requests on thread-pool
+        // reuse), and an AsyncLocal fallback for non-HTTP code paths (Wolverine handlers,
+        // background jobs, migrations).
+        services.AddHttpContextAccessor();
         services.Replace(ServiceDescriptor.Singleton<ICurrentTenant, CurrentTenant>());
+
+        // Host-access signal — read by EfStoreBase to distinguish a deliberate
+        // .AllowHostAccess() bypass (origin=host_endpoint) from an unsignaled
+        // tenant-context loss (origin=implicit_unsignaled, alert-worthy).
+        services.TryAddSingleton<IHostAccessContext, HttpContextHostAccessContext>();
 
         // NullTenantReader fallback — replaced by EfCoreTenantStore when
         // Granit.MultiTenancy.EntityFrameworkCore is in the module tree.
         services.TryAddScoped<ITenantReader, NullTenantReader>();
+
+        // NullUserTenantMembershipReader fallback — permissive (returns true) so
+        // single-tenant deployments and tests are unaffected. Hosts wiring the
+        // membership-check feature must register a concrete reader AND set
+        // MultiTenancyOptions.RequireMembershipCheck = true; the validator at
+        // startup refuses the latter without the former.
+        services.TryAddScoped<IUserTenantMembershipReader, NullUserTenantMembershipReader>();
 
         // Resolvers: CustomDomain (25) → Domain (50) → Header (100) → JWT (200) → QueryString (300)
         // Registered as scoped: DomainTenantResolver depends on ITenantReader (scoped, EF Core).

--- a/src/Granit.MultiTenancy/ITenantContextFeature.cs
+++ b/src/Granit.MultiTenancy/ITenantContextFeature.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// HTTP feature that carries the active tenant for the current request.
+/// Stored on <see cref="IFeatureCollection"/> by <see cref="CurrentTenant"/>
+/// instead of the legacy <see cref="System.Threading.AsyncLocal{T}"/> backend.
+/// </summary>
+/// <remarks>
+/// SECURITY: by binding the tenant value to the request's feature collection,
+/// the lifetime is the request itself — there is no execution-context state
+/// to leak across requests on thread-pool reuse.
+/// </remarks>
+public interface ITenantContextFeature
+{
+    /// <summary>The active tenant for the current request, or <see langword="null"/>.</summary>
+    TenantInfo? Tenant { get; }
+}

--- a/src/Granit.MultiTenancy/Internal/HttpContextHostAccessContext.cs
+++ b/src/Granit.MultiTenancy/Internal/HttpContextHostAccessContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.MultiTenancy.Internal;
+
+/// <summary>
+/// HTTP-backed <see cref="IHostAccessContext"/> reading the
+/// <see cref="IHostAccessFeature"/> placed on the request feature collection
+/// by <c>RequireHostContextEndpointFilter</c>.
+/// </summary>
+internal sealed class HttpContextHostAccessContext(IHttpContextAccessor httpContextAccessor)
+    : IHostAccessContext
+{
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+
+    public bool IsHostAccess =>
+        _httpContextAccessor.HttpContext?.Features.Get<IHostAccessFeature>()?.IsHostAccess
+        ?? false;
+}

--- a/src/Granit.MultiTenancy/Internal/TenantContextFeature.cs
+++ b/src/Granit.MultiTenancy/Internal/TenantContextFeature.cs
@@ -1,0 +1,8 @@
+namespace Granit.MultiTenancy.Internal;
+
+/// <summary>
+/// Default <see cref="ITenantContextFeature"/> implementation, written to
+/// <see cref="Microsoft.AspNetCore.Http.HttpContext.Features"/> by
+/// <see cref="CurrentTenant"/> on the HTTP path.
+/// </summary>
+internal sealed record TenantContextFeature(TenantInfo? Tenant) : ITenantContextFeature;

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -22,6 +22,7 @@ public sealed partial class TenantResolutionMiddleware(
     ICurrentTenant currentTenant,
     TenantResolverPipeline pipeline,
     ITenantReader tenantReader,
+    IUserTenantMembershipReader membershipReader,
     MultiTenancyMetrics metrics,
     IOptions<MultiTenancyOptions> options,
     ILogger<TenantResolutionMiddleware> logger) : IMiddleware
@@ -29,6 +30,7 @@ public sealed partial class TenantResolutionMiddleware(
     private readonly ICurrentTenant _currentTenant = currentTenant;
     private readonly TenantResolverPipeline _pipeline = pipeline;
     private readonly ITenantReader _tenantReader = tenantReader;
+    private readonly IUserTenantMembershipReader _membershipReader = membershipReader;
     private readonly MultiTenancyMetrics _metrics = metrics;
     private readonly MultiTenancyOptions _options = options.Value;
     private readonly ILogger _logger = logger;
@@ -76,6 +78,27 @@ public sealed partial class TenantResolutionMiddleware(
                 return;
             }
 
+            // Server-side membership check. Without it, an authenticated user whose
+            // identity provider lets them set their own `tenant_id` claim could pivot
+            // to any tenant. The check is opt-in via RequireMembershipCheck and only
+            // runs when the request is actually authenticated — anonymous flows
+            // (login, public webhooks) are unaffected.
+            if (_options.RequireMembershipCheck
+                && result.Tenant.Id.HasValue
+                && context.User.Identity?.IsAuthenticated == true)
+            {
+                string? userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                    ?? context.User.FindFirstValue("sub");
+                if (string.IsNullOrEmpty(userId)
+                    || !await _membershipReader.IsMemberAsync(userId, result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false))
+                {
+                    _metrics.RecordMembershipRejected();
+                    LogMembershipRejected(userId ?? "(no sub claim)", result.Tenant.Id.Value, result.ResolverType);
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return;
+                }
+            }
+
             _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
 
             using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name);
@@ -93,4 +116,7 @@ public sealed partial class TenantResolutionMiddleware(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Phantom tenant rejected: resolved tenant {TenantId} via {ResolverType} does not exist in the tenant store.")]
     private partial void LogPhantomTenant(Guid tenantId, string resolverType);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Membership check rejected user {UserId} for tenant {TenantId} (resolver: {ResolverType}). Possible tenant-claim spoofing attempt.")]
+    private partial void LogMembershipRejected(string userId, Guid tenantId, string resolverType);
 }

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
@@ -104,4 +104,27 @@ public sealed class MultiTenancyOptions
     /// No trailing slash.
     /// </summary>
     public string? FallbackBaseUrl { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the middleware verifies that the authenticated
+    /// user is recorded as a member of the resolved tenant before activating the
+    /// context. Mismatches return 403 Forbidden.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SECURITY: the JWT <c>tenant_id</c> claim is otherwise trusted implicitly.
+    /// If an upstream identity provider lets the user set their own claim value,
+    /// that user can pivot to any tenant. Enabling this flag adds a server-side
+    /// membership lookup via <see cref="Stores.IUserTenantMembershipReader"/>.
+    /// </para>
+    /// <para>
+    /// Default: <see langword="false"/>. When set to <see langword="true"/>, the
+    /// host MUST register a concrete <see cref="Stores.IUserTenantMembershipReader"/>;
+    /// otherwise the
+    /// <see cref="Stores.NullUserTenantMembershipReader"/> fallback would silently
+    /// accept every membership claim. Misconfiguration is detected at startup by
+    /// <see cref="MultiTenancyOptionsValidator"/>.
+    /// </para>
+    /// </remarks>
+    public bool RequireMembershipCheck { get; set; }
 }

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptionsValidator.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptionsValidator.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy.Stores;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -5,9 +7,13 @@ namespace Granit.MultiTenancy.Options;
 
 /// <summary>
 /// Production-time validator for <see cref="MultiTenancyOptions"/>.
-/// Refuses to start when development-only resolvers are enabled outside Development.
+/// Refuses to start when development-only resolvers are enabled outside Development,
+/// or when <see cref="MultiTenancyOptions.RequireMembershipCheck"/> is enabled but
+/// no concrete <see cref="IUserTenantMembershipReader"/> is registered.
 /// </summary>
-internal sealed class MultiTenancyOptionsValidator(IHostEnvironment environment)
+internal sealed class MultiTenancyOptionsValidator(
+    IHostEnvironment environment,
+    IServiceProvider serviceProvider)
     : IValidateOptions<MultiTenancyOptions>
 {
     public ValidateOptionsResult Validate(string? name, MultiTenancyOptions options)
@@ -20,6 +26,22 @@ internal sealed class MultiTenancyOptionsValidator(IHostEnvironment environment)
                 + $"environment (current: '{environment.EnvironmentName}'). The query-string "
                 + "tenant resolver allows any caller to select an arbitrary tenant context "
                 + "and is forbidden in production.");
+        }
+
+        if (options.RequireMembershipCheck)
+        {
+            using IServiceScope scope = serviceProvider.CreateScope();
+            IUserTenantMembershipReader? reader = scope.ServiceProvider
+                .GetService<IUserTenantMembershipReader>();
+            if (reader is null or NullUserTenantMembershipReader)
+            {
+                return ValidateOptionsResult.Fail(
+                    "MultiTenancy:RequireMembershipCheck is enabled but no concrete "
+                    + "IUserTenantMembershipReader is registered. The fallback "
+                    + "NullUserTenantMembershipReader returns true for every check, "
+                    + "which would silently accept any tenant claim — defeating the "
+                    + "purpose of the flag. Register a real reader or disable the flag.");
+            }
         }
 
         return ValidateOptionsResult.Success;

--- a/src/Granit.MultiTenancy/Stores/IUserTenantMembershipReader.cs
+++ b/src/Granit.MultiTenancy/Stores/IUserTenantMembershipReader.cs
@@ -1,0 +1,40 @@
+namespace Granit.MultiTenancy.Stores;
+
+/// <summary>
+/// Verifies that a user is a member of a given tenant.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SECURITY: the JWT <c>tenant_id</c> claim is trusted today by
+/// <see cref="Resolvers.JwtClaimTenantResolver"/> to identify the active tenant.
+/// If the upstream identity provider is misconfigured to allow the user to set
+/// their own claim value, that user can pivot to any tenant they choose. This
+/// reader provides server-side verification: the claim is honored only when the
+/// user is recorded as a member of that tenant.
+/// </para>
+/// <para>
+/// Concrete implementations are shipped by the identity / membership module
+/// (e.g. <c>Granit.Identity.Local.EntityFrameworkCore</c>). When no real
+/// implementation is registered, <see cref="NullUserTenantMembershipReader"/>
+/// is the permissive fallback (returns <see langword="true"/>) so that
+/// downstream code paths do not fail in single-tenant or test deployments.
+/// </para>
+/// <para>
+/// Enforcement is gated by
+/// <see cref="Options.MultiTenancyOptions.RequireMembershipCheck"/>; when that
+/// flag is enabled, <see cref="Middleware.TenantResolutionMiddleware"/> calls
+/// <see cref="IsMemberAsync"/> after resolution and rejects the request with
+/// 403 if it returns <see langword="false"/>.
+/// </para>
+/// </remarks>
+public interface IUserTenantMembershipReader
+{
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="userId"/> is a member of the
+    /// tenant identified by <paramref name="tenantId"/>.
+    /// </summary>
+    /// <param name="userId">The user identifier (typically the <c>sub</c> JWT claim).</param>
+    /// <param name="tenantId">The tenant identifier resolved from the request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> IsMemberAsync(string userId, Guid tenantId, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.MultiTenancy/Stores/NullUserTenantMembershipReader.cs
+++ b/src/Granit.MultiTenancy/Stores/NullUserTenantMembershipReader.cs
@@ -1,0 +1,19 @@
+namespace Granit.MultiTenancy.Stores;
+
+/// <summary>
+/// No-op <see cref="IUserTenantMembershipReader"/> used when no concrete membership
+/// store is registered. Returns <see langword="true"/> for every request.
+/// </summary>
+/// <remarks>
+/// SECURITY: this fallback intentionally does not enforce membership — it preserves
+/// existing behavior for deployments that have not yet wired a real reader. To
+/// activate enforcement, the host must (a) register a concrete
+/// <see cref="IUserTenantMembershipReader"/> AND (b) set
+/// <c>MultiTenancyOptions.RequireMembershipCheck = true</c>. The latter is
+/// validated at startup against the registered reader to fail-fast on misconfiguration.
+/// </remarks>
+internal sealed class NullUserTenantMembershipReader : IUserTenantMembershipReader
+{
+    public Task<bool> IsMemberAsync(string userId, Guid tenantId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(true);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/PersistenceMetrics.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Diagnostics/PersistenceMetrics.cs
@@ -17,7 +17,11 @@ public sealed class PersistenceMetrics
     private const string TagTenantId = "tenant_id";
     private const string DefaultTenant = "global";
 
+    private const string TagEntity = "entity";
+    private const string TagOrigin = "origin";
+
     private readonly Counter<long> _entitiesPurged;
+    private readonly Counter<long> _crossTenantQueries;
 
     public PersistenceMetrics(IMeterFactory meterFactory)
     {
@@ -26,11 +30,39 @@ public sealed class PersistenceMetrics
         _entitiesPurged = meter.CreateCounter<long>(
             "granit.persistence.entity.purged",
             description: "Number of soft-deleted entities permanently purged.");
+
+        _crossTenantQueries = meter.CreateCounter<long>(
+            "granit.persistence.cross_tenant_query",
+            description:
+                "Number of EfStoreBase queries that bypassed the multi-tenant filter. "
+                + "Tagged with `entity` (CLR name) and `origin` (`host_endpoint` = served "
+                + "via a route marked .AllowHostAccess(); `explicit` = caller used "
+                + "QueryAcrossTenants(); `implicit_unsignaled` = bypass without host-access "
+                + "signal — alert-worthy, may indicate a tenant-context leak in flight).");
     }
 
     public void RecordEntitiesPurged(string? tenantId, int count) =>
         _entitiesPurged.Add(count, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
+        });
+
+    /// <summary>
+    /// Records a query that bypassed the <c>MultiTenant</c> named filter.
+    /// </summary>
+    /// <param name="entityName">The CLR name of the queried entity.</param>
+    /// <param name="origin">
+    /// <c>"host_endpoint"</c> when the bypass is served via a route marked
+    /// <c>.AllowHostAccess()</c> (signal observed on <c>HttpContext.Features</c>);
+    /// <c>"explicit"</c> when the caller invoked
+    /// <see cref="EfStoreBase{TEntity, TContext}.QueryAcrossTenants(TContext, string, string, int)"/>;
+    /// <c>"implicit_unsignaled"</c> when the bypass occurred without any host-access
+    /// signal — this is the alert-worthy origin that may indicate a tenant-context leak.
+    /// </param>
+    public void RecordCrossTenantQuery(string entityName, string origin) =>
+        _crossTenantQueries.Add(1, new TagList
+        {
+            { TagEntity, entityName },
+            { TagOrigin, origin },
         });
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -1,10 +1,14 @@
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Granit.Domain;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.Diagnostics;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Specification;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Granit.Persistence.EntityFrameworkCore;
 
@@ -33,23 +37,57 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// </remarks>
 /// <typeparam name="TEntity">The entity type (must inherit <see cref="Entity"/>).</typeparam>
 /// <typeparam name="TContext">The isolated <see cref="DbContext"/> type.</typeparam>
-/// <param name="contextFactory">The factory for creating isolated <typeparamref name="TContext"/> instances.</param>
-/// <param name="currentTenant">
-/// Optional tenant context. When provided for <see cref="IMultiTenant"/> entities, enables
-/// automatic host-context bypass of the multi-tenant query filter. Pass <c>null</c> (or omit)
-/// to keep the default filtering behavior.
-/// </param>
-public abstract class EfStoreBase<TEntity, TContext>(
-    IDbContextFactory<TContext> contextFactory,
-    ICurrentTenant? currentTenant = null)
+public abstract class EfStoreBase<TEntity, TContext>
     where TEntity : Entity
     where TContext : DbContext
 {
-    // Pre-computed at construction (Scoped = once per request).
-    // True only when TEntity implements IMultiTenant AND no tenant is active.
-    private readonly bool _bypassTenantFilter =
-        typeof(IMultiTenant).IsAssignableFrom(typeof(TEntity))
-        && currentTenant is { IsAvailable: false };
+    private static readonly bool s_isMultiTenantEntity =
+        typeof(IMultiTenant).IsAssignableFrom(typeof(TEntity));
+
+    private readonly IDbContextFactory<TContext> _contextFactory;
+    private readonly ICurrentTenant? _currentTenant;
+    private readonly IHostAccessContext? _hostAccess;
+    private readonly PersistenceMetrics? _metrics;
+    private readonly ILogger _logger;
+
+    /// <param name="contextFactory">The factory for creating isolated <typeparamref name="TContext"/> instances.</param>
+    /// <param name="currentTenant">
+    /// Optional tenant context. When provided for <see cref="IMultiTenant"/> entities, enables
+    /// automatic host-context bypass of the multi-tenant query filter. Pass <c>null</c> (or omit)
+    /// to keep the default filtering behavior.
+    /// </param>
+    /// <param name="hostAccess">
+    /// Optional host-access signal. Distinguishes a legitimate <c>.AllowHostAccess()</c> call
+    /// (metric tag <c>host_endpoint</c>, log Information) from an unsignaled tenant-context
+    /// loss (metric tag <c>implicit_unsignaled</c>, log Warning — alert-worthy). When omitted,
+    /// every implicit bypass is reported as <c>implicit_unsignaled</c>.
+    /// </param>
+    /// <param name="metrics">
+    /// Optional persistence metrics sink. When provided, every multi-tenant filter bypass is
+    /// recorded as <c>granit.persistence.cross_tenant_query</c> tagged by entity and origin
+    /// (<c>host_endpoint</c>, <c>implicit_unsignaled</c>, or <c>explicit</c>) — gives the SOC a
+    /// signal to alert on anomalous cross-tenant read volume.
+    /// </param>
+    /// <param name="logger">
+    /// Optional logger. When provided, unsignaled bypasses log a <see cref="LogLevel.Warning"/>
+    /// (anomalous tenant-context loss) and signaled / explicit opt-ins log
+    /// <see cref="LogLevel.Information"/> carrying the caller member / file / line —
+    /// searchable trail for incident response that the metric alone cannot provide.
+    /// Defaults to <see cref="NullLogger.Instance"/>.
+    /// </param>
+    protected EfStoreBase(
+        IDbContextFactory<TContext> contextFactory,
+        ICurrentTenant? currentTenant = null,
+        IHostAccessContext? hostAccess = null,
+        PersistenceMetrics? metrics = null,
+        ILogger? logger = null)
+    {
+        _contextFactory = contextFactory;
+        _currentTenant = currentTenant;
+        _hostAccess = hostAccess;
+        _metrics = metrics;
+        _logger = logger ?? NullLogger.Instance;
+    }
 
     // ── Query helper ───────────────────────────────────────────────────
 
@@ -60,13 +98,95 @@ public abstract class EfStoreBase<TEntity, TContext>(
     /// All other filters (soft-delete, GDPR, active) remain active.
     /// </summary>
     /// <remarks>
-    /// This method is safe to call in any context — when a tenant is active, it returns
-    /// the standard <c>DbSet</c> with all filters applied.
+    /// <para>
+    /// SECURITY: the bypass is evaluated on every call instead of being cached at
+    /// construction time, closing the edge case where a Scoped store was constructed
+    /// before the tenant was activated and then served cross-tenant queries for the
+    /// rest of the scope.
+    /// </para>
+    /// <para>
+    /// Every implicit bypass is recorded as
+    /// <c>granit.persistence.cross_tenant_query</c> with <c>origin=implicit</c> on
+    /// <see cref="PersistenceMetrics"/>. New call-sites that need cross-tenant access
+    /// should prefer the explicit <see cref="QueryAcrossTenants(TContext)"/> for
+    /// readability and to receive an <c>origin=explicit</c> metric tag.
+    /// </para>
     /// </remarks>
-    protected IQueryable<TEntity> Query(TContext db) =>
-        _bypassTenantFilter
+    protected IQueryable<TEntity> Query(TContext db)
+    {
+        if (s_isMultiTenantEntity && _currentTenant is { IsAvailable: false })
+        {
+            string entity = typeof(TEntity).Name;
+            bool signaled = _hostAccess?.IsHostAccess == true;
+            string origin = signaled ? "host_endpoint" : "implicit_unsignaled";
+            _metrics?.RecordCrossTenantQuery(entity, origin);
+            if (signaled)
+            {
+                LogHostEndpointCrossTenantQuery(entity);
+            }
+            else
+            {
+                LogUnsignaledCrossTenantQuery(entity);
+            }
+
+            return db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
+        }
+
+        return db.Set<TEntity>();
+    }
+
+    /// <summary>
+    /// Returns the base queryable with the <see cref="GranitFilterNames.MultiTenant"/>
+    /// filter explicitly disabled. Use only for legitimate host-scope queries (admin
+    /// dashboards, system health checks) where the caller is authorized to see data
+    /// across tenants.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SECURITY: callers MUST gate access with <c>.AllowHostAccess()</c> or an equivalent
+    /// authorization filter at the endpoint level. Misuse exposes cross-tenant data —
+    /// every invocation is recorded as <c>granit.persistence.cross_tenant_query</c> with
+    /// <c>origin=explicit</c> for SOC observability.
+    /// </para>
+    /// <para>
+    /// Prefer this method over the implicit bypass branch of <see cref="Query(TContext)"/>:
+    /// it makes the intent visible in the call site, distinguishes the metric tag, and
+    /// will remain available when a future release flips the implicit bypass to
+    /// fail-closed.
+    /// </para>
+    /// </remarks>
+    protected IQueryable<TEntity> QueryAcrossTenants(
+        TContext db,
+        [CallerMemberName] string callerMember = "",
+        [CallerFilePath] string callerFile = "",
+        [CallerLineNumber] int callerLine = 0)
+    {
+        string entity = typeof(TEntity).Name;
+        _metrics?.RecordCrossTenantQuery(entity, "explicit");
+        LogExplicitCrossTenantQuery(entity, callerMember, callerFile, callerLine);
+        return s_isMultiTenantEntity
             ? db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             : db.Set<TEntity>();
+    }
+
+    private void LogUnsignaledCrossTenantQuery(string entity) =>
+        _logger.LogWarning(
+            "Unsignaled cross-tenant query on {Entity}: ICurrentTenant.IsAvailable=false and "
+            + "no host-access signal was set on the request. This signals a tenant-context "
+            + "loss between request entry and the data layer. Investigate the call-site or "
+            + "mark the endpoint with .AllowHostAccess() if the bypass is intentional.",
+            entity);
+
+    private void LogHostEndpointCrossTenantQuery(string entity) =>
+        _logger.LogInformation(
+            "Host-endpoint cross-tenant query on {Entity}: served via .AllowHostAccess() route.",
+            entity);
+
+    private void LogExplicitCrossTenantQuery(
+        string entity, string callerMember, string callerFile, int callerLine) =>
+        _logger.LogInformation(
+            "Explicit cross-tenant query on {Entity} from {CallerMember} ({CallerFile}:{CallerLine}).",
+            entity, callerMember, callerFile, callerLine);
 
     // ── Read helpers ────────────────────────────────────────────────────
 
@@ -84,7 +204,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Guid id,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await Query(db)
             .FirstOrDefaultAsync(e => e.Id == id, ct).ConfigureAwait(false);
     }
@@ -94,7 +214,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Expression<Func<TEntity, bool>> predicate,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await Query(db)
             .FirstOrDefaultAsync(predicate, ct).ConfigureAwait(false);
     }
@@ -104,7 +224,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Specification<TEntity> spec,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
             .Apply(Query(db), spec)
             .ToListAsync(ct).ConfigureAwait(false);
@@ -117,7 +237,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         int pageSize,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
             .Apply(Query(db), spec)
             .ToPagedResultAsync(page, pageSize, ct).ConfigureAwait(false);
@@ -128,7 +248,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Expression<Func<TEntity, bool>>? predicate = null,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return predicate is null
             ? await Query(db).CountAsync(ct).ConfigureAwait(false)
             : await Query(db).CountAsync(predicate, ct).ConfigureAwait(false);
@@ -139,7 +259,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Expression<Func<TEntity, bool>> predicate,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await Query(db).AnyAsync(predicate, ct).ConfigureAwait(false);
     }
 
@@ -156,7 +276,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Func<TContext, Task<TResult>> query,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await query(db).ConfigureAwait(false);
     }
 
@@ -167,7 +287,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         TEntity entity,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         db.Set<TEntity>().Add(entity);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -177,7 +297,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         TEntity entity,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         db.Set<TEntity>().Update(entity);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -187,7 +307,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         TEntity entity,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         db.Set<TEntity>().Remove(entity);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -205,7 +325,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Func<TContext, Task> mutation,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         await mutation(db).ConfigureAwait(false);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -216,7 +336,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         Func<TContext, Task<TResult>> mutation,
         CancellationToken ct = default)
     {
-        await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        await using TContext db = await _contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         TResult result = await mutation(db).ConfigureAwait(false);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
         return result;

--- a/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
+++ b/src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs
@@ -1,4 +1,7 @@
 using Granit.MultiTenancy;
+using Granit.Wolverine.Diagnostics;
+using Granit.Wolverine.Options;
+using Microsoft.Extensions.Options;
 using Wolverine;
 
 namespace Granit.Wolverine.Behaviors;
@@ -17,15 +20,21 @@ namespace Granit.Wolverine.Behaviors;
 /// <para>
 /// Without this behavior, <c>ICurrentTenant.Id</c> is null in background handlers,
 /// causing EF Core global query filters (<c>WHERE TenantId = X</c>) to be skipped —
-/// a potential cross-tenant data leak.
-/// </para>
-/// <para>
-/// If the header is absent or its value cannot be parsed as a <see cref="Guid"/>,
-/// no exception is raised and the handler executes without a tenant context.
+/// a potential cross-tenant data leak. Envelopes received without a tenant header
+/// are recorded as <c>granit.wolverine.envelope.no_tenant</c>; when
+/// <see cref="WolverineMessagingOptions.RequireEnvelopeTenant"/> is enabled, they
+/// are rejected with an <see cref="InvalidOperationException"/> unless the
+/// message type is annotated with <see cref="CrossTenantMessageAttribute"/>.
 /// </para>
 /// </remarks>
-public sealed class TenantContextBehavior(ICurrentTenant currentTenant)
+public sealed class TenantContextBehavior(
+    ICurrentTenant currentTenant,
+    WolverineMetrics metrics,
+    IOptions<WolverineMessagingOptions> options)
 {
+    private readonly ICurrentTenant _currentTenant = currentTenant;
+    private readonly WolverineMetrics _metrics = metrics;
+    private readonly WolverineMessagingOptions _options = options.Value;
     private IDisposable? _scope;
 
     /// <summary>
@@ -38,8 +47,41 @@ public sealed class TenantContextBehavior(ICurrentTenant currentTenant)
                 Middleware.OutgoingContextMiddleware.TenantIdHeader, out string? tenantIdStr)
             && Guid.TryParse(tenantIdStr, out Guid tenantId))
         {
-            _scope = currentTenant.Change(tenantId);
+            _scope = _currentTenant.Change(tenantId);
+            return;
         }
+
+        // Envelope arrived without a tenant header. Always record the metric so
+        // operators can quantify the migration backlog before flipping the gate.
+        // Prefer the runtime CLR type when available — Wolverine's
+        // `envelope.MessageType` uses a wire-format identifier that is not always
+        // resolvable via `Type.GetType` across assemblies.
+        Type? messageType = envelope.Message?.GetType()
+            ?? (envelope.MessageType is not null ? Type.GetType(envelope.MessageType) : null);
+        string messageTypeName = messageType?.Name
+            ?? envelope.MessageType
+            ?? "(unknown)";
+
+        bool isCrossTenant = messageType is not null
+            && Attribute.IsDefined(messageType, typeof(CrossTenantMessageAttribute), inherit: false);
+
+        if (isCrossTenant)
+        {
+            _metrics.RecordEnvelopeWithoutTenant(messageTypeName, "allowed_marked");
+            return;
+        }
+
+        if (_options.RequireEnvelopeTenant)
+        {
+            _metrics.RecordEnvelopeWithoutTenant(messageTypeName, "rejected");
+            throw new InvalidOperationException(
+                $"Envelope for message type '{messageTypeName}' lacks an X-Tenant-Id header. "
+                + "RequireEnvelopeTenant is enabled and the message is not marked "
+                + $"[{nameof(CrossTenantMessageAttribute)}]. Either ensure the publisher "
+                + "propagates the tenant context, or annotate the message type as host-scope.");
+        }
+
+        _metrics.RecordEnvelopeWithoutTenant(messageTypeName, "allowed");
     }
 
     /// <summary>Restores the previous tenant context after the handler completes.</summary>

--- a/src/Granit.Wolverine/CrossTenantMessageAttribute.cs
+++ b/src/Granit.Wolverine/CrossTenantMessageAttribute.cs
@@ -1,0 +1,26 @@
+namespace Granit.Wolverine;
+
+/// <summary>
+/// Marks a Wolverine message type as legitimately tenant-agnostic — the framework
+/// will not require an <c>X-Tenant-Id</c> envelope header when dispatching to its
+/// handlers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SECURITY: most integration events flow within a single tenant context, and a
+/// missing tenant header is therefore a sign of a producer-side bug or an
+/// envelope-forgery attempt. The
+/// <see cref="Behaviors.TenantContextBehavior"/> records every untenanted envelope
+/// as <c>granit.wolverine.envelope.no_tenant</c> for SOC observability, and —
+/// when <see cref="Options.WolverineMessagingOptions.RequireEnvelopeTenant"/> is
+/// enabled — rejects them as an exception.
+/// </para>
+/// <para>
+/// Apply this attribute on the message record/class (<see cref="AttributeTargets.Class"/>
+/// or <see cref="AttributeTargets.Struct"/>) only when the message is intentionally
+/// host-scope — system health checks, configuration broadcasts, scheduling tick
+/// events. The marker is read by reflection at message-receive time.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class CrossTenantMessageAttribute : Attribute;

--- a/src/Granit.Wolverine/Diagnostics/WolverineMetrics.cs
+++ b/src/Granit.Wolverine/Diagnostics/WolverineMetrics.cs
@@ -19,6 +19,7 @@ public sealed class WolverineMetrics
     private readonly Counter<long> _retriesExhausted;
     private readonly Counter<long> _claimCheckStored;
     private readonly Counter<long> _claimCheckRetrieved;
+    private readonly Counter<long> _envelopeNoTenant;
 
     public WolverineMetrics(IMeterFactory meterFactory)
     {
@@ -43,6 +44,16 @@ public sealed class WolverineMetrics
         _claimCheckRetrieved = meter.CreateCounter<long>(
             "granit.wolverine.claimcheck.retrieved",
             description: "Number of payloads retrieved via the claim check pattern.");
+
+        _envelopeNoTenant = meter.CreateCounter<long>(
+            "granit.wolverine.envelope.no_tenant",
+            description:
+                "Number of received envelopes that did not carry an X-Tenant-Id "
+                + "header. Tagged with `message_type` and `outcome` "
+                + "(`allowed` = passed through; `allowed_marked` = passed because "
+                + "the message type is [CrossTenantMessage]; `rejected` = blocked "
+                + "by RequireEnvelopeTenant). Anomalous volume on `allowed` is "
+                + "the migration backlog before flipping RequireEnvelopeTenant=true.");
     }
 
     public void RecordMessageDispatched(string? tenantId) =>
@@ -75,5 +86,23 @@ public sealed class WolverineMetrics
         _claimCheckRetrieved.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
+        });
+
+    /// <summary>
+    /// Records an incoming envelope that did not carry an <c>X-Tenant-Id</c> header.
+    /// </summary>
+    /// <param name="messageType">The CLR name of the message type.</param>
+    /// <param name="outcome">
+    /// <c>"allowed"</c> when the envelope was processed without a tenant scope,
+    /// <c>"allowed_marked"</c> when the message type is annotated with
+    /// <see cref="CrossTenantMessageAttribute"/>, or <c>"rejected"</c> when
+    /// <see cref="Options.WolverineMessagingOptions.RequireEnvelopeTenant"/>
+    /// is enabled and blocked the dispatch.
+    /// </param>
+    public void RecordEnvelopeWithoutTenant(string messageType, string outcome) =>
+        _envelopeNoTenant.Add(1, new TagList
+        {
+            { "message_type", messageType },
+            { "outcome", outcome },
         });
 }

--- a/src/Granit.Wolverine/Options/WolverineMessagingOptions.cs
+++ b/src/Granit.Wolverine/Options/WolverineMessagingOptions.cs
@@ -30,4 +30,30 @@ public sealed class WolverineMessagingOptions
     /// Must be ≥ 1. Default: 3.
     /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// When <see langword="true"/>, the
+    /// <see cref="Behaviors.TenantContextBehavior"/> rejects incoming envelopes
+    /// that lack an <c>X-Tenant-Id</c> header unless the message type carries
+    /// <see cref="CrossTenantMessageAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SECURITY: closes the cross-tenant code path that opens when a Wolverine
+    /// handler runs without a tenant scope and falls through to
+    /// <c>EfStoreBase</c>'s implicit cross-tenant query branch. Producer-side
+    /// bugs (forgot to propagate the tenant) and forged envelopes both surface
+    /// as <see cref="InvalidOperationException"/> instead of silent
+    /// cross-tenant data access.
+    /// </para>
+    /// <para>
+    /// Default: <see langword="false"/>. The metric
+    /// <c>granit.wolverine.envelope.no_tenant</c> is emitted regardless, so SOC
+    /// can quantify the migration burden before flipping the gate. Once the
+    /// metric is steady at 0 (excluding events legitimately tagged
+    /// <see cref="CrossTenantMessageAttribute"/>), the option can be set to
+    /// <see langword="true"/> safely.
+    /// </para>
+    /// </remarks>
+    public bool RequireEnvelopeTenant { get; set; }
 }

--- a/src/Granit/MultiTenancy/IHostAccessContext.cs
+++ b/src/Granit/MultiTenancy/IHostAccessContext.cs
@@ -1,0 +1,31 @@
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// Reports whether the current execution context is running under a deliberate
+/// host-access endpoint (route marked <c>.AllowHostAccess()</c>) as opposed to
+/// an accidental tenant-context loss.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both states leave <see cref="ICurrentTenant.IsAvailable"/> at <c>false</c>, but
+/// the data layer needs to distinguish them: a signaled host-access call is the
+/// expected cross-tenant read path; an unsignaled call is an anomaly that may
+/// indicate a tenant-context leak in flight and should raise an alert.
+/// </para>
+/// <para>
+/// Implementations are scoped to the request and are read by
+/// <c>EfStoreBase</c> when emitting the
+/// <c>granit.persistence.cross_tenant_query</c> metric and the companion log
+/// event. Default DI registration is the HTTP-backed implementation; callers
+/// outside an HTTP request observe <see cref="IsHostAccess"/> as <c>false</c>.
+/// </para>
+/// </remarks>
+public interface IHostAccessContext
+{
+    /// <summary>
+    /// <c>true</c> when the current request was admitted through a route marked
+    /// <c>.AllowHostAccess()</c> in host mode (no tenant header, authenticated
+    /// caller). <c>false</c> otherwise.
+    /// </summary>
+    bool IsHostAccess { get; }
+}

--- a/src/Granit/MultiTenancy/IHostAccessFeature.cs
+++ b/src/Granit/MultiTenancy/IHostAccessFeature.cs
@@ -1,0 +1,26 @@
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// HTTP feature placed on <c>HttpContext.Features</c> by
+/// <c>RequireHostContextEndpointFilter</c> when an endpoint marked
+/// <c>.AllowHostAccess()</c> is invoked in host mode.
+/// </summary>
+/// <remarks>
+/// Consumed by the HTTP-backed <see cref="IHostAccessContext"/> implementation.
+/// Lives on the request feature collection (not in DI) so the signal is naturally
+/// scoped to the request and never leaks across requests. Use
+/// <see cref="HostMode"/> to obtain the canonical instance to store.
+/// </remarks>
+public interface IHostAccessFeature
+{
+    /// <summary>Always <c>true</c> on instances stored on the feature collection.</summary>
+    bool IsHostAccess { get; }
+
+    /// <summary>Canonical singleton stored on <c>HttpContext.Features</c>.</summary>
+    public static IHostAccessFeature HostMode { get; } = new HostModeFeature();
+
+    private sealed class HostModeFeature : IHostAccessFeature
+    {
+        public bool IsHostAccess => true;
+    }
+}

--- a/tests/Granit.Authorization.Tests/Filters/RequireHostContextEndpointFilterTests.cs
+++ b/tests/Granit.Authorization.Tests/Filters/RequireHostContextEndpointFilterTests.cs
@@ -1,0 +1,109 @@
+// =============================================================================
+// Tests - RequireHostContextEndpointFilter
+// =============================================================================
+// Verifies that the filter (a) authenticates host-mode callers, (b) signals the
+// data layer via IHostAccessFeature so EfStoreBase can distinguish a deliberate
+// .AllowHostAccess() bypass from an accidental tenant-context loss.
+// =============================================================================
+
+using System.Security.Claims;
+using Granit.Authorization.Filters;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests.Filters;
+
+public sealed class RequireHostContextEndpointFilterTests
+{
+    private readonly RequireHostContextEndpointFilter _filter = new();
+
+    [Fact]
+    public async Task PassesThrough_WhenTenantIsActive_NoFeatureSet()
+    {
+        // Tenant active = normal request, filter is a no-op. The feature must NOT
+        // be set so EfStoreBase doesn't mis-tag the metric on a tenant-scoped read.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        EndpointFilterInvocationContext context = BuildContext(tenant, authenticated: true);
+
+        bool nextCalled = false;
+        await _filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return new ValueTask<object?>("ok");
+        });
+
+        nextCalled.ShouldBeTrue();
+        context.HttpContext.Features.Get<IHostAccessFeature>().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PassesThrough_WhenNoMultiTenancyModule_NoFeatureSet()
+    {
+        // No ICurrentTenant in DI = single-tenant deployment, filter is a no-op.
+        EndpointFilterInvocationContext context = BuildContext(currentTenant: null, authenticated: true);
+
+        await _filter.InvokeAsync(context, _ => new ValueTask<object?>("ok"));
+
+        context.HttpContext.Features.Get<IHostAccessFeature>().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Returns401_WhenHostMode_AndUnauthenticated()
+    {
+        // Host mode without auth must be rejected — anonymous callers cannot
+        // reach cross-tenant data even on .AllowHostAccess() endpoints.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        EndpointFilterInvocationContext context = BuildContext(tenant, authenticated: false);
+
+        object? result = await _filter.InvokeAsync(context, _ => new ValueTask<object?>("should-not-run"));
+
+        result.ShouldBeOfType<ProblemHttpResult>()
+            .StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+        context.HttpContext.Features.Get<IHostAccessFeature>().ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetsHostAccessFeature_WhenHostMode_AndAuthenticated()
+    {
+        // The signal contract: host mode + authenticated = IHostAccessFeature
+        // is set on the request feature collection so EfStoreBase tags the
+        // metric origin=host_endpoint instead of implicit_unsignaled.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        EndpointFilterInvocationContext context = BuildContext(tenant, authenticated: true);
+
+        await _filter.InvokeAsync(context, _ => new ValueTask<object?>("ok"));
+
+        IHostAccessFeature? feature = context.HttpContext.Features.Get<IHostAccessFeature>();
+        feature.ShouldNotBeNull();
+        feature.IsHostAccess.ShouldBeTrue();
+    }
+
+    private static DefaultEndpointFilterInvocationContext BuildContext(
+        ICurrentTenant? currentTenant,
+        bool authenticated)
+    {
+        ServiceCollection services = new();
+        if (currentTenant is not null)
+        {
+            services.AddSingleton(currentTenant);
+        }
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        DefaultHttpContext httpContext = new() { RequestServices = sp };
+        if (authenticated)
+        {
+            httpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "u1")], "test"));
+        }
+
+        return new DefaultEndpointFilterInvocationContext(httpContext);
+    }
+}

--- a/tests/Granit.MultiTenancy.Tests/CurrentTenantTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/CurrentTenantTests.cs
@@ -3,6 +3,9 @@
 // =============================================================================
 
 using Granit.MultiTenancy;
+using Granit.MultiTenancy.Internal;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -10,6 +13,11 @@ namespace Granit.MultiTenancy.Tests;
 
 public sealed class CurrentTenantTests
 {
+    /// <summary>
+    /// Default factory: no HttpContextAccessor, so all reads/writes go through the
+    /// AsyncLocal fallback (the legacy non-HTTP code path used by Wolverine,
+    /// background jobs, migrations).
+    /// </summary>
     private static CurrentTenant Create() => new();
 
     [Fact]
@@ -132,5 +140,107 @@ public sealed class CurrentTenantTests
         tenant.Id.ShouldBe(id);
         tenant.Name.ShouldBeNull();
         tenant.IsAvailable.ShouldBeTrue();
+    }
+
+    // ====================================================================
+    // HTTP backend — when an HttpContext is active, the tenant lives on
+    // HttpContext.Features (not on the AsyncLocal). The lifetime is the
+    // request itself, so there is no execution-context state to leak
+    // across requests on thread-pool reuse.
+    // ====================================================================
+
+    [Fact]
+    public void HttpContextActive_Change_Stores_Tenant_On_Features()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        DefaultHttpContext httpContext = new();
+        accessor.HttpContext.Returns(httpContext);
+        CurrentTenant tenant = new(accessor);
+        var id = Guid.NewGuid();
+
+        using IDisposable _ = tenant.Change(id, "Acme");
+
+        tenant.Id.ShouldBe(id);
+        tenant.Name.ShouldBe("Acme");
+        // The feature has been written to the request's feature collection,
+        // not to the framework's AsyncLocal.
+        httpContext.Features.Get<ITenantContextFeature>().ShouldNotBeNull();
+        httpContext.Features.Get<ITenantContextFeature>()!.Tenant!.Id.ShouldBe(id);
+    }
+
+    [Fact]
+    public void HttpContextActive_Dispose_Restores_Previous_Feature()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        DefaultHttpContext httpContext = new();
+        accessor.HttpContext.Returns(httpContext);
+        CurrentTenant tenant = new(accessor);
+
+        IDisposable scope = tenant.Change(Guid.NewGuid(), "Acme");
+        scope.Dispose();
+
+        tenant.IsAvailable.ShouldBeFalse();
+        httpContext.Features.Get<ITenantContextFeature>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void HttpContextActive_Two_Parallel_Requests_Are_Isolated()
+    {
+        // Core safety property: the tenant value lives on the request's
+        // FeatureCollection, so two parallel HTTP requests cannot read each
+        // other's tenant — by construction, no shared static state.
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        CurrentTenant tenant = new(accessor);
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        DefaultHttpContext requestA = new();
+        DefaultHttpContext requestB = new();
+        requestA.Features.Set<ITenantContextFeature>(new TenantContextFeature(new TenantInfo(tenantA, "A")));
+        requestB.Features.Set<ITenantContextFeature>(new TenantContextFeature(new TenantInfo(tenantB, "B")));
+
+        accessor.HttpContext.Returns(requestA);
+        tenant.Id.ShouldBe(tenantA);
+
+        accessor.HttpContext.Returns(requestB);
+        tenant.Id.ShouldBe(tenantB);
+
+        accessor.HttpContext.Returns((HttpContext?)null);
+        tenant.IsAvailable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HttpContextActive_AsyncLocal_Fallback_Is_Not_Consulted()
+    {
+        // Defense-in-depth: even if the legacy AsyncLocal is set (legitimately
+        // by some deeper non-HTTP code path), the HTTP context wins. The two
+        // backends never alias.
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        DefaultHttpContext httpContext = new();
+        accessor.HttpContext.Returns(httpContext);
+        CurrentTenant httpTenant = new(accessor);
+        CurrentTenant asyncLocalTenant = new();
+
+        var asyncLocalId = Guid.NewGuid();
+        var httpId = Guid.NewGuid();
+
+        using IDisposable _outer = asyncLocalTenant.Change(asyncLocalId, "AsyncLocal");
+        using IDisposable _inner = httpTenant.Change(httpId, "Http");
+
+        httpTenant.Id.ShouldBe(httpId, "HTTP backend reads from HttpContext.Features");
+        asyncLocalTenant.Id.ShouldBe(asyncLocalId, "non-HTTP instance still sees its AsyncLocal value");
+    }
+
+    [Fact]
+    public void HttpContextNull_Falls_Back_To_AsyncLocal()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        CurrentTenant tenant = new(accessor);
+        var id = Guid.NewGuid();
+
+        using IDisposable _ = tenant.Change(id, "Job");
+
+        tenant.Id.ShouldBe(id, "no HttpContext active → AsyncLocal fallback used");
     }
 }

--- a/tests/Granit.MultiTenancy.Tests/MultiTenancyServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/MultiTenancyServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 using Granit.MultiTenancy;
 using Granit.MultiTenancy.Extensions;
+using Granit.MultiTenancy.Internal;
 using Granit.MultiTenancy.Middleware;
 using Granit.MultiTenancy.Options;
 using Granit.MultiTenancy.Pipeline;
@@ -18,11 +19,12 @@ namespace Granit.MultiTenancy.Tests;
 
 public sealed class MultiTenancyServiceCollectionExtensionsTests
 {
-    private static ServiceProvider BuildProvider()
+    private static ServiceProvider BuildProvider(IDictionary<string, string?>? config = null)
     {
         ServiceCollection services = new();
-        // BindConfiguration requires IConfiguration in the container
-        IConfiguration configuration = new ConfigurationBuilder().Build();
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config ?? new Dictionary<string, string?>())
+            .Build();
         services.AddSingleton(configuration);
         services.AddLogging();
         services.AddMetrics();

--- a/tests/Granit.MultiTenancy.Tests/Options/MultiTenancyOptionsValidatorTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/Options/MultiTenancyOptionsValidatorTests.cs
@@ -1,0 +1,99 @@
+using Granit.MultiTenancy.Options;
+using Granit.MultiTenancy.Stores;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.MultiTenancy.Tests.Options;
+
+/// <summary>
+/// Startup-time validations for <see cref="MultiTenancyOptions"/>.
+/// </summary>
+public sealed class MultiTenancyOptionsValidatorTests
+{
+    private static IHostEnvironment Env(string name)
+    {
+        IHostEnvironment env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(name);
+        return env;
+    }
+
+    private static ServiceProvider WithMembershipReader(IUserTenantMembershipReader reader)
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => reader);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void QueryStringParam_NonEmpty_OutsideDevelopment_Fails()
+    {
+        IServiceProvider sp = WithMembershipReader(new NullUserTenantMembershipReader());
+        MultiTenancyOptionsValidator validator = new(Env("Production"), sp);
+        MultiTenancyOptions options = new() { QueryStringParamName = "__tenant" };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("QueryStringParamName");
+    }
+
+    [Fact]
+    public void QueryStringParam_NonEmpty_InDevelopment_Succeeds()
+    {
+        IServiceProvider sp = WithMembershipReader(new NullUserTenantMembershipReader());
+        MultiTenancyOptionsValidator validator = new(Env("Development"), sp);
+        MultiTenancyOptions options = new() { QueryStringParamName = "__tenant" };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequireMembershipCheck_Without_Concrete_Reader_Fails()
+    {
+        // The fallback NullUserTenantMembershipReader returns true for every
+        // membership check. Enabling the flag without a real reader registered
+        // would silently accept any tenant claim — the validator must catch
+        // this misconfiguration at startup.
+        IServiceProvider sp = WithMembershipReader(new NullUserTenantMembershipReader());
+        MultiTenancyOptionsValidator validator = new(Env("Production"), sp);
+        MultiTenancyOptions options = new() { RequireMembershipCheck = true };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("IUserTenantMembershipReader");
+    }
+
+    [Fact]
+    public void RequireMembershipCheck_With_Concrete_Reader_Succeeds()
+    {
+        IUserTenantMembershipReader concrete = Substitute.For<IUserTenantMembershipReader>();
+        IServiceProvider sp = WithMembershipReader(concrete);
+        MultiTenancyOptionsValidator validator = new(Env("Production"), sp);
+        MultiTenancyOptions options = new() { RequireMembershipCheck = true };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequireMembershipCheck_Disabled_DoesNot_Inspect_Reader()
+    {
+        // Even with only the NullReader registered, the validator must succeed
+        // when the flag is off — we don't inspect the reader at all.
+        IServiceProvider sp = WithMembershipReader(new NullUserTenantMembershipReader());
+        MultiTenancyOptionsValidator validator = new(Env("Production"), sp);
+        MultiTenancyOptions options = new() { RequireMembershipCheck = false };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -33,13 +33,16 @@ public sealed class TenantResolutionMiddlewareTests
         TenantResolverPipeline pipeline,
         bool isEnabled = true,
         TenantHeaderTrustMode headerTrustMode = TenantHeaderTrustMode.Unrestricted,
-        bool validateTenantExistence = false)
+        bool validateTenantExistence = false,
+        bool requireMembershipCheck = false,
+        IUserTenantMembershipReader? membershipReader = null)
     {
         IOptions<MultiTenancyOptions> options = Microsoft.Extensions.Options.Options.Create(new MultiTenancyOptions
         {
             IsEnabled = isEnabled,
             HeaderTrustMode = headerTrustMode,
             ValidateTenantExistence = validateTenantExistence,
+            RequireMembershipCheck = requireMembershipCheck,
         });
         ITenantReader tenantReader = Substitute.For<ITenantReader>();
         tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -48,6 +51,7 @@ public sealed class TenantResolutionMiddlewareTests
             currentTenant,
             pipeline,
             tenantReader,
+            membershipReader ?? new NullUserTenantMembershipReader(),
             CreateMetrics(),
             options,
             NullLogger<TenantResolutionMiddleware>.Instance);
@@ -208,8 +212,131 @@ public sealed class TenantResolutionMiddlewareTests
             currentTenant,
             pipeline,
             tenantReader,
+            new NullUserTenantMembershipReader(),
             CreateMetrics(),
             options,
             NullLogger<TenantResolutionMiddleware>.Instance);
+    }
+
+    // ── Membership check ──────────────────────────────────────────────
+
+    private static DefaultHttpContext AuthenticatedContext(string subject)
+    {
+        DefaultHttpContext context = new();
+        var identity = new System.Security.Claims.ClaimsIdentity("test");
+        identity.AddClaim(new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.NameIdentifier, subject));
+        context.User = new System.Security.Claims.ClaimsPrincipal(identity);
+        return context;
+    }
+
+    [Fact]
+    public async Task RequireMembershipCheck_Off_DoesNotConsultReader()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        IUserTenantMembershipReader reader = Substitute.For<IUserTenantMembershipReader>();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(Guid.NewGuid()));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            requireMembershipCheck: false, membershipReader: reader);
+        DefaultHttpContext context = AuthenticatedContext("alice");
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        await reader.DidNotReceive().IsMemberAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task RequireMembershipCheck_On_AnonymousRequest_BypassesCheck()
+    {
+        // Anonymous flows (login, public webhooks) reach the middleware without
+        // an authenticated user. The check is skipped — no claim to validate.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        IUserTenantMembershipReader reader = Substitute.For<IUserTenantMembershipReader>();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(Guid.NewGuid()));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            requireMembershipCheck: true, membershipReader: reader);
+        DefaultHttpContext context = new();
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        await reader.DidNotReceive().IsMemberAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequireMembershipCheck_On_AuthenticatedMember_PassesThrough()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        IUserTenantMembershipReader reader = Substitute.For<IUserTenantMembershipReader>();
+        reader.IsMemberAsync("alice", Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        var tenantId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(tenantId));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            requireMembershipCheck: true, membershipReader: reader);
+        DefaultHttpContext context = AuthenticatedContext("alice");
+        bool nextCalled = false;
+
+        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+
+        await reader.Received(1).IsMemberAsync("alice", tenantId, Arg.Any<CancellationToken>());
+        nextCalled.ShouldBeTrue();
+        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task RequireMembershipCheck_On_AuthenticatedNonMember_Returns403()
+    {
+        // Core defense: the JWT carried a tenant_id claim that the JwtClaimTenantResolver
+        // honored, but the user is not actually a member of that tenant. Rejected.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IUserTenantMembershipReader reader = Substitute.For<IUserTenantMembershipReader>();
+        reader.IsMemberAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false));
+        var tenantId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(tenantId));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            requireMembershipCheck: true, membershipReader: reader);
+        DefaultHttpContext context = AuthenticatedContext("mallory");
+        bool nextCalled = false;
+
+        await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        nextCalled.ShouldBeFalse();
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task RequireMembershipCheck_On_AuthenticatedWithoutSubClaim_Returns403()
+    {
+        // No `sub` / NameIdentifier claim — we have no user identity to check
+        // membership against. Fail-closed.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IUserTenantMembershipReader reader = Substitute.For<IUserTenantMembershipReader>();
+        reader.IsMemberAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(Guid.NewGuid()));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline,
+            requireMembershipCheck: true, membershipReader: reader);
+        DefaultHttpContext context = new();
+        // Authenticated but without NameIdentifier or sub claim.
+        context.User = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity("test"));
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        await reader.DidNotReceive().IsMemberAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/Diagnostics/PersistenceMetricsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/Diagnostics/PersistenceMetricsTests.cs
@@ -60,4 +60,35 @@ public sealed class PersistenceMetricsTests : IDisposable
         snapshot.ShouldHaveSingleItem();
         snapshot[0].Tags["tenant_id"].ShouldBe("global");
     }
+
+    // ──── RecordCrossTenantQuery ────
+
+    [Fact]
+    public void RecordCrossTenantQuery_Implicit_TaggedByEntityAndOrigin()
+    {
+        using var collector = new MetricCollector<long>(
+            _meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        _metrics.RecordCrossTenantQuery("Invoice", "implicit");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Value.ShouldBe(1);
+        snapshot[0].Tags["entity"].ShouldBe("Invoice");
+        snapshot[0].Tags["origin"].ShouldBe("implicit");
+    }
+
+    [Fact]
+    public void RecordCrossTenantQuery_Explicit_TaggedByEntityAndOrigin()
+    {
+        using var collector = new MetricCollector<long>(
+            _meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        _metrics.RecordCrossTenantQuery("Webhook", "explicit");
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["entity"].ShouldBe("Webhook");
+        snapshot[0].Tags["origin"].ShouldBe("explicit");
+    }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/EfStoreBaseTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/EfStoreBaseTests.cs
@@ -1,0 +1,268 @@
+// =============================================================================
+// Tests - EfStoreBase
+// =============================================================================
+// Cover the cross-tenant filter behavior:
+//   1. Per-call evaluation (no constructor-time caching) — closes the edge
+//      case where a Scoped store was constructed before the tenant was activated
+//      and stayed in cross-tenant mode for the rest of the scope.
+//   2. Bypass when ICurrentTenant.IsAvailable=false — split by IHostAccessContext:
+//        - host-access signaled (via .AllowHostAccess()) → origin=host_endpoint
+//        - no signal → origin=implicit_unsignaled (alert-worthy: leak in flight)
+//   3. Explicit QueryAcrossTenants() → origin=explicit (caller opt-in).
+// =============================================================================
+
+using System.Diagnostics.Metrics;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Tests;
+
+public sealed class EfStoreBaseTests : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly PersistenceMetrics _metrics;
+    private readonly TestDbContextFactory _contextFactory;
+
+    public EfStoreBaseTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new PersistenceMetrics(_meterFactory);
+        _contextFactory = new TestDbContextFactory();
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    [Fact]
+    public async Task Query_WithActiveTenant_DoesNotRecord_CrossTenantQuery()
+    {
+        // Sanity: the happy path (active tenant) must not emit any
+        // cross-tenant metric. Anything else would create alert noise.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Guid.NewGuid());
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        collector.GetMeasurementSnapshot().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Query_WithoutActiveTenant_NoSignal_RecordsImplicitUnsignaled()
+    {
+        // No tenant + no host-access signal = the alert-worthy origin. SOC alerts
+        // on this counter > 0 to detect tenant-context loss in flight.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["entity"].ShouldBe(nameof(TestMultiTenantEntity));
+        snapshot[0].Tags["origin"].ShouldBe("implicit_unsignaled");
+    }
+
+    [Fact]
+    public async Task Query_WithoutActiveTenant_HostSignalled_RecordsHostEndpoint()
+    {
+        // No tenant + host-access signal = expected .AllowHostAccess() path.
+        // Distinct origin so SOC can suppress this from leak alerts.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        IHostAccessContext hostAccess = Substitute.For<IHostAccessContext>();
+        hostAccess.IsHostAccess.Returns(true);
+        TestStore store = new(_contextFactory, tenant, hostAccess, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["origin"].ShouldBe("host_endpoint");
+    }
+
+    [Fact]
+    public async Task Query_TenantBecomesAvailableAfterConstruction_NoBypass()
+    {
+        // Root-cause check: the previous implementation cached the bypass
+        // decision at construction. A Scoped store created before the tenant
+        // was activated kept bypassing for the rest of the scope. With
+        // per-call evaluation, this no longer happens.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        // Tenant becomes available after the store was created.
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Guid.NewGuid());
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        collector.GetMeasurementSnapshot().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryAcrossTenants_RecordsExplicitBypass()
+    {
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Guid.NewGuid());
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntitiesAcrossTenants(db);
+
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["entity"].ShouldBe(nameof(TestMultiTenantEntity));
+        snapshot[0].Tags["origin"].ShouldBe("explicit");
+    }
+
+    [Fact]
+    public async Task Query_UnsignaledBypass_LogsWarning()
+    {
+        // Unsignaled bypass logs a Warning so the SOC can correlate the metric tick
+        // with a searchable trace pointing at the entity.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        FakeLogger logger = new();
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics, logger);
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        FakeLogRecord record = logger.LatestRecord;
+        record.Level.ShouldBe(LogLevel.Warning);
+        record.Message.ShouldContain(nameof(TestMultiTenantEntity));
+    }
+
+    [Fact]
+    public async Task QueryAcrossTenants_LogsInformation_WithCallerFrame()
+    {
+        // Explicit opt-in logs Information with the caller member/file/line so an
+        // operator can pinpoint which call-site triggered the cross-tenant read
+        // without spelunking through stack traces.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(Guid.NewGuid());
+        FakeLogger logger = new();
+        TestStore store = new(_contextFactory, tenant, hostAccess: null, _metrics, logger);
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntitiesAcrossTenants(db);
+
+        FakeLogRecord record = logger.LatestRecord;
+        record.Level.ShouldBe(LogLevel.Information);
+        record.Message.ShouldContain(nameof(TestStore.QueryEntitiesAcrossTenants));
+        record.Message.ShouldContain(nameof(EfStoreBaseTests));
+    }
+
+    [Fact]
+    public async Task Query_NonMultiTenantEntity_NeverBypasses()
+    {
+        // EfStoreBase only triggers the bypass when TEntity implements IMultiTenant.
+        // Non-tenant entities are always served unfiltered (the named filter does
+        // not exist for them) — and must not emit the metric.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(false);
+        TestNonTenantStore store = new(_contextFactory, tenant, _metrics);
+        using MetricCollector<long> collector = new(_meterFactory, PersistenceMetrics.MeterName, "granit.persistence.cross_tenant_query");
+
+        await using TestDbContext db = await _contextFactory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        _ = store.QueryEntities(db);
+
+        collector.GetMeasurementSnapshot().ShouldBeEmpty();
+    }
+
+    // ──── Test fixtures ────
+
+    private sealed class TestMultiTenantEntity : Entity, IMultiTenant
+    {
+        public Guid? TenantId { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestNonTenantEntity : Entity
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<TestMultiTenantEntity> MultiTenantEntities => Set<TestMultiTenantEntity>();
+        public DbSet<TestNonTenantEntity> NonTenantEntities => Set<TestNonTenantEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestMultiTenantEntity>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<TestNonTenantEntity>().Property(e => e.Id).ValueGeneratedNever();
+        }
+    }
+
+    private sealed class TestDbContextFactory : IDbContextFactory<TestDbContext>
+    {
+        private readonly string _databaseName = Guid.NewGuid().ToString();
+
+        public TestDbContext CreateDbContext()
+        {
+            DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase(_databaseName)
+                .Options;
+            return new TestDbContext(options);
+        }
+
+        public Task<TestDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    /// <summary>
+    /// Test concrete subclass exposing the protected <c>Query</c> /
+    /// <c>QueryAcrossTenants</c> for direct assertion.
+    /// </summary>
+    private sealed class TestStore(
+        IDbContextFactory<TestDbContext> contextFactory,
+        ICurrentTenant currentTenant,
+        IHostAccessContext? hostAccess,
+        PersistenceMetrics metrics,
+        ILogger? logger = null)
+        : EfStoreBase<TestMultiTenantEntity, TestDbContext>(contextFactory, currentTenant, hostAccess, metrics, logger)
+    {
+        public IQueryable<TestMultiTenantEntity> QueryEntities(TestDbContext db) => Query(db);
+
+        public IQueryable<TestMultiTenantEntity> QueryEntitiesAcrossTenants(TestDbContext db) => QueryAcrossTenants(db);
+    }
+
+    private sealed class TestNonTenantStore(
+        IDbContextFactory<TestDbContext> contextFactory,
+        ICurrentTenant currentTenant,
+        PersistenceMetrics metrics)
+        : EfStoreBase<TestNonTenantEntity, TestDbContext>(contextFactory, currentTenant, hostAccess: null, metrics)
+    {
+        public IQueryable<TestNonTenantEntity> QueryEntities(TestDbContext db) => Query(db);
+    }
+}

--- a/tests/Granit.Wolverine.Tests/Granit.Wolverine.Tests.csproj
+++ b/tests/Granit.Wolverine.Tests/Granit.Wolverine.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />

--- a/tests/Granit.Wolverine.Tests/TenantContextBehaviorTests.cs
+++ b/tests/Granit.Wolverine.Tests/TenantContextBehaviorTests.cs
@@ -1,13 +1,21 @@
 // =============================================================================
 // Tests - TenantContextBehavior
 // =============================================================================
-// Verifies that X-Tenant-Id header is correctly restored to ICurrentTenant
-// in incoming Wolverine envelopes, and that the scope is disposed on After().
+// Verifies that X-Tenant-Id header is correctly restored to ICurrentTenant in
+// incoming Wolverine envelopes, that the scope is disposed on After(), and
+// that envelopes without a tenant header are observable / fail-closed when
+// requested.
 // =============================================================================
 
+using System.Diagnostics.Metrics;
 using Granit.MultiTenancy;
 using Granit.Wolverine.Behaviors;
+using Granit.Wolverine.Diagnostics;
 using Granit.Wolverine.Middleware;
+using Granit.Wolverine.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Wolverine;
@@ -15,49 +23,120 @@ using Xunit;
 
 namespace Granit.Wolverine.Tests;
 
-public sealed class TenantContextBehaviorTests
+public sealed class TenantContextBehaviorTests : IDisposable
 {
+    private readonly ServiceProvider _sp;
+    private readonly IMeterFactory _meterFactory;
+    private readonly WolverineMetrics _metrics;
+
+    public TenantContextBehaviorTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        _meterFactory = _sp.GetRequiredService<IMeterFactory>();
+        _metrics = new WolverineMetrics(_meterFactory);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private TenantContextBehavior CreateBehavior(
+        ICurrentTenant currentTenant,
+        bool requireEnvelopeTenant = false)
+    {
+        IOptions<WolverineMessagingOptions> options = Microsoft.Extensions.Options.Options.Create(
+            new WolverineMessagingOptions { RequireEnvelopeTenant = requireEnvelopeTenant });
+        return new TenantContextBehavior(currentTenant, _metrics, options);
+    }
+
+    private MetricCollector<long> NoTenantCollector() =>
+        new(_meterFactory, WolverineMetrics.MeterName, "granit.wolverine.envelope.no_tenant");
+
     [Fact]
     public void Before_WithValidTenantHeader_CallsChange()
     {
         var tenantId = Guid.NewGuid();
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
         tenant.Change(tenantId).Returns(Substitute.For<IDisposable>());
-
-        TenantContextBehavior behavior = new(tenant);
+        TenantContextBehavior behavior = CreateBehavior(tenant);
+        using MetricCollector<long> collector = NoTenantCollector();
         Envelope envelope = new();
         envelope.Headers[OutgoingContextMiddleware.TenantIdHeader] = tenantId.ToString();
 
         behavior.Before(envelope);
 
         tenant.Received(1).Change(tenantId);
+        collector.GetMeasurementSnapshot().ShouldBeEmpty();
     }
 
     [Fact]
-    public void Before_WithMissingHeader_DoesNotCallChange()
+    public void Before_WithMissingHeader_PassesThrough_AndRecordsMetric()
     {
+        // Default behavior is permissive: handler runs without scope. The metric
+        // makes the occurrence visible so SOC can quantify the migration backlog
+        // before flipping RequireEnvelopeTenant.
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
-
-        TenantContextBehavior behavior = new(tenant);
-        Envelope envelope = new();
+        TenantContextBehavior behavior = CreateBehavior(tenant);
+        using MetricCollector<long> collector = NoTenantCollector();
+        Envelope envelope = new() { Message = new TenantScopedMessage() };
 
         behavior.Before(envelope);
 
         tenant.DidNotReceive().Change(Arg.Any<Guid?>());
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["outcome"].ShouldBe("allowed");
+        snapshot[0].Tags["message_type"].ShouldBe(nameof(TenantScopedMessage));
     }
 
     [Fact]
-    public void Before_WithInvalidGuidHeader_DoesNotCallChange()
+    public void Before_WithInvalidGuidHeader_PassesThrough_AndRecordsMetric()
     {
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
-
-        TenantContextBehavior behavior = new(tenant);
-        Envelope envelope = new();
+        TenantContextBehavior behavior = CreateBehavior(tenant);
+        using MetricCollector<long> collector = NoTenantCollector();
+        Envelope envelope = new() { Message = new TenantScopedMessage() };
         envelope.Headers[OutgoingContextMiddleware.TenantIdHeader] = "not-a-guid";
 
         behavior.Before(envelope);
 
         tenant.DidNotReceive().Change(Arg.Any<Guid?>());
+        collector.GetMeasurementSnapshot().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Before_WithCrossTenantMessage_NoHeader_AllowedMarked()
+    {
+        // System-wide messages opt out of the gate via [CrossTenantMessage].
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        TenantContextBehavior behavior = CreateBehavior(tenant, requireEnvelopeTenant: true);
+        using MetricCollector<long> collector = NoTenantCollector();
+        Envelope envelope = new() { Message = new SystemBroadcastMessage() };
+
+        behavior.Before(envelope);
+
+        tenant.DidNotReceive().Change(Arg.Any<Guid?>());
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["outcome"].ShouldBe("allowed_marked");
+        snapshot[0].Tags["message_type"].ShouldBe(nameof(SystemBroadcastMessage));
+    }
+
+    [Fact]
+    public void Before_WhenRequireEnvelopeTenant_NoHeader_NotMarked_Throws()
+    {
+        // With the gate enabled, untenanted envelopes for tenant-scoped messages
+        // must throw — they signal a producer-side bug or an envelope forgery.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        TenantContextBehavior behavior = CreateBehavior(tenant, requireEnvelopeTenant: true);
+        using MetricCollector<long> collector = NoTenantCollector();
+        Envelope envelope = new() { Message = new TenantScopedMessage() };
+
+        Should.Throw<InvalidOperationException>(() => behavior.Before(envelope))
+            .Message.ShouldContain(nameof(CrossTenantMessageAttribute));
+        IReadOnlyList<CollectedMeasurement<long>> snapshot = collector.GetMeasurementSnapshot();
+        snapshot.ShouldHaveSingleItem();
+        snapshot[0].Tags["outcome"].ShouldBe("rejected");
     }
 
     [Fact]
@@ -65,11 +144,9 @@ public sealed class TenantContextBehaviorTests
     {
         var tenantId = Guid.NewGuid();
         IDisposable scope = Substitute.For<IDisposable>();
-
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
         tenant.Change(tenantId).Returns(scope);
-
-        TenantContextBehavior behavior = new(tenant);
+        TenantContextBehavior behavior = CreateBehavior(tenant);
         Envelope envelope = new();
         envelope.Headers[OutgoingContextMiddleware.TenantIdHeader] = tenantId.ToString();
 
@@ -83,10 +160,15 @@ public sealed class TenantContextBehaviorTests
     public void After_WhenNoScopeWasSet_DoesNotThrow()
     {
         ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
-        TenantContextBehavior behavior = new(tenant);
+        TenantContextBehavior behavior = CreateBehavior(tenant);
 
-        Action act = behavior.After;
-
-        Should.NotThrow(act);
+        Should.NotThrow(behavior.After);
     }
+
+    // ──── Test message types ────
+
+    private sealed record TenantScopedMessage;
+
+    [CrossTenantMessage]
+    private sealed record SystemBroadcastMessage;
 }

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -20,6 +20,15 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Diagnostics.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.5.0",
+        "contentHash": "EiERK24AmaxMa7hkgV5UqdfIlrMxg3n+7XdkaV3FWLoyEzca6gvGiaRZofl6KzAtvMBJoZvb5a+EyYqq+M9CoQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.5.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -100,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.28.2",
-        "contentHash": "PqiJQrZ02ytH+BBNkKm2mc+CD5OSIcx8HIElQuI8KNkqHgBQ3LRQ07wmeniHvOVkXmiEIH2CAhksA3wj0n+aeQ==",
+        "resolved": "1.29.0",
+        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -112,10 +121,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.31.1",
-        "contentHash": "VTiVkFYgQFixA1KupIcOCAQUxfczhPrYLB6Qi9KKsdygfk4yEGyK+qQN81uoARz8TSOrEgjpCz9dx1wnQVUYHQ==",
+        "resolved": "1.33.1",
+        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
         "dependencies": {
-          "JasperFx": "1.28.2"
+          "JasperFx": "1.29.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -236,6 +245,19 @@
         "type": "Transitive",
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.5.0",
+        "contentHash": "xbWZji13Vb2jDJNtwVrKpI09jd8x3n3fL+GzhiLK+8O5Wc2A+GyqCZalST2fV46Pf0QfCwkXf83y+3/rDkCd7A=="
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.5.0",
+        "contentHash": "VmU7e6xHqoubWKl7y9MtWyQAjlDpvbds3gY8ZKMS/1GxY2+U1/aMNnMj09aOXAa3p5qhHSSkBzDJvyokCjVkPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.5.0"
+        }
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
@@ -607,11 +629,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.1",
-        "contentHash": "wP3Ez6usBGWmhJ67Z7MX07RVB6WKRxUEwUASn7NDfeH8jQVBZSc1aUprCijMIYHk5Ulsxx5vxwiVKSAlTMILFA==",
+        "resolved": "5.37.2",
+        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
         "dependencies": {
-          "JasperFx": "1.28.2",
-          "JasperFx.Events": "1.31.1",
+          "JasperFx": "1.29.0",
+          "JasperFx.Events": "1.33.1",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "NewId": "4.0.1",
@@ -621,11 +643,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.36.1",
-        "contentHash": "0iBtbbPI3RsiqILFde56C6XYhHU4OxI1J5ONycHGqIYGy6xRDu8OrByj1DWv6T5K3n50qEUBHxp/0/vZBfMyBw==",
+        "resolved": "5.37.2",
+        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.36.1"
+          "WolverineFx": "5.37.2"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary

Closes the cross-tenant data leak surface raised by the security audit.

### Multi-tenancy
- **CurrentTenant**: dual-backend storage. HTTP path uses `HttpContext.Features` (request-scoped, no thread-pool reuse leak); non-HTTP fallback to `AsyncLocal` for Wolverine handlers, jobs, migrations. Closes the AsyncLocal leak documented in memory.
- **`IUserTenantMembershipReader` + `RequireMembershipCheck` option**: the resolution middleware verifies the authenticated caller is a member of the resolved tenant before activating it. Validator at startup refuses `RequireMembershipCheck=true` without a concrete reader.
- **`IHostAccessContext` / `IHostAccessFeature`**: HTTP feature set by `RequireHostContextEndpointFilter` when an `.AllowHostAccess()` route is admitted in host mode. Lets the data layer distinguish a deliberate host-access bypass from an accidental tenant-context loss without touching individual stores.

### Persistence
- **`EfStoreBase`**: per-call evaluation of the multi-tenant filter bypass (replaces ctor-cached decision that survived the entire scope — root cause of cross-tenant reads after a scoped store was constructed pre-activation). `QueryAcrossTenants()` opt-in with `[CallerMemberName/FilePath/LineNumber]` for searchable traces. New origin tags on `granit.persistence.cross_tenant_query`:
  - `host_endpoint` — `.AllowHostAccess()` signaled, expected
  - `explicit` — caller used `QueryAcrossTenants()`
  - `implicit_unsignaled` — bypass without signal, **alert-worthy**
- Logger: `Warning` on `implicit_unsignaled`, `Information` on signaled paths.

### Wolverine
- **`[CrossTenantMessage]`** attribute marks message types legitimately host-scope.
- **`TenantContextBehavior`**: emits `granit.wolverine.envelope.no_tenant` always (`allowed` / `allowed_marked` / `rejected`). Opt-in fail-closed via `WolverineMessagingOptions.RequireEnvelopeTenant`.

## Test plan
- [x] `Granit.Persistence.EntityFrameworkCore.Tests` 322/322
- [x] `Granit.MultiTenancy.Tests` 116/116
- [x] `Granit.Wolverine.Tests` (TenantContextBehavior) 7/7
- [x] `Granit.Authorization.Tests` 232/232 (incl. new `RequireHostContextEndpointFilterTests`)
- [x] Architecture tests 208/210 (2 pre-existing Taxonomy failures, unrelated)
- [x] `dotnet format --verify-no-changes` clean on all touched projects
- [ ] CI matrix green on develop merge target
- [ ] SOC dashboard updated with new alert: `granit.persistence.cross_tenant_query{origin="implicit_unsignaled"} > 0`

## Follow-ups (not in this PR)
- Migrate the 50+ `.AllowHostAccess()` endpoints to inject `PersistenceMetrics` + `IHostAccessContext` + `ILogger<T>` into their stores (currently the metric infra is wired but stores must opt in). Mechanical, can be done module by module.
- Concrete `IUserTenantMembershipReader` in `Granit.Identity.Local.EntityFrameworkCore`.
- EPIC 2: Wolverine envelope HMAC signing (closes envelope forgery; `RequireEnvelopeTenant=true` only protects buggy producers, not adversarial ones).