### PR TITLE
chore(security): arch test — every Map* endpoint declares an auth stance

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -976,6 +976,7 @@
       "name": "Granit.Entities.Customization",
       "deps": [
         "Granit",
+        "Granit.Entities",
         "Granit.Entities.Abstractions"
       ],
       "framework": "net10.0"
@@ -21109,6 +21110,15 @@
       ]
     },
     {
+      "name": "CalendarItemResponse",
+      "fqn": "Granit.Entities.CalendarItemResponse",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/CalendarItemResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
       "name": "HideDelta",
       "fqn": "Granit.Entities.Customization.Domain.Deltas.HideDelta",
       "kind": "record",
@@ -21222,7 +21232,7 @@
       "kind": "class",
       "project": "Granit.Entities.Customization.Endpoints",
       "file": "src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21357,8 +21367,15 @@
       "kind": "class",
       "project": "Granit.Entities.Customization",
       "file": "src/Granit.Entities.Customization/GranitEntitiesCustomizationModule.cs",
-      "line": 12,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IEntityCustomizationReader",
@@ -21499,13 +21516,20 @@
       "members": []
     },
     {
-      "name": "CalendarItemResponse",
-      "fqn": "Granit.Entities.Endpoints.Dtos.CalendarItemResponse",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs",
-      "line": 12,
-      "members": []
+      "name": "EntityActivitySource",
+      "fqn": "Granit.Entities.Diagnostics.EntityActivitySource",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Diagnostics/EntityActivitySource.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(Name)",
+          "returnType": "ActivitySource Source ="
+        }
+      ]
     },
     {
       "name": "CalendarRangeRequest",
@@ -21514,87 +21538,6 @@
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs",
       "line": 15,
-      "members": []
-    },
-    {
-      "name": "EntityActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs",
-      "line": 21,
-      "members": []
-    },
-    {
-      "name": "EntityActivitiesManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActivitiesManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActivitiesManifest.cs",
-      "line": 11,
-      "members": []
-    },
-    {
-      "name": "EntityCalendarLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCalendarLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 107,
-      "members": []
-    },
-    {
-      "name": "EntityCalendarTileActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCalendarTileActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 122,
-      "members": []
-    },
-    {
-      "name": "EntityCollectionReference",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCollectionReference",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 74,
-      "members": []
-    },
-    {
-      "name": "EntityCollectionsSection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCollectionsSection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 19,
-      "members": []
-    },
-    {
-      "name": "EntityDetailManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 9,
-      "members": []
-    },
-    {
-      "name": "EntityDetailSectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailSectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 20,
-      "members": []
-    },
-    {
-      "name": "EntityDetailSidePanelManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailSidePanelManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 30,
       "members": []
     },
     {
@@ -21634,201 +21577,12 @@
       "members": []
     },
     {
-      "name": "EntityFormFieldManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormFieldManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 53,
-      "members": []
-    },
-    {
-      "name": "EntityFormManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 16,
-      "members": []
-    },
-    {
-      "name": "EntityFormOwnedCollectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormOwnedCollectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 71,
-      "members": []
-    },
-    {
-      "name": "EntityFormSectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormSectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 29,
-      "members": []
-    },
-    {
-      "name": "EntityGalleryCardActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityGalleryCardActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 157,
-      "members": []
-    },
-    {
-      "name": "EntityGalleryLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityGalleryLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 141,
-      "members": []
-    },
-    {
-      "name": "EntityHeaderActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityHeaderActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 41,
-      "members": []
-    },
-    {
-      "name": "EntityIdentitySection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityIdentitySection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs",
-      "line": 11,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 216,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 184,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardRelationManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardRelationManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 200,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanColumnManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanColumnManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 226,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 168,
-      "members": []
-    },
-    {
-      "name": "EntityListLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityListLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 89,
-      "members": []
-    },
-    {
-      "name": "EntityManifestResponse",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityManifestResponse",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs",
-      "line": 17,
-      "members": []
-    },
-    {
       "name": "EntityModuleGroupResponse",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityModuleGroupResponse",
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityDiscoveryItemResponse.cs",
       "line": 30,
-      "members": []
-    },
-    {
-      "name": "EntityPermissionsSection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityPermissionsSection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityPermissionsSection.cs",
-      "line": 16,
-      "members": []
-    },
-    {
-      "name": "EntityProvenance",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenance",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
-      "line": 18,
-      "members": []
-    },
-    {
-      "name": "EntityProvenanceLayers",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenanceLayers",
-      "kind": "class",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
-      "line": 21,
-      "members": []
-    },
-    {
-      "name": "EntityRelationAggregateManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityRelationAggregateManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityRelationsSection.cs",
-      "line": 35,
-      "members": []
-    },
-    {
-      "name": "EntityRelationManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityRelationManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityRelationsSection.cs",
-      "line": 18,
-      "members": []
-    },
-    {
-      "name": "EntitySelectionActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntitySelectionActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 61,
       "members": []
     },
     {
@@ -21891,38 +21645,6 @@
       ]
     },
     {
-      "name": "ICalendarRangeService",
-      "fqn": "Granit.Entities.Endpoints.ICalendarRangeService",
-      "kind": "interface",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 19,
-      "members": [
-        {
-          "name": "GetItemsAsync",
-          "kind": "method",
-          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
-          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
-        }
-      ]
-    },
-    {
-      "name": "IManifestCustomizationApplier",
-      "fqn": "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier",
-      "kind": "interface",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Internal/IManifestCustomizationApplier.cs",
-      "line": 27,
-      "members": [
-        {
-          "name": "ApplyAsync",
-          "kind": "method",
-          "signature": "ApplyAsync(string entityName, EntityManifestResponse composedManifest, CancellationToken cancellationToken = default)",
-          "returnType": "Task<EntityManifestResponse>"
-        }
-      ]
-    },
-    {
       "name": "EntitiesEndpointsOptions",
       "fqn": "Granit.Entities.Endpoints.Options.EntitiesEndpointsOptions",
       "kind": "class",
@@ -21961,15 +21683,6 @@
           "returnType": "TimeSpan CalendarRangeCacheTtl { get; set; } = TimeSpan."
         }
       ]
-    },
-    {
-      "name": "struct",
-      "fqn": "Granit.Entities.Endpoints.struct",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 34,
-      "members": []
     },
     {
       "name": "EntityDefinition",
@@ -22037,7 +21750,7 @@
       "kind": "class",
       "project": "Granit.Entities.EntityFrameworkCore",
       "file": "src/Granit.Entities.EntityFrameworkCore/Extensions/EntitiesEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntitiesEntityFrameworkCore",
@@ -22069,7 +21782,7 @@
       "kind": "class",
       "project": "Granit.Entities",
       "file": "src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntities",
@@ -22182,6 +21895,22 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICalendarRangeService",
+      "fqn": "Granit.Entities.ICalendarRangeService",
+      "kind": "interface",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "GetItemsAsync",
+          "kind": "method",
+          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
         }
       ]
     },
@@ -22409,6 +22138,276 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "EntityActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityActionManifest.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "EntityActivitiesManifest",
+      "fqn": "Granit.Entities.Manifests.EntityActivitiesManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityActivitiesManifest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "EntityCalendarLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityCalendarLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 107,
+      "members": []
+    },
+    {
+      "name": "EntityCalendarTileActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityCalendarTileActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 122,
+      "members": []
+    },
+    {
+      "name": "EntityCollectionReference",
+      "fqn": "Granit.Entities.Manifests.EntityCollectionReference",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 74,
+      "members": []
+    },
+    {
+      "name": "EntityCollectionsSection",
+      "fqn": "Granit.Entities.Manifests.EntityCollectionsSection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "EntityDetailManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "EntityDetailSectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailSectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "EntityDetailSidePanelManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailSidePanelManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "EntityFormFieldManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormFieldManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "EntityFormManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityFormOwnedCollectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormOwnedCollectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 71,
+      "members": []
+    },
+    {
+      "name": "EntityFormSectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormSectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "EntityGalleryCardActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityGalleryCardActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 157,
+      "members": []
+    },
+    {
+      "name": "EntityGalleryLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityGalleryLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 141,
+      "members": []
+    },
+    {
+      "name": "EntityHeaderActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityHeaderActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 41,
+      "members": []
+    },
+    {
+      "name": "EntityIdentitySection",
+      "fqn": "Granit.Entities.Manifests.EntityIdentitySection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityIdentitySection.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 216,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 184,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardRelationManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardRelationManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 200,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanColumnManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanColumnManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 226,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 168,
+      "members": []
+    },
+    {
+      "name": "EntityListLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityListLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 89,
+      "members": []
+    },
+    {
+      "name": "EntityManifestResponse",
+      "fqn": "Granit.Entities.Manifests.EntityManifestResponse",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityManifestResponse.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityPermissionsSection",
+      "fqn": "Granit.Entities.Manifests.EntityPermissionsSection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityPermissionsSection.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityProvenance",
+      "fqn": "Granit.Entities.Manifests.EntityProvenance",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityProvenance.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntityProvenanceLayers",
+      "fqn": "Granit.Entities.Manifests.EntityProvenanceLayers",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityProvenance.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "EntityRelationAggregateManifest",
+      "fqn": "Granit.Entities.Manifests.EntityRelationAggregateManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityRelationsSection.cs",
+      "line": 35,
+      "members": []
+    },
+    {
+      "name": "EntityRelationManifest",
+      "fqn": "Granit.Entities.Manifests.EntityRelationManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityRelationsSection.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntitySelectionActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntitySelectionActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 61,
       "members": []
     },
     {
@@ -22723,11 +22722,11 @@
       "members": []
     },
     {
-      "name": "EntityViewSharedWithDto",
-      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithDto",
+      "name": "EntityViewSharedWithResponse",
+      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithResponse",
       "kind": "record",
       "project": "Granit.Entities.Views.Endpoints",
-      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithDto.cs",
+      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithResponse.cs",
       "line": 6,
       "members": []
     },
@@ -22911,6 +22910,22 @@
       "members": []
     },
     {
+      "name": "EntitiesViewsServiceCollectionExtensions",
+      "fqn": "Granit.Entities.Views.Extensions.EntitiesViewsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Entities.Views",
+      "file": "src/Granit.Entities.Views/Extensions/EntitiesViewsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitEntitiesViews",
+          "kind": "method",
+          "signature": "AddGranitEntitiesViews(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitEntitiesViewsAbstractionsModule",
       "fqn": "Granit.Entities.Views.GranitEntitiesViewsAbstractionsModule",
       "kind": "class",
@@ -22925,8 +22940,15 @@
       "kind": "class",
       "project": "Granit.Entities.Views",
       "file": "src/Granit.Entities.Views/GranitEntitiesViewsModule.cs",
-      "line": 12,
-      "members": []
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IEntityViewReader",
@@ -23024,6 +23046,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Visibility/VisibilityCondition.cs",
       "line": 32,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.struct",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 31,
       "members": []
     },
     {

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -142,7 +142,8 @@ public static class BffEndpointRouteBuilderExtensions
             + "BFF API routes under /bff/ are skipped and handled by the endpoint group.")
         .Produces(StatusCodes.Status200OK, contentType: "application/octet-stream")
         .ProducesProblem(StatusCodes.Status404NotFound)
-        .ExcludeFromDescription();
+        .ExcludeFromDescription()
+        .AllowAnonymous();
     }
 
     internal static string GetContentType(string path) =>

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
@@ -36,12 +36,13 @@ internal static class IdentityWebhookEndpoints
         endpoints.MapPost(webhookRoute, HandleWebhookAsync)
             .WithName("IdentityWebhook")
             .WithSummary("Receives identity provider webhook events (user created/updated/deleted).")
-            .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No authentication required — security relies on the HMAC signature validation.")
+            .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No bearer authentication — security relies on HMAC signature validation in the handler.")
             .WithTags(tagName)
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status413PayloadTooLarge);
+            .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
+            .AllowAnonymous();
 
         return endpoints;
     }

--- a/tests/Granit.ArchitectureTests/EndpointAuthorizationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointAuthorizationConventionTests.cs
@@ -1,0 +1,162 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces the central authorization principle: every Minimal API endpoint must
+/// declare an explicit authorization stance — either <c>.RequireAuthorization(...)</c>
+/// (with or without a permission) or <c>.AllowAnonymous()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Granit's security model collapses to a single rule: the per-(user, tenant, action)
+/// permission check at the endpoint boundary. If an endpoint fails to declare an auth
+/// stance, the rule cannot be enforced — an anonymous caller may reach a tenant-scoped
+/// resource. This test catches that drift at build time.
+/// </para>
+/// <para>
+/// Granit endpoints commonly use a parent-child registration pattern: a registration
+/// extension on <see cref="Microsoft.AspNetCore.Routing.IEndpointRouteBuilder"/> creates
+/// a <c>RouteGroupBuilder</c> with <c>.RequireAuthorization(...)</c> on it, then passes
+/// the group to internal <c>Map*Endpoints</c> extensions that just compose <c>MapGet</c>
+/// / <c>MapPost</c> calls. The internal files contain no auth literal — the parent
+/// supplied it. The test recognizes this pattern via the
+/// <c>this RouteGroupBuilder</c> extension signature.
+/// </para>
+/// </remarks>
+public sealed partial class EndpointAuthorizationConventionTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// Files known to register endpoints whose authorization is enforced by an
+    /// out-of-band mechanism (protocol flow, framework convention) rather than the
+    /// standard <c>RequireAuthorization</c> / <c>AllowAnonymous</c> pair.
+    /// </summary>
+    /// <remarks>
+    /// Each entry must carry an inline justification — silent additions defeat the
+    /// purpose of the allowlist.
+    /// </remarks>
+    private static readonly HashSet<string> Exemptions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // OIDC protocol endpoints. Authorization is enforced by OpenIddict's own
+        // pipeline (the [Authorize] / [AllowAnonymous] split lives inside the OIDC
+        // server), not by ASP.NET Core authorization policies on the route handler.
+        "ConnectAuthorizationEndpoints",
+        "ConnectTokenEndpoints",
+        "ConnectLogoutEndpoints",
+        "ConnectUserInfoEndpoints",
+        "ConnectIntrospectionEndpoints",
+        "ConnectRevocationEndpoints",
+    };
+
+    [Fact]
+    public void Every_Map_endpoint_must_declare_authorization()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+
+        List<string> violations = [];
+
+        foreach (string csFile in EndpointFiles(srcDir))
+        {
+            string fileName = Path.GetFileNameWithoutExtension(csFile);
+            if (Exemptions.Contains(fileName))
+            {
+                continue;
+            }
+
+            string content = File.ReadAllText(csFile);
+
+            if (!ContainsMapInvocation(content))
+            {
+                continue;
+            }
+
+            // Acceptable auth markers anywhere in the file:
+            //   .RequireAuthorization( … )    explicit policy / permission
+            //   .AllowAnonymous( )            explicit public
+            if (RequireAuthorization().IsMatch(content) || AllowAnonymous().IsMatch(content))
+            {
+                continue;
+            }
+
+            // Callee pattern: this file is an internal composition extension whose
+            // group was preauthorized by the caller (registration root). The
+            // signature `this RouteGroupBuilder <param>` proves the group came in
+            // from the caller — auth is the caller's responsibility, verified on
+            // the caller's file by this same test.
+            if (RouteGroupExtension().IsMatch(content))
+            {
+                continue;
+            }
+
+            string relativePath = Path.GetRelativePath(RepoRoot, csFile);
+            violations.Add(relativePath);
+        }
+
+        violations.ShouldBeEmpty(
+            "Every Minimal API endpoint file must declare an authorization stance. "
+            + "Add `.RequireAuthorization(<permission>)` or `.AllowAnonymous()` to the "
+            + "endpoint chain (or to the parent group) for each Map* invocation, or — "
+            + "for internal composition extensions — accept a pre-authorized "
+            + "`this RouteGroupBuilder` parameter from the registration root. "
+            + $"Violators: {string.Join("; ", violations)}");
+    }
+
+    private static IEnumerable<string> EndpointFiles(string srcDir)
+    {
+        foreach (string dir in Directory.EnumerateDirectories(srcDir))
+        {
+            string moduleName = Path.GetFileName(dir);
+            if (!moduleName.EndsWith(".Endpoints", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (string csFile in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                    || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+                {
+                    continue;
+                }
+
+                yield return csFile;
+            }
+        }
+    }
+
+    private static bool ContainsMapInvocation(string content) =>
+        MapInvocation().IsMatch(content);
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(EndpointAuthorizationConventionTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+
+    [GeneratedRegex(@"\.Map(Get|Post|Put|Delete|Patch|Methods)\s*\(", RegexOptions.Compiled)]
+    private static partial Regex MapInvocation();
+
+    [GeneratedRegex(@"\.RequireAuthorization\s*\(", RegexOptions.Compiled)]
+    private static partial Regex RequireAuthorization();
+
+    [GeneratedRegex(@"\.AllowAnonymous\s*\(", RegexOptions.Compiled)]
+    private static partial Regex AllowAnonymous();
+
+    [GeneratedRegex(@"\bthis\s+RouteGroupBuilder\b", RegexOptions.Compiled)]
+    private static partial Regex RouteGroupExtension();
+}


### PR DESCRIPTION
## Summary

Adds an architecture test that enforces the central security principle: every Minimal API endpoint must declare \`.RequireAuthorization(...)\` (with or without a permission) or \`.AllowAnonymous()\`. Closes step A of the security audit thread (#1894, #1899).

The test scans \`src/*.Endpoints/\` source files for \`Map(Get|Post|Put|Delete|Patch|Methods)\` invocations. A file passes when:
- The chain contains \`.RequireAuthorization\` or \`.AllowAnonymous\`, OR
- The file is an internal composition extension (\`this RouteGroupBuilder\`) — auth set by the registration root upstream, OR
- The file name is in the OIDC allowlist (\`Connect*Endpoints\` — auth enforced by OpenIddict's own pipeline).

Each allowlist entry carries an inline justification.

### Fixes the two violations the test caught

- \`BffEndpointRouteBuilderExtensions.cs\` — frontend static-files \`MapGet\` now carries \`.AllowAnonymous()\` (SPA assets, intentionally public).
- \`IdentityWebhookEndpoints.cs\` — webhook \`MapPost\` now carries \`.AllowAnonymous()\` (HMAC signature validation in the handler, no bearer auth by design).

Both were already public in practice; the test forces the stance to be explicit.

## What's NOT in this PR

The companion arch test for Wolverine handlers (\"every handler invokes \`IPermissionChecker\` or carries \`[CrossTenantMessage]\`\") is deferred. Empirical scan shows **zero** \`IPermissionChecker\` usage across \`src/*.Wolverine/\` — handlers run downstream of authorized endpoints (outbox pattern), so the rule would generate massive false positives. Reconsider when an inbound message path without an originating user (signed external webhook handler dispatched via Wolverine, scheduled cross-tenant tick) enters the framework.

## Test plan
- [x] \`Granit.ArchitectureTests.EndpointAuthorizationConventionTests\` — green after fixing the 2 detected violations
- [x] \`dotnet format --verify-no-changes\` clean on the 3 touched projects
- [ ] CI matrix green