### PR TITLE
refactor(entities-customization): move applier + manifest DTOs to base modules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -976,6 +976,7 @@
       "name": "Granit.Entities.Customization",
       "deps": [
         "Granit",
+        "Granit.Entities",
         "Granit.Entities.Abstractions"
       ],
       "framework": "net10.0"
@@ -21109,6 +21110,15 @@
       ]
     },
     {
+      "name": "CalendarItemResponse",
+      "fqn": "Granit.Entities.CalendarItemResponse",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/CalendarItemResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
       "name": "HideDelta",
       "fqn": "Granit.Entities.Customization.Domain.Deltas.HideDelta",
       "kind": "record",
@@ -21222,7 +21232,7 @@
       "kind": "class",
       "project": "Granit.Entities.Customization.Endpoints",
       "file": "src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21357,8 +21367,15 @@
       "kind": "class",
       "project": "Granit.Entities.Customization",
       "file": "src/Granit.Entities.Customization/GranitEntitiesCustomizationModule.cs",
-      "line": 12,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IEntityCustomizationReader",
@@ -21499,13 +21516,20 @@
       "members": []
     },
     {
-      "name": "CalendarItemResponse",
-      "fqn": "Granit.Entities.Endpoints.Dtos.CalendarItemResponse",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/CalendarItemResponse.cs",
-      "line": 12,
-      "members": []
+      "name": "EntityActivitySource",
+      "fqn": "Granit.Entities.Diagnostics.EntityActivitySource",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Diagnostics/EntityActivitySource.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(Name)",
+          "returnType": "ActivitySource Source ="
+        }
+      ]
     },
     {
       "name": "CalendarRangeRequest",
@@ -21514,87 +21538,6 @@
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/CalendarRangeRequest.cs",
       "line": 15,
-      "members": []
-    },
-    {
-      "name": "EntityActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActionManifest.cs",
-      "line": 21,
-      "members": []
-    },
-    {
-      "name": "EntityActivitiesManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityActivitiesManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityActivitiesManifest.cs",
-      "line": 11,
-      "members": []
-    },
-    {
-      "name": "EntityCalendarLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCalendarLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 107,
-      "members": []
-    },
-    {
-      "name": "EntityCalendarTileActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCalendarTileActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 122,
-      "members": []
-    },
-    {
-      "name": "EntityCollectionReference",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCollectionReference",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 74,
-      "members": []
-    },
-    {
-      "name": "EntityCollectionsSection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityCollectionsSection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 19,
-      "members": []
-    },
-    {
-      "name": "EntityDetailManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 9,
-      "members": []
-    },
-    {
-      "name": "EntityDetailSectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailSectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 20,
-      "members": []
-    },
-    {
-      "name": "EntityDetailSidePanelManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityDetailSidePanelManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityDetailManifest.cs",
-      "line": 30,
       "members": []
     },
     {
@@ -21634,201 +21577,12 @@
       "members": []
     },
     {
-      "name": "EntityFormFieldManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormFieldManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 53,
-      "members": []
-    },
-    {
-      "name": "EntityFormManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 16,
-      "members": []
-    },
-    {
-      "name": "EntityFormOwnedCollectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormOwnedCollectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 71,
-      "members": []
-    },
-    {
-      "name": "EntityFormSectionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityFormSectionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityFormManifest.cs",
-      "line": 29,
-      "members": []
-    },
-    {
-      "name": "EntityGalleryCardActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityGalleryCardActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 157,
-      "members": []
-    },
-    {
-      "name": "EntityGalleryLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityGalleryLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 141,
-      "members": []
-    },
-    {
-      "name": "EntityHeaderActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityHeaderActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 41,
-      "members": []
-    },
-    {
-      "name": "EntityIdentitySection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityIdentitySection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityIdentitySection.cs",
-      "line": 11,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 216,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 184,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanCardRelationManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanCardRelationManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 200,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanColumnManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanColumnManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 226,
-      "members": []
-    },
-    {
-      "name": "EntityKanbanLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityKanbanLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 168,
-      "members": []
-    },
-    {
-      "name": "EntityListLayoutManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityListLayoutManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 89,
-      "members": []
-    },
-    {
-      "name": "EntityManifestResponse",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityManifestResponse",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityManifestResponse.cs",
-      "line": 17,
-      "members": []
-    },
-    {
       "name": "EntityModuleGroupResponse",
       "fqn": "Granit.Entities.Endpoints.Dtos.EntityModuleGroupResponse",
       "kind": "record",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Dtos/EntityDiscoveryItemResponse.cs",
       "line": 30,
-      "members": []
-    },
-    {
-      "name": "EntityPermissionsSection",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityPermissionsSection",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityPermissionsSection.cs",
-      "line": 16,
-      "members": []
-    },
-    {
-      "name": "EntityProvenance",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenance",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
-      "line": 18,
-      "members": []
-    },
-    {
-      "name": "EntityProvenanceLayers",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityProvenanceLayers",
-      "kind": "class",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityProvenance.cs",
-      "line": 21,
-      "members": []
-    },
-    {
-      "name": "EntityRelationAggregateManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityRelationAggregateManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityRelationsSection.cs",
-      "line": 35,
-      "members": []
-    },
-    {
-      "name": "EntityRelationManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntityRelationManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityRelationsSection.cs",
-      "line": 18,
-      "members": []
-    },
-    {
-      "name": "EntitySelectionActionManifest",
-      "fqn": "Granit.Entities.Endpoints.Dtos.EntitySelectionActionManifest",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Dtos/EntityCollectionsSection.cs",
-      "line": 61,
       "members": []
     },
     {
@@ -21891,38 +21645,6 @@
       ]
     },
     {
-      "name": "ICalendarRangeService",
-      "fqn": "Granit.Entities.Endpoints.ICalendarRangeService",
-      "kind": "interface",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 19,
-      "members": [
-        {
-          "name": "GetItemsAsync",
-          "kind": "method",
-          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
-          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
-        }
-      ]
-    },
-    {
-      "name": "IManifestCustomizationApplier",
-      "fqn": "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier",
-      "kind": "interface",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/Internal/IManifestCustomizationApplier.cs",
-      "line": 27,
-      "members": [
-        {
-          "name": "ApplyAsync",
-          "kind": "method",
-          "signature": "ApplyAsync(string entityName, EntityManifestResponse composedManifest, CancellationToken cancellationToken = default)",
-          "returnType": "Task<EntityManifestResponse>"
-        }
-      ]
-    },
-    {
       "name": "EntitiesEndpointsOptions",
       "fqn": "Granit.Entities.Endpoints.Options.EntitiesEndpointsOptions",
       "kind": "class",
@@ -21961,15 +21683,6 @@
           "returnType": "TimeSpan CalendarRangeCacheTtl { get; set; } = TimeSpan."
         }
       ]
-    },
-    {
-      "name": "struct",
-      "fqn": "Granit.Entities.Endpoints.struct",
-      "kind": "record",
-      "project": "Granit.Entities.Endpoints",
-      "file": "src/Granit.Entities.Endpoints/ICalendarRangeService.cs",
-      "line": 34,
-      "members": []
     },
     {
       "name": "EntityDefinition",
@@ -22037,7 +21750,7 @@
       "kind": "class",
       "project": "Granit.Entities.EntityFrameworkCore",
       "file": "src/Granit.Entities.EntityFrameworkCore/Extensions/EntitiesEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntitiesEntityFrameworkCore",
@@ -22069,7 +21782,7 @@
       "kind": "class",
       "project": "Granit.Entities",
       "file": "src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitEntities",
@@ -22182,6 +21895,22 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICalendarRangeService",
+      "fqn": "Granit.Entities.ICalendarRangeService",
+      "kind": "interface",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "GetItemsAsync",
+          "kind": "method",
+          "signature": "GetItemsAsync(EntityDefinitionDescriptor entity, CalendarLayoutDescriptor layout, CalendarRange range, CancellationToken cancellationToken)",
+          "returnType": "Task<IReadOnlyList<CalendarItemResponse>>"
         }
       ]
     },
@@ -22409,6 +22138,276 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Layouts/CalendarRangeFilterBuilder.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "EntityActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityActionManifest.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "EntityActivitiesManifest",
+      "fqn": "Granit.Entities.Manifests.EntityActivitiesManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityActivitiesManifest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "EntityCalendarLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityCalendarLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 107,
+      "members": []
+    },
+    {
+      "name": "EntityCalendarTileActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityCalendarTileActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 122,
+      "members": []
+    },
+    {
+      "name": "EntityCollectionReference",
+      "fqn": "Granit.Entities.Manifests.EntityCollectionReference",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 74,
+      "members": []
+    },
+    {
+      "name": "EntityCollectionsSection",
+      "fqn": "Granit.Entities.Manifests.EntityCollectionsSection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "EntityDetailManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "EntityDetailSectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailSectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "EntityDetailSidePanelManifest",
+      "fqn": "Granit.Entities.Manifests.EntityDetailSidePanelManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityDetailManifest.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "EntityFormFieldManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormFieldManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "EntityFormManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityFormOwnedCollectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormOwnedCollectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 71,
+      "members": []
+    },
+    {
+      "name": "EntityFormSectionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityFormSectionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityFormManifest.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "EntityGalleryCardActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityGalleryCardActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 157,
+      "members": []
+    },
+    {
+      "name": "EntityGalleryLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityGalleryLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 141,
+      "members": []
+    },
+    {
+      "name": "EntityHeaderActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityHeaderActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 41,
+      "members": []
+    },
+    {
+      "name": "EntityIdentitySection",
+      "fqn": "Granit.Entities.Manifests.EntityIdentitySection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityIdentitySection.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 216,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 184,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanCardRelationManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanCardRelationManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 200,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanColumnManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanColumnManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 226,
+      "members": []
+    },
+    {
+      "name": "EntityKanbanLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityKanbanLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 168,
+      "members": []
+    },
+    {
+      "name": "EntityListLayoutManifest",
+      "fqn": "Granit.Entities.Manifests.EntityListLayoutManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 89,
+      "members": []
+    },
+    {
+      "name": "EntityManifestResponse",
+      "fqn": "Granit.Entities.Manifests.EntityManifestResponse",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityManifestResponse.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityPermissionsSection",
+      "fqn": "Granit.Entities.Manifests.EntityPermissionsSection",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityPermissionsSection.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityProvenance",
+      "fqn": "Granit.Entities.Manifests.EntityProvenance",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityProvenance.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntityProvenanceLayers",
+      "fqn": "Granit.Entities.Manifests.EntityProvenanceLayers",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityProvenance.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "EntityRelationAggregateManifest",
+      "fqn": "Granit.Entities.Manifests.EntityRelationAggregateManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityRelationsSection.cs",
+      "line": 35,
+      "members": []
+    },
+    {
+      "name": "EntityRelationManifest",
+      "fqn": "Granit.Entities.Manifests.EntityRelationManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityRelationsSection.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntitySelectionActionManifest",
+      "fqn": "Granit.Entities.Manifests.EntitySelectionActionManifest",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Manifests/EntityCollectionsSection.cs",
+      "line": 61,
       "members": []
     },
     {
@@ -22723,11 +22722,11 @@
       "members": []
     },
     {
-      "name": "EntityViewSharedWithDto",
-      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithDto",
+      "name": "EntityViewSharedWithResponse",
+      "fqn": "Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithResponse",
       "kind": "record",
       "project": "Granit.Entities.Views.Endpoints",
-      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithDto.cs",
+      "file": "src/Granit.Entities.Views.Endpoints/Dtos/EntityViewSharedWithResponse.cs",
       "line": 6,
       "members": []
     },
@@ -22911,6 +22910,22 @@
       "members": []
     },
     {
+      "name": "EntitiesViewsServiceCollectionExtensions",
+      "fqn": "Granit.Entities.Views.Extensions.EntitiesViewsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Entities.Views",
+      "file": "src/Granit.Entities.Views/Extensions/EntitiesViewsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitEntitiesViews",
+          "kind": "method",
+          "signature": "AddGranitEntitiesViews(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
       "name": "GranitEntitiesViewsAbstractionsModule",
       "fqn": "Granit.Entities.Views.GranitEntitiesViewsAbstractionsModule",
       "kind": "class",
@@ -22925,8 +22940,15 @@
       "kind": "class",
       "project": "Granit.Entities.Views",
       "file": "src/Granit.Entities.Views/GranitEntitiesViewsModule.cs",
-      "line": 12,
-      "members": []
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IEntityViewReader",
@@ -23024,6 +23046,15 @@
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Visibility/VisibilityCondition.cs",
       "line": 32,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Entities.struct",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/ICalendarRangeService.cs",
+      "line": 31,
       "members": []
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,1040 +2,238 @@
 
 ## Project
 
-- **Type**: Modular .NET framework — 128 packages, 134 test projects
-- **Repo**: `granit-dotnet` (company-level, not product-specific)
-- **License**: Apache-2.0 (open-source)
+- **Type**: Modular .NET framework (~128 packages, ~134 test projects)
+- **Repo**: `granit-dotnet` (open-source, Apache-2.0)
 - **Compliance**: GDPR + ISO 27001
-- **Publication**: nuget.org (planned), GitHub Packages (internal)
-
-## Stack & versions
-
-.NET 10 (LTS) | C# 14 | EF Core 10 | VaultSharp 1.17+ | Serilog 9+ | OpenTelemetry 1.15+
+- **Stack**: .NET 10 (LTS) | C# 14 | EF Core 10 | VaultSharp 1.17+ | Serilog 9+ | OpenTelemetry 1.15+
 
 ## Architecture
 
 ```text
 src/
-  Granit/                             # Module system, shared domain types
-  Granit.{Module}/                         # Abstractions + DI registration (e.g. Granit.BlobStorage)
-  Granit.{Module}.Endpoints/               # Minimal API endpoints
-  Granit.{Module}.EntityFrameworkCore/      # Isolated DbContext, EF configurations, migrations
-  Granit.{Module}.{Provider}/              # Provider implementations (e.g. .S3, .AzureBlob, .Keycloak)
-  Granit.{Module}.Wolverine/               # Wolverine message handlers
-  Granit.{Module}.Notifications/           # Notification channel integration
-  bundles/
-    Granit.Bundle.{Name}/                  # Meta-packages grouping related modules
-
-tests/
-  Granit.{Module}.Tests/                   # Unit tests (xUnit + Shouldly + NSubstitute + Bogus)
-  Granit.{Module}.Tests.Integration/       # Integration tests (Testcontainers)
-  Granit.ArchitectureTests/                # Cross-cutting architecture rules (NetArchTest)
-
-templates/
-  granit-api/                              # dotnet new template: minimal API project
-  granit-api-full/                         # dotnet new template: full API project
-  granit-module/                           # dotnet new template: new Granit module
-
-docs-site/                                 # Astro + Starlight documentation site
+  Granit/                         # Module system, shared domain types
+  Granit.{Module}/                # Abstractions, DI, *Module class, *Definitions, Diagnostics
+  Granit.{Module}.Endpoints/      # HTTP-only: Minimal API, *Request/*Response, validators, permissions
+  Granit.{Module}.EntityFrameworkCore/  # Data-only: isolated DbContext, configs, interceptors, executors
+  Granit.{Module}.{Provider}/     # Provider impls (.S3, .Keycloak, ...)
+  Granit.{Module}.Wolverine/      # Wolverine handlers, sagas
+  Granit.{Module}.Notifications/  # Notification channel integration
+  Granit.{Module}.BackgroundJobs/ # IBackgroundJob records + handlers
+  bundles/Granit.Bundle.{Name}/   # Meta-packages
+tests/{*.Tests, *.Tests.Integration, ArchitectureTests}
+docs-site/                        # Astro + Starlight docs
 ```
 
-### Package naming convention
+One project = one NuGet package. Namespace = project name. Zero circular refs. Discover packages via `ls src/`.
 
-One project = one NuGet package. Namespace = project name. Zero circular refs.
-
-Discover packages: `ls src/` — do NOT rely on a hardcoded list.
-
-### Module anatomy
-
-Each module follows a consistent layered split:
-
-| Layer | Project suffix | Contains |
-| ----- | -------------- | -------- |
-| Abstractions | `Granit.{Module}` | Interfaces, options, DI extension, `*Module` class, **declarative definitions** (`*QueryDefinition`, `*ExportDefinition`, `*MetricDefinition`), **domain orchestration** (registries, runners, evaluators, snapshots, period resolvers, delta calculators), diagnostics (`*Metrics`, `*ActivitySource`) |
-| Background Jobs | `.BackgroundJobs` | `IBackgroundJob` records, handlers, module class |
-| Endpoints | `.Endpoints` | **HTTP-only**: Minimal API route groups, wire-shape `*Request`/`*Response` DTOs, FluentValidation validators, permission providers, HTTP options (route prefix, FusionCache TTL), HTTP cache key composers, FusionCache-backed orchestrators |
-| Persistence | `.EntityFrameworkCore` | **Data-only**: Isolated `DbContext`, entity type configs, EF Core migrations, EF Core interceptors, value converters, `IQueryable<T>` consumers (typed `*Runner<TEntity>` / `*Executor<,>` impls), DI extension that wires the executors |
-| Provider | `.{Provider}` | External service implementation (S3, Keycloak, SMTP...) |
-| Messaging | `.Wolverine` | Wolverine handlers, saga state machines |
-
-**Layer purity — STRICT.** `.Endpoints` and `.EntityFrameworkCore` are **single-purpose**.
-Domain orchestration (name → runner registries, snapshots, value-shape DTOs consumed by
-domain renderers, pure helpers like `PeriodResolver` / `DeltaCalculator` /
-`*FilterBuilder`, non-generic interfaces like `IMetricRunner`, datasource evaluators
-without HTTP coupling) lives in **`Granit.{Module}`** — never in `.Endpoints` and never
-in `.EntityFrameworkCore`. A type belongs in `.EntityFrameworkCore` only if it touches
-`Microsoft.EntityFrameworkCore` (`DbSet`, `SumAsync`, `ExecuteUpdate`, …); it belongs
-in `.Endpoints` only if it touches `Microsoft.AspNetCore.*`, `FluentValidation`,
-`ZiggyCreatures.Caching.Fusion`, or HTTP-bound options. Anything else leaks the layer.
-Enforced by the `/audit --scope layer-purity` check.
+**Layer purity — STRICT.** `.Endpoints` belongs only to types touching `Microsoft.AspNetCore.*`,
+`FluentValidation`, `ZiggyCreatures.Caching.Fusion`, or HTTP-bound options. `.EntityFrameworkCore`
+only to types touching `Microsoft.EntityFrameworkCore`. Domain orchestration (registries, runners,
+period resolvers, delta calculators, value-shape DTOs, declarative definitions) lives in the base
+`Granit.{Module}`. Enforced by `/audit --scope layer-purity`.
 
 ## Commands
 
-> ⚠️ **NEVER `dotnet build` / `dotnet test` on the full solution.** The repo (128 packages,
-> 134 test projects) is too large — Roslyn OOMs and `dotnet format` chokes. **Always
-> target a `.slnf` shard filter or a single project.**
+> ⚠️ **NEVER `dotnet build`/`test`/`format` on the full solution.** Roslyn OOMs. Always target a `.slnf` shard or single project.
 
 ```bash
-# Shard build/test (PREFERRED — these are the CI shards)
-dotnet build .github/shard-filters/core-ai.slnf
-dotnet build .github/shard-filters/business.slnf
-dotnet build .github/shard-filters/api-data.slnf
-dotnet build .github/shard-filters/infrastructure.slnf
-dotnet build .github/shard-filters/security.slnf
-dotnet build .github/shard-filters/saas.slnf
-dotnet build .github/shard-filters/integration.slnf
-dotnet build .github/shard-filters/architecture.slnf
-dotnet test  .github/shard-filters/<shard>.slnf --no-build
-
-# Single package (PREFERRED for tight feedback loops)
-dotnet build src/Granit.BlobStorage
-dotnet test tests/Granit.BlobStorage.Tests --no-build
-
-# Architecture tests
-dotnet test tests/Granit.ArchitectureTests
-
-# Format — also shard-scoped (full solution is too slow)
+# Shards (CI parity)
+dotnet build  .github/shard-filters/<shard>.slnf
+dotnet test   .github/shard-filters/<shard>.slnf --no-build
 dotnet format .github/shard-filters/<shard>.slnf --verify-no-changes
 
-# Pack for local feed
-dotnet pack -c Release -o ./nupkgs
+# Single package (tight feedback)
+dotnet build src/Granit.BlobStorage
+dotnet test  tests/Granit.BlobStorage.Tests --no-build
 
-# Docs site
-cd docs-site && npx astro build   # must produce 0 errors
+# Pack / docs
+dotnet pack -c Release -o ./nupkgs
+cd docs-site && npx astro build
 ```
 
-**Picking the right shard:** match the directory you're touching against the
-[Shard mapping](#ci-test-sharding--mandatory-when-adding-test-projects) table below.
-When in doubt, the file you're editing belongs to the shard listed in
-[`.github/test-shards.json`](.github/test-shards.json).
+Shard mapping is the source of truth at [`.github/test-shards.json`](.github/test-shards.json) — match a file's directory against that map, no duplicate table here.
 
-## Code quality
+## Code style
 
-Modern C# 14 with idiomatic .NET 10. Write code that a senior .NET developer would recognize
-as current and clean. Actively use the latest language and runtime features listed below.
+Idiomatic modern C# 14 / .NET 10. Default to: primary constructors, collection expressions
+(`[x, y]`, `[]`), `field` keyword, file-scoped namespaces, pattern matching, `System.Threading.Lock`,
+`params ReadOnlySpan<T>`, native OpenAPI 3.1 (`AddOpenApi()` — never Swashbuckle/NSwag), Named Query
+Filters (`HasQueryFilter(name, expr)` — never unnamed), `IMeterFactory` (never `new Meter`),
+`ActivitySource` per module.
 
-### C# 14 features — use by default
-
-- **Primary constructors**: for all DI service classes. Keep `private readonly T _x = x;`
-  fields when the parameter is used in multiple methods.
-- **Collection expressions**: `[x, y]` instead of `new[] { x, y }`, `[]` instead of
-  `Array.Empty<T>()` or `new List<T>()`. Exception: `new[]` inside anonymous types
-  (JSON payloads) where the compiler cannot infer the target type.
-- **`field` keyword** (semi-auto properties): use `set => field = value;` in properties
-  with custom setter logic instead of declaring a manual backing field.
-- **Extension members** (`extension` blocks): prefer over static extension classes when
-  adding multiple related members to the same type (especially FluentValidation
-  `IRuleBuilder<T,P>` extensions).
-- **`nameof` on unbound generics**: `nameof(List<>)` returns `"List"` — use for concrete
-  generic types. NEVER use `nameof(T)` on a type parameter (returns the param name
-  `"T"`, not the runtime type name — use `typeof(T).Name` instead).
-- **Pattern matching**: prefer `is`, `switch` expressions, list patterns, property patterns.
-- **File-scoped namespaces**: always (one `namespace X;` per file, no braces).
-
-### C# 13 features — use by default
-
-- **`System.Threading.Lock`**: ALWAYS use `private readonly Lock _lock = new();` for
-  synchronization. NEVER lock on `object`, collections, or `this`.
-- **`params ReadOnlySpan<T>`**: prefer over `params T[]` for non-attribute methods to
-  reduce allocations. Attributes must keep `params T[]` (compile-time constraint).
-- **`\e` escape**: use `\e` instead of `\u001b` or `\x1b` for ESCAPE characters.
-
-### .NET 10 / EF Core 10 features — use by default
-
-- **Named Query Filters** (EF Core 10): use `HasQueryFilter(name, expr)` for individually
-  toggleable filters. See `GranitFilterNames` constants. Never use unnamed
-  `HasQueryFilter(expr)`.
-- **Native OpenAPI 3.1**: use `Microsoft.AspNetCore.OpenApi` + `AddOpenApi()` /
-  `MapOpenApi()`. NEVER use Swashbuckle or NSwag. Scalar UI for documentation.
-- **`IMeterFactory`**: use for metrics creation. NEVER use `new Meter(...)` directly.
-- **`ActivitySource`**: native .NET diagnostics, one per module
-  (`{Module}ActivitySource.cs`). Register via `GranitActivitySourceRegistry`.
-- **`string.Split(char, count)`**: prefer `"a:b".Split(':', 2)` over `Split(new[]{':'}, 2)`
-  (except in `netstandard2.0` source generators).
-
-## Code conventions
-
-Full standards: [`docs/guide/conventions/`](docs/guide/conventions/index.md)
+`nameof(T)` on a type parameter returns `"T"` — use `typeof(T).Name` instead. `nameof(List<>)` works for unbound generics.
 
 ### Must-use patterns
 
-- **`var`**: when type is apparent; explicit type otherwise (IDE0008)
-- **Expression body** (`=>`): for single-statement methods (IDE0022)
-- **String interpolation**: prefer `$"..."` over `string.Concat(...)` or `string.Format(...)`
-- **`[GeneratedRegex]`**: ALWAYS — never `new Regex(..., Compiled)`. Timeout on user input.
-- **`[LoggerMessage]`**: ALWAYS — never string interpolation in log calls
-- **`TimeProvider` / `IClock`**: NEVER `DateTime.Now`/`UtcNow`
-- **`ConfigureAwait(false)`**: in library code. `CancellationToken` as last param.
-- **`ArgumentNullException.ThrowIfNull()`**: over manual null checks
-- **`ArgumentException.ThrowIfNullOrEmpty()`** / `ThrowIfNullOrWhiteSpace()`: for strings
-- **`AddAuthorizationBuilder()`**: not `AddAuthorization(Action<>)` (ASP0025)
+- `var` when type is apparent (IDE0008); expression body for single-statement methods
+- `[GeneratedRegex]` always; `[LoggerMessage]` always (no string interpolation in log calls)
+- `TimeProvider` / `IClock` — never `DateTime.Now`/`UtcNow`
+- `ConfigureAwait(false)` in library code; `CancellationToken` last param
+- `ArgumentNullException.ThrowIfNull()` / `ArgumentException.ThrowIfNullOrEmpty()`
+- `AddAuthorizationBuilder()` — not `AddAuthorization(Action<>)` (ASP0025)
 
-### Metrics & diagnostics — MANDATORY conventions
+## Conventions
 
-- **Directory**: `Diagnostics/` folder in the base module project
-- **Class**: `sealed class {Module}Metrics` with `IMeterFactory` constructor injection
-- **Meter name**: `"Granit.{Module}"` (PascalCase, one per module)
-- **Metric name**: `granit.{module}.{entity}.{action}` (all lowercase, dot-separated)
-- **Tags**: `snake_case`, always include `tenant_id` (coalesced to `"global"`), passed via `TagList`
-- **DI**: `services.TryAddSingleton<{Module}Metrics>();`
-- **ActivitySource**: `internal static class {Module}ActivitySource` in same `Diagnostics/` folder
-- **Registration**: `GranitActivitySourceRegistry.Register(Name)` in `Add*()` extension
+Full reference: [`docs/guide/conventions/`](docs/guide/conventions/index.md).
 
-### Permissions — naming convention (STRICT)
+### Diagnostics
 
-All permission strings MUST follow the `[Group].[Resource].[Action]` format (three dot-separated
-segments). Enforced across all `*.Endpoints` modules.
+- `Diagnostics/` folder in base module. `sealed class {Module}Metrics` with `IMeterFactory` ctor.
+- Meter name `"Granit.{Module}"` (PascalCase). Metric name `granit.{module}.{entity}.{action}` (lowercase). Tags `snake_case`, always include `tenant_id` (coalesced to `"global"`).
+- DI: `services.TryAddSingleton<{Module}Metrics>()`.
+- `internal static class {Module}ActivitySource` registered via `GranitActivitySourceRegistry.Register(Name)`.
 
-| Component | Convention | Example |
-| --------- | ---------- | ------- |
-| **Group** | `{Module}Permissions.GroupName` (PascalCase) | `"BackgroundJobs"`, `"BlobStorage"` |
-| **Resource** | Nested static class name (plural noun) | `Jobs`, `Blobs`, `Templates`, `Flags` |
-| **Action** | Verb describing the access level | `Read`, `Manage`, `Execute`, `Create` |
+### Permissions (STRICT)
 
-- **Permission constant**: `public const string Read = "{Group}.{Resource}.Read";`
-- **Localization key (group)**: `PermissionGroup:{Group}` (e.g. `"PermissionGroup:BackgroundJobs"`)
-- **Localization key (permission)**: `Permission:{Group}.{Resource}.{Action}` (e.g. `"Permission:BackgroundJobs.Jobs.Read"`)
-- **Provider class**: `internal sealed class {Module}PermissionDefinitionProvider : IPermissionDefinitionProvider`
-- **Localization resource**: `internal sealed class {Module}EndpointsLocalizationResource` with `[LocalizationResourceName]`
-- **Auto-discovery**: providers are auto-discovered by `GranitAuthorizationModule` (no manual registration)
-- **Standard actions**: `Read` (consultation, never `View`), `Manage` (grouped writes),
-  `Execute` (single actions), `Create` (resource creation). Domain-specific actions
-  (`Upload`, `Download`, `Delete`, `Revoke`, `Rotate`, `Sync`) are allowed when
-  `Manage` would be too coarse for least-privilege (ISO 27001 A.9.4)
+Format `[Group].[Resource].[Action]` (PascalCase, plural Resource). Loc keys: `PermissionGroup:{Group}` and `Permission:{Group}.{Resource}.{Action}`. Provider class `{Module}PermissionDefinitionProvider : IPermissionDefinitionProvider` (auto-discovered). Standard actions: `Read`, `Manage`, `Execute`, `Create` — domain-specific (`Upload`, `Revoke`, `Rotate`...) allowed when `Manage` is too coarse for least-privilege (ISO 27001 A.9.4).
 
-### Events — naming convention (STRICT)
-
-Two suffixes — enforced by architecture tests:
+### Events (STRICT, archi-tested)
 
 | Suffix | Interface | Dispatch | Example |
 | ------ | --------- | -------- | ------- |
-| `*Event` | `IDomainEvent` or none | `AddDomainEvent()` (aggregate) or `ILocalEventBus.PublishAsync()` (service) | `BlobValidatedEvent` |
-| `*Eto` | `IIntegrationEvent` | `AddDistributedEvent()` (aggregate) or `IDistributedEventBus.PublishAsync()` (service) → Wolverine outbox | `PersonalDataDeletedEto` |
+| `*Event` | `IDomainEvent` (or none) | `AddDomainEvent()` / `ILocalEventBus` | `BlobValidatedEvent` |
+| `*Eto` | `IIntegrationEvent` | `AddDistributedEvent()` / `IDistributedEventBus` (Wolverine outbox) | `PersonalDataDeletedEto` |
 
-- Past-tense verb + suffix. NEVER bare names (`BlobValidated` → `BlobValidatedEvent`)
-- Generic lifecycle: `EntityCreatedEvent<T>` / `EntityCreatedEto<T>` via `IEmitEntityLifecycleEvents`
+Past-tense verb + suffix. Generic lifecycle: `EntityCreatedEvent<T>`/`EntityCreatedEto<T>`.
 
-### Wolverine handler visibility — CRITICAL
+### Wolverine handlers — CRITICAL
 
-Wolverine discovers handlers via `Assembly.ExportedTypes` and requires **public types
-with public constructors** ([docs](https://wolverinefx.net/guide/handlers/)).
-`static class` types are additionally skipped unless decorated with
-`[WolverineHandler]`, which creates an unwanted dependency on WolverineFx.
+Wolverine discovers via `Assembly.ExportedTypes` and needs **public types with public ctors**.
 
-- **Handlers MUST be `public class` (non-static) with `public static` Handle methods.**
-  This ensures discovery without any attribute or WolverineFx dependency.
-- NEVER use `public static class` — requires `[WolverineHandler]` to be discovered.
-- NEVER use `internal` — invisible to `Assembly.ExportedTypes`.
-- NEVER add a `protected` constructor — Wolverine requires a public constructor for
-  discovery. The implicit parameterless public constructor is intentional.
-- If a handler injects an `internal` service, make the service `public` or extract an
-  interface. Never make the handler `internal` to match the service visibility.
-- Background job handlers follow the same rule.
-- **SonarQube S1118** ("utility classes should not have public constructors") is a
-  **false positive** on these handlers — mark as **Won't Fix**. These are not utility
-  classes; they are convention-discovered message handlers.
+- Handlers MUST be `public class` (non-static) with `public static` Handle methods. NEVER `static class`, NEVER `internal`, NEVER `protected` ctor.
+- If a handler injects an `internal` service, make the service public or extract an interface.
+- SonarQube **S1118** is a false positive on these — mark **Won't Fix**.
 
-### Background Jobs — naming convention (STRICT)
+### Background Jobs
 
-Single category with **mandatory suffix** — enforced by architecture tests:
+- `sealed record *Job : IBackgroundJob` with `[RecurringJob("cron", "name")]`, lives in `Granit.{Module}.BackgroundJobs/Jobs/`. Job name `{module-kebab}-{action-kebab}` (globally unique).
+- Handler `{Action}Handler` — `public static partial class`. Same Wolverine visibility rules.
+- Dedicated `Granit.{Module}.BackgroundJobs` sub-project keeps base module free from `Granit.BackgroundJobs` dep. Never create a `.Wolverine` package for jobs (handled by `Granit.BackgroundJobs.Wolverine`).
+- NEVER use `*Command` suffix — commands are CQRS, jobs are scheduled work units.
 
-| Interface | Attribute | Suffix | Example | Location |
-| --------- | --------- | ------ | ------- | -------- |
-| `IBackgroundJob` | `[RecurringJob]` | `*Job` | `OrphanBlobCleanupJob` | `Granit.{Module}.BackgroundJobs/Jobs/` |
+### `*.Notifications` packages
 
-- **`*Job`**: `sealed record` implementing `IBackgroundJob`, decorated with
-  `[RecurringJob("cron", "name")]`. Handler in same `Jobs/` folder.
-- **Dedicated sub-project**: each module's jobs live in `Granit.{Module}.BackgroundJobs`
-  with a `Granit{Module}BackgroundJobsModule : GranitModule` class. This keeps the base
-  module free from the `Granit.BackgroundJobs` dependency.
-- **Job name format**: `{module-kebab}-{action-kebab}` (e.g., `"blob-storage-orphan-cleanup"`).
-  Module prefix ensures global uniqueness.
-- **Handler naming**: `{Action}Handler` (e.g., `OrphanBlobCleanupHandler`) — `public static partial class`.
-- **NEVER** use `*Command` suffix for jobs — commands are CQRS, jobs are scheduled work units.
-- **NEVER** create a separate `.Wolverine` package for jobs. Wolverine scheduling is
-  handled by `Granit.BackgroundJobs.Wolverine`.
+Full conventions: [docs-site notifications/conventions.mdx](docs-site/src/content/docs/dotnet/infrastructure/notifications/conventions.mdx). Reference impls: `Granit.Privacy.Notifications`, `Granit.Identity.Local.Notifications`.
 
-### `*.Notifications` package — canonical checklist (STRICT)
+Critical gotchas:
 
-Every `Granit.{Module}.Notifications` package follows the same shape. Reference
-implementations: `Granit.Privacy.Notifications` (most recent, embedded templates +
-`{{ privacy }}` global context + manifest pinning test) and
-`Granit.Identity.Local.Notifications` (largest catalog: 9 notification types,
-145 templates).
+- `<EmbeddedResource Include="Templates\**\*.html" WithCulture="false" />` — without `WithCulture="false"` MSBuild treats `*.fr.html` as satellite resources.
+- `*Display` companion field MANDATORY for `IReadOnlyList<T>` data fields — JSON arrays don't iterate in Scriban after `JsonElementToDictionary` flattening. Pattern: `string MissingProvidersDisplay = string.Join(", ", MissingProviders)`.
+- Template first line MUST be `<title>...</title>` — email channel extracts subject from it.
+- Notification type `Name`: `snake_case` preferred (`privacy.deletion_acknowledged`). Singleton `Instance` referenced by handlers.
+- Wolverine routing — explicitly state local (`ILocalEventBus`, in-process) vs distributed (`*Eto` over bus) per story; default-to-distributed for in-process events wastes a round trip.
+- Tests ship a manifest pinning theory test (one row per (notification, culture)) — copy from `Granit.Privacy.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs`.
+- Framework baseline ships **EN + FR**. Other cultures generated by `scripts/translate-templates.py` with `<!-- AUTO-TRANSLATED -->` marker.
 
-Public docs equivalent (audience: open-source consumers):
-[`docs-site/src/content/docs/dotnet/infrastructure/notifications/conventions.mdx`](docs-site/src/content/docs/dotnet/infrastructure/notifications/conventions.mdx).
-Keep the two in sync.
+### `*.Analytics` (MetricDefinition)
 
-#### 1. csproj structure
+Full conventions: [docs-site analytics/conventions.mdx](docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx). Reference impl: `Granit.Invoicing` (`UnpaidInvoiceCount/TotalMetricDefinition`).
 
-```xml
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <PackageId>Granit.{Module}.Notifications</PackageId>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-  <ItemGroup>
-    <InternalsVisibleTo Include="Granit.{Module}.Notifications.Tests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Templates\**\*.html" WithCulture="false" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Granit.{Module}\Granit.{Module}.csproj" />
-    <ProjectReference Include="..\Granit.Notifications.Abstractions\Granit.Notifications.Abstractions.csproj" />
-    <ProjectReference Include="..\Granit.Templating\Granit.Templating.csproj" />
-  </ItemGroup>
-</Project>
-```
+Critical rules:
 
-`WithCulture="false"` is **mandatory** — without it MSBuild treats files like
-`privacy.export_ready.fr.html` as satellite resources and breaks the manifest layout.
+- Concrete `*MetricDefinition` lives in **base module** (`Granit.{Module}/Metrics/`), not in `.Endpoints` or `.EntityFrameworkCore` (mirrors ADR-020 placement for Query/Export).
+- Naming formula: `{Subset?}{Entity}{Field?}{Aggregation}` — aggregation always last (`InvoicePaymentDelayAverage`, never `AverageInvoicePaymentDelay`). Wire `Name`: `Granit.{Module}.{MetricName}`.
+- Registration: `services.AddMetricDefinition<TEntity, TValue, TDefinition>()` — `TValue` required to dispatch typed `SumAsync<int>`/`<decimal>` without reflection.
+- **`Selector` MUST be `Expression<Func<T, TValue?>>?`** (nullable) — empty `IQueryable` => `SUM(NULL)` would otherwise throw.
+- **Empty-set semantics (locked, never relax):** `Count→0`, `Sum→default`, `Avg/Min/Max→null`. Pinned by `MetricExecutorEmptySetTests`.
+- Period tokens are query params, NEVER part of the metric `Name` (one definition serves `?period=mtd`, `?period=ytd`, etc.). Exception: canonical industry terms (e.g. `MonthlyRecurringRevenue`).
+- Localization MANDATORY: `Metric:{Name}` key in all 18 cultures (archi test D2 #1397 planned).
+- Permissions inherit from underlying entity — a metric over `Invoice` is gated by `Invoicing.Invoices.Read`, never a metric-specific permission.
+- **Pairing**: a `MetricDefinition` requires an existing `QueryDefinition` for the same entity (D1 inverse strict, archi-tested).
 
-#### 2. Module class — `Granit{Module}NotificationsModule.cs`
+### Declarative definitions placement (Query/Export/Metric)
 
-```csharp
-[DependsOn(
-    typeof(GranitNotificationsAbstractionsModule),
-    typeof(Granit{Module}Module),
-    typeof(GranitTemplatingModule))]
-public sealed class Granit{Module}NotificationsModule : GranitModule
-{
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
-        context.Services.AddEmbeddedTemplates(typeof(Granit{Module}NotificationsModule).Assembly);
-        context.Services.AddTemplateLayout("{module-prefix}.*", "Layout.Email");
-        // Optional — only if the module ships a global context (e.g. PrivacyContactGlobalContext).
-        // context.Services.AddTemplateGlobalContext<{Module}ContactGlobalContext>();
-        // Optional — only when the module needs to expose definitions to the admin UI.
-        // context.Services.AddSingleton<INotificationDefinitionProvider, {Module}NotificationDefinitionProvider>();
-    }
-}
-```
+Concrete `*QueryDefinition`, `*ExportDefinition`, `*MetricDefinition` live in **base module** `Granit.{Module}` (in `Queries/`, `Exports/`, `Metrics/`). NEVER in `.Endpoints`, NEVER in `.EntityFrameworkCore`. Reference `Granit.{X}.Abstractions` (lightweight contracts), never `Granit.QueryEngine`/`Granit.DataExchange` directly. Each module owns its registrations — NEVER aggregate into a central `Granit.{X}.Definitions` package.
 
-Layout glob: `"{module-prefix}.*"` — covers all snake_case names. Add a second
-`"{Module}.*"` line if the package still ships legacy PascalCase template names
-(see `Granit.Privacy.Notifications` → `Privacy.LegalDocumentObsolete`).
-
-#### 3. Notification types — `*NotificationType.cs`
-
-```csharp
-public sealed class {Action}NotificationType : NotificationType<{Action}NotificationData>
-{
-    public static readonly {Action}NotificationType Instance = new();
-    public override string Name => "{module}.{event_name}";          // snake_case — preferred
-    public override NotificationSeverity DefaultSeverity => NotificationSeverity.Info;
-    public override IReadOnlyList<string> DefaultChannels { get; } =
-        [NotificationChannels.Email, NotificationChannels.InApp];
-}
-
-public sealed record {Action}NotificationData(/* fields */);
-```
-
-- **Naming**: `snake_case` is preferred (`privacy.deletion_acknowledged`,
-  `customer-balance.credit_expiring`). Legacy PascalCase (`Privacy.LegalDocumentObsolete`)
-  still works — never repeat that pattern in new types.
-- **`Name`** is the resource key for templates (`Templates/{Name}.html`) AND the
-  notification definition id surfaced in the admin UI.
-- **Singleton `Instance`** — Wolverine handlers reference it directly when calling
-  `INotificationPublisher.PublishAsync(...)`.
-- Data record stays in the same file (matches the rest of the codebase).
-
-#### 4. JSON-array gotcha — `*Display` companion field (MANDATORY when shipping `IReadOnlyList<T>`)
-
-The email channel serializes the data record to JSON and flattens it into a Scriban
-dictionary via `JsonElementToDictionary` (in
-`src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs`). **Arrays
-round-trip as their JSON string representation and are NOT iterable in Scriban.**
-
-Workaround: ship a `*Display` (string CSV) companion field alongside any list:
-
-```csharp
-public sealed record PrivacyExportFailedNotificationData(
-    Guid RequestId,
-    string ArchiveBlobReferenceId,
-    IReadOnlyList<string> MissingProviders,        // kept for audit/programmatic consumers
-    string MissingProvidersDisplay,                // template-friendly: string.Join(", ", MissingProviders)
-    DateTimeOffset RequestedAt,
-    string Regulation);
-```
-
-Reference: `Granit.Privacy.Notifications/PrivacyExportFailedNotificationType.cs`.
-Future US #1329 (architecture test D1) will warn when a list field has no `*Display` peer.
-
-#### 5. Wolverine handlers — `Handlers/{Trigger}Handler.cs`
-
-```csharp
-public class {Trigger}NotificationHandler           // public class — NEVER static, NEVER internal
-{
-    public static async Task HandleAsync(           // public static method
-        {Trigger}Eto evt,
-        INotificationPublisher publisher,
-        CancellationToken cancellationToken)
-    {
-        await publisher.PublishAsync(
-            {Action}NotificationType.Instance,
-            new {Action}NotificationData(/* ... */),
-            recipients: [evt.UserId.ToString()],
-            cancellationToken).ConfigureAwait(false);
-    }
-}
-```
-
-**Wolverine routing — local vs distributed (decide per story).** Wolverine discovers the
-handler the same way regardless of where the trigger comes from, but the *transport*
-differs:
-
-- **Local trigger** — emitted in the same process that hosts the `*.Notifications`
-  package (e.g. `WebhookDeliveryFailureThresholdExceededEto` originating in
-  `Granit.Webhooks` when both modules ship in the same API). Subscribe via the local
-  event bus (`ILocalEventBus`) — no network hop, no outbox. Use a domain `*Event`
-  rather than an `*Eto` if both producer and consumer live together.
-- **Distributed trigger** — emitted by another microservice and consumed via the bus
-  (e.g. `IdentityTokenExchangedEto` flowing from an identity service to a notifications
-  worker). Configure the queue/topic routing in Wolverine and keep `*Eto` semantics.
-
-Each Feature B / Feature C story under epic #1306 must explicitly state which mode it
-uses — defaulting silently to distributed for an in-process event wastes a round trip
-and breaks ordering guarantees.
-
-See [Wolverine handler visibility — CRITICAL](#wolverine-handler-visibility--critical)
-above. SonarQube S1118 on these handlers is a false positive — mark **Won't Fix**.
-
-#### 6. Templates — `Templates/{Name}.html` (+ per-culture variants)
-
-```html
-<title>Your data has been deleted</title>
-<p>Hi,</p>
-<p>We confirm that your personal data has been permanently deleted on
-   <strong>{{ model.executed_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>.</p>
-<p>Reference: <code>{{ model.request_id }}</code></p>
-{{ if privacy.dpo_email }}
-<p>Contact our DPO at <a href="mailto:{{ privacy.dpo_email }}">{{ privacy.dpo_email }}</a>.</p>
-{{ end }}
-```
-
-- **First line MUST be `<title>...</title>`** — the email channel extracts the subject
-  from this tag. Without it, the subject defaults to `notification_type.Replace('.', ' ')`
-  (ugly, e.g. `"privacy export_failed"`).
-- **Neutral file = English** — `Templates/{Name}.html` (no culture suffix). Per-culture
-  files: `Templates/{Name}.{culture}.html` (e.g. `.fr.html`, `.de.html`). Framework
-  baseline ships **EN + FR**; the rest are generated by `scripts/translate-templates.py`
-  (US #1311 / Feature A0) and carry a
-  `<!-- AUTO-TRANSLATED ({model}, {date}) — REVIEW BEFORE PRODUCTION -->` marker.
-- **Graceful degradation** — wrap optional fields in `{{ if ... }} ... {{ end }}` so
-  hosts that don't populate the global context (e.g. `{{ privacy.dpo_email }}`) still
-  render a usable email instead of `<empty href>` links.
-
-#### 7. Template variables available
-
-| Variable | Source | Notes |
-| -------- | ------ | ----- |
-| `{{ model.* }}` | The notification data record | Field names rendered `snake_case` via `StandardMemberRenamer` (`MissingProvidersDisplay` → `missing_providers_display`) |
-| `{{ privacy.* }}` | `PrivacyContactGlobalContext` (when `Granit.Privacy.Notifications` is loaded) | Controller name/email, DPO email, supervisory authority URL |
-| `{{ now.* }}` | Time provider | `now.utc_now`, `now.local_now` |
-| `{{ context.* }}` | Notification dispatch context | Recipient locale, channel name, tenant id |
-| `{{ app.* }}` | Host-provided global context | Branding (`app.name`, `app.support_email`, `app.logo_url`) — registered by the application, not the framework |
-
-Each module that ships its own global context registers it via
-`AddTemplateGlobalContext<TContext>()` in its `Granit{Module}NotificationsModule`.
-
-#### 8. Tests — `tests/Granit.{Module}.Notifications.Tests/`
-
-```text
-tests/Granit.{Module}.Notifications.Tests/
-  Handlers/
-    {Trigger}NotificationHandlerTests.cs   # one per Wolverine handler
-  Templates/
-    EmbeddedTemplatesTests.cs              # manifest pinning theory test
-```
-
-Manifest pinning theory test (skeleton — copy from
-`tests/Granit.Privacy.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs`):
-
-```csharp
-public sealed class EmbeddedTemplatesTests
-{
-    public static TheoryData<string> ExpectedTemplates() =>
-    [
-        "Templates.{module}.{name1}.html",        // EN neutral
-        "Templates.{module}.{name1}.fr.html",     // FR baseline
-        // ... one row per (notification, culture) shipped
-    ];
-
-    [Theory, MemberData(nameof(ExpectedTemplates))]
-    public void EachExpectedTemplate_IsEmbeddedInTheAssembly(string suffix)
-    {
-        Assembly assembly = typeof(Granit{Module}NotificationsModule).Assembly;
-        string fullResourceName = $"{assembly.GetName().Name}.{suffix}";
-        assembly.GetManifestResourceNames().ShouldContain(fullResourceName);
-    }
-}
-```
-
-#### 9. CI test sharding (MANDATORY)
-
-Add `tests/Granit.{Module}.Notifications.Tests` to the **`infrastructure`** shard of
-[`.github/test-shards.json`](.github/test-shards.json) (where the rest of
-`*.Notifications.*` lives). Then run `python3 scripts/generate-shard-filters.py` to
-regenerate the `.slnf` files. The pre-push hook does this automatically when
-`.csproj` or `test-shards.json` changes.
-
-Without registration, CI silently skips the project.
-
-#### 10. Translation strategy
-
-- Framework ships **EN + FR** out of the box for every `*.Notifications` package.
-- Additional cultures via `scripts/translate-templates.py` (US #1311 / Feature A0):
-  reproducible, idempotent, validates Scriban placeholder integrity post-translation.
-- Generated files carry `<!-- AUTO-TRANSLATED ({model}, {date}) — REVIEW BEFORE PRODUCTION -->`
-  on the first line.
-- Apps requiring legally-validated wording override embedded templates at runtime via
-  the `Granit.Templating` admin API (the DB-backed resolver runs at higher priority
-  than the embedded one).
-
-#### 11. Architecture enforcement (future)
-
-US #1329 (Feature D1) will assert, for every assembly matching `Granit.*.Notifications`:
-for every type that derives from `NotificationType<>` and whose `DefaultChannels`
-include a text-rendered channel (Email, SMS, WhatsApp, Web Push…), an `EmbeddedResource`
-named `Templates.{Name}.html` is present in the same assembly. Cross-link this section
-when the test lands.
-
-### `*.Analytics` — canonical checklist (STRICT)
-
-Every `MetricDefinition` and (planned) `DashboardDefinition` follows the same shape.
-Reference implementation: `Granit.Invoicing` ships
-`UnpaidInvoiceCountMetricDefinition` and `UnpaidInvoiceTotalMetricDefinition` (story
-A4 #1377) — copy from there.
-
-Public docs equivalent (audience: open-source consumers):
-[`docs-site/.../analytics/conventions.mdx`](docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx).
-Keep the two in sync.
-
-#### 1. Package layout
-
-Three framework packages, plus per-module placement of definitions:
-
-| Package | Role |
-| ------- | ---- |
-| `Granit.Analytics` | Abstractions: `MetricDefinition<TEntity, TValue>`, `MetricValueKind`, `RefreshHint`, `PeriodSpec`, `DashboardDefinition`. Pure declarations, no runtime. |
-| `Granit.Analytics.EntityFrameworkCore` | `MetricExecutor<TEntity, TValue>` — runs metrics through the same filter pipeline as `Granit.QueryEngine`. Empty-set semantics enforced here. |
-| `Granit.Analytics.Endpoints` | HTTP layer: `POST /api/{version}/metrics/{name}` + period resolution + FusionCache wiring + period-comparison `DeltaCalculator`. |
-
-Per-module placement (mirrors ADR-020 — same rule as `QueryDefinition` /
-`ExportDefinition`):
-
-```text
-src/Granit.{Module}/
-  Metrics/
-    {Subset?}{Entity}{Field?}{Aggregation}MetricDefinition.cs
-  Dashboards/                              # planned (Feature B, ADR-038)
-    {Name}DashboardDefinition.cs
-```
-
-Concrete metric and dashboard classes live in the **base module**, NOT in
-`.Endpoints` and NOT in `.EntityFrameworkCore`. The base module references
-`Granit.Analytics` (lightweight). Hosts that execute metrics pull
-`Granit.Analytics.EntityFrameworkCore` and `Granit.Analytics.Endpoints` separately.
-
-#### 2. Module class registration
-
-```csharp
-[DependsOn(typeof(GranitAnalyticsModule), typeof(Granit{Module}Module))]
-public sealed class Granit{Module}AnalyticsModule : GranitModule { /* ... */ }
-```
-
-In practice metrics are registered from the host's `AddGranit{Module}()` extension:
-
-```csharp
-builder.Services.AddMetricDefinition<Invoice, int, UnpaidInvoiceCountMetricDefinition>();
-builder.Services.AddMetricDefinition<Invoice, decimal, UnpaidInvoiceTotalMetricDefinition>();
-// Future B1 (#1382):
-// builder.Services.AddDashboardDefinition<FinanceOverviewDashboardDefinition>();
-```
-
-Three generic args on `AddMetricDefinition`: `TEntity`, `TValue`, `TDefinition`.
-`TValue` is required because the executor dispatches per primitive type
-(`int` / `long` / `decimal` / `double`) — keeps EF Core's typed
-`SumAsync<int>` / `SumAsync<decimal>` reachable without reflection.
-
-#### 3. `MetricDefinition` skeleton
-
-```csharp
-public sealed class UnpaidInvoiceCountMetricDefinition : MetricDefinition<Invoice, int>
-{
-    public override string Name => "Granit.Invoicing.UnpaidInvoiceCount";   // wire identifier
-    public override MetricValueKind ValueKind => MetricValueKind.Count;
-    public override AggregateFunction Aggregation => AggregateFunction.Count;
-    public override Expression<Func<Invoice, int?>>? Selector => null;       // null for Count
-    public override bool IsHigherBetter => false;                            // unpaid is bad
-    public override RefreshHint RefreshHint => RefreshHint.Dynamic;
-    public override Expression<Func<Invoice, bool>>? BaseFilter
-        => i => i.Status == InvoiceStatus.Open;
-    public override Expression<Func<Invoice, DateTimeOffset>>? PeriodSelector
-        => i => i.IssuedAt;
-}
-```
-
-- **Naming formula**: `{Subset?}{Entity}{Field?}{Aggregation}` — PascalCase,
-  aggregation **always last** (`InvoicePaymentDelayAverage`, NEVER
-  `AverageInvoicePaymentDelay`). Groups metrics alphabetically by entity in IDE
-  autocomplete, admin UI, OpenAPI schema.
-- **`Name` (wire identifier)**: `Granit.{Module}.{MetricName}` — drop the
-  `Definition` suffix, keep `Metric` is **NOT** appended (the definition's `Name`
-  is the bare measure name; `Definition` lives on the C# class only).
-  Reference: `UnpaidInvoiceCountMetricDefinition.Name == "Granit.Invoicing.UnpaidInvoiceCount"`.
-- **`BaseFilter`**: declarative subset (e.g. `Status == Open`) composed BEFORE the
-  user filter. Caches keyed per (metric, filter) so two metrics over the same
-  entity with different base filters do not collide.
-- **`PeriodSelector`**: which `DateTimeOffset` field the `?period=` window applies
-  to (e.g. `IssuedAt` for invoices, `CreatedAt` for blobs).
-
-#### 4. EF Core empty-set gotcha — `Selector` MUST be nullable
-
-```csharp
-public override Expression<Func<TEntity, TValue?>>? Selector { get; }
-//                                          ^^^^^^^ TValue? — nullable
-```
-
-`SumAsync` / `AverageAsync` over an empty `IQueryable<>` translate to SQL
-`SUM(NULL)` / `AVG(NULL)`. With a non-nullable `Expression<Func<T, TValue>>`,
-EF Core throws `InvalidOperationException: Nullable object must have a value`.
-Typing the selector `TValue?` makes the projection explicitly nullable, and the
-executor coalesces to the convention-mandated empty-set value before returning.
-
-**Empty-set semantics — locked by tests in story A3 #1374, never relax without
-architectural review:**
-
-| Aggregation | Empty result | Rationale |
-| ----------- | ------------ | --------- |
-| `Count` | `0` | Mathematically defined; no rows = zero rows. |
-| `Sum` | `default(TValue)` (`0` for numerics) | Identity element of addition. |
-| `Avg` | `null` | Division by zero — "no data" is not "zero". |
-| `Min` / `Max` | `null` | No element to compare; explicit absence. |
-
-Reference: `Granit.Analytics.EntityFrameworkCore/Internal/MetricExecutor.cs` and
-`tests/Granit.Analytics.EntityFrameworkCore.Tests/Internal/MetricExecutorEmptySetTests.cs`.
-
-#### 5. Period tokens — DAX-aligned
-
-Tokens are case-insensitive, resolved server-side via `IClock` (never
-`DateTimeOffset.UtcNow`):
-
-| Token | Meaning |
-| ----- | ------- |
-| `today`, `yesterday`, `last_7d`, `last_30d` | Calendar windows |
-| `mtd`, `qtd`, `ytd`, `mat` | Month / Quarter / Year-to-date, Moving Annual Total |
-| `previous_period` | `compareTo` only — equal-length window immediately preceding the main one |
-| `pm`, `pq`, `py`, `pmc`, `pqc`, `pyc` | Previous Month / Quarter / Year (rolling or complete) — planned |
-
-Period tokens are query parameters, NEVER part of the metric `Name`. One
-`Granit.Subscriptions.RecurringRevenue` answers MRR with `?period=mtd`, ARR with
-`?period=ytd`, last-quarter revenue with `?period=pqc`. Bake-into-name is allowed
-**only** for canonical industry terms (e.g. `MonthlyRecurringRevenue` — SaaS-MRR
-is always the monthly-equivalent regardless of the queried period).
-
-Full reference: [docs-site analytics conventions](docs-site/src/content/docs/dotnet/business/analytics/conventions.mdx).
-
-#### 6. Localization — MANDATORY
-
-Every `MetricDefinition.Name` MUST have a `Metric:{Name}` key in **all 18 cultures**
-of the owning module's `Localization/{Module}/` folder (15 base + 3 regional).
-Architecture test (D2 #1397, planned) will fail the build on missing keys.
-
-```jsonc
-// src/Granit.Invoicing/Localization/Invoicing/en.json
-{
-  "Metric:Granit.Invoicing.UnpaidInvoiceCount": "Unpaid invoices",
-  "Metric:Granit.Invoicing.UnpaidInvoiceTotal": "Total amount unpaid"
-}
-```
-
-Same convention for `Dashboard:{Name}` (planned).
-
-#### 7. Permissions — inherit from the underlying entity
-
-Metric endpoints inherit the underlying entity's read permission. A metric over
-`Invoice` is gated by `Invoicing.Invoices.Read` — NEVER a metric-specific
-permission. Rationale: the metric exposes an aggregate of data the user could
-already see via the list endpoint; granting a separate metric permission would be
-a confusing layer without security value.
-
-OData EntitySet permissions (Feature C #1393) follow the same rule:
-`OData.{Module}.{Entity}.Read` mirrors the existing list endpoint permission.
-
-#### 8. Pairing rules (STRICT, enforced by archi tests)
-
-Every admin-visible entity now participates in three pairings:
-
-| Browse | Export | Measure |
-| ------ | ------ | ------- |
-| `QueryDefinition` | `ExportDefinition` | `MetricDefinition` |
-| ADR-020 | ADR-020 | (D1 #1396) |
-
-- Adding a `MetricDefinition` for an entity **requires** an existing
-  `QueryDefinition` for the same entity (D1 inverse rule, no exemption — a metric
-  without a drill-down query is always a bug).
-- Adding a `QueryDefinition` for an admin-visible entity **should** be paired with
-  a `MetricDefinition` over the same entity (D1 forward rule, with categorised
-  baseline exemption list — `[INFRA]` for audit/config/internal cache,
-  `[BACKLOG]` for entities awaiting metrics).
-- Pure infrastructure entities (audit log details, internal cache rows like
-  `AIWorkspaceEntity`, `TenantFeatureOverride`) are exempt — see
-  `tests/Granit.ArchitectureTests/QueryMetricPairingTests.PairingExemptions`.
-
-#### 9. Tests — `tests/Granit.Analytics.EntityFrameworkCore.Tests/`
-
-Locked in story A3 #1374. Three families:
-
-```text
-tests/Granit.Analytics.EntityFrameworkCore.Tests/
-  Internal/
-    MetricExecutorTests.cs              # happy-path Sum / Avg / Min / Max / Count
-    MetricExecutorEmptySetTests.cs      # empty-set matrix per (Aggregation × TValue)
-    MetricExecutorPostgresParityTests.cs # SQLite vs Postgres parity
-```
-
-The empty-set matrix is the crown-jewel test — it pins the contract above. Touch
-it only after architectural review.
-
-#### 10. CI test sharding (MANDATORY)
-
-`*.Analytics.*` tests live in the **`business`** shard of
-[`.github/test-shards.json`](.github/test-shards.json). Run
-`python3 scripts/generate-shard-filters.py` after editing the shard map to
-regenerate the `.slnf` files (the pre-push hook does this automatically).
-
-Without registration, CI silently skips the project.
-
-#### 11. Architecture enforcement
-
-Active rules (`tests/Granit.ArchitectureTests/`):
-
-- **D1 #1396 — Pairing**: `QueryDefinition` ↔ `MetricDefinition` (forward with
-  exemption baseline + inverse strict). See
-  `QueryMetricPairingTests.cs`.
-
-Planned:
-
-- **D2 #1397** — `Metric:` and `Dashboard:` localization completeness across the
-  18 cultures.
-
-### Declarative definitions (`*QueryDefinition`, `*ExportDefinition`) — placement (STRICT)
-
-Two declarative primitives describe how an entity is consulted (grid filter/sort) and
-exported (CSV/XLSX whitelist). They are **pure declarations** — no HTTP, no DbContext —
-so they live with the domain, not with the HTTP layer.
-
-| Primitive | Base class location | Concrete instance location |
-| --------- | ------------------- | -------------------------- |
-| `QueryDefinition<T>` | `Granit.QueryEngine.Abstractions` | `Granit.{Module}/Queries/{Entity}QueryDefinition.cs` |
-| `ExportDefinition<T>` | `Granit.DataExchange.Abstractions` | `Granit.{Module}/Exports/{Entity}ExportDefinition.cs` |
-
-**Rules:**
-
-- **Concrete `*QueryDefinition` / `*ExportDefinition` classes MUST live in the base module
-  `Granit.{Module}`**, NOT in `Granit.{Module}.Endpoints`. The `.Endpoints` package is
-  reserved for HTTP-layer artifacts (route groups, request/response DTOs, validators,
-  permission providers).
-- **Base modules reference `Granit.QueryEngine.Abstractions` / `Granit.DataExchange.Abstractions`**
-  (lightweight contracts, no runtime). NEVER reference `Granit.QueryEngine` or
-  `Granit.DataExchange` directly from a base module.
-- **Registration in the module class** (`Granit{Module}Module.ConfigureServices`):
-  `services.AddQueryDefinition<TEntity, TDefinition>()` and
-  `services.AddExportDefinition<TEntity, TDefinition>()`. Each module owns its
-  registrations — NEVER aggregate them into a central package.
-- **Localization keys** (`Column:{Entity}.{Field}`, `ExportHeader:{Entity}.{Field}`) live
-  in the base module's localization resource alongside the definitions.
-- **Naming**: `{Entity}QueryDefinition` and `{Entity}ExportDefinition` (no other suffix).
-  `Name` property uses `"Granit.{Module}.{Entity}{Query|Export}"` (e.g.,
-  `"Granit.Invoicing.InvoiceQuery"`, `"Granit.Invoicing.InvoiceExport"`).
-- **Why this placement**: queries and exports are part of the module's public contract —
-  the same definition is consumed by HTTP endpoints (`MapGranitQueryEndpoint`),
-  background jobs (export orchestrator), and tests. Coupling the declaration to
-  `.Endpoints` would make it inaccessible to non-HTTP consumers.
-
-**Anti-pattern — central aggregation package**: NEVER create a `Granit.{X}.Definitions`
-package that depends on every module to register definitions. Each module owns its own.
-
-**Pairing rule — STRICT**: every "admin-visible" entity MUST have **both** a
-`QueryDefinition` AND a matching `ExportDefinition`. Query and Export are two facets of
-the same admin-grid use case (browse + export). If you add one, you MUST add the other.
-Architecture tests enforce this pairing for every entity registered with either primitive.
-A third primitive — `MetricDefinition` — pairs with `QueryDefinition` for the
-*measure* facet (see the *.Analytics canonical checklist above). Adding a metric
-without an underlying query is rejected by the D1 archi test.
-
-**What counts as "admin-visible"**: any aggregate root or entity exposed in an admin
-panel — typically those with a CRUD endpoint group or those returned in a paginated grid.
-Pure infrastructure entities (audit log details, internal cache rows like
-`AIWorkspaceEntity`, `TenantFeatureOverride`) are exempt and use the reflection-based
-fallback.
-
-**Exemption list — canonical location**: `tests/Granit.ArchitectureTests/PairingExemptions.cs`
-holds the **shared** `[INFRA]` set consumed by both `QueryExportPairingTests` and
-`QueryMetricPairingTests`. Adding an `[INFRA]` entry exempts the entity from **both**
-pairings (it surfaces in neither admin grids nor business KPIs). Each entry MUST carry
-a one-line inline-comment justification.
-
-`[BACKLOG]` exemptions (admin-visible entities awaiting their first metric) live
-locally in `QueryMetricPairingTests.MetricBacklog` — the backlog is metric-specific and
-is removed entry-by-entry as each module ships its first `MetricDefinition` for that
-entity. The Query↔Export pairing has no backlog mechanism: an admin-visible entity
-without an `ExportDefinition` is always rejected.
+**Pairing (STRICT, archi-tested):** every admin-visible entity MUST have both `QueryDefinition` AND `ExportDefinition`. Adding a `MetricDefinition` requires the matching `QueryDefinition`. Exemption list (shared `[INFRA]`): `tests/Granit.ArchitectureTests/PairingExemptions.cs` — each entry carries an inline justification. `[BACKLOG]` (metric-only) lives in `QueryMetricPairingTests.MetricBacklog`.
 
 ### DTOs & API responses
 
-- **Prefixed names**: `WorkflowTransitionRequest`, not `TransitionRequest` — OpenAPI flattens namespaces
-- **Suffixes**: `*Request` for input, `*Response` for output. NEVER `*Dto`.
-- **Errors**: Always `TypedResults.Problem(detail, statusCode)` (RFC 7807). Return type: `ProblemHttpResult`.
-- **No entity exposure**: EF entities must NOT be returned — create `*Response` records.
+- `*Request` for input, `*Response` for output. NEVER `*Dto`. Prefixed names (`WorkflowTransitionRequest`, not `TransitionRequest`) — OpenAPI flattens namespaces.
+- Errors: `TypedResults.Problem(detail, statusCode)` (RFC 7807). EF entities NEVER returned — always project to `*Response` records.
 
-### OpenAPI endpoint metadata — MANDATORY (5 elements)
-
-Every endpoint MUST declare all 5 metadata elements, chained in this order:
+### OpenAPI endpoint metadata (5 elements MANDATORY)
 
 ```csharp
 group.MapGet("/{id:guid}", GetByIdAsync)
-    .WithName("GetBlobDescriptor")                          // PascalCase operation ID
-    .WithSummary("Returns a blob descriptor by ID.")        // Imperative, ~100 chars, period
-    .WithDescription("Fetches the full metadata...")        // 2-4 sentences: what, context, errors
-    .Produces<BlobDescriptorResponse>()                     // Success response type
-    .ProducesProblem(StatusCodes.Status404NotFound);        // One per error path
+    .WithName("GetBlobDescriptor")                       // PascalCase VerbNoun
+    .WithSummary("Returns a blob descriptor by ID.")     // imperative, ~100 chars, period
+    .WithDescription("Fetches the full metadata...")     // 2-4 sentences
+    .Produces<BlobDescriptorResponse>()                  // match handler return type
+    .ProducesProblem(StatusCodes.Status404NotFound);     // one per error path
 ```
 
-**Produces mapping:** Match handler return type → `Ok<T>` = `.Produces<T>()`,
-`Created<T>` = `.Produces<T>(201)`, `NotFound` = `.ProducesProblem(404)`,
-`ValidationProblem` = `.ProducesValidationProblem()`, `FileStreamHttpResult` =
-`.Produces(200, contentType: "application/octet-stream")`. Never omit `.Produces()`.
+`Ok<T>`→`.Produces<T>()`, `Created<T>`→`.Produces<T>(201)`, `NotFound`→`.ProducesProblem(404)`, `ValidationProblem`→`.ProducesValidationProblem()`, `FileStreamHttpResult`→`.Produces(200, contentType: "application/octet-stream")`.
 
-**Rules:** WithName = PascalCase VerbNoun, WithSummary = imperative ~100 chars with period,
-WithDescription = 2-4 sentences, ProducesProblem = one per error status code.
+### OpenAPI tags (STRICT)
 
-### OpenAPI tags — naming convention (STRICT)
-
-Every `*.Endpoints` module MUST attach a `.WithTags(...)` call on its root `RouteGroupBuilder`.
-Without it, .NET's OpenAPI generator falls back to the handler's declaring class name
-(e.g. `AccountLoginEndpoints`) — ugly and leaks internal structure.
-
-**Format: `Title Case With Spaces`.**
-
-- Prefer natural English: `Blob Storage`, `Background Jobs`, `Reference Data`, `Data Exchange`.
-- NEVER glued PascalCase (`BlobStorage`, `MobilePush`, `CustomerBalance`) — that's a class name, not a UI label.
-- NEVER kebab-case or snake_case (those belong in URLs and metric tags, not OpenAPI UI labels).
-
-**Module sub-tags: `<Module> - <SubGroup>`.**
-
-When a module exposes multiple distinct tag groups, prefix every sub-tag with the module
-name followed by ` - ` (space-dash-space). This makes Scalar's left column group them
-visually and alphabetically.
-
-| Module | Tags |
-| ------ | ---- |
-| `Granit.AI.Endpoints` | `AI - Workspaces`, `AI - Inference`, `AI - Providers`, `AI - Usage` |
-| `Granit.Identity.Endpoints` | `Identity - User Cache`, `Identity - Provider`, `Identity - Webhook` |
-| `Granit.Notifications.Endpoints` | `Notifications`, `Notifications - Mobile Push` |
-| `Granit.MultiTenancy.Endpoints` | `Platform - Tenants` |
-
-Single-tag modules use the module's user-facing name directly (e.g. `Blob Storage`,
-`Privacy`, `Webhooks`, `Workflow`). The tag name does NOT have to match the .NET
-namespace — it's a human label.
-
-**Expose the tag via options.** Every module MUST ship a `TagName` property (or
-`{Role}TagName` for multi-tag modules) on its `*EndpointsOptions` with a sensible
-default. Consumers can override per-app.
-
-**Declarative tag list.** `Granit.Http.ApiDocumentation` auto-emits a sorted
-`document.Tags` array (via `SortedTagsDocumentTransformer`), so Scalar renders tags
-alphabetically without per-app configuration.
+Every `*.Endpoints` module attaches `.WithTags(...)` on its root group. Format: `Title Case With Spaces` (e.g. `Blob Storage`, `Background Jobs`) — NEVER glued PascalCase, kebab-case, or snake_case. Multi-tag modules: `<Module> - <SubGroup>` (space-dash-space) — e.g. `AI - Workspaces`, `Identity - Webhook`. Expose via `TagName` property on `*EndpointsOptions` (overridable per-app). `Granit.Http.ApiDocumentation` auto-emits a sorted `document.Tags` array.
 
 ### Validation
 
-- **Auto-validation**: use `endpoints.MapGranitGroup(prefix)` instead of `MapGroup()` — applies
-  `FluentValidationAutoEndpointFilter` automatically to all endpoints in the group
-- **Validator discovery**: `GranitValidationModule` auto-discovers all `IValidator<T>` from
-  loaded module assemblies (no manual registration needed)
-- **Opt-out**: `group.MapPost("/x", Handler).WithMetadata(new SkipAutoValidationAttribute())`
-- **OpenAPI enrichment**: `FluentValidationSchemaTransformer` exposes validation constraints
-  (maxLength, pattern, required, etc.) in the OpenAPI schema for frontend code generators
-- **Architecture tests**: `ValidationConventionTests` ensures all `*Request` types have
-  validators and all route groups use `MapGranitGroup()`
-- **Localized messages — MANDATORY**: NEVER use hardcoded `.WithMessage("...")` strings in
-  validators. Built-in validators (NotEmpty, MaximumLength, etc.) are automatically converted
-  to error codes by `GranitErrorCodeLanguageManager`. For custom `.Must()` validators, use
-  `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")` and add the corresponding key
-  to all 17 JSON files in `src/Granit.Validation/Localization/Validation/`. The frontend
-  resolves error codes to localized strings via `GET /api/{version}/localization`.
+- `endpoints.MapGranitGroup(prefix)` — applies `FluentValidationAutoEndpointFilter` automatically.
+- Validators auto-discovered by `GranitValidationModule`. Opt-out: `WithMetadata(new SkipAutoValidationAttribute())`.
+- `FluentValidationSchemaTransformer` exposes constraints (maxLength, pattern...) in OpenAPI for codegen.
+- **Localized messages MANDATORY**: never hardcode `.WithMessage("...")`. Built-ins (NotEmpty, MaximumLength) auto-converted to error codes by `GranitErrorCodeLanguageManager`. Custom `.Must()` → `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")` + add the key to all 17 JSON files in `src/Granit.Validation/Localization/Validation/`.
 
-### Isolated DbContext — MANDATORY for `*.EntityFrameworkCore` packages
+### Isolated DbContext (each `*.EntityFrameworkCore` package)
 
-Every isolated `DbContext` MUST:
+1. `<ProjectReference>` to `Granit.Persistence`.
+2. Constructor-inject `ICurrentTenant?` and `IDataFilter?` (both optional, default `null`).
+3. Call `modelBuilder.ApplyGranitConventions(currentTenant, dataFilter)` at end of `OnModelCreating` — NO manual `HasQueryFilter`.
+4. Wire interceptors via `(sp, options)` overload of `AddDbContextFactory` (Scoped) — resolve `AuditedEntityInterceptor` / `SoftDeleteInterceptor`.
+5. `[DependsOn(typeof(GranitPersistenceModule))]` on module class.
+6. `IMultiTenant` entities use `Guid? TenantId` (never `string`).
 
-1. `<ProjectReference>` to `Granit.Persistence`
-2. Constructor-inject `ICurrentTenant?` and `IDataFilter?` (both optional, default `null`)
-3. Call `modelBuilder.ApplyGranitConventions(currentTenant, dataFilter)` at end of `OnModelCreating`
-4. Wire interceptors via `(sp, options)` overload of `AddDbContextFactory` (Scoped), resolving `AuditedEntityInterceptor` / `SoftDeleteInterceptor`
-5. `[DependsOn(typeof(GranitPersistenceModule))]` on module class
-6. **No manual `HasQueryFilter`** — `ApplyGranitConventions` handles all standard filters
-7. `IMultiTenant` entities use `Guid? TenantId` (never `string`)
+Reference: [`docs/framework/data/persistence.md`](docs/framework/data/persistence.md).
 
-Reference: [`docs/framework/data/persistence.md`](docs/framework/data/persistence.md)
+### DDD — AggregateRoot vs Entity
 
-### DDD — Aggregate Root vs Entity
+`AggregateRoot` (or audited variants) when the entity has a state machine, raises domain events, or encapsulates invariants. Plain `Entity` for append-only / config / lookup.
 
-Use `AggregateRoot` (or audited variants) when the entity has a state machine, raises
-domain events, or encapsulates invariants. Use plain `Entity` for append-only records,
-configuration, caches, or lookup tables.
+Aggregate Root rules (enforced by `DomainConventionTests`):
 
-**Aggregate Root rules (enforced by `DomainConventionTests`):**
+- All properties `{ get; private set; }`. State changes via behavior methods (`MarkAsValid()`, `Revoke()`).
+- `public static Xxx Create(...)` factory + `private Xxx() { }` for EF Core materialization.
+- For `IMultiTenant` with private setter: add explicit `Guid? IMultiTenant.TenantId { get; set; }` for interceptor injection.
+- Events via base class (`AddDomainEvent`/`AddDistributedEvent`) — NEVER manual `IDomainEventSource`.
 
-- **Private setters**: all properties `{ get; private set; }`. Use behavior methods for
-  state transitions (e.g., `MarkAsValid()`, `Revoke()`)
-- **Factory method**: `public static Xxx Create(...)` — the only way to construct
-- **Private EF Core constructor**: keep `private Xxx() { }` for materialization
-- **Explicit interface for `IMultiTenant`**: when `TenantId` has `private set`, add
-  explicit `Guid? IMultiTenant.TenantId { get; set; }` for interceptor injection
-- **Domain events via base class**: use `AddDomainEvent()` / `AddDistributedEvent()` —
-  NEVER manually implement `IDomainEventSource`
-- **No public setters on aggregate roots** — architecture test enforces this
+`SingleValueObject<T>`: `sealed`, `init` props, `Create()` with validation, implicit operators. EF converters auto-applied by `ApplyGranitConventions`. JSON via `SingleValueObjectJsonConverterFactory`. Reference: [ADR-017](docs-site/src/content/docs/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy.md).
 
-**Value Objects (`SingleValueObject<T>`):**
+### Multi-tenancy (soft dep)
 
-- Inherit from `SingleValueObject<T>` for single-primitive wrappers
-- Must be `sealed` with `init` properties
-- Provide `Create()` factory with validation + implicit operators for backward compat
-- EF Core converters auto-applied by `ApplyGranitConventions` (no migration needed)
-- JSON serialization handled by `SingleValueObjectJsonConverterFactory`
+`ICurrentTenant` lives in `Granit.MultiTenancy` — `using Granit.MultiTenancy;` everywhere without `[DependsOn]`. Always check `IsAvailable` before `Id` (`NullTenantContext` is the default). Hard `[DependsOn]` only when enforcing strict tenant isolation (GDPR).
 
-Reference: [ADR-017](docs-site/src/content/docs/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy.md)
+### `[DependsOn]` rules
 
-### Multi-tenancy — soft dependency
+Direct project ref with a `*Module` → declare it. Transitive → omit. `Granit` is the implicit base — never declared. Alphabetical order. Zero-dep modules have no attribute (correct).
 
-`ICurrentTenant` lives in `Granit.MultiTenancy` — available everywhere without referencing `Granit.MultiTenancy`.
+### Tests + CI sharding (MANDATORY)
 
-- Use `using Granit.MultiTenancy;` — do NOT add `[DependsOn(GranitMultiTenancyModule)]`
-- Always check `IsAvailable` before using `Id` — `NullTenantContext` is the default
-- Hard dependency on `Granit.MultiTenancy` only when enforcing strict tenant isolation (GDPR)
+8 parallel shards (6 unit-test layers + `integration` + `architecture`). Each has a `.slnf` (auto-generated). When adding a test project: edit `.github/test-shards.json` (`*.Tests.Integration` → `integration` shard always; everything else → its domain shard), run `python3 scripts/generate-shard-filters.py`, commit both. Pre-push hook auto-regenerates and amends. **Without registration, CI silently skips the project.**
 
-### `[DependsOn]` convention
+## Anti-patterns
 
-- **Direct = declare it.** Every `<ProjectReference>` with a `*Module` needs a `[DependsOn]`
-- **Transitive = omit it.** Already pulled in by another declared dependency → skip
-- **`Granit`** = implicit base, never needs `DependsOn`
-- **Alphabetical order** for `DependsOn` entries
-- **Zero-dependency modules** have no `[DependsOn]` attribute — this is correct
-
-### Tests
-
-Each package has `*.Tests` project (xUnit + Shouldly + NSubstitute + Bogus). Part of DoD.
-
-### CI test sharding — MANDATORY when adding test projects
-
-Tests run in **8 parallel shards**: 6 unit-test shards aligned with the
-architecture layers, plus a dedicated `integration` shard that owns every
-`*.Tests.Integration` project, plus the `architecture` shard. Each shard has a
-**solution filter** (`.slnf`) that builds only the required subset of projects —
-no full-solution rebuild per shard.
-
-Shard definitions: `.github/test-shards.json` (source of truth).
-Solution filters: `.github/shard-filters/*.slnf` (auto-generated).
-
-**When creating a new test project:**
-
-1. Add its directory to the correct shard in `test-shards.json` —
-   **`*.Tests.Integration` projects ALWAYS go in the `integration` shard**,
-   regardless of the domain layer. All other tests go in their domain shard.
-2. Run `python3 scripts/generate-shard-filters.py` to regenerate `.slnf` files
-3. Commit both `test-shards.json` and `.github/shard-filters/*.slnf`
-
-The pre-push hook auto-regenerates filters when `.csproj` or `test-shards.json`
-files change and folds the result into HEAD via `git commit --amend`.
-
-Shard mapping:
-
-| Shard | Layer | Modules |
-| ----- | ----- | ------- |
-| `core-ai` | Core + AI | Core, Validation, Analyzers, Diagnostics, Observability, Timing, Guids, Testing, AI.* |
-| `business` | Business Features | Workflow, DataExchange, Templating, DocumentGeneration, Timeline, QueryEngine, ReferenceData, Parties |
-| `api-data` | API & Http + Data | Http.*, BlobStorage, Persistence, Caching, Imaging, RateLimiting, Webhooks |
-| `infrastructure` | Infrastructure | Notifications, BackgroundJobs, Wolverine, Localization, Settings, Features, MultiTenancy, EventBus |
-| `security` | Security & Compliance | Auditing, Authentication, Authorization, Identity, Vault, Encryption, Privacy, Security |
-| `saas` | SaaS | Invoicing, Subscriptions, CustomerBalance, Tax, Payments |
-| `integration` | Integration Tests | All `*.Tests.Integration` projects (Postgres / Testcontainers — isolated shard so unit shards are not held back by container spin-up) |
-| `architecture` | Architecture Tests | ArchitectureTests (references all src projects — isolated shard) |
-
-**NEVER** create a test project without adding it to a shard — the CI will silently skip it.
-
-## Anti-patterns — NEVER do this
-
-Code anti-patterns are the inverse of conventions above. Key additional rules:
-
-### Code (not covered above)
-
-- `new HttpClient()` → `IHttpClientFactory`
-- `async void` → always return `Task`
-- `.Result` / `.Wait()` → `await`
-- Bare `catch (Exception)` → catch specific types
-
-### Architecture
-
-- Merge `I*Reader`/`I*Writer` into `I*Store` → CQRS, keep separate
-- Share DbContext across modules → isolated DbContext per module
-- Cross-module direct method calls → integration events (Wolverine)
-- Repository pattern over EF Core → use DbContext directly
-
-### Refactoring
-
-See global `~/.claude/CLAUDE.md` for base rules. Additional Granit-specific:
-
-- Remove/change interface implementations on `ValueObject`/`Entity`/`AggregateRoot` for SonarQube → mark as won't fix
-- Reduce constructor params via wrapper types that aren't real domain concepts → mark `brain-overload` as won't fix
+- `new HttpClient()` → `IHttpClientFactory`. `async void` → `Task`. `.Result`/`.Wait()` → `await`. Bare `catch (Exception)` → catch specific.
+- Repository pattern over EF Core → use DbContext directly. Cross-module direct calls → integration events. Shared DbContext → isolated per module. Merging `I*Reader`/`I*Writer` for SonarQube → keep CQRS, mark won't fix.
+- Removing/changing interface impls on ValueObject/Entity/AggregateRoot for SonarQube → won't fix. Param-count refactors via fake wrapper types → won't fix `brain-overload`.
 
 ### Git — CRITICAL
 
-- **NEVER `git push` to a PR branch without verifying the PR is still open first.**
-  Run `gh pr view <number> --json state -q .state` immediately before every `git push`.
-  If result is NOT `"OPEN"`, do NOT push. Instead: fetch develop, create a new branch,
-  cherry-pick changes, create a new PR. This is a **BLOCKING** check — never skip it.
-
-## Compliance
-
-1. **GDPR**: Minimization, right to erasure, pseudonymization
-2. **ISO 27001**: Audit trail, encryption at rest and in transit
-3. **Secrets**: No plaintext secrets, mandatory rotation
+**NEVER `git push` to a PR branch without `gh pr view <n> --json state -q .state` first.** If not `"OPEN"`: branch from develop, cherry-pick, new PR. BLOCKING.
 
 ## Localization
 
-See [`docs/guide/conventions/langues.md`](docs/guide/conventions/langues.md) for full rules.
-
-18 cultures — 15 base (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi) + 3 regional (fr-CA, en-GB, pt-BR). Every `src/*/Localization/**/*.json` must exist for all 18. Regional files only contain differing keys.
+15 base + 3 regional = 18 cultures (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi + fr-CA, en-GB, pt-BR). Every `src/*/Localization/**/*.json` exists for all 18; regional files contain only differing keys. Full rules: [`docs/guide/conventions/langues.md`](docs/guide/conventions/langues.md).
 
 ## Documentation site
 
-The docs live in `docs-site/` (Astro + Starlight). Key paths:
-
-| Path | Content |
-| ---- | ------- |
-| `docs-site/src/content/docs/reference/modules/` | .NET module reference (one `.mdx` per module) |
-| `docs-site/src/content/docs/reference/frontend/` | Frontend SDK reference |
-| `docs-site/src/content/docs/architecture/patterns/` | Design patterns |
-| `docs-site/src/content/docs/architecture/adr/` | ADRs |
-| `docs-site/src/data/constants.ts` | Counters (update when adding packages/patterns/ADRs) |
-
-**When creating a new module**: create `.mdx` in `reference/modules/`, update `PACKAGE_COUNT` in `constants.ts`, add "See also" links from related pages.
+Lives in `docs-site/` (Astro + Starlight). When creating a new module: add `.mdx` in `reference/modules/`, bump `PACKAGE_COUNT` in `docs-site/src/data/constants.ts`, cross-link from related pages.
 
 ## MCP & Code index
 
-MCP tools (roslyn-lens + granit-tools) — see global `~/.claude/CLAUDE.md`.
-
-`.mcp-code-index.json` is auto-regenerated by the **pre-push** hook on `.cs`/`.csproj`
-changes, then folded into HEAD via `git commit --amend` so it ships with the push.
-Script: `python3 scripts/generate-code-index.py`. **NEVER edit manually.**
+MCP tools (roslyn-lens, granit-tools) — see global `~/.claude/CLAUDE.md`. `.mcp-code-index.json` is auto-regenerated by the pre-push hook (script: `python3 scripts/generate-code-index.py`). **NEVER edit manually.**
 
 ## Definition of Done
 
-See [`docs/guide/conventions/dod.md`](docs/guide/conventions/dod.md)
-
-**NEVER push or create an MR** without: tests passing, docs updated, `dotnet format --verify-no-changes`, markdownlint clean. These are **blocking**. Refuse until satisfied or user explicitly overrides.
+See [`docs/guide/conventions/dod.md`](docs/guide/conventions/dod.md). NEVER push or open a PR without: tests passing, docs updated, `dotnet format --verify-no-changes` clean, markdownlint clean. **Blocking.**

--- a/src/Granit.Entities.Customization.Endpoints/EntityCustomizationEndpoints.cs
+++ b/src/Granit.Entities.Customization.Endpoints/EntityCustomizationEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Entities.Customization.Domain.Deltas;
 using Granit.Entities.Customization.Endpoints.Dtos;
 using Granit.Entities.Customization.Endpoints.Internal;
 using Granit.Entities.Customization.Endpoints.Permissions;
+using Granit.Entities.Customization.Internal;
 using Granit.Entities.Endpoints.Internal;
 using Granit.Guids;
 using Granit.MultiTenancy;

--- a/src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs
+++ b/src/Granit.Entities.Customization.Endpoints/GranitEntitiesCustomizationEndpointsModule.cs
@@ -2,7 +2,6 @@ using Granit.Auditing;
 using Granit.Authorization;
 using Granit.Entities.Customization.Endpoints.Internal;
 using Granit.Entities.Endpoints;
-using Granit.Entities.Endpoints.Internal;
 using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
@@ -14,11 +13,10 @@ namespace Granit.Entities.Customization.Endpoints;
 
 /// <summary>
 /// Granit module for the entities-customization HTTP endpoints — exposes the
-/// per-tenant Layer 1 GET / PUT / DELETE per ADR-053. Loading this module also
-/// replaces the manifest endpoint's no-op
-/// <see cref="IManifestCustomizationApplier"/> with the real
-/// <see cref="EntityCustomizationManifestApplier"/> so subsequent manifest
-/// reads honour the tenant's customization deltas (B4).
+/// per-tenant Layer 1 GET / PUT / DELETE per ADR-053. The real
+/// <see cref="IManifestCustomizationApplier"/> is registered by the base
+/// <see cref="GranitEntitiesCustomizationModule"/>; this module only contributes
+/// the HTTP surface and the auditing writer.
 /// </summary>
 /// <remarks>
 /// Map endpoints in your application:
@@ -40,9 +38,6 @@ public sealed class GranitEntitiesCustomizationEndpointsModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        context.Services.TryAddScoped<DescriptorDeltaValidator>();
         context.Services.TryAddScoped<EntityCustomizationAuditWriter>();
-        context.Services.Replace(
-            ServiceDescriptor.Scoped<IManifestCustomizationApplier, EntityCustomizationManifestApplier>());
     }
 }

--- a/src/Granit.Entities.Customization.Endpoints/packages.lock.json
+++ b/src/Granit.Entities.Customization.Endpoints/packages.lock.json
@@ -117,6 +117,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.Entities.Customization.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Entities.Customization.EntityFrameworkCore/packages.lock.json
@@ -112,6 +112,15 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -127,6 +136,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.Entities.Customization/Granit.Entities.Customization.csproj
+++ b/src/Granit.Entities.Customization/Granit.Entities.Customization.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Entities\Granit.Entities.csproj" />
     <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Entities.Customization/GranitEntitiesCustomizationModule.cs
+++ b/src/Granit.Entities.Customization/GranitEntitiesCustomizationModule.cs
@@ -1,12 +1,30 @@
+using Granit.Entities.Customization.Internal;
+using Granit.Entities.Internal;
 using Granit.Modularity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Entities.Customization;
 
 /// <summary>
 /// Module marker for <c>Granit.Entities.Customization</c> — the Layer 1
 /// tenant-customization runtime per ADR-053. Pull this from hosts that
-/// resolve and persist customization deltas; the manifest composer (B4)
-/// consumes the reader to apply deltas at request time.
+/// resolve and persist customization deltas; loading the module replaces
+/// the manifest pipeline's no-op
+/// <see cref="IManifestCustomizationApplier"/> with the real
+/// <see cref="EntityCustomizationManifestApplier"/> so subsequent manifest
+/// reads honour the tenant's customization deltas.
 /// </summary>
-[DependsOn(typeof(GranitEntitiesAbstractionsModule))]
-public sealed class GranitEntitiesCustomizationModule : GranitModule;
+[DependsOn(
+    typeof(GranitEntitiesAbstractionsModule),
+    typeof(GranitEntitiesModule))]
+public sealed class GranitEntitiesCustomizationModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.TryAddScoped<DescriptorDeltaValidator>();
+        context.Services.Replace(
+            ServiceDescriptor.Scoped<IManifestCustomizationApplier, EntityCustomizationManifestApplier>());
+    }
+}

--- a/src/Granit.Entities.Customization/Internal/DescriptorDeltaValidator.cs
+++ b/src/Granit.Entities.Customization/Internal/DescriptorDeltaValidator.cs
@@ -2,7 +2,7 @@ using Granit.Entities.Customization.Domain;
 using Granit.Entities.Customization.Domain.Deltas;
 using Granit.Entities.Forms;
 
-namespace Granit.Entities.Customization.Endpoints.Internal;
+namespace Granit.Entities.Customization.Internal;
 
 /// <summary>
 /// Validates a delta payload against the compiled

--- a/src/Granit.Entities.Customization/Internal/EntityCustomizationManifestApplier.cs
+++ b/src/Granit.Entities.Customization/Internal/EntityCustomizationManifestApplier.cs
@@ -1,10 +1,10 @@
 using Granit.Entities.Customization.Domain;
 using Granit.Entities.Customization.Domain.Deltas;
-using Granit.Entities.Endpoints.Dtos;
-using Granit.Entities.Endpoints.Internal;
+using Granit.Entities.Internal;
+using Granit.Entities.Manifests;
 using Granit.MultiTenancy;
 
-namespace Granit.Entities.Customization.Endpoints.Internal;
+namespace Granit.Entities.Customization.Internal;
 
 /// <summary>
 /// Real <see cref="IManifestCustomizationApplier"/> — applies the active

--- a/src/Granit.Entities.Customization/packages.lock.json
+++ b/src/Granit.Entities.Customization/packages.lock.json
@@ -8,6 +8,36 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -37,6 +67,15 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -59,6 +98,44 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       }
     }

--- a/src/Granit.Entities.Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/EntitiesEndpoints.cs
@@ -5,6 +5,8 @@ using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Endpoints.Internal;
 using Granit.Entities.Endpoints.Options;
 using Granit.Entities.Forms;
+using Granit.Entities.Internal;
+using Granit.Entities.Manifests;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
@@ -68,9 +68,6 @@ public static class EntitiesEndpointRouteBuilderExtensions
         // concrete ICalendarRangeService BEFORE calling AddGranitEntitiesEndpoints,
         // or by calling Replace afterwards.
         services.TryAddSingleton<ICalendarRangeService, NullCalendarRangeService>();
-        // Layer 1 customization (ADR-053): default no-op applier. Replaced by
-        // Granit.Entities.Customization.Endpoints when that package is loaded.
-        services.TryAddScoped<IManifestCustomizationApplier, NullManifestCustomizationApplier>();
         services.AddOptions<EntitiesEndpointsOptions>();
         return services;
     }

--- a/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
+++ b/src/Granit.Entities.Endpoints/Internal/EntityManifestComposer.cs
@@ -4,6 +4,7 @@ using Granit.Entities.Details;
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Forms;
 using Granit.Entities.Layouts;
+using Granit.Entities.Manifests;
 using Granit.Entities.Relations;
 
 namespace Granit.Entities.Endpoints.Internal;

--- a/src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs
+++ b/src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs
@@ -44,6 +44,10 @@ public static class EntitiesServiceCollectionExtensions
         services.TryAddSingleton<IEntityDefinitionRegistry, EntityDefinitionRegistry>();
         services.AddHostedService<IntegrityCheckRunner>();
 
+        // Default Layer-4 customization applier (ADR-053 §5) — no-op until the
+        // Granit.Entities.Customization module replaces the registration.
+        services.TryAddScoped<IManifestCustomizationApplier, NullManifestCustomizationApplier>();
+
         GranitActivitySourceRegistry.Register(EntityActivitySource.Name);
 
         return services;

--- a/src/Granit.Entities/Granit.Entities.csproj
+++ b/src/Granit.Entities/Granit.Entities.csproj
@@ -10,6 +10,10 @@
     <InternalsVisibleTo Include="Granit.Entities.Tests" />
     <InternalsVisibleTo Include="Granit.Entities.Endpoints" />
     <InternalsVisibleTo Include="Granit.Entities.Endpoints.Tests" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization.Tests" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Entities.Customization.Endpoints.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Entities/Internal/IManifestCustomizationApplier.cs
+++ b/src/Granit.Entities/Internal/IManifestCustomizationApplier.cs
@@ -1,6 +1,6 @@
-using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Manifests;
 
-namespace Granit.Entities.Endpoints.Internal;
+namespace Granit.Entities.Internal;
 
 /// <summary>
 /// Layer 4 of the manifest resolution hierarchy (ADR-053 §5) — the per-tenant
@@ -24,7 +24,7 @@ namespace Granit.Entities.Endpoints.Internal;
 /// <see cref="EntityCacheKey.EvictionTagForManifest"/> tag.
 /// </para>
 /// </remarks>
-public interface IManifestCustomizationApplier
+internal interface IManifestCustomizationApplier
 {
     /// <summary>
     /// Returns a customized copy of <paramref name="composedManifest"/> with

--- a/src/Granit.Entities/Internal/NullManifestCustomizationApplier.cs
+++ b/src/Granit.Entities/Internal/NullManifestCustomizationApplier.cs
@@ -1,6 +1,7 @@
-using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities;
+using Granit.Entities.Manifests;
 
-namespace Granit.Entities.Endpoints.Internal;
+namespace Granit.Entities.Internal;
 
 /// <summary>
 /// Default no-op <see cref="IManifestCustomizationApplier"/> registered by

--- a/src/Granit.Entities/Manifests/EntityActionManifest.cs
+++ b/src/Granit.Entities/Manifests/EntityActionManifest.cs
@@ -1,6 +1,6 @@
 using Granit.Entities.Actions;
 
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Wire shape for one action exposed on an entity manifest. Mirrors

--- a/src/Granit.Entities/Manifests/EntityActivitiesManifest.cs
+++ b/src/Granit.Entities/Manifests/EntityActivitiesManifest.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Activities opt-in section of the per-entity manifest (ADR-046 §3). Present

--- a/src/Granit.Entities/Manifests/EntityCollectionsSection.cs
+++ b/src/Granit.Entities/Manifests/EntityCollectionsSection.cs
@@ -1,6 +1,6 @@
 using Granit.Entities.Layouts;
 
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Collections facet — lists the wire identifiers of the queries / exports / dashboards

--- a/src/Granit.Entities/Manifests/EntityDetailManifest.cs
+++ b/src/Granit.Entities/Manifests/EntityDetailManifest.cs
@@ -1,6 +1,6 @@
 using Granit.Entities.Details;
 
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>One detail-view variant exposed in the manifest.</summary>
 /// <param name="Name">Variant name, unique per entity (e.g. <c>"default"</c>).</param>

--- a/src/Granit.Entities/Manifests/EntityFormManifest.cs
+++ b/src/Granit.Entities/Manifests/EntityFormManifest.cs
@@ -1,6 +1,6 @@
 using Granit.Entities.Visibility;
 
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>One form variant exposed in the manifest.</summary>
 /// <param name="Name">Variant name, unique per entity (e.g. <c>"default"</c>).</param>

--- a/src/Granit.Entities/Manifests/EntityIdentitySection.cs
+++ b/src/Granit.Entities/Manifests/EntityIdentitySection.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>Identity facet of the per-entity manifest.</summary>
 /// <param name="Name">Wire identifier.</param>

--- a/src/Granit.Entities/Manifests/EntityManifestResponse.cs
+++ b/src/Granit.Entities/Manifests/EntityManifestResponse.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Per-entity manifest payload returned by <c>GET /api/entities/{name}</c>. Every

--- a/src/Granit.Entities/Manifests/EntityPermissionsSection.cs
+++ b/src/Granit.Entities/Manifests/EntityPermissionsSection.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Permissions facet — boolean snapshot of which actions the requesting user is

--- a/src/Granit.Entities/Manifests/EntityProvenance.cs
+++ b/src/Granit.Entities/Manifests/EntityProvenance.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// Per-field attribution token added by the manifest composer (ADR-053 §6).

--- a/src/Granit.Entities/Manifests/EntityRelationsSection.cs
+++ b/src/Granit.Entities/Manifests/EntityRelationsSection.cs
@@ -1,6 +1,6 @@
 using Granit.Entities.Relations;
 
-namespace Granit.Entities.Endpoints.Dtos;
+namespace Granit.Entities.Manifests;
 
 /// <summary>
 /// One relation surfaced in the manifest's Relations facet.

--- a/tests/Granit.ArchitectureTests/ClassDesignTests.cs
+++ b/tests/Granit.ArchitectureTests/ClassDesignTests.cs
@@ -44,13 +44,7 @@ public sealed class ClassDesignTests
             Architecture, "Granit.",
             // Wolverine requires middleware constructor parameters to be public,
             // even when the interface is an internal implementation detail.
-            "Granit.Wolverine.Internal.IWolverineUserContextSetter",
-            // ADR-053 §5 layer-4 extension point: Granit.Entities.Customization.Endpoints
-            // replaces the default no-op via services.Replace, which requires the
-            // interface to be visible across assemblies. The framework keeps the
-            // applier name in the Internal namespace because callers should never
-            // resolve it directly — only the composer pipeline does.
-            "Granit.Entities.Endpoints.Internal.IManifestCustomizationApplier");
+            "Granit.Wolverine.Internal.IWolverineUserContextSetter");
 
     [Fact]
     public void Concrete_exception_classes_should_be_sealed() =>

--- a/tests/Granit.Entities.Customization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Customization.Endpoints.Tests/packages.lock.json
@@ -402,6 +402,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Entities.Customization.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Customization.EntityFrameworkCore.Tests/packages.lock.json
@@ -412,6 +412,15 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -427,6 +436,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Entities.Customization.Tests/Internal/DescriptorDeltaValidatorTests.cs
+++ b/tests/Granit.Entities.Customization.Tests/Internal/DescriptorDeltaValidatorTests.cs
@@ -1,13 +1,13 @@
 using Granit.Entities;
 using Granit.Entities.Customization.Domain;
 using Granit.Entities.Customization.Domain.Deltas;
-using Granit.Entities.Customization.Endpoints.Internal;
+using Granit.Entities.Customization.Internal;
 using Granit.Entities.Forms;
 using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.Entities.Customization.Endpoints.Tests.Internal;
+namespace Granit.Entities.Customization.Tests.Internal;
 
 public sealed class DescriptorDeltaValidatorTests
 {

--- a/tests/Granit.Entities.Customization.Tests/Internal/EntityCustomizationManifestApplierTests.cs
+++ b/tests/Granit.Entities.Customization.Tests/Internal/EntityCustomizationManifestApplierTests.cs
@@ -1,13 +1,14 @@
+using Granit.Entities;
 using Granit.Entities.Customization.Domain;
 using Granit.Entities.Customization.Domain.Deltas;
-using Granit.Entities.Customization.Endpoints.Internal;
-using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Customization.Internal;
+using Granit.Entities.Manifests;
 using Granit.MultiTenancy;
 using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.Entities.Customization.Endpoints.Tests.Internal;
+namespace Granit.Entities.Customization.Tests.Internal;
 
 public sealed class EntityCustomizationManifestApplierTests
 {

--- a/tests/Granit.Entities.Customization.Tests/packages.lock.json
+++ b/tests/Granit.Entities.Customization.Tests/packages.lock.json
@@ -101,6 +101,36 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -269,6 +299,15 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.entities": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -284,6 +323,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Entities": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )"
         }
       },
@@ -298,6 +338,44 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       }
     }

--- a/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityActivitiesManifestTests.cs
@@ -2,6 +2,7 @@ using Granit.Activities;
 using Granit.Entities.Activities;
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Endpoints.Internal;
+using Granit.Entities.Manifests;
 using NSubstitute;
 using Shouldly;
 using Xunit;

--- a/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
+++ b/tests/Granit.Entities.Endpoints.Tests/EntityManifestComposerTests.cs
@@ -2,6 +2,7 @@ using Granit.Entities.Details;
 using Granit.Entities.Endpoints.Dtos;
 using Granit.Entities.Endpoints.Internal;
 using Granit.Entities.Forms;
+using Granit.Entities.Manifests;
 using Shouldly;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- Closes #1895
- Layer-purity fix: `EntityCustomizationManifestApplier` and `DescriptorDeltaValidator` were pure domain logic but lived under `Granit.Entities.Customization.Endpoints/Internal/`. They now live in `Granit.Entities.Customization/Internal/`.
- Cascade: the applier consumes `EntityManifestResponse`, `EntityFormManifest`, `EntityProvenance`, … which themselves were "value-shape DTOs consumed by domain renderers" stuck in `Granit.Entities.Endpoints/Dtos/`. Eleven of them now live in `Granit.Entities/Manifests/` (namespace `Granit.Entities.Manifests`). HTTP-bound shapes (`CalendarRangeRequest`, `EntityDiscoveryItemResponse`, `EntityFacets`, `RelationAggregatesDtos`) stay in `.Endpoints`.
- `IManifestCustomizationApplier` + `NullManifestCustomizationApplier` moved to `Granit.Entities/Internal/` and the interface is now `internal` (cross-assembly visibility via `InternalsVisibleTo`). Default no-op registration moves to `AddGranitEntities()`; the `Replace<>()` with the real applier moves to `GranitEntitiesCustomizationModule.ConfigureServices`.
- Tests for the applier + descriptor validator moved to `Granit.Entities.Customization.Tests` (matching SUT location).
- `ClassDesignTests` exclusion for `IManifestCustomizationApplier` removed — making the interface internal removes the violation entirely.
- Drive-by: condense + restructure `CLAUDE.md` (separate commit; no behavioural change).

## Why
Per CLAUDE.md "Layer purity — STRICT": non-HTTP domain orchestration must live in the base module, not in `.Endpoints`. The applier had zero HTTP / FluentValidation / FusionCache imports — only `Granit.MultiTenancy` + manifest types — yet was stuck in the HTTP layer because the manifest DTOs it consumed lived there.

## Test plan
- [x] `dotnet build` clean for `Granit.Entities`, `Granit.Entities.Customization`, `Granit.Entities.Endpoints`, `Granit.Entities.Customization.Endpoints` (0 warnings)
- [x] `Granit.Entities.Endpoints.Tests` — 86 pass
- [x] `Granit.Entities.Customization.Tests` — 25 pass (includes the 13 moved tests)
- [x] `Granit.Entities.Customization.Endpoints.Tests` — 7 pass
- [x] Architecture: `Namespace_should_match_folder_structure_in_src` and `Public_types_should_not_reside_in_Internal_namespaces` pass
- [x] Net result: zero reference from `Granit.Entities.Customization` to `Granit.Entities.Endpoints`

## Out of scope
Two unrelated arch test failures (`Internal_types_should_not_be_at_module_root`, `Endpoint_classes_should_reside_in_Endpoints_folder`) reproduce on `develop` and were introduced by the namespace flattening in #1898. Tracked separately.