### PR TITLE
feat(security): API key pepper via versioned HMAC-SHA256 hash

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35475,12 +35475,6 @@
           "kind": "method",
           "signature": "RecordContextSwitched(string? tenantId)",
           "returnType": "void"
-        },
-        {
-          "name": "RecordMembershipRejected",
-          "kind": "method",
-          "signature": "RecordMembershipRejected()",
-          "returnType": "void"
         }
       ]
     },
@@ -36253,22 +36247,6 @@
           "kind": "method",
           "signature": "DeactivateAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "IUserTenantMembershipReader",
-      "fqn": "Granit.MultiTenancy.Stores.IUserTenantMembershipReader",
-      "kind": "interface",
-      "project": "Granit.MultiTenancy",
-      "file": "src/Granit.MultiTenancy/Stores/IUserTenantMembershipReader.cs",
-      "line": 30,
-      "members": [
-        {
-          "name": "IsMemberAsync",
-          "kind": "method",
-          "signature": "IsMemberAsync(string userId, Guid tenantId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<bool>"
         }
       ]
     },
@@ -62221,7 +62199,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs",
-      "line": 30,
+      "line": 33,
       "members": [
         {
           "name": "Before",

--- a/src/Granit.Authentication.ApiKeys/Extensions/ApiKeyServiceCollectionExtensions.cs
+++ b/src/Granit.Authentication.ApiKeys/Extensions/ApiKeyServiceCollectionExtensions.cs
@@ -22,16 +22,18 @@ public static class ApiKeyServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // Register the API key generator
+        // Register the API key generator + the versioned hasher it depends on
+        services.TryAddSingleton<IApiKeyHasher, ApiKeyHasher>();
         services.TryAddSingleton<IApiKeyGenerator, ApiKeyGenerator>();
         services.TryAddSingleton<ApiKeysMetrics>();
 
-        // Module-level options (lead time for expiring-soon scanner, etc.).
+        // Module-level options (lead time for expiring-soon scanner, pepper, etc.).
         // The scanner itself ships in Granit.Authentication.ApiKeys.BackgroundJobs;
         // binding here keeps host configuration in one place.
         services.AddOptions<ApiKeysOptions>()
             .BindConfiguration(ApiKeysOptions.SectionName)
             .ValidateDataAnnotations()
+            .Validate(ValidatePepper, "ApiKeys:Pepper must be base64-encoded and decode to at least 32 bytes (256 bits) when configured.")
             .ValidateOnStart();
 
         // Add the authentication scheme
@@ -41,5 +43,23 @@ public static class ApiKeyServiceCollectionExtensions
                 configureOptions);
 
         return services;
+    }
+
+    private static bool ValidatePepper(ApiKeysOptions options)
+    {
+        if (string.IsNullOrEmpty(options.Pepper))
+        {
+            return true;
+        }
+
+        try
+        {
+            byte[] decoded = Convert.FromBase64String(options.Pepper);
+            return decoded.Length >= 32;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyAuthenticationHandler.cs
@@ -29,10 +29,13 @@ internal sealed partial class ApiKeyAuthenticationHandler(
     ILoggerFactory logger,
     UrlEncoder encoder,
     IApiKeyStore store,
+    IApiKeyHasher hasher,
     IClock clock,
     IApiKeyCacheService? cacheService = null)
     : AuthenticationHandler<ApiKeyOptions>(options, logger, encoder)
 {
+    private readonly IApiKeyHasher _hasher = hasher;
+
     /// <inheritdoc/>
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
@@ -50,11 +53,18 @@ internal sealed partial class ApiKeyAuthenticationHandler(
             return AuthenticateResult.NoResult();
         }
 
-        string hashedKey = ApiKeyGenerator.ComputeSha256(token);
-
-        // Lookup: cache first (if available), then store
-        ApiKeyEntry? apiKey = await ResolveApiKeyAsync(hashedKey, Context.RequestAborted)
-            .ConfigureAwait(false);
+        // Try every accepted hash variant (v2-then-v1 when peppered, v1 only otherwise).
+        // Returns on the first hit so the cache absorbs the common case to a single lookup.
+        ApiKeyEntry? apiKey = null;
+        foreach (string candidate in _hasher.ComputeCandidateHashes(token))
+        {
+            apiKey = await ResolveApiKeyAsync(candidate, Context.RequestAborted)
+                .ConfigureAwait(false);
+            if (apiKey is not null)
+            {
+                break;
+            }
+        }
 
         if (apiKey is null)
         {

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyGenerator.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyGenerator.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Granit.Authentication.ApiKeys.Internal;
 
@@ -9,11 +8,15 @@ namespace Granit.Authentication.ApiKeys.Internal;
 /// <remarks>
 /// Key format: <c>gk_{environment}_{typeCode}_{random}</c> where <c>random</c>
 /// is 32 bytes of <see cref="RandomNumberGenerator"/> output encoded as base62.
+/// The persisted hash is delegated to <see cref="IApiKeyHasher"/> and is
+/// versioned (<c>v1$</c> = SHA-256 only, <c>v2$</c> = HMAC-SHA256 with pepper).
 /// </remarks>
-internal sealed class ApiKeyGenerator : IApiKeyGenerator
+internal sealed class ApiKeyGenerator(IApiKeyHasher hasher) : IApiKeyGenerator
 {
     private const int RandomByteCount = 32;
     private const string Base62Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    private readonly IApiKeyHasher _hasher = hasher;
 
     /// <inheritdoc/>
     public ApiKeyGenerationResult Generate(ApiKeyType type, string environment)
@@ -23,16 +26,10 @@ internal sealed class ApiKeyGenerator : IApiKeyGenerator
         string prefix = $"gk_{environment}_{GetTypeCode(type)}_";
         string random = GenerateRandomBase62(RandomByteCount);
         string rawSecret = $"{prefix}{random}";
-        string hashedKey = ComputeSha256(rawSecret);
+        string hashedKey = _hasher.ComputeCurrentHash(rawSecret);
         string lastFour = rawSecret[^4..];
 
         return new ApiKeyGenerationResult(rawSecret, hashedKey, prefix, lastFour);
-    }
-
-    internal static string ComputeSha256(string input)
-    {
-        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
-        return Convert.ToHexStringLower(hash);
     }
 
     private static string GetTypeCode(ApiKeyType type) => type switch

--- a/src/Granit.Authentication.ApiKeys/Internal/ApiKeyHasher.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/ApiKeyHasher.cs
@@ -1,0 +1,56 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Authentication.ApiKeys.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Authentication.ApiKeys.Internal;
+
+/// <summary>
+/// Default <see cref="IApiKeyHasher"/> implementation. Reads the pepper from
+/// <see cref="ApiKeysOptions.Pepper"/> at startup and selects the hashing
+/// scheme accordingly.
+/// </summary>
+internal sealed class ApiKeyHasher : IApiKeyHasher
+{
+    internal const string V1Prefix = "v1$";
+    internal const string V2Prefix = "v2$";
+
+    private readonly byte[]? _pepper;
+
+    public ApiKeyHasher(IOptions<ApiKeysOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        string? raw = options.Value.Pepper;
+        _pepper = string.IsNullOrEmpty(raw) ? null : Convert.FromBase64String(raw);
+    }
+
+    public bool IsPeppered => _pepper is not null;
+
+    public string ComputeCurrentHash(string rawKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rawKey);
+        return _pepper is null ? ComputeV1(rawKey) : ComputeV2(rawKey, _pepper);
+    }
+
+    public IReadOnlyList<string> ComputeCandidateHashes(string rawKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rawKey);
+        // v2 first when pepper is configured, then v1 fallback for keys
+        // issued before the pepper was set.
+        return _pepper is null
+            ? [ComputeV1(rawKey)]
+            : [ComputeV2(rawKey, _pepper), ComputeV1(rawKey)];
+    }
+
+    private static string ComputeV1(string rawKey)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
+        return V1Prefix + Convert.ToHexStringLower(hash);
+    }
+
+    private static string ComputeV2(string rawKey, byte[] pepper)
+    {
+        byte[] hash = HMACSHA256.HashData(pepper, Encoding.UTF8.GetBytes(rawKey));
+        return V2Prefix + Convert.ToHexStringLower(hash);
+    }
+}

--- a/src/Granit.Authentication.ApiKeys/Internal/IApiKeyHasher.cs
+++ b/src/Granit.Authentication.ApiKeys/Internal/IApiKeyHasher.cs
@@ -1,0 +1,24 @@
+namespace Granit.Authentication.ApiKeys.Internal;
+
+/// <summary>
+/// Computes versioned API-key hashes. The version prefix lets the framework
+/// add a server-side pepper (HMAC) to new keys without invalidating keys
+/// hashed before the pepper was configured.
+/// </summary>
+internal interface IApiKeyHasher
+{
+    /// <summary>
+    /// Computes the hash for a freshly generated key in the current preferred
+    /// format. Format: <c>v2$&lt;hmac-sha256-hex&gt;</c> when a pepper is configured,
+    /// <c>v1$&lt;sha256-hex&gt;</c> otherwise.
+    /// </summary>
+    string ComputeCurrentHash(string rawKey);
+
+    /// <summary>
+    /// Returns every hash that the framework still accepts for verification of
+    /// a presented raw key, ordered from preferred to legacy. The auth handler
+    /// queries the store with each in turn and returns on the first hit, so
+    /// keys hashed before a pepper rotation remain usable until rotated.
+    /// </summary>
+    IReadOnlyList<string> ComputeCandidateHashes(string rawKey);
+}

--- a/src/Granit.Authentication.ApiKeys/Options/ApiKeysOptions.cs
+++ b/src/Granit.Authentication.ApiKeys/Options/ApiKeysOptions.cs
@@ -22,4 +22,26 @@ public sealed class ApiKeysOptions
     /// </summary>
     [Range(1, 90)]
     public int ExpirationLeadTimeDays { get; set; } = 14;
+
+    /// <summary>
+    /// Server-side secret mixed into the API key hash via HMAC-SHA256. Without
+    /// this pepper, a database dump alone is sufficient to enumerate valid keys
+    /// against any precomputed table; with it, an attacker also needs the
+    /// pepper from the configuration / secret store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Format: base64-encoded, must decode to at least 32 bytes (256 bits).
+    /// Source it from a secret manager (Azure Key Vault, HashiCorp Vault,
+    /// Kubernetes Secret, AWS Secrets Manager) — never commit it.
+    /// </para>
+    /// <para>
+    /// When unset, new keys are stored with the legacy <c>v1$&lt;sha256&gt;</c>
+    /// format. When set, new keys are stored with <c>v2$&lt;hmac-sha256&gt;</c>;
+    /// existing v1 keys remain valid (the auth handler falls back from v2 to
+    /// v1 lookup) until rotated. Configure the pepper as soon as practical
+    /// to harden new key issuance.
+    /// </para>
+    /// </remarks>
+    public string? Pepper { get; set; }
 }

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -23,7 +23,10 @@ public sealed class ApiKeyAuthenticationHandlerTests
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly IApiKeyCacheService _cacheService = Substitute.For<IApiKeyCacheService>();
     private readonly ApiKeyOptions _options = new();
-    private readonly ApiKeyGenerator _generator = new();
+    private readonly IApiKeyHasher _hasher =
+        new ApiKeyHasher(Microsoft.Extensions.Options.Options.Create(new ApiKeysOptions()));
+    private readonly ApiKeyGenerator _generator = new(
+        new ApiKeyHasher(Microsoft.Extensions.Options.Options.Create(new ApiKeysOptions())));
 
     private static readonly DateTimeOffset Now = new(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
 
@@ -48,6 +51,7 @@ public sealed class ApiKeyAuthenticationHandlerTests
             loggerFactory,
             UrlEncoder.Default,
             _store,
+            _hasher,
             _clock,
             cacheService);
 

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyGeneratorTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyGeneratorTests.cs
@@ -1,4 +1,6 @@
 using Granit.Authentication.ApiKeys.Internal;
+using Granit.Authentication.ApiKeys.Options;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -6,7 +8,12 @@ namespace Granit.Authentication.ApiKeys.Tests;
 
 public sealed class ApiKeyGeneratorTests
 {
-    private readonly ApiKeyGenerator _sut = new();
+    private static ApiKeyGenerator Create(string? pepper = null)
+    {
+        IApiKeyHasher hasher = new ApiKeyHasher(
+            Microsoft.Extensions.Options.Options.Create(new ApiKeysOptions { Pepper = pepper }));
+        return new ApiKeyGenerator(hasher);
+    }
 
     [Theory]
     [InlineData(ApiKeyType.Secret, "live", "gk_live_sk_")]
@@ -15,7 +22,7 @@ public sealed class ApiKeyGeneratorTests
     [InlineData(ApiKeyType.Ephemeral, "dev", "gk_dev_ep_")]
     public void Generate_ProducesCorrectPrefix(ApiKeyType type, string env, string expectedPrefix)
     {
-        ApiKeyGenerationResult result = _sut.Generate(type, env);
+        ApiKeyGenerationResult result = Create().Generate(type, env);
 
         result.RawSecret.ShouldStartWith(expectedPrefix);
         result.Prefix.ShouldBe(expectedPrefix);
@@ -24,25 +31,34 @@ public sealed class ApiKeyGeneratorTests
     [Fact]
     public void Generate_RawSecretHasSufficientLength()
     {
-        ApiKeyGenerationResult result = _sut.Generate(ApiKeyType.Secret, "live");
+        ApiKeyGenerationResult result = Create().Generate(ApiKeyType.Secret, "live");
 
         // Prefix (11 chars "gk_live_sk_") + 32 random chars = 43 characters
         result.RawSecret.Length.ShouldBeGreaterThanOrEqualTo(43);
     }
 
     [Fact]
-    public void Generate_HashedKeyIsSha256OfRawSecret()
+    public void Generate_WithoutPepper_HashedKeyIsV1()
     {
-        ApiKeyGenerationResult result = _sut.Generate(ApiKeyType.Secret, "live");
+        ApiKeyGenerationResult result = Create().Generate(ApiKeyType.Secret, "live");
 
-        string expected = ApiKeyGenerator.ComputeSha256(result.RawSecret);
-        result.HashedKey.ShouldBe(expected);
+        result.HashedKey.ShouldStartWith("v1$");
+    }
+
+    [Fact]
+    public void Generate_WithPepper_HashedKeyIsV2()
+    {
+        // 32-byte pepper, base64-encoded.
+        string pepper = Convert.ToBase64String(new byte[32]);
+        ApiKeyGenerationResult result = Create(pepper).Generate(ApiKeyType.Secret, "live");
+
+        result.HashedKey.ShouldStartWith("v2$");
     }
 
     [Fact]
     public void Generate_LastFourCharsMatchRawSecret()
     {
-        ApiKeyGenerationResult result = _sut.Generate(ApiKeyType.Secret, "live");
+        ApiKeyGenerationResult result = Create().Generate(ApiKeyType.Secret, "live");
 
         result.LastFourChars.ShouldBe(result.RawSecret[^4..]);
     }
@@ -50,34 +66,17 @@ public sealed class ApiKeyGeneratorTests
     [Fact]
     public void Generate_ProducesUniqueKeys()
     {
+        ApiKeyGenerator sut = Create();
         var hashes = new HashSet<string>();
 
         for (int i = 0; i < 1000; i++)
         {
-            ApiKeyGenerationResult result = _sut.Generate(ApiKeyType.Secret, "live");
+            ApiKeyGenerationResult result = sut.Generate(ApiKeyType.Secret, "live");
             hashes.Add(result.HashedKey).ShouldBeTrue($"Duplicate key at iteration {i}");
         }
     }
 
     [Fact]
     public void Generate_ThrowsOnNullEnvironment() =>
-        Should.Throw<ArgumentNullException>(() => _sut.Generate(ApiKeyType.Secret, null!));
-
-    [Fact]
-    public void ComputeSha256_IsDeterministic()
-    {
-        string hash1 = ApiKeyGenerator.ComputeSha256("test-input");
-        string hash2 = ApiKeyGenerator.ComputeSha256("test-input");
-
-        hash1.ShouldBe(hash2);
-    }
-
-    [Fact]
-    public void ComputeSha256_ProducesHexString()
-    {
-        string hash = ApiKeyGenerator.ComputeSha256("test");
-
-        hash.Length.ShouldBe(64); // SHA-256 = 32 bytes = 64 hex chars
-        hash.ShouldMatch("^[0-9a-f]{64}$");
-    }
+        Should.Throw<ArgumentNullException>(() => Create().Generate(ApiKeyType.Secret, null!));
 }

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyHasherTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyHasherTests.cs
@@ -1,0 +1,87 @@
+using Granit.Authentication.ApiKeys.Internal;
+using Granit.Authentication.ApiKeys.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.ApiKeys.Tests;
+
+public sealed class ApiKeyHasherTests
+{
+    private static ApiKeyHasher Create(string? pepper = null) =>
+        new(Microsoft.Extensions.Options.Options.Create(new ApiKeysOptions { Pepper = pepper }));
+
+    [Fact]
+    public void Current_WithoutPepper_IsV1Sha256()
+    {
+        ApiKeyHasher sut = Create();
+
+        string hash = sut.ComputeCurrentHash("gk_test_sk_abc");
+
+        hash.ShouldStartWith("v1$");
+        // SHA-256 hex = 64 chars + 3 prefix chars
+        hash.Length.ShouldBe(67);
+    }
+
+    [Fact]
+    public void Current_WithPepper_IsV2Hmac()
+    {
+        string pepper = Convert.ToBase64String(new byte[32]);
+        ApiKeyHasher sut = Create(pepper);
+
+        string hash = sut.ComputeCurrentHash("gk_test_sk_abc");
+
+        hash.ShouldStartWith("v2$");
+        hash.Length.ShouldBe(67);
+    }
+
+    [Fact]
+    public void Current_DifferentPeppers_ProduceDifferentHashes()
+    {
+        // Pepper rotation produces different v2 hashes for the same raw key.
+        string pepperA = Convert.ToBase64String(Enumerable.Range(0, 32).Select(i => (byte)i).ToArray());
+        string pepperB = Convert.ToBase64String(Enumerable.Range(32, 32).Select(i => (byte)i).ToArray());
+
+        string hashA = Create(pepperA).ComputeCurrentHash("gk_test_sk_abc");
+        string hashB = Create(pepperB).ComputeCurrentHash("gk_test_sk_abc");
+
+        hashA.ShouldNotBe(hashB);
+    }
+
+    [Fact]
+    public void Candidates_WithoutPepper_ReturnsOnlyV1()
+    {
+        IReadOnlyList<string> candidates = Create().ComputeCandidateHashes("gk_test_sk_abc");
+
+        candidates.Count.ShouldBe(1);
+        candidates[0].ShouldStartWith("v1$");
+    }
+
+    [Fact]
+    public void Candidates_WithPepper_ReturnsV2ThenV1()
+    {
+        // Auth handler uses this list to look up keys hashed before the pepper
+        // was configured (v1) AND keys hashed after (v2) with a single hasher.
+        string pepper = Convert.ToBase64String(new byte[32]);
+        IReadOnlyList<string> candidates = Create(pepper).ComputeCandidateHashes("gk_test_sk_abc");
+
+        candidates.Count.ShouldBe(2);
+        candidates[0].ShouldStartWith("v2$");
+        candidates[1].ShouldStartWith("v1$");
+    }
+
+    [Fact]
+    public void Hashing_IsDeterministic()
+    {
+        string pepper = Convert.ToBase64String(new byte[32]);
+        ApiKeyHasher sut = Create(pepper);
+
+        sut.ComputeCurrentHash("input").ShouldBe(sut.ComputeCurrentHash("input"));
+    }
+
+    [Fact]
+    public void ComputeCurrentHash_ThrowsOnEmptyInput()
+    {
+        Should.Throw<ArgumentException>(() => Create().ComputeCurrentHash(string.Empty));
+    }
+}

--- a/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/ApiKeyServiceCollectionExtensionsTests.cs
@@ -16,6 +16,8 @@ public sealed class ApiKeyServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
         services.AddAuthentication();
 
         services.AddGranitApiKeyAuthentication();
@@ -32,6 +34,8 @@ public sealed class ApiKeyServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
         services.AddAuthentication();
 
         services.AddGranitApiKeyAuthentication();


### PR DESCRIPTION
## Summary

Closes the OWASP V2 Authentication finding from the security audit: a database dump alone is now insufficient to reverse API keys against a precomputed table — an attacker also needs the server-side pepper from the configuration / secret store.

### Hash format
- \`v1$<sha256-hex>\` — legacy, no pepper.
- \`v2$<hmac-sha256-hex>\` — peppered (HMAC-SHA256, pepper as the HMAC key).

The version prefix lives inside the persisted hash, so a single store table holds both formats during the migration window.

### Pepper
- Source: \`ApiKeysOptions.Pepper\` (\`Granit:ApiKeys:Pepper\` section).
- Format: base64-encoded, must decode to ≥ 32 bytes (256 bits).
- Validator at startup refuses misconfigured peppers (non-base64 or too short).

### Auth handler
Computes both v2 and v1 hashes when a pepper is configured (v1 only otherwise) and queries the store with each in turn. Returns on the first hit, so the cache absorbs the common case to a single lookup.

### Migration
Existing v1 keys stay valid until rotated. New keys issued after the pepper is configured are v2. **No code or data migration required.** The v1 fallback can be removed in a future release once a deployment has cycled through full key rotation.

## Test plan
- [x] \`ApiKeyHasher\`: v1 (no pepper), v2 (with pepper), pepper rotation, candidate ordering (v2 first, v1 fallback), determinism, empty input — 7 new tests
- [x] \`ApiKeyGenerator\`: v1 / v2 prefix selection, uniqueness across 1000 generations
- [x] \`ApiKeyAuthenticationHandler\`: refactored to inject \`IApiKeyHasher\`; 131/131 still green
- [x] Adjacent suites green: \`Endpoints.Tests\` 74/74, \`EntityFrameworkCore.Tests\` 35/35
- [x] \`dotnet format\` clean
- [ ] CI matrix green
- [ ] Hosts: configure \`Granit:ApiKeys:Pepper\` from secret store before next deploy