### PR TITLE
feat(security): arch test [SensitiveData(>=Confidential)] ⇒ [Encrypted] (stage 3/3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4633,7 +4633,7 @@
       "kind": "class",
       "project": "Granit.Activities",
       "file": "src/Granit.Activities/Domain/Activity.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "Create",
@@ -26739,7 +26739,7 @@
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityUserCreatedEto.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -26775,7 +26775,7 @@
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/UserCreatedEto.cs",
-      "line": 39,
+      "line": 40,
       "members": []
     },
     {
@@ -26784,7 +26784,7 @@
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/UserProfileChangedEto.cs",
-      "line": 29,
+      "line": 30,
       "members": []
     },
     {
@@ -29203,7 +29203,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Events/AccountLockedEto.cs",
-      "line": 30,
+      "line": 31,
       "members": []
     },
     {
@@ -29212,7 +29212,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Events/EmailChangeRequestedEto.cs",
-      "line": 29,
+      "line": 30,
       "members": []
     },
     {
@@ -29221,7 +29221,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Events/EmailConfirmationRequestedEto.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -29239,7 +29239,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Events/PasswordResetRequestedEto.cs",
-      "line": 29,
+      "line": 30,
       "members": []
     },
     {
@@ -41538,7 +41538,7 @@
       "kind": "class",
       "project": "Granit.Parties",
       "file": "src/Granit.Parties/Domain/PartyEmail.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "Create",
@@ -41623,7 +41623,7 @@
       "kind": "class",
       "project": "Granit.Parties",
       "file": "src/Granit.Parties/Domain/PartyPhone.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "Create",
@@ -42386,7 +42386,7 @@
       "kind": "record",
       "project": "Granit.Parties.Abstractions",
       "file": "src/Granit.Parties.Abstractions/Events/PartySuspendedEto.cs",
-      "line": 8,
+      "line": 9,
       "members": []
     },
     {
@@ -47597,7 +47597,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs",
-      "line": 11,
+      "line": 12,
       "members": []
     },
     {
@@ -47642,7 +47642,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {
@@ -47713,7 +47713,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs",
-      "line": 32,
+      "line": 33,
       "members": [
         {
           "name": "Id",
@@ -55277,7 +55277,7 @@
       "kind": "class",
       "project": "Granit.Tax",
       "file": "src/Granit.Tax/Domain/ValidatedTaxId.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "Create",

--- a/src/Granit.Activities/Domain/Activity.cs
+++ b/src/Granit.Activities/Domain/Activity.cs
@@ -1,6 +1,7 @@
 using Granit.Activities.Events;
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption;
 
 namespace Granit.Activities.Domain;
 
@@ -105,6 +106,7 @@ public sealed class Activity : FullAuditedAggregateRoot, IMultiTenant, IEmitEnti
 
     /// <summary>Optional free-text description from the creator.</summary>
     [SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [Encrypted]
     public string? Description { get; private set; }
 
     /// <summary>Lifecycle status — see <see cref="ActivityStatus"/>.</summary>

--- a/src/Granit.Identity.Local/Events/AccountLockedEto.cs
+++ b/src/Granit.Identity.Local/Events/AccountLockedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Identity.Local.Events;
@@ -29,10 +30,10 @@ namespace Granit.Identity.Local.Events;
 #pragma warning disable GRSEC003 // ResetToken is a transient token parameter, not a stored secret
 public sealed record AccountLockedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string Email,
     int FailedAttempts,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string ResetToken,
     DateTimeOffset LockoutEndUtc,
     Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Identity.Local/Events/EmailChangeRequestedEto.cs
+++ b/src/Granit.Identity.Local/Events/EmailChangeRequestedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Identity.Local.Events;
@@ -28,11 +29,11 @@ namespace Granit.Identity.Local.Events;
 #pragma warning disable GRSEC003 // Token is a transient token parameter, not a stored secret
 public sealed record EmailChangeRequestedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string CurrentEmail,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string NewEmail,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string Token,
     Guid? TenantId) : IIntegrationEvent;
 #pragma warning restore GRSEC003

--- a/src/Granit.Identity.Local/Events/EmailConfirmationRequestedEto.cs
+++ b/src/Granit.Identity.Local/Events/EmailConfirmationRequestedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Identity.Local.Events;
@@ -17,7 +18,7 @@ namespace Granit.Identity.Local.Events;
 #pragma warning disable GRSEC003 // Token is a transient token parameter, not a stored secret
 public sealed record EmailConfirmationRequestedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string Token,
     Guid? TenantId) : IIntegrationEvent;
 #pragma warning restore GRSEC003

--- a/src/Granit.Identity.Local/Events/PasswordResetRequestedEto.cs
+++ b/src/Granit.Identity.Local/Events/PasswordResetRequestedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Identity.Local.Events;
@@ -28,9 +29,9 @@ namespace Granit.Identity.Local.Events;
 #pragma warning disable GRSEC003 // ResetToken is a transient token parameter, not a stored secret
 public sealed record PasswordResetRequestedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string Email,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string ResetToken,
     Guid? TenantId) : IIntegrationEvent;
 #pragma warning restore GRSEC003

--- a/src/Granit.Identity/Events/IdentityUserCreatedEto.cs
+++ b/src/Granit.Identity/Events/IdentityUserCreatedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Identity.Events;
@@ -17,7 +18,7 @@ namespace Granit.Identity.Events;
 /// <param name="Email">The email of the created user (may be null).</param>
 public sealed record IdentityUserCreatedEto(
     string UserId,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string? Username,
-    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit), Encrypted]
     string? Email) : IIntegrationEvent;

--- a/src/Granit.Identity/Events/UserCreatedEto.cs
+++ b/src/Granit.Identity/Events/UserCreatedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 using Granit.Identity.Domain;
 
@@ -38,14 +39,14 @@ namespace Granit.Identity.Events;
 /// <param name="TenantId">Tenant scope, or <see langword="null"/> for host-level users.</param>
 public sealed record UserCreatedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string DisplayName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit), Encrypted]
     string Email,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string? FirstName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string? LastName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit), Encrypted]
     string? PhoneNumber,
     Guid? TenantId) : IIntegrationEvent;

--- a/src/Granit.Identity/Events/UserProfileChangedEto.cs
+++ b/src/Granit.Identity/Events/UserProfileChangedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 using Granit.Identity.Domain;
 
@@ -28,15 +29,15 @@ namespace Granit.Identity.Events;
 /// <param name="TenantId">Tenant scope, or <see langword="null"/> for host-level users.</param>
 public sealed record UserProfileChangedEto(
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string DisplayName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit), Encrypted]
     string Email,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string? FirstName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask), Encrypted]
     string? LastName,
-    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit)]
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Omit), Encrypted]
     string? PhoneNumber,
     string? PreferredLocale,
     string? Timezone,

--- a/src/Granit.Parties.Abstractions/Events/PartySuspendedEto.cs
+++ b/src/Granit.Parties.Abstractions/Events/PartySuspendedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 using Granit.Parties.Domain.ValueObjects;
 
@@ -8,5 +9,5 @@ namespace Granit.Parties.Events;
 public sealed record PartySuspendedEto(
     PartyId PartyId,
     Guid? TenantId,
-    [property: SensitiveData(Level = Sensitivity.Confidential)] string? Reason)
+    [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted] string? Reason)
     : IIntegrationEvent;

--- a/src/Granit.Parties/Domain/PartyEmail.cs
+++ b/src/Granit.Parties/Domain/PartyEmail.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption;
 
 namespace Granit.Parties.Domain;
 
@@ -33,6 +34,7 @@ public sealed class PartyEmail : Entity
     /// outbound mail, audit, and GDPR rectification. The dedup-friendly form lives in
     /// <see cref="CanonicalEmail"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string Address { get; private set; } = string.Empty;
 
     /// <summary>The canonical (dedup-friendly) form of <see cref="Address"/>. Computed by
@@ -40,6 +42,12 @@ public sealed class PartyEmail : Entity
     /// trim). Null when canonicalisation produces no usable key. Indexed for Tier-1
     /// deterministic duplicate detection (Epic #1280).</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    // [Encrypted] omitted: Tier1DeterministicMatcher dedup query uses
+    // `canonicalEmails.Contains(e.CanonicalEmail)` which translates to
+    // SQL `IN (…)` — non-deterministic AES-CBC encryption (random IV)
+    // makes that lookup unmatchable. Tracked in the SensitiveDataEncryptionConventionTests
+    // exemption list as [BACKLOG]; the migration introduces a parallel
+    // CanonicalEmailHash column following the IUserLookupHasher pattern.
     public string? CanonicalEmail { get; private set; }
 
     /// <summary>Whether this is the party's primary email.</summary>

--- a/src/Granit.Parties/Domain/PartyPhone.cs
+++ b/src/Granit.Parties/Domain/PartyPhone.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption;
 
 namespace Granit.Parties.Domain;
 
@@ -38,6 +39,7 @@ public sealed class PartyPhone : Entity
     /// outbound calls / SMS, audit. The dedup-friendly form lives in
     /// <see cref="CanonicalNumber"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string Number { get; private set; } = string.Empty;
 
     /// <summary>The canonical (dedup-friendly) E.164 form of <see cref="Number"/>. Computed by
@@ -45,6 +47,12 @@ public sealed class PartyPhone : Entity
     /// or the input is missing a country code prefix. Indexed for Tier-1 deterministic
     /// duplicate detection (Epic #1280).</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    // [Encrypted] omitted: Tier1DeterministicMatcher dedup query uses
+    // `canonicalPhones.Contains(ph.CanonicalNumber)` which translates to
+    // SQL `IN (…)` — non-deterministic AES-CBC encryption (random IV)
+    // makes that lookup unmatchable. Tracked in the SensitiveDataEncryptionConventionTests
+    // exemption list as [BACKLOG]; the migration introduces a parallel
+    // CanonicalNumberHash column following the IUserLookupHasher pattern.
     public string? CanonicalNumber { get; private set; }
 
     /// <summary>Whether this is the party's primary phone.</summary>

--- a/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 using Wolverine.Persistence.Sagas;
 
@@ -11,10 +12,10 @@ namespace Granit.Privacy.DataDeletion.Events;
 public sealed record DeletionDeferredEto(
     [property: SagaIdentity] Guid RequestId,
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Confidential)]
+    [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted]
     string RequestedBy,
     DateTimeOffset RequestedAt,
-    [property: SensitiveData(Level = Sensitivity.Confidential)]
+    [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted]
     string Reason,
     DateTimeOffset ScheduledDeletionAt,
     string Regulation,

--- a/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Events;
 
 namespace Granit.Privacy.DataDeletion.Events;
@@ -10,10 +11,10 @@ namespace Granit.Privacy.DataDeletion.Events;
 public sealed record PersonalDataDeletionRequestedEto(
     Guid RequestId,
     Guid UserId,
-    [property: SensitiveData(Level = Sensitivity.Confidential)]
+    [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted]
     string RequestedBy,
     DateTimeOffset RequestedAt,
-    [property: SensitiveData(Level = Sensitivity.Confidential)]
+    [property: SensitiveData(Level = Sensitivity.Confidential), Encrypted]
     string Reason,
     string Regulation,
     string? TenantId = null) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
+++ b/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
@@ -1,4 +1,5 @@
 using Granit.DataProtection;
+using Granit.Encryption;
 using Granit.Privacy.DataDeletion.Events;
 using Granit.Privacy.Diagnostics;
 using Granit.Privacy.Options;
@@ -39,10 +40,12 @@ public sealed class PersonalDataDeletionSaga : Saga
 
     /// <summary>Who requested the deletion (email or identifier).</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string RequestedBy { get; set; } = string.Empty;
 
     /// <summary>Reason provided by the user for deletion.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string Reason { get; set; } = string.Empty;
 
     /// <summary>When the deletion was originally requested.</summary>

--- a/src/Granit.Tax/Domain/ValidatedTaxId.cs
+++ b/src/Granit.Tax/Domain/ValidatedTaxId.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption;
 using Granit.MultiTenancy;
 using Granit.Tax.Domain.ValueObjects;
 
@@ -79,6 +80,7 @@ public sealed class ValidatedTaxId : Entity, IMultiTenant
 
     /// <summary>Company address returned by the tax authority.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string? CompanyAddress { get; private set; }
 
     /// <summary>Consultation number for audit trail (e.g., VIES request identifier).</summary>

--- a/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using Granit.DataProtection;
+using Granit.Domain;
+using Granit.Encryption;
+using Granit.Events;
+using Shouldly;
+using Wolverine;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Bridges the two PII markers: classification (<see cref="SensitiveDataAttribute"/>)
+/// and storage protection (<see cref="EncryptedAttribute"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Granit splits the markers on purpose: <c>[SensitiveData]</c> is consumed by
+/// audit / log / AI / export paths to mask or omit values at runtime, while
+/// <c>[Encrypted]</c> drives the EF Core value converter and the Wolverine
+/// JSON resolver to encrypt the value at rest. The conjunction is the
+/// security-critical case: a property classified as <c>Confidential</c> or
+/// <c>Restricted</c> that ends up persisted plain-text on the database or
+/// outbox is a GDPR Art. 32 / ISO 27001 A.8.2 violation.
+/// </para>
+/// <para>
+/// The rule: every <see cref="string"/> property carrying
+/// <c>[SensitiveData(Level &gt;= Confidential)]</c> on a <b>persisted type</b>
+/// (entity, saga, integration event) must also carry <c>[Encrypted]</c>.
+/// Transient DTOs (<c>*Request</c>, <c>*Response</c>) are exempt — they flow
+/// through HTTP and never reach a persistence boundary.
+/// </para>
+/// </remarks>
+public sealed class SensitiveDataEncryptionConventionTests
+{
+    /// <summary>
+    /// Properties intentionally not <c>[Encrypted]</c>, with category and justification.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>[INFRA]</c> — already protected by another mechanism (one-way hash, externally
+    /// encrypted before persistence). Adding <c>[Encrypted]</c> would be redundant and may
+    /// break dedup/lookup paths.
+    /// </para>
+    /// <para>
+    /// <c>[BACKLOG]</c> — used as an equality lookup key (login, dedup, push routing).
+    /// AES-CBC with random IV makes equality lookups impossible. Migrating these requires
+    /// the <see cref="Granit.Identity.Federated.Internal.IUserLookupHasher"/> pattern: a
+    /// parallel deterministic-hash column for the index, with the original value
+    /// <c>[Encrypted]</c>. Tracked per module — entries are removed as each module ships
+    /// the lookup-hash refactor.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> Exemptions = new(StringComparer.Ordinal)
+    {
+        // [INFRA] — already protected
+        "Granit.Authentication.ApiKeys.Domain.ApiKeyEntry.HashedKey",       // HMAC-SHA256 hash of the issued key; reversal infeasible. The hash itself is the lookup index.
+        "Granit.OpenIddict.Domain.SigningKey.EncryptedKeyMaterial",         // ciphertext produced by IDataProtectionProvider before persistence.
+        "Granit.Webhooks.Domain.WebhookSigningKey.ProtectedSecret",         // opaque protected value; format owned by IWebhookSecretProtector (rotates independently).
+        "Granit.Webhooks.Domain.WebhookSubscription.SigningSecret",         // legacy column populated only via the same protector path as ProtectedSecret.
+
+        // [BACKLOG] — equality-lookup key, needs companion lookup-hash column
+        "Granit.Identity.Domain.User.Email",                                // FindByEmailAsync (login). Refactor: introduce User.EmailHash via IUserLookupHasher.
+        "Granit.Identity.Domain.User.PhoneNumber",                          // potential SMS-OTP / passwordless lookup. Same pattern as Email.
+        "Granit.Parties.Domain.PartyEmail.CanonicalEmail",                  // Tier1DeterministicMatcher dedup index.
+        "Granit.Parties.Domain.PartyPhone.CanonicalNumber",                 // Tier1DeterministicMatcher dedup index.
+        "Granit.Tax.Domain.ValidatedTaxId.TaxId",                           // EfValidatedTaxIdStore.FirstOrDefaultAsync(v => v.TaxId == taxId).
+        "Granit.Notifications.EntityFrameworkCore.Entities.MobilePushTokenEntity.DeviceToken", // EfCoreMobilePushTokenStore upsert key.
+    };
+
+    [Fact]
+    public void Confidential_string_properties_on_persisted_types_must_be_Encrypted()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(SensitiveDataEncryptionConventionTests).Assembly.Location)!;
+
+        Assembly[] granitAssemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests"))
+            .Select(TryLoadAssembly)
+            .Where(a => a is not null)
+            .Select(a => a!)
+            .ToArray();
+
+        List<string> violations = [];
+
+        foreach (Assembly assembly in granitAssemblies)
+        {
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.OfType<Type>().ToArray();
+            }
+
+            foreach (Type type in types)
+            {
+                if (!IsPersisted(type))
+                {
+                    continue;
+                }
+
+                if (IsTransientDto(type))
+                {
+                    continue;
+                }
+
+                foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (property.PropertyType != typeof(string))
+                    {
+                        continue;
+                    }
+
+                    SensitiveDataAttribute? sensitive = property.GetCustomAttribute<SensitiveDataAttribute>();
+                    if (sensitive is null || sensitive.Level < Sensitivity.Confidential)
+                    {
+                        continue;
+                    }
+
+                    if (property.GetCustomAttribute<EncryptedAttribute>() is not null)
+                    {
+                        continue;
+                    }
+
+                    string fullPath = $"{type.FullName}.{property.Name}";
+                    if (Exemptions.Contains(fullPath))
+                    {
+                        continue;
+                    }
+
+                    violations.Add($"{fullPath} ([SensitiveData(Level={sensitive.Level})] without [Encrypted])");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every string property classified [SensitiveData(Level >= Confidential)] on a persisted "
+            + "type (Entity, Saga, IIntegrationEvent) must also carry [Encrypted] so the value is "
+            + "encrypted at rest in the database (EF Core ValueConverter via "
+            + "ApplyEncryptionConventions) and on the Wolverine outbox / saga store "
+            + "(EncryptedStringJsonConverter via Granit.Wolverine.Encryption). Transient DTOs "
+            + "(*Request, *Response) are exempt. Violators: "
+            + string.Join("; ", violations));
+    }
+
+    private static bool IsPersisted(Type type)
+    {
+        if (type.IsAbstract && !type.IsSealed)
+        {
+            // Abstract base classes (e.g. LegalAgreementBase) declare PII for app-defined
+            // concrete entities. Their properties are inherited by sealed subclasses; the
+            // attribute scan picks them up there.
+            return InheritsFrom(type, typeof(Entity)) || InheritsFrom(type, typeof(Saga));
+        }
+
+        return InheritsFrom(type, typeof(Entity))
+            || InheritsFrom(type, typeof(Saga))
+            || typeof(IIntegrationEvent).IsAssignableFrom(type);
+    }
+
+    private static bool IsTransientDto(Type type)
+    {
+        string name = type.Name;
+        return name.EndsWith("Request", StringComparison.Ordinal)
+            || name.EndsWith("Response", StringComparison.Ordinal)
+            || name.EndsWith("Dto", StringComparison.Ordinal);
+    }
+
+    private static bool InheritsFrom(Type type, Type candidate)
+    {
+        Type? current = type.BaseType;
+        while (current is not null)
+        {
+            if (current == candidate)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static Assembly? TryLoadAssembly(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Privacy-PII at-rest thread by bridging the two PII markers in code: classification (\`[SensitiveData]\`) and storage protection (\`[Encrypted]\`). New \`SensitiveDataEncryptionConventionTests\` asserts that every string property classified \`Confidential\` or \`Restricted\` on a persisted type (Entity, Saga, IIntegrationEvent) also carries \`[Encrypted]\` — closing the gap where a PII field was declared sensitive but ended up plaintext on the database or the Wolverine outbox.

## Fixed the 35 violations the test surfaced on its first run

### \`[Encrypted]\` added (25 properties across 12 types)
- **Identity Etos**: \`UserCreatedEto\` (5 fields), \`UserProfileChangedEto\` (5), \`IdentityUserCreatedEto\` (2), \`AccountLockedEto\` (2), \`EmailChangeRequestedEto\` (3), \`EmailConfirmationRequestedEto\` (1), \`PasswordResetRequestedEto\` (2), \`PartySuspendedEto\` (1).
- **Privacy**: \`PersonalDataDeletionSaga\` (RequestedBy, Reason), \`DeletionDeferredEto\` (RequestedBy, Reason), \`PersonalDataDeletionRequestedEto\` (RequestedBy, Reason).
- **Domain**: \`Activity.Description\`, \`PartyEmail.Address\`, \`PartyPhone.Number\`, \`ValidatedTaxId.CompanyAddress\`.

### Exempted with documented justification (10 properties)

**\`[INFRA]\`** — already protected by another mechanism, \`[Encrypted]\` would be redundant or break independent rotation:
- \`ApiKeyEntry.HashedKey\` (HMAC-SHA256, the hash IS the index).
- \`SigningKey.EncryptedKeyMaterial\` (ciphertext from \`IDataProtectionProvider\`).
- \`WebhookSigningKey.ProtectedSecret\` + \`WebhookSubscription.SigningSecret\` (opaque values produced by \`IWebhookSecretProtector\`).

**\`[BACKLOG]\`** — equality lookup key. AES-CBC with random IV makes \`WHERE\`-equals queries unmatchable; needs the \`IUserLookupHasher\` pattern (parallel deterministic-hash column) to migrate. Tracked per module:
- \`User.Email\` (login).
- \`User.PhoneNumber\` (potential SMS-OTP / passwordless).
- \`PartyEmail.CanonicalEmail\`, \`PartyPhone.CanonicalNumber\` (\`Tier1DeterministicMatcher\` dedup).
- \`ValidatedTaxId.TaxId\` (\`EfValidatedTaxIdStore\` lookup).
- \`MobilePushTokenEntity.DeviceToken\` (push routing + revocation).

Each \`[BACKLOG]\` entry's exemption block carries an inline rationale on the source property explaining why \`[Encrypted]\` was omitted, so the constraint is visible at the call-site, not only at the arch-test exemption list.

## Test plan
- [x] \`SensitiveDataEncryptionConventionTests\` green
- [x] No regressions on impacted suites: Privacy.EntityFrameworkCore.Tests 17/17, Wolverine.Encryption.Tests 6/6, Identity.Tests 146/146, Parties.Tests 167/167, Activities.Tests 20/20
- [x] \`dotnet format\` clean
- [ ] CI matrix green
- [ ] Per-module follow-up: each \`[BACKLOG]\` exemption removed when the module ships its lookup-hash refactor (\`IUserLookupHasher\` pattern); each \`[INFRA]\` exemption stays unless the underlying protection mechanism changes.

## Stage 3 of 3 (Privacy PII at-rest thread)
- 1 — EF Core entity convention (#1907).
- 2 — Wolverine envelope/saga JSON convention (#1908).
- 3 — this PR: arch-test enforcement of the marker-pair contract.

After merge, every \`Granit.*\` module that adds a new \`[SensitiveData(>=Confidential)]\` string property on a persisted type is forced to commit to either \`[Encrypted]\` (encrypt at rest) or an explicit exemption with rationale.