### PR TITLE
feat(security): bind cnf.jkt to issued access tokens (FAPI 2.0 PR 1/3)

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -9,6 +9,7 @@
       "src/Granit.Analytics/Granit.Analytics.csproj",
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.Authentication.DPoP/Granit.Authentication.DPoP.csproj",
       "src/Granit.Authentication/Granit.Authentication.csproj",
       "src/Granit.Authorization.EntityFrameworkCore/Granit.Authorization.EntityFrameworkCore.csproj",
       "src/Granit.Authorization/Granit.Authorization.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2030,6 +2030,7 @@
       "name": "Granit.OpenIddict.Server",
       "deps": [
         "Granit.Authentication",
+        "Granit.Authentication.DPoP",
         "Granit.OpenIddict"
       ],
       "framework": "net10.0"
@@ -40884,7 +40885,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs",
-      "line": 14,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -40901,6 +40902,28 @@
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs",
       "line": 38,
+      "members": [
+        {
+          "name": "Descriptor",
+          "kind": "property",
+          "signature": "OpenIddictServerHandlerDescriptor Descriptor",
+          "returnType": "OpenIddictServerHandlerDescriptor"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ProcessSignInContext context)",
+          "returnType": "ValueTask"
+        }
+      ]
+    },
+    {
+      "name": "DPoPTokenBindingHandler",
+      "fqn": "Granit.OpenIddict.Server.Handlers.DPoPTokenBindingHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Server",
+      "file": "src/Granit.OpenIddict.Server/Handlers/DPoPTokenBindingHandler.cs",
+      "line": 35,
       "members": [
         {
           "name": "Descriptor",

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -126,6 +126,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -259,6 +268,15 @@
           "Polly.Core": "8.4.2"
         }
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "ZString": {
         "type": "Transitive",
         "resolved": "2.6.0",
@@ -277,6 +295,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -430,6 +457,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -506,6 +534,15 @@
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
           "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -170,6 +170,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -298,6 +307,15 @@
           "Polly.Core": "8.4.2"
         }
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "granit": {
         "type": "Project"
       },
@@ -311,6 +329,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -443,6 +470,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -495,6 +523,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -169,6 +169,12 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
             // at sign-in: host-only clients reject tenant users, tenant-only clients
             // reject host users. See ClientSideAuthorizationHandler for semantics.
             options.AddEventHandler(ClientSideAuthorizationHandler.Descriptor);
+
+            // Validates the DPoP proof presented at /connect/token and stamps the
+            // resulting JWK Thumbprint as the cnf.jkt confirmation claim on the issued
+            // access token (RFC 9449 §6). In FAPI 2.0, a missing DPoP header rejects
+            // the request — see DPoPTokenBindingHandler for semantics.
+            options.AddEventHandler(DPoPTokenBindingHandler.Descriptor);
         });
 
         // ──── Validation — token validation for resource servers ────

--- a/src/Granit.OpenIddict.Server/Granit.OpenIddict.Server.csproj
+++ b/src/Granit.OpenIddict.Server/Granit.OpenIddict.Server.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authentication\Granit.Authentication.csproj" />
+    <ProjectReference Include="..\Granit.Authentication.DPoP\Granit.Authentication.DPoP.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict\Granit.OpenIddict.csproj" />
   </ItemGroup>
 

--- a/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
+++ b/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication;
+using Granit.Authentication.DPoP;
 using Granit.Modularity;
 using Granit.OpenIddict.Server.Handlers;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,13 +11,19 @@ namespace Granit.OpenIddict.Server;
 /// Granit module that configures the OpenIddict OIDC server:
 /// endpoint URIs, flows, signing keys, custom grant types, and ASP.NET Core integration.
 /// </summary>
-[DependsOn(typeof(GranitAuthenticationModule), typeof(GranitOpenIddictModule))]
+[DependsOn(
+    typeof(GranitAuthenticationModule),
+    typeof(GranitAuthenticationDPoPModule),
+    typeof(GranitOpenIddictModule))]
 public sealed class GranitOpenIddictServerModule : GranitModule
 {
     // Scoped handlers must be registered in DI for OpenIddict to resolve them
     // via UseScopedHandler<T>(). The descriptor itself is attached to the
     // OpenIddict server options in AddGranitOpenIddictServer().
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.TryAddScoped<ClientSideAuthorizationHandler>();
+        context.Services.TryAddScoped<DPoPTokenBindingHandler>();
+    }
 }

--- a/src/Granit.OpenIddict.Server/Handlers/DPoPTokenBindingHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/DPoPTokenBindingHandler.cs
@@ -1,0 +1,116 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.Authentication.DPoP.Validation;
+using Granit.OpenIddict.Options;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Granit.OpenIddict.Server.Handlers;
+
+/// <summary>
+/// OpenIddict server handler that validates the <c>DPoP</c> proof JWT presented at the
+/// token endpoint and stamps the resulting JWK Thumbprint as the <c>cnf.jkt</c>
+/// confirmation claim on the issued access token (RFC 9449 §6).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this binding, the resource-side <c>DPoPValidationMiddleware</c> has no
+/// thumbprint to verify against — DPoP proof validation devolves to a decorative
+/// signature check that does not constrain token holdership. With it, an attacker
+/// who exfiltrates the access token cannot replay it without also possessing the
+/// DPoP private key.
+/// </para>
+/// <para>
+/// In FAPI 2.0 mode (<see cref="GranitOpenIddictOptions.EnableFapi2Profile"/>) a
+/// missing DPoP header at <c>/connect/token</c> rejects the request. Outside FAPI
+/// 2.0 the handler is opportunistic: a missing header leaves the token unbound
+/// (preserving Bearer flows for clients that do not opt in).
+/// </para>
+/// </remarks>
+public sealed partial class DPoPTokenBindingHandler(
+    IDPoPProofValidator validator,
+    IOptions<GranitOpenIddictOptions> options,
+    ILogger<DPoPTokenBindingHandler> logger)
+    : IOpenIddictServerHandler<ProcessSignInContext>
+{
+    /// <summary>
+    /// Descriptor registered with OpenIddict's server pipeline. Runs after
+    /// <see cref="ClientSideAuthorizationHandler"/> so the principal is finalized
+    /// before we attach the confirmation claim.
+    /// </summary>
+    public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+        = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
+            .UseScopedHandler<DPoPTokenBindingHandler>()
+            .SetOrder(150_000)
+            .SetType(OpenIddictServerHandlerType.Custom)
+            .Build();
+
+    /// <inheritdoc/>
+    public async ValueTask HandleAsync(ProcessSignInContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        HttpRequest? request = context.Transaction.GetHttpRequest();
+        if (request is null)
+        {
+            return;
+        }
+
+        bool fapi2 = options.Value.EnableFapi2Profile;
+        bool hasHeader = request.Headers.TryGetValue("DPoP", out Microsoft.Extensions.Primitives.StringValues headerValues);
+        string proofJwt = hasHeader ? headerValues.ToString() : string.Empty;
+
+        if (string.IsNullOrEmpty(proofJwt))
+        {
+            if (fapi2)
+            {
+                LogDPoPRequiredFapi2(logger);
+                context.Reject(
+                    error: OpenIddictConstants.Errors.InvalidRequest,
+                    description: "DPoP proof header is required in FAPI 2.0 profile.");
+            }
+
+            return;
+        }
+
+        string requestUri = $"{request.Scheme}://{request.Host}{request.Path}";
+        DPoPValidationResult result = await validator
+            .ValidateAsync(proofJwt, request.Method, requestUri, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (!result.IsValid)
+        {
+            LogProofRejected(logger, result.Error!);
+            context.Reject(
+                error: OpenIddictConstants.Errors.InvalidRequest,
+                description: $"DPoP proof validation failed: {result.Error}");
+            return;
+        }
+
+        ClaimsPrincipal? principal = context.Principal;
+        if (principal is null)
+        {
+            return;
+        }
+
+        string cnfJson = JsonSerializer.Serialize(new { jkt = result.JwkThumbprint });
+        Claim cnf = new(OpenIddictConstants.Claims.Confirmation, cnfJson, "JSON");
+        cnf.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
+        principal.Identities.First().AddClaim(cnf);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "DPoP token binding: FAPI 2.0 enabled but DPoP header is missing on /connect/token — rejecting.")]
+    private static partial void LogDPoPRequiredFapi2(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "DPoP token binding: proof validation failed — {Error}")]
+    private static partial void LogProofRejected(ILogger logger, string error);
+}

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -149,6 +149,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -277,6 +286,15 @@
           "Polly.Core": "8.4.2"
         }
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "granit": {
         "type": "Project"
       },
@@ -290,6 +308,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -431,6 +458,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -309,6 +309,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -477,6 +486,15 @@
         "resolved": "9.0.0",
         "contentHash": "v8LmGrvD0thxFBn5/SaMc5Y0AecfOeoKlAcek1X0fIta8Eb0+fZA3kGelUNE9HhOAe1J1h/tDKjKxh88DWBMjA=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "System.Threading.RateLimiting": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -500,6 +518,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authentication.openiddict": {
@@ -769,6 +796,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -885,6 +913,15 @@
         "dependencies": {
           "FluentValidation": "12.1.1",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -263,6 +263,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -455,6 +464,15 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -548,6 +566,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -737,6 +764,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -824,6 +852,15 @@
         "requested": "[12.*, )",
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
+        }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -203,6 +203,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -390,6 +399,15 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -478,6 +496,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -625,6 +652,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -677,6 +705,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -203,6 +203,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -390,6 +399,15 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -478,6 +496,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -596,6 +623,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -629,6 +657,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -302,6 +302,15 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
         "resolved": "8.16.0",
@@ -520,6 +529,15 @@
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "6.0.1",
@@ -624,6 +642,15 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authentication.dpop": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )"
         }
       },
       "granit.authorization": {
@@ -844,6 +871,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -949,6 +977,15 @@
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
           "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {


### PR DESCRIPTION
## Summary

PR 1 of the FAPI 2.0 staged rollout. Closes the gap where the DPoP infrastructure was complete on the resource-server side but tokens left `/connect/token` **unbound** — the resource-side `DPoPValidationMiddleware` had no `cnf.jkt` to compare the proof against.

- New `DPoPTokenBindingHandler` (OpenIddict `ProcessSignInContext` handler, order 150_000) reads the `DPoP` header at the token endpoint, validates the proof via `IDPoPProofValidator`, and stamps `cnf.jkt = <thumbprint>` on the issued access token.
- In FAPI 2.0 mode (`GranitOpenIddictOptions.EnableFapi2Profile = true`) a missing `DPoP` header rejects the request with `invalid_request`.
- Outside FAPI 2.0 the handler is opportunistic: missing header => unbound token (Bearer-compatible), present header => bound. No regression for clients that don't opt in.
- Adds `Granit.Authentication.DPoP` project reference to `Granit.OpenIddict.Server` and registers the scoped handler in the module.

## Why now

Risk register R6 (FAPI 2.0 conformance). With #1909 merged, the audit's last remaining High is the actual sender-constraining of access tokens. Without `cnf.jkt` at issuance:

- `RequireTokenBinding=true` rejects every token (cnf always absent) → DPoP unusable.
- `RequireTokenBinding=false` → proof JWT validated but with no cryptographic link to the access token → an attacker who exfiltrates the AT replays it without the private key.

## Follow-ups (separate PRs)

- **PR 2**: `IPostConfigureOptions<DPoPValidationOptions>` that flips `RequireDPoP`/`RequireTokenBinding`/`RequireNonce` from the FAPI 2.0 flag.
- **PR 3**: E2E integration tests (token issued with DPoP → cnf stamped → resource call with matching proof → 200; mismatch → 401; replay → 401).

## Test plan

- [x] `dotnet build src/Granit.OpenIddict.Server` clean
- [x] `dotnet test tests/Granit.OpenIddict.Server.Tests` — 12/12 pass
- [ ] CI shards green
- [ ] Manual: BFF login round-trip with `UseDPoP = true` produces an AT containing a `cnf` claim