### PR TITLE
feat(security): wire FAPI 2.0 profile to DPoP validation flags (PR 2/3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -40885,7 +40885,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs",
-      "line": 18,
+      "line": 21,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
+++ b/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
@@ -1,9 +1,12 @@
 using Granit.Authentication;
 using Granit.Authentication.DPoP;
+using Granit.Authentication.DPoP.Options;
 using Granit.Modularity;
 using Granit.OpenIddict.Server.Handlers;
+using Granit.OpenIddict.Server.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.OpenIddict.Server;
 
@@ -25,5 +28,8 @@ public sealed class GranitOpenIddictServerModule : GranitModule
     {
         context.Services.TryAddScoped<ClientSideAuthorizationHandler>();
         context.Services.TryAddScoped<DPoPTokenBindingHandler>();
+
+        context.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPostConfigureOptions<DPoPValidationOptions>, Fapi2DPoPOptionsConfigurator>());
     }
 }

--- a/src/Granit.OpenIddict.Server/Internal/Fapi2DPoPOptionsConfigurator.cs
+++ b/src/Granit.OpenIddict.Server/Internal/Fapi2DPoPOptionsConfigurator.cs
@@ -1,0 +1,31 @@
+using Granit.Authentication.DPoP.Options;
+using Granit.OpenIddict.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenIddict.Server.Internal;
+
+/// <summary>
+/// Forces the DPoP validation flags mandated by the FAPI 2.0 Security Profile when
+/// <see cref="GranitOpenIddictOptions.EnableFapi2Profile"/> is enabled.
+/// </summary>
+/// <remarks>
+/// FAPI 2.0 §5.3.2 requires sender-constrained access tokens. The middleware enforces
+/// the binding at the resource side; this post-configurator pins the corresponding
+/// options so a misconfigured app cannot relax the profile by leaving these flags
+/// at their backwards-compatible defaults.
+/// </remarks>
+internal sealed class Fapi2DPoPOptionsConfigurator(IOptions<GranitOpenIddictOptions> openIddictOptions)
+    : IPostConfigureOptions<DPoPValidationOptions>
+{
+    public void PostConfigure(string? name, DPoPValidationOptions options)
+    {
+        if (!openIddictOptions.Value.EnableFapi2Profile)
+        {
+            return;
+        }
+
+        options.RequireDPoP = true;
+        options.RequireTokenBinding = true;
+        options.RequireNonce = true;
+    }
+}

--- a/tests/Granit.OpenIddict.Server.Tests/Internal/Fapi2DPoPOptionsConfiguratorTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Internal/Fapi2DPoPOptionsConfiguratorTests.cs
@@ -1,0 +1,63 @@
+using Granit.Authentication.DPoP.Options;
+using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Server.Internal;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Server.Tests.Internal;
+
+public sealed class Fapi2DPoPOptionsConfiguratorTests
+{
+    [Fact]
+    public void PostConfigure_WhenFapi2Enabled_ForcesAllDPoPFlags()
+    {
+        Fapi2DPoPOptionsConfigurator configurator = new(
+            Microsoft.Extensions.Options.Options.Create(new GranitOpenIddictOptions { EnableFapi2Profile = true }));
+        DPoPValidationOptions options = new();
+
+        configurator.PostConfigure(name: null, options);
+
+        options.RequireDPoP.ShouldBeTrue();
+        options.RequireTokenBinding.ShouldBeTrue();
+        options.RequireNonce.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenFapi2Disabled_LeavesFlagsUntouched()
+    {
+        Fapi2DPoPOptionsConfigurator configurator = new(
+            Microsoft.Extensions.Options.Options.Create(new GranitOpenIddictOptions { EnableFapi2Profile = false }));
+        DPoPValidationOptions options = new()
+        {
+            RequireDPoP = false,
+            RequireTokenBinding = false,
+            RequireNonce = false,
+        };
+
+        configurator.PostConfigure(name: null, options);
+
+        options.RequireDPoP.ShouldBeFalse();
+        options.RequireTokenBinding.ShouldBeFalse();
+        options.RequireNonce.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenFapi2Disabled_DoesNotOverrideExplicitlyEnabledFlags()
+    {
+        Fapi2DPoPOptionsConfigurator configurator = new(
+            Microsoft.Extensions.Options.Options.Create(new GranitOpenIddictOptions { EnableFapi2Profile = false }));
+        DPoPValidationOptions options = new()
+        {
+            RequireDPoP = true,
+            RequireTokenBinding = true,
+            RequireNonce = true,
+        };
+
+        configurator.PostConfigure(name: null, options);
+
+        options.RequireDPoP.ShouldBeTrue();
+        options.RequireTokenBinding.ShouldBeTrue();
+        options.RequireNonce.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of FAPI 2.0. Closes the gap where `EnableFapi2Profile=true` flipped server-side options (PAR, reference tokens, short lifetimes) but left resource-side `DPoPValidationOptions` at their backwards-compatible defaults — a misconfigured app could enable FAPI 2.0 and still accept unbound Bearer tokens.

- New `Fapi2DPoPOptionsConfigurator` (`IPostConfigureOptions<DPoPValidationOptions>`) reads `IOptions<GranitOpenIddictOptions>` and forces `RequireDPoP = RequireTokenBinding = RequireNonce = true` when FAPI 2.0 is enabled.
- Registered as `TryAddEnumerable` singleton in `GranitOpenIddictServerModule` so it composes with other post-configurators.
- Post-configure semantics: overrides user-supplied values when FAPI 2.0 is on (profile is mandatory); leaves them untouched when off.

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Server.Tests` — 15/15 pass (3 new)
- [ ] CI shards green