### PR TITLE
feat(security): apply encryption conventions in Activities, Parties, Tax DbContexts

### DIFF
--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -38,6 +38,7 @@
       "src/Granit.DocumentGeneration.Excel/Granit.DocumentGeneration.Excel.csproj",
       "src/Granit.DocumentGeneration.Pdf/Granit.DocumentGeneration.Pdf.csproj",
       "src/Granit.DocumentGeneration/Granit.DocumentGeneration.csproj",
+      "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",
       "src/Granit.Entities.Customization.Endpoints/Granit.Entities.Customization.Endpoints.csproj",

--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -29,6 +29,7 @@
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Documents.EntityFrameworkCore/Granit.Documents.EntityFrameworkCore.csproj",
       "src/Granit.Documents/Granit.Documents.csproj",
+      "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",
       "src/Granit.Events/Granit.Events.csproj",

--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -25,6 +25,8 @@
       "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
       "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.DocumentGeneration/Granit.DocumentGeneration.csproj",
+      "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
+      "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",
       "src/Granit.Features/Granit.Features.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -120,6 +120,7 @@
       "name": "Granit.Activities.EntityFrameworkCore",
       "deps": [
         "Granit.Activities",
+        "Granit.Encryption.EntityFrameworkCore",
         "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
@@ -2104,6 +2105,7 @@
     {
       "name": "Granit.Parties.EntityFrameworkCore",
       "deps": [
+        "Granit.Encryption.EntityFrameworkCore",
         "Granit.Parties",
         "Granit.Persistence.EntityFrameworkCore",
         "Granit.QueryEngine.Abstractions"
@@ -2672,6 +2674,7 @@
     {
       "name": "Granit.Tax.EntityFrameworkCore",
       "deps": [
+        "Granit.Encryption.EntityFrameworkCore",
         "Granit.Parties",
         "Granit.Persistence.EntityFrameworkCore",
         "Granit.Tax"
@@ -5010,7 +5013,7 @@
       "kind": "class",
       "project": "Granit.Activities.EntityFrameworkCore",
       "file": "src/Granit.Activities.EntityFrameworkCore/GranitActivitiesEntityFrameworkCoreModule.cs",
-      "line": 15,
+      "line": 17,
       "members": []
     },
     {
@@ -42238,7 +42241,7 @@
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/GranitPartiesEntityFrameworkCoreModule.cs",
-      "line": 10,
+      "line": 12,
       "members": []
     },
     {
@@ -55498,7 +55501,7 @@
       "kind": "class",
       "project": "Granit.Tax.EntityFrameworkCore",
       "file": "src/Granit.Tax.EntityFrameworkCore/GranitTaxEntityFrameworkCoreModule.cs",
-      "line": 10,
+      "line": 12,
       "members": []
     },
     {

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -49,6 +49,7 @@
       "src/Granit.Documents.Endpoints/Granit.Documents.Endpoints.csproj",
       "src/Granit.Documents.EntityFrameworkCore/Granit.Documents.EntityFrameworkCore.csproj",
       "src/Granit.Documents/Granit.Documents.csproj",
+      "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Entities.Abstractions/Granit.Entities.Abstractions.csproj",
       "src/Granit.Entities.Customization.Endpoints/Granit.Entities.Customization.Endpoints.csproj",

--- a/src/Granit.Activities.EntityFrameworkCore/Granit.Activities.EntityFrameworkCore.csproj
+++ b/src/Granit.Activities.EntityFrameworkCore/Granit.Activities.EntityFrameworkCore.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Granit.Activities\Granit.Activities.csproj" />
+    <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Granit.Activities.EntityFrameworkCore/GranitActivitiesEntityFrameworkCoreModule.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/GranitActivitiesEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption.EntityFrameworkCore;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
@@ -11,5 +12,6 @@ namespace Granit.Activities.EntityFrameworkCore;
 /// </summary>
 [DependsOn(
     typeof(GranitActivitiesModule),
+    typeof(GranitEncryptionEntityFrameworkCoreModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitActivitiesEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Activities.EntityFrameworkCore/Internal/ActivitiesDbContext.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/Internal/ActivitiesDbContext.cs
@@ -1,6 +1,8 @@
 using Granit.Activities.Domain;
 using Granit.Activities.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
+using Granit.Encryption;
+using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +17,7 @@ namespace Granit.Activities.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class ActivitiesDbContext(
     DbContextOptions<ActivitiesDbContext> options,
+    IStringEncryptionService encryption,
     ICurrentTenant? currentTenant = null,
     IDataFilter? dataFilter = null)
     : DbContext(options)
@@ -28,5 +31,6 @@ internal sealed class ActivitiesDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureActivitiesModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+        modelBuilder.ApplyEncryptionConventions(encryption);
     }
 }

--- a/src/Granit.Activities.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Activities.EntityFrameworkCore/packages.lock.json
@@ -190,6 +190,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
@@ -213,6 +213,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -296,6 +315,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Parties.Deduplication/packages.lock.json
+++ b/src/Granit.Parties.Deduplication/packages.lock.json
@@ -214,6 +214,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -282,6 +301,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Parties.Endpoints/packages.lock.json
+++ b/src/Granit.Parties.Endpoints/packages.lock.json
@@ -133,6 +133,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -229,6 +244,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
+++ b/src/Granit.Parties.EntityFrameworkCore/Granit.Parties.EntityFrameworkCore.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />

--- a/src/Granit.Parties.EntityFrameworkCore/GranitPartiesEntityFrameworkCoreModule.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/GranitPartiesEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption.EntityFrameworkCore;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
@@ -5,6 +6,7 @@ namespace Granit.Parties.EntityFrameworkCore;
 
 /// <summary>EF Core persistence for Granit.Parties.</summary>
 [DependsOn(
+    typeof(GranitEncryptionEntityFrameworkCoreModule),
     typeof(GranitPartiesModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitPartiesEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartiesDbContext.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartiesDbContext.cs
@@ -1,4 +1,6 @@
 using Granit.DataFiltering;
+using Granit.Encryption;
+using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Parties.Domain;
 using Granit.Parties.EntityFrameworkCore.Deduplication;
@@ -12,6 +14,7 @@ namespace Granit.Parties.EntityFrameworkCore.Internal;
 /// <summary>Dedicated EF Core <see cref="DbContext"/> for the central <see cref="Party"/> aggregate.</summary>
 internal sealed class PartiesDbContext(
     DbContextOptions<PartiesDbContext> options,
+    IStringEncryptionService encryption,
     ICurrentTenant? currentTenant = null,
     IDataFilter? dataFilter = null)
     : DbContext(options)
@@ -25,5 +28,6 @@ internal sealed class PartiesDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigurePartiesModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+        modelBuilder.ApplyEncryptionConventions(encryption);
     }
 }

--- a/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
@@ -192,6 +192,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Parties.Mergeable/packages.lock.json
+++ b/src/Granit.Parties.Mergeable/packages.lock.json
@@ -196,6 +196,15 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -278,6 +287,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Tax.EntityFrameworkCore/Granit.Tax.EntityFrameworkCore.csproj
+++ b/src/Granit.Tax.EntityFrameworkCore/Granit.Tax.EntityFrameworkCore.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Parties\Granit.Parties.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Tax\Granit.Tax.csproj" />

--- a/src/Granit.Tax.EntityFrameworkCore/GranitTaxEntityFrameworkCoreModule.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/GranitTaxEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption.EntityFrameworkCore;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
@@ -5,6 +6,7 @@ namespace Granit.Tax.EntityFrameworkCore;
 
 /// <summary>EF Core persistence for Granit.Tax.</summary>
 [DependsOn(
+    typeof(GranitEncryptionEntityFrameworkCoreModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule),
     typeof(GranitTaxModule))]
 public sealed class GranitTaxEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Tax.EntityFrameworkCore/Internal/TaxDbContext.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/Internal/TaxDbContext.cs
@@ -1,4 +1,6 @@
 using Granit.DataFiltering;
+using Granit.Encryption;
+using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Tax.Domain;
@@ -10,6 +12,7 @@ namespace Granit.Tax.EntityFrameworkCore.Internal;
 /// <summary>Dedicated EF Core DbContext for Granit.Tax.</summary>
 internal sealed class TaxDbContext(
     DbContextOptions<TaxDbContext> options,
+    IStringEncryptionService encryption,
     ICurrentTenant? currentTenant = null,
     IDataFilter? dataFilter = null)
     : DbContext(options)
@@ -23,5 +26,6 @@ internal sealed class TaxDbContext(
         base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureTaxModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+        modelBuilder.ApplyEncryptionConventions(encryption);
     }
 }

--- a/src/Granit.Tax.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Tax.EntityFrameworkCore/packages.lock.json
@@ -186,6 +186,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Activities.EntityFrameworkCore.Tests/Configurations/ActivityConfigurationTests.cs
+++ b/tests/Granit.Activities.EntityFrameworkCore.Tests/Configurations/ActivityConfigurationTests.cs
@@ -1,6 +1,7 @@
 using Granit.Activities.Domain;
 using Granit.Activities.EntityFrameworkCore;
 using Granit.Activities.EntityFrameworkCore.Internal;
+using Granit.Encryption;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;
@@ -15,9 +16,15 @@ public sealed class ActivityConfigurationTests
         DbContextOptions<ActivitiesDbContext> options = new DbContextOptionsBuilder<ActivitiesDbContext>()
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
             .Options;
-        using ActivitiesDbContext ctx = new(options);
+        using ActivitiesDbContext ctx = new(options, new PassthroughEncryption());
         return ctx.Model.FindEntityType(typeof(Activity))
             ?? throw new InvalidOperationException("Activity entity type missing from model");
+    }
+
+    private sealed class PassthroughEncryption : IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
     }
 
     [Fact]

--- a/tests/Granit.Activities.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Activities.EntityFrameworkCore.Tests/packages.lock.json
@@ -352,6 +352,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Activities": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
@@ -427,6 +428,25 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.entities.abstractions": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1480,6 +1480,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Activities": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
@@ -2611,7 +2612,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -3342,6 +3342,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authentication": "[0.1.0-dev, )",
+          "Granit.Authentication.DPoP": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
@@ -3416,6 +3417,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
@@ -3653,6 +3655,7 @@
       "granit.privacy.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Privacy": "[0.1.0-dev, )",
@@ -3945,6 +3948,7 @@
       "granit.tax.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",
@@ -4390,8 +4394,8 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.22.2",
-        "contentHash": "RYBhoTFlMRq2tiqv/8FfSRFkNz0OCY2U5AbwH5PWpI/XhI3eQp34ujVAT9gD9DqOUHKDaQvJegauypUSO6wkjQ==",
+        "resolved": "4.0.23",
+        "contentHash": "yPvCj0ITnniE8j2YVVCrTfutOfaw+a9CememSzqYL2Y7zQaKLZL6F5385zI8NqnCpw26OzU5cwmKzAC6xssbGw==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.6.1, 5.0.0)"
         }

--- a/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/Internal/EfDuplicateCandidateSinkTests.cs
+++ b/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/Internal/EfDuplicateCandidateSinkTests.cs
@@ -197,9 +197,15 @@ internal sealed class StubDbContextFactory : IDbContextFactory<PartiesDbContext>
             .Options;
     }
 
-    public PartiesDbContext CreateDbContext() => new(_options, _tenant, _filter);
+    public PartiesDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), _tenant, _filter);
     public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(new PartiesDbContext(_options, _tenant, _filter));
+        Task.FromResult(new PartiesDbContext(_options, new PassthroughEncryption(), _tenant, _filter));
+}
+
+internal sealed class PassthroughEncryption : Granit.Encryption.IStringEncryptionService
+{
+    public string Encrypt(string plainText) => plainText;
+    public string? Decrypt(string cipherText) => cipherText;
 }
 
 internal sealed class StubMeterFactory : IMeterFactory

--- a/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
@@ -431,6 +431,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -528,6 +547,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Parties.Deduplication.Tests/Internal/DeduplicationTestHelpers.cs
+++ b/tests/Granit.Parties.Deduplication.Tests/Internal/DeduplicationTestHelpers.cs
@@ -54,8 +54,14 @@ internal sealed class InMemoryPartiesDbContextFactory : IDbContextFactory<Partie
             .Options;
     }
 
-    public PartiesDbContext CreateDbContext() => new(_options, _tenant, _filter);
+    public PartiesDbContext CreateDbContext() => new(_options, new PassthroughEncryption(), _tenant, _filter);
 
     public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(new PartiesDbContext(_options, _tenant, _filter));
+        Task.FromResult(new PartiesDbContext(_options, new PassthroughEncryption(), _tenant, _filter));
+}
+
+internal sealed class PassthroughEncryption : Granit.Encryption.IStringEncryptionService
+{
+    public string Encrypt(string plainText) => plainText;
+    public string? Decrypt(string cipherText) => cipherText;
 }

--- a/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
@@ -417,6 +417,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -500,6 +519,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
@@ -439,6 +439,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -558,6 +577,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartyResolverTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartyResolverTests.cs
@@ -20,7 +20,7 @@ public sealed class EfDefaultContactResolverTests : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         StubCurrentTenant t = new();
-        await using PartiesDbContext db = new(BuildOptions(), t, _filter);
+        await using PartiesDbContext db = new(BuildOptions(), new PassthroughEncryption(), t, _filter);
         await db.Database.EnsureDeletedAsync();
     }
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartySeederTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfDefaultPartySeederTests.cs
@@ -28,7 +28,7 @@ public sealed class EfDefaultContactSeederTests : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         StubCurrentTenant t = new();
-        await using PartiesDbContext db = new(BuildOptions(), t, _filter);
+        await using PartiesDbContext db = new(BuildOptions(), new PassthroughEncryption(), t, _filter);
         await db.Database.EnsureDeletedAsync();
     }
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreScopeTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreScopeTests.cs
@@ -41,7 +41,7 @@ public sealed class EfContactStoreScopeTests : IAsyncDisposable
         // Each test scope creates its own context; cleanup is per-test via the unique DB name.
         StubCurrentTenant t = new();
         DbContextOptions<PartiesDbContext> opts = BuildOptions();
-        await using PartiesDbContext db = new(opts, t, _filter);
+        await using PartiesDbContext db = new(opts, new PassthroughEncryption(), t, _filter);
         await db.Database.EnsureDeletedAsync();
     }
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/EfPartyStoreTests.cs
@@ -232,10 +232,10 @@ public sealed class EfContactStoreTests : IAsyncDisposable
     {
         public ICurrentTenant Tenant { get; } = Substitute.For<ICurrentTenant>();
 
-        public PartiesDbContext CreateDbContext() => new(options);
+        public PartiesDbContext CreateDbContext() => new(options, new PassthroughEncryption());
 
         public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new PartiesDbContext(options));
+            Task.FromResult(new PartiesDbContext(options, new PassthroughEncryption()));
     }
 }
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartiesTestHelpers.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartiesTestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using Granit.DataFiltering;
+using Granit.Encryption;
 using Granit.MultiTenancy;
 using Granit.Parties.Diagnostics;
 using Granit.Parties.EntityFrameworkCore.Internal;
@@ -68,8 +69,14 @@ internal sealed class ScopedFactory(
     ICurrentTenant tenant,
     IDataFilter filter) : IDbContextFactory<PartiesDbContext>
 {
-    public PartiesDbContext CreateDbContext() => new(options, tenant, filter);
+    public PartiesDbContext CreateDbContext() => new(options, new PassthroughEncryption(), tenant, filter);
 
     public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(new PartiesDbContext(options, tenant, filter));
+        Task.FromResult(new PartiesDbContext(options, new PassthroughEncryption(), tenant, filter));
+}
+
+internal sealed class PassthroughEncryption : IStringEncryptionService
+{
+    public string Encrypt(string plainText) => plainText;
+    public string? Decrypt(string cipherText) => cipherText;
 }

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
@@ -37,6 +37,7 @@ public sealed class PartyCanonicalisationInterceptorTests : IAsyncDisposable
                 .EnableServiceProviderCaching(false)
                 .AddInterceptors(new PartyCanonicalisationInterceptor())
                 .Options,
+            new PassthroughEncryption(),
             _tenant,
             _filter);
 

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
@@ -404,6 +404,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -472,6 +491,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/TestPartiesDbContextFactory.cs
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/TestPartiesDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption;
 using Granit.Parties.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,7 @@ namespace Granit.Parties.Mergeable.Tests.Integration;
 internal sealed class TestPartiesDbContextFactory : IDbContextFactory<PartiesDbContext>, IAsyncDisposable
 {
     private readonly DbContextOptions<PartiesDbContext> _options;
+    private readonly IStringEncryptionService _encryption = new PassthroughEncryption();
 
     public TestPartiesDbContextFactory(string connectionString)
     {
@@ -20,10 +22,16 @@ internal sealed class TestPartiesDbContextFactory : IDbContextFactory<PartiesDbC
             .Options;
     }
 
-    public PartiesDbContext CreateDbContext() => new(_options);
+    public PartiesDbContext CreateDbContext() => new(_options, _encryption);
 
     public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult(new PartiesDbContext(_options));
+        Task.FromResult(new PartiesDbContext(_options, _encryption));
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private sealed class PassthroughEncryption : IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
+    }
 }

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
@@ -492,6 +492,15 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -581,6 +590,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Parties.Mergeable.Tests/Internal/PartyMergeableAggregateAdapterTests.cs
+++ b/tests/Granit.Parties.Mergeable.Tests/Internal/PartyMergeableAggregateAdapterTests.cs
@@ -99,9 +99,15 @@ public sealed class PartyMergeableAggregateAdapterTests
                     w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
-        public PartiesDbContext CreateDbContext() => new(_options);
+        public PartiesDbContext CreateDbContext() => new(_options, new PassthroughEncryption());
 
         public Task<PartiesDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new PartiesDbContext(_options));
+            Task.FromResult(new PartiesDbContext(_options, new PassthroughEncryption()));
+    }
+
+    private sealed class PassthroughEncryption : Granit.Encryption.IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
     }
 }

--- a/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
@@ -414,6 +414,15 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -496,6 +505,7 @@
       "granit.parties.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/Internal/EfTaxRateProviderTests.cs
@@ -236,10 +236,16 @@ public sealed class EfTaxRateProviderTests : IAsyncDisposable
     private sealed class TestFactory(DbContextOptions<TaxDbContext> options)
         : IDbContextFactory<TaxDbContext>
     {
-        public TaxDbContext CreateDbContext() => new(options);
+        public TaxDbContext CreateDbContext() => new(options, new PassthroughEncryption());
 
         public Task<TaxDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new TaxDbContext(options));
+            Task.FromResult(new TaxDbContext(options, new PassthroughEncryption()));
+    }
+
+    private sealed class PassthroughEncryption : Granit.Encryption.IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
     }
 }
 

--- a/tests/Granit.Tax.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Tax.EntityFrameworkCore.Tests/packages.lock.json
@@ -404,6 +404,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -511,6 +530,7 @@
       "granit.tax.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Parties": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Closes the silent plaintext-at-rest gap in the three remaining modules with `[Encrypted]`-marked entities. PR #1907 fixed Privacy; this PR finishes the sweep:

| DbContext | Encrypted property |
|---|---|
| `ActivitiesDbContext` | `Activity.Description` |
| `PartiesDbContext` | `PartyEmail.Address`, `PartyPhone.Number` |
| `TaxDbContext` | `ValidatedTaxId.CompanyAddress` |

Each affected `Granit.{Module}.EntityFrameworkCore` now:

- Constructor-injects `IStringEncryptionService` (mandatory — same hard-dep rationale as Privacy: silent plaintext-at-rest is worse than a missing registration at startup).
- Calls `ApplyEncryptionConventions(encryption)` after `ApplyGranitConventions(...)`.
- Project-references `Granit.Encryption.EntityFrameworkCore`.
- Module declares `[DependsOn(typeof(GranitEncryptionEntityFrameworkCoreModule))]` so transitive registration of `IStringEncryptionService` kicks in.

## Why hard-dep, not soft-dep

A nullable `IStringEncryptionService?` would let an app boot without encryption registered while the entity carries `[Encrypted]` — and silently store plaintext. Hard-dep means the app fails fast at DI resolution time. Privacy adopted this rationale; same applies here.

## Modules NOT touched (intentional)

The other ~30 framework DbContexts have no `[Encrypted]` entities. Wiring them would add a hard dep on encryption with zero current benefit. The arch test from #1909 catches future `[Encrypted]` additions; new modules pick up this pattern by mirroring it.

## Test changes

7 dependent test projects pass the new ctor argument (each ships a `PassthroughEncryption : IStringEncryptionService` test fake — same pattern as `Privacy.Tests`).

## Test plan

- [x] `dotnet test tests/Granit.Activities.EntityFrameworkCore.Tests` — 10/10
- [x] `dotnet test tests/Granit.Parties.EntityFrameworkCore.Tests` — 95/95
- [x] `dotnet test tests/Granit.Tax.EntityFrameworkCore.Tests` — 11/11
- [x] `dotnet test tests/Granit.Parties.Mergeable.Tests` — 5/5
- [x] `dotnet test tests/Granit.Parties.Deduplication.Tests` — 14/14
- [x] `dotnet test tests/Granit.Parties.Deduplication.BackgroundJobs.Tests` — 4/4
- [ ] CI shards green