### PR TITLE
chore(security): reclassify VAT/Tax IDs as Internal — no encryption mandate

### DIFF
--- a/src/Granit.Parties.Abstractions/Domain/BillingAddress.cs
+++ b/src/Granit.Parties.Abstractions/Domain/BillingAddress.cs
@@ -87,7 +87,14 @@ public sealed class BillingAddress : ValueObject
     public string Country { get; private set; } = string.Empty;
 
     /// <summary>VAT number for B2B reverse charge (e.g., <c>"BE0123456789"</c>).</summary>
-    [SensitiveData(Level = Sensitivity.Confidential)]
+    /// <remarks>
+    /// Classified <see cref="Sensitivity.Internal"/> — VAT numbers are public
+    /// registration data: they appear on every invoice the company issues, are
+    /// searchable in national registries (KBO/BCE, Companies House) and in VIES,
+    /// and the field exists precisely because the value is publicly required for
+    /// B2B reverse charge. No at-rest encryption mandate.
+    /// </remarks>
+    [SensitiveData(Level = Sensitivity.Internal)]
     public string? VatNumber { get; private set; }
 
     /// <inheritdoc />

--- a/src/Granit.Tax/Domain/ValidatedTaxId.cs
+++ b/src/Granit.Tax/Domain/ValidatedTaxId.cs
@@ -56,7 +56,16 @@ public sealed class ValidatedTaxId : Entity, IMultiTenant
     }
 
     /// <summary>The validated tax ID (e.g., "BE0123456789").</summary>
-    [SensitiveData(Level = Sensitivity.Confidential)]
+    /// <remarks>
+    /// Classified <see cref="Sensitivity.Internal"/> — not direct PII. VAT/tax IDs
+    /// are public registration data: they appear on every invoice, are searchable
+    /// in national company registries (KBO/BCE, Companies House, VIES), and the
+    /// online validation cache exists precisely because the value is public.
+    /// Sole-proprietor cases where the number doubles as the personal tax number
+    /// are still subject to publication in VIES once the business is registered.
+    /// Logged / audited as low-sensitivity — no at-rest encryption mandate.
+    /// </remarks>
+    [SensitiveData(Level = Sensitivity.Internal)]
     public string TaxId { get; private set; } = string.Empty;
 
     /// <summary>ISO 3166-1 alpha-2 country code.</summary>

--- a/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
@@ -64,7 +64,6 @@ public sealed class SensitiveDataEncryptionConventionTests
         "Granit.Identity.Domain.User.PhoneNumber",                          // potential SMS-OTP / passwordless lookup. Same pattern as Email.
         "Granit.Parties.Domain.PartyEmail.CanonicalEmail",                  // Tier1DeterministicMatcher dedup index.
         "Granit.Parties.Domain.PartyPhone.CanonicalNumber",                 // Tier1DeterministicMatcher dedup index.
-        "Granit.Tax.Domain.ValidatedTaxId.TaxId",                           // EfValidatedTaxIdStore.FirstOrDefaultAsync(v => v.TaxId == taxId).
     };
 
     [Fact]


### PR DESCRIPTION
## Summary

VAT numbers and tax IDs are **public registration data**, not direct PII:

- They appear on every invoice (legal requirement).
- Searchable in national registries (KBO/BCE, Companies House) and in VIES (open API).
- The whole point of `ValidatedTaxId` is that the cache mirrors a public online lookup — encrypting the cache key would be theatre.

Two fields reclassified `[SensitiveData(Confidential)]` → `[SensitiveData(Internal)]`:

- `ValidatedTaxId.TaxId` (cached lookup key for VIES/Stripe/HMRC).
- `BillingAddress.VatNumber` (B2B reverse-charge VAT number on `Party`).

Removes `ValidatedTaxId.TaxId` from the `[BACKLOG]` exemption list in `SensitiveDataEncryptionConventionTests` — the arch test does not gate `Internal`-classified fields, so no `[Encrypted]` / lookup-hash refactor is needed. The original `Confidential` classification was an over-call from the early audit pass; this corrects the model.

Sole-proprietor cases (where the VAT number doubles as the personal tax number) are still subject to publication in VIES once the business is registered — the public-data argument holds across the EU.

## Out of scope

- `ValidatedTaxId.CompanyAddress` (postal address — real PII) keeps `[Encrypted]`.
- `ValidatedTaxId.CompanyName` keeps default `[SensitiveData]` for masking.
- The 4 remaining `[BACKLOG]` exemptions (User.Email, User.PhoneNumber, PartyEmail.CanonicalEmail, PartyPhone.CanonicalNumber) remain — they are real PII that warrants the lookup-hash pattern.

## Test plan

- [x] `dotnet build src/Granit.Parties.Abstractions src/Granit.Tax`
- [x] `dotnet test tests/Granit.ArchitectureTests --filter SensitiveData` — passes
- [ ] CI shards green