### PR TITLE
feat(security): encrypt PartyEmail/PartyPhone canonical projections via lookup hash

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -41577,7 +41577,7 @@
           "name": "MarkPrimary",
           "kind": "method",
           "signature": "MarkPrimary(bool isPrimary)",
-          "returnType": "string? CanonicalEmail { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
+          "returnType": "string? CanonicalEmail { get; private set; } public string? CanonicalEmailHash { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
         }
       ]
     },
@@ -41662,7 +41662,7 @@
           "name": "MarkPrimary",
           "kind": "method",
           "signature": "MarkPrimary(bool isPrimary)",
-          "returnType": "string? CanonicalNumber { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
+          "returnType": "string? CanonicalNumber { get; private set; } public string? CanonicalNumberHash { get; private set; } public bool IsPrimary { get; private set; } public string? Label { get; private set; } internal void"
         }
       ]
     },
@@ -42194,7 +42194,7 @@
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitPartiesEntityFrameworkCore",
@@ -42243,6 +42243,15 @@
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/GranitPartiesEntityFrameworkCoreModule.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "PartyLookupHasherOptions",
+      "fqn": "Granit.Parties.EntityFrameworkCore.Options.PartyLookupHasherOptions",
+      "kind": "class",
+      "project": "Granit.Parties.EntityFrameworkCore",
+      "file": "src/Granit.Parties.EntityFrameworkCore/Options/PartyLookupHasherOptions.cs",
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.Parties.Deduplication/Internal/Tier1DeterministicMatcher.cs
+++ b/src/Granit.Parties.Deduplication/Internal/Tier1DeterministicMatcher.cs
@@ -30,7 +30,9 @@ namespace Granit.Parties.Deduplication.Internal;
 /// background-job or HTTP-request scopes interchangeably.
 /// </para>
 /// </remarks>
-internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbContext> contextFactory)
+internal sealed class Tier1DeterministicMatcher(
+    IDbContextFactory<PartiesDbContext> contextFactory,
+    IPartyLookupHasher hasher)
 {
     public async Task<IReadOnlyList<DuplicateCandidate>> MatchAsync(
         PartyDraft draft,
@@ -39,11 +41,14 @@ internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbConte
         ArgumentNullException.ThrowIfNull(draft);
 
         // No canonical inputs → no Tier-1 hits possible. Skip the DB round-trip.
+        // Email / phone canonical columns are encrypted at rest; equality lookups
+        // route through the parallel CanonicalEmailHash / CanonicalNumberHash
+        // index columns (peppered HMAC).
         string? canonicalTaxId = TaxIdCanonicaliser.Canonicalise(draft.TaxId);
-        List<string> canonicalEmails = CanonicaliseAll(draft.Emails, EmailCanonicaliser.Canonicalise);
-        List<string> canonicalPhones = CanonicaliseAll(draft.Phones, PhoneCanonicaliser.Canonicalise);
+        List<string> emailHashes = HashAll(draft.Emails, EmailCanonicaliser.Canonicalise);
+        List<string> phoneHashes = HashAll(draft.Phones, PhoneCanonicaliser.Canonicalise);
 
-        if (canonicalTaxId is null && canonicalEmails.Count == 0 && canonicalPhones.Count == 0)
+        if (canonicalTaxId is null && emailHashes.Count == 0 && phoneHashes.Count == 0)
         {
             return [];
         }
@@ -75,13 +80,14 @@ internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbConte
         }
 
         // ── Email — joined via the parent Party so we can apply the tenant filter on the
-        // parent (the child has no tenant column).
-        if (canonicalEmails.Count > 0)
+        // parent (the child has no tenant column). Query keyed on CanonicalEmailHash
+        // because the encrypted CanonicalEmail column cannot serve IN (…) lookups.
+        if (emailHashes.Count > 0)
         {
             List<Guid> emailMatches = await db.Parties
                 .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
                 .Where(p => p.TenantId == draftTenantId
-                    && p.Emails.Any(e => e.CanonicalEmail != null && canonicalEmails.Contains(e.CanonicalEmail)))
+                    && p.Emails.Any(e => e.CanonicalEmailHash != null && emailHashes.Contains(e.CanonicalEmailHash)))
                 .Select(p => p.Id)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -91,13 +97,13 @@ internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbConte
             }
         }
 
-        // ── Phone — same shape as email.
-        if (canonicalPhones.Count > 0)
+        // ── Phone — same shape as email, keyed on CanonicalNumberHash.
+        if (phoneHashes.Count > 0)
         {
             List<Guid> phoneMatches = await db.Parties
                 .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
                 .Where(p => p.TenantId == draftTenantId
-                    && p.Phones.Any(ph => ph.CanonicalNumber != null && canonicalPhones.Contains(ph.CanonicalNumber)))
+                    && p.Phones.Any(ph => ph.CanonicalNumberHash != null && phoneHashes.Contains(ph.CanonicalNumberHash)))
                 .Select(p => p.Id)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -115,7 +121,7 @@ internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbConte
                 Signals: kv.Value))];
     }
 
-    private static List<string> CanonicaliseAll(
+    private List<string> HashAll(
         IReadOnlyList<string>? inputs,
         Func<string?, string?> canonicaliser)
     {
@@ -127,10 +133,10 @@ internal sealed class Tier1DeterministicMatcher(IDbContextFactory<PartiesDbConte
         List<string> result = new(inputs.Count);
         foreach (string raw in inputs)
         {
-            string? canonical = canonicaliser(raw);
-            if (canonical is not null)
+            string? hash = hasher.ComputeHash(canonicaliser(raw));
+            if (hash is not null)
             {
-                result.Add(canonical);
+                result.Add(hash);
             }
         }
 

--- a/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Extensions/PartiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Parties.EntityFrameworkCore.Deduplication;
 using Granit.Parties.EntityFrameworkCore.Internal;
+using Granit.Parties.EntityFrameworkCore.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Granit.QueryEngine;
@@ -36,6 +37,14 @@ public static class PartiesEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddScoped<PartyCanonicalisationInterceptor>();
         builder.Services.AddScoped<IGranitAutoInterceptor>(sp =>
             sp.GetRequiredService<PartyCanonicalisationInterceptor>());
+
+        // Lookup hasher backing the CanonicalEmailHash / CanonicalNumberHash columns.
+        // Pepper validated at first resolution (HmacPartyLookupHasher ctor) — fail-fast
+        // on missing configuration so production deployments cannot run with a known-zero
+        // key.
+        builder.Services.AddOptions<PartyLookupHasherOptions>()
+            .Bind(builder.Configuration.GetSection(PartyLookupHasherOptions.SectionName));
+        builder.Services.TryAddSingleton<IPartyLookupHasher, HmacPartyLookupHasher>();
 
         // Tier-2 / Tier-3 thresholds — bound from the "Granit:Parties:Deduplication"
         // configuration section so apps can tune per-environment without recompiling.

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/HmacPartyLookupHasher.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/HmacPartyLookupHasher.cs
@@ -1,0 +1,63 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Parties.EntityFrameworkCore.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Parties.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// HMAC-SHA256 <see cref="IPartyLookupHasher"/>. Pepper sourced from
+/// <see cref="PartyLookupHasherOptions.Pepper"/> and validated at startup —
+/// an unset pepper fails fast so production deployments cannot accidentally
+/// run with a known-zero key.
+/// </summary>
+internal sealed class HmacPartyLookupHasher(IOptions<PartyLookupHasherOptions> options)
+    : IPartyLookupHasher
+{
+    private readonly byte[] _pepper = ResolvePepper(options.Value);
+
+    public string? ComputeHash(string? canonical)
+    {
+        if (string.IsNullOrEmpty(canonical))
+        {
+            return null;
+        }
+
+        // Canonical inputs are already canonicalised by EmailCanonicaliser /
+        // PhoneCanonicaliser (lower-case, separator-stripped) — no further
+        // normalisation here would change the hash.
+        byte[] payload = Encoding.UTF8.GetBytes(canonical);
+        byte[] digest = HMACSHA256.HashData(_pepper, payload);
+        return Convert.ToHexStringLower(digest);
+    }
+
+    private static byte[] ResolvePepper(PartyLookupHasherOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Pepper))
+        {
+            throw new InvalidOperationException(
+                "Parties:LookupHasher:Pepper is required when at-rest encryption is enabled " +
+                "on Granit.Parties. The pepper must be at least 32 bytes of high-entropy " +
+                "random data (e.g. openssl rand -hex 32) and stored separately from the " +
+                "encryption key ring so the two can be rotated independently.");
+        }
+
+        string pepper = options.Pepper.Trim();
+        if (pepper.Length % 2 == 0 && pepper.All(IsHexDigit))
+        {
+            try
+            {
+                return Convert.FromHexString(pepper);
+            }
+            catch (FormatException)
+            {
+                // fall through to UTF-8 interpretation
+            }
+        }
+
+        return Encoding.UTF8.GetBytes(pepper);
+    }
+
+    private static bool IsHexDigit(char c) =>
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/IPartyLookupHasher.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/IPartyLookupHasher.cs
@@ -1,0 +1,35 @@
+namespace Granit.Parties.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Computes deterministic lookup digests for party canonical-projection columns
+/// (<see cref="Granit.Parties.Domain.PartyEmail.CanonicalEmail"/>,
+/// <see cref="Granit.Parties.Domain.PartyPhone.CanonicalNumber"/>) so the Tier-1
+/// duplicate matcher can index them without decrypting every row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The canonical columns are encrypted at rest via
+/// <see cref="Granit.Encryption.EncryptedAttribute"/>; AES-CBC ciphertext is
+/// non-deterministic (random IV) and cannot serve the
+/// <c>WHERE canonical IN (…)</c> equality lookups that
+/// <see cref="Granit.Parties.Deduplication.Internal.Tier1DeterministicMatcher"/>
+/// performs. A parallel <c>*Hash</c> column (<c>HMAC-SHA256(pepper, canonical)</c>)
+/// is indexed instead. Same pattern as
+/// <see cref="Granit.Identity.Federated.Internal.IUserLookupHasher"/>.
+/// </para>
+/// <para>
+/// The pepper MUST be distinct from the encryption key so the two can be rotated
+/// independently. A shared key would leak re-identification risk into the
+/// encryption domain.
+/// </para>
+/// </remarks>
+internal interface IPartyLookupHasher
+{
+    /// <summary>
+    /// Computes the deterministic lookup digest of a canonical email or phone
+    /// string. Returns <see langword="null"/> when <paramref name="canonical"/>
+    /// is <see langword="null"/> or empty so callers can persist <c>null</c>
+    /// verbatim alongside a <c>null</c> canonical value.
+    /// </summary>
+    string? ComputeHash(string? canonical);
+}

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyCanonicalisationInterceptor.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyCanonicalisationInterceptor.cs
@@ -11,15 +11,20 @@ namespace Granit.Parties.EntityFrameworkCore.Internal;
 /// EF Core interceptor that populates the dedup-friendly canonical projections of party
 /// identity fields on every save:
 /// <list type="bullet">
-///   <item><see cref="PartyEmail.CanonicalEmail"/> — derived from <see cref="PartyEmail.Address"/></item>
-///   <item><see cref="PartyPhone.CanonicalNumber"/> — derived from <see cref="PartyPhone.Number"/></item>
+///   <item><see cref="PartyEmail.CanonicalEmail"/> + <see cref="PartyEmail.CanonicalEmailHash"/>
+///         — derived from <see cref="PartyEmail.Address"/></item>
+///   <item><see cref="PartyPhone.CanonicalNumber"/> + <see cref="PartyPhone.CanonicalNumberHash"/>
+///         — derived from <see cref="PartyPhone.Number"/></item>
 ///   <item><see cref="Party.TaxId"/> — overwritten in place with the canonical form (single
 ///         column by design — TaxId has a legal canonical shape, no display ambiguity)</item>
 /// </list>
-/// Powers Tier-1 deterministic duplicate detection (Epic #1280). Auto-wired via
-/// <see cref="IGranitAutoInterceptor"/> through the same path as <c>AuditingChangeTrackingInterceptor</c>.
+/// Powers Tier-1 deterministic duplicate detection (Epic #1280). The hash columns are
+/// indexed because the canonical columns themselves are encrypted at rest (random-IV
+/// AES) and cannot serve equality lookups; the hasher is keyed off a pepper distinct
+/// from the encryption key. Auto-wired via <see cref="IGranitAutoInterceptor"/>.
 /// </summary>
-internal sealed class PartyCanonicalisationInterceptor : SaveChangesInterceptor, IGranitAutoInterceptor
+internal sealed class PartyCanonicalisationInterceptor(IPartyLookupHasher hasher)
+    : SaveChangesInterceptor, IGranitAutoInterceptor
 {
     /// <inheritdoc/>
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
@@ -40,7 +45,7 @@ internal sealed class PartyCanonicalisationInterceptor : SaveChangesInterceptor,
         return result;
     }
 
-    private static void Apply(DbContextEventData eventData)
+    private void Apply(DbContextEventData eventData)
     {
         if (eventData.Context is null)
         {
@@ -89,24 +94,28 @@ internal sealed class PartyCanonicalisationInterceptor : SaveChangesInterceptor,
     // Email — preserved verbatim on Address; canonical projected to CanonicalEmail. UX
     // cost of overwriting Address would be too high (admin would see "alice+x@gmail.com"
     // collapse to "alice@gmail.com" and think the system corrupted their input).
-    private static void ApplyToEmail(PartyEmail email)
+    private void ApplyToEmail(PartyEmail email)
     {
         string? canonical = EmailCanonicaliser.Canonicalise(email.Address);
-        if (!string.Equals(canonical, email.CanonicalEmail, StringComparison.Ordinal))
+        string? hash = hasher.ComputeHash(canonical);
+        if (!string.Equals(canonical, email.CanonicalEmail, StringComparison.Ordinal)
+            || !string.Equals(hash, email.CanonicalEmailHash, StringComparison.Ordinal))
         {
-            email.SetCanonicalEmail(canonical);
+            email.SetCanonicalEmail(canonical, hash);
         }
     }
 
     // Phone — preserved verbatim on Number; canonical (E.164) projected to CanonicalNumber.
     // Same UX rationale as email: a Belgian admin recognises "+32 470 12 34 56" and would
     // be surprised to see it rewritten as "+3247012345678".
-    private static void ApplyToPhone(PartyPhone phone)
+    private void ApplyToPhone(PartyPhone phone)
     {
         string? canonical = PhoneCanonicaliser.Canonicalise(phone.Number);
-        if (!string.Equals(canonical, phone.CanonicalNumber, StringComparison.Ordinal))
+        string? hash = hasher.ComputeHash(canonical);
+        if (!string.Equals(canonical, phone.CanonicalNumber, StringComparison.Ordinal)
+            || !string.Equals(hash, phone.CanonicalNumberHash, StringComparison.Ordinal))
         {
-            phone.SetCanonicalNumber(canonical);
+            phone.SetCanonicalNumber(canonical, hash);
         }
     }
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/PartyConfiguration.cs
@@ -116,8 +116,18 @@ internal sealed class PartyEmailConfiguration : IEntityTypeConfiguration<PartyEm
 
         builder.HasKey(e => e.Id);
 
-        builder.Property(e => e.Address).HasMaxLength(320).IsRequired();
-        builder.Property(e => e.CanonicalEmail).HasMaxLength(320);
+        // Address / CanonicalEmail are encrypted at rest. Ciphertext is longer than
+        // plaintext (AES + base64 overhead); 4096 holds an RFC-5321-cap email (320 chars)
+        // wrapped as ciphertext.
+        builder.Property(e => e.Address).HasMaxLength(4096).IsRequired();
+        builder.Property(e => e.CanonicalEmail).HasMaxLength(4096);
+
+        // CanonicalEmailHash is an HMAC-SHA256 digest (32 bytes → 64 hex chars). It is
+        // NOT a secret and NOT a plain hash (peppered HMAC). Indexed for Tier-1
+        // deterministic duplicate detection since the encrypted CanonicalEmail column
+        // is non-deterministic and cannot serve WHERE … IN (…) equality lookups.
+        builder.Property(e => e.CanonicalEmailHash).HasMaxLength(64);
+
         builder.Property(e => e.IsPrimary).IsRequired();
         builder.Property(e => e.Label).HasMaxLength(64);
 
@@ -126,7 +136,7 @@ internal sealed class PartyEmailConfiguration : IEntityTypeConfiguration<PartyEm
         // Tier-1 deterministic duplicate detection (Epic #1280): non-unique because two
         // legitimately distinct parties may share an email (household, family). Tenant
         // filtering happens via JOIN on the parent Party in the dedup engine.
-        builder.HasIndex(e => e.CanonicalEmail);
+        builder.HasIndex(e => e.CanonicalEmailHash);
     }
 }
 
@@ -141,8 +151,18 @@ internal sealed class PartyPhoneConfiguration : IEntityTypeConfiguration<PartyPh
         builder.HasKey(p => p.Id);
 
         builder.Property(p => p.Kind).IsRequired();
-        builder.Property(p => p.Number).HasMaxLength(64).IsRequired();
-        builder.Property(p => p.CanonicalNumber).HasMaxLength(20);
+
+        // Number / CanonicalNumber are encrypted at rest. Ciphertext is longer than
+        // plaintext; 4096 comfortably holds the longest international phone format
+        // (E.164 max 15 digits) wrapped as ciphertext.
+        builder.Property(p => p.Number).HasMaxLength(4096).IsRequired();
+        builder.Property(p => p.CanonicalNumber).HasMaxLength(4096);
+
+        // CanonicalNumberHash is an HMAC-SHA256 digest (32 bytes → 64 hex chars).
+        // Indexed for Tier-1 deterministic duplicate detection since the encrypted
+        // CanonicalNumber column cannot serve equality lookups.
+        builder.Property(p => p.CanonicalNumberHash).HasMaxLength(64);
+
         builder.Property(p => p.IsPrimary).IsRequired();
         builder.Property(p => p.Label).HasMaxLength(64);
 
@@ -150,7 +170,7 @@ internal sealed class PartyPhoneConfiguration : IEntityTypeConfiguration<PartyPh
 
         // Tier-1 deterministic duplicate detection (Epic #1280): non-unique because two
         // legitimately distinct parties may share a phone (family, shared landline).
-        builder.HasIndex(p => p.CanonicalNumber);
+        builder.HasIndex(p => p.CanonicalNumberHash);
     }
 }
 

--- a/src/Granit.Parties.EntityFrameworkCore/Options/PartyLookupHasherOptions.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Options/PartyLookupHasherOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.Parties.EntityFrameworkCore.Options;
+
+/// <summary>
+/// Configuration for the party canonical-projection lookup hasher. The pepper
+/// is an HMAC key distinct from the encryption key; rotating it invalidates
+/// the email / phone duplicate-detection indexes and requires a backfill —
+/// schedule rotations during a maintenance window.
+/// </summary>
+public sealed class PartyLookupHasherOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Parties:LookupHasher";
+
+    /// <summary>
+    /// Gets or sets the HMAC-SHA256 pepper for canonical email / phone lookup
+    /// digests. MUST be at least 32 bytes of high-entropy random data (e.g.
+    /// <c>openssl rand -hex 32</c>) and stored separately from the encryption
+    /// key ring. Hex-encoded values are auto-decoded; everything else is taken
+    /// as raw UTF-8.
+    /// </summary>
+    public string? Pepper { get; set; }
+}

--- a/src/Granit.Parties/Domain/PartyEmail.cs
+++ b/src/Granit.Parties/Domain/PartyEmail.cs
@@ -39,16 +39,19 @@ public sealed class PartyEmail : Entity
 
     /// <summary>The canonical (dedup-friendly) form of <see cref="Address"/>. Computed by
     /// the EF canonicalisation interceptor on save (Gmail dot/plus-tag stripping, lower-case,
-    /// trim). Null when canonicalisation produces no usable key. Indexed for Tier-1
-    /// deterministic duplicate detection (Epic #1280).</summary>
+    /// trim). Null when canonicalisation produces no usable key. Encrypted at rest;
+    /// Tier-1 dedup queries go through <see cref="CanonicalEmailHash"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
-    // [Encrypted] omitted: Tier1DeterministicMatcher dedup query uses
-    // `canonicalEmails.Contains(e.CanonicalEmail)` which translates to
-    // SQL `IN (…)` — non-deterministic AES-CBC encryption (random IV)
-    // makes that lookup unmatchable. Tracked in the SensitiveDataEncryptionConventionTests
-    // exemption list as [BACKLOG]; the migration introduces a parallel
-    // CanonicalEmailHash column following the IUserLookupHasher pattern.
+    [Encrypted]
     public string? CanonicalEmail { get; private set; }
+
+    /// <summary>HMAC-SHA256 lookup digest of <see cref="CanonicalEmail"/>
+    /// (lower-case hex). Indexed for Tier-1 deterministic duplicate detection
+    /// (Epic #1280) since AES-CBC ciphertext on <see cref="CanonicalEmail"/> is
+    /// non-deterministic and cannot serve <c>WHERE … IN (…)</c> equality
+    /// lookups. Computed by the EF canonicalisation interceptor in lockstep
+    /// with <see cref="CanonicalEmail"/>.</summary>
+    public string? CanonicalEmailHash { get; private set; }
 
     /// <summary>Whether this is the party's primary email.</summary>
     public bool IsPrimary { get; private set; }
@@ -66,9 +69,13 @@ public sealed class PartyEmail : Entity
     }
 
     /// <summary>
-    /// Sets the canonical form. Called exclusively by the EF canonicalisation interceptor
-    /// at save time — never by aggregate logic, since the canonical form is a derived value
-    /// recomputable from <see cref="Address"/>.
+    /// Sets the canonical form and its lookup hash. Called exclusively by the EF
+    /// canonicalisation interceptor at save time — never by aggregate logic, since
+    /// the canonical form is a derived value recomputable from <see cref="Address"/>.
     /// </summary>
-    internal void SetCanonicalEmail(string? canonicalEmail) => CanonicalEmail = canonicalEmail;
+    internal void SetCanonicalEmail(string? canonicalEmail, string? canonicalEmailHash)
+    {
+        CanonicalEmail = canonicalEmail;
+        CanonicalEmailHash = canonicalEmailHash;
+    }
 }

--- a/src/Granit.Parties/Domain/PartyPhone.cs
+++ b/src/Granit.Parties/Domain/PartyPhone.cs
@@ -44,16 +44,19 @@ public sealed class PartyPhone : Entity
 
     /// <summary>The canonical (dedup-friendly) E.164 form of <see cref="Number"/>. Computed by
     /// the EF canonicalisation interceptor on save via libphonenumber. Null when parsing fails
-    /// or the input is missing a country code prefix. Indexed for Tier-1 deterministic
-    /// duplicate detection (Epic #1280).</summary>
+    /// or the input is missing a country code prefix. Encrypted at rest; Tier-1 dedup queries
+    /// go through <see cref="CanonicalNumberHash"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
-    // [Encrypted] omitted: Tier1DeterministicMatcher dedup query uses
-    // `canonicalPhones.Contains(ph.CanonicalNumber)` which translates to
-    // SQL `IN (…)` — non-deterministic AES-CBC encryption (random IV)
-    // makes that lookup unmatchable. Tracked in the SensitiveDataEncryptionConventionTests
-    // exemption list as [BACKLOG]; the migration introduces a parallel
-    // CanonicalNumberHash column following the IUserLookupHasher pattern.
+    [Encrypted]
     public string? CanonicalNumber { get; private set; }
+
+    /// <summary>HMAC-SHA256 lookup digest of <see cref="CanonicalNumber"/>
+    /// (lower-case hex). Indexed for Tier-1 deterministic duplicate detection
+    /// (Epic #1280) since AES-CBC ciphertext on <see cref="CanonicalNumber"/>
+    /// is non-deterministic and cannot serve <c>WHERE … IN (…)</c> equality
+    /// lookups. Computed by the EF canonicalisation interceptor in lockstep
+    /// with <see cref="CanonicalNumber"/>.</summary>
+    public string? CanonicalNumberHash { get; private set; }
 
     /// <summary>Whether this is the party's primary phone.</summary>
     public bool IsPrimary { get; private set; }
@@ -72,9 +75,13 @@ public sealed class PartyPhone : Entity
     }
 
     /// <summary>
-    /// Sets the canonical E.164 form. Called exclusively by the EF canonicalisation interceptor
-    /// at save time — never by aggregate logic, since the canonical form is a derived value
-    /// recomputable from <see cref="Number"/>.
+    /// Sets the canonical E.164 form and its lookup hash. Called exclusively by the EF
+    /// canonicalisation interceptor at save time — never by aggregate logic, since the
+    /// canonical form is a derived value recomputable from <see cref="Number"/>.
     /// </summary>
-    internal void SetCanonicalNumber(string? canonicalNumber) => CanonicalNumber = canonicalNumber;
+    internal void SetCanonicalNumber(string? canonicalNumber, string? canonicalNumberHash)
+    {
+        CanonicalNumber = canonicalNumber;
+        CanonicalNumberHash = canonicalNumberHash;
+    }
 }

--- a/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
@@ -62,8 +62,6 @@ public sealed class SensitiveDataEncryptionConventionTests
         // [BACKLOG] — equality-lookup key, needs companion lookup-hash column
         "Granit.Identity.Domain.User.Email",                                // FindByEmailAsync (login). Refactor: introduce User.EmailHash via IUserLookupHasher.
         "Granit.Identity.Domain.User.PhoneNumber",                          // potential SMS-OTP / passwordless lookup. Same pattern as Email.
-        "Granit.Parties.Domain.PartyEmail.CanonicalEmail",                  // Tier1DeterministicMatcher dedup index.
-        "Granit.Parties.Domain.PartyPhone.CanonicalNumber",                 // Tier1DeterministicMatcher dedup index.
     };
 
     [Fact]

--- a/tests/Granit.Parties.Deduplication.Tests/Internal/DeduplicationTestHelpers.cs
+++ b/tests/Granit.Parties.Deduplication.Tests/Internal/DeduplicationTestHelpers.cs
@@ -38,7 +38,7 @@ internal sealed class InMemoryPartiesDbContextFactory : IDbContextFactory<Partie
     private readonly DbContextOptions<PartiesDbContext> _options;
     private readonly StubCurrentTenant _tenant;
     private readonly DataFilter _filter;
-    private readonly PartyCanonicalisationInterceptor _canonicaliser = new();
+    private readonly PartyCanonicalisationInterceptor _canonicaliser = new(new IdentityHasher());
 
     public InMemoryPartiesDbContextFactory(string databaseName, StubCurrentTenant tenant, DataFilter filter)
     {
@@ -64,4 +64,10 @@ internal sealed class PassthroughEncryption : Granit.Encryption.IStringEncryptio
 {
     public string Encrypt(string plainText) => plainText;
     public string? Decrypt(string cipherText) => cipherText;
+}
+
+internal sealed class IdentityHasher : Granit.Parties.EntityFrameworkCore.Internal.IPartyLookupHasher
+{
+    public string? ComputeHash(string? canonical) =>
+        string.IsNullOrEmpty(canonical) ? null : $"hash:{canonical}";
 }

--- a/tests/Granit.Parties.Deduplication.Tests/Internal/DefaultPartyDuplicateDetectorTests.cs
+++ b/tests/Granit.Parties.Deduplication.Tests/Internal/DefaultPartyDuplicateDetectorTests.cs
@@ -29,7 +29,7 @@ public sealed class DefaultPartyDuplicateDetectorTests : IAsyncDisposable
         _factory = new InMemoryPartiesDbContextFactory($"composer-{Guid.NewGuid()}", _tenant, _filter);
         IOptions<PartyDeduplicationOptions> options = Options.Create(new PartyDeduplicationOptions());
 
-        Tier1DeterministicMatcher tier1 = new(_factory);
+        Tier1DeterministicMatcher tier1 = new(_factory, new IdentityHasher());
         Tier2TrigramBlocker tier2 = new(_factory, options);
         Tier3WeightedScorer tier3 = new(_factory);
 

--- a/tests/Granit.Parties.Deduplication.Tests/Internal/Tier1DeterministicMatcherTests.cs
+++ b/tests/Granit.Parties.Deduplication.Tests/Internal/Tier1DeterministicMatcherTests.cs
@@ -18,7 +18,7 @@ public sealed class Tier1DeterministicMatcherTests : IAsyncDisposable
     public Tier1DeterministicMatcherTests()
     {
         _factory = new InMemoryPartiesDbContextFactory($"tier1-{Guid.NewGuid()}", _tenant, _filter);
-        _matcher = new Tier1DeterministicMatcher(_factory);
+        _matcher = new Tier1DeterministicMatcher(_factory, new IdentityHasher());
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/Internal/PartyCanonicalisationInterceptorTests.cs
@@ -35,7 +35,7 @@ public sealed class PartyCanonicalisationInterceptorTests : IAsyncDisposable
                 .UseInMemoryDatabase(_dbName, _dbRoot)
                 .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
                 .EnableServiceProviderCaching(false)
-                .AddInterceptors(new PartyCanonicalisationInterceptor())
+                .AddInterceptors(new PartyCanonicalisationInterceptor(new IdentityHasher()))
                 .Options,
             new PassthroughEncryption(),
             _tenant,
@@ -153,5 +153,13 @@ public sealed class PartyCanonicalisationInterceptorTests : IAsyncDisposable
         await using PartiesDbContext readBack = NewContext();
         Party reloaded = await readBack.Parties.Include(x => x.Emails).FirstAsync(x => x.Id == p.Id, ct);
         reloaded.Emails.ShouldContain(e => e.Address == "Carol+Tag@GMAIL.com" && e.CanonicalEmail == "carol@gmail.com");
+    }
+
+    /// <summary>Identity hasher — for canonicalisation tests we just need a deterministic
+    /// digest function. Production uses peppered HMAC-SHA256.</summary>
+    private sealed class IdentityHasher : IPartyLookupHasher
+    {
+        public string? ComputeHash(string? canonical) =>
+            string.IsNullOrEmpty(canonical) ? null : $"hash:{canonical}";
     }
 }


### PR DESCRIPTION
## Summary

Closes the `[BACKLOG]` exemptions on `PartyEmail.CanonicalEmail` and `PartyPhone.CanonicalNumber` from PR #1909. Both columns now ship `[Encrypted]` (AES-CBC at rest); Tier-1 deterministic duplicate detection routes through parallel HMAC-SHA256 lookup-hash columns indexed in their place.

| Plaintext (encrypted) | Lookup hash (indexed) | Used by |
|---|---|---|
| `CanonicalEmail` | `CanonicalEmailHash` | `Tier1DeterministicMatcher` email path |
| `CanonicalNumber` | `CanonicalNumberHash` | `Tier1DeterministicMatcher` phone path |

## Pieces

- `IPartyLookupHasher` + `HmacPartyLookupHasher` (HMAC-SHA256, peppered, fail-fast on missing pepper).
- `PartyLookupHasherOptions.Pepper` — a secret distinct from the encryption key (independent rotation; defence-in-depth).
- `PartyCanonicalisationInterceptor` injects the hasher and now computes canonical + hash atomically on `Added`/`Modified` entries.
- `Tier1DeterministicMatcher` queries on the hash columns instead of the encrypted canonical ones.
- Aggregates enforce the pair: `SetCanonicalEmail(canonical, hash)` / `SetCanonicalNumber(canonical, hash)` — the hash CANNOT drift from the encrypted plaintext.

## Schema impact (consuming app responsibility)

Per Granit convention, no migrations ship in the framework. Apps need:

- `CanonicalEmail` / `CanonicalNumber` widened: `320`/`20` → `4096` (AES + base64 overhead).
- New columns: `CanonicalEmailHash`, `CanonicalNumberHash` (`varchar(64)`).
- Backfill hashes before re-indexing.
- Drop old indexes on `CanonicalEmail` / `CanonicalNumber`; create new indexes on the hash columns.

## Test plan

- [x] `dotnet test tests/Granit.Parties.EntityFrameworkCore.Tests` — 95/95
- [x] `dotnet test tests/Granit.Parties.Deduplication.Tests` — 14/14
- [x] `dotnet test tests/Granit.Parties.Deduplication.BackgroundJobs.Tests` — 4/4
- [x] `dotnet test tests/Granit.Parties.Mergeable.Tests` — 5/5
- [x] `dotnet test tests/Granit.ArchitectureTests --filter SensitiveData` — passes (2 BACKLOG exemptions removed)
- [ ] CI shards green

## Remaining `[BACKLOG]`

After this merges: `User.Email` and `User.PhoneNumber`. Identity module — biggest of the lot (touches AspNetIdentity).