### PR TITLE
feat(security): encrypt User.Email + User.PhoneNumber via lookup hash

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1259,6 +1259,7 @@
     {
       "name": "Granit.Identity.EntityFrameworkCore",
       "deps": [
+        "Granit.Encryption.EntityFrameworkCore",
         "Granit.Identity",
         "Granit.Persistence.EntityFrameworkCore"
       ],
@@ -26263,7 +26264,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Domain/User.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
           "name": "DisplayName",
@@ -26278,9 +26279,9 @@
           "returnType": "string"
         },
         {
-          "name": "FirstName",
+          "name": "EmailHash",
           "kind": "property",
-          "signature": "string? FirstName",
+          "signature": "string? EmailHash",
           "returnType": "string?"
         },
         {
@@ -26649,7 +26650,7 @@
       "kind": "class",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitIdentityEntityFrameworkCore",
@@ -26690,7 +26691,7 @@
       "kind": "class",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs",
-      "line": 20,
+      "line": 22,
       "members": []
     },
     {
@@ -30567,6 +30568,15 @@
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Models/IdentityUserUpdate.cs",
       "line": 22,
+      "members": []
+    },
+    {
+      "name": "UserLookupHasherOptions",
+      "fqn": "Granit.Identity.Options.UserLookupHasherOptions",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Options/UserLookupHasherOptions.cs",
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/EntityConfigurations/UserConfiguration.cs
@@ -28,18 +28,30 @@ internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
         builder.HasIndex(u => u.TenantId)
             .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}users_tenant_id");
 
-        // Email index — point lookups via IUserLookupService (case-insensitive
-        // search lives at the consumer, but the index supports the underlying
-        // equality probe). Not unique — Odoo-style: multiple Users may legitimately
-        // share an email (corporate inbox shared across role accounts).
-        builder.HasIndex(u => u.Email)
-            .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}users_email");
+        // EmailHash index — point lookups via IUserLookupService keyed on the
+        // peppered HMAC digest, since the Email column itself is encrypted at rest
+        // (random-IV AES) and cannot serve `WHERE col = ?` equality probes. Not
+        // unique — Odoo-style: multiple Users may legitimately share an email
+        // (corporate inbox shared across role accounts).
+        builder.HasIndex(u => u.EmailHash)
+            .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}users_email_hash");
 
         builder.Property(u => u.DisplayName).HasMaxLength(256).IsRequired();
-        builder.Property(u => u.Email).HasMaxLength(320).IsRequired();    // RFC 5321 max local + @ + domain
+
+        // Email + PhoneNumber are encrypted at rest. Ciphertext is longer than
+        // plaintext (AES + base64 overhead); 4096 holds the RFC-5321 email max
+        // (320 chars) and any plausible international phone format.
+        builder.Property(u => u.Email).HasMaxLength(4096).IsRequired();
+        builder.Property(u => u.PhoneNumber).HasMaxLength(4096);
+
+        // *Hash columns are HMAC-SHA256 digests (32 bytes → 64 hex chars). NOT a
+        // secret and NOT a plain hash (peppered HMAC). Indexed for the email
+        // lookup; phone hash is currently unindexed (no exact-match lookup yet).
+        builder.Property(u => u.EmailHash).HasMaxLength(64);
+        builder.Property(u => u.PhoneNumberHash).HasMaxLength(64);
+
         builder.Property(u => u.FirstName).HasMaxLength(128);
         builder.Property(u => u.LastName).HasMaxLength(128);
-        builder.Property(u => u.PhoneNumber).HasMaxLength(32);            // E.164 max
         builder.Property(u => u.PreferredLocale).HasMaxLength(20);        // BCP-47 worst case
         builder.Property(u => u.Timezone).HasMaxLength(64);               // IANA tz worst case
         builder.Property(u => u.IsEnabled).IsRequired();

--- a/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using Granit.Identity.EntityFrameworkCore.Internal;
+using Granit.Identity.Internal;
+using Granit.Identity.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -35,6 +38,22 @@ public static class IdentityEntityFrameworkCoreServiceCollectionExtensions
 
         services.TryAddScoped<IUserDirectoryQueryableSource, EfUserDirectoryQueryableSource>();
         services.TryAddScoped<IUserDirectoryWriter, EfUserDirectoryWriter>();
+
+        // Lookup hasher backing User.EmailHash / User.PhoneNumberHash. Pepper
+        // validated at first resolution (HmacUserLookupHasher ctor) — fail-fast
+        // on missing configuration so production deployments cannot run with a
+        // known-zero key.
+        services.AddOptions<UserLookupHasherOptions>()
+            .BindConfiguration(UserLookupHasherOptions.SectionName);
+        services.TryAddSingleton<IUserLookupHasher, HmacUserLookupHasher>();
+
+        // Save-time interceptor that recomputes the digests in lockstep with
+        // the encrypted plaintext columns. Registered via IGranitAutoInterceptor
+        // (same pattern as AuditingChangeTrackingInterceptor) so any DbContext
+        // wired through AddGranitDbContext picks it up.
+        services.AddScoped<UserLookupHashInterceptor>();
+        services.AddScoped<IGranitAutoInterceptor>(sp =>
+            sp.GetRequiredService<UserLookupHashInterceptor>());
 
         return services;
     }

--- a/src/Granit.Identity.EntityFrameworkCore/Granit.Identity.EntityFrameworkCore.csproj
+++ b/src/Granit.Identity.EntityFrameworkCore/Granit.Identity.EntityFrameworkCore.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption.EntityFrameworkCore;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
@@ -15,6 +16,7 @@ namespace Granit.Identity.EntityFrameworkCore;
 /// (no migrations live inside framework packages).
 /// </remarks>
 [DependsOn(
+    typeof(GranitEncryptionEntityFrameworkCoreModule),
     typeof(GranitIdentityModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitIdentityEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/IdentityDbContext.cs
@@ -1,4 +1,6 @@
 using Granit.DataFiltering;
+using Granit.Encryption;
+using Granit.Encryption.EntityFrameworkCore.Extensions;
 using Granit.Identity.Domain;
 using Granit.Identity.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
@@ -22,10 +24,12 @@ namespace Granit.Identity.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class IdentityDbContext(
     DbContextOptions<IdentityDbContext> options,
+    IStringEncryptionService encryption,
     ICurrentTenant? currentTenant = null,
     IDataFilter? dataFilter = null)
     : DbContext(options)
 {
+    private readonly IStringEncryptionService _encryption = encryption;
     private readonly ICurrentTenant? _currentTenant = currentTenant;
     private readonly IDataFilter? _dataFilter = dataFilter;
 
@@ -40,5 +44,6 @@ internal sealed class IdentityDbContext(
 
         modelBuilder.ConfigureGranitIdentityModule();
         modelBuilder.ApplyGranitConventions(_currentTenant, _dataFilter);
+        modelBuilder.ApplyEncryptionConventions(_encryption);
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/Internal/UserLookupHashInterceptor.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Internal/UserLookupHashInterceptor.cs
@@ -1,0 +1,77 @@
+using Granit.Identity.Domain;
+using Granit.Identity.Internal;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Granit.Identity.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core interceptor that keeps <see cref="User.EmailHash"/> and
+/// <see cref="User.PhoneNumberHash"/> in lockstep with the encrypted plaintext
+/// columns (<see cref="User.Email"/>, <see cref="User.PhoneNumber"/>) on every
+/// save. The encrypted columns are non-deterministic AES-CBC; admin-grid
+/// exact-match lookups index the peppered HMAC digests instead.
+/// </summary>
+/// <remarks>
+/// Auto-wired via <see cref="IGranitAutoInterceptor"/>, so any DbContext
+/// registered through <c>AddGranitDbContext</c> picks it up — same pattern as
+/// <c>AuditingChangeTrackingInterceptor</c> and
+/// <c>PartyCanonicalisationInterceptor</c>.
+/// </remarks>
+internal sealed class UserLookupHashInterceptor(IUserLookupHasher hasher)
+    : SaveChangesInterceptor, IGranitAutoInterceptor
+{
+    /// <inheritdoc/>
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        Apply(eventData);
+        return ValueTask.FromResult(result);
+    }
+
+    /// <inheritdoc/>
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        Apply(eventData);
+        return result;
+    }
+
+    private void Apply(DbContextEventData eventData)
+    {
+        if (eventData.Context is null)
+        {
+            return;
+        }
+
+        foreach (EntityEntry entry in eventData.Context.ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            if (entry.Entity is User user)
+            {
+                ApplyToUser(user);
+            }
+        }
+    }
+
+    private void ApplyToUser(User user)
+    {
+        string? emailHash = hasher.ComputeEmailHash(user.Email);
+        string? phoneHash = hasher.ComputePhoneHash(user.PhoneNumber);
+
+        if (!string.Equals(emailHash, user.EmailHash, StringComparison.Ordinal)
+            || !string.Equals(phoneHash, user.PhoneNumberHash, StringComparison.Ordinal))
+        {
+            user.SetLookupHashes(emailHash, phoneHash);
+        }
+    }
+}

--- a/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.EntityFrameworkCore/packages.lock.json
@@ -42,6 +42,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -122,6 +131,25 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.entities.abstractions": {
@@ -222,6 +250,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -280,6 +318,19 @@
         "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       }

--- a/src/Granit.Identity/Domain/User.cs
+++ b/src/Granit.Identity/Domain/User.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption;
 using Granit.Identity.Events;
 using Granit.MultiTenancy;
 
@@ -49,9 +50,18 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
     /// Login email and primary contact. Required at creation (used by
     /// recovery flows). Sync-target of <see cref="IIdentityUser.Username"/>
     /// where the local backend imposes a username-equals-email convention.
+    /// Encrypted at rest; equality lookups go through <see cref="EmailHash"/>.
     /// </summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string Email { get; private set; } = string.Empty;
+
+    /// <summary>HMAC-SHA256 lookup digest of <see cref="Email"/> (lower-case
+    /// hex). Indexed for admin-grid exact-match search since AES-CBC ciphertext
+    /// on <see cref="Email"/> is non-deterministic and cannot serve equality
+    /// lookups. Computed by the EF lookup-hash interceptor in lockstep with
+    /// <see cref="Email"/>.</summary>
+    public string? EmailHash { get; private set; }
 
     /// <summary>Given name (optional).</summary>
     [SensitiveData]
@@ -61,9 +71,18 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
     [SensitiveData]
     public string? LastName { get; private set; }
 
-    /// <summary>E.164 phone number (optional).</summary>
+    /// <summary>E.164 phone number (optional). Encrypted at rest; equality
+    /// lookups go through <see cref="PhoneNumberHash"/>.</summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string? PhoneNumber { get; private set; }
+
+    /// <summary>HMAC-SHA256 lookup digest of <see cref="PhoneNumber"/>
+    /// (lower-case hex, separators stripped). Indexed for admin-grid exact-match
+    /// search since AES-CBC ciphertext on <see cref="PhoneNumber"/> is
+    /// non-deterministic. Computed by the EF lookup-hash interceptor in
+    /// lockstep with <see cref="PhoneNumber"/>.</summary>
+    public string? PhoneNumberHash { get; private set; }
 
     /// <summary>BCP-47 culture preferred by the user (e.g. <c>"en-GB"</c>, <c>"fr"</c>).</summary>
     public string? PreferredLocale { get; private set; }
@@ -201,4 +220,17 @@ public sealed class User : AuditedAggregateRoot, IIdentityUser, IMultiTenant
 
     /// <summary>Disables sign-in for the user. Linked <c>LocalIdentity</c> and <c>FederatedIdentity</c> records survive — only the gate flips.</summary>
     public void Disable() => IsEnabled = false;
+
+    /// <summary>
+    /// Sets the lookup digests of <see cref="Email"/> and <see cref="PhoneNumber"/>.
+    /// Called exclusively by the EF lookup-hash interceptor at save time — never by
+    /// aggregate logic, since the digests are derived values recomputable from the
+    /// plaintext columns. Pair update guarantees the hash never drifts from the
+    /// encrypted value when a single column is rewritten in isolation.
+    /// </summary>
+    internal void SetLookupHashes(string? emailHash, string? phoneNumberHash)
+    {
+        EmailHash = emailHash;
+        PhoneNumberHash = phoneNumberHash;
+    }
 }

--- a/src/Granit.Identity/Granit.Identity.csproj
+++ b/src/Granit.Identity/Granit.Identity.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Identity.EntityFrameworkCore" />
+    <InternalsVisibleTo Include="Granit.Identity.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.Identity.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.Identity/Internal/HmacUserLookupHasher.cs
+++ b/src/Granit.Identity/Internal/HmacUserLookupHasher.cs
@@ -1,0 +1,101 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Identity.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Internal;
+
+/// <summary>
+/// HMAC-SHA256 <see cref="IUserLookupHasher"/>. Pepper sourced from
+/// <see cref="UserLookupHasherOptions.Pepper"/> and validated at first
+/// resolution — an unset pepper fails fast so production deployments cannot
+/// accidentally run with a known-zero key.
+/// </summary>
+internal sealed class HmacUserLookupHasher(IOptions<UserLookupHasherOptions> options)
+    : IUserLookupHasher
+{
+    private readonly byte[] _pepper = ResolvePepper(options.Value);
+
+    public string? ComputeEmailHash(string? email) =>
+        Compute(NormaliseEmail(email));
+
+    public string? ComputePhoneHash(string? phoneNumber) =>
+        Compute(NormalisePhone(phoneNumber));
+
+    private string? Compute(string? normalised)
+    {
+        if (string.IsNullOrEmpty(normalised))
+        {
+            return null;
+        }
+
+        byte[] payload = Encoding.UTF8.GetBytes(normalised);
+        byte[] digest = HMACSHA256.HashData(_pepper, payload);
+        return Convert.ToHexStringLower(digest);
+    }
+
+    // Same canonicalisation as Granit.Identity.Federated.HmacUserLookupHasher:
+    // case-insensitive lookup, leading/trailing whitespace collapsed.
+    private static string? NormaliseEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return null;
+        }
+        return email.Trim().ToLowerInvariant();
+    }
+
+    // Phones are case-insensitive trivially (digits + plus sign); whitespace
+    // and separators collapsed so "+32 470 12 34 56" and "+32470123456"
+    // produce the same digest. Separators allowed: space, dash, dot,
+    // parenthesis. Anything else passes through (E.164 plus prefix, digits).
+    private static string? NormalisePhone(string? phoneNumber)
+    {
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            return null;
+        }
+
+        Span<char> buffer = stackalloc char[phoneNumber.Length];
+        int length = 0;
+        foreach (char c in phoneNumber)
+        {
+            if (c is ' ' or '-' or '.' or '(' or ')')
+            {
+                continue;
+            }
+            buffer[length++] = c;
+        }
+        return length == 0 ? null : new string(buffer[..length]);
+    }
+
+    private static byte[] ResolvePepper(UserLookupHasherOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Pepper))
+        {
+            throw new InvalidOperationException(
+                "Identity:LookupHasher:Pepper is required when at-rest encryption is enabled " +
+                "on Granit.Identity. The pepper must be at least 32 bytes of high-entropy " +
+                "random data (e.g. openssl rand -hex 32) and stored separately from the " +
+                "encryption key ring so the two can be rotated independently.");
+        }
+
+        string pepper = options.Pepper.Trim();
+        if (pepper.Length % 2 == 0 && pepper.All(IsHexDigit))
+        {
+            try
+            {
+                return Convert.FromHexString(pepper);
+            }
+            catch (FormatException)
+            {
+                // fall through to UTF-8 interpretation
+            }
+        }
+
+        return Encoding.UTF8.GetBytes(pepper);
+    }
+
+    private static bool IsHexDigit(char c) =>
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}

--- a/src/Granit.Identity/Internal/IUserLookupHasher.cs
+++ b/src/Granit.Identity/Internal/IUserLookupHasher.cs
@@ -1,0 +1,35 @@
+namespace Granit.Identity.Internal;
+
+/// <summary>
+/// Computes deterministic lookup digests for canonical-user PII columns
+/// (<see cref="Granit.Identity.Domain.User.Email"/>,
+/// <see cref="Granit.Identity.Domain.User.PhoneNumber"/>) so admin search and
+/// future exact-match recovery flows can resolve a user without decrypting
+/// every row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The plaintext columns are encrypted at rest via
+/// <see cref="Granit.Encryption.EncryptedAttribute"/>. AES-CBC ciphertext is
+/// non-deterministic (random IV) and cannot serve <c>WHERE col = ?</c>
+/// equality lookups; parallel <c>*Hash</c> columns
+/// (<c>HMAC-SHA256(pepper, lower-cased value)</c>) are indexed instead.
+/// Same pattern as
+/// <see cref="Granit.Identity.Federated.Internal.IUserLookupHasher"/>;
+/// each module owns its own hasher so the peppers — and therefore the indexes
+/// — can be rotated independently.
+/// </para>
+/// <para>
+/// The pepper MUST be distinct from the encryption key so the two can be
+/// rotated independently; sharing a key would leak re-identification risk
+/// into the encryption domain.
+/// </para>
+/// </remarks>
+internal interface IUserLookupHasher
+{
+    /// <summary>Computes the deterministic digest of a user email.</summary>
+    string? ComputeEmailHash(string? email);
+
+    /// <summary>Computes the deterministic digest of a user phone number.</summary>
+    string? ComputePhoneHash(string? phoneNumber);
+}

--- a/src/Granit.Identity/Options/UserLookupHasherOptions.cs
+++ b/src/Granit.Identity/Options/UserLookupHasherOptions.cs
@@ -1,0 +1,21 @@
+namespace Granit.Identity.Options;
+
+/// <summary>
+/// Configuration for the canonical-user lookup hasher. The pepper is an HMAC
+/// key distinct from the encryption key; rotating it invalidates the email /
+/// phone admin-search indexes and requires a backfill — schedule rotations
+/// during a maintenance window.
+/// </summary>
+public sealed class UserLookupHasherOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Identity:LookupHasher";
+
+    /// <summary>
+    /// Gets or sets the HMAC-SHA256 pepper. MUST be at least 32 bytes of
+    /// high-entropy random data (e.g. <c>openssl rand -hex 32</c>) and stored
+    /// separately from the encryption key ring. Hex-encoded values are
+    /// auto-decoded; everything else is taken as raw UTF-8.
+    /// </summary>
+    public string? Pepper { get; set; }
+}

--- a/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
@@ -59,9 +59,6 @@ public sealed class SensitiveDataEncryptionConventionTests
         "Granit.Webhooks.Domain.WebhookSigningKey.ProtectedSecret",         // opaque protected value; format owned by IWebhookSecretProtector (rotates independently).
         "Granit.Webhooks.Domain.WebhookSubscription.SigningSecret",         // legacy column populated only via the same protector path as ProtectedSecret.
 
-        // [BACKLOG] — equality-lookup key, needs companion lookup-hash column
-        "Granit.Identity.Domain.User.Email",                                // FindByEmailAsync (login). Refactor: introduce User.EmailHash via IUserLookupHasher.
-        "Granit.Identity.Domain.User.PhoneNumber",                          // potential SMS-OTP / passwordless lookup. Same pattern as Email.
     };
 
     [Fact]

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContextFactory.cs
@@ -1,3 +1,4 @@
+using Granit.Encryption;
 using Granit.Identity.EntityFrameworkCore.Internal;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +40,7 @@ internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext
         DbContextOptions<IdentityDbContext> options = optionsBuilder.Options;
 
         // Create the schema once for the connection lifetime.
-        using (IdentityDbContext db = new(options))
+        using (IdentityDbContext db = new(options, new PassthroughEncryption()))
         {
             db.Database.EnsureCreated();
         }
@@ -47,9 +48,15 @@ internal sealed class TestDbContextFactory : IDbContextFactory<IdentityDbContext
         return new TestDbContextFactory(connection, options);
     }
 
-    public IdentityDbContext CreateDbContext() => new(_options);
+    public IdentityDbContext CreateDbContext() => new(_options, new PassthroughEncryption());
 
     public void Dispose() => _connection.Dispose();
+
+    private sealed class PassthroughEncryption : IStringEncryptionService
+    {
+        public string Encrypt(string plainText) => plainText;
+        public string? Decrypt(string cipherText) => cipherText;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Closes the last two `[BACKLOG]` exemptions in `SensitiveDataEncryptionConventionTests`. The canonical `User` aggregate (ADR-051) now ships `[Encrypted]` on its PII columns; admin-grid exact-match lookups route through parallel HMAC-SHA256 hash columns indexed in their place.

| Plaintext (encrypted) | Lookup hash | Indexed |
|---|---|---|
| `User.Email` | `User.EmailHash` | yes |
| `User.PhoneNumber` | `User.PhoneNumberHash` | not yet (no exact-match phone lookup yet) |

## Pieces

- `IUserLookupHasher` + `HmacUserLookupHasher` (HMAC-SHA256, peppered, fail-fast on missing pepper). Distinct from the same-named hasher in `Granit.Identity.Federated.Internal` so the two modules' peppers / indexes rotate independently.
- `UserLookupHasherOptions.Pepper` — secret distinct from the encryption key.
- `UserLookupHashInterceptor` (`IGranitAutoInterceptor`) recomputes both digests on `Added`/`Modified` User entries.
- `IdentityDbContext` now requires `IStringEncryptionService` and calls `ApplyEncryptionConventions`. Module `DependsOn` `GranitEncryptionEntityFrameworkCoreModule`.
- Aggregate enforces the pair: `SetLookupHashes(emailHash, phoneHash)` — hashes cannot drift from the encrypted plaintext.

## Schema impact (consuming app responsibility)

Per Granit convention, no migrations ship in the framework. Apps need:

- `Email` / `PhoneNumber` widened: `320` / `32` → `4096` (AES + base64 overhead).
- New columns: `EmailHash`, `PhoneNumberHash` (`varchar(64)`).
- Backfill hashes before re-indexing.
- Drop old index on `Email`; create new index on `EmailHash`.

## Out of scope

- **`LocalIdentity.Email`** (ASP.NET Identity-backed sibling) is unchanged — we don't own the `IdentityUser<TKey>` base shape, and `FindByEmailAsync` goes through a `NormalizedEmail` column managed by AspNetIdentity. Encrypting that requires a `UserStore<LocalIdentity>` override — separate refactor.
- **`UserQueryDefinition.GlobalSearch`** on Email / FirstName / LastName: same state as `FederatedIdentityQueryDefinition` — the LIKE-search is silently no-op against ciphertext. Admin can still search by exact email via `EmailHash` once the consumer wires it. Tracked as follow-up.

## Test plan

- [x] `dotnet test tests/Granit.Identity.EntityFrameworkCore.Tests` — 6/6
- [x] `dotnet test tests/Granit.Identity.Tests` — 146/146
- [x] `dotnet test tests/Granit.ArchitectureTests --filter SensitiveData` — passes (last two BACKLOG exemptions removed)
- [x] `dotnet build .github/shard-filters/security.slnf` — clean
- [ ] CI shards green

## After merge

The `[BACKLOG]` exemption list is empty. Only `[INFRA]` exemptions remain (already-protected fields like `ApiKeyEntry.HashedKey`, `WebhookSigningKey.ProtectedSecret`).