### PR TITLE
feat(documents): DocumentShare entity + grant/revoke endpoints (F6.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19362,6 +19362,28 @@
       ]
     },
     {
+      "name": "DocumentShare",
+      "fqn": "Granit.Documents.Domain.DocumentShare",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/DocumentShare.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ShareToFolder",
+          "kind": "method",
+          "signature": "ShareToFolder(Guid id, Guid? tenantId, Guid folderId, ShareGranteeType granteeType, Guid granteeId, SharePermissionLevel permission, bool isDefault, Guid createdByUserId, DateTimeOffset createdAt, DateTimeOffset? expiresAt = null)",
+          "returnType": "DocumentShare"
+        },
+        {
+          "name": "Revoke",
+          "kind": "method",
+          "signature": "Revoke()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "DocumentStatus",
       "fqn": "Granit.Documents.Domain.DocumentStatus",
       "kind": "enum",
@@ -19414,6 +19436,33 @@
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/Domain/FolderStatus.cs",
       "line": 10,
+      "members": []
+    },
+    {
+      "name": "ShareGranteeType",
+      "fqn": "Granit.Documents.Domain.ShareGranteeType",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/ShareGranteeType.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "SharePermissionLevel",
+      "fqn": "Granit.Documents.Domain.SharePermissionLevel",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/SharePermissionLevel.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ShareTargetType",
+      "fqn": "Granit.Documents.Domain.ShareTargetType",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/ShareTargetType.cs",
+      "line": 11,
       "members": []
     },
     {
@@ -19539,7 +19588,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitDocuments",
@@ -19669,6 +19718,42 @@
       "members": []
     },
     {
+      "name": "Shares",
+      "fqn": "Granit.Documents.Endpoints.Permissions.Shares",
+      "kind": "class",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "GrantShareRequest",
+      "fqn": "Granit.Documents.Endpoints.Shares.Dtos.GrantShareRequest",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Shares/Dtos/GrantShareRequest.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "ListSharesResponse",
+      "fqn": "Granit.Documents.Endpoints.Shares.Dtos.ListSharesResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Shares/Dtos/ListSharesResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ShareResponse",
+      "fqn": "Granit.Documents.Endpoints.Shares.Dtos.ShareResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Shares/Dtos/ShareResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Documents.EntityFrameworkCore.Extensions.DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -19777,6 +19862,24 @@
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/Events/DocumentRestoredEvent.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "DocumentShareGrantedEvent",
+      "fqn": "Granit.Documents.Events.DocumentShareGrantedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentShareGrantedEvent.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "DocumentShareRevokedEvent",
+      "fqn": "Granit.Documents.Events.DocumentShareRevokedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentShareRevokedEvent.cs",
+      "line": 12,
       "members": []
     },
     {
@@ -19968,6 +20071,46 @@
           "kind": "method",
           "signature": "TrashAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Document?>"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentShareService",
+      "fqn": "Granit.Documents.IDocumentShareService",
+      "kind": "interface",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/IDocumentShareService.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GrantOnFolderAsync",
+          "kind": "method",
+          "signature": "GrantOnFolderAsync(Guid folderId, ShareGranteeType granteeType, Guid granteeId, SharePermissionLevel permission, bool isDefault, Guid createdByUserId, DateTimeOffset? expiresAt = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentShare?>"
+        },
+        {
+          "name": "GrantOnDocumentAsync",
+          "kind": "method",
+          "signature": "GrantOnDocumentAsync(Guid documentId, ShareGranteeType granteeType, Guid granteeId, SharePermissionLevel permission, Guid createdByUserId, DateTimeOffset? expiresAt = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentShare?>"
+        },
+        {
+          "name": "RevokeAsync",
+          "kind": "method",
+          "signature": "RevokeAsync(Guid shareId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "ListForFolderAsync",
+          "kind": "method",
+          "signature": "ListForFolderAsync(Guid folderId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<DocumentShare>>"
+        },
+        {
+          "name": "ListForDocumentAsync",
+          "kind": "method",
+          "signature": "ListForDocumentAsync(Guid documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<DocumentShare>>"
         }
       ]
     },

--- a/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -792,11 +792,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,8 +5,8 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.22.2",
-        "contentHash": "RYBhoTFlMRq2tiqv/8FfSRFkNz0OCY2U5AbwH5PWpI/XhI3eQp34ujVAT9gD9DqOUHKDaQvJegauypUSO6wkjQ==",
+        "resolved": "4.0.23",
+        "contentHash": "yPvCj0ITnniE8j2YVVCrTfutOfaw+a9CememSzqYL2Y7zQaKLZL6F5385zI8NqnCpw26OzU5cwmKzAC6xssbGw==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.6.1, 5.0.0)"
         }

--- a/src/Granit.DataExchange.Excel/packages.lock.json
+++ b/src/Granit.DataExchange.Excel/packages.lock.json
@@ -24,8 +24,8 @@
       "Sylvan.Data.Excel": {
         "type": "Direct",
         "requested": "[0.5.*, )",
-        "resolved": "0.5.5",
-        "contentHash": "HBsTVzAupf2tg/koLNEalzsJfWRl0sbtFOaTSdrweujeyEx3zO5BxcxTzW55TD2db9sn1xpRcSLP04tUG0v/jQ=="
+        "resolved": "0.5.6",
+        "contentHash": "6OcGGQRT0dfg1bBEl0AIakNUfuAQCMRclq7ZJEeWejRuIypp0zxzLB52/8FTgw7wFYdLcikI8fK7oLpMA4F7Lw=="
       },
       "ClosedXML.Parser": {
         "type": "Transitive",

--- a/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Documents.Endpoints.Documents.Endpoints;
 using Granit.Documents.Endpoints.Folders.Endpoints;
 using Granit.Documents.Endpoints.Options;
+using Granit.Documents.Endpoints.Shares.Endpoints;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -41,6 +42,7 @@ public static class DocumentsEndpointRouteBuilderExtensions
         group.MapFolderEndpoints();
         group.MapDocumentEndpoints();
         group.MapDocumentTagProxyEndpoints();
+        group.MapShareEndpoints();
 
         return group;
     }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Zobrazit a stáhnout dokumenty",
     "Permission:Documents.Folders.Manage": "Vytvářet, přejmenovávat, přesouvat a odstraňovat složky",
     "Permission:Documents.Folders.Read": "Zobrazit složky",
+    "Permission:Documents.Shares.Manage": "Udělovat a odvolávat sdílení složek a dokumentů",
+    "Permission:Documents.Shares.Read": "Zobrazit sdílení složek a dokumentů",
     "PermissionGroup:Documents": "Dokumenty"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Dokumente anzeigen und herunterladen",
     "Permission:Documents.Folders.Manage": "Ordner erstellen, umbenennen, verschieben und in den Papierkorb legen",
     "Permission:Documents.Folders.Read": "Ordner anzeigen",
+    "Permission:Documents.Shares.Manage": "Freigaben für Ordner und Dokumente erteilen und widerrufen",
+    "Permission:Documents.Shares.Read": "Freigaben für Ordner und Dokumente anzeigen",
     "PermissionGroup:Documents": "Dokumente"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "View and download documents",
     "Permission:Documents.Folders.Manage": "Create, rename, move, and trash folders",
     "Permission:Documents.Folders.Read": "View folders",
+    "Permission:Documents.Shares.Manage": "Grant and revoke share access on folders and documents",
+    "Permission:Documents.Shares.Read": "View share grants on folders and documents",
     "PermissionGroup:Documents": "Documents"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Ver y descargar documentos",
     "Permission:Documents.Folders.Manage": "Crear, renombrar, mover y enviar carpetas a la papelera",
     "Permission:Documents.Folders.Read": "Ver carpetas",
+    "Permission:Documents.Shares.Manage": "Conceder y revocar permisos compartidos en carpetas y documentos",
+    "Permission:Documents.Shares.Read": "Ver los permisos compartidos en carpetas y documentos",
     "PermissionGroup:Documents": "Documentos"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Consulter et télécharger les documents",
     "Permission:Documents.Folders.Manage": "Créer, renommer, déplacer et corbeillir des dossiers",
     "Permission:Documents.Folders.Read": "Consulter les dossiers",
+    "Permission:Documents.Shares.Manage": "Accorder et révoquer les partages sur les dossiers et les documents",
+    "Permission:Documents.Shares.Read": "Consulter les partages sur les dossiers et les documents",
     "PermissionGroup:Documents": "Documents"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "दस्तावेज़ देखें और डाउनलोड करें",
     "Permission:Documents.Folders.Manage": "फ़ोल्डर बनाएँ, नाम बदलें, स्थानांतरित करें और कूड़ेदान में डालें",
     "Permission:Documents.Folders.Read": "फ़ोल्डर देखें",
+    "Permission:Documents.Shares.Manage": "फ़ोल्डर और दस्तावेज़ों पर साझाकरण प्रदान करें और रद्द करें",
+    "Permission:Documents.Shares.Read": "फ़ोल्डर और दस्तावेज़ों पर साझाकरण देखें",
     "PermissionGroup:Documents": "दस्तावेज़"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Visualizzare e scaricare documenti",
     "Permission:Documents.Folders.Manage": "Creare, rinominare, spostare e cestinare cartelle",
     "Permission:Documents.Folders.Read": "Visualizzare le cartelle",
+    "Permission:Documents.Shares.Manage": "Concedere e revocare le condivisioni su cartelle e documenti",
+    "Permission:Documents.Shares.Read": "Visualizzare le condivisioni su cartelle e documenti",
     "PermissionGroup:Documents": "Documenti"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "ドキュメントの表示とダウンロード",
     "Permission:Documents.Folders.Manage": "フォルダーの作成、名前変更、移動、ゴミ箱への移動",
     "Permission:Documents.Folders.Read": "フォルダーを表示",
+    "Permission:Documents.Shares.Manage": "フォルダーとドキュメントの共有権限を付与・取り消し",
+    "Permission:Documents.Shares.Read": "フォルダーとドキュメントの共有権限を表示",
     "PermissionGroup:Documents": "ドキュメント"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "문서 보기 및 다운로드",
     "Permission:Documents.Folders.Manage": "폴더 만들기, 이름 바꾸기, 이동 및 휴지통으로 이동",
     "Permission:Documents.Folders.Read": "폴더 보기",
+    "Permission:Documents.Shares.Manage": "폴더와 문서의 공유 권한 부여 및 취소",
+    "Permission:Documents.Shares.Read": "폴더와 문서의 공유 권한 보기",
     "PermissionGroup:Documents": "문서"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Documenten bekijken en downloaden",
     "Permission:Documents.Folders.Manage": "Mappen aanmaken, hernoemen, verplaatsen en in de prullenbak gooien",
     "Permission:Documents.Folders.Read": "Mappen bekijken",
+    "Permission:Documents.Shares.Manage": "Deelmachtigingen op mappen en documenten verlenen en intrekken",
+    "Permission:Documents.Shares.Read": "Deelmachtigingen op mappen en documenten bekijken",
     "PermissionGroup:Documents": "Documenten"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Wyświetlanie i pobieranie dokumentów",
     "Permission:Documents.Folders.Manage": "Tworzenie, zmiana nazwy, przenoszenie i przenoszenie do kosza folderów",
     "Permission:Documents.Folders.Read": "Wyświetlanie folderów",
+    "Permission:Documents.Shares.Manage": "Przyznawanie i odbieranie udostępnień folderów i dokumentów",
+    "Permission:Documents.Shares.Read": "Wyświetlanie udostępnień folderów i dokumentów",
     "PermissionGroup:Documents": "Dokumenty"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt-BR.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt-BR.json
@@ -2,6 +2,8 @@
   "culture": "pt-BR",
   "texts": {
     "Permission:Documents.Documents.Manage": "Carregar, renomear, mover e enviar documentos para a lixeira",
-    "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a lixeira"
+    "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a lixeira",
+    "Permission:Documents.Shares.Manage": "Conceder e revogar compartilhamentos em pastas e documentos",
+    "Permission:Documents.Shares.Read": "Ver os compartilhamentos em pastas e documentos"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Ver e transferir documentos",
     "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a reciclagem",
     "Permission:Documents.Folders.Read": "Ver pastas",
+    "Permission:Documents.Shares.Manage": "Conceder e revogar partilhas em pastas e documentos",
+    "Permission:Documents.Shares.Read": "Ver as partilhas em pastas e documentos",
     "PermissionGroup:Documents": "Documentos"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Visa och ladda ner dokument",
     "Permission:Documents.Folders.Manage": "Skapa, byta namn på, flytta och papperskorga mappar",
     "Permission:Documents.Folders.Read": "Visa mappar",
+    "Permission:Documents.Shares.Manage": "Bevilja och återkalla delningar på mappar och dokument",
+    "Permission:Documents.Shares.Read": "Visa delningar på mappar och dokument",
     "PermissionGroup:Documents": "Dokument"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "Belgeleri görüntüle ve indir",
     "Permission:Documents.Folders.Manage": "Klasörleri oluşturma, yeniden adlandırma, taşıma ve geri dönüşüm kutusuna gönderme",
     "Permission:Documents.Folders.Read": "Klasörleri görüntüle",
+    "Permission:Documents.Shares.Manage": "Klasör ve belgelerdeki paylaşım izinlerini ver ve geri al",
+    "Permission:Documents.Shares.Read": "Klasör ve belgelerdeki paylaşım izinlerini görüntüle",
     "PermissionGroup:Documents": "Belgeler"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
@@ -5,6 +5,8 @@
     "Permission:Documents.Documents.Read": "查看和下载文档",
     "Permission:Documents.Folders.Manage": "创建、重命名、移动和回收文件夹",
     "Permission:Documents.Folders.Read": "查看文件夹",
+    "Permission:Documents.Shares.Manage": "授予和撤销文件夹与文档的共享授权",
+    "Permission:Documents.Shares.Read": "查看文件夹与文档的共享授权",
     "PermissionGroup:Documents": "文档"
   }
 }

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
@@ -48,5 +48,17 @@ internal sealed class DocumentsPermissionDefinitionProvider : IPermissionDefinit
             LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
                 "Permission:Documents.Documents.Manage"),
             MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Shares.Read,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Shares.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Shares.Manage,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Shares.Manage"),
+            MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
@@ -31,4 +31,14 @@ public static class DocumentsPermissions
         /// <summary>Manage documents (upload, rename, move, trash, restore, permanent delete).</summary>
         public const string Manage = "Documents.Documents.Manage";
     }
+
+    /// <summary>Permissions on share ACL grants (F6).</summary>
+    public static class Shares
+    {
+        /// <summary>List share grants on a folder or a document.</summary>
+        public const string Read = "Documents.Shares.Read";
+
+        /// <summary>Grant and revoke share ACL on folders and documents.</summary>
+        public const string Manage = "Documents.Shares.Manage";
+    }
 }

--- a/src/Granit.Documents.Endpoints/Shares/Dtos/GrantShareRequest.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Dtos/GrantShareRequest.cs
@@ -1,0 +1,23 @@
+using Granit.Documents.Domain;
+
+namespace Granit.Documents.Endpoints.Shares.Dtos;
+
+/// <summary>
+/// Wire-shape request for <c>POST /folders/{id}/shares</c> and <c>POST /documents/{id}/shares</c>.
+/// </summary>
+/// <param name="GranteeType">Whether the grant targets a user, a role, or a group.</param>
+/// <param name="GranteeId">Identifier of the grantee (user / role / group depending on <paramref name="GranteeType"/>).</param>
+/// <param name="Permission">Permission level conferred (<see cref="SharePermissionLevel.Read"/> / <see cref="SharePermissionLevel.Edit"/> / <see cref="SharePermissionLevel.Manage"/>).</param>
+/// <param name="IsDefault">
+/// When granting on a folder, controls whether the grant inherits to descendants via the
+/// path-based resolver (F6.4 — F6.1 only persists the flag). Ignored for document shares.
+/// Defaults to <c>true</c> on folder shares so the typical user expectation (a folder share
+/// applies to its contents) holds without an explicit flag.
+/// </param>
+/// <param name="ExpiresAt">Optional expiration timestamp (UTC). <c>null</c> means the grant never expires.</param>
+public sealed record GrantShareRequest(
+    ShareGranteeType GranteeType,
+    Guid GranteeId,
+    SharePermissionLevel Permission,
+    bool IsDefault = true,
+    DateTimeOffset? ExpiresAt = null);

--- a/src/Granit.Documents.Endpoints/Shares/Dtos/ListSharesResponse.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Dtos/ListSharesResponse.cs
@@ -1,0 +1,6 @@
+namespace Granit.Documents.Endpoints.Shares.Dtos;
+
+/// <summary>
+/// Wire-shape response wrapping the list of <see cref="ShareResponse"/> entries.
+/// </summary>
+public sealed record ListSharesResponse(IReadOnlyList<ShareResponse> Items);

--- a/src/Granit.Documents.Endpoints/Shares/Dtos/ShareResponse.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Dtos/ShareResponse.cs
@@ -1,0 +1,26 @@
+using Granit.Documents.Domain;
+
+namespace Granit.Documents.Endpoints.Shares.Dtos;
+
+/// <summary>
+/// Wire-shape response for a single <see cref="DocumentShare"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Exactly one of <see cref="FolderId"/> / <see cref="DocumentId"/> is non-null, matching
+/// <see cref="TargetType"/>; the others stay <c>null</c> so OpenAPI consumers can branch on
+/// the discriminator without fishing through nullables.
+/// </para>
+/// </remarks>
+public sealed record ShareResponse(
+    Guid Id,
+    ShareTargetType TargetType,
+    Guid? FolderId,
+    Guid? DocumentId,
+    ShareGranteeType GranteeType,
+    Guid GranteeId,
+    SharePermissionLevel Permission,
+    bool IsDefault,
+    DateTimeOffset? ExpiresAt,
+    DateTimeOffset CreatedAt,
+    Guid CreatedByUserId);

--- a/src/Granit.Documents.Endpoints/Shares/Endpoints/ShareEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Endpoints/ShareEndpoints.cs
@@ -1,0 +1,227 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Permissions;
+using Granit.Documents.Endpoints.Shares.Dtos;
+using Granit.Documents.Endpoints.Shares.Mapping;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Documents.Endpoints.Shares.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for ACL share grant / revoke / listing (F6.1).
+/// </summary>
+/// <remarks>
+/// Five endpoints across three URL prefixes:
+/// <list type="bullet">
+///   <item><c>POST /folders/{id}/shares</c></item>
+///   <item><c>GET  /folders/{id}/shares</c></item>
+///   <item><c>POST /documents/{id}/shares</c></item>
+///   <item><c>GET  /documents/{id}/shares</c></item>
+///   <item><c>DELETE /shares/{id}</c></item>
+/// </list>
+/// </remarks>
+internal static class ShareEndpoints
+{
+    private const string TagName = "Documents - Shares";
+
+    public static RouteGroupBuilder MapShareEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        // Folder share endpoints — nested under /folders/{folderId}/shares.
+        RouteGroupBuilder folderShares = group
+            .MapGroup("/folders/{folderId:guid}/shares")
+            .WithTags(TagName);
+
+        folderShares.MapGet("/", ListFolderSharesAsync)
+            .WithName("ListFolderShares")
+            .WithSummary("Lists active share grants on a folder.")
+            .WithDescription(
+                "Returns the share grants on the folder identified by `folderId`, ordered by "
+                + "creation time. Expired grants are excluded. The path-based inheritance "
+                + "(F6.4) is not flattened in this listing — callers see only grants directly "
+                + "attached to this folder.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Read))
+            .Produces<ListSharesResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        folderShares.MapPost("/", GrantOnFolderAsync)
+            .WithName("GrantFolderShare")
+            .WithSummary("Grants a share on a folder.")
+            .WithDescription(
+                "Creates a `DocumentShare` row targeting the folder identified by `folderId`. "
+                + "When `isDefault` is true (the default), the grant inherits to descendants "
+                + "via the path-based effective-permission resolver introduced by F6.4 — F6.1 "
+                + "only persists the flag.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .Produces<ShareResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem();
+
+        // Document share endpoints — nested under /documents/{documentId}/shares.
+        RouteGroupBuilder documentShares = group
+            .MapGroup("/documents/{documentId:guid}/shares")
+            .WithTags(TagName);
+
+        documentShares.MapGet("/", ListDocumentSharesAsync)
+            .WithName("ListDocumentShares")
+            .WithSummary("Lists active share grants on a document.")
+            .WithDescription(
+                "Returns the share grants on the document identified by `documentId`, ordered "
+                + "by creation time. Expired grants are excluded. Inherited grants from the "
+                + "document's parent folder are not included — see the F6.5 effective ACL "
+                + "field on document list responses for the resolved view.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Read))
+            .Produces<ListSharesResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        documentShares.MapPost("/", GrantOnDocumentAsync)
+            .WithName("GrantDocumentShare")
+            .WithSummary("Grants a share on a document.")
+            .WithDescription(
+                "Creates a `DocumentShare` row targeting the document identified by "
+                + "`documentId`. The `isDefault` flag is ignored for document shares.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .Produces<ShareResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem();
+
+        // Top-level revoke endpoint — share id is globally unique inside a tenant.
+        RouteGroupBuilder shares = group.MapGroup("/shares").WithTags(TagName);
+
+        shares.MapDelete("/{id:guid}", RevokeAsync)
+            .WithName("RevokeShare")
+            .WithSummary("Revokes a share grant.")
+            .WithDescription(
+                "Deletes the share row identified by `id` and emits `DocumentShareRevokedEvent` "
+                + "for downstream cache invalidation (F6.3). Returns 404 when the share does "
+                + "not exist or is excluded by the tenant filter.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<ListSharesResponse>, ProblemHttpResult>> ListFolderSharesAsync(
+        Guid folderId,
+        [FromServices] IDocumentShareService shares,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<DocumentShare> rows = await shares
+            .ListForFolderAsync(folderId, cancellationToken)
+            .ConfigureAwait(false);
+
+        ShareResponse[] mapped = [.. rows.Select(s => s.ToResponse())];
+        return TypedResults.Ok(new ListSharesResponse(mapped));
+    }
+
+    private static async Task<Results<Ok<ListSharesResponse>, ProblemHttpResult>> ListDocumentSharesAsync(
+        Guid documentId,
+        [FromServices] IDocumentShareService shares,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<DocumentShare> rows = await shares
+            .ListForDocumentAsync(documentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        ShareResponse[] mapped = [.. rows.Select(s => s.ToResponse())];
+        return TypedResults.Ok(new ListSharesResponse(mapped));
+    }
+
+    private static async Task<Results<Created<ShareResponse>, ProblemHttpResult>> GrantOnFolderAsync(
+        Guid folderId,
+        GrantShareRequest request,
+        [FromServices] IDocumentShareService shares,
+        [FromServices] IHttpContextAccessor accessor,
+        CancellationToken cancellationToken)
+    {
+        Guid createdByUserId = ResolveUserId(accessor.HttpContext);
+
+        DocumentShare? share = await shares
+            .GrantOnFolderAsync(
+                folderId,
+                request.GranteeType,
+                request.GranteeId,
+                request.Permission,
+                request.IsDefault,
+                createdByUserId,
+                request.ExpiresAt,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (share is null)
+        {
+            return TypedResults.Problem(
+                $"Folder '{folderId}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Created($"/shares/{share.Id}", share.ToResponse());
+    }
+
+    private static async Task<Results<Created<ShareResponse>, ProblemHttpResult>> GrantOnDocumentAsync(
+        Guid documentId,
+        GrantShareRequest request,
+        [FromServices] IDocumentShareService shares,
+        [FromServices] IHttpContextAccessor accessor,
+        CancellationToken cancellationToken)
+    {
+        Guid createdByUserId = ResolveUserId(accessor.HttpContext);
+
+        DocumentShare? share = await shares
+            .GrantOnDocumentAsync(
+                documentId,
+                request.GranteeType,
+                request.GranteeId,
+                request.Permission,
+                createdByUserId,
+                request.ExpiresAt,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (share is null)
+        {
+            return TypedResults.Problem(
+                $"Document '{documentId}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Created($"/shares/{share.Id}", share.ToResponse());
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> RevokeAsync(
+        Guid id,
+        [FromServices] IDocumentShareService shares,
+        CancellationToken cancellationToken)
+    {
+        bool removed = await shares.RevokeAsync(id, cancellationToken).ConfigureAwait(false);
+        if (!removed)
+        {
+            return TypedResults.Problem(
+                $"Share '{id}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        return TypedResults.NoContent();
+    }
+
+    private static Guid ResolveUserId(HttpContext? httpContext)
+    {
+        if (httpContext is null)
+        {
+            return Guid.Empty;
+        }
+        // The User aggregate id (ADR-051) is exposed on the principal as the standard
+        // ClaimTypes.NameIdentifier ("sub"). Falling back to Guid.Empty keeps anonymous
+        // flows (test harnesses) working; production deployments enforce authentication
+        // via .RequireAuthorization() on the route group.
+        string? sub = httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(sub, out Guid id) ? id : Guid.Empty;
+    }
+}

--- a/src/Granit.Documents.Endpoints/Shares/Mapping/ShareMapper.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Mapping/ShareMapper.cs
@@ -1,0 +1,27 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Shares.Dtos;
+
+namespace Granit.Documents.Endpoints.Shares.Mapping;
+
+/// <summary>
+/// Aggregate → wire-shape mapping for <see cref="DocumentShare"/>.
+/// </summary>
+internal static class ShareMapper
+{
+    public static ShareResponse ToResponse(this DocumentShare share)
+    {
+        ArgumentNullException.ThrowIfNull(share);
+        return new ShareResponse(
+            share.Id,
+            share.TargetType,
+            share.FolderId,
+            share.DocumentId,
+            share.GranteeType,
+            share.GranteeId,
+            share.Permission,
+            share.IsDefault,
+            share.ExpiresAt,
+            share.CreatedAt,
+            share.CreatedByUserId);
+    }
+}

--- a/src/Granit.Documents.Endpoints/Shares/Validators/GrantShareRequestValidator.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Validators/GrantShareRequestValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using Granit.Documents.Endpoints.Shares.Dtos;
+
+namespace Granit.Documents.Endpoints.Shares.Validators;
+
+/// <summary>
+/// Validator for <see cref="GrantShareRequest"/> — both folder and document grants share the same shape.
+/// </summary>
+internal sealed class GrantShareRequestValidator : AbstractValidator<GrantShareRequest>
+{
+    public GrantShareRequestValidator()
+    {
+        RuleFor(x => x.GranteeId)
+            .NotEqual(Guid.Empty);
+
+        RuleFor(x => x.GranteeType)
+            .IsInEnum();
+
+        RuleFor(x => x.Permission)
+            .IsInEnum();
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -52,6 +52,11 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // DocumentVersion atomically.
         builder.Services.AddScoped<IDocumentService, DocumentService>();
 
+        // Share service (F6.1): grant / revoke / list ACL grants on folders and documents.
+        // Effective-permission resolution (F6.2) and FusionCache invalidation (F6.3) plug
+        // in on top in subsequent stories.
+        builder.Services.AddScoped<IDocumentShareService, DocumentShareService>();
+
         return builder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
@@ -20,6 +20,7 @@ public static class DocumentsModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new FolderConfiguration());
         modelBuilder.ApplyConfiguration(new DocumentConfiguration());
         modelBuilder.ApplyConfiguration(new DocumentVersionConfiguration());
+        modelBuilder.ApplyConfiguration(new DocumentShareConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentShareConfiguration.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentShareConfiguration.cs
@@ -1,0 +1,97 @@
+using Granit.Documents.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="DocumentShare"/>.
+/// Table: <c>documents_shares</c>.
+/// </summary>
+/// <remarks>
+/// Implements ADR-052 §Permission resolution model: a CHECK constraint pins the
+/// "exactly one of FolderId / DocumentId is non-null" invariant at the database level,
+/// and two filtered indexes back the F6.2 effective-permission resolver query.
+/// </remarks>
+internal sealed class DocumentShareConfiguration : IEntityTypeConfiguration<DocumentShare>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<DocumentShare> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitDocumentsDbProperties.DbTablePrefix + "shares",
+            GranitDocumentsDbProperties.DbSchema,
+            tb =>
+            {
+                // Per ADR-052: exactly one of FolderId / DocumentId is populated, matching
+                // the TargetType discriminator. Stored as a string column (HasConversion<string>
+                // below) so the literals 'Folder' / 'Document' are stable across providers.
+                // Identifiers are quoted to preserve PascalCase across providers (Postgres
+                // lowercases unquoted identifiers; SQLite is case-insensitive but accepts quotes).
+                tb.HasCheckConstraint(
+                    $"ck_{GranitDocumentsDbProperties.DbTablePrefix}shares_target_exactly_one",
+                    $"(\"{nameof(DocumentShare.TargetType)}\" = 'Folder'   AND \"{nameof(DocumentShare.FolderId)}\"   IS NOT NULL AND \"{nameof(DocumentShare.DocumentId)}\" IS NULL)"
+                    + $" OR (\"{nameof(DocumentShare.TargetType)}\" = 'Document' AND \"{nameof(DocumentShare.DocumentId)}\" IS NOT NULL AND \"{nameof(DocumentShare.FolderId)}\"   IS NULL)");
+            });
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+
+        builder.Property(e => e.TargetType)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.FolderId);
+        builder.Property(e => e.DocumentId);
+
+        builder.Property(e => e.GranteeType)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.GranteeId)
+            .IsRequired();
+
+        builder.Property(e => e.Permission)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(e => e.IsDefault)
+            .IsRequired();
+
+        builder.Property(e => e.ExpiresAt);
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedByUserId)
+            .IsRequired();
+
+        // F6.2 resolver lookup paths — filtered indexes so each row appears in exactly one
+        // of the two structures (matches the CHECK partitioning above). Filter literals are
+        // quoted to preserve PascalCase identifiers; the value 'Folder' / 'Document' matches
+        // the string conversion configured above.
+        builder.HasIndex(e => new { e.TenantId, e.GranteeId, e.FolderId })
+            .HasFilter($"\"{nameof(DocumentShare.TargetType)}\" = 'Folder'")
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}shares_grantee_folder");
+
+        builder.HasIndex(e => new { e.TenantId, e.GranteeId, e.DocumentId })
+            .HasFilter($"\"{nameof(DocumentShare.TargetType)}\" = 'Document'")
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}shares_grantee_document");
+
+        // Listing endpoints (GET /folders/{id}/shares, GET /documents/{id}/shares) sort by
+        // CreatedAt — the supporting index also covers tenant-scoped pagination cheaply.
+        builder.HasIndex(e => new { e.TenantId, e.FolderId, e.CreatedAt })
+            .HasFilter($"\"{nameof(DocumentShare.TargetType)}\" = 'Folder'")
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}shares_folder_listing");
+
+        builder.HasIndex(e => new { e.TenantId, e.DocumentId, e.CreatedAt })
+            .HasFilter($"\"{nameof(DocumentShare.TargetType)}\" = 'Document'")
+            .HasDatabaseName($"ix_{GranitDocumentsDbProperties.DbTablePrefix}shares_document_listing");
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentShareService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentShareService.cs
@@ -1,0 +1,156 @@
+using Granit.Documents.Domain;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="IDocumentShareService"/>.
+/// </summary>
+internal sealed class DocumentShareService(
+    IDbContextFactory<DocumentsDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator,
+    IClock clock) : IDocumentShareService
+{
+    /// <inheritdoc />
+    public async Task<DocumentShare?> GrantOnFolderAsync(
+        Guid folderId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        bool isDefault,
+        Guid createdByUserId,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? folder = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == folderId, cancellationToken)
+            .ConfigureAwait(false);
+        if (folder is null)
+        {
+            return null;
+        }
+
+        var share = DocumentShare.ShareToFolder(
+            id: guidGenerator.Create(),
+            tenantId: folder.TenantId ?? currentTenant.Id,
+            folderId: folder.Id,
+            granteeType: granteeType,
+            granteeId: granteeId,
+            permission: permission,
+            isDefault: isDefault,
+            createdByUserId: createdByUserId,
+            createdAt: clock.Now,
+            expiresAt: expiresAt);
+
+        context.DocumentShares.Add(share);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return share;
+    }
+
+    /// <inheritdoc />
+    public async Task<DocumentShare?> GrantOnDocumentAsync(
+        Guid documentId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        Guid createdByUserId,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == documentId, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        var share = DocumentShare.ShareToDocument(
+            id: guidGenerator.Create(),
+            tenantId: document.TenantId ?? currentTenant.Id,
+            documentId: document.Id,
+            granteeType: granteeType,
+            granteeId: granteeId,
+            permission: permission,
+            createdByUserId: createdByUserId,
+            createdAt: clock.Now,
+            expiresAt: expiresAt);
+
+        context.DocumentShares.Add(share);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return share;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RevokeAsync(Guid shareId, CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DocumentShare? share = await context.DocumentShares
+            .FirstOrDefaultAsync(s => s.Id == shareId, cancellationToken)
+            .ConfigureAwait(false);
+        if (share is null)
+        {
+            return false;
+        }
+
+        // Emit the revoked event before delete so event dispatch picks it up alongside
+        // SaveChanges. The aggregate is removed in the same transaction.
+        share.Revoke();
+        context.DocumentShares.Remove(share);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DocumentShare>> ListForFolderAsync(
+        Guid folderId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        return await context.DocumentShares
+            .Where(s => s.TargetType == ShareTargetType.Folder
+                && s.FolderId == folderId
+                && (s.ExpiresAt == null || s.ExpiresAt > now))
+            .OrderBy(s => s.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DocumentShare>> ListForDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        return await context.DocumentShares
+            .Where(s => s.TargetType == ShareTargetType.Document
+                && s.DocumentId == documentId
+                && (s.ExpiresAt == null || s.ExpiresAt > now))
+            .OrderBy(s => s.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
@@ -35,6 +35,9 @@ internal sealed class DocumentsDbContext(
     /// <summary>Append-only version history. The current pointer lives on <see cref="Document.CurrentVersionId"/>.</summary>
     public DbSet<DocumentVersion> DocumentVersions { get; set; } = null!;
 
+    /// <summary>ACL grants on folders and documents (F6.1 — see ADR-052 §Permission resolution model).</summary>
+    public DbSet<DocumentShare> DocumentShares { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Documents/Domain/DocumentShare.cs
+++ b/src/Granit.Documents/Domain/DocumentShare.cs
@@ -1,0 +1,258 @@
+using Granit.Documents.Events;
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Aggregate root representing an ACL grant on a folder or a document, conferring a
+/// <see cref="SharePermissionLevel"/> level to a user, role, or group, optionally with an expiration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per ADR-052, exactly one of <see cref="FolderId"/> or <see cref="DocumentId"/> is non-null
+/// — enforced both at the C# factory level (<see cref="ShareToFolder"/> / <see cref="ShareToDocument"/>)
+/// and at the database level (CHECK <c>ck_share_target_exactly_one</c>).
+/// </para>
+/// <para>
+/// Folder shares with <see cref="IsDefault"/> = <c>true</c> propagate to descendants via the
+/// path-based effective-permission resolver introduced by F6.4 — F6.1 only persists the flag.
+/// Document shares ignore <see cref="IsDefault"/>; the factories normalise it accordingly.
+/// </para>
+/// </remarks>
+public sealed class DocumentShare : AggregateRoot, IMultiTenant
+{
+    /// <summary>Parameterless constructor required by the EF Core materialiser.</summary>
+    private DocumentShare() { }
+
+    /// <summary>
+    /// Creates a share that grants <paramref name="permission"/> to (<paramref name="granteeType"/>,
+    /// <paramref name="granteeId"/>) on the folder identified by <paramref name="folderId"/>.
+    /// </summary>
+    /// <param name="id">Unique identifier of the new share.</param>
+    /// <param name="tenantId">Identifier of the tenant the share belongs to.</param>
+    /// <param name="folderId">Target folder identifier.</param>
+    /// <param name="granteeType">Grantee kind (User / Role / Group).</param>
+    /// <param name="granteeId">Identifier of the grantee.</param>
+    /// <param name="permission">Permission level conferred.</param>
+    /// <param name="isDefault">When <c>true</c> the grant inherits to descendants via path-prefix matching.</param>
+    /// <param name="createdByUserId">Identifier of the user creating the share (audit attribution).</param>
+    /// <param name="createdAt">Creation timestamp.</param>
+    /// <param name="expiresAt">Optional expiration (UTC). Past expirations are rejected.</param>
+    public static DocumentShare ShareToFolder(
+        Guid id,
+        Guid? tenantId,
+        Guid folderId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        bool isDefault,
+        Guid createdByUserId,
+        DateTimeOffset createdAt,
+        DateTimeOffset? expiresAt = null)
+    {
+        if (folderId == Guid.Empty)
+        {
+            throw new ArgumentException("FolderId cannot be empty.", nameof(folderId));
+        }
+        return Create(
+            id, tenantId, ShareTargetType.Folder, folderId: folderId, documentId: null,
+            granteeType, granteeId, permission, isDefault,
+            createdByUserId, createdAt, expiresAt);
+    }
+
+    /// <summary>
+    /// Creates a share that grants <paramref name="permission"/> to (<paramref name="granteeType"/>,
+    /// <paramref name="granteeId"/>) on the document identified by <paramref name="documentId"/>.
+    /// </summary>
+    /// <remarks>
+    /// Document shares never inherit; <see cref="IsDefault"/> is always stored as <c>false</c>.
+    /// </remarks>
+    public static DocumentShare ShareToDocument(
+        Guid id,
+        Guid? tenantId,
+        Guid documentId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        Guid createdByUserId,
+        DateTimeOffset createdAt,
+        DateTimeOffset? expiresAt = null)
+    {
+        if (documentId == Guid.Empty)
+        {
+            throw new ArgumentException("DocumentId cannot be empty.", nameof(documentId));
+        }
+        return Create(
+            id, tenantId, ShareTargetType.Document, folderId: null, documentId: documentId,
+            granteeType, granteeId, permission, isDefault: false,
+            createdByUserId, createdAt, expiresAt);
+    }
+
+    /// <summary>
+    /// Canonical aggregate factory. Use the type-safe wrappers <see cref="ShareToFolder"/>
+    /// and <see cref="ShareToDocument"/> from application code; this overload exists primarily
+    /// to satisfy the <c>Create(...)</c> factory convention enforced by the architecture
+    /// tests and to centralise the invariant checks shared between the two wrappers.
+    /// </summary>
+    public static DocumentShare Create(
+        Guid id,
+        Guid? tenantId,
+        ShareTargetType targetType,
+        Guid? folderId,
+        Guid? documentId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        bool isDefault,
+        Guid createdByUserId,
+        DateTimeOffset createdAt,
+        DateTimeOffset? expiresAt = null)
+    {
+        ValidateTarget(targetType, folderId, documentId);
+        ValidateGrantee(granteeId);
+        ValidatePermission(permission);
+        ValidateGranteeType(granteeType);
+        ValidateExpiration(expiresAt, createdAt);
+
+        DocumentShare share = new()
+        {
+            Id = id,
+            TenantId = tenantId,
+            TargetType = targetType,
+            FolderId = folderId,
+            DocumentId = documentId,
+            GranteeType = granteeType,
+            GranteeId = granteeId,
+            Permission = permission,
+            // Document shares never inherit — normalise here so the wrapper signatures stay
+            // honest even if a caller bypasses them and reaches Create directly.
+            IsDefault = targetType == ShareTargetType.Folder && isDefault,
+            CreatedByUserId = createdByUserId,
+            CreatedAt = createdAt,
+            ExpiresAt = expiresAt,
+        };
+        share.AddDomainEvent(new DocumentShareGrantedEvent(
+            share.Id, share.TenantId, share.TargetType, share.FolderId, share.DocumentId,
+            share.GranteeType, share.GranteeId, share.Permission, share.IsDefault, share.ExpiresAt));
+        return share;
+    }
+
+    private static void ValidateTarget(
+        ShareTargetType targetType,
+        Guid? folderId,
+        Guid? documentId)
+    {
+        if (!Enum.IsDefined(targetType))
+        {
+            throw new ArgumentException(
+                $"Unknown share target type '{targetType}'.", nameof(targetType));
+        }
+        bool folderProvided = folderId is { } fid && fid != Guid.Empty;
+        bool documentProvided = documentId is { } did && did != Guid.Empty;
+        if (targetType == ShareTargetType.Folder && (!folderProvided || documentProvided))
+        {
+            throw new ArgumentException(
+                "Folder shares require a non-empty folderId and no documentId.", nameof(folderId));
+        }
+        if (targetType == ShareTargetType.Document && (!documentProvided || folderProvided))
+        {
+            throw new ArgumentException(
+                "Document shares require a non-empty documentId and no folderId.", nameof(documentId));
+        }
+    }
+
+    /// <summary>Identifier of the tenant that owns this share.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>Explicit implementation preserves <c>private set</c> on the public property.</remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Whether this grant is on a folder or a document.</summary>
+    public ShareTargetType TargetType { get; private set; }
+
+    /// <summary>Target folder identifier — non-null exactly when <see cref="TargetType"/> is <see cref="ShareTargetType.Folder"/>.</summary>
+    public Guid? FolderId { get; private set; }
+
+    /// <summary>Target document identifier — non-null exactly when <see cref="TargetType"/> is <see cref="ShareTargetType.Document"/>.</summary>
+    public Guid? DocumentId { get; private set; }
+
+    /// <summary>Kind of principal the grant targets.</summary>
+    public ShareGranteeType GranteeType { get; private set; }
+
+    /// <summary>Identifier of the grantee (user, role, or group depending on <see cref="GranteeType"/>).</summary>
+    public Guid GranteeId { get; private set; }
+
+    /// <summary>Permission level conferred.</summary>
+    public SharePermissionLevel Permission { get; private set; }
+
+    /// <summary>
+    /// For folder shares: when <c>true</c>, the grant inherits to descendants via path-prefix
+    /// matching (semantics introduced by F6.4). Always <c>false</c> for document shares.
+    /// </summary>
+    public bool IsDefault { get; private set; }
+
+    /// <summary>Optional expiration timestamp. <c>null</c> means the grant never expires.</summary>
+    public DateTimeOffset? ExpiresAt { get; private set; }
+
+    /// <summary>UTC creation timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>Identifier of the user who granted the share (audit attribution).</summary>
+    public Guid CreatedByUserId { get; private set; }
+
+    /// <summary>
+    /// Returns <c>true</c> when the share has expired relative to <paramref name="now"/>.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset now) =>
+        ExpiresAt is { } expiresAt && expiresAt <= now;
+
+    /// <summary>
+    /// Marks the share as revoked by emitting <see cref="DocumentShareRevokedEvent"/>. The
+    /// service layer is responsible for the actual delete; this method exists so revocation
+    /// goes through the aggregate and the event is dispatched alongside the SaveChanges.
+    /// </summary>
+    public void Revoke() =>
+        AddDomainEvent(new DocumentShareRevokedEvent(
+            Id, TenantId, TargetType, FolderId, DocumentId, GranteeType, GranteeId));
+
+    private static void ValidateGrantee(Guid granteeId)
+    {
+        if (granteeId == Guid.Empty)
+        {
+            throw new ArgumentException("GranteeId cannot be empty.", nameof(granteeId));
+        }
+    }
+
+    private static void ValidatePermission(SharePermissionLevel permission)
+    {
+        if (!Enum.IsDefined(permission))
+        {
+            throw new ArgumentException(
+                $"Unknown share permission '{permission}'.", nameof(permission));
+        }
+    }
+
+    private static void ValidateGranteeType(ShareGranteeType granteeType)
+    {
+        if (!Enum.IsDefined(granteeType))
+        {
+            throw new ArgumentException(
+                $"Unknown grantee type '{granteeType}'.", nameof(granteeType));
+        }
+    }
+
+    private static void ValidateExpiration(DateTimeOffset? expiresAt, DateTimeOffset createdAt)
+    {
+        if (expiresAt is { } v && v <= createdAt)
+        {
+            throw new ArgumentException(
+                "ExpiresAt must be strictly greater than the creation time.", nameof(expiresAt));
+        }
+    }
+}

--- a/src/Granit.Documents/Domain/ShareGranteeType.cs
+++ b/src/Granit.Documents/Domain/ShareGranteeType.cs
@@ -1,0 +1,21 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// The kind of principal a <see cref="DocumentShare"/> is granted to.
+/// </summary>
+/// <remarks>
+/// The <see cref="DocumentShare.GranteeId"/> is a plain <see cref="Guid"/> regardless of type;
+/// resolution against the user's effective principal set (user id ∪ role ids ∪ group ids) is
+/// performed by the F6.2 effective-permission resolver.
+/// </remarks>
+public enum ShareGranteeType
+{
+    /// <summary>Grant targets a single user (matches <c>User.Id</c>).</summary>
+    User,
+
+    /// <summary>Grant targets a role (matches any of the principal's role ids).</summary>
+    Role,
+
+    /// <summary>Grant targets a group (matches any of the principal's group ids).</summary>
+    Group,
+}

--- a/src/Granit.Documents/Domain/SharePermissionLevel.cs
+++ b/src/Granit.Documents/Domain/SharePermissionLevel.cs
@@ -1,0 +1,21 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Permission level conferred by a <see cref="DocumentShare"/>.
+/// </summary>
+/// <remarks>
+/// Effective permission across overlapping grants is the highest level, ordered
+/// <see cref="Read"/> &lt; <see cref="Edit"/> &lt; <see cref="Manage"/>. Phase 1 has no
+/// deny-override semantics — see ADR-052 §Permission resolution model.
+/// </remarks>
+public enum SharePermissionLevel
+{
+    /// <summary>Download / view metadata.</summary>
+    Read = 0,
+
+    /// <summary>Edit metadata, upload new versions, rename, move, trash.</summary>
+    Edit = 1,
+
+    /// <summary>Full control, including managing shares on the target.</summary>
+    Manage = 2,
+}

--- a/src/Granit.Documents/Domain/ShareTargetType.cs
+++ b/src/Granit.Documents/Domain/ShareTargetType.cs
@@ -1,0 +1,18 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// What a <see cref="DocumentShare"/> is granted on.
+/// </summary>
+/// <remarks>
+/// Persisted as a string (per Granit conventions) and constrained at the database level by the
+/// <c>ck_share_target_exactly_one</c> CHECK so that exactly one of <see cref="DocumentShare.FolderId"/>
+/// or <see cref="DocumentShare.DocumentId"/> is non-null for any given row.
+/// </remarks>
+public enum ShareTargetType
+{
+    /// <summary>Grant applies to a folder (and, when default, propagates via path prefix per ADR-052).</summary>
+    Folder,
+
+    /// <summary>Grant applies to a single document.</summary>
+    Document,
+}

--- a/src/Granit.Documents/Events/DocumentShareGrantedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentShareGrantedEvent.cs
@@ -1,0 +1,23 @@
+using Granit.Documents.Domain;
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <see cref="DocumentShare"/> is granted on a folder or a document.
+/// </summary>
+/// <remarks>
+/// Consumed by the F6.3 cache layer to invalidate the matching ACL tag
+/// (<c>acl:{tenantId}:folder:{folderId}</c> or <c>acl:{tenantId}:doc:{documentId}</c>).
+/// </remarks>
+public sealed record DocumentShareGrantedEvent(
+    Guid ShareId,
+    Guid? TenantId,
+    ShareTargetType TargetType,
+    Guid? FolderId,
+    Guid? DocumentId,
+    ShareGranteeType GranteeType,
+    Guid GranteeId,
+    SharePermissionLevel Permission,
+    bool IsDefault,
+    DateTimeOffset? ExpiresAt) : IDomainEvent;

--- a/src/Granit.Documents/Events/DocumentShareRevokedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentShareRevokedEvent.cs
@@ -1,0 +1,19 @@
+using Granit.Documents.Domain;
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <see cref="DocumentShare"/> is revoked.
+/// </summary>
+/// <remarks>
+/// Consumed by the F6.3 cache layer to invalidate the matching ACL tag.
+/// </remarks>
+public sealed record DocumentShareRevokedEvent(
+    Guid ShareId,
+    Guid? TenantId,
+    ShareTargetType TargetType,
+    Guid? FolderId,
+    Guid? DocumentId,
+    ShareGranteeType GranteeType,
+    Guid GranteeId) : IDomainEvent;

--- a/src/Granit.Documents/IDocumentShareService.cs
+++ b/src/Granit.Documents/IDocumentShareService.cs
@@ -1,0 +1,67 @@
+using Granit.Documents.Domain;
+
+namespace Granit.Documents;
+
+/// <summary>
+/// Domain orchestration contract for ACL share grant / revoke / listing (F6.1).
+/// The HTTP layer (<c>Granit.Documents.Endpoints</c>) consumes this interface; the EF Core
+/// implementation lives in <c>Granit.Documents.EntityFrameworkCore</c>.
+/// </summary>
+/// <remarks>
+/// Effective-permission resolution (F6.2) and FusionCache invalidation (F6.3) are layered
+/// on top in subsequent stories — F6.1 is limited to write/read of the share rows.
+/// </remarks>
+public interface IDocumentShareService
+{
+    /// <summary>
+    /// Grants <paramref name="permission"/> on the folder identified by
+    /// <paramref name="folderId"/> to (<paramref name="granteeType"/>, <paramref name="granteeId"/>).
+    /// </summary>
+    /// <returns>The created <see cref="DocumentShare"/>, or <c>null</c> when the folder does not exist.</returns>
+    /// <exception cref="ArgumentException">When inputs are invalid (per the aggregate factory).</exception>
+    Task<DocumentShare?> GrantOnFolderAsync(
+        Guid folderId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        bool isDefault,
+        Guid createdByUserId,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Grants <paramref name="permission"/> on the document identified by
+    /// <paramref name="documentId"/> to (<paramref name="granteeType"/>, <paramref name="granteeId"/>).
+    /// </summary>
+    /// <returns>The created <see cref="DocumentShare"/>, or <c>null</c> when the document does not exist.</returns>
+    Task<DocumentShare?> GrantOnDocumentAsync(
+        Guid documentId,
+        ShareGranteeType granteeType,
+        Guid granteeId,
+        SharePermissionLevel permission,
+        Guid createdByUserId,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes the share with the given identifier.
+    /// </summary>
+    /// <returns><c>true</c> when a row was deleted; <c>false</c> when the share does not exist.</returns>
+    Task<bool> RevokeAsync(Guid shareId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the active shares granted on the folder identified by <paramref name="folderId"/>,
+    /// ordered by creation time. Expired shares are excluded.
+    /// </summary>
+    Task<IReadOnlyList<DocumentShare>> ListForFolderAsync(
+        Guid folderId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the active shares granted on the document identified by <paramref name="documentId"/>,
+    /// ordered by creation time. Expired shares are excluded.
+    /// </summary>
+    Task<IReadOnlyList<DocumentShare>> ListForDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Events.Wolverine/packages.lock.json
+++ b/src/Granit.Events.Wolverine/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -772,11 +772,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -180,25 +180,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -238,7 +219,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -188,25 +188,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -246,7 +227,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
@@ -102,21 +102,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -154,7 +139,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
@@ -320,25 +320,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -385,7 +366,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -345,25 +345,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -410,7 +391,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
@@ -81,16 +81,6 @@
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -106,46 +96,6 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -252,25 +202,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -290,12 +221,6 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -310,7 +235,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -328,27 +252,6 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
-        }
-      },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -370,30 +273,6 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -433,42 +312,6 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
-        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
@@ -320,25 +320,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -385,7 +366,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak/packages.lock.json
@@ -345,25 +345,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -410,7 +391,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -8,16 +8,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -35,14 +25,6 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -52,27 +34,12 @@
           "Microsoft.Extensions.Options": "10.0.7"
         }
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
-      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -184,15 +151,6 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -220,12 +178,6 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -240,7 +192,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -258,27 +209,6 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
-        }
-      },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.privacy": {
@@ -337,30 +267,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -398,29 +304,6 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
-        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Federated/packages.lock.json
+++ b/src/Granit.Identity.Federated/packages.lock.json
@@ -8,16 +8,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "ZString": {
         "type": "Transitive",
         "resolved": "2.6.0",
@@ -92,21 +82,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -122,12 +97,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )"
-        }
-      },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.identity": {
@@ -149,25 +118,6 @@
           "SmartFormat": "[3.*, )"
         }
       },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -185,34 +135,6 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/src/Granit.MultiTenancy.Provisioning/packages.lock.json
+++ b/src/Granit.MultiTenancy.Provisioning/packages.lock.json
@@ -25,8 +25,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -41,10 +41,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -850,11 +850,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -873,11 +873,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -21,11 +21,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -58,8 +58,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -74,10 +74,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -867,11 +867,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/packages.lock.json
@@ -389,8 +389,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Granit.Parties.Deduplication/packages.lock.json
+++ b/src/Granit.Parties.Deduplication/packages.lock.json
@@ -355,8 +355,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Granit.Parties.Endpoints/packages.lock.json
+++ b/src/Granit.Parties.Endpoints/packages.lock.json
@@ -358,8 +358,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Parties.EntityFrameworkCore/packages.lock.json
@@ -5,8 +5,8 @@
       "libphonenumber-csharp": {
         "type": "Direct",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",

--- a/src/Granit.Parties.Mergeable/packages.lock.json
+++ b/src/Granit.Parties.Mergeable/packages.lock.json
@@ -341,8 +341,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {

--- a/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Scheduling.BackgroundJobs/packages.lock.json
@@ -25,8 +25,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -41,10 +41,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -789,11 +789,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -812,11 +812,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Scheduling.Wolverine/packages.lock.json
+++ b/src/Granit.Scheduling.Wolverine/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -784,11 +784,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -993,11 +993,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Encryption/packages.lock.json
+++ b/src/Granit.Wolverine.Encryption/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -48,8 +48,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -64,10 +64,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -774,11 +774,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -58,24 +58,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "HZp1P+jszq8JmXjzYNHv80xhN4DwJArg0Z5GaVbtMFmtH+ku5yIqPEnKSwXsrMaoOYtNgwYRHpMAaL0jFqDYQA==",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
         "dependencies": {
-          "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "DistributedLock.Core": {
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -660,39 +660,39 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.Postgresql": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "bi2XmS2t8/6y95SXG15pF7bkX7na+bbUHj1Nr2rLTlrOUP1IZJJCnllRHYnFHuiYOthx50LhqZ1QZT+XhhnHTg==",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
         "dependencies": {
           "DistributedLock.Postgres": "1.3.0",
           "Npgsql": "9.0.4",
           "Npgsql.NetTopologySuite": "9.0.4",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "ZString": {
@@ -1025,11 +1025,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1048,11 +1048,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -60,24 +60,24 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "ZjZXwaGu2SMMPKp0zgqVxq0jjtDV/vSFeDxMZe/PuvgH6bktYu0vnUPSMQXovYGHRWJMLaPzT3dLQ2RZLDDIiw==",
+        "resolved": "5.39.0",
+        "contentHash": "jSl+l2K1yZioWBMKNj6e92WrNuvPmUHIrhLwZJAIQ0KSXyIzmw5W+PYa8B5jni/LakzHcu2rsbJb6sxsQ41cvQ==",
         "dependencies": {
-          "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.SqlServer": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "Azure.Core": {
@@ -107,8 +107,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -123,10 +123,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -769,38 +769,38 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.SqlServer": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "04wtlTJ8M/lBe30TtAOpHALJVrlZtPU4PyPPSm5Fa3nd96lkkeNiPa9l+XcI52hYtBCD0z50Lbd93fMz/1NB4g==",
+        "resolved": "8.15.1",
+        "contentHash": "DJSFH8Scq2UGa+gbSVT97X9usApkn81Zfzu68gMObA5f+tsFjbrPGSLp9gEqNtYiN2rFeyqVcF74c6gzRgxtIA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.3",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "ZString": {
@@ -1123,11 +1123,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1146,11 +1146,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.Wolverine/packages.lock.json
+++ b/src/Granit.Wolverine/packages.lock.json
@@ -11,11 +11,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "NewId": "4.0.1",
@@ -25,11 +25,11 @@
       "WolverineFx.FluentValidation": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "FastExpressionCompiler": {
@@ -49,8 +49,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -61,10 +61,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -359,8 +359,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -371,10 +371,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1310,39 +1310,39 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.Postgresql": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "bi2XmS2t8/6y95SXG15pF7bkX7na+bbUHj1Nr2rLTlrOUP1IZJJCnllRHYnFHuiYOthx50LhqZ1QZT+XhhnHTg==",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
         "dependencies": {
           "DistributedLock.Postgres": "1.3.0",
           "Npgsql": "9.0.4",
           "Npgsql.NetTopologySuite": "9.0.4",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.SqlServer": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "04wtlTJ8M/lBe30TtAOpHALJVrlZtPU4PyPPSm5Fa3nd96lkkeNiPa9l+XcI52hYtBCD0z50Lbd93fMz/1NB4g==",
+        "resolved": "8.15.1",
+        "contentHash": "DJSFH8Scq2UGa+gbSVT97X9usApkn81Zfzu68gMObA5f+tsFjbrPGSLp9gEqNtYiN2rFeyqVcF74c6gzRgxtIA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.3",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WebDriverBiDi": {
@@ -1352,11 +1352,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "xunit.analyzers": {
@@ -2601,6 +2601,7 @@
       "granit.identity.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
@@ -4614,8 +4615,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
@@ -5145,8 +5146,8 @@
       "Sylvan.Data.Excel": {
         "type": "CentralTransitive",
         "requested": "[0.5.*, )",
-        "resolved": "0.5.5",
-        "contentHash": "HBsTVzAupf2tg/koLNEalzsJfWRl0sbtFOaTSdrweujeyEx3zO5BxcxTzW55TD2db9sn1xpRcSLP04tUG0v/jQ=="
+        "resolved": "0.5.6",
+        "contentHash": "6OcGGQRT0dfg1bBEl0AIakNUfuAQCMRclq7ZJEeWejRuIypp0zxzLB52/8FTgw7wFYdLcikI8fK7oLpMA4F7Lw=="
       },
       "System.Composition.AttributedModel": {
         "type": "CentralTransitive",
@@ -5163,11 +5164,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "NewId": "4.0.1",
@@ -5177,44 +5178,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "HZp1P+jszq8JmXjzYNHv80xhN4DwJArg0Z5GaVbtMFmtH+ku5yIqPEnKSwXsrMaoOYtNgwYRHpMAaL0jFqDYQA==",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
         "dependencies": {
-          "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "ZjZXwaGu2SMMPKp0zgqVxq0jjtDV/vSFeDxMZe/PuvgH6bktYu0vnUPSMQXovYGHRWJMLaPzT3dLQ2RZLDDIiw==",
+        "resolved": "5.39.0",
+        "contentHash": "jSl+l2K1yZioWBMKNj6e92WrNuvPmUHIrhLwZJAIQ0KSXyIzmw5W+PYa8B5jni/LakzHcu2rsbJb6sxsQ41cvQ==",
         "dependencies": {
-          "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.SqlServer": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
@@ -52,11 +52,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -126,8 +126,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -142,10 +142,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1017,11 +1017,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -994,11 +994,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1017,11 +1017,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.S3.Tests/packages.lock.json
@@ -438,8 +438,8 @@
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.22.2",
-        "contentHash": "RYBhoTFlMRq2tiqv/8FfSRFkNz0OCY2U5AbwH5PWpI/XhI3eQp34ujVAT9gD9DqOUHKDaQvJegauypUSO6wkjQ==",
+        "resolved": "4.0.23",
+        "contentHash": "yPvCj0ITnniE8j2YVVCrTfutOfaw+a9CememSzqYL2Y7zQaKLZL6F5385zI8NqnCpw26OzU5cwmKzAC6xssbGw==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.6.1, 5.0.0)"
         }

--- a/tests/Granit.Bundle.Tests/packages.lock.json
+++ b/tests/Granit.Bundle.Tests/packages.lock.json
@@ -608,6 +608,15 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -785,6 +794,7 @@
       "granit.notifications.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Notifications": "[0.1.0-dev, )",
           "Granit.Notifications.MobilePush": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",

--- a/tests/Granit.DataExchange.Excel.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Excel.Tests/packages.lock.json
@@ -574,8 +574,8 @@
       "Sylvan.Data.Excel": {
         "type": "CentralTransitive",
         "requested": "[0.5.*, )",
-        "resolved": "0.5.5",
-        "contentHash": "HBsTVzAupf2tg/koLNEalzsJfWRl0sbtFOaTSdrweujeyEx3zO5BxcxTzW55TD2db9sn1xpRcSLP04tUG0v/jQ=="
+        "resolved": "0.5.6",
+        "contentHash": "6OcGGQRT0dfg1bBEl0AIakNUfuAQCMRclq7ZJEeWejRuIypp0zxzLB52/8FTgw7wFYdLcikI8fK7oLpMA4F7Lw=="
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentSharePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentSharePostgresTests.cs
@@ -1,0 +1,238 @@
+using Granit.Documents;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed integration tests for <see cref="DocumentShareService"/> (F6.1).
+/// Covers grant on folder + document + revoke + listing, plus the database-level CHECK
+/// that pins the exactly-one-target invariant.
+/// </summary>
+public sealed class DocumentSharePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private DocumentShareService _sut = null!;
+    private DocumentBootstrapService _bootstrap = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+    private static readonly Guid GranteeId = Guid.NewGuid();
+
+    public DocumentSharePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_shares, documents_document_versions, documents_documents, documents_folders RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        _bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(new DateTimeOffset(2026, 5, 10, 12, 0, 0, TimeSpan.Zero));
+
+        _sut = new DocumentShareService(_factory, currentTenant, new SimpleGuidGenerator(), clock);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task GrantOnFolder_PersistsRowWithFolderTarget()
+    {
+        Folder folder = await SeedFolderAsync();
+
+        DocumentShare? share = await _sut.GrantOnFolderAsync(
+            folder.Id, ShareGranteeType.User, GranteeId, SharePermissionLevel.Read,
+            isDefault: true, OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken);
+
+        share.ShouldNotBeNull();
+        share.TargetType.ShouldBe(ShareTargetType.Folder);
+        share.FolderId.ShouldBe(folder.Id);
+        share.DocumentId.ShouldBeNull();
+        share.IsDefault.ShouldBeTrue();
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        DocumentShare reloaded = await db.DocumentShares.SingleAsync(
+            s => s.Id == share.Id, TestContext.Current.CancellationToken);
+        reloaded.FolderId.ShouldBe(folder.Id);
+        reloaded.DocumentId.ShouldBeNull();
+        reloaded.GranteeType.ShouldBe(ShareGranteeType.User);
+        reloaded.Permission.ShouldBe(SharePermissionLevel.Read);
+    }
+
+    [Fact]
+    public async Task GrantOnFolder_MissingFolder_ReturnsNull()
+    {
+        DocumentShare? share = await _sut.GrantOnFolderAsync(
+            Guid.NewGuid(), ShareGranteeType.User, GranteeId, SharePermissionLevel.Read,
+            isDefault: true, OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken);
+
+        share.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GrantOnDocument_PersistsRowWithDocumentTarget()
+    {
+        (Folder folder, Document doc) = await SeedFolderAndDocumentAsync();
+
+        DocumentShare? share = await _sut.GrantOnDocumentAsync(
+            doc.Id, ShareGranteeType.Role, GranteeId, SharePermissionLevel.Edit,
+            OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken);
+
+        share.ShouldNotBeNull();
+        share.TargetType.ShouldBe(ShareTargetType.Document);
+        share.DocumentId.ShouldBe(doc.Id);
+        share.FolderId.ShouldBeNull();
+        share.IsDefault.ShouldBeFalse();
+        _ = folder; // used to seed the document
+    }
+
+    [Fact]
+    public async Task RevokeAsync_DeletesRow()
+    {
+        Folder folder = await SeedFolderAsync();
+        DocumentShare share = (await _sut.GrantOnFolderAsync(
+            folder.Id, ShareGranteeType.Group, GranteeId, SharePermissionLevel.Manage,
+            isDefault: false, OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken))!;
+
+        bool removed = await _sut.RevokeAsync(share.Id, TestContext.Current.CancellationToken);
+        removed.ShouldBeTrue();
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        (await db.DocumentShares.AnyAsync(s => s.Id == share.Id, TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RevokeAsync_MissingShare_ReturnsFalse() =>
+        (await _sut.RevokeAsync(Guid.NewGuid(), TestContext.Current.CancellationToken)).ShouldBeFalse();
+
+    [Fact]
+    public async Task ListForFolderAsync_ExcludesExpiredAndOrdersByCreatedAt()
+    {
+        Folder folder = await SeedFolderAsync();
+        DateTimeOffset now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+        // Manually craft a clock whose Now advances per call so CreatedAt diverges.
+        IClock clock = Substitute.For<IClock>();
+        var queue = new Queue<DateTimeOffset>([now, now.AddSeconds(1), now.AddSeconds(2)]);
+        clock.Now.Returns(_ => queue.Dequeue());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        var sut = new DocumentShareService(_factory, currentTenant, new SimpleGuidGenerator(), clock);
+
+        DocumentShare a = (await sut.GrantOnFolderAsync(
+            folder.Id, ShareGranteeType.User, GranteeId, SharePermissionLevel.Read,
+            isDefault: true, OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken))!;
+        DocumentShare expired = (await sut.GrantOnFolderAsync(
+            folder.Id, ShareGranteeType.User, Guid.NewGuid(), SharePermissionLevel.Read,
+            isDefault: true, OwnerId, expiresAt: now.AddMilliseconds(500),
+            TestContext.Current.CancellationToken))!;
+        DocumentShare c = (await sut.GrantOnFolderAsync(
+            folder.Id, ShareGranteeType.Role, Guid.NewGuid(), SharePermissionLevel.Edit,
+            isDefault: true, OwnerId, expiresAt: null,
+            TestContext.Current.CancellationToken))!;
+
+        // List uses the service's clock; align it to "after the expired share".
+        clock.Now.Returns(now.AddSeconds(10));
+
+        IReadOnlyList<DocumentShare> rows = await sut
+            .ListForFolderAsync(folder.Id, TestContext.Current.CancellationToken);
+
+        rows.Select(s => s.Id).ShouldBe([a.Id, c.Id]);
+        rows.Any(s => s.Id == expired.Id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CheckConstraint_InconsistentRow_RaisesDbException()
+    {
+        // Bypass the aggregate factory to attempt persisting a row that violates
+        // ck_documents_shares_target_exactly_one. This proves the database guard,
+        // not just the C# invariant.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_shares;",
+            TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<DbUpdateException>(async () =>
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO documents_shares
+                    ("Id", "TenantId", "TargetType", "FolderId", "DocumentId",
+                     "GranteeType", "GranteeId", "Permission", "IsDefault",
+                     "ExpiresAt", "CreatedAt", "CreatedByUserId")
+                VALUES
+                    (@id, @tenant, 'Folder', NULL, NULL,
+                     'User', @grantee, 'Read', TRUE,
+                     NULL, NOW(), @creator);
+                """,
+                TestContext.Current.CancellationToken,
+                new Npgsql.NpgsqlParameter("id", Guid.NewGuid()),
+                new Npgsql.NpgsqlParameter("tenant", TenantId),
+                new Npgsql.NpgsqlParameter("grantee", GranteeId),
+                new Npgsql.NpgsqlParameter("creator", OwnerId));
+        });
+    }
+
+    private async Task<Folder> SeedFolderAsync()
+    {
+        Guid rootId = await _bootstrap.EnsureTenantRootAsync(TenantId, OwnerId, TestContext.Current.CancellationToken);
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder root = await db.Folders.SingleAsync(f => f.Id == rootId, TestContext.Current.CancellationToken);
+        var folder = Folder.Create(Guid.NewGuid(), root, "Contracts", OwnerId);
+        db.Folders.Add(folder);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return folder;
+    }
+
+    private async Task<(Folder, Document)> SeedFolderAndDocumentAsync()
+    {
+        Folder folder = await SeedFolderAsync();
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder reloaded = await db.Folders.SingleAsync(f => f.Id == folder.Id, TestContext.Current.CancellationToken);
+        var doc = Document.Create(Guid.NewGuid(), reloaded, OwnerId, "Contract.pdf");
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (folder, doc);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}

--- a/tests/Granit.Documents.Tests/Domain/DocumentShareTests.cs
+++ b/tests/Granit.Documents.Tests/Domain/DocumentShareTests.cs
@@ -1,0 +1,145 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Domain;
+
+public sealed class DocumentShareTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid GranteeId = Guid.NewGuid();
+    private static readonly Guid CreatedBy = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ShareToFolder_Defaults_AreCorrect()
+    {
+        var folderId = Guid.NewGuid();
+        var id = Guid.NewGuid();
+
+        var share = DocumentShare.ShareToFolder(
+            id, TenantId, folderId, ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now);
+
+        share.Id.ShouldBe(id);
+        share.TenantId.ShouldBe(TenantId);
+        share.TargetType.ShouldBe(ShareTargetType.Folder);
+        share.FolderId.ShouldBe(folderId);
+        share.DocumentId.ShouldBeNull();
+        share.GranteeType.ShouldBe(ShareGranteeType.User);
+        share.GranteeId.ShouldBe(GranteeId);
+        share.Permission.ShouldBe(SharePermissionLevel.Read);
+        share.IsDefault.ShouldBeTrue();
+        share.CreatedAt.ShouldBe(Now);
+        share.CreatedByUserId.ShouldBe(CreatedBy);
+        share.ExpiresAt.ShouldBeNull();
+
+        DocumentShareGrantedEvent granted = share.DomainEvents
+            .OfType<DocumentShareGrantedEvent>()
+            .ShouldHaveSingleItem();
+        granted.TargetType.ShouldBe(ShareTargetType.Folder);
+        granted.FolderId.ShouldBe(folderId);
+        granted.IsDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShareToDocument_AlwaysClearsIsDefault()
+    {
+        var documentId = Guid.NewGuid();
+
+        var share = DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, documentId, ShareGranteeType.Role, GranteeId,
+            SharePermissionLevel.Edit, CreatedBy, Now);
+
+        share.TargetType.ShouldBe(ShareTargetType.Document);
+        share.DocumentId.ShouldBe(documentId);
+        share.FolderId.ShouldBeNull();
+        share.IsDefault.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShareToFolder_EmptyFolderId_Throws() =>
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.Empty, ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now));
+
+    [Fact]
+    public void ShareToDocument_EmptyDocumentId_Throws() =>
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, Guid.Empty, ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, CreatedBy, Now));
+
+    [Fact]
+    public void EmptyGranteeId_Throws() =>
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, Guid.Empty,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now));
+
+    [Fact]
+    public void UnknownGranteeType_Throws() =>
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), (ShareGranteeType)42, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now));
+
+    [Fact]
+    public void UnknownPermission_Throws() =>
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, GranteeId,
+            (SharePermissionLevel)42, isDefault: true, CreatedBy, Now));
+
+    [Fact]
+    public void ExpiresAt_AtOrBeforeCreatedAt_Throws()
+    {
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now, expiresAt: Now));
+        Should.Throw<ArgumentException>(() => DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now, expiresAt: Now.AddDays(-1)));
+    }
+
+    [Fact]
+    public void IsExpired_BeforeAndAfterExpiresAt()
+    {
+        DateTimeOffset expiresAt = Now.AddHours(1);
+        var share = DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now, expiresAt: expiresAt);
+
+        share.IsExpired(Now).ShouldBeFalse();
+        share.IsExpired(expiresAt.AddTicks(-1)).ShouldBeFalse();
+        share.IsExpired(expiresAt).ShouldBeTrue();
+        share.IsExpired(expiresAt.AddSeconds(1)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsExpired_NeverExpiringShare_AlwaysFalse()
+    {
+        var share = DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, Guid.NewGuid(), ShareGranteeType.User, GranteeId,
+            SharePermissionLevel.Read, isDefault: true, CreatedBy, Now);
+
+        share.IsExpired(Now.AddYears(100)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Revoke_EmitsRevokedEvent()
+    {
+        var folderId = Guid.NewGuid();
+        var share = DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folderId, ShareGranteeType.Group, GranteeId,
+            SharePermissionLevel.Manage, isDefault: false, CreatedBy, Now);
+        // Drop the granted event so we can assert the revoked one cleanly.
+        share.ClearDomainEvents();
+
+        share.Revoke();
+
+        DocumentShareRevokedEvent revoked = share.DomainEvents
+            .OfType<DocumentShareRevokedEvent>()
+            .ShouldHaveSingleItem();
+        revoked.TargetType.ShouldBe(ShareTargetType.Folder);
+        revoked.FolderId.ShouldBe(folderId);
+        revoked.GranteeType.ShouldBe(ShareGranteeType.Group);
+    }
+}

--- a/tests/Granit.Events.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Events.Wolverine.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -974,11 +974,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -997,11 +997,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/packages.lock.json
@@ -131,6 +131,15 @@
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -379,6 +388,25 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -416,6 +444,7 @@
       "granit.identity.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
@@ -510,6 +539,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -568,6 +607,19 @@
         "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       }

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -412,25 +412,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -470,7 +451,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -1388,25 +1388,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -1446,7 +1427,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -398,25 +398,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -456,7 +437,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -410,25 +410,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -468,7 +449,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
@@ -552,25 +552,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -617,7 +598,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -1499,25 +1499,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -1564,7 +1545,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -538,25 +538,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -603,7 +584,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
@@ -146,16 +146,6 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -171,46 +161,6 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -438,25 +388,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -476,12 +407,6 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -496,7 +421,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -522,27 +446,6 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
-        }
-      },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -574,30 +477,6 @@
         "dependencies": {
           "Google.Api.Gax.Rest": "4.13.1",
           "Google.Apis.Auth": "1.73.0"
-        }
-      },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -637,42 +516,6 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
-        }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
@@ -552,25 +552,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -617,7 +598,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
@@ -765,25 +765,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -830,7 +811,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
@@ -549,25 +549,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -614,7 +595,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",

--- a/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
@@ -101,16 +101,6 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -128,14 +118,6 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -145,27 +127,12 @@
           "Microsoft.Extensions.Options": "10.0.7"
         }
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
-      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -416,15 +383,6 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -452,12 +410,6 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -472,7 +424,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -497,27 +448,6 @@
           "Microsoft.Extensions.Localization": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "SmartFormat": "[3.*, )"
-        }
-      },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.privacy": {
@@ -576,30 +506,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7",
-          "Microsoft.Extensions.Caching.Memory": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7"
-        }
-      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -637,29 +543,6 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
-        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Federated.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Tests/packages.lock.json
@@ -110,16 +110,6 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
-      "Microsoft.EntityFrameworkCore.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
-      },
-      "Microsoft.EntityFrameworkCore.Analyzers": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
-      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -328,21 +318,6 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.encryption": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.encryption.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )"
-        }
-      },
       "granit.entities.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -360,12 +335,6 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.http.exceptionhandling": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -380,7 +349,6 @@
         "dependencies": {
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
-          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
@@ -396,25 +364,6 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "SmartFormat": "[3.*, )"
-        }
-      },
-      "granit.persistence": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "granit.persistence.entityframeworkcore": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
-          "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.EntityFrameworkCore": "[10.*, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -434,34 +383,6 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Provisioning.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1075,11 +1075,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1098,11 +1098,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1071,11 +1071,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1094,11 +1094,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.BackgroundJobs.Tests/packages.lock.json
@@ -621,8 +621,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Deduplication.Tests/packages.lock.json
@@ -579,8 +579,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Endpoints.Tests/packages.lock.json
@@ -697,8 +697,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Parties.EntityFrameworkCore.Tests/packages.lock.json
@@ -545,8 +545,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests.Integration/packages.lock.json
@@ -662,8 +662,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
+++ b/tests/Granit.Parties.Mergeable.Tests/packages.lock.json
@@ -571,8 +571,8 @@
       "libphonenumber-csharp": {
         "type": "CentralTransitive",
         "requested": "[9.*, )",
-        "resolved": "9.0.29",
-        "contentHash": "Z6FqHRx0gpHYr+EpW5heEadCSh9VnXJHUScPGEDCrpPLHxkB2mccUZfz+FDo+9yMF1Bxz7RBVMFL4MgV6eYoRA=="
+        "resolved": "9.0.30",
+        "contentHash": "jnGz07XEj63MHtKv6s4U0DC8bGHhnsCtwYRTAjlu5MmzqFSxkss5HBEEdU55Rg0l72HTU518kiLaQM9dcJYVjw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -63,11 +63,11 @@
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -137,8 +137,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -153,10 +153,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {

--- a/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.BackgroundJobs.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -125,10 +125,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1020,11 +1020,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1043,11 +1043,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Wolverine.Tests/packages.lock.json
@@ -120,8 +120,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -136,10 +136,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1023,11 +1023,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1046,11 +1046,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -1195,11 +1195,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1218,11 +1218,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Encryption.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -119,10 +119,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -976,11 +976,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -999,11 +999,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -170,8 +170,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -186,10 +186,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -814,39 +814,39 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.Postgresql": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "bi2XmS2t8/6y95SXG15pF7bkX7na+bbUHj1Nr2rLTlrOUP1IZJJCnllRHYnFHuiYOthx50LhqZ1QZT+XhhnHTg==",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
         "dependencies": {
           "DistributedLock.Postgres": "1.3.0",
           "Npgsql": "9.0.4",
           "Npgsql.NetTopologySuite": "9.0.4",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "xunit.analyzers": {
@@ -1284,11 +1284,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1307,34 +1307,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "HZp1P+jszq8JmXjzYNHv80xhN4DwJArg0Z5GaVbtMFmtH+ku5yIqPEnKSwXsrMaoOYtNgwYRHpMAaL0jFqDYQA==",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
         "dependencies": {
-          "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -117,8 +117,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -133,10 +133,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -735,39 +735,39 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.Postgresql": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "bi2XmS2t8/6y95SXG15pF7bkX7na+bbUHj1Nr2rLTlrOUP1IZJJCnllRHYnFHuiYOthx50LhqZ1QZT+XhhnHTg==",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
         "dependencies": {
           "DistributedLock.Postgres": "1.3.0",
           "Npgsql": "9.0.4",
           "Npgsql.NetTopologySuite": "9.0.4",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "xunit.analyzers": {
@@ -1228,11 +1228,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1251,34 +1251,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "HZp1P+jszq8JmXjzYNHv80xhN4DwJArg0Z5GaVbtMFmtH+ku5yIqPEnKSwXsrMaoOYtNgwYRHpMAaL0jFqDYQA==",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
         "dependencies": {
-          "Weasel.Postgresql": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
@@ -168,8 +168,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -184,10 +184,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -928,38 +928,38 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.SqlServer": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "04wtlTJ8M/lBe30TtAOpHALJVrlZtPU4PyPPSm5Fa3nd96lkkeNiPa9l+XcI52hYtBCD0z50Lbd93fMz/1NB4g==",
+        "resolved": "8.15.1",
+        "contentHash": "DJSFH8Scq2UGa+gbSVT97X9usApkn81Zfzu68gMObA5f+tsFjbrPGSLp9gEqNtYiN2rFeyqVcF74c6gzRgxtIA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.3",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "xunit.analyzers": {
@@ -1413,11 +1413,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1436,34 +1436,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "ZjZXwaGu2SMMPKp0zgqVxq0jjtDV/vSFeDxMZe/PuvgH6bktYu0vnUPSMQXovYGHRWJMLaPzT3dLQ2RZLDDIiw==",
+        "resolved": "5.39.0",
+        "contentHash": "jSl+l2K1yZioWBMKNj6e92WrNuvPmUHIrhLwZJAIQ0KSXyIzmw5W+PYa8B5jni/LakzHcu2rsbJb6sxsQ41cvQ==",
         "dependencies": {
-          "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.SqlServer": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -113,8 +113,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -129,10 +129,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -842,38 +842,38 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
         "dependencies": {
           "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "Weasel.SqlServer": {
         "type": "Transitive",
-        "resolved": "8.14.1",
-        "contentHash": "04wtlTJ8M/lBe30TtAOpHALJVrlZtPU4PyPPSm5Fa3nd96lkkeNiPa9l+XcI52hYtBCD0z50Lbd93fMz/1NB4g==",
+        "resolved": "8.15.1",
+        "contentHash": "DJSFH8Scq2UGa+gbSVT97X9usApkn81Zfzu68gMObA5f+tsFjbrPGSLp9gEqNtYiN2rFeyqVcF74c6gzRgxtIA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.3",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Weasel.Core": "8.14.1"
+          "Weasel.Core": "8.15.1"
         }
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.37.2",
-        "contentHash": "0kcFJJm5SCPPBGb2213gyGguhlTUs/VsCFZQwL9nr4SNLEFAFDentpoUYggsq1mcSJLqONQDj238kNPnHavrag==",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
         "dependencies": {
-          "Weasel.Core": "8.14.1",
-          "WolverineFx": "5.37.2"
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
         }
       },
       "xunit.analyzers": {
@@ -1325,11 +1325,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
@@ -1348,34 +1348,34 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "+0aVaCR0jqpthKdJj+74HgWr7PmmHJiUTi2s9eSLS+6kK0ho+wno4K7efrL3L1+yxBtfEknzthgCbhFkcpQrLg==",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "ZjZXwaGu2SMMPKp0zgqVxq0jjtDV/vSFeDxMZe/PuvgH6bktYu0vnUPSMQXovYGHRWJMLaPzT3dLQ2RZLDDIiw==",
+        "resolved": "5.39.0",
+        "contentHash": "jSl+l2K1yZioWBMKNj6e92WrNuvPmUHIrhLwZJAIQ0KSXyIzmw5W+PYa8B5jni/LakzHcu2rsbJb6sxsQ41cvQ==",
         "dependencies": {
-          "Weasel.SqlServer": "8.14.1",
-          "WolverineFx.RDBMS": "5.37.2"
+          "Weasel.SqlServer": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -109,8 +109,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.29.0",
-        "contentHash": "O446BLcT9kIs7i88lSxoc+JZMWjH8mt7bCSwQe6qGrI/Tx9JG9C1T5GuIuqURHIDpzCiIKTKN/b+bFK8PxyVqA==",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -121,10 +121,10 @@
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.33.1",
-        "contentHash": "FxgheaJlnNXeJognjNH6WtDuzchj7yoJiziXONM6sCZInaH9xhhufGS4LG1W8/g0rBOthY/YSiwhcKQhYQEvfA==",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
         "dependencies": {
-          "JasperFx": "1.29.0"
+          "JasperFx": "1.31.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -629,11 +629,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "MjVHBPfNQNjRsmI4pX6NLpc1M8/TFvMfvmVfhUswddS7IU1Ni+o/c/1gNU2VShNz4xufCvfBFPAx+RqZePWpFA==",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
         "dependencies": {
-          "JasperFx": "1.29.0",
-          "JasperFx.Events": "1.33.1",
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "NewId": "4.0.1",
@@ -643,11 +643,11 @@
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.37.2",
-        "contentHash": "e8RopP/2Spo8g2b+IDHxNHs82WjdBsH5kECM2yDQpH4qFi+QpqHjEi9SLDkjPpH7D03E6Gr9G5rY+xZh4KdDxw==",
+        "resolved": "5.39.0",
+        "contentHash": "Cn9W5QmAxz+emiAhq9o9eGkWPrwIKz44MkbgVBhLnA+esoJYs5jRl0s0Ft7KESPXXt8KkeL1WNJSve3QMeStqA==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.37.2"
+          "WolverineFx": "5.39.0"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary

First story of feature #1744 (Share ACL with path-based resolution + FusionCache) on epic #1721 (Granit.Documents). Introduces ACL share grants on folders and documents per [ADR-052](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md).

- `DocumentShare` aggregate with `ShareToFolder` / `ShareToDocument` factories plus a canonical `Create()` that satisfies the DDD factory convention. Stores the `TargetType` discriminator, `GranteeType` (User/Role/Group), permission level, `IsDefault` for folder shares (consumed by F6.4), and an optional expiration.
- EF Core configuration with the `ck_documents_shares_target_exactly_one` CHECK pinning exactly one of `FolderId`/`DocumentId`, plus filtered indexes (grantee/folder, grantee/document, listing) backing the F6.2 effective-permission resolver.
- `IDocumentShareService` + EF-backed implementation: grant on folder, grant on document, revoke, list (excludes expired).
- `Documents.Shares.Read` + `Documents.Shares.Manage` permissions registered in `DocumentsPermissionDefinitionProvider`, with localisation across all 18 base + regional cultures.
- Endpoints under the `Documents - Shares` OpenAPI tag: `POST/GET` on `/folders/{id}/shares` and `/documents/{id}/shares`, plus `DELETE /shares/{id}`, with FluentValidation and RFC 7807 problem responses.
- Domain unit tests + Postgres integration tests covering grant on folder / grant on document / revoke / listing / expiration filtering / CHECK enforcement at the database layer.

Effective-permission resolution (F6.2), FusionCache (F6.3), default-share inheritance semantics (F6.4) and the `permission` field on list responses (F6.5) come in subsequent stories — this PR only persists the rows.

Closes #1745

## Test plan

- [x] `dotnet build .github/shard-filters/infrastructure.slnf` clean
- [x] `dotnet build .github/shard-filters/integration.slnf` clean
- [x] `dotnet build .github/shard-filters/architecture.slnf` clean
- [x] `dotnet test tests/Granit.Documents.Tests` — 74 passing (12 new)
- [x] `dotnet format` clean on infrastructure + integration shards (`--verify-no-changes`)
- [x] No new architecture-test regressions (the 6 failing tests on this branch all fail identically on `develop`)
- [ ] CI runs the Postgres integration tests (`DocumentSharePostgresTests`) on the `integration` shard