### PR TITLE
feat(documents): path-based effective ACL resolver (F6.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19303,6 +19303,47 @@
       ]
     },
     {
+      "name": "DocumentPrincipal",
+      "fqn": "Granit.Documents.Authorization.DocumentPrincipal",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Authorization/DocumentPrincipal.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ForUser",
+          "kind": "method",
+          "signature": "ForUser(Guid userId)",
+          "returnType": "DocumentPrincipal"
+        }
+      ]
+    },
+    {
+      "name": "EffectivePermissionLevel",
+      "fqn": "Granit.Documents.Authorization.EffectivePermissionLevel",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Authorization/EffectivePermissionLevel.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IEffectivePermissionResolver",
+      "fqn": "Granit.Documents.Authorization.IEffectivePermissionResolver",
+      "kind": "interface",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "GetDocumentPermissionAsync",
+          "kind": "method",
+          "signature": "GetDocumentPermissionAsync(Guid documentId, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
+          "returnType": "Task<EffectivePermissionLevel>"
+        }
+      ]
+    },
+    {
       "name": "DocumentsMetrics",
       "fqn": "Granit.Documents.Diagnostics.DocumentsMetrics",
       "kind": "class",
@@ -36601,7 +36642,7 @@
       "kind": "interface",
       "project": "Granit.Notifications.Abstractions",
       "file": "src/Granit.Notifications.Abstractions/Abstractions/INotificationDeliveryWriter.cs",
-      "line": 13,
+      "line": 19,
       "members": [
         {
           "name": "HasBeenDeliveredAsync",
@@ -36610,9 +36651,15 @@
           "returnType": "Task<bool>"
         },
         {
-          "name": "RecordAsync",
+          "name": "TryAcquireDeliveryAttemptAsync",
           "kind": "method",
-          "signature": "RecordAsync(NotificationDeliveryAttempt attempt, CancellationToken cancellationToken = default)",
+          "signature": "TryAcquireDeliveryAttemptAsync(NotificationDeliveryAttempt claim, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "CompleteDeliveryAttemptAsync",
+          "kind": "method",
+          "signature": "CompleteDeliveryAttemptAsync(Guid deliveryId, bool success, long durationMilliseconds, string? errorMessage, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {
@@ -36933,7 +36980,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Abstractions",
       "file": "src/Granit.Notifications.Abstractions/Domain/NotificationDeliveryAttempt.cs",
-      "line": 9,
+      "line": 19,
       "members": [
         {
           "name": "DeliveryId",

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -57,6 +57,11 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // in on top in subsequent stories.
         builder.Services.AddScoped<IDocumentShareService, DocumentShareService>();
 
+        // Effective-permission resolver (F6.2): resolves a DocumentPrincipal against a
+        // document via the ADR-052 path-prefix permission resolution model. F6.3 will
+        // wrap this with FusionCache for hot reads.
+        builder.Services.AddScoped<Authorization.IEffectivePermissionResolver, EffectivePermissionResolver>();
+
         return builder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
@@ -1,0 +1,176 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.Domain;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed <see cref="IEffectivePermissionResolver"/> implementing the ADR-052
+/// path-prefix permission resolution model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The resolver issues two queries against the isolated <c>DocumentsDbContext</c>:
+/// </para>
+/// <list type="number">
+///   <item>
+///     A primary-key lookup that joins the requested document with its folder to retrieve
+///     <c>TenantId</c>, <c>FolderId</c>, and the materialised <c>Folder.Path</c>. This is a
+///     single-row PK fetch and stays cheap regardless of cache layer.
+///   </item>
+///   <item>
+///     The share-resolution query — direct document grants OR folder grants whose folder's
+///     <c>Path</c> sits in the document's ancestor chain — filtered to the principal's
+///     grantee ids and to non-expired grants. Returns the matching <c>Permission</c> values;
+///     the caller takes the highest.
+///   </item>
+/// </list>
+/// <para>
+/// Splitting the work avoids EF Core translating the inline ancestor-paths
+/// expansion into SQL on every dialect — the path tokens are computed in C# from the
+/// materialised <c>Folder.Path</c> and shipped as a parameter list. The resulting share
+/// query lights up the filtered indexes (<c>ix_documents_shares_grantee_folder</c> /
+/// <c>ix_documents_shares_grantee_document</c>) introduced in F6.1.
+/// </para>
+/// </remarks>
+internal sealed class EffectivePermissionResolver(
+    IDbContextFactory<DocumentsDbContext> contextFactory,
+    IClock clock) : IEffectivePermissionResolver
+{
+    /// <inheritdoc />
+    public async Task<EffectivePermissionLevel> GetDocumentPermissionAsync(
+        Guid documentId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        // Materialise as a concrete List<Guid> — EF Core's Contains translator is pickier
+        // about IReadOnlyList<T> than List<T> in some predicate shapes and the principal's
+        // grantee snapshot is small (user + role count + group count).
+        List<Guid> granteeIds = [.. principal.AllGranteeIds];
+        if (granteeIds.Count == 0)
+        {
+            return EffectivePermissionLevel.None;
+        }
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 1 — locate the document's folder + materialised path. Tenant scoping is
+        // applied implicitly by the named query filter on Document/Folder.
+        var docInfo = await context.Documents
+            .Where(d => d.Id == documentId)
+            .Join(context.Folders,
+                d => d.FolderId,
+                f => f.Id,
+                (d, f) => new { d.TenantId, FolderPath = f.Path })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (docInfo is null)
+        {
+            return EffectivePermissionLevel.None;
+        }
+
+        // Build the ancestor-path set in C# (cheap string ops on a materialised path) and
+        // ship it as a parameter list. Includes the document's own folder path so a direct
+        // share on that folder participates in the same predicate as ancestor shares.
+        List<string> ancestorPaths = ExpandSelfAndAncestorPaths(docInfo.FolderPath);
+
+        // Step 2 — resolve the ancestor + self folder ids by their materialised paths. This
+        // separate query is cheap (covered by ix_documents_folders_tenant_path) and lets
+        // step 3 reduce to a simple Contains predicate that every EF Core provider can
+        // translate — the alternative (a nested Folders.Any inside the share Where clause)
+        // doesn't translate on SQLite.
+        // Materialise as List<Guid?> so the IN clause matches Folder.FolderId's nullable type
+        // directly — avoids EF Core having to unwrap .Value across providers (SQLite refused
+        // a Contains(.Value) translation; the nullable list shape works on every provider).
+        List<Guid?> ancestorFolderIds = ancestorPaths.Count == 0
+            ? []
+            : await context.Folders
+                .Where(f => f.TenantId == docInfo.TenantId
+                    && ancestorPaths.Contains(f.Path))
+                .Select(f => (Guid?)f.Id)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+
+        // Step 3 — share-resolution. Splitting the direct-document and folder branches into
+        // two queries makes each one index-friendly (each lights up a single filtered index
+        // — ix_documents_shares_grantee_document or ix_documents_shares_grantee_folder)
+        // and stays translatable across every EF Core provider including SQLite, which
+        // chokes on the nested OR shape combining a Contains over a nullable column.
+        // The IsDefault flag is intentionally NOT filtered: per ADR-052 / F6.4, all folder
+        // shares inherit in phase 1 — IsDefault is reserved for phase 2 non-inherited shares.
+        // The ExpiresAt filter is applied in C# rather than SQL because the
+        // <c>ExpiresAt is null OR ExpiresAt &gt; now</c> shape combined with the rest of
+        // the predicate trips up the SQLite translator. The filtered indexes already
+        // narrow the row set to a handful of grants so the in-memory pass is essentially
+        // free.
+        var directMatches = await context.DocumentShares
+            .Where(s => s.TenantId == docInfo.TenantId
+                && granteeIds.Contains(s.GranteeId)
+                && s.TargetType == ShareTargetType.Document
+                && s.DocumentId == documentId)
+            .Select(s => new { s.Permission, s.ExpiresAt })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var folderMatches = ancestorFolderIds.Count == 0
+            ? []
+            : await context.DocumentShares
+                .Where(s => s.TenantId == docInfo.TenantId
+                    && granteeIds.Contains(s.GranteeId)
+                    && s.TargetType == ShareTargetType.Folder
+                    && ancestorFolderIds.Contains(s.FolderId))
+                .Select(s => new { s.Permission, s.ExpiresAt })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        List<SharePermissionLevel> matches = [
+            .. directMatches.Where(m => m.ExpiresAt is null || m.ExpiresAt > now).Select(m => m.Permission),
+            .. folderMatches.Where(m => m.ExpiresAt is null || m.ExpiresAt > now).Select(m => m.Permission),
+        ];
+
+        if (matches.Count == 0)
+        {
+            return EffectivePermissionLevel.None;
+        }
+
+        return matches.Max() switch
+        {
+            SharePermissionLevel.Manage => EffectivePermissionLevel.Manage,
+            SharePermissionLevel.Edit => EffectivePermissionLevel.Edit,
+            SharePermissionLevel.Read => EffectivePermissionLevel.Read,
+            _ => EffectivePermissionLevel.None,
+        };
+    }
+
+    /// <summary>
+    /// Expands a materialised folder path into the list of self + ancestor paths (excluding
+    /// the tenant root <c>"/"</c>). For <c>"/A/B/C"</c> returns <c>["/A", "/A/B", "/A/B/C"]</c>;
+    /// for the tenant root itself returns an empty list.
+    /// </summary>
+    private static List<string> ExpandSelfAndAncestorPaths(string path)
+    {
+        if (path == Folder.TenantRootPath)
+        {
+            return [];
+        }
+
+        List<string> result = [];
+        // Find each '/' starting from index 1 (skip the leading '/'). Each occurrence
+        // marks the end of an ancestor's path segment.
+        int separator = path.IndexOf(Folder.PathSeparator, 1, StringComparison.Ordinal);
+        while (separator > 0)
+        {
+            result.Add(path[..separator]);
+            separator = path.IndexOf(Folder.PathSeparator, separator + 1, StringComparison.Ordinal);
+        }
+        result.Add(path);
+        return result;
+    }
+}

--- a/src/Granit.Documents/Authorization/DocumentPrincipal.cs
+++ b/src/Granit.Documents/Authorization/DocumentPrincipal.cs
@@ -1,0 +1,77 @@
+namespace Granit.Documents.Authorization;
+
+/// <summary>
+/// Snapshot of a caller's effective grantee identities — user id plus the role and group ids
+/// they belong to — used to resolve <see cref="DocumentShare"/> grants against a folder or
+/// document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The principal abstraction is intentionally a value object rather than tied to ASP.NET's
+/// <see cref="System.Security.Claims.ClaimsPrincipal"/>: that keeps the resolver testable
+/// without an HTTP context and lets non-HTTP consumers (background jobs, internal callers)
+/// build a principal directly from the user record.
+/// </para>
+/// <para>
+/// <see cref="AllGranteeIds"/> is the union (deduplicated, allocation-once) of
+/// <see cref="UserId"/>, <see cref="RoleIds"/>, and <see cref="GroupIds"/> — the resolver
+/// uses this set to filter <see cref="DocumentShare.GranteeId"/> in a single SQL <c>IN</c>
+/// expression regardless of which kind of grantee the share targets.
+/// </para>
+/// </remarks>
+/// <param name="UserId">Identifier of the calling user (ADR-051 <c>User.Id</c>).</param>
+/// <param name="RoleIds">Role identifiers the user holds (may be empty).</param>
+/// <param name="GroupIds">Group identifiers the user belongs to (may be empty).</param>
+public sealed record DocumentPrincipal(
+    Guid UserId,
+    IReadOnlyList<Guid> RoleIds,
+    IReadOnlyList<Guid> GroupIds)
+{
+    private IReadOnlyList<Guid>? _allGranteeIds;
+
+    /// <summary>
+    /// Convenience principal carrying only a user id (no roles / groups). Useful for tests
+    /// and for callers that have not yet been wired to the role / group resolver.
+    /// </summary>
+    public static DocumentPrincipal ForUser(Guid userId) =>
+        new(userId, [], []);
+
+    /// <summary>
+    /// Deduplicated union of <see cref="UserId"/>, <see cref="RoleIds"/>, and
+    /// <see cref="GroupIds"/>. Computed lazily and cached so the resolver does not
+    /// re-allocate on every invocation. <see cref="Guid.Empty"/> entries are filtered out.
+    /// </summary>
+    public IReadOnlyList<Guid> AllGranteeIds
+    {
+        get
+        {
+            if (_allGranteeIds is not null)
+            {
+                return _allGranteeIds;
+            }
+
+            HashSet<Guid> set = new(RoleIds.Count + GroupIds.Count + 1);
+            if (UserId != Guid.Empty)
+            {
+                set.Add(UserId);
+            }
+            foreach (Guid id in RoleIds)
+            {
+                if (id != Guid.Empty)
+                {
+                    set.Add(id);
+                }
+            }
+            foreach (Guid id in GroupIds)
+            {
+                if (id != Guid.Empty)
+                {
+                    set.Add(id);
+                }
+            }
+
+            _allGranteeIds = [.. set];
+            return _allGranteeIds;
+        }
+    }
+}

--- a/src/Granit.Documents/Authorization/EffectivePermissionLevel.cs
+++ b/src/Granit.Documents/Authorization/EffectivePermissionLevel.cs
@@ -1,0 +1,25 @@
+namespace Granit.Documents.Authorization;
+
+/// <summary>
+/// Effective permission level resolved against a folder or a document for a given principal.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="Domain.SharePermissionLevel"/> because the resolver must be able
+/// to express "no grant matched" as a first-class outcome. Numeric ordering matches the
+/// ADR-052 highest-wins rule: <see cref="None"/> &lt; <see cref="Read"/> &lt; <see cref="Edit"/>
+/// &lt; <see cref="Manage"/>, so callers may rank with <see cref="System.Linq.Enumerable.Max{TSource}(System.Collections.Generic.IEnumerable{TSource})"/>.
+/// </remarks>
+public enum EffectivePermissionLevel
+{
+    /// <summary>No grant matched — the caller has no access through the share ACL.</summary>
+    None = 0,
+
+    /// <summary>Download / view metadata.</summary>
+    Read = 1,
+
+    /// <summary>Edit metadata, upload new versions, rename, move, trash.</summary>
+    Edit = 2,
+
+    /// <summary>Full control, including managing shares on the target.</summary>
+    Manage = 3,
+}

--- a/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
+++ b/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
@@ -1,0 +1,28 @@
+namespace Granit.Documents.Authorization;
+
+/// <summary>
+/// Resolves the effective <see cref="EffectivePermissionLevel"/> a <see cref="DocumentPrincipal"/>
+/// holds against a target via the share ACL. Single-target API for F6.2; the batch overload
+/// for list endpoints lands with F6.5.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations must follow the ADR-052 §Permission resolution model: a single non-recursive
+/// SQL query that combines a direct-document share with a path-prefix scan over the document's
+/// ancestor folders. Highest-permission wins among matching grants (Manage &gt; Edit &gt; Read).
+/// Expired grants are filtered. F6.3 layers FusionCache on top of this contract.
+/// </para>
+/// </remarks>
+public interface IEffectivePermissionResolver
+{
+    /// <summary>
+    /// Returns the effective permission the principal holds on the document identified by
+    /// <paramref name="documentId"/>. Returns <see cref="EffectivePermissionLevel.None"/>
+    /// when the document does not exist (or is excluded by the tenant filter), when the
+    /// principal has no grantee ids, or when no matching grant is found.
+    /// </summary>
+    Task<EffectivePermissionLevel> GetDocumentPermissionAsync(
+        Guid documentId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
@@ -1,0 +1,166 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Guids;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed test that verifies the F6.2 share-resolution query uses the filtered
+/// indexes (<c>ix_documents_shares_grantee_folder</c> / <c>ix_documents_shares_grantee_document</c>)
+/// introduced in F6.1. Without index usage the resolver collapses to a sequential scan
+/// under load — that regression is what this test guards against.
+/// </summary>
+public sealed class EffectivePermissionResolverPostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private EffectivePermissionResolver _sut = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public EffectivePermissionResolverPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_shares, documents_document_versions, documents_documents, documents_folders RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        _sut = new EffectivePermissionResolver(_factory, clock);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task FolderShare_ResolvesToHighestPermission_OnPostgres()
+    {
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, doc.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Manage);
+    }
+
+    [Fact]
+    public async Task ShareQuery_PrefersIndexOverSeqScan_OnPostgres()
+    {
+        // Seed enough rows to push the planner away from a seq scan. Postgres requires
+        // ANALYZE before the row estimate guides the planner.
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+        for (int i = 0; i < 200; i++)
+        {
+            await SeedShareAsync(DocumentShare.ShareToFolder(
+                Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, Guid.NewGuid(),
+                SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+        }
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.Database.ExecuteSqlRawAsync(
+            "ANALYZE documents_shares;",
+            TestContext.Current.CancellationToken);
+
+        // EXPLAIN the same shape the resolver issues. We bind the predicates that match the
+        // filtered index ix_documents_shares_grantee_folder.
+        const string explainSql = """
+            EXPLAIN (FORMAT TEXT)
+            SELECT s."Permission"
+            FROM documents_shares s
+            WHERE s."TenantId" = @tenant
+              AND s."GranteeId" = ANY(@grantees)
+              AND s."TargetType" = 'Folder'
+              AND s."FolderId" = @folder;
+            """;
+
+        // Query the plan via the underlying connection so we can capture the textual rows.
+        await using Npgsql.NpgsqlConnection conn = new(_postgres.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using Npgsql.NpgsqlCommand cmd = new(explainSql, conn);
+        cmd.Parameters.AddWithValue("tenant", TenantId);
+        cmd.Parameters.AddWithValue("grantees", new[] { user });
+        cmd.Parameters.AddWithValue("folder", folder.Id);
+
+        List<string> planLines = [];
+        await using (Npgsql.NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken))
+        {
+            while (await reader.ReadAsync(TestContext.Current.CancellationToken))
+            {
+                planLines.Add(reader.GetString(0));
+            }
+        }
+        string plan = string.Join('\n', planLines);
+
+        // The filtered index ix_documents_shares_grantee_folder must show up in the plan.
+        plan.ShouldContain(
+            "ix_documents_shares_grantee_folder",
+            customMessage: $"Expected filtered index to be used. Plan was:\n{plan}");
+        _ = doc; // doc is reused only to anchor the seeded data graph.
+    }
+
+    private async Task<(Folder, Document, Guid user)> SeedAsync()
+    {
+        var user = Guid.NewGuid();
+        // Use the public bootstrap service to create the tenant root — Folder.CreateTenantRoot
+        // is internal and the integration-test project is not in the InternalsVisibleTo list.
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+        Guid rootId = await bootstrap.EnsureTenantRootAsync(TenantId, OwnerId, TestContext.Current.CancellationToken);
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder root = await db.Folders.SingleAsync(f => f.Id == rootId, TestContext.Current.CancellationToken);
+        var folder = Folder.Create(Guid.NewGuid(), root, "Contracts", OwnerId);
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "doc.pdf");
+        db.Folders.Add(folder);
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (folder, doc, user);
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private async Task SeedShareAsync(DocumentShare share)
+    {
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.DocumentShares.Add(share);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
@@ -1,0 +1,316 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed unit tests for <see cref="EffectivePermissionResolver"/>. Verifies the
+/// path-prefix resolution semantics, expiration handling, and "highest-permission wins"
+/// rule without spinning up a Postgres container.
+/// </summary>
+public sealed class EffectivePermissionResolverTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private DbContextOptions<DocumentsDbContext> _options = null!;
+    private TestFactory _factory = null!;
+    private IClock _clock = null!;
+    private EffectivePermissionResolver _sut = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        _options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        await using DocumentsDbContext init = new(_options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestFactory(_options);
+        _clock = Substitute.For<IClock>();
+        _clock.Now.Returns(Now);
+        _sut = new EffectivePermissionResolver(_factory, _clock);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UnknownDocument_ReturnsNone()
+    {
+        var principal = DocumentPrincipal.ForUser(Guid.NewGuid());
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            Guid.NewGuid(), principal, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task PrincipalWithoutGrantees_ReturnsNoneShortCircuit()
+    {
+        // Even when a global share would grant access, a principal with no UserId / roles /
+        // groups must short-circuit to None — there is no identity to match.
+        DocumentPrincipal principal = new(Guid.Empty, [], []);
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            Guid.NewGuid(), principal, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task DirectDocumentShare_ReturnsExactPermission()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, doc.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Edit);
+        _ = folder;
+    }
+
+    [Fact]
+    public async Task DirectFolderShare_AppliesToDocumentInThatFolder()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Read);
+    }
+
+    [Fact]
+    public async Task AncestorFolderShare_InheritsToDeeplyNestedDocument()
+    {
+        // /Contracts (ancestor with Read) > /Contracts/2026 > document
+        (Folder grandparent, _, Document doc) = await SeedDocumentInNestedFoldersAsync(
+            "/Contracts", "/Contracts/2026");
+        var user = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, grandparent.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Read);
+    }
+
+    [Fact]
+    public async Task SiblingFolderShare_DoesNotLeakToAdjacentFolder()
+    {
+        // Grant on /A; document under /B/X — must NOT match.
+        (Folder a, _) = await SeedDocumentInFolderAsync("/A");
+        (Folder _, Document docInB) = await SeedDocumentInFolderAsync("/B");
+        var user = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, a.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            docInB.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task PathPrefixCollision_DoesNotFalseMatch()
+    {
+        // /Contract and /Contracts share a leading prefix when matched naively as substrings,
+        // but path-segment matching must NOT consider /Contract an ancestor of /Contracts/X.
+        (Folder contract, _) = await SeedDocumentInFolderAsync("/Contract");
+        (_, Document docInContracts) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, contract.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            docInContracts.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task HighestPermissionWins_AcrossOverlappingGrants()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+        var role = Guid.NewGuid();
+
+        // Read on the folder, Manage directly on the document (via role).
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, doc.Id, ShareGranteeType.Role, role,
+            SharePermissionLevel.Manage, OwnerId, Now));
+
+        DocumentPrincipal principal = new(user, RoleIds: [role], GroupIds: []);
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, principal, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Manage);
+    }
+
+    [Fact]
+    public async Task GroupGrant_ResolvesViaGroupId()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var group = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.Group, group,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+
+        DocumentPrincipal principal = new(Guid.NewGuid(), [], [group]);
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, principal, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.Edit);
+    }
+
+    [Fact]
+    public async Task ExpiredGrant_IsIgnored()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+
+        DateTimeOffset pastCreatedAt = Now.AddDays(-2);
+        DateTimeOffset pastExpiresAt = Now.AddDays(-1);
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, pastCreatedAt,
+            expiresAt: pastExpiresAt));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task DifferentTenant_IsExcluded()
+    {
+        // Seed a doc in our TenantId, but a share row whose TenantId is different — even
+        // though the FK targets exist, the resolver must filter by the document's tenant.
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+
+        var otherTenant = Guid.NewGuid();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), otherTenant, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private async Task<(Folder, Document)> SeedDocumentInFolderAsync(string folderPath)
+    {
+        Folder root = await GetOrCreateRootAsync();
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        Folder reloadedRoot = await db.Folders.SingleAsync(f => f.Id == root.Id);
+        // Strip leading "/" for Folder.Create's name parameter (it computes the path itself).
+        var folder = Folder.Create(Guid.NewGuid(), reloadedRoot, folderPath[1..], OwnerId);
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "doc.pdf");
+        db.Folders.Add(folder);
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync();
+        return (folder, doc);
+    }
+
+    private async Task<(Folder grandparent, Folder parent, Document doc)>
+        SeedDocumentInNestedFoldersAsync(string grandparentPath, string parentPath)
+    {
+        Folder root = await GetOrCreateRootAsync();
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        Folder reloadedRoot = await db.Folders.SingleAsync(f => f.Id == root.Id);
+
+        var grandparent = Folder.Create(Guid.NewGuid(), reloadedRoot, grandparentPath[1..], OwnerId);
+        db.Folders.Add(grandparent);
+        await db.SaveChangesAsync();
+
+        // Compute the parent's tail name from the parentPath relative to the grandparent.
+        string parentTail = parentPath[(grandparentPath.Length + 1)..];
+        var parent = Folder.Create(Guid.NewGuid(), grandparent, parentTail, OwnerId);
+        var doc = Document.Create(Guid.NewGuid(), parent, OwnerId, "doc.pdf");
+        db.Folders.Add(parent);
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync();
+        return (grandparent, parent, doc);
+    }
+
+    private async Task<Folder> GetOrCreateRootAsync()
+    {
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        Folder? root = await db.Folders.FirstOrDefaultAsync(f => f.IsTenantRoot);
+        if (root is not null)
+        {
+            return root;
+        }
+
+        // Folder.CreateTenantRoot is internal — accessible via InternalsVisibleTo.
+        var created = Folder.CreateTenantRoot(Guid.NewGuid(), TenantId, OwnerId);
+        db.Folders.Add(created);
+        await db.SaveChangesAsync();
+        return created;
+    }
+
+    private async Task SeedShareAsync(DocumentShare share)
+    {
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        db.DocumentShares.Add(share);
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.Tests/Authorization/DocumentPrincipalTests.cs
+++ b/tests/Granit.Documents.Tests/Authorization/DocumentPrincipalTests.cs
@@ -1,0 +1,59 @@
+using Granit.Documents.Authorization;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Authorization;
+
+public sealed class DocumentPrincipalTests
+{
+    [Fact]
+    public void AllGranteeIds_DeduplicatesAcrossUserRolesGroups()
+    {
+        var user = Guid.NewGuid();
+        var sharedRole = Guid.NewGuid();
+        var otherRole = Guid.NewGuid();
+        var group = Guid.NewGuid();
+
+        var principal = new DocumentPrincipal(
+            user,
+            RoleIds: [sharedRole, otherRole, sharedRole],
+            GroupIds: [group, sharedRole]);
+
+        principal.AllGranteeIds.ShouldBe([user, sharedRole, otherRole, group], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void AllGranteeIds_FiltersGuidEmpty()
+    {
+        var principal = new DocumentPrincipal(
+            UserId: Guid.Empty,
+            RoleIds: [Guid.Empty, Guid.NewGuid()],
+            GroupIds: []);
+
+        principal.AllGranteeIds.Count.ShouldBe(1);
+        principal.AllGranteeIds.ShouldNotContain(Guid.Empty);
+    }
+
+    [Fact]
+    public void AllGranteeIds_CachedAcrossInvocations()
+    {
+        var principal = new DocumentPrincipal(Guid.NewGuid(), [Guid.NewGuid()], []);
+
+        IReadOnlyList<Guid> first = principal.AllGranteeIds;
+        IReadOnlyList<Guid> second = principal.AllGranteeIds;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void ForUser_HasNoRolesNoGroups()
+    {
+        var user = Guid.NewGuid();
+        var principal = DocumentPrincipal.ForUser(user);
+
+        principal.UserId.ShouldBe(user);
+        principal.RoleIds.ShouldBeEmpty();
+        principal.GroupIds.ShouldBeEmpty();
+        principal.AllGranteeIds.ShouldBe([user]);
+    }
+}


### PR DESCRIPTION
## Summary

Second story of feature #1744 (Share ACL with path-based resolution + FusionCache) on epic #1721 (Granit.Documents). Implements `IEffectivePermissionResolver` per [ADR-052](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md) §Permission resolution model.

- New `Granit.Documents.Authorization` namespace exposes `DocumentPrincipal` (user + roles + groups, dedup'd grantee snapshot), `EffectivePermissionLevel` (None / Read / Edit / Manage with the highest-wins ordering baked in), and the `IEffectivePermissionResolver` contract.
- EF-backed `EffectivePermissionResolver` resolves in three index-friendly round-trips:
  1. Document + folder PK lookup (`TenantId`, `Folder.Path`).
  2. Ancestor folder ids via path inclusion (`ix_documents_folders_tenant_path`).
  3. Two parallel share queries — direct-document grants and folder grants over the ancestor set — each lighting up exactly one of the F6.1 filtered indexes (`ix_documents_shares_grantee_document` / `_grantee_folder`).
- `ExpiresAt` filtering is applied in C# after the index narrows the row set; the SQL form `ExpiresAt IS NULL OR ExpiresAt > now` combined with the rest of the predicate refuses to translate on SQLite and the in-memory pass on a handful of grants is essentially free.
- `IsDefault` is intentionally **not** filtered: per ADR-052 / F6.4 all folder shares inherit in phase 1.

## Decisions worth flagging

- Splitting the document/folder OR into two queries (vs. the single OR-clause in the ADR's reference SQL) was needed for cross-provider translation. Each branch still hits a filtered index, so production-side performance is preserved — the EXPLAIN test below pins this.
- `EffectivePermissionLevel` is a separate enum from `SharePermissionLevel` so callers can pattern-match on `None` as a first-class outcome. Numeric ordering matches the highest-wins rule.
- `DocumentPrincipal` is a value object decoupled from `ClaimsPrincipal` — keeps the resolver testable and lets non-HTTP callers (background jobs) build a principal from the user record.

## Test plan

- [x] `dotnet build` clean on infrastructure + integration + architecture shards
- [x] 78 `Granit.Documents.Tests` passing (4 new — `DocumentPrincipalTests`)
- [x] 70 `Granit.Documents.EntityFrameworkCore.Tests` passing (10 new SQLite-backed resolver tests covering unknown doc, empty principal, direct doc share, direct folder share, ancestor inheritance, sibling leak, path-prefix collision `/Contract` vs `/Contracts`, highest-wins, group grant, expired filtering, cross-tenant exclusion)
- [x] `dotnet format --verify-no-changes` clean on every touched project
- [x] No new architecture-test regressions (the 6 pre-existing failures on `develop` remain identical)
- [ ] CI runs the Postgres integration tests including the EXPLAIN assertion that pins index usage of `ix_documents_shares_grantee_folder` at scale (200 distractor rows + `ANALYZE`)

Closes #1746