### PR TITLE
fix(ci): unblock architecture + OpenIddict integration shards

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8631,12 +8631,18 @@
       "kind": "class",
       "project": "Granit.Authentication.DPoP",
       "file": "src/Granit.Authentication.DPoP/Extensions/DPoPJwtBearerExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitDPoPValidation",
           "kind": "method",
           "signature": "AddGranitDPoPValidation(this IServiceCollection services, Action<DPoPValidationOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        },
+        {
+          "name": "AddGranitDPoPProofValidator",
+          "kind": "method",
+          "signature": "AddGranitDPoPProofValidator(this IServiceCollection services)",
           "returnType": "IServiceCollection"
         }
       ]
@@ -21414,7 +21420,7 @@
       "kind": "class",
       "project": "Granit.Entities.Customization.Endpoints",
       "file": "src/Granit.Entities.Customization.Endpoints/Extensions/EntitiesCustomizationEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitEntitiesCustomization",
@@ -21816,7 +21822,7 @@
       "kind": "class",
       "project": "Granit.Entities.Endpoints",
       "file": "src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "MapGranitEntitiesEndpoints",
@@ -22961,7 +22967,7 @@
       "kind": "class",
       "project": "Granit.Entities.Views.Endpoints",
       "file": "src/Granit.Entities.Views.Endpoints/Extensions/EntityViewsEndpointRouteBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "MapGranitEntityViewsEndpoints",
@@ -23065,15 +23071,6 @@
       "members": []
     },
     {
-      "name": "EntityViewNotFoundException",
-      "fqn": "Granit.Entities.Views.EntityViewNotFoundException",
-      "kind": "class",
-      "project": "Granit.Entities.Views.Abstractions",
-      "file": "src/Granit.Entities.Views.Abstractions/EntityViewNotFoundException.cs",
-      "line": 7,
-      "members": []
-    },
-    {
       "name": "EntityViewPermissions",
       "fqn": "Granit.Entities.Views.EntityViewPermissions",
       "kind": "class",
@@ -23114,6 +23111,15 @@
       "project": "Granit.Entities.Views.Abstractions",
       "file": "src/Granit.Entities.Views.Abstractions/EntityViewVisibility.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "EntityViewNotFoundException",
+      "fqn": "Granit.Entities.Views.Exceptions.EntityViewNotFoundException",
+      "kind": "class",
+      "project": "Granit.Entities.Views.Abstractions",
+      "file": "src/Granit.Entities.Views.Abstractions/Exceptions/EntityViewNotFoundException.cs",
+      "line": 7,
       "members": []
     },
     {
@@ -41073,7 +41079,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitOpenIddictServer",

--- a/src/Granit.Authentication.DPoP/Extensions/DPoPJwtBearerExtensions.cs
+++ b/src/Granit.Authentication.DPoP/Extensions/DPoPJwtBearerExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Authentication.DPoP.Diagnostics;
 using Granit.Authentication.DPoP.Middleware;
 using Granit.Authentication.DPoP.Options;
 using Granit.Authentication.DPoP.Validation;
@@ -30,7 +31,7 @@ public static class DPoPJwtBearerExtensions
             services.Configure(configure);
         }
 
-        services.TryAddSingleton<IDPoPProofValidator, DPoPProofValidator>();
+        services.AddGranitDPoPProofValidator();
 
         // Configure JwtBearer to accept "DPoP <token>" in addition to "Bearer <token>"
         services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
@@ -75,4 +76,21 @@ public static class DPoPJwtBearerExtensions
     /// <returns>The application builder for chaining.</returns>
     public static IApplicationBuilder UseGranitDPoPValidation(this IApplicationBuilder app) =>
         app.UseMiddleware<DPoPValidationMiddleware>();
+
+    /// <summary>
+    /// Registers <see cref="IDPoPProofValidator"/> alone, without configuring the JwtBearer
+    /// event pipeline. Useful for hosts that need the validator from a non-JwtBearer code
+    /// path — for example the OpenIddict server's <c>DPoPTokenBindingHandler</c>, which
+    /// validates the proof presented at <c>/connect/token</c> independently of any
+    /// resource-side bearer authentication.
+    /// </summary>
+    public static IServiceCollection AddGranitDPoPProofValidator(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        // The validator depends on DPoPValidationMetrics — register it alongside so the
+        // helper is fully self-contained, regardless of which entry point the host calls.
+        services.TryAddSingleton<DPoPValidationMetrics>();
+        services.TryAddSingleton<IDPoPProofValidator, DPoPProofValidator>();
+        return services;
+    }
 }

--- a/src/Granit.Entities.Customization.Endpoints/Endpoints/EntityCustomizationEndpoints.cs
+++ b/src/Granit.Entities.Customization.Endpoints/Endpoints/EntityCustomizationEndpoints.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.Entities.Customization.Endpoints;
+namespace Granit.Entities.Customization.Endpoints.Endpoints;
 
 /// <summary>
 /// CRUD endpoints for the per-tenant Layer 1 customization on each

--- a/src/Granit.Entities.Customization.Endpoints/Extensions/EntitiesCustomizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Customization.Endpoints/Extensions/EntitiesCustomizationEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Customization.Endpoints.Endpoints;
 using Granit.Entities.Customization.Endpoints.Options;
 using Granit.Entities.Customization.Endpoints.Permissions;
 using Granit.Validation.AspNetCore;

--- a/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/CalendarRangeEndpoint.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.Entities.Endpoints;
+namespace Granit.Entities.Endpoints.Endpoints;
 
 /// <summary>
 /// Range-query handler for the calendar list-view layout. Mounted under

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.Entities.Endpoints;
+namespace Granit.Entities.Endpoints.Endpoints;
 
 /// <summary>
 /// Minimal API handlers for the entity-manifest surface (Phase 1.C).

--- a/src/Granit.Entities.Endpoints/Endpoints/RelationAggregatesEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/RelationAggregatesEndpoint.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.Entities.Endpoints;
+namespace Granit.Entities.Endpoints.Endpoints;
 
 /// <summary>
 /// <c>POST /api/entities/{name}/{id}/relations/aggregates</c> — returns the

--- a/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Endpoints/Extensions/EntitiesEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Endpoints.Endpoints;
 using Granit.Entities.Endpoints.Internal;
 using Granit.Entities.Endpoints.Options;
 using Granit.Entities.Internal;

--- a/src/Granit.Entities.Views.Abstractions/Exceptions/EntityViewNotFoundException.cs
+++ b/src/Granit.Entities.Views.Abstractions/Exceptions/EntityViewNotFoundException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Entities.Views;
+namespace Granit.Entities.Views.Exceptions;
 
 /// <summary>
 /// Thrown by <see cref="IEntityViewWriter"/> when the targeted view does not exist

--- a/src/Granit.Entities.Views.Endpoints/Endpoints/EntityViewsEndpoints.cs
+++ b/src/Granit.Entities.Views.Endpoints/Endpoints/EntityViewsEndpoints.cs
@@ -1,11 +1,12 @@
 using Granit.Entities.Views.Endpoints.Dtos;
+using Granit.Entities.Views.Exceptions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
-namespace Granit.Entities.Views.Endpoints;
+namespace Granit.Entities.Views.Endpoints.Endpoints;
 
 /// <summary>
 /// Minimal API handlers for the EntityView surface (per ADR-047 §6).

--- a/src/Granit.Entities.Views.Endpoints/Extensions/EntityViewsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Entities.Views.Endpoints/Extensions/EntityViewsEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Entities.Views.Endpoints.Endpoints;
 using Granit.Entities.Views.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;

--- a/src/Granit.Entities.Views.EntityFrameworkCore/Internal/EntityViewWriter.cs
+++ b/src/Granit.Entities.Views.EntityFrameworkCore/Internal/EntityViewWriter.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization;
 using Granit.Entities.Views.Domain;
+using Granit.Entities.Views.Exceptions;
 using Granit.Users;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Granit.Authentication.DPoP.Extensions;
 using Granit.Authentication.Extensions;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Server.Handlers;
@@ -52,6 +53,15 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                     + "Set EnableEntityCaching = false (default) or remove multi-tenancy.");
             }
         }
+
+        // The DPoP token-binding event handler (registered below via
+        // DPoPTokenBindingHandler.Descriptor) requires IDPoPProofValidator. Register it
+        // here so the OpenIddict server is self-contained — hosts that also call
+        // AddGranitDPoPValidation() on the resource side benefit from the same
+        // TryAddSingleton; without this, the OIDC server fails at sign-in time when no
+        // resource-side DPoP validation is registered (e.g. dedicated authorization-server
+        // deployments and integration tests).
+        builder.Services.AddGranitDPoPProofValidator();
 
         OpenIddictBuilder openIddict = builder.Services.AddOpenIddict();
 

--- a/src/Granit.Wolverine.Encryption/README.md
+++ b/src/Granit.Wolverine.Encryption/README.md
@@ -1,0 +1,20 @@
+# Granit.Wolverine.Encryption
+
+Field-level encryption for Wolverine envelopes and sagas. Scans `System.Text.Json` type metadata for `[Encrypted]` string properties and applies a transparent encrypt/decrypt converter backed by `IStringEncryptionService`. Closes the cleartext-PII gap on the outbox / saga store for messages that travel between processes or across deployments.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Wolverine.Encryption
+```
+
+## Dependencies
+
+- `Granit.Encryption`
+- `Granit.Wolverine`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/tests/Granit.ArchitectureTests/WolverineCouplingTests.cs
+++ b/tests/Granit.ArchitectureTests/WolverineCouplingTests.cs
@@ -51,6 +51,10 @@ public sealed class WolverineCouplingTests
         // Granit.Privacy defines Wolverine Sagas (scatter-gather export/deletion orchestration).
         // These use the Wolverine.Saga base type — genuine coupling at the core domain layer.
         "Granit.Privacy",
+        // Granit.Wolverine.Encryption is a field-level encryption adapter that hooks into
+        // the Wolverine envelope/saga JSON pipeline — the WolverineFx reference and Wolverine
+        // namespace usage are intrinsic to the package's purpose.
+        "Granit.Wolverine.Encryption",
     };
 
     [Fact]

--- a/tests/Granit.Entities.Views.EntityFrameworkCore.Tests/EntityViewWriterTests.cs
+++ b/tests/Granit.Entities.Views.EntityFrameworkCore.Tests/EntityViewWriterTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using Granit.Authorization;
 using Granit.Entities.Views.Domain;
 using Granit.Entities.Views.EntityFrameworkCore.Internal;
+using Granit.Entities.Views.Exceptions;
 using Granit.Users;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.Metrics;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Granit.Caching.Extensions;
 using Granit.Events;
 using Granit.Identity;
 using Granit.Identity.Extensions;
@@ -114,6 +115,10 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
         builder.Services.TryAddSingleton<ICurrentTenant>(
             _ => Substitute.For<ICurrentTenant>());
         builder.Services.AddDistributedMemoryCache();
+
+        // FAPI 2.0 enables DPoP — IDPoPProofValidator depends on IClock + IFusionCache.
+        // AddGranitCaching() pulls in AddGranitTiming() transitively.
+        builder.Services.AddGranitCaching();
 
         // 4. Metrics (requires IMeterFactory)
         builder.Services.TryAddSingleton<IMeterFactory>(


### PR DESCRIPTION
## Summary

CI on `develop` had two unrelated red clusters. This PR addresses both with surgical, framework-respectful fixes.

### Architecture shard — 6 failures → 0

- **`Granit.Wolverine.Encryption` is a legitimate Wolverine adapter** (field-level encryption on the envelope / saga JSON pipeline). Added to `WolverineCouplingTests.WolverineAdapterProjects` so the `WolverineFx` package reference and `using Wolverine` lines are recognised as part of the package's contract. README.md added — `TestProjectConventionTests.Every_src_package_should_have_a_README` requires one.
- **`EntityViewNotFoundException.cs`** moved to `Granit.Entities.Views.Abstractions/Exceptions/` per `FileOrganizationTests.Exception_classes_should_reside_in_Exceptions_folder`.
- **Five internal endpoint classes** (`EntitiesEndpoints`, `CalendarRangeEndpoint`, `RelationAggregatesEndpoint`, `EntityViewsEndpoints`, `EntityCustomizationEndpoints`) moved to `Endpoints/` subfolders, fixing both `Internal_types_should_not_be_at_module_root` and `Endpoint_classes_should_reside_in_Endpoints_folder`. Namespaces and consuming `using` directives updated to match `SourceCodeAntiPatternTests.Namespace_should_match_folder_structure_in_src`.

### OpenIddict integration shard — 7 failures → 0

`AddGranitOpenIddictServer` registered `DPoPTokenBindingHandler` unconditionally but not its `IDPoPProofValidator` dependency, so resolution failed at sign-in time on dedicated authorization-server deployments (and the integration-test suite).

- Extracted a public **`AddGranitDPoPProofValidator(IServiceCollection)`** helper from `AddGranitDPoPValidation`. The new helper registers `IDPoPProofValidator` + `DPoPValidationMetrics` so the OpenIddict server is self-contained regardless of which entry point the host calls (resource-side bearer auth or pure auth-server).
- The integration-test fixture additionally registers `AddGranitCaching()` (transitively pulls `IClock` + `IFusionCache`) — both are dependencies of `DPoPProofValidator` that the fixture wasn't providing.

## Test plan

- [x] `dotnet test .github/shard-filters/architecture.slnf` — **212/212 passing**
- [x] `dotnet test tests/Granit.OpenIddict.Tests.Integration` — **25 passing, 1 expected skip** (`Should_issue_token_with_valid_private_key_jwt_assertion` needs OpenIddict 7.5+)
- [x] `dotnet test tests/Granit.Entities.Endpoints.Tests` — 86/86
- [x] `dotnet test tests/Granit.Entities.Views.EntityFrameworkCore.Tests` — 15/15
- [x] `dotnet test tests/Granit.Entities.Customization.Endpoints.Tests` — 7/7
- [x] `dotnet format --verify-no-changes` clean on every touched project
- [ ] CI runs the full suite to confirm green