### PR TITLE
feat(documents): FusionCache layer + tag-based invalidation (F6.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -926,6 +926,7 @@
     {
       "name": "Granit.Documents.EntityFrameworkCore",
       "deps": [
+        "Granit.Caching",
         "Granit.Documents",
         "Granit.Persistence.EntityFrameworkCore"
       ],
@@ -19374,6 +19375,18 @@
           "kind": "method",
           "signature": "RecordQuotaRejected(string? tenantId)",
           "returnType": "void"
+        },
+        {
+          "name": "RecordAclCacheHit",
+          "kind": "method",
+          "signature": "RecordAclCacheHit(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordAclCacheMiss",
+          "kind": "method",
+          "signature": "RecordAclCacheMiss(string? tenantId)",
+          "returnType": "void"
         }
       ]
     },
@@ -19801,12 +19814,46 @@
       "members": []
     },
     {
+      "name": "AclCacheInvalidationHandler",
+      "fqn": "Granit.Documents.EntityFrameworkCore.Authorization.AclCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Documents.EntityFrameworkCore",
+      "file": "src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheInvalidationHandler.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DocumentShareGrantedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DocumentShareRevokedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FolderPathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FolderTreePathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Documents.EntityFrameworkCore.Extensions.DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitDocumentsEntityFrameworkCore",
@@ -19854,7 +19901,7 @@
       "kind": "class",
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs",
-      "line": 26,
+      "line": 28,
       "members": []
     },
     {
@@ -20238,6 +20285,12 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan AclCacheTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "AclCacheEnabled",
+          "kind": "property",
+          "signature": "bool AclCacheEnabled",
+          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheInvalidationHandler.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheInvalidationHandler.cs
@@ -1,0 +1,85 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Documents.EntityFrameworkCore.Authorization;
+
+/// <summary>
+/// Wolverine message handlers that invalidate the F6.3 effective-ACL cache when share
+/// grants change or the folder hierarchy moves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Discovered by Wolverine's handler scanning convention: public class with
+/// <c>public static</c> <c>HandleAsync</c> methods. The cache is the tenant-aware
+/// <see cref="IFusionCache"/> singleton — tag operations are auto-scoped to the current
+/// tenant context, which matches the share / folder mutation that emitted the event.
+/// </para>
+/// <para>
+/// Tag scheme:
+/// <list type="bullet">
+///   <item>Document share change → <c>acl:doc:{documentId}</c></item>
+///   <item>Folder share change → <c>acl:folder:{folderId}</c> (cached entries attach this
+///     tag for the document's folder AND every ancestor)</item>
+///   <item>Folder path change (move / rename or tree-wide) → <see cref="AclCacheKeys.AllTag"/>
+///     bulk wipe inside the tenant prefix. Path changes alter ancestor sets across the
+///     subtree; tagging individually would require enumerating every descendant document.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public class AclCacheInvalidationHandler
+{
+    /// <summary>Invalidates entries that depended on the share's target.</summary>
+    public static Task HandleAsync(
+        DocumentShareGrantedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        InvalidateForShareTargetAsync(cache, @event.TargetType, @event.FolderId, @event.DocumentId, cancellationToken);
+
+    /// <summary>Invalidates entries that depended on the revoked share's target.</summary>
+    public static Task HandleAsync(
+        DocumentShareRevokedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        InvalidateForShareTargetAsync(cache, @event.TargetType, @event.FolderId, @event.DocumentId, cancellationToken);
+
+    /// <summary>
+    /// Invalidates the entire tenant ACL cache when a folder's path changes — the move /
+    /// rename shifts the ancestor set of every descendant document, which can affect any
+    /// cached entry that depended on a folder share in the moved subtree.
+    /// </summary>
+    public static Task HandleAsync(
+        FolderPathChangedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        cache.RemoveByTagAsync(AclCacheKeys.AllTag, token: cancellationToken).AsTask();
+
+    /// <summary>
+    /// Invalidates the entire tenant ACL cache when an entire folder subtree is
+    /// re-pathed (F2.4 bulk move). Tree-level events arrive once per move, even when
+    /// hundreds of descendants shift.
+    /// </summary>
+    public static Task HandleAsync(
+        FolderTreePathChangedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        cache.RemoveByTagAsync(AclCacheKeys.AllTag, token: cancellationToken).AsTask();
+
+    private static Task InvalidateForShareTargetAsync(
+        IFusionCache cache,
+        ShareTargetType targetType,
+        Guid? folderId,
+        Guid? documentId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        return targetType switch
+        {
+            ShareTargetType.Folder when folderId is { } fid =>
+                cache.RemoveByTagAsync(AclCacheKeys.FolderTag(fid), token: cancellationToken).AsTask(),
+            ShareTargetType.Document when documentId is { } did =>
+                cache.RemoveByTagAsync(AclCacheKeys.DocumentTag(did), token: cancellationToken).AsTask(),
+            _ => Task.CompletedTask,
+        };
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheKeys.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheKeys.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Documents.Authorization;
+
+namespace Granit.Documents.EntityFrameworkCore.Authorization;
+
+/// <summary>
+/// Centralised cache-key and tag construction for the F6.3 effective-ACL cache layer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keys are tenant-scoped automatically by the framework's
+/// <c>TenantAwareFusionCache</c> decorator — these helpers therefore compose the
+/// tenant-relative segment only and never bake the tenant id into the string.
+/// </para>
+/// <para>
+/// Tags drive <c>RemoveByTagAsync</c> invalidation and follow the ADR-052 scheme:
+/// <list type="bullet">
+///   <item><c>acl:doc:{documentId}</c> — invalidated on a direct document share change.</item>
+///   <item><c>acl:folder:{folderId}</c> — invalidated on a folder share change. Cache
+///     entries attach this tag for the document's folder AND every ancestor folder, so
+///     a grant change on any ancestor invalidates the matching entries.</item>
+///   <item><c>acl:all</c> — invalidated when the folder hierarchy changes (move / rename) —
+///     too cheap to walk and tag descendants individually for an event that is rare.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal static class AclCacheKeys
+{
+    /// <summary>
+    /// Cache-key segment for "principal P resolves on document D". The grantee-set hash
+    /// disambiguates principals that share <see cref="DocumentPrincipal.UserId"/> but hold
+    /// different roles or groups.
+    /// </summary>
+    public static string Document(Guid documentId, DocumentPrincipal principal) =>
+        $"acl:doc:{documentId.ToString("N", CultureInfo.InvariantCulture)}"
+        + $":user:{principal.UserId.ToString("N", CultureInfo.InvariantCulture)}"
+        + $":{HashGranteeSet(principal)}";
+
+    /// <summary>
+    /// Stable, allocation-light hash of the principal's deduplicated grantee set.
+    /// </summary>
+    /// <remarks>
+    /// Sorted SHA-256 ensures two principals with the same effective grant set produce the
+    /// same hash regardless of role / group iteration order. Truncated to 16 hex chars —
+    /// sufficient to disambiguate principals on the cache key without bloating the string.
+    /// </remarks>
+    public static string HashGranteeSet(DocumentPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        IReadOnlyList<Guid> ids = principal.AllGranteeIds;
+        if (ids.Count == 0)
+        {
+            return "0";
+        }
+
+        Guid[] sorted = [.. ids];
+        Array.Sort(sorted);
+
+        // 16 bytes per Guid; avoid LINQ to keep allocations down on the hot path.
+        byte[] buffer = new byte[sorted.Length * 16];
+        for (int i = 0; i < sorted.Length; i++)
+        {
+            sorted[i].TryWriteBytes(buffer.AsSpan(i * 16));
+        }
+
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(buffer, hash);
+        // 8 bytes → 16 hex chars; collisions are astronomically unlikely within a single
+        // tenant's principal namespace and keep the cache key compact.
+        return Convert.ToHexString(hash[..8]);
+    }
+
+    /// <summary>Tag attached to entries resolved against a specific document.</summary>
+    public static string DocumentTag(Guid documentId) =>
+        $"acl:doc:{documentId.ToString("N", CultureInfo.InvariantCulture)}";
+
+    /// <summary>Tag attached to entries that depended on a folder grant or path inclusion.</summary>
+    public static string FolderTag(Guid folderId) =>
+        $"acl:folder:{folderId.ToString("N", CultureInfo.InvariantCulture)}";
+
+    /// <summary>Tenant-wide ACL tag — set on every entry for cheap mass invalidation.</summary>
+    public const string AllTag = "acl:all";
+
+    /// <summary>
+    /// Builds the tag set attached to a cached entry for the given document and the
+    /// folder ids participating in its resolution (the document's folder + all ancestor
+    /// folders contributing to the path-prefix scan).
+    /// </summary>
+    public static string[] BuildEntryTags(Guid documentId, IReadOnlyList<Guid> folderIds)
+    {
+        ArgumentNullException.ThrowIfNull(folderIds);
+
+        // documentId tag + each folder tag + the all-tag.
+        string[] tags = new string[folderIds.Count + 2];
+        int i = 0;
+        tags[i++] = DocumentTag(documentId);
+        foreach (Guid folderId in folderIds)
+        {
+            tags[i++] = FolderTag(folderId);
+        }
+        tags[i] = AllTag;
+        return tags;
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
@@ -1,0 +1,90 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Options;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Documents.EntityFrameworkCore.Authorization;
+
+/// <summary>
+/// FusionCache-backed decorator over <see cref="EffectivePermissionResolver"/> implementing
+/// the F6.3 cache layer described in ADR-052 §Cache layer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// On cache miss, delegates to <see cref="EffectivePermissionResolver.ResolveDocumentAsync"/>
+/// to compute the effective level + ancestor folder ids, then writes the entry tagged with
+/// <c>acl:doc:{documentId}</c>, one <c>acl:folder:{folderId}</c> per ancestor, and the
+/// tenant-wide <see cref="AclCacheKeys.AllTag"/>. Subsequent share grant / revoke events
+/// invalidate by tag through <see cref="AclCacheInvalidationHandler"/>.
+/// </para>
+/// <para>
+/// TTL comes from <see cref="GranitDocumentsOptions.AclCacheTtl"/> (default 5 minutes).
+/// Cache hits and misses are recorded on <c>granit.documents.acl.cache.hits</c> /
+/// <c>.misses</c>; the hit ratio is derived downstream by the observability pipeline.
+/// </para>
+/// </remarks>
+internal sealed class CachedEffectivePermissionResolver(
+    EffectivePermissionResolver inner,
+    IFusionCache cache,
+    ICurrentTenant currentTenant,
+    DocumentsMetrics metrics,
+    IOptions<GranitDocumentsOptions> options) : IEffectivePermissionResolver
+{
+    /// <inheritdoc />
+    public async Task<EffectivePermissionLevel> GetDocumentPermissionAsync(
+        Guid documentId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        // Short-circuit: a principal with no grantee identities can never match a grant.
+        // Mirrors the inner resolver's behaviour and avoids polluting the cache with No-result
+        // entries for an empty key.
+        if (principal.AllGranteeIds.Count == 0)
+        {
+            return EffectivePermissionLevel.None;
+        }
+
+        GranitDocumentsOptions opts = options.Value;
+        string tenantTag = currentTenant.IsAvailable
+            ? currentTenant.Id!.Value.ToString("N")
+            : "global";
+        string key = AclCacheKeys.Document(documentId, principal);
+
+        FusionCacheEntryOptions entryOptions = cache.CreateEntryOptions(
+            o => o.SetDuration(opts.AclCacheTtl),
+            duration: opts.AclCacheTtl);
+
+        // Try-get first so the entry's tag set can include the per-ancestor folder ids
+        // computed during a real resolution. FusionCache's GetOrSetAsync evaluates the
+        // tags parameter up front (before the factory runs) — splitting the call lets the
+        // tag set match the resolution context exactly.
+        MaybeValue<EffectivePermissionLevel> hit = await cache
+            .TryGetAsync<EffectivePermissionLevel>(key, options: entryOptions, token: cancellationToken)
+            .ConfigureAwait(false);
+        if (hit.HasValue)
+        {
+            metrics.RecordAclCacheHit(tenantTag);
+            return hit.Value;
+        }
+
+        metrics.RecordAclCacheMiss(tenantTag);
+
+        DocumentResolutionResult resolved = await inner
+            .ResolveDocumentAsync(documentId, principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        await cache.SetAsync(
+            key,
+            resolved.Permission,
+            options: entryOptions,
+            tags: AclCacheKeys.BuildEntryTags(documentId, resolved.AncestorFolderIds),
+            token: cancellationToken).ConfigureAwait(false);
+
+        return resolved.Permission;
+    }
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,8 +1,12 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.EntityFrameworkCore.Authorization;
 using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Documents.EntityFrameworkCore.Extensions;
 
@@ -57,10 +61,20 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // in on top in subsequent stories.
         builder.Services.AddScoped<IDocumentShareService, DocumentShareService>();
 
-        // Effective-permission resolver (F6.2): resolves a DocumentPrincipal against a
-        // document via the ADR-052 path-prefix permission resolution model. F6.3 will
-        // wrap this with FusionCache for hot reads.
-        builder.Services.AddScoped<Authorization.IEffectivePermissionResolver, EffectivePermissionResolver>();
+        // Effective-permission resolver (F6.2 + F6.3). The concrete EffectivePermissionResolver
+        // is registered first so the cache decorator can delegate to it; the public
+        // IEffectivePermissionResolver registration depends on whether the FusionCache layer
+        // is enabled (DocumentsOptions.AclCacheEnabled — default true).
+        builder.Services.AddScoped<EffectivePermissionResolver>();
+        builder.Services.AddScoped<IEffectivePermissionResolver>(sp =>
+        {
+            GranitDocumentsOptions opts = sp
+                .GetRequiredService<IOptions<GranitDocumentsOptions>>().Value;
+            EffectivePermissionResolver inner = sp.GetRequiredService<EffectivePermissionResolver>();
+            return opts.AclCacheEnabled
+                ? ActivatorUtilities.CreateInstance<CachedEffectivePermissionResolver>(sp, inner)
+                : inner;
+        });
 
         return builder;
     }

--- a/src/Granit.Documents.EntityFrameworkCore/Granit.Documents.EntityFrameworkCore.csproj
+++ b/src/Granit.Documents.EntityFrameworkCore/Granit.Documents.EntityFrameworkCore.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Documents\Granit.Documents.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>

--- a/src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Caching;
 using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 
@@ -21,6 +22,7 @@ namespace Granit.Documents.EntityFrameworkCore;
 /// </para>
 /// </remarks>
 [DependsOn(
+    typeof(GranitCachingModule),
     typeof(GranitDocumentsModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]
 public sealed class GranitDocumentsEntityFrameworkCoreModule : GranitModule;

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentResolutionResult.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentResolutionResult.cs
@@ -1,0 +1,13 @@
+using Granit.Documents.Authorization;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Internal result shape returned by <see cref="EffectivePermissionResolver.ResolveDocumentAsync"/>
+/// — carries the resolved permission level plus the ancestor folder ids visited during
+/// resolution. The cache decorator (F6.3) tags the cached entry with each ancestor id so a
+/// folder share change invalidates exactly the entries that depended on it.
+/// </summary>
+internal readonly record struct DocumentResolutionResult(
+    EffectivePermissionLevel Permission,
+    IReadOnlyList<Guid> AncestorFolderIds);

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
@@ -44,6 +44,25 @@ internal sealed class EffectivePermissionResolver(
         DocumentPrincipal principal,
         CancellationToken cancellationToken = default)
     {
+        DocumentResolutionResult result = await ResolveDocumentAsync(documentId, principal, cancellationToken)
+            .ConfigureAwait(false);
+        return result.Permission;
+    }
+
+    /// <summary>
+    /// Resolves the effective permission AND returns the ancestor folder ids visited during
+    /// resolution. The cache decorator (F6.3) uses the folder ids to tag the cached entry,
+    /// so a folder share change invalidates exactly the entries that depended on it.
+    /// </summary>
+    /// <remarks>
+    /// Internal contract — the public <see cref="IEffectivePermissionResolver"/> stays a
+    /// single-value API.
+    /// </remarks>
+    internal async Task<DocumentResolutionResult> ResolveDocumentAsync(
+        Guid documentId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(principal);
 
         // Materialise as a concrete List<Guid> — EF Core's Contains translator is pickier
@@ -52,7 +71,7 @@ internal sealed class EffectivePermissionResolver(
         List<Guid> granteeIds = [.. principal.AllGranteeIds];
         if (granteeIds.Count == 0)
         {
-            return EffectivePermissionLevel.None;
+            return new DocumentResolutionResult(EffectivePermissionLevel.None, []);
         }
 
         await using DocumentsDbContext context = await contextFactory
@@ -71,7 +90,7 @@ internal sealed class EffectivePermissionResolver(
             .ConfigureAwait(false);
         if (docInfo is null)
         {
-            return EffectivePermissionLevel.None;
+            return new DocumentResolutionResult(EffectivePermissionLevel.None, []);
         }
 
         // Build the ancestor-path set in C# (cheap string ops on a materialised path) and
@@ -84,17 +103,18 @@ internal sealed class EffectivePermissionResolver(
         // step 3 reduce to a simple Contains predicate that every EF Core provider can
         // translate — the alternative (a nested Folders.Any inside the share Where clause)
         // doesn't translate on SQLite.
-        // Materialise as List<Guid?> so the IN clause matches Folder.FolderId's nullable type
-        // directly — avoids EF Core having to unwrap .Value across providers (SQLite refused
-        // a Contains(.Value) translation; the nullable list shape works on every provider).
-        List<Guid?> ancestorFolderIds = ancestorPaths.Count == 0
+        List<Guid> ancestorFolderIds = ancestorPaths.Count == 0
             ? []
             : await context.Folders
                 .Where(f => f.TenantId == docInfo.TenantId
                     && ancestorPaths.Contains(f.Path))
-                .Select(f => (Guid?)f.Id)
+                .Select(f => f.Id)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
+
+        // Materialise as List<Guid?> for the share-IN clause — Folder.FolderId is nullable
+        // and SQLite refused a Contains(.Value) translation; nullable list works everywhere.
+        List<Guid?> ancestorFolderIdsForShareLookup = [.. ancestorFolderIds.Select(id => (Guid?)id)];
 
         DateTimeOffset now = clock.Now;
 
@@ -119,13 +139,13 @@ internal sealed class EffectivePermissionResolver(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var folderMatches = ancestorFolderIds.Count == 0
+        var folderMatches = ancestorFolderIdsForShareLookup.Count == 0
             ? []
             : await context.DocumentShares
                 .Where(s => s.TenantId == docInfo.TenantId
                     && granteeIds.Contains(s.GranteeId)
                     && s.TargetType == ShareTargetType.Folder
-                    && ancestorFolderIds.Contains(s.FolderId))
+                    && ancestorFolderIdsForShareLookup.Contains(s.FolderId))
                 .Select(s => new { s.Permission, s.ExpiresAt })
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
@@ -135,18 +155,17 @@ internal sealed class EffectivePermissionResolver(
             .. folderMatches.Where(m => m.ExpiresAt is null || m.ExpiresAt > now).Select(m => m.Permission),
         ];
 
-        if (matches.Count == 0)
-        {
-            return EffectivePermissionLevel.None;
-        }
+        EffectivePermissionLevel level = matches.Count == 0
+            ? EffectivePermissionLevel.None
+            : matches.Max() switch
+            {
+                SharePermissionLevel.Manage => EffectivePermissionLevel.Manage,
+                SharePermissionLevel.Edit => EffectivePermissionLevel.Edit,
+                SharePermissionLevel.Read => EffectivePermissionLevel.Read,
+                _ => EffectivePermissionLevel.None,
+            };
 
-        return matches.Max() switch
-        {
-            SharePermissionLevel.Manage => EffectivePermissionLevel.Manage,
-            SharePermissionLevel.Edit => EffectivePermissionLevel.Edit,
-            SharePermissionLevel.Read => EffectivePermissionLevel.Read,
-            _ => EffectivePermissionLevel.None,
-        };
+        return new DocumentResolutionResult(level, ancestorFolderIds);
     }
 
     /// <summary>

--- a/src/Granit.Documents/Diagnostics/DocumentsMetrics.cs
+++ b/src/Granit.Documents/Diagnostics/DocumentsMetrics.cs
@@ -23,6 +23,8 @@ public sealed class DocumentsMetrics
     private readonly Counter<long> _downloads;
     private readonly Counter<long> _sharesGranted;
     private readonly Counter<long> _quotaRejected;
+    private readonly Counter<long> _aclCacheHits;
+    private readonly Counter<long> _aclCacheMisses;
 
     /// <summary>Initialises the meter and counters.</summary>
     public DocumentsMetrics(IMeterFactory meterFactory)
@@ -46,6 +48,17 @@ public sealed class DocumentsMetrics
         _quotaRejected = meter.CreateCounter<long>(
             "granit.documents.quota.rejected.count",
             description: "Number of upload finalisations rejected because the tenant storage quota would be exceeded.");
+
+        // F6.3 — ACL cache hit/miss counters. Hit ratio is computed downstream by the
+        // observability pipeline (e.g. Prometheus/Grafana) as
+        //   hits / (hits + misses) → granit.documents.acl.cache.hit_ratio.
+        _aclCacheHits = meter.CreateCounter<long>(
+            "granit.documents.acl.cache.hits",
+            description: "Number of effective-ACL resolutions served from the FusionCache layer.");
+
+        _aclCacheMisses = meter.CreateCounter<long>(
+            "granit.documents.acl.cache.misses",
+            description: "Number of effective-ACL resolutions that fell through to the database.");
     }
 
     /// <summary>Records a successful document upload (new document or new version).</summary>
@@ -63,6 +76,14 @@ public sealed class DocumentsMetrics
     /// <summary>Records an upload rejection due to tenant storage quota being exceeded.</summary>
     public void RecordQuotaRejected(string? tenantId) =>
         _quotaRejected.Add(1, CreateTags(tenantId));
+
+    /// <summary>Records an effective-ACL cache hit.</summary>
+    public void RecordAclCacheHit(string? tenantId) =>
+        _aclCacheHits.Add(1, CreateTags(tenantId));
+
+    /// <summary>Records an effective-ACL cache miss (resolution fell through to the database).</summary>
+    public void RecordAclCacheMiss(string? tenantId) =>
+        _aclCacheMisses.Add(1, CreateTags(tenantId));
 
     private static TagList CreateTags(string? tenantId) => new()
     {

--- a/src/Granit.Documents/Options/GranitDocumentsOptions.cs
+++ b/src/Granit.Documents/Options/GranitDocumentsOptions.cs
@@ -38,4 +38,12 @@ public sealed class GranitDocumentsOptions
     /// </summary>
     [Range(typeof(TimeSpan), "00:00:30", "01:00:00")]
     public TimeSpan AclCacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Enables the FusionCache decorator on top of the effective-ACL resolver (F6.3).
+    /// Disabling this falls back to direct database resolution on every read — useful for
+    /// load-test investigations or environments where Redis is unavailable.
+    /// Default: <c>true</c>.
+    /// </summary>
+    public bool AclCacheEnabled { get; set; } = true;
 }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2322,6 +2322,7 @@
       "granit.documents.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -487,6 +487,7 @@
       "granit.documents.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/AclCacheKeysTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/AclCacheKeysTests.cs
@@ -1,0 +1,63 @@
+using Granit.Documents.Authorization;
+using Granit.Documents.EntityFrameworkCore.Authorization;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Authorization;
+
+public sealed class AclCacheKeysTests
+{
+    [Fact]
+    public void Document_KeyIsStable_ForSamePrincipal()
+    {
+        var docId = Guid.NewGuid();
+        var principal = new DocumentPrincipal(Guid.NewGuid(), [Guid.NewGuid()], [Guid.NewGuid()]);
+
+        string a = AclCacheKeys.Document(docId, principal);
+        string b = AclCacheKeys.Document(docId, principal);
+
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void Document_KeyDiffers_OnGranteeSetChange()
+    {
+        var docId = Guid.NewGuid();
+        var user = Guid.NewGuid();
+        var p1 = new DocumentPrincipal(user, [Guid.NewGuid()], []);
+        var p2 = new DocumentPrincipal(user, [Guid.NewGuid()], []);
+
+        AclCacheKeys.Document(docId, p1).ShouldNotBe(AclCacheKeys.Document(docId, p2));
+    }
+
+    [Fact]
+    public void HashGranteeSet_IgnoresOrder()
+    {
+        var r1 = Guid.NewGuid();
+        var r2 = Guid.NewGuid();
+        var g = Guid.NewGuid();
+        var a = new DocumentPrincipal(Guid.NewGuid(), [r1, r2], [g]);
+        var b = new DocumentPrincipal(a.UserId, [r2, r1], [g]);
+
+        AclCacheKeys.HashGranteeSet(a).ShouldBe(AclCacheKeys.HashGranteeSet(b));
+    }
+
+    [Fact]
+    public void HashGranteeSet_EmptyPrincipal_ReturnsZero() =>
+        AclCacheKeys.HashGranteeSet(new DocumentPrincipal(Guid.Empty, [], [])).ShouldBe("0");
+
+    [Fact]
+    public void BuildEntryTags_IncludesDocFolderAndAllTags()
+    {
+        var docId = Guid.NewGuid();
+        var f1 = Guid.NewGuid();
+        var f2 = Guid.NewGuid();
+
+        string[] tags = AclCacheKeys.BuildEntryTags(docId, [f1, f2]);
+
+        tags.ShouldContain(AclCacheKeys.DocumentTag(docId));
+        tags.ShouldContain(AclCacheKeys.FolderTag(f1));
+        tags.ShouldContain(AclCacheKeys.FolderTag(f2));
+        tags.ShouldContain(AclCacheKeys.AllTag);
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
@@ -1,0 +1,290 @@
+using System.Diagnostics.Metrics;
+using Granit.Caching.Extensions;
+using Granit.Documents.Authorization;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Authorization;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Authorization;
+
+/// <summary>
+/// SQLite + real FusionCache integration test for the F6.3 cache layer. Validates the hit /
+/// miss path, the cache hit / miss metrics, and the tag-based invalidation flow on share
+/// grant / revoke and folder path change events.
+/// </summary>
+public sealed class CachedEffectivePermissionResolverTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private TestFactory _factory = null!;
+    private CachedEffectivePermissionResolver _sut = null!;
+    private EffectivePermissionResolver _inner = null!;
+    private IFusionCache _cache = null!;
+    private TestMeterListener _meter = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestFactory(options);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        _inner = new EffectivePermissionResolver(_factory, clock);
+
+        // Real FusionCache via Granit.Caching — covers the tag invalidation pipeline that
+        // the production decorator relies on. Tenant context is set explicitly so cache
+        // keys stay scoped to TenantId.
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddSingleton(tenant);
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddGranitCaching();
+        ServiceProvider provider = services.BuildServiceProvider();
+        _cache = provider.GetRequiredService<IFusionCache>();
+
+        _meter = new TestMeterListener();
+        DocumentsMetrics metrics = new(_meter);
+
+        _sut = new CachedEffectivePermissionResolver(
+            _inner, _cache, tenant, metrics,
+            Microsoft.Extensions.Options.Options.Create(
+                new GranitDocumentsOptions { AclCacheTtl = TimeSpan.FromMinutes(5) }));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task FirstCall_IsMiss_SecondCall_IsHit()
+    {
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel first = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        EffectivePermissionLevel second = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        first.ShouldBe(EffectivePermissionLevel.Edit);
+        second.ShouldBe(EffectivePermissionLevel.Edit);
+        _meter.Misses.ShouldBe(1);
+        _meter.Hits.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task EmptyPrincipal_ShortCircuits_DoesNotTouchCache()
+    {
+        var docId = Guid.NewGuid();
+        var emptyPrincipal = new DocumentPrincipal(Guid.Empty, [], []);
+
+        EffectivePermissionLevel result = await _sut.GetDocumentPermissionAsync(
+            docId, emptyPrincipal, TestContext.Current.CancellationToken);
+
+        result.ShouldBe(EffectivePermissionLevel.None);
+        _meter.Hits.ShouldBe(0);
+        _meter.Misses.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DocumentShareGranted_InvalidatesEntry()
+    {
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+
+        // First call — None (no shares yet), populates cache.
+        EffectivePermissionLevel first = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        first.ShouldBe(EffectivePermissionLevel.None);
+
+        // Second call — still None, served from cache.
+        await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        // Grant + emit event (the decorator subscribes via the AclCacheInvalidationHandler).
+        var share = DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, doc.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, OwnerId, Now);
+        await SeedShareAsync(share);
+        await AclCacheInvalidationHandler.HandleAsync(
+            new Events.DocumentShareGrantedEvent(
+                share.Id, TenantId, share.TargetType, share.FolderId, share.DocumentId,
+                share.GranteeType, share.GranteeId, share.Permission, share.IsDefault, share.ExpiresAt),
+            _cache, TestContext.Current.CancellationToken);
+
+        // Third call — must miss (invalidated) and resolve to Manage.
+        EffectivePermissionLevel third = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        third.ShouldBe(EffectivePermissionLevel.Manage);
+
+        _meter.Misses.ShouldBe(2); // first call + after invalidation
+        _meter.Hits.ShouldBe(1); // second call
+        _ = folder;
+    }
+
+    [Fact]
+    public async Task FolderShareGranted_InvalidatesAncestorTaggedEntries()
+    {
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+        // Seed an unrelated share so the cached entry is tagged with the doc's folder.
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+
+        await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        // New folder share grant on the same folder → handler invalidates by folder tag.
+        var upgrade = DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now);
+        await SeedShareAsync(upgrade);
+        await AclCacheInvalidationHandler.HandleAsync(
+            new Events.DocumentShareGrantedEvent(
+                upgrade.Id, TenantId, upgrade.TargetType, upgrade.FolderId, upgrade.DocumentId,
+                upgrade.GranteeType, upgrade.GranteeId, upgrade.Permission, upgrade.IsDefault, upgrade.ExpiresAt),
+            _cache, TestContext.Current.CancellationToken);
+
+        EffectivePermissionLevel after = await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        after.ShouldBe(EffectivePermissionLevel.Manage);
+
+        _meter.Misses.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task FolderPathChanged_BulkInvalidatesTenantEntries()
+    {
+        (Folder folder, Document doc, Guid user) = await SeedAsync();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId, Now));
+
+        // Populate cache for two different documents.
+        await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        await AclCacheInvalidationHandler.HandleAsync(
+            new Events.FolderPathChangedEvent(folder.Id, TenantId, "/old", "/new"),
+            _cache, TestContext.Current.CancellationToken);
+
+        // Next call must miss (acl:all wiped).
+        await _sut.GetDocumentPermissionAsync(
+            doc.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        _meter.Misses.ShouldBe(2);
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private async Task<(Folder, Document, Guid user)> SeedAsync()
+    {
+        var user = Guid.NewGuid();
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        var root = Folder.CreateTenantRoot(Guid.NewGuid(), TenantId, OwnerId);
+        var folder = Folder.Create(Guid.NewGuid(), root, "Contracts", OwnerId);
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "doc.pdf");
+        db.Folders.Add(root);
+        db.Folders.Add(folder);
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync();
+        return (folder, doc, user);
+    }
+
+    private async Task SeedShareAsync(DocumentShare share)
+    {
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        db.DocumentShares.Add(share);
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    /// <summary>
+    /// Minimal IMeterFactory + MeterListener that observes the Granit.Documents counters and
+    /// exposes hit/miss totals. Avoids pulling DiagnosticsMetricsListener into the test pkg.
+    /// </summary>
+    private sealed class TestMeterListener : IMeterFactory
+    {
+        private readonly Meter _meter = new("Granit.Documents");
+        private readonly MeterListener _listener;
+
+        public long Hits { get; private set; }
+        public long Misses { get; private set; }
+
+        public TestMeterListener()
+        {
+            _listener = new MeterListener();
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Granit.Documents")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((inst, value, _, _) =>
+            {
+                if (inst.Name == "granit.documents.acl.cache.hits")
+                {
+                    Hits += value;
+                }
+                else if (inst.Name == "granit.documents.acl.cache.misses")
+                {
+                    Misses += value;
+                }
+            });
+            _listener.Start();
+        }
+
+        public Meter Create(MeterOptions options) => _meter;
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+            _meter.Dispose();
+        }
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/packages.lock.json
@@ -492,6 +492,7 @@
       "granit.documents.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",


### PR DESCRIPTION
## Summary

Third story of feature #1744 (Share ACL with path-based resolution + FusionCache) on epic #1721 (Granit.Documents). Wraps the F6.2 effective-ACL resolver with a FusionCache decorator + tag-based invalidation handlers per [ADR-052](https://github.com/granit-fx/granit-dotnet/blob/develop/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md) §Cache layer.

### Cache decorator — `CachedEffectivePermissionResolver`

- `TryGet` first → on hit, return + record `granit.documents.acl.cache.hits`.
- On miss, delegate to the inner EF resolver (extended with an internal `ResolveDocumentAsync` that exposes the ancestor folder ids it visited), then `Set` with tags `acl:doc:{documentId}` + one `acl:folder:{folderId}` per ancestor + `acl:all`. Records `granit.documents.acl.cache.misses`; hit ratio derives downstream.
- Short-circuits empty principals before touching the cache (no identity to match).
- TTL from `GranitDocumentsOptions.AclCacheTtl` (default 5 minutes).
- Decoration toggleable via `GranitDocumentsOptions.AclCacheEnabled` (default `true`) — the DI factory falls back to the raw EF resolver when caching is off.
- Tenant scoping inherited from `Granit.Caching.TenantAwareFusionCache` — keys/tags auto-prefixed per tenant context.

### Invalidation handlers — `AclCacheInvalidationHandler` (Wolverine-discoverable)

- `DocumentShareGrantedEvent` / `DocumentShareRevokedEvent` → `RemoveByTagAsync(acl:doc:{X})` or `acl:folder:{X}` depending on target.
- `FolderPathChangedEvent` / `FolderTreePathChangedEvent` → `RemoveByTagAsync(acl:all)`. Path changes shift ancestor sets across the moved subtree; the bulk wipe inside the tenant prefix is correct and avoids enumerating descendants.

### Decisions worth flagging

- **TryGet + Set instead of GetOrSetAsync** — FusionCache evaluates the `tags` parameter up front, so the per-ancestor folder-id tags need to be known before the cache call. Splitting lets us tag with the exact ancestor set computed during the real resolution.
- **Inner resolver extended, public interface unchanged** — added `internal Task<DocumentResolutionResult> ResolveDocumentAsync(...)` returning permission + ancestor folder ids; the public `IEffectivePermissionResolver.GetDocumentPermissionAsync` stays a single-value API.
- **`acl:all` for folder path changes** — F2.4 already aggregates per-tree events; bulk wipe is cheaper than walking descendants per move and acceptable given the rarity of path mutations.

## Test plan

- [x] 5 `AclCacheKeysTests` unit tests (key stability, grantee-set hash order-independence, tag composition)
- [x] 4 SQLite + real FusionCache `CachedEffectivePermissionResolverTests`: hit/miss path, empty-principal short-circuit, document-share invalidation flow, folder-share invalidation flow, folder-path bulk invalidation. Cache metrics observed via a custom `MeterListener`.
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — **80/80 passing** (10 new)
- [x] `dotnet build` clean on infrastructure + integration + architecture shards
- [x] 212/212 architecture tests pass
- [x] `dotnet format --verify-no-changes` clean on every touched project
- [x] `dotnet restore Granit.slnx --force-evaluate` — lockfiles refreshed for the new `Granit.Caching` project ref on `Granit.Documents.EntityFrameworkCore`

Closes #1747