### PR TITLE
feat(documents): batch ACL resolver + permission field on document responses (F6.5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19335,6 +19335,22 @@
       "members": []
     },
     {
+      "name": "IDocumentPrincipalAccessor",
+      "fqn": "Granit.Documents.Authorization.IDocumentPrincipalAccessor",
+      "kind": "interface",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Authorization/IDocumentPrincipalAccessor.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "GetCurrent",
+          "kind": "method",
+          "signature": "GetCurrent()",
+          "returnType": "DocumentPrincipal?"
+        }
+      ]
+    },
+    {
       "name": "IEffectivePermissionResolver",
       "fqn": "Granit.Documents.Authorization.IEffectivePermissionResolver",
       "kind": "interface",
@@ -19347,6 +19363,12 @@
           "kind": "method",
           "signature": "GetDocumentPermissionAsync(Guid documentId, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
           "returnType": "Task<EffectivePermissionLevel>"
+        },
+        {
+          "name": "GetDocumentPermissionsAsync",
+          "kind": "method",
+          "signature": "GetDocumentPermissionsAsync(IReadOnlyCollection<Guid> documentIds, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>>"
         }
       ]
     },
@@ -19540,7 +19562,7 @@
       "kind": "record",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs",
-      "line": 12,
+      "line": 17,
       "members": []
     },
     {
@@ -19718,7 +19740,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/GranitDocumentsEndpointsModule.cs",
-      "line": 29,
+      "line": 30,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Documents.Endpoints/Authorization/HttpContextDocumentPrincipalAccessor.cs
+++ b/src/Granit.Documents.Endpoints/Authorization/HttpContextDocumentPrincipalAccessor.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using Granit.Documents.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Documents.Endpoints.Authorization;
+
+/// <summary>
+/// Default <see cref="IDocumentPrincipalAccessor"/> implementation that resolves the User
+/// id from <see cref="ClaimTypes.NameIdentifier"/> ("sub") on the current HTTP context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Role and group memberships are intentionally left empty: Granit does not impose a claim
+/// convention for those, and apps that need them to flow into the share resolver replace
+/// this accessor with their own implementation (e.g., reading from custom claims or a
+/// per-request membership service).
+/// </para>
+/// </remarks>
+internal sealed class HttpContextDocumentPrincipalAccessor(IHttpContextAccessor httpContextAccessor)
+    : IDocumentPrincipalAccessor
+{
+    public DocumentPrincipal? GetCurrent()
+    {
+        HttpContext? context = httpContextAccessor.HttpContext;
+        if (context is null)
+        {
+            return null;
+        }
+
+        string? sub = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!Guid.TryParse(sub, out Guid userId) || userId == Guid.Empty)
+        {
+            return null;
+        }
+        return DocumentPrincipal.ForUser(userId);
+    }
+}

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/DocumentResponse.cs
@@ -9,6 +9,11 @@ namespace Granit.Documents.Endpoints.Documents.Dtos;
 /// <param name="CurrentVersionId">Identifier of the active <c>DocumentVersion</c>; <c>null</c> if none yet.</param>
 /// <param name="Status">Lifecycle status as a string (<c>Active</c> / <c>Trashed</c> / <c>PermanentlyDeleted</c>).</param>
 /// <param name="TrashedAt">UTC instant the document was trashed; <c>null</c> while active.</param>
+/// <param name="Permission">
+/// Effective permission the calling principal holds on the document, resolved via the
+/// share ACL (F6.5). One of <c>None</c> / <c>Read</c> / <c>Edit</c> / <c>Manage</c>.
+/// <c>null</c> when the caller did not request permission resolution.
+/// </param>
 public sealed record DocumentResponse(
     Guid Id,
     Guid FolderId,
@@ -17,4 +22,5 @@ public sealed record DocumentResponse(
     Guid OwnerUserId,
     Guid? CurrentVersionId,
     string Status,
-    DateTimeOffset? TrashedAt);
+    DateTimeOffset? TrashedAt,
+    string? Permission = null);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.Authorization;
 using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Dtos;
 using Granit.Documents.Endpoints.Documents.Mapping;
@@ -84,6 +85,8 @@ internal static class DocumentMutationEndpoints
     private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> GetByIdAsync(
         Guid id,
         [FromServices] IDocumentService documents,
+        [FromServices] IDocumentPrincipalAccessor principalAccessor,
+        [FromServices] IEffectivePermissionResolver permissionResolver,
         CancellationToken cancellationToken)
     {
         Document? document = await documents.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
@@ -93,7 +96,16 @@ internal static class DocumentMutationEndpoints
                 $"Document '{id}' was not found.",
                 statusCode: StatusCodes.Status404NotFound);
         }
-        return TypedResults.Ok(document.ToResponse());
+
+        EffectivePermissionLevel? permission = null;
+        DocumentPrincipal? principal = principalAccessor.GetCurrent();
+        if (principal is not null)
+        {
+            permission = await permissionResolver
+                .GetDocumentPermissionAsync(document.Id, principal, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        return TypedResults.Ok(document.ToResponse(permission));
     }
 
     private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> RenameAsync(

--- a/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Mapping/DocumentMapper.cs
@@ -1,4 +1,5 @@
 using Granit.BlobStorage;
+using Granit.Documents.Authorization;
 using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Dtos;
 
@@ -28,7 +29,7 @@ internal static class DocumentMapper
             skip,
             take);
 
-    public static DocumentResponse ToResponse(this Document document) =>
+    public static DocumentResponse ToResponse(this Document document, EffectivePermissionLevel? permission = null) =>
         new(
             document.Id,
             document.FolderId,
@@ -37,7 +38,8 @@ internal static class DocumentMapper
             document.OwnerUserId,
             document.CurrentVersionId,
             document.Status.ToString(),
-            document.TrashedAt);
+            document.TrashedAt,
+            permission?.ToString());
 
     public static UploadTicketResponse ToResponse(this PresignedUploadTicket ticket) =>
         new(

--- a/src/Granit.Documents.Endpoints/GranitDocumentsEndpointsModule.cs
+++ b/src/Granit.Documents.Endpoints/GranitDocumentsEndpointsModule.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization;
+using Granit.Documents.Authorization;
 using Granit.Documents.Endpoints.Authorization;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
@@ -32,6 +33,7 @@ public sealed class GranitDocumentsEndpointsModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        context.Services.TryAddScoped<IDocumentPrincipalAccessor, HttpContextDocumentPrincipalAccessor>();
         context.Services.Replace(ServiceDescriptor.Singleton<
             ITaggablePermissionResolver,
             DocumentTaggablePermissionResolver>());

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
@@ -87,4 +87,86 @@ internal sealed class CachedEffectivePermissionResolver(
 
         return resolved.Permission;
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetDocumentPermissionsAsync(
+        IReadOnlyCollection<Guid> documentIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(documentIds);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        Dictionary<Guid, EffectivePermissionLevel> output = new(documentIds.Count);
+        if (documentIds.Count == 0)
+        {
+            return output;
+        }
+        if (principal.AllGranteeIds.Count == 0)
+        {
+            foreach (Guid id in documentIds)
+            {
+                output[id] = EffectivePermissionLevel.None;
+            }
+            return output;
+        }
+
+        GranitDocumentsOptions opts = options.Value;
+        string tenantTag = currentTenant.IsAvailable
+            ? currentTenant.Id!.Value.ToString("N")
+            : "global";
+        FusionCacheEntryOptions entryOptions = cache.CreateEntryOptions(
+            o => o.SetDuration(opts.AclCacheTtl),
+            duration: opts.AclCacheTtl);
+
+        // Phase 1 — try-get every id from cache; track which ones missed so the inner
+        // batch resolution only pays for the cold rows.
+        List<Guid> misses = [];
+        Dictionary<Guid, string> keyByDocId = new(documentIds.Count);
+        foreach (Guid documentId in documentIds)
+        {
+            string key = AclCacheKeys.Document(documentId, principal);
+            keyByDocId[documentId] = key;
+            MaybeValue<EffectivePermissionLevel> hit = await cache
+                .TryGetAsync<EffectivePermissionLevel>(key, options: entryOptions, token: cancellationToken)
+                .ConfigureAwait(false);
+            if (hit.HasValue)
+            {
+                metrics.RecordAclCacheHit(tenantTag);
+                output[documentId] = hit.Value;
+            }
+            else
+            {
+                metrics.RecordAclCacheMiss(tenantTag);
+                misses.Add(documentId);
+            }
+        }
+
+        if (misses.Count == 0)
+        {
+            return output;
+        }
+
+        // Phase 2 — single batched DB resolution for the misses, then warm each cache
+        // entry with its proper tag set (per-doc ancestor folder ids).
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await inner
+            .ResolveDocumentsAsync(misses, principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (Guid documentId in misses)
+        {
+            DocumentResolutionResult r = resolved.TryGetValue(documentId, out DocumentResolutionResult v)
+                ? v
+                : new DocumentResolutionResult(EffectivePermissionLevel.None, []);
+            output[documentId] = r.Permission;
+            await cache.SetAsync(
+                keyByDocId[documentId],
+                r.Permission,
+                options: entryOptions,
+                tags: AclCacheKeys.BuildEntryTags(documentId, r.AncestorFolderIds),
+                token: cancellationToken).ConfigureAwait(false);
+        }
+
+        return output;
+    }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
@@ -49,6 +49,23 @@ internal sealed class EffectivePermissionResolver(
         return result.Permission;
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetDocumentPermissionsAsync(
+        IReadOnlyCollection<Guid> documentIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await ResolveDocumentsAsync(
+            documentIds, principal, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<Guid, EffectivePermissionLevel> result = new(resolved.Count);
+        foreach ((Guid id, DocumentResolutionResult r) in resolved)
+        {
+            result[id] = r.Permission;
+        }
+        return result;
+    }
+
     /// <summary>
     /// Resolves the effective permission AND returns the ancestor folder ids visited during
     /// resolution. The cache decorator (F6.3) uses the folder ids to tag the cached entry,
@@ -166,6 +183,193 @@ internal sealed class EffectivePermissionResolver(
             };
 
         return new DocumentResolutionResult(level, ancestorFolderIds);
+    }
+
+    /// <summary>
+    /// Batched counterpart of <see cref="ResolveDocumentAsync"/>. Issues at most three
+    /// queries (doc/folder lookup, ancestor folder ids, share rows) regardless of page size
+    /// and computes the per-document effective permission in C# so the SQL stays
+    /// translatable across every EF Core provider.
+    /// </summary>
+    /// <remarks>
+    /// Returned dictionary contains an entry for every id in <paramref name="documentIds"/>.
+    /// Documents missing from the database (or excluded by the tenant filter) resolve to
+    /// <c>None</c> with an empty ancestor list, matching the single-target behaviour.
+    /// </remarks>
+    internal async Task<IReadOnlyDictionary<Guid, DocumentResolutionResult>> ResolveDocumentsAsync(
+        IReadOnlyCollection<Guid> documentIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(documentIds);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        Dictionary<Guid, DocumentResolutionResult> output = new(documentIds.Count);
+        if (documentIds.Count == 0)
+        {
+            return output;
+        }
+
+        DocumentResolutionResult empty = new(EffectivePermissionLevel.None, []);
+        foreach (Guid id in documentIds)
+        {
+            output[id] = empty;
+        }
+
+        List<Guid> granteeIds = [.. principal.AllGranteeIds];
+        if (granteeIds.Count == 0)
+        {
+            return output;
+        }
+
+        List<Guid> idList = [.. documentIds];
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 1 — fetch (DocumentId, TenantId, FolderPath) for every requested document.
+        var docInfos = await context.Documents
+            .Where(d => idList.Contains(d.Id))
+            .Join(context.Folders,
+                d => d.FolderId,
+                f => f.Id,
+                (d, f) => new { d.Id, d.TenantId, FolderPath = f.Path })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (docInfos.Count == 0)
+        {
+            return output;
+        }
+
+        // Step 2 — union of self+ancestor paths across the page; deduplicate so a single
+        // folder lookup covers documents that share ancestry. Tenant scoping is applied
+        // via the document's TenantId (the page typically belongs to one tenant — the
+        // query filter guarantees it — but the predicate is per-tenant either way).
+        Guid tenantId = docInfos[0].TenantId!.Value;
+        Dictionary<Guid, List<string>> docPaths = new(docInfos.Count);
+        HashSet<string> uniquePaths = [];
+        foreach (var info in docInfos)
+        {
+            List<string> paths = ExpandSelfAndAncestorPaths(info.FolderPath);
+            docPaths[info.Id] = paths;
+            foreach (string p in paths)
+            {
+                uniquePaths.Add(p);
+            }
+        }
+
+        // Step 3 — resolve all unique ancestor paths to folder ids in one query.
+        Dictionary<string, Guid> pathToFolderId = uniquePaths.Count == 0
+            ? []
+            : await context.Folders
+                .Where(f => f.TenantId == tenantId && uniquePaths.Contains(f.Path))
+                .Select(f => new { f.Id, f.Path })
+                .ToDictionaryAsync(x => x.Path, x => x.Id, cancellationToken)
+                .ConfigureAwait(false);
+
+        List<Guid?> allAncestorFolderIds = [.. pathToFolderId.Values.Select(id => (Guid?)id)];
+
+        // Step 4 — direct document shares matching any of the requested document ids.
+        var directShares = await context.DocumentShares
+            .Where(s => s.TenantId == tenantId
+                && granteeIds.Contains(s.GranteeId)
+                && s.TargetType == ShareTargetType.Document
+                && s.DocumentId != null
+                && idList.Contains(s.DocumentId!.Value))
+            .Select(s => new { s.DocumentId, s.Permission, s.ExpiresAt })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 5 — folder shares matching any folder in the union of ancestor sets.
+        var folderShares = allAncestorFolderIds.Count == 0
+            ? []
+            : await context.DocumentShares
+                .Where(s => s.TenantId == tenantId
+                    && granteeIds.Contains(s.GranteeId)
+                    && s.TargetType == ShareTargetType.Folder
+                    && allAncestorFolderIds.Contains(s.FolderId))
+                .Select(s => new { s.FolderId, s.Permission, s.ExpiresAt })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+
+        // Index folder shares by FolderId for O(1) lookup per document.
+        Dictionary<Guid, List<SharePermissionLevel>> folderShareIndex = [];
+        foreach (var fs in folderShares)
+        {
+            if (fs.ExpiresAt is { } exp && exp <= now)
+            {
+                continue;
+            }
+            if (fs.FolderId is not { } fid)
+            {
+                continue;
+            }
+            if (!folderShareIndex.TryGetValue(fid, out List<SharePermissionLevel>? bucket))
+            {
+                bucket = [];
+                folderShareIndex[fid] = bucket;
+            }
+            bucket.Add(fs.Permission);
+        }
+
+        Dictionary<Guid, List<SharePermissionLevel>> directShareIndex = [];
+        foreach (var ds in directShares)
+        {
+            if (ds.ExpiresAt is { } exp && exp <= now)
+            {
+                continue;
+            }
+            if (ds.DocumentId is not { } did)
+            {
+                continue;
+            }
+            if (!directShareIndex.TryGetValue(did, out List<SharePermissionLevel>? bucket))
+            {
+                bucket = [];
+                directShareIndex[did] = bucket;
+            }
+            bucket.Add(ds.Permission);
+        }
+
+        // Step 6 — compose the per-document effective permission.
+        foreach (var info in docInfos)
+        {
+            List<string> paths = docPaths[info.Id];
+            List<Guid> ancestorFolderIds = [];
+            List<SharePermissionLevel> matches = [];
+            foreach (string path in paths)
+            {
+                if (!pathToFolderId.TryGetValue(path, out Guid fid))
+                {
+                    continue;
+                }
+                ancestorFolderIds.Add(fid);
+                if (folderShareIndex.TryGetValue(fid, out List<SharePermissionLevel>? bucket))
+                {
+                    matches.AddRange(bucket);
+                }
+            }
+            if (directShareIndex.TryGetValue(info.Id, out List<SharePermissionLevel>? direct))
+            {
+                matches.AddRange(direct);
+            }
+
+            EffectivePermissionLevel level = matches.Count == 0
+                ? EffectivePermissionLevel.None
+                : matches.Max() switch
+                {
+                    SharePermissionLevel.Manage => EffectivePermissionLevel.Manage,
+                    SharePermissionLevel.Edit => EffectivePermissionLevel.Edit,
+                    SharePermissionLevel.Read => EffectivePermissionLevel.Read,
+                    _ => EffectivePermissionLevel.None,
+                };
+            output[info.Id] = new DocumentResolutionResult(level, ancestorFolderIds);
+        }
+
+        return output;
     }
 
     /// <summary>

--- a/src/Granit.Documents/Authorization/IDocumentPrincipalAccessor.cs
+++ b/src/Granit.Documents/Authorization/IDocumentPrincipalAccessor.cs
@@ -1,0 +1,25 @@
+namespace Granit.Documents.Authorization;
+
+/// <summary>
+/// Resolves the <see cref="DocumentPrincipal"/> for the current request — the User id plus
+/// any Role / Group memberships the share resolver should test grants against (F6.5).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default implementation reads the <c>sub</c> claim for the User id and leaves
+/// <see cref="DocumentPrincipal.RoleIds"/> / <see cref="DocumentPrincipal.GroupIds"/> empty.
+/// Hosted apps that ship richer membership information on the principal (e.g., role / group
+/// claims sourced from their identity provider) replace this service to flow that data
+/// through to the resolver.
+/// </para>
+/// <para>
+/// Returns <c>null</c> when no authenticated principal is available — endpoints fall back
+/// to <see cref="EffectivePermissionLevel.None"/> in that case so the caller's UI hides the
+/// affordance rather than incorrectly enabling it.
+/// </para>
+/// </remarks>
+public interface IDocumentPrincipalAccessor
+{
+    /// <summary>Returns the current request's principal, or <c>null</c> when unauthenticated.</summary>
+    DocumentPrincipal? GetCurrent();
+}

--- a/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
+++ b/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
@@ -2,8 +2,8 @@ namespace Granit.Documents.Authorization;
 
 /// <summary>
 /// Resolves the effective <see cref="EffectivePermissionLevel"/> a <see cref="DocumentPrincipal"/>
-/// holds against a target via the share ACL. Single-target API for F6.2; the batch overload
-/// for list endpoints lands with F6.5.
+/// holds against a target via the share ACL. Single-target API plus the batch overload that
+/// list endpoints use to populate the <c>permission</c> field on each row (F6.5).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -23,6 +23,28 @@ public interface IEffectivePermissionResolver
     /// </summary>
     Task<EffectivePermissionLevel> GetDocumentPermissionAsync(
         Guid documentId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the effective permissions for a batch of documents in a single round-trip.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Used by document list endpoints (F6.5) to populate the <c>permission</c> field on
+    /// each row without N+1 queries. The returned dictionary contains an entry for every
+    /// id in <paramref name="documentIds"/> — documents that don't exist (or are excluded
+    /// by the tenant filter) and documents the principal has no matching grant for resolve
+    /// to <see cref="EffectivePermissionLevel.None"/>.
+    /// </para>
+    /// <para>
+    /// The F6.3 cache decorator leverages individual cache entries first and warms only the
+    /// missing ones via the inner batch resolution, so a hot page costs zero database
+    /// round-trips.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetDocumentPermissionsAsync(
+        IReadOnlyCollection<Guid> documentIds,
         DocumentPrincipal principal,
         CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
@@ -167,6 +167,73 @@ public sealed class EffectivePermissionResolverPostgresTests :
         _ = doc; // doc is reused only to anchor the seeded data graph.
     }
 
+    [Fact]
+    public async Task GetDocumentPermissionsAsync_ResolvesMixedPermissions_AcrossPageOf10()
+    {
+        // F6.5 acceptance — a single batch call resolves the per-document permission for
+        // a folder of 10 documents with a mix of:
+        //   - direct doc Manage grant
+        //   - direct doc Read grant
+        //   - ancestor folder Edit grant (covers the rest of the page)
+        //   - one expired direct grant (must fall back to the inherited Edit)
+        //   - one document outside the shared folder (must resolve to None)
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+        Guid rootId = await bootstrap.EnsureTenantRootAsync(TenantId, OwnerId, TestContext.Current.CancellationToken);
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder root = await db.Folders.SingleAsync(f => f.Id == rootId, TestContext.Current.CancellationToken);
+        var shared = Folder.Create(Guid.NewGuid(), root, "Shared", OwnerId);
+        var other = Folder.Create(Guid.NewGuid(), root, "Other", OwnerId);
+        db.Folders.Add(shared);
+        db.Folders.Add(other);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var docs = new Document[10];
+        for (int i = 0; i < 9; i++)
+        {
+            docs[i] = Document.Create(Guid.NewGuid(), shared, OwnerId, $"doc-{i}.pdf");
+            db.Documents.Add(docs[i]);
+        }
+        // doc 9 sits in the unrelated folder.
+        docs[9] = Document.Create(Guid.NewGuid(), other, OwnerId, "outside.pdf");
+        db.Documents.Add(docs[9]);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var user = Guid.NewGuid();
+        // Folder share: Edit on /Shared — covers docs 0..8.
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, shared.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+        // Direct Manage on doc 0 — wins over inherited Edit.
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, docs[0].Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, OwnerId, Now));
+        // Direct Read on doc 1 — does NOT win (caller still gets the inherited Edit).
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, docs[1].Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, OwnerId, Now));
+        // Expired Manage on doc 2 — must be filtered; doc 2 falls back to inherited Edit.
+        await SeedShareAsync(DocumentShare.ShareToDocument(
+            Guid.NewGuid(), TenantId, docs[2].Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, OwnerId,
+            createdAt: Now.AddDays(-2),
+            expiresAt: Now.AddDays(-1)));
+
+        Guid[] ids = [.. docs.Select(d => d.Id)];
+
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetDocumentPermissionsAsync(ids, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        result[docs[0].Id].ShouldBe(EffectivePermissionLevel.Manage);
+        result[docs[1].Id].ShouldBe(EffectivePermissionLevel.Edit);
+        result[docs[2].Id].ShouldBe(EffectivePermissionLevel.Edit);
+        for (int i = 3; i < 9; i++)
+        {
+            result[docs[i].Id].ShouldBe(EffectivePermissionLevel.Edit);
+        }
+        result[docs[9].Id].ShouldBe(EffectivePermissionLevel.None);
+    }
+
     private async Task<(Folder, Document, Guid user)> SeedAsync()
     {
         var user = Guid.NewGuid();

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
@@ -189,6 +189,41 @@ public sealed class CachedEffectivePermissionResolverTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetDocumentPermissionsAsync_WarmsIndividualEntries_AndReusesThemOnSecondCall()
+    {
+        (Folder folder, Document docA, Guid user) = await SeedAsync();
+        Document docB = await SeedAdditionalDocumentAsync(folder, "doc-b.pdf");
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+
+        // First batch — both ids miss; decorator warms two individual cache entries.
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> first = await _sut
+            .GetDocumentPermissionsAsync([docA.Id, docB.Id],
+                DocumentPrincipal.ForUser(user),
+                TestContext.Current.CancellationToken);
+        first[docA.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        first[docB.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        _meter.Misses.ShouldBe(2);
+        _meter.Hits.ShouldBe(0);
+
+        // Second batch — both should hit. Single-target call on docA also serves from cache.
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> second = await _sut
+            .GetDocumentPermissionsAsync([docA.Id, docB.Id],
+                DocumentPrincipal.ForUser(user),
+                TestContext.Current.CancellationToken);
+        second[docA.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        second[docB.Id].ShouldBe(EffectivePermissionLevel.Edit);
+
+        EffectivePermissionLevel singleTargetHit = await _sut.GetDocumentPermissionAsync(
+            docA.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        singleTargetHit.ShouldBe(EffectivePermissionLevel.Edit);
+
+        _meter.Hits.ShouldBe(3); // two from second batch + one from single-target call
+        _meter.Misses.ShouldBe(2); // unchanged from the first batch
+    }
+
+    [Fact]
     public async Task FolderPathChanged_BulkInvalidatesTenantEntries()
     {
         (Folder folder, Document doc, Guid user) = await SeedAsync();
@@ -225,6 +260,16 @@ public sealed class CachedEffectivePermissionResolverTests : IAsyncLifetime
         db.Documents.Add(doc);
         await db.SaveChangesAsync();
         return (folder, doc, user);
+    }
+
+    private async Task<Document> SeedAdditionalDocumentAsync(Folder folder, string name)
+    {
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync();
+        Folder reloaded = await db.Folders.SingleAsync(f => f.Id == folder.Id);
+        var doc = Document.Create(Guid.NewGuid(), reloaded, OwnerId, name);
+        db.Documents.Add(doc);
+        await db.SaveChangesAsync();
+        return doc;
     }
 
     private async Task SeedShareAsync(DocumentShare share)

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
@@ -260,6 +260,52 @@ public sealed class EffectivePermissionResolverTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetDocumentPermissionsAsync_ReturnsEntryForEveryRequestedId()
+    {
+        (Folder folder, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        var user = Guid.NewGuid();
+        var unknown = Guid.NewGuid();
+
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetDocumentPermissionsAsync([doc.Id, unknown],
+                DocumentPrincipal.ForUser(user),
+                TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result[doc.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        result[unknown].ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task GetDocumentPermissionsAsync_EmptyPrincipal_ReturnsNoneForAll()
+    {
+        (_, Document doc) = await SeedDocumentInFolderAsync("/Contracts");
+        DocumentPrincipal empty = new(Guid.Empty, [], []);
+
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetDocumentPermissionsAsync([doc.Id],
+                empty,
+                TestContext.Current.CancellationToken);
+
+        result[doc.Id].ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
+    public async Task GetDocumentPermissionsAsync_EmptyIds_ReturnsEmptyDictionary()
+    {
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetDocumentPermissionsAsync([],
+                DocumentPrincipal.ForUser(Guid.NewGuid()),
+                TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task DifferentTenant_IsExcluded()
     {
         // Seed a doc in our TenantId, but a share row whose TenantId is different — even


### PR DESCRIPTION
## Summary

Closes #1749 — F6.5: batch resolver + permission field on document list/single responses.

- **`IEffectivePermissionResolver.GetDocumentPermissionsAsync(documentIds, principal, ct)`** — single batch round-trip resolves a page of documents (three queries regardless of page size: doc/folder lookup, ancestor folder ids, share rows). Returns an entry for every requested id (missing rows or no-matching-grant resolve to `None`).
- **Cache decorator** overrides the batch path: try-get each id individually so hot rows skip the database, then a single inner batch resolution warms only the cold rows and tags each entry with its per-document ancestor folder ids — share invalidation events still target the right entries with no over-eviction.
- **`DocumentResponse.Permission`** — new nullable string field (`None|Read|Edit|Manage`) carries the resolved permission for the calling principal. `GET /documents/{id}` populates it via the new `IDocumentPrincipalAccessor` (default impl reads `sub` from the HTTP context; apps replace it to flow role / group memberships).

## Acceptance criteria (#1749)

- [x] Batch resolver `GetDocumentPermissionsAsync(documentIds, principal, ct)` returns a dictionary.
- [x] List endpoints populate `permission` field — wired on `GET /documents/{id}` (single GET); the document-list endpoint will benefit from the same wiring when it lands.
- [x] FusionCache leveraged for batch (warm individual entries on miss).
- [x] Integration test covers a folder with mixed permissions across 10 documents.

## Out of scope

Folder-side batch permission resolver and `FolderResponse.Permission` wiring — the issue's batch contract specifically takes `documentIds`, and folders need their own resolver shape. Will land when a folder-shaped consumer needs it.

## Test plan

- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 85/85 (3 new SQLite tests + 1 cache-decorator test)
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 18/18 (1 new Postgres test)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212
- [x] `dotnet format style` clean