### PR TITLE
feat(documents): folder ACL resolver + permission field on folder responses (F6.5b)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19369,6 +19369,18 @@
           "kind": "method",
           "signature": "GetDocumentPermissionsAsync(IReadOnlyCollection<Guid> documentIds, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>>"
+        },
+        {
+          "name": "GetFolderPermissionAsync",
+          "kind": "method",
+          "signature": "GetFolderPermissionAsync(Guid folderId, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
+          "returnType": "Task<EffectivePermissionLevel>"
+        },
+        {
+          "name": "GetFolderPermissionsAsync",
+          "kind": "method",
+          "signature": "GetFolderPermissionsAsync(IReadOnlyCollection<Guid> folderIds, DocumentPrincipal principal, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>>"
         }
       ]
     },
@@ -19704,7 +19716,7 @@
       "kind": "record",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Folders/Dtos/FolderResponse.cs",
-      "line": 17,
+      "line": 22,
       "members": []
     },
     {

--- a/src/Granit.Documents.Endpoints/Folders/Dtos/FolderResponse.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Dtos/FolderResponse.cs
@@ -14,6 +14,11 @@ namespace Granit.Documents.Endpoints.Folders.Dtos;
 /// <param name="OwnerUserId">Identifier of the user who owns the folder.</param>
 /// <param name="Status">Lifecycle status (<c>Active</c> or <c>Trashed</c>).</param>
 /// <param name="TrashedAt">UTC instant the folder was trashed; <c>null</c> while active.</param>
+/// <param name="Permission">
+/// Effective permission the calling principal holds on the folder, resolved via the share
+/// ACL (F6.5b). One of <c>None</c> / <c>Read</c> / <c>Edit</c> / <c>Manage</c>. <c>null</c>
+/// when the caller did not request permission resolution.
+/// </param>
 public sealed record FolderResponse(
     Guid Id,
     Guid? ParentFolderId,
@@ -22,4 +27,5 @@ public sealed record FolderResponse(
     int Depth,
     Guid OwnerUserId,
     string Status,
-    DateTimeOffset? TrashedAt);
+    DateTimeOffset? TrashedAt,
+    string? Permission = null);

--- a/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.Authorization;
 using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Folders.Dtos;
 using Granit.Documents.Endpoints.Folders.Mapping;
@@ -119,19 +120,37 @@ internal static class FolderEndpoints
     private static async Task<Ok<ListFoldersResponse>> ListChildrenAsync(
         [FromQuery] Guid? parentId,
         [FromServices] IFolderService folders,
+        [FromServices] IDocumentPrincipalAccessor principalAccessor,
+        [FromServices] IEffectivePermissionResolver permissionResolver,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<Folder> children = await folders
             .ListChildrenAsync(parentId, cancellationToken)
             .ConfigureAwait(false);
 
-        FolderResponse[] mapped = [.. children.Select(f => f.ToResponse())];
+        // F6.5b — populate the per-row Permission via a single batch call when an
+        // authenticated principal is available; unauthenticated calls leave it null.
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel>? permissions = null;
+        DocumentPrincipal? principal = principalAccessor.GetCurrent();
+        if (principal is not null && children.Count > 0)
+        {
+            permissions = await permissionResolver
+                .GetFolderPermissionsAsync([.. children.Select(f => f.Id)], principal, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        FolderResponse[] mapped = [.. children.Select(f => f.ToResponse(
+            permissions is not null && permissions.TryGetValue(f.Id, out EffectivePermissionLevel p)
+                ? p
+                : null))];
         return TypedResults.Ok(new ListFoldersResponse(mapped));
     }
 
     private static async Task<Results<Ok<FolderResponse>, ProblemHttpResult>> GetByIdAsync(
         Guid id,
         [FromServices] IFolderService folders,
+        [FromServices] IDocumentPrincipalAccessor principalAccessor,
+        [FromServices] IEffectivePermissionResolver permissionResolver,
         CancellationToken cancellationToken)
     {
         Folder? folder = await folders.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
@@ -141,7 +160,16 @@ internal static class FolderEndpoints
                 $"Folder '{id}' was not found.",
                 statusCode: StatusCodes.Status404NotFound);
         }
-        return TypedResults.Ok(folder.ToResponse());
+
+        EffectivePermissionLevel? permission = null;
+        DocumentPrincipal? principal = principalAccessor.GetCurrent();
+        if (principal is not null)
+        {
+            permission = await permissionResolver
+                .GetFolderPermissionAsync(folder.Id, principal, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        return TypedResults.Ok(folder.ToResponse(permission));
     }
 
     private static async Task<Results<Ok<FolderBreadcrumbResponse>, ProblemHttpResult>> GetBreadcrumbAsync(

--- a/src/Granit.Documents.Endpoints/Folders/Mapping/FolderMapper.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Mapping/FolderMapper.cs
@@ -1,3 +1,4 @@
+using Granit.Documents.Authorization;
 using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Folders.Dtos;
 
@@ -6,7 +7,7 @@ namespace Granit.Documents.Endpoints.Folders.Mapping;
 /// <summary>Maps the <see cref="Folder"/> aggregate to wire-shape DTOs.</summary>
 internal static class FolderMapper
 {
-    public static FolderResponse ToResponse(this Folder folder) =>
+    public static FolderResponse ToResponse(this Folder folder, EffectivePermissionLevel? permission = null) =>
         new(
             folder.Id,
             folder.ParentFolderId,
@@ -15,5 +16,6 @@ internal static class FolderMapper
             folder.Depth,
             folder.OwnerUserId,
             folder.Status.ToString(),
-            folder.TrashedAt);
+            folder.TrashedAt,
+            permission?.ToString());
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheKeys.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheKeys.cs
@@ -73,6 +73,36 @@ internal static class AclCacheKeys
         return Convert.ToHexString(hash[..8]);
     }
 
+    /// <summary>
+    /// Cache-key segment for "principal P resolves on folder F" (F6.5b). Distinct prefix
+    /// from <see cref="Document"/> so a folder and a document with the same id can never
+    /// collide.
+    /// </summary>
+    public static string Folder(Guid folderId, DocumentPrincipal principal) =>
+        $"acl:folder-perm:{folderId.ToString("N", CultureInfo.InvariantCulture)}"
+        + $":user:{principal.UserId.ToString("N", CultureInfo.InvariantCulture)}"
+        + $":{HashGranteeSet(principal)}";
+
+    /// <summary>
+    /// Builds the tag set attached to a cached folder-permission entry: the target folder
+    /// and every ancestor that participated in the path-prefix scan, plus the tenant-wide
+    /// tag for bulk wipes. Mirrors <see cref="BuildEntryTags(Guid, IReadOnlyList{Guid})"/>
+    /// without the <c>acl:doc:</c> tag (folder entries don't depend on a document id).
+    /// </summary>
+    public static string[] BuildFolderEntryTags(IReadOnlyList<Guid> folderIds)
+    {
+        ArgumentNullException.ThrowIfNull(folderIds);
+
+        string[] tags = new string[folderIds.Count + 1];
+        int i = 0;
+        foreach (Guid folderId in folderIds)
+        {
+            tags[i++] = FolderTag(folderId);
+        }
+        tags[i] = AllTag;
+        return tags;
+    }
+
     /// <summary>Tag attached to entries resolved against a specific document.</summary>
     public static string DocumentTag(Guid documentId) =>
         $"acl:doc:{documentId.ToString("N", CultureInfo.InvariantCulture)}";

--- a/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Authorization/CachedEffectivePermissionResolver.cs
@@ -169,4 +169,133 @@ internal sealed class CachedEffectivePermissionResolver(
 
         return output;
     }
+
+    /// <inheritdoc />
+    public async Task<EffectivePermissionLevel> GetFolderPermissionAsync(
+        Guid folderId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        if (principal.AllGranteeIds.Count == 0)
+        {
+            return EffectivePermissionLevel.None;
+        }
+
+        GranitDocumentsOptions opts = options.Value;
+        string tenantTag = currentTenant.IsAvailable
+            ? currentTenant.Id!.Value.ToString("N")
+            : "global";
+        string key = AclCacheKeys.Folder(folderId, principal);
+
+        FusionCacheEntryOptions entryOptions = cache.CreateEntryOptions(
+            o => o.SetDuration(opts.AclCacheTtl),
+            duration: opts.AclCacheTtl);
+
+        MaybeValue<EffectivePermissionLevel> hit = await cache
+            .TryGetAsync<EffectivePermissionLevel>(key, options: entryOptions, token: cancellationToken)
+            .ConfigureAwait(false);
+        if (hit.HasValue)
+        {
+            metrics.RecordAclCacheHit(tenantTag);
+            return hit.Value;
+        }
+
+        metrics.RecordAclCacheMiss(tenantTag);
+
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await inner
+            .ResolveFoldersAsync([folderId], principal, cancellationToken)
+            .ConfigureAwait(false);
+        DocumentResolutionResult r = resolved.TryGetValue(folderId, out DocumentResolutionResult v)
+            ? v
+            : new DocumentResolutionResult(EffectivePermissionLevel.None, []);
+
+        await cache.SetAsync(
+            key,
+            r.Permission,
+            options: entryOptions,
+            tags: AclCacheKeys.BuildFolderEntryTags(r.AncestorFolderIds),
+            token: cancellationToken).ConfigureAwait(false);
+
+        return r.Permission;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetFolderPermissionsAsync(
+        IReadOnlyCollection<Guid> folderIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(folderIds);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        Dictionary<Guid, EffectivePermissionLevel> output = new(folderIds.Count);
+        if (folderIds.Count == 0)
+        {
+            return output;
+        }
+        if (principal.AllGranteeIds.Count == 0)
+        {
+            foreach (Guid id in folderIds)
+            {
+                output[id] = EffectivePermissionLevel.None;
+            }
+            return output;
+        }
+
+        GranitDocumentsOptions opts = options.Value;
+        string tenantTag = currentTenant.IsAvailable
+            ? currentTenant.Id!.Value.ToString("N")
+            : "global";
+        FusionCacheEntryOptions entryOptions = cache.CreateEntryOptions(
+            o => o.SetDuration(opts.AclCacheTtl),
+            duration: opts.AclCacheTtl);
+
+        List<Guid> misses = [];
+        Dictionary<Guid, string> keyByFolderId = new(folderIds.Count);
+        foreach (Guid folderId in folderIds)
+        {
+            string key = AclCacheKeys.Folder(folderId, principal);
+            keyByFolderId[folderId] = key;
+            MaybeValue<EffectivePermissionLevel> hit = await cache
+                .TryGetAsync<EffectivePermissionLevel>(key, options: entryOptions, token: cancellationToken)
+                .ConfigureAwait(false);
+            if (hit.HasValue)
+            {
+                metrics.RecordAclCacheHit(tenantTag);
+                output[folderId] = hit.Value;
+            }
+            else
+            {
+                metrics.RecordAclCacheMiss(tenantTag);
+                misses.Add(folderId);
+            }
+        }
+
+        if (misses.Count == 0)
+        {
+            return output;
+        }
+
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await inner
+            .ResolveFoldersAsync(misses, principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (Guid folderId in misses)
+        {
+            DocumentResolutionResult r = resolved.TryGetValue(folderId, out DocumentResolutionResult v)
+                ? v
+                : new DocumentResolutionResult(EffectivePermissionLevel.None, []);
+            output[folderId] = r.Permission;
+            await cache.SetAsync(
+                keyByFolderId[folderId],
+                r.Permission,
+                options: entryOptions,
+                tags: AclCacheKeys.BuildFolderEntryTags(r.AncestorFolderIds),
+                token: cancellationToken).ConfigureAwait(false);
+        }
+
+        return output;
+    }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/EffectivePermissionResolver.cs
@@ -66,6 +66,36 @@ internal sealed class EffectivePermissionResolver(
         return result;
     }
 
+    /// <inheritdoc />
+    public async Task<EffectivePermissionLevel> GetFolderPermissionAsync(
+        Guid folderId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await ResolveFoldersAsync(
+            [folderId], principal, cancellationToken).ConfigureAwait(false);
+        return resolved.TryGetValue(folderId, out DocumentResolutionResult r)
+            ? r.Permission
+            : EffectivePermissionLevel.None;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetFolderPermissionsAsync(
+        IReadOnlyCollection<Guid> folderIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyDictionary<Guid, DocumentResolutionResult> resolved = await ResolveFoldersAsync(
+            folderIds, principal, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<Guid, EffectivePermissionLevel> result = new(resolved.Count);
+        foreach ((Guid id, DocumentResolutionResult r) in resolved)
+        {
+            result[id] = r.Permission;
+        }
+        return result;
+    }
+
     /// <summary>
     /// Resolves the effective permission AND returns the ancestor folder ids visited during
     /// resolution. The cache decorator (F6.3) uses the folder ids to tag the cached entry,
@@ -367,6 +397,153 @@ internal sealed class EffectivePermissionResolver(
                     _ => EffectivePermissionLevel.None,
                 };
             output[info.Id] = new DocumentResolutionResult(level, ancestorFolderIds);
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Folder counterpart of <see cref="ResolveDocumentsAsync"/> — same path-prefix scan,
+    /// minus the direct-document-share branch (folders never receive document shares). Used
+    /// by the F6.5b folder list endpoint to populate the <c>permission</c> field in batch.
+    /// </summary>
+    /// <remarks>
+    /// The result type <see cref="DocumentResolutionResult"/> is reused as a generic
+    /// "(permission, contributing folder ids)" carrier — the cache decorator tags each
+    /// entry with the contributing folder ids so a folder share change invalidates exactly
+    /// the entries that depended on it.
+    /// </remarks>
+    internal async Task<IReadOnlyDictionary<Guid, DocumentResolutionResult>> ResolveFoldersAsync(
+        IReadOnlyCollection<Guid> folderIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(folderIds);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        Dictionary<Guid, DocumentResolutionResult> output = new(folderIds.Count);
+        if (folderIds.Count == 0)
+        {
+            return output;
+        }
+
+        DocumentResolutionResult empty = new(EffectivePermissionLevel.None, []);
+        foreach (Guid id in folderIds)
+        {
+            output[id] = empty;
+        }
+
+        List<Guid> granteeIds = [.. principal.AllGranteeIds];
+        if (granteeIds.Count == 0)
+        {
+            return output;
+        }
+
+        List<Guid> idList = [.. folderIds];
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 1 — fetch (Id, TenantId, Path) for every requested folder.
+        var folderInfos = await context.Folders
+            .Where(f => idList.Contains(f.Id))
+            .Select(f => new { f.Id, f.TenantId, f.Path })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (folderInfos.Count == 0)
+        {
+            return output;
+        }
+
+        Guid tenantId = folderInfos[0].TenantId!.Value;
+
+        // Step 2 — union of self+ancestor paths across the page.
+        Dictionary<Guid, List<string>> folderPaths = new(folderInfos.Count);
+        HashSet<string> uniquePaths = [];
+        foreach (var info in folderInfos)
+        {
+            List<string> paths = ExpandSelfAndAncestorPaths(info.Path);
+            folderPaths[info.Id] = paths;
+            foreach (string p in paths)
+            {
+                uniquePaths.Add(p);
+            }
+        }
+
+        // Step 3 — resolve all unique paths to folder ids in one query.
+        Dictionary<string, Guid> pathToFolderId = uniquePaths.Count == 0
+            ? []
+            : await context.Folders
+                .Where(f => f.TenantId == tenantId && uniquePaths.Contains(f.Path))
+                .Select(f => new { f.Id, f.Path })
+                .ToDictionaryAsync(x => x.Path, x => x.Id, cancellationToken)
+                .ConfigureAwait(false);
+
+        List<Guid?> allAncestorFolderIds = [.. pathToFolderId.Values.Select(id => (Guid?)id)];
+
+        // Step 4 — folder shares matching any folder in the union of ancestor sets.
+        var folderShares = allAncestorFolderIds.Count == 0
+            ? []
+            : await context.DocumentShares
+                .Where(s => s.TenantId == tenantId
+                    && granteeIds.Contains(s.GranteeId)
+                    && s.TargetType == ShareTargetType.Folder
+                    && allAncestorFolderIds.Contains(s.FolderId))
+                .Select(s => new { s.FolderId, s.Permission, s.ExpiresAt })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+
+        Dictionary<Guid, List<SharePermissionLevel>> folderShareIndex = [];
+        foreach (var fs in folderShares)
+        {
+            if (fs.ExpiresAt is { } exp && exp <= now)
+            {
+                continue;
+            }
+            if (fs.FolderId is not { } fid)
+            {
+                continue;
+            }
+            if (!folderShareIndex.TryGetValue(fid, out List<SharePermissionLevel>? bucket))
+            {
+                bucket = [];
+                folderShareIndex[fid] = bucket;
+            }
+            bucket.Add(fs.Permission);
+        }
+
+        // Step 5 — compose the per-folder effective permission.
+        foreach (var info in folderInfos)
+        {
+            List<string> paths = folderPaths[info.Id];
+            List<Guid> contributingFolderIds = [];
+            List<SharePermissionLevel> matches = [];
+            foreach (string path in paths)
+            {
+                if (!pathToFolderId.TryGetValue(path, out Guid fid))
+                {
+                    continue;
+                }
+                contributingFolderIds.Add(fid);
+                if (folderShareIndex.TryGetValue(fid, out List<SharePermissionLevel>? bucket))
+                {
+                    matches.AddRange(bucket);
+                }
+            }
+
+            EffectivePermissionLevel level = matches.Count == 0
+                ? EffectivePermissionLevel.None
+                : matches.Max() switch
+                {
+                    SharePermissionLevel.Manage => EffectivePermissionLevel.Manage,
+                    SharePermissionLevel.Edit => EffectivePermissionLevel.Edit,
+                    SharePermissionLevel.Read => EffectivePermissionLevel.Read,
+                    _ => EffectivePermissionLevel.None,
+                };
+            output[info.Id] = new DocumentResolutionResult(level, contributingFolderIds);
         }
 
         return output;

--- a/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
+++ b/src/Granit.Documents/Authorization/IEffectivePermissionResolver.cs
@@ -47,4 +47,25 @@ public interface IEffectivePermissionResolver
         IReadOnlyCollection<Guid> documentIds,
         DocumentPrincipal principal,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the effective permission the principal holds on the folder identified by
+    /// <paramref name="folderId"/>. Resolution scans the folder's own shares plus every
+    /// ancestor folder share via the same path-prefix model used for documents (F6.5b).
+    /// </summary>
+    Task<EffectivePermissionLevel> GetFolderPermissionAsync(
+        Guid folderId,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Batched counterpart of <see cref="GetFolderPermissionAsync"/> — used by folder list
+    /// endpoints to populate the <c>permission</c> field on each row without N+1 queries.
+    /// Returns an entry for every requested id; missing rows / no-matching-grant resolve to
+    /// <see cref="EffectivePermissionLevel.None"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, EffectivePermissionLevel>> GetFolderPermissionsAsync(
+        IReadOnlyCollection<Guid> folderIds,
+        DocumentPrincipal principal,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/EffectivePermissionResolverPostgresTests.cs
@@ -234,6 +234,58 @@ public sealed class EffectivePermissionResolverPostgresTests :
         result[docs[9].Id].ShouldBe(EffectivePermissionLevel.None);
     }
 
+    [Fact]
+    public async Task GetFolderPermissionsAsync_ResolvesMixedPermissions_AcrossFolderListing()
+    {
+        // F6.5b acceptance — single batch resolves the per-folder permission for a
+        // listing of 5 folders with mixed direct / inherited / no shares.
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+        Guid rootId = await bootstrap.EnsureTenantRootAsync(TenantId, OwnerId, TestContext.Current.CancellationToken);
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Folder root = await db.Folders.SingleAsync(f => f.Id == rootId, TestContext.Current.CancellationToken);
+
+        // /Shared has an Edit share for the user; /Shared/Inner inherits.
+        var shared = Folder.Create(Guid.NewGuid(), root, "Shared", OwnerId);
+        db.Folders.Add(shared);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var inner = Folder.Create(Guid.NewGuid(), shared, "Inner", OwnerId);
+        // /Direct gets a direct Manage share; /Other has nothing.
+        var direct = Folder.Create(Guid.NewGuid(), root, "Direct", OwnerId);
+        var other = Folder.Create(Guid.NewGuid(), root, "Other", OwnerId);
+        // /Expired holds only an expired Read share — must resolve to None.
+        var expired = Folder.Create(Guid.NewGuid(), root, "Expired", OwnerId);
+        db.Folders.Add(inner);
+        db.Folders.Add(direct);
+        db.Folders.Add(other);
+        db.Folders.Add(expired);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var user = Guid.NewGuid();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, shared.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, direct.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, expired.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Read, isDefault: true, OwnerId,
+            createdAt: Now.AddDays(-2), expiresAt: Now.AddDays(-1)));
+
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetFolderPermissionsAsync(
+                [shared.Id, inner.Id, direct.Id, other.Id, expired.Id],
+                DocumentPrincipal.ForUser(user),
+                TestContext.Current.CancellationToken);
+
+        result[shared.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        result[inner.Id].ShouldBe(EffectivePermissionLevel.Edit); // inherited
+        result[direct.Id].ShouldBe(EffectivePermissionLevel.Manage);
+        result[other.Id].ShouldBe(EffectivePermissionLevel.None);
+        result[expired.Id].ShouldBe(EffectivePermissionLevel.None);
+    }
+
     private async Task<(Folder, Document, Guid user)> SeedAsync()
     {
         var user = Guid.NewGuid();

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/CachedEffectivePermissionResolverTests.cs
@@ -224,6 +224,55 @@ public sealed class CachedEffectivePermissionResolverTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetFolderPermissionAsync_HitsCacheOnSecondCall()
+    {
+        (Folder folder, _, Guid user) = await SeedAsync();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel first = await _sut.GetFolderPermissionAsync(
+            folder.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        EffectivePermissionLevel second = await _sut.GetFolderPermissionAsync(
+            folder.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        first.ShouldBe(EffectivePermissionLevel.Manage);
+        second.ShouldBe(EffectivePermissionLevel.Manage);
+        _meter.Misses.ShouldBe(1);
+        _meter.Hits.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task FolderShareGrantedOnAncestor_InvalidatesFolderPermissionEntry()
+    {
+        (Folder folder, _, Guid user) = await SeedAsync();
+
+        // Cold call — no shares yet, resolves to None and caches the entry tagged with
+        // the folder's own id (it's the only ancestor in /Contracts).
+        await _sut.GetFolderPermissionAsync(
+            folder.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+
+        // Grant on the same folder + emit the event the production decorator subscribes to.
+        var share = DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, folder.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now);
+        await SeedShareAsync(share);
+        await AclCacheInvalidationHandler.HandleAsync(
+            new Events.DocumentShareGrantedEvent(
+                share.Id, TenantId, share.TargetType, share.FolderId, share.DocumentId,
+                share.GranteeType, share.GranteeId, share.Permission, share.IsDefault, share.ExpiresAt),
+            _cache, TestContext.Current.CancellationToken);
+
+        // Next call must miss (entry was tagged acl:folder:{folderId} → invalidated) and
+        // resolve to Manage.
+        EffectivePermissionLevel after = await _sut.GetFolderPermissionAsync(
+            folder.Id, DocumentPrincipal.ForUser(user), TestContext.Current.CancellationToken);
+        after.ShouldBe(EffectivePermissionLevel.Manage);
+
+        _meter.Misses.ShouldBe(2);
+    }
+
+    [Fact]
     public async Task FolderPathChanged_BulkInvalidatesTenantEntries()
     {
         (Folder folder, Document doc, Guid user) = await SeedAsync();

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/EffectivePermissionResolverTests.cs
@@ -295,6 +295,72 @@ public sealed class EffectivePermissionResolverTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetFolderPermissionAsync_AppliesAncestorShare()
+    {
+        // /A (Edit) > /A/B > resolved on /A/B → Edit (inherited).
+        Folder root = await GetOrCreateRootAsync();
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(ct);
+        Folder reloadedRoot = await db.Folders.SingleAsync(f => f.Id == root.Id, ct);
+
+        var a = Folder.Create(Guid.NewGuid(), reloadedRoot, "A", OwnerId);
+        db.Folders.Add(a);
+        await db.SaveChangesAsync(ct);
+        var b = Folder.Create(Guid.NewGuid(), a, "B", OwnerId);
+        db.Folders.Add(b);
+        await db.SaveChangesAsync(ct);
+
+        var user = Guid.NewGuid();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, a.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+
+        EffectivePermissionLevel result = await _sut.GetFolderPermissionAsync(
+            b.Id, DocumentPrincipal.ForUser(user), ct);
+
+        result.ShouldBe(EffectivePermissionLevel.Edit);
+    }
+
+    [Fact]
+    public async Task GetFolderPermissionsAsync_BatchResolvesMixedTargets()
+    {
+        // /Root + /A (Edit) + /B (Manage) + /C (no share) — batch must return correct
+        // per-folder permissions and folders missing from the DB resolve to None.
+        Folder root = await GetOrCreateRootAsync();
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(ct);
+        Folder reloadedRoot = await db.Folders.SingleAsync(f => f.Id == root.Id, ct);
+
+        var a = Folder.Create(Guid.NewGuid(), reloadedRoot, "A", OwnerId);
+        var bRoot = Folder.Create(Guid.NewGuid(), reloadedRoot, "B", OwnerId);
+        var c = Folder.Create(Guid.NewGuid(), reloadedRoot, "C", OwnerId);
+        db.Folders.Add(a);
+        db.Folders.Add(bRoot);
+        db.Folders.Add(c);
+        await db.SaveChangesAsync(ct);
+
+        var user = Guid.NewGuid();
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, a.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Edit, isDefault: true, OwnerId, Now));
+        await SeedShareAsync(DocumentShare.ShareToFolder(
+            Guid.NewGuid(), TenantId, bRoot.Id, ShareGranteeType.User, user,
+            SharePermissionLevel.Manage, isDefault: true, OwnerId, Now));
+
+        var unknown = Guid.NewGuid();
+        IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut
+            .GetFolderPermissionsAsync(
+                [a.Id, bRoot.Id, c.Id, unknown],
+                DocumentPrincipal.ForUser(user),
+                ct);
+
+        result[a.Id].ShouldBe(EffectivePermissionLevel.Edit);
+        result[bRoot.Id].ShouldBe(EffectivePermissionLevel.Manage);
+        result[c.Id].ShouldBe(EffectivePermissionLevel.None);
+        result[unknown].ShouldBe(EffectivePermissionLevel.None);
+    }
+
+    [Fact]
     public async Task GetDocumentPermissionsAsync_EmptyIds_ReturnsEmptyDictionary()
     {
         IReadOnlyDictionary<Guid, EffectivePermissionLevel> result = await _sut


### PR DESCRIPTION
## Summary

Closes the gap left by F6.5 (#1924): the original story acceptance listed both `GET /documents` and `GET /folders` responses, but the F6.5 PR pruned folders out citing the batch contract shape. Folder permission resolution is the same path-prefix scan minus the direct-doc-share branch, so it lands here as a follow-up.

- **`IEffectivePermissionResolver.GetFolderPermissionAsync`** + **`GetFolderPermissionsAsync`** — single + batch APIs symmetrical to the document side.
- **Inner `ResolveFoldersAsync`** mirrors `ResolveDocumentsAsync` (three queries for any page size: folder lookup, ancestor folder ids, share rows). Reuses `DocumentResolutionResult` as a generic `(permission, contributing folder ids)` carrier — the cache decorator tags each entry with those folder ids.
- **Cache decorator** uses a dedicated `acl:folder-perm:` key prefix to avoid colliding with `acl:doc:` entries; `BuildFolderEntryTags` tags entries with each contributing folder id + the tenant-wide `acl:all` tag, so the existing share-grant / revoke / folder-path-changed handlers invalidate folder-permission entries with the same tag operations.
- **`FolderResponse.Permission`** field. `GET /folders/?parentId=` populates it via the batch resolver; `GET /folders/{id}` via the single-target one.

## Test plan

- [x] 2 SQLite unit tests on the inner folder resolver (single ancestor share + batch with mixed targets).
- [x] 2 cache decorator tests (cache-hit on second call + ancestor-share-grant invalidation).
- [x] 1 Postgres integration test: `/Shared` (Edit), `/Shared/Inner` (inherited Edit), `/Direct` (Manage), `/Other` (None), `/Expired` (None).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 89/89.
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 19/19.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212.
- [x] `dotnet format style` clean on touched projects.