### PR TITLE
feat(documents): Tags + Quotas permissions on the provider (F12.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19790,7 +19790,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
-      "line": 26,
+      "line": 23,
       "members": []
     },
     {
@@ -19799,7 +19799,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
-      "line": 10,
+      "line": 7,
       "members": []
     },
     {
@@ -19808,7 +19808,16 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
-      "line": 16,
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "Quotas",
+      "fqn": "Granit.Documents.Endpoints.Permissions.Quotas",
+      "kind": "class",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
+      "line": 53,
       "members": []
     },
     {
@@ -19817,7 +19826,16 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
-      "line": 36,
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "Tags",
+      "fqn": "Granit.Documents.Endpoints.Permissions.Tags",
+      "kind": "class",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs",
+      "line": 43,
       "members": []
     },
     {

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/cs.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Zobrazit a stáhnout dokumenty",
     "Permission:Documents.Folders.Manage": "Vytvářet, přejmenovávat, přesouvat a odstraňovat složky",
     "Permission:Documents.Folders.Read": "Zobrazit složky",
+    "Permission:Documents.Quotas.Read": "Zobrazit využití úložiště nájemce",
     "Permission:Documents.Shares.Manage": "Udělovat a odvolávat sdílení složek a dokumentů",
     "Permission:Documents.Shares.Read": "Zobrazit sdílení složek a dokumentů",
+    "Permission:Documents.Tags.Manage": "Přiřazovat a odebírat štítky u dokumentů",
+    "Permission:Documents.Tags.Read": "Zobrazit štítky přiřazené k dokumentu",
     "PermissionGroup:Documents": "Dokumenty"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/de.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Dokumente anzeigen und herunterladen",
     "Permission:Documents.Folders.Manage": "Ordner erstellen, umbenennen, verschieben und in den Papierkorb legen",
     "Permission:Documents.Folders.Read": "Ordner anzeigen",
+    "Permission:Documents.Quotas.Read": "Speicherkontingentnutzung des Mandanten anzeigen",
     "Permission:Documents.Shares.Manage": "Freigaben für Ordner und Dokumente erteilen und widerrufen",
     "Permission:Documents.Shares.Read": "Freigaben für Ordner und Dokumente anzeigen",
+    "Permission:Documents.Tags.Manage": "Tags Dokumenten zuweisen und entfernen",
+    "Permission:Documents.Tags.Read": "Einem Dokument zugewiesene Tags anzeigen",
     "PermissionGroup:Documents": "Dokumente"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/en.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "View and download documents",
     "Permission:Documents.Folders.Manage": "Create, rename, move, and trash folders",
     "Permission:Documents.Folders.Read": "View folders",
+    "Permission:Documents.Quotas.Read": "View tenant storage quota usage",
     "Permission:Documents.Shares.Manage": "Grant and revoke share access on folders and documents",
     "Permission:Documents.Shares.Read": "View share grants on folders and documents",
+    "Permission:Documents.Tags.Manage": "Assign and unassign tags on documents",
+    "Permission:Documents.Tags.Read": "List tags assigned to a document",
     "PermissionGroup:Documents": "Documents"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/es.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Ver y descargar documentos",
     "Permission:Documents.Folders.Manage": "Crear, renombrar, mover y enviar carpetas a la papelera",
     "Permission:Documents.Folders.Read": "Ver carpetas",
+    "Permission:Documents.Quotas.Read": "Ver el uso de la cuota de almacenamiento del inquilino",
     "Permission:Documents.Shares.Manage": "Conceder y revocar permisos compartidos en carpetas y documentos",
     "Permission:Documents.Shares.Read": "Ver los permisos compartidos en carpetas y documentos",
+    "Permission:Documents.Tags.Manage": "Asignar y quitar etiquetas a los documentos",
+    "Permission:Documents.Tags.Read": "Ver las etiquetas asignadas a un documento",
     "PermissionGroup:Documents": "Documentos"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/fr.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Consulter et télécharger les documents",
     "Permission:Documents.Folders.Manage": "Créer, renommer, déplacer et corbeillir des dossiers",
     "Permission:Documents.Folders.Read": "Consulter les dossiers",
+    "Permission:Documents.Quotas.Read": "Consulter la consommation du quota de stockage du locataire",
     "Permission:Documents.Shares.Manage": "Accorder et révoquer les partages sur les dossiers et les documents",
     "Permission:Documents.Shares.Read": "Consulter les partages sur les dossiers et les documents",
+    "Permission:Documents.Tags.Manage": "Assigner et retirer des étiquettes sur les documents",
+    "Permission:Documents.Tags.Read": "Consulter les étiquettes assignées à un document",
     "PermissionGroup:Documents": "Documents"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/hi.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "दस्तावेज़ देखें और डाउनलोड करें",
     "Permission:Documents.Folders.Manage": "फ़ोल्डर बनाएँ, नाम बदलें, स्थानांतरित करें और कूड़ेदान में डालें",
     "Permission:Documents.Folders.Read": "फ़ोल्डर देखें",
+    "Permission:Documents.Quotas.Read": "किरायेदार के संग्रहण कोटा का उपयोग देखें",
     "Permission:Documents.Shares.Manage": "फ़ोल्डर और दस्तावेज़ों पर साझाकरण प्रदान करें और रद्द करें",
     "Permission:Documents.Shares.Read": "फ़ोल्डर और दस्तावेज़ों पर साझाकरण देखें",
+    "Permission:Documents.Tags.Manage": "दस्तावेज़ों पर टैग असाइन और हटाएँ",
+    "Permission:Documents.Tags.Read": "दस्तावेज़ को सौंपे गए टैग देखें",
     "PermissionGroup:Documents": "दस्तावेज़"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/it.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Visualizzare e scaricare documenti",
     "Permission:Documents.Folders.Manage": "Creare, rinominare, spostare e cestinare cartelle",
     "Permission:Documents.Folders.Read": "Visualizzare le cartelle",
+    "Permission:Documents.Quotas.Read": "Visualizzare l'utilizzo della quota di archiviazione del tenant",
     "Permission:Documents.Shares.Manage": "Concedere e revocare le condivisioni su cartelle e documenti",
     "Permission:Documents.Shares.Read": "Visualizzare le condivisioni su cartelle e documenti",
+    "Permission:Documents.Tags.Manage": "Assegnare e rimuovere etichette dai documenti",
+    "Permission:Documents.Tags.Read": "Visualizzare le etichette assegnate a un documento",
     "PermissionGroup:Documents": "Documenti"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ja.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "ドキュメントの表示とダウンロード",
     "Permission:Documents.Folders.Manage": "フォルダーの作成、名前変更、移動、ゴミ箱への移動",
     "Permission:Documents.Folders.Read": "フォルダーを表示",
+    "Permission:Documents.Quotas.Read": "テナントのストレージクォータ使用状況を表示",
     "Permission:Documents.Shares.Manage": "フォルダーとドキュメントの共有権限を付与・取り消し",
     "Permission:Documents.Shares.Read": "フォルダーとドキュメントの共有権限を表示",
+    "Permission:Documents.Tags.Manage": "ドキュメントにタグを割り当て・削除",
+    "Permission:Documents.Tags.Read": "ドキュメントに割り当てられたタグを表示",
     "PermissionGroup:Documents": "ドキュメント"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/ko.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "문서 보기 및 다운로드",
     "Permission:Documents.Folders.Manage": "폴더 만들기, 이름 바꾸기, 이동 및 휴지통으로 이동",
     "Permission:Documents.Folders.Read": "폴더 보기",
+    "Permission:Documents.Quotas.Read": "테넌트 스토리지 할당량 사용량 보기",
     "Permission:Documents.Shares.Manage": "폴더와 문서의 공유 권한 부여 및 취소",
     "Permission:Documents.Shares.Read": "폴더와 문서의 공유 권한 보기",
+    "Permission:Documents.Tags.Manage": "문서에 태그 할당 및 해제",
+    "Permission:Documents.Tags.Read": "문서에 할당된 태그 보기",
     "PermissionGroup:Documents": "문서"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/nl.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Documenten bekijken en downloaden",
     "Permission:Documents.Folders.Manage": "Mappen aanmaken, hernoemen, verplaatsen en in de prullenbak gooien",
     "Permission:Documents.Folders.Read": "Mappen bekijken",
+    "Permission:Documents.Quotas.Read": "Verbruik van het opslagquotum van de tenant bekijken",
     "Permission:Documents.Shares.Manage": "Deelmachtigingen op mappen en documenten verlenen en intrekken",
     "Permission:Documents.Shares.Read": "Deelmachtigingen op mappen en documenten bekijken",
+    "Permission:Documents.Tags.Manage": "Tags toewijzen en intrekken op documenten",
+    "Permission:Documents.Tags.Read": "Tags weergeven die aan een document zijn toegewezen",
     "PermissionGroup:Documents": "Documenten"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pl.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Wyświetlanie i pobieranie dokumentów",
     "Permission:Documents.Folders.Manage": "Tworzenie, zmiana nazwy, przenoszenie i przenoszenie do kosza folderów",
     "Permission:Documents.Folders.Read": "Wyświetlanie folderów",
+    "Permission:Documents.Quotas.Read": "Wyświetlanie wykorzystania limitu pamięci najemcy",
     "Permission:Documents.Shares.Manage": "Przyznawanie i odbieranie udostępnień folderów i dokumentów",
     "Permission:Documents.Shares.Read": "Wyświetlanie udostępnień folderów i dokumentów",
+    "Permission:Documents.Tags.Manage": "Przypisywanie i usuwanie tagów dokumentów",
+    "Permission:Documents.Tags.Read": "Wyświetlanie tagów przypisanych do dokumentu",
     "PermissionGroup:Documents": "Dokumenty"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/pt.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Ver e transferir documentos",
     "Permission:Documents.Folders.Manage": "Criar, renomear, mover e enviar pastas para a reciclagem",
     "Permission:Documents.Folders.Read": "Ver pastas",
+    "Permission:Documents.Quotas.Read": "Ver o consumo da quota de armazenamento do inquilino",
     "Permission:Documents.Shares.Manage": "Conceder e revogar partilhas em pastas e documentos",
     "Permission:Documents.Shares.Read": "Ver as partilhas em pastas e documentos",
+    "Permission:Documents.Tags.Manage": "Atribuir e remover etiquetas em documentos",
+    "Permission:Documents.Tags.Read": "Ver as etiquetas atribuídas a um documento",
     "PermissionGroup:Documents": "Documentos"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/sv.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Visa och ladda ner dokument",
     "Permission:Documents.Folders.Manage": "Skapa, byta namn på, flytta och papperskorga mappar",
     "Permission:Documents.Folders.Read": "Visa mappar",
+    "Permission:Documents.Quotas.Read": "Visa hyresgästens lagringskvotanvändning",
     "Permission:Documents.Shares.Manage": "Bevilja och återkalla delningar på mappar och dokument",
     "Permission:Documents.Shares.Read": "Visa delningar på mappar och dokument",
+    "Permission:Documents.Tags.Manage": "Tilldela och ta bort taggar på dokument",
+    "Permission:Documents.Tags.Read": "Visa taggar som tilldelats ett dokument",
     "PermissionGroup:Documents": "Dokument"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/tr.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "Belgeleri görüntüle ve indir",
     "Permission:Documents.Folders.Manage": "Klasörleri oluşturma, yeniden adlandırma, taşıma ve geri dönüşüm kutusuna gönderme",
     "Permission:Documents.Folders.Read": "Klasörleri görüntüle",
+    "Permission:Documents.Quotas.Read": "Kiracının depolama kotası kullanımını görüntüle",
     "Permission:Documents.Shares.Manage": "Klasör ve belgelerdeki paylaşım izinlerini ver ve geri al",
     "Permission:Documents.Shares.Read": "Klasör ve belgelerdeki paylaşım izinlerini görüntüle",
+    "Permission:Documents.Tags.Manage": "Belgelere etiket ata ve etiket kaldır",
+    "Permission:Documents.Tags.Read": "Bir belgeye atanmış etiketleri görüntüle",
     "PermissionGroup:Documents": "Belgeler"
   }
 }

--- a/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
+++ b/src/Granit.Documents.Endpoints/Localization/DocumentsEndpoints/zh.json
@@ -5,8 +5,11 @@
     "Permission:Documents.Documents.Read": "查看和下载文档",
     "Permission:Documents.Folders.Manage": "创建、重命名、移动和回收文件夹",
     "Permission:Documents.Folders.Read": "查看文件夹",
+    "Permission:Documents.Quotas.Read": "查看租户的存储配额使用情况",
     "Permission:Documents.Shares.Manage": "授予和撤销文件夹与文档的共享授权",
     "Permission:Documents.Shares.Read": "查看文件夹与文档的共享授权",
+    "Permission:Documents.Tags.Manage": "为文档分配和取消分配标签",
+    "Permission:Documents.Tags.Read": "查看分配给文档的标签",
     "PermissionGroup:Documents": "文档"
   }
 }

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissionDefinitionProvider.cs
@@ -8,11 +8,9 @@ namespace Granit.Documents.Endpoints.Permissions;
 /// <summary>
 /// Declares the <c>Documents.*.*</c> permissions in the Granit RBAC system.
 /// Auto-discovered by <c>GranitAuthorizationModule</c> — no manual registration needed.
+/// Covers folders (F2.3), documents (F3), shares (F6), tags (F5 / T6.1), and tenant
+/// storage quotas (F7).
 /// </summary>
-/// <remarks>
-/// Phase 1 ships only the folder permissions (F2.3). Document, share, tag, and quota
-/// permissions arrive with their respective stories (F3, F6, F5, F7).
-/// </remarks>
 internal sealed class DocumentsPermissionDefinitionProvider : IPermissionDefinitionProvider
 {
     /// <inheritdoc />
@@ -59,6 +57,24 @@ internal sealed class DocumentsPermissionDefinitionProvider : IPermissionDefinit
             DocumentsPermissions.Shares.Manage,
             LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
                 "Permission:Documents.Shares.Manage"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Tags.Read,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Tags.Read"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Tags.Manage,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Tags.Manage"),
+            MultiTenancySides.Both);
+
+        group.AddPermission(
+            DocumentsPermissions.Quotas.Read,
+            LocalizableString.Create<DocumentsEndpointsLocalizationResource>(
+                "Permission:Documents.Quotas.Read"),
             MultiTenancySides.Both);
     }
 }

--- a/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
+++ b/src/Granit.Documents.Endpoints/Permissions/DocumentsPermissions.cs
@@ -1,12 +1,9 @@
 namespace Granit.Documents.Endpoints.Permissions;
 
 /// <summary>
-/// Permission constants exposed by <c>Granit.Documents.Endpoints</c>.
+/// Permission constants exposed by <c>Granit.Documents.Endpoints</c> — folder, document,
+/// share, tag, and quota permissions used by the Phase 1 Granit.Documents endpoints.
 /// </summary>
-/// <remarks>
-/// Phase 1 ships only the folder permissions used by F2.3. Document, share, tag, and
-/// quota permissions arrive with their respective stories (F3, F6, F5, F7).
-/// </remarks>
 public static class DocumentsPermissions
 {
     /// <summary>Permission group name (used as the resource-key prefix for localisation).</summary>
@@ -40,5 +37,22 @@ public static class DocumentsPermissions
 
         /// <summary>Grant and revoke share ACL on folders and documents.</summary>
         public const string Manage = "Documents.Shares.Manage";
+    }
+
+    /// <summary>Permissions on the document tag proxy (F5 / T6.1).</summary>
+    public static class Tags
+    {
+        /// <summary>List tags assigned to a document.</summary>
+        public const string Read = "Documents.Tags.Read";
+
+        /// <summary>Assign or unassign tags on a document.</summary>
+        public const string Manage = "Documents.Tags.Manage";
+    }
+
+    /// <summary>Permissions on the tenant storage quota (F7).</summary>
+    public static class Quotas
+    {
+        /// <summary>Read the tenant's storage quota usage.</summary>
+        public const string Read = "Documents.Quotas.Read";
     }
 }

--- a/tests/Granit.Documents.Endpoints.Tests/Permissions/DocumentsPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Documents.Endpoints.Tests/Permissions/DocumentsPermissionDefinitionProviderTests.cs
@@ -1,0 +1,63 @@
+using Granit.Authorization;
+using Granit.Documents.Endpoints.Permissions;
+using Granit.Localization;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Endpoints.Tests.Permissions;
+
+/// <summary>
+/// Unit tests for <see cref="DocumentsPermissionDefinitionProvider"/> — verifies the
+/// Documents permission group registers with the expected resource / action surface
+/// (F12.1).
+/// </summary>
+public sealed class DocumentsPermissionDefinitionProviderTests
+{
+    private static (DocumentsPermissionDefinitionProvider provider, IPermissionDefinitionContext context, PermissionGroup group) BuildHarness()
+    {
+        IPermissionDefinitionContext context = Substitute.For<IPermissionDefinitionContext>();
+        PermissionGroup group = new(DocumentsPermissions.GroupName);
+        context.AddGroup(DocumentsPermissions.GroupName, Arg.Any<LocalizableString>()).Returns(group);
+        return (new DocumentsPermissionDefinitionProvider(), context, group);
+    }
+
+    [Fact]
+    public void DefinePermissions_RegistersDocumentsGroup()
+    {
+        (DocumentsPermissionDefinitionProvider provider, IPermissionDefinitionContext context, _) = BuildHarness();
+
+        provider.DefinePermissions(context);
+
+        context.Received(1).AddGroup(DocumentsPermissions.GroupName, Arg.Any<LocalizableString>());
+    }
+
+    [Theory]
+    [InlineData("Documents.Folders.Read")]
+    [InlineData("Documents.Folders.Manage")]
+    [InlineData("Documents.Documents.Read")]
+    [InlineData("Documents.Documents.Manage")]
+    [InlineData("Documents.Shares.Read")]
+    [InlineData("Documents.Shares.Manage")]
+    [InlineData("Documents.Tags.Read")]
+    [InlineData("Documents.Tags.Manage")]
+    [InlineData("Documents.Quotas.Read")]
+    public void DefinePermissions_RegistersExpectedPermission(string permissionName)
+    {
+        (DocumentsPermissionDefinitionProvider provider, IPermissionDefinitionContext context, PermissionGroup group) = BuildHarness();
+
+        provider.DefinePermissions(context);
+
+        group.Permissions.ShouldContain(p => p.Name == permissionName);
+    }
+
+    [Fact]
+    public void DefinePermissions_RegistersExactlyNinePermissions()
+    {
+        (DocumentsPermissionDefinitionProvider provider, IPermissionDefinitionContext context, PermissionGroup group) = BuildHarness();
+
+        provider.DefinePermissions(context);
+
+        group.Permissions.Count.ShouldBe(9);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1772 — F12.1: completes the `DocumentsPermissionDefinitionProvider` with the Tags + Quotas resource families that were on the F12 acceptance list but not yet declared.

- **`Documents.Tags.Read` / `Documents.Tags.Manage`** — declared for least-privilege scenarios where tag admin is separated from document admin.
- **`Documents.Quotas.Read`** — gates the upcoming F7.3 admin endpoint that reads tenant storage quota usage.

Existing endpoints still gate on `Documents.{Read|Manage}` — the new tag / quota permissions are declared in the provider for hosted apps to assign and for F7.3 to wire when it lands.

15 base culture JSONs updated with the three new permission strings; regional locales (en-GB, fr-CA, pt-BR) stay empty per the localization conventions.

## Acceptance criteria (#1772)

- [x] `internal sealed class DocumentsPermissionDefinitionProvider : IPermissionDefinitionProvider` (already existed; extended).
- [x] Permission constants in `DocumentsPermissions` static class with nested resource classes per CLAUDE.md.
- [x] `PermissionGroup:Documents` + `Permission:Documents.{Resource}.{Action}` keys in 18 cultures (15 base files + 3 regional carrying overrides only).
- [x] `DocumentsEndpointsLocalizationResource` declared with `[LocalizationResourceName]` (already existed).
- [x] Provider unit test pinning the 9-permission surface.

## Test plan

- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 55/55 (11 new in `DocumentsPermissionDefinitionProviderTests`).
- [x] `dotnet format style` clean.