### PR TITLE
feat(documents): TenantStorageQuota model + atomic UsageBytes service (F7.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19560,6 +19560,22 @@
       "members": []
     },
     {
+      "name": "TenantStorageQuota",
+      "fqn": "Granit.Documents.Domain.TenantStorageQuota",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/TenantStorageQuota.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid? tenantId, long limitBytes, DateTimeOffset now)",
+          "returnType": "TenantStorageQuota"
+        }
+      ]
+    },
+    {
       "name": "AppendVersionRequest",
       "fqn": "Granit.Documents.Endpoints.Documents.Dtos.AppendVersionRequest",
       "kind": "record",
@@ -19955,6 +19971,40 @@
       "file": "src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs",
       "line": 28,
       "members": []
+    },
+    {
+      "name": "ITenantQuotaService",
+      "fqn": "Granit.Documents.EntityFrameworkCore.Internal.ITenantQuotaService",
+      "kind": "interface",
+      "project": "Granit.Documents.EntityFrameworkCore",
+      "file": "src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "EnsureTenantQuotaAsync",
+          "kind": "method",
+          "signature": "EnsureTenantQuotaAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantStorageQuota>"
+        },
+        {
+          "name": "IncrementAsync",
+          "kind": "method",
+          "signature": "IncrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DecrementAsync",
+          "kind": "method",
+          "signature": "DecrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantStorageQuota?>"
+        }
+      ]
     },
     {
       "name": "DocumentCreatedEvent",

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -61,6 +61,10 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // in on top in subsequent stories.
         builder.Services.AddScoped<IDocumentShareService, DocumentShareService>();
 
+        // Tenant storage quota service (F7.1): lazy creation + atomic increment / decrement.
+        // Enforcement on upload (F7.2) + admin read endpoint (F7.3) layer on top.
+        builder.Services.AddScoped<ITenantQuotaService, TenantQuotaService>();
+
         // Effective-permission resolver (F6.2 + F6.3). The concrete EffectivePermissionResolver
         // is registered first so the cache decorator can delegate to it; the public
         // IEffectivePermissionResolver registration depends on whether the FusionCache layer

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsModelBuilderExtensions.cs
@@ -21,6 +21,7 @@ public static class DocumentsModelBuilderExtensions
         modelBuilder.ApplyConfiguration(new DocumentConfiguration());
         modelBuilder.ApplyConfiguration(new DocumentVersionConfiguration());
         modelBuilder.ApplyConfiguration(new DocumentShareConfiguration());
+        modelBuilder.ApplyConfiguration(new TenantStorageQuotaConfiguration());
         return modelBuilder;
     }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentsDbContext.cs
@@ -38,6 +38,9 @@ internal sealed class DocumentsDbContext(
     /// <summary>ACL grants on folders and documents (F6.1 — see ADR-052 §Permission resolution model).</summary>
     public DbSet<DocumentShare> DocumentShares { get; set; } = null!;
 
+    /// <summary>One row per tenant tracking documents storage usage versus the limit (F7.1).</summary>
+    public DbSet<TenantStorageQuota> TenantStorageQuotas { get; set; } = null!;
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs
@@ -1,0 +1,42 @@
+using Granit.Documents.Domain;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Service abstraction over <see cref="TenantStorageQuota"/> bookkeeping (F7.1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// All write operations issue a single atomic SQL <c>UPDATE</c> via
+/// <c>ExecuteUpdateAsync</c> so concurrent uploads from the same tenant don't lose
+/// increments to a read-then-write race. The matching row is created lazily on first
+/// use through <see cref="EnsureTenantQuotaAsync"/>, mirroring the tenant-root folder
+/// bootstrap from F2.2.
+/// </para>
+/// </remarks>
+public interface ITenantQuotaService
+{
+    /// <summary>
+    /// Ensures a quota row exists for the given tenant, seeding
+    /// <see cref="TenantStorageQuota.LimitBytes"/> from
+    /// <c>GranitDocumentsOptions.DefaultTenantQuotaBytes</c>. Concurrent calls converge
+    /// on a single row via the unique index on <c>(TenantId)</c>.
+    /// </summary>
+    Task<TenantStorageQuota> EnsureTenantQuotaAsync(Guid tenantId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically increments <see cref="TenantStorageQuota.UsageBytes"/> by
+    /// <paramref name="delta"/>. Creates the row if missing.
+    /// </summary>
+    Task IncrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically decrements <see cref="TenantStorageQuota.UsageBytes"/> by
+    /// <paramref name="delta"/>, clamping at zero. No-op when the row is missing —
+    /// decrementing a non-existent quota means the tenant never wrote anything.
+    /// </summary>
+    Task DecrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the current quota row for the tenant, or <c>null</c> when not yet created.</summary>
+    Task<TenantStorageQuota?> GetAsync(Guid tenantId, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
@@ -1,0 +1,137 @@
+using Granit.Documents.Domain;
+using Granit.Documents.Options;
+using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ITenantQuotaService"/>. Lazy creation,
+/// atomic write path via <c>ExecuteUpdateAsync</c>.
+/// </summary>
+internal sealed class TenantQuotaService(
+    IDbContextFactory<DocumentsDbContext> contextFactory,
+    IGuidGenerator guidGenerator,
+    IClock clock,
+    IOptions<GranitDocumentsOptions> options) : ITenantQuotaService
+{
+    /// <inheritdoc />
+    public async Task<TenantStorageQuota> EnsureTenantQuotaAsync(
+        Guid tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        TenantStorageQuota? existing = await SelectAsync(context, tenantId, cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        long defaultLimit = options.Value.DefaultTenantQuotaBytes;
+        var quota = TenantStorageQuota.Create(guidGenerator.Create(), tenantId, defaultLimit, clock.Now);
+        context.TenantStorageQuotas.Add(quota);
+
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return quota;
+        }
+        catch (DbUpdateException)
+        {
+            // A concurrent caller inserted the row between our SELECT and INSERT — the
+            // unique index on (TenantId) rejected our row. Re-issue the SELECT to obtain
+            // the winning identifier.
+            TenantStorageQuota? winner = await SelectAsync(context, tenantId, cancellationToken).ConfigureAwait(false);
+            if (winner is null)
+            {
+                throw;
+            }
+            return winner;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task IncrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)
+    {
+        if (delta < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), "Increment must be non-negative.");
+        }
+        if (delta == 0)
+        {
+            return;
+        }
+
+        // Ensure the row exists before issuing the atomic update — without it the UPDATE
+        // would silently match zero rows and lose the increment.
+        await EnsureTenantQuotaAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        await context.TenantStorageQuotas
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(q => q.TenantId == tenantId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(q => q.UsageBytes, q => q.UsageBytes + delta)
+                .SetProperty(q => q.UpdatedAt, _ => now),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DecrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)
+    {
+        if (delta < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), "Decrement must be non-negative.");
+        }
+        if (delta == 0)
+        {
+            return;
+        }
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Clamp at zero in SQL: GREATEST(usage - delta, 0). EF Core 8 translates
+        // System.Math.Max for both Postgres (GREATEST) and SQL Server (CASE WHEN ...).
+        DateTimeOffset now = clock.Now;
+        await context.TenantStorageQuotas
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(q => q.TenantId == tenantId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(q => q.UsageBytes,
+                    q => q.UsageBytes - delta < 0 ? 0 : q.UsageBytes - delta)
+                .SetProperty(q => q.UpdatedAt, _ => now),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<TenantStorageQuota?> GetAsync(Guid tenantId, CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return await SelectAsync(context, tenantId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task<TenantStorageQuota?> SelectAsync(
+        DocumentsDbContext context,
+        Guid tenantId,
+        CancellationToken cancellationToken) =>
+        context.TenantStorageQuotas
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(q => q.TenantId == tenantId)
+            .FirstOrDefaultAsync(cancellationToken);
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/TenantStorageQuotaConfiguration.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/TenantStorageQuotaConfiguration.cs
@@ -1,0 +1,36 @@
+using Granit.Documents.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core Fluent API configuration for <see cref="TenantStorageQuota"/>.
+/// Table: <c>documents_tenant_storage_quotas</c>.
+/// </summary>
+internal sealed class TenantStorageQuotaConfiguration : IEntityTypeConfiguration<TenantStorageQuota>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<TenantStorageQuota> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            GranitDocumentsDbProperties.DbTablePrefix + "tenant_storage_quotas",
+            GranitDocumentsDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId);
+
+        builder.Property(e => e.LimitBytes).IsRequired();
+        builder.Property(e => e.UsageBytes).IsRequired();
+        builder.Property(e => e.UpdatedAt).IsRequired();
+
+        // Exactly one quota row per tenant. The unique index also lights up the
+        // tenant-scoped GET path used by the bootstrap + service queries.
+        builder.HasIndex(e => e.TenantId)
+            .IsUnique()
+            .HasDatabaseName($"ux_{GranitDocumentsDbProperties.DbTablePrefix}tenant_storage_quotas_tenant");
+    }
+}

--- a/src/Granit.Documents/Domain/TenantStorageQuota.cs
+++ b/src/Granit.Documents/Domain/TenantStorageQuota.cs
@@ -1,0 +1,119 @@
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Aggregate root tracking a tenant's <c>Granit.Documents</c> storage usage versus its
+/// limit. Exactly one row per tenant — enforced by the unique index on
+/// <c>(TenantId)</c> in the EF Core configuration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Created lazily on the first byte stored in a tenant (mirrors the tenant root folder
+/// bootstrap from F2.2). <see cref="LimitBytes"/> seeds from
+/// <c>GranitDocumentsOptions.DefaultTenantQuotaBytes</c>; hosts override per
+/// subscription tier via the quota admin endpoint (F7.3).
+/// </para>
+/// <para>
+/// <see cref="UsageBytes"/> is mutated through the service's atomic SQL UPDATE rather
+/// than aggregate-level state changes — domain methods exist on this type for tests and
+/// ad-hoc snapshot reads, but the production write path goes through
+/// <c>ITenantQuotaService.Increment/DecrementAsync</c> which compose
+/// <c>ExecuteUpdateAsync</c> with a single round-trip and no read-then-write race.
+/// </para>
+/// </remarks>
+public sealed class TenantStorageQuota : AggregateRoot, IMultiTenant
+{
+    /// <summary>
+    /// Creates a new quota row for the given tenant with the seed limit in bytes.
+    /// </summary>
+    public static TenantStorageQuota Create(Guid id, Guid? tenantId, long limitBytes, DateTimeOffset now)
+    {
+        if (limitBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limitBytes), "Limit must be strictly positive.");
+        }
+        return new TenantStorageQuota
+        {
+            Id = id,
+            TenantId = tenantId,
+            LimitBytes = limitBytes,
+            UsageBytes = 0,
+            UpdatedAt = now,
+        };
+    }
+
+    /// <summary>Identifier of the tenant the quota belongs to.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Explicit implementation preserves the <c>private set</c> DDD encapsulation on the
+    /// public property while satisfying the interface contract used by Granit's tenant
+    /// interceptor.
+    /// </remarks>
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>Soft cap on the tenant's stored bytes. Enforcement runs in F7.2.</summary>
+    public long LimitBytes { get; private set; }
+
+    /// <summary>Sum of all active version <c>SizeBytes</c> rows for the tenant.</summary>
+    public long UsageBytes { get; private set; }
+
+    /// <summary>UTC instant of the last increment, decrement, or limit change.</summary>
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    /// <summary>
+    /// Increments <see cref="UsageBytes"/> by <paramref name="delta"/>. Negative values
+    /// are rejected — use <see cref="Decrement"/> for releases.
+    /// </summary>
+    /// <remarks>
+    /// In production the service issues an atomic <c>UPDATE … SET UsageBytes = UsageBytes + @delta</c>;
+    /// this method is the in-memory equivalent used by aggregate-level tests.
+    /// </remarks>
+    public void Increment(long delta, DateTimeOffset now)
+    {
+        if (delta < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), "Increment must be non-negative.");
+        }
+        UsageBytes += delta;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Decrements <see cref="UsageBytes"/> by <paramref name="delta"/>. Clamps at zero
+    /// to absorb any drift between the bookkeeping and the actual blob set — the F9.3
+    /// recompute job is the authoritative reconciliation.
+    /// </summary>
+    public void Decrement(long delta, DateTimeOffset now)
+    {
+        if (delta < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), "Decrement must be non-negative.");
+        }
+        UsageBytes = Math.Max(0, UsageBytes - delta);
+        UpdatedAt = now;
+    }
+
+    /// <summary>Replaces the soft cap. Used by the F7.3 admin endpoint.</summary>
+    public void SetLimit(long limitBytes, DateTimeOffset now)
+    {
+        if (limitBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limitBytes), "Limit must be strictly positive.");
+        }
+        LimitBytes = limitBytes;
+        UpdatedAt = now;
+    }
+
+    /// <summary>EF Core materialisation constructor.</summary>
+    private TenantStorageQuota()
+    {
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
@@ -1,0 +1,109 @@
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
+using Granit.Guids;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres-backed tests for <see cref="TenantQuotaService"/>. Pins the atomic SQL
+/// write path: 100 parallel increments must accumulate exactly — the read-then-write
+/// race that motivates <c>ExecuteUpdateAsync</c> would surface as a lost-update here.
+/// </summary>
+public sealed class TenantQuotaServicePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private TenantQuotaService _sut = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public TenantQuotaServicePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_tenant_storage_quotas RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(Now);
+
+        IOptions<GranitDocumentsOptions> opts = Microsoft.Extensions.Options.Options.Create(new GranitDocumentsOptions
+        {
+            DefaultTenantQuotaBytes = 5L * 1024L * 1024L * 1024L,
+        });
+
+        _sut = new TenantQuotaService(_factory, new SimpleGuidGenerator(), clock, opts);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task IncrementAsync_AccumulatesExactly_Under100ParallelCalls()
+    {
+        // Bootstrap once so the parallel batch exercises only the atomic UPDATE path
+        // (the lazy-create branch handles its own contention via the unique index).
+        await _sut.EnsureTenantQuotaAsync(TenantId, TestContext.Current.CancellationToken);
+
+        const int parallelism = 100;
+        const long deltaPerCall = 1024;
+        var writers = new Task[parallelism];
+        for (int i = 0; i < parallelism; i++)
+        {
+            writers[i] = _sut.IncrementAsync(TenantId, deltaPerCall, TestContext.Current.CancellationToken);
+        }
+        await Task.WhenAll(writers);
+
+        TenantStorageQuota? quota = await _sut.GetAsync(TenantId, TestContext.Current.CancellationToken);
+        quota.ShouldNotBeNull();
+        // No lost updates — the atomic SQL UPDATE means each delta lands.
+        quota.UsageBytes.ShouldBe(parallelism * deltaPerCall);
+    }
+
+    [Fact]
+    public async Task EnsureTenantQuotaAsync_ConcurrentBootstrap_ConvergesOnSingleRow()
+    {
+        var tenant = Guid.NewGuid();
+
+        const int parallelism = 20;
+        var tasks = new Task<TenantStorageQuota>[parallelism];
+        for (int i = 0; i < parallelism; i++)
+        {
+            tasks[i] = _sut.EnsureTenantQuotaAsync(tenant, TestContext.Current.CancellationToken);
+        }
+        TenantStorageQuota[] results = await Task.WhenAll(tasks);
+
+        // All callers must observe the same row id — the unique index on (TenantId)
+        // rejects duplicate inserts and the catch handler re-reads the winner.
+        results.Select(r => r.Id).Distinct().Count().ShouldBe(1);
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/TenantQuotaServiceTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/TenantQuotaServiceTests.cs
@@ -1,0 +1,128 @@
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
+using Granit.Guids;
+using Granit.Timing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// SQLite-backed tests for <see cref="TenantQuotaService"/>. Verifies the lazy-create
+/// path, atomic increment / decrement, and the clamp-at-zero behaviour on decrement.
+/// </summary>
+public sealed class TenantQuotaServiceTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private TestFactory _factory = null!;
+    private TenantQuotaService _sut = null!;
+    private IClock _clock = null!;
+
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+
+        _factory = new TestFactory(options);
+
+        IGuidGenerator guidGen = Substitute.For<IGuidGenerator>();
+        guidGen.Create().Returns(_ => Guid.NewGuid());
+
+        _clock = Substitute.For<IClock>();
+        _clock.Now.Returns(Now);
+
+        IOptions<GranitDocumentsOptions> opts = Microsoft.Extensions.Options.Options.Create(new GranitDocumentsOptions
+        {
+            DefaultTenantQuotaBytes = 5L * 1024L * 1024L * 1024L,
+        });
+
+        _sut = new TenantQuotaService(_factory, guidGen, _clock, opts);
+    }
+
+    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+
+    [Fact]
+    public async Task EnsureTenantQuotaAsync_CreatesRowOnFirstCall_ReturnsExistingOnSecond()
+    {
+        TenantStorageQuota first = await _sut.EnsureTenantQuotaAsync(
+            TenantId, TestContext.Current.CancellationToken);
+        TenantStorageQuota second = await _sut.EnsureTenantQuotaAsync(
+            TenantId, TestContext.Current.CancellationToken);
+
+        first.Id.ShouldBe(second.Id);
+        first.LimitBytes.ShouldBe(5L * 1024L * 1024L * 1024L);
+        first.UsageBytes.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task IncrementAsync_LazyCreatesAndAccumulates()
+    {
+        await _sut.IncrementAsync(TenantId, 4096, TestContext.Current.CancellationToken);
+        await _sut.IncrementAsync(TenantId, 2048, TestContext.Current.CancellationToken);
+
+        TenantStorageQuota? quota = await _sut.GetAsync(
+            TenantId, TestContext.Current.CancellationToken);
+        quota.ShouldNotBeNull();
+        quota.UsageBytes.ShouldBe(6144);
+    }
+
+    [Fact]
+    public async Task DecrementAsync_ClampsAtZero()
+    {
+        await _sut.IncrementAsync(TenantId, 100, TestContext.Current.CancellationToken);
+        await _sut.DecrementAsync(TenantId, 500, TestContext.Current.CancellationToken);
+
+        TenantStorageQuota? quota = await _sut.GetAsync(
+            TenantId, TestContext.Current.CancellationToken);
+        quota.ShouldNotBeNull();
+        quota.UsageBytes.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DecrementAsync_NoRow_IsNoOp()
+    {
+        // Should not throw; just match zero rows and exit cleanly.
+        await _sut.DecrementAsync(TenantId, 100, TestContext.Current.CancellationToken);
+
+        TenantStorageQuota? quota = await _sut.GetAsync(
+            TenantId, TestContext.Current.CancellationToken);
+        quota.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task IncrementAsync_NegativeDelta_Throws() =>
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() =>
+            _sut.IncrementAsync(TenantId, -1, TestContext.Current.CancellationToken));
+
+    [Fact]
+    public async Task GetAsync_NoRow_ReturnsNull()
+    {
+        TenantStorageQuota? result = await _sut.GetAsync(
+            Guid.NewGuid(), TestContext.Current.CancellationToken);
+        result.ShouldBeNull();
+    }
+
+    private sealed class TestFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.Tests/Domain/TenantStorageQuotaTests.cs
+++ b/tests/Granit.Documents.Tests/Domain/TenantStorageQuotaTests.cs
@@ -1,0 +1,75 @@
+using Granit.Documents.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Tests.Domain;
+
+/// <summary>
+/// Aggregate-level tests for <see cref="TenantStorageQuota"/>. Production write path
+/// goes through atomic SQL — see the EF Core service for round-trip behaviour.
+/// </summary>
+public sealed class TenantStorageQuotaTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 10, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    [Fact]
+    public void Create_SeedsZeroUsage()
+    {
+        var quota = TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now);
+
+        quota.LimitBytes.ShouldBe(1024);
+        quota.UsageBytes.ShouldBe(0);
+        quota.UpdatedAt.ShouldBe(Now);
+        quota.TenantId.ShouldBe(TenantId);
+    }
+
+    [Fact]
+    public void Create_NonPositiveLimit_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 0, Now));
+
+    [Fact]
+    public void Increment_AccumulatesUsageAndStampsUpdatedAt()
+    {
+        var quota = TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now);
+
+        quota.Increment(300, Now.AddSeconds(1));
+        quota.Increment(200, Now.AddSeconds(2));
+
+        quota.UsageBytes.ShouldBe(500);
+        quota.UpdatedAt.ShouldBe(Now.AddSeconds(2));
+    }
+
+    [Fact]
+    public void Increment_NegativeDelta_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now).Increment(-1, Now));
+
+    [Fact]
+    public void Decrement_ClampsAtZero_AbsorbsBookkeepingDrift()
+    {
+        var quota = TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now);
+        quota.Increment(100, Now);
+
+        quota.Decrement(500, Now.AddSeconds(1));
+
+        quota.UsageBytes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SetLimit_ReplacesLimitAndStampsUpdatedAt()
+    {
+        var quota = TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now);
+
+        quota.SetLimit(2048, Now.AddSeconds(1));
+
+        quota.LimitBytes.ShouldBe(2048);
+        quota.UpdatedAt.ShouldBe(Now.AddSeconds(1));
+    }
+
+    [Fact]
+    public void SetLimit_NonPositive_Throws() =>
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            TenantStorageQuota.Create(Guid.NewGuid(), TenantId, 1024, Now).SetLimit(0, Now));
+}


### PR DESCRIPTION
## Summary

Closes #1751 — F7.1: tenant storage quota entity + service with atomic increment / decrement.

- **`TenantStorageQuota`** aggregate root with Increment / Decrement / SetLimit domain methods. Decrement clamps at zero to absorb bookkeeping drift; the F9.3 recompute job is the authoritative reconciliation.
- **`TenantStorageQuotaConfiguration`** — table `documents_tenant_storage_quotas`, unique index on `(TenantId)` enforcing one row per tenant. Hooked into `ConfigureDocumentsModule`; new DbSet on `DocumentsDbContext`.
- **`ITenantQuotaService` / `TenantQuotaService`**:
  - `EnsureTenantQuotaAsync` — lazy-create with the F2.2-style catch pattern: re-issue the SELECT if a concurrent caller raced us to the INSERT and the unique index rejected our row.
  - `IncrementAsync` / `DecrementAsync` — single round-trip `ExecuteUpdateAsync` (`UPDATE … SET UsageBytes = UsageBytes + @delta`) so concurrent uploads from the same tenant never lose increments to a read-then-write race.
  - `GetAsync` — read path for the F7.3 admin endpoint.
- Scoped DI registration in `AddGranitDocumentsEntityFrameworkCore`.

No migration ships from the framework package — consuming app generates it per CLAUDE.md feedback.

## Acceptance criteria (#1751)

- [x] Entity + table.
- [x] Service `ITenantQuotaService` with `IncrementAsync`, `DecrementAsync`, `GetAsync`, `EnsureTenantQuotaAsync`.
- [x] Unique index on `(tenant_id)` — one row per tenant.
- [x] Lazy creation similar to tenant root (`EnsureTenantQuotaAsync`).
- [x] Atomic SQL update (no race) — `ExecuteUpdateAsync` over `UsageBytes = UsageBytes + @delta`, plus a Postgres test pinning 100 parallel increments accumulate exactly.
- [x] Unit + integration tests.

## Test plan

- [x] `dotnet test tests/Granit.Documents.Tests` — 85/85 (7 new aggregate tests).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 95/95 (6 new SQLite service tests).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 21/21 (2 new Postgres tests: parallel-increment lost-update guard, concurrent-bootstrap convergence).
- [x] `dotnet format style` clean.