### PR TITLE
feat(documents): tenant storage quota enforcement on upload (F7.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20003,6 +20003,12 @@
           "kind": "method",
           "signature": "GetAsync(Guid tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<TenantStorageQuota?>"
+        },
+        {
+          "name": "TryReserveAsync",
+          "kind": "method",
+          "signature": "TryReserveAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -20157,6 +20163,15 @@
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/Events/FolderTreePathChangedEvent.cs",
       "line": 24,
+      "members": []
+    },
+    {
+      "name": "TenantStorageQuotaExceededException",
+      "fqn": "Granit.Documents.Exceptions.TenantStorageQuotaExceededException",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Exceptions/TenantStorageQuotaExceededException.cs",
+      "line": 9,
       "members": []
     },
     {

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Dtos;
 using Granit.Documents.Endpoints.Documents.Mapping;
 using Granit.Documents.Endpoints.Permissions;
+using Granit.Documents.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -51,6 +52,7 @@ internal static class DocumentEndpoints
             .RequireAuthorization(p => p.RequireClaim(
                 "permission", DocumentsPermissions.Documents.Manage))
             .Produces<DocumentResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
@@ -69,6 +71,7 @@ internal static class DocumentEndpoints
             .RequireAuthorization(p => p.RequireClaim(
                 "permission", DocumentsPermissions.Documents.Manage))
             .Produces<DocumentVersionResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
@@ -148,11 +151,14 @@ internal static class DocumentEndpoints
 
             return TypedResults.Created($"/documents/{document.Id}", document.ToResponse());
         }
+        catch (TenantStorageQuotaExceededException ex)
+        {
+            return QuotaExceededProblem(ex);
+        }
         catch (InvalidOperationException ex)
         {
-            // Catches both validation failures (blob rejected) and missing-target-folder.
-            // Status code is the right granularity here: 422 fits both for v1; F7 will
-            // refine the quota path to 403.
+            // Validation failures (blob rejected) and missing-target-folder. Status 422
+            // is the right granularity here for both.
             return TypedResults.Problem(
                 ex.Message,
                 statusCode: StatusCodes.Status422UnprocessableEntity);
@@ -183,6 +189,10 @@ internal static class DocumentEndpoints
                 $"/documents/{id}/versions/{version.Id}",
                 version.ToResponse(isCurrent: true));
         }
+        catch (TenantStorageQuotaExceededException ex)
+        {
+            return QuotaExceededProblem(ex);
+        }
         catch (InvalidOperationException ex)
         {
             // Blob validation failure or trashed-document append.
@@ -191,6 +201,18 @@ internal static class DocumentEndpoints
                 statusCode: StatusCodes.Status422UnprocessableEntity);
         }
     }
+
+    /// <summary>
+    /// Builds the RFC 7807 problem document returned when an upload would push the tenant
+    /// past its storage quota (F7.2). The <c>type</c> URI is the stable identifier the
+    /// frontend matches on to render a quota-specific error UI.
+    /// </summary>
+    private static ProblemHttpResult QuotaExceededProblem(TenantStorageQuotaExceededException ex) =>
+        TypedResults.Problem(
+            detail: ex.Message,
+            statusCode: StatusCodes.Status403Forbidden,
+            type: "https://granit.dev/problems/quota-exceeded",
+            title: "Tenant storage quota exceeded");
 
     private static async Task<Results<Ok<ListDocumentVersionsResponse>, ProblemHttpResult>> ListVersionsAsync(
         Guid id,

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -1,7 +1,9 @@
 using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
 using Granit.Documents.Diagnostics;
 using Granit.Documents.Domain;
 using Granit.Documents.Events;
+using Granit.Documents.Exceptions;
 using Granit.Events;
 using Granit.Guids;
 using Granit.MultiTenancy;
@@ -21,7 +23,8 @@ internal sealed class DocumentService(
     IGuidGenerator guidGenerator,
     IClock clock,
     ILocalEventBus localEventBus,
-    DocumentsMetrics metrics) : IDocumentService
+    DocumentsMetrics metrics,
+    ITenantQuotaService quotas) : IDocumentService
 {
     /// <summary>
     /// Container name used for every blob created by Granit.Documents. Hosts can layer
@@ -63,28 +66,95 @@ internal sealed class DocumentService(
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-        // 1. Confirm the blob with BlobStorage — runs validators (size + magic-bytes), then
-        //    transitions Pending → Valid (or Rejected). Idempotent only across the
-        //    Pending → Uploading transition; subsequent calls on a Valid blob throw
-        //    BlobNotValidException with status Valid, which is the signal we want.
-        BlobConfirmationResult confirmation = await blobStorage
-            .ConfirmUploadAsync(ContainerName, blobId, cancellationToken)
-            .ConfigureAwait(false);
-        if (!confirmation.IsValid)
+        // 1. Pre-confirm quota check (F7.2). Use the upload ticket's declared
+        //    MaxAllowedBytes as the conservative reservation: the actual SizeBytes is
+        //    only known post-confirmation, but reserving up-front leaves the
+        //    BlobDescriptor in Pending status on rejection so the orphan-cleanup job
+        //    can reclaim the bytes (the issue's "NOT promoted to Valid" requirement).
+        //    Over-reservation is released after the confirm succeeds.
+        BlobDescriptor? descriptor = await blobStorage
+            .GetDescriptorAsync(ContainerName, blobId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"Blob {blobId} was not found in container '{ContainerName}'.");
+        long reservedBytes = descriptor.MaxAllowedBytes;
+
+        bool reserved = false;
+        if (currentTenant.IsAvailable && currentTenant.Id is { } tid)
         {
-            metrics.RecordQuotaRejected(currentTenant.Id?.ToString());
-            throw new InvalidOperationException(
-                $"Blob {blobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+            reserved = await quotas
+                .TryReserveAsync(tid, reservedBytes, cancellationToken)
+                .ConfigureAwait(false);
+            if (!reserved)
+            {
+                metrics.RecordQuotaRejected(tid.ToString());
+                throw new TenantStorageQuotaExceededException(tid, reservedBytes);
+            }
         }
 
-        long sizeBytes = confirmation.SizeBytes
-            ?? throw new InvalidOperationException(
-                $"Blob {blobId} validated successfully but BlobStorage returned no size.");
-        string contentType = confirmation.VerifiedContentType
-            ?? throw new InvalidOperationException(
-                $"Blob {blobId} validated successfully but BlobStorage returned no content type.");
+        try
+        {
+            // 2. Confirm the blob with BlobStorage — runs validators (size + magic-bytes), then
+            //    transitions Pending → Valid (or Rejected). Idempotent only across the
+            //    Pending → Uploading transition; subsequent calls on a Valid blob throw
+            //    BlobNotValidException with status Valid, which is the signal we want.
+            BlobConfirmationResult confirmation = await blobStorage
+                .ConfirmUploadAsync(ContainerName, blobId, cancellationToken)
+                .ConfigureAwait(false);
+            if (!confirmation.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Blob {blobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+            }
 
-        // 2. Open a fresh DocumentsDbContext and resolve the target folder, defaulting to
+            long sizeBytes = confirmation.SizeBytes
+                ?? throw new InvalidOperationException(
+                    $"Blob {blobId} validated successfully but BlobStorage returned no size.");
+            string contentType = confirmation.VerifiedContentType
+                ?? throw new InvalidOperationException(
+                    $"Blob {blobId} validated successfully but BlobStorage returned no content type.");
+
+            // Release over-reservation: declared MaxAllowedBytes is an upper bound, the
+            // real SizeBytes is typically smaller. Release the slack so the next
+            // finalisation sees an accurate UsageBytes.
+            if (reserved && reservedBytes > sizeBytes)
+            {
+                await quotas
+                    .DecrementAsync(currentTenant.Id!.Value, reservedBytes - sizeBytes, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return await PersistDocumentAsync(
+                blobId, folderId, ownerUserId, name, description, commitMessage,
+                sizeBytes, contentType, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Anything fails between the reservation and the document persistence — fully
+            // release the reservation. The blob is either still Pending (orphan cleanup)
+            // or Valid-but-orphaned (the F9.1 OrphanDocumentCleanupJob picks it up).
+            if (reserved && currentTenant.IsAvailable && currentTenant.Id is { } releasedTid)
+            {
+                await quotas
+                    .DecrementAsync(releasedTid, reservedBytes, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            throw;
+        }
+    }
+
+    private async Task<Document> PersistDocumentAsync(
+        Guid blobId,
+        Guid? folderId,
+        Guid ownerUserId,
+        string name,
+        string? description,
+        string? commitMessage,
+        long sizeBytes,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        // 3. Open a fresh DocumentsDbContext and resolve the target folder, defaulting to
         //    the tenant root via the bootstrap service.
         await using DocumentsDbContext context = await contextFactory
             .CreateDbContextAsync(cancellationToken)
@@ -150,27 +220,68 @@ internal sealed class DocumentService(
         string? commitMessage = null,
         CancellationToken cancellationToken = default)
     {
-        // 1. Confirm the blob — runs validators and transitions Pending → Valid. Done
-        //    outside the retry loop because the transition is non-idempotent past Valid:
-        //    re-calling ConfirmUploadAsync on a Valid blob throws BlobNotValidException.
-        BlobConfirmationResult confirmation = await blobStorage
-            .ConfirmUploadAsync(ContainerName, blobId, cancellationToken)
-            .ConfigureAwait(false);
-        if (!confirmation.IsValid)
+        // 1. Pre-confirm quota check (F7.2) — see FinalizeUploadAsync for the rationale
+        //    behind reserving on MaxAllowedBytes and releasing the slack post-confirmation.
+        BlobDescriptor? descriptor = await blobStorage
+            .GetDescriptorAsync(ContainerName, blobId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"Blob {blobId} was not found in container '{ContainerName}'.");
+        long reservedBytes = descriptor.MaxAllowedBytes;
+
+        bool reserved = false;
+        if (currentTenant.IsAvailable && currentTenant.Id is { } tid)
         {
-            metrics.RecordQuotaRejected(currentTenant.Id?.ToString());
-            throw new InvalidOperationException(
-                $"Blob {blobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+            reserved = await quotas
+                .TryReserveAsync(tid, reservedBytes, cancellationToken)
+                .ConfigureAwait(false);
+            if (!reserved)
+            {
+                metrics.RecordQuotaRejected(tid.ToString());
+                throw new TenantStorageQuotaExceededException(tid, reservedBytes);
+            }
         }
 
-        long sizeBytes = confirmation.SizeBytes
-            ?? throw new InvalidOperationException(
-                $"Blob {blobId} validated successfully but BlobStorage returned no size.");
-        string contentType = confirmation.VerifiedContentType
-            ?? throw new InvalidOperationException(
-                $"Blob {blobId} validated successfully but BlobStorage returned no content type.");
+        long sizeBytes;
+        string contentType;
+        try
+        {
+            // 2. Confirm the blob — runs validators and transitions Pending → Valid.
+            BlobConfirmationResult confirmation = await blobStorage
+                .ConfirmUploadAsync(ContainerName, blobId, cancellationToken)
+                .ConfigureAwait(false);
+            if (!confirmation.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Blob {blobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+            }
 
-        // 2. Append loop — at most 2 attempts. The unique index on
+            sizeBytes = confirmation.SizeBytes
+                ?? throw new InvalidOperationException(
+                    $"Blob {blobId} validated successfully but BlobStorage returned no size.");
+            contentType = confirmation.VerifiedContentType
+                ?? throw new InvalidOperationException(
+                    $"Blob {blobId} validated successfully but BlobStorage returned no content type.");
+
+            if (reserved && reservedBytes > sizeBytes)
+            {
+                await quotas
+                    .DecrementAsync(currentTenant.Id!.Value, reservedBytes - sizeBytes, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            if (reserved && currentTenant.IsAvailable && currentTenant.Id is { } releasedTid)
+            {
+                await quotas
+                    .DecrementAsync(releasedTid, reservedBytes, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            throw;
+        }
+
+        // 3. Append loop — at most 2 attempts. The unique index on
         //    (DocumentId, VersionNumber) plus the optimistic-concurrency token on
         //    Document.RowVersion together guarantee that two parallel callers cannot
         //    both succeed with the same VersionNumber: the second writer either trips
@@ -178,22 +289,41 @@ internal sealed class DocumentService(
         //    (DbUpdateConcurrencyException). Either way we re-read and retry once;
         //    a second collision propagates as the original exception.
         const int MaxAttempts = 2;
-        for (int attempt = 1; attempt <= MaxAttempts; attempt++)
+        try
         {
-            try
+            for (int attempt = 1; attempt <= MaxAttempts; attempt++)
             {
-                return await TryAppendVersionAsync(
-                    documentId, blobId, uploadedByUserId, sizeBytes, contentType, commitMessage,
-                    cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    DocumentVersion? appended = await TryAppendVersionAsync(
+                        documentId, blobId, uploadedByUserId, sizeBytes, contentType, commitMessage,
+                        cancellationToken).ConfigureAwait(false);
+                    if (appended is null && reserved && currentTenant.Id is { } missingTid)
+                    {
+                        // Target document missing — release the bytes; caller sees null.
+                        await quotas.DecrementAsync(missingTid, sizeBytes, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    return appended;
+                }
+                catch (DbUpdateConcurrencyException) when (attempt < MaxAttempts)
+                {
+                    // RowVersion drifted under us — reload and try again.
+                }
+                catch (DbUpdateException) when (attempt < MaxAttempts)
+                {
+                    // Unique-index collision on (DocumentId, VersionNumber) — reload and retry.
+                }
             }
-            catch (DbUpdateConcurrencyException) when (attempt < MaxAttempts)
+        }
+        catch
+        {
+            if (reserved && currentTenant.Id is { } persistFailedTid)
             {
-                // RowVersion drifted under us — reload and try again.
+                await quotas.DecrementAsync(persistFailedTid, sizeBytes, cancellationToken)
+                    .ConfigureAwait(false);
             }
-            catch (DbUpdateException) when (attempt < MaxAttempts)
-            {
-                // Unique-index collision on (DocumentId, VersionNumber) — reload and retry.
-            }
+            throw;
         }
 
         // Unreachable: the loop either returns inside the try, or the final attempt's

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs
@@ -39,4 +39,17 @@ public interface ITenantQuotaService
 
     /// <summary>Returns the current quota row for the tenant, or <c>null</c> when not yet created.</summary>
     Task<TenantStorageQuota?> GetAsync(Guid tenantId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically reserves <paramref name="delta"/> bytes against the tenant's quota: the
+    /// underlying SQL is a conditional <c>UPDATE … WHERE UsageBytes + @delta &lt;= LimitBytes</c>
+    /// and returns <c>true</c> only when the reservation succeeded. Used by upload finalize
+    /// (F7.2) so concurrent finalisations from the same tenant cannot collectively exceed
+    /// the limit through a read-then-increment race.
+    /// </summary>
+    /// <remarks>
+    /// Lazy-creates the row on first use. <paramref name="delta"/> must be non-negative;
+    /// zero is a no-op that always returns <c>true</c>.
+    /// </remarks>
+    Task<bool> TryReserveAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
@@ -118,6 +118,42 @@ internal sealed class TenantQuotaService(
     }
 
     /// <inheritdoc />
+    public async Task<bool> TryReserveAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)
+    {
+        if (delta < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), "Reservation must be non-negative.");
+        }
+        if (delta == 0)
+        {
+            return true;
+        }
+
+        // Lazy-create so the conditional UPDATE has a row to match. The bootstrap also
+        // seeds LimitBytes from options.
+        await EnsureTenantQuotaAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        // Conditional atomic update — the WHERE clause guards against quota overshoot
+        // when several concurrent finalisations from the same tenant race. Returns the
+        // affected row count: 0 means the predicate failed (would-exceed); 1 means we
+        // reserved the bytes.
+        int affected = await context.TenantStorageQuotas
+            .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            .Where(q => q.TenantId == tenantId && q.UsageBytes + delta <= q.LimitBytes)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(q => q.UsageBytes, q => q.UsageBytes + delta)
+                .SetProperty(q => q.UpdatedAt, _ => now),
+                cancellationToken)
+            .ConfigureAwait(false);
+        return affected == 1;
+    }
+
+    /// <inheritdoc />
     public async Task<TenantStorageQuota?> GetAsync(Guid tenantId, CancellationToken cancellationToken = default)
     {
         await using DocumentsDbContext context = await contextFactory

--- a/src/Granit.Documents/Exceptions/TenantStorageQuotaExceededException.cs
+++ b/src/Granit.Documents/Exceptions/TenantStorageQuotaExceededException.cs
@@ -1,0 +1,21 @@
+namespace Granit.Documents.Exceptions;
+
+/// <summary>
+/// Thrown by the document upload pipeline when a finalisation would push the tenant past
+/// its <c>TenantStorageQuota.LimitBytes</c> (F7.2). Endpoints translate this into an
+/// HTTP 403 RFC-7807 problem document with
+/// <c>type=https://granit.dev/problems/quota-exceeded</c>.
+/// </summary>
+public sealed class TenantStorageQuotaExceededException(
+    Guid tenantId,
+    long requestedBytes,
+    string? message = null)
+    : InvalidOperationException(
+        message ?? $"Tenant '{tenantId}' would exceed its storage quota by accepting {requestedBytes} additional bytes.")
+{
+    /// <summary>Identifier of the tenant whose quota would be exceeded.</summary>
+    public Guid TenantId { get; } = tenantId;
+
+    /// <summary>The number of bytes the rejected upload would have consumed.</summary>
+    public long RequestedBytes { get; } = requestedBytes;
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentVersionsListPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/DocumentVersionsListPostgresTests.cs
@@ -50,6 +50,16 @@ public sealed class DocumentVersionsListPostgresTests :
         var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
 
         _blobStorage = Substitute.For<IBlobStorage>();
+        // F7.2 quota path requires GetDescriptorAsync to return a blob with
+        // MaxAllowedBytes; default to a permissive descriptor so the existing tests don't
+        // need to stub it explicitly.
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => BlobDescriptor.Create(
+                (Guid)ci[1], TenantId, DocumentService.ContainerName,
+                $"docs/{(Guid)ci[1]:N}",
+                new BlobUploadRequest("file.pdf", "application/pdf", long.MaxValue),
+                DateTimeOffset.UtcNow));
 
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
         currentTenant.Id.Returns(TenantId);
@@ -64,9 +74,13 @@ public sealed class DocumentVersionsListPostgresTests :
 
         ILocalEventBus localEventBus = Substitute.For<ILocalEventBus>();
 
+        ITenantQuotaService quotas = Substitute.For<ITenantQuotaService>();
+        quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
         _sut = new DocumentService(
             _factory, bootstrap, _blobStorage, currentTenant,
-            new SimpleGuidGenerator(), clock, localEventBus, metrics);
+            new SimpleGuidGenerator(), clock, localEventBus, metrics, quotas);
     }
 
     public ValueTask DisposeAsync() => default;

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
@@ -76,6 +76,44 @@ public sealed class TenantQuotaServicePostgresTests :
     }
 
     [Fact]
+    public async Task TryReserveAsync_RejectsWhenWouldExceedLimit_AcceptsWithinLimit()
+    {
+        // F7.2 acceptance: tenant at 99% quota uploads 100 MB → rejected;
+        // tenant at 50% uploads 100 MB → accepted.
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        const long limit = 1_000_000_000; // 1 GB for this test (overrides default)
+        const long uploadBytes = 100_000_000; // 100 MB
+
+        // Bootstrap quota row + override LimitBytes via direct EF Core update.
+        await _sut.EnsureTenantQuotaAsync(tenantA, TestContext.Current.CancellationToken);
+        await _sut.EnsureTenantQuotaAsync(tenantB, TestContext.Current.CancellationToken);
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        await db.TenantStorageQuotas
+            .Where(q => q.TenantId == tenantA || q.TenantId == tenantB)
+            .ExecuteUpdateAsync(s => s.SetProperty(q => q.LimitBytes, _ => limit), TestContext.Current.CancellationToken);
+
+        // Tenant A at 99% — IncrementAsync directly (already rounded under limit).
+        await _sut.IncrementAsync(tenantA, 990_000_000, TestContext.Current.CancellationToken);
+        // Tenant B at 50%.
+        await _sut.IncrementAsync(tenantB, 500_000_000, TestContext.Current.CancellationToken);
+
+        bool aReserved = await _sut.TryReserveAsync(tenantA, uploadBytes, TestContext.Current.CancellationToken);
+        bool bReserved = await _sut.TryReserveAsync(tenantB, uploadBytes, TestContext.Current.CancellationToken);
+
+        aReserved.ShouldBeFalse();
+        bReserved.ShouldBeTrue();
+
+        // Tenant B's usage advanced; tenant A's usage unchanged (no race).
+        TenantStorageQuota? a = await _sut.GetAsync(tenantA, TestContext.Current.CancellationToken);
+        TenantStorageQuota? b = await _sut.GetAsync(tenantB, TestContext.Current.CancellationToken);
+        a.ShouldNotBeNull();
+        b.ShouldNotBeNull();
+        a.UsageBytes.ShouldBe(990_000_000);
+        b.UsageBytes.ShouldBe(600_000_000);
+    }
+
+    [Fact]
     public async Task EnsureTenantQuotaAsync_ConcurrentBootstrap_ConvergesOnSingleRow()
     {
         var tenant = Guid.NewGuid();

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -52,6 +52,12 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         _bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
 
         _blobStorage = Substitute.For<IBlobStorage>();
+        // Default descriptor stub so the F7.2 pre-confirm quota lookup doesn't error out
+        // for tests that only stub ConfirmUploadAsync. Tests overriding the descriptor —
+        // e.g. to test quota over-reservation release — substitute their own.
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => StubDescriptor((Guid)ci[1], maxAllowedBytes: long.MaxValue));
         _localEventBus = new CapturingLocalEventBus();
 
         ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
@@ -65,6 +71,10 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         ServiceProvider provider = services.BuildServiceProvider();
         var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
 
+        ITenantQuotaService quotas = Substitute.For<ITenantQuotaService>();
+        quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
         _sut = new DocumentService(
             _factory,
             _bootstrap,
@@ -73,10 +83,20 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
             new SimpleGuidGenerator(),
             clock,
             _localEventBus,
-            metrics);
+            metrics,
+            quotas);
     }
 
     public ValueTask DisposeAsync() => _holdOpen.DisposeAsync();
+
+    private static BlobDescriptor StubDescriptor(Guid blobId, long maxAllowedBytes) =>
+        BlobDescriptor.Create(
+            blobId,
+            tenantId: TenantId,
+            containerName: DocumentService.ContainerName,
+            objectKey: $"docs/{blobId:N}",
+            request: new BlobUploadRequest("file.pdf", "application/pdf", maxAllowedBytes),
+            createdAt: DateTimeOffset.UtcNow);
 
     [Fact]
     public async Task RequestUploadTicketAsync_DelegatesToBlobStorage()
@@ -138,6 +158,97 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         ev.DocumentId.ShouldBe(doc.Id);
         ev.VersionNumber.ShouldBe(1);
         ev.BlobDescriptorId.ShouldBe(blobId);
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_QuotaExceeded_Throws_AndDoesNotConfirmBlob()
+    {
+        // F7.2: when the tenant quota is exhausted, finalize must throw the quota-exceeded
+        // exception, leave the blob in Pending status (no ConfirmUploadAsync call), and
+        // record the quota.rejected counter.
+        var blobId = Guid.NewGuid();
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(StubDescriptor(blobId, maxAllowedBytes: 1_000_000));
+
+        // Override the quota stub built in InitializeAsync — caller-specific instance.
+        ITenantQuotaService quotas = Substitute.For<ITenantQuotaService>();
+        quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(false); // quota would be exceeded
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        var sut = new DocumentService(
+            _factory, _bootstrap, _blobStorage, tenant,
+            new SimpleGuidGenerator(), clock, _localEventBus, metrics, quotas);
+
+        Granit.Documents.Exceptions.TenantStorageQuotaExceededException ex =
+            await Should.ThrowAsync<Granit.Documents.Exceptions.TenantStorageQuotaExceededException>(async () =>
+                await sut.FinalizeUploadAsync(
+                    blobId, null, OwnerId, "F.pdf", null, null, TestContext.Current.CancellationToken));
+        ex.TenantId.ShouldBe(TenantId);
+        ex.RequestedBytes.ShouldBe(1_000_000);
+
+        await _blobStorage.DidNotReceive()
+            .ConfirmUploadAsync(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        // No document row created.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        (await db.Documents.AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task FinalizeUploadAsync_OverReservation_IsReleasedAfterConfirm()
+    {
+        // F7.2 release path: declared MaxAllowedBytes (1 MB) but real SizeBytes (100 KB)
+        // means the service must Decrement the slack so UsageBytes ends up at the actual
+        // size, not the declared upper bound.
+        var blobId = Guid.NewGuid();
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(StubDescriptor(blobId, maxAllowedBytes: 1_000_000));
+        _blobStorage.ConfirmUploadAsync(
+                DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf",
+                SizeBytes: 100_000, RejectionReason: null));
+
+        ITenantQuotaService quotas = Substitute.For<ITenantQuotaService>();
+        quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        var sut = new DocumentService(
+            _factory, _bootstrap, _blobStorage, tenant,
+            new SimpleGuidGenerator(), clock, _localEventBus, metrics, quotas);
+
+        await sut.FinalizeUploadAsync(
+            blobId, null, OwnerId, "F.pdf", null, null, TestContext.Current.CancellationToken);
+
+        await quotas.Received(1).TryReserveAsync(TenantId, 1_000_000, Arg.Any<CancellationToken>());
+        await quotas.Received(1).DecrementAsync(TenantId, 900_000, Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1752 — F7.2: enforce the tenant storage quota at upload finalize + version append.

- **Reservation pre-confirm.** Upload paths now call `TryReserveAsync(tenantId, MaxAllowedBytes)` before `ConfirmUploadAsync`. The underlying SQL is a conditional `UPDATE … WHERE UsageBytes + @delta <= LimitBytes`, so concurrent finalisations from the same tenant cannot collectively exceed the limit through a read-then-increment race.
- **Slack release.** `MaxAllowedBytes` is an upper bound — once `ConfirmUploadAsync` returns the actual `SizeBytes`, the service decrements by `(declared - actual)` so `UsageBytes` converges on the real size.
- **Rejection contract.** `TenantStorageQuotaExceededException` propagates from the service; the endpoint maps it to RFC 7807 with `type=https://granit.dev/problems/quota-exceeded`, status 403. `granit.documents.quota.rejected.count` is incremented at rejection.
- **Pending-on-rejection.** `ConfirmUploadAsync` is only called after the reservation succeeds, so a rejected upload leaves the `BlobDescriptor` in `Pending` status — the F9.1 OrphanDocumentCleanupJob picks it up. Matches the issue's "NOT promoted to Valid" requirement.
- **Failure-path release.** If persistence fails after the reservation (DB exception, missing target document on `AppendVersion`, etc.), the service `Decrement`s the reserved bytes so failed uploads don't leak quota.
- **OpenAPI:** `ProducesProblem(403)` added on `POST /documents/finalize` and `POST /documents/{id}/versions`.

## Acceptance criteria (#1752)

- [x] Quota check executed before the BlobDescriptor is promoted to Valid (read-current-usage + check + increment is the atomic conditional UPDATE).
- [x] Rejected upload returns 403 with `type=https://granit.dev/problems/quota-exceeded`.
- [x] BlobDescriptor stays in `Pending` on rejection (no `ConfirmUploadAsync` call).
- [x] Counter `granit.documents.quota.rejected.count` incremented.
- [x] Integration test: tenant at 99% quota rejects 100 MB upload; tenant at 50% accepts.

## Test plan

- [x] `dotnet test tests/Granit.Documents.Tests` — 85/85.
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 97/97 (2 new SQLite tests on quota rejection + over-reservation release).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 22/22 (1 new Postgres test pinning the 99% / 50% scenario).
- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 55/55.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212.
- [x] `dotnet format style` clean on touched projects.