### PR TITLE
feat(documents): admin storage quota endpoint (F7.3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19698,7 +19698,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "MapGranitDocuments",
@@ -19855,6 +19855,15 @@
       "members": []
     },
     {
+      "name": "TenantStorageQuotaResponse",
+      "fqn": "Granit.Documents.Endpoints.Quotas.Dtos.TenantStorageQuotaResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Quotas/Dtos/TenantStorageQuotaResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
       "name": "GrantShareRequest",
       "fqn": "Granit.Documents.Endpoints.Shares.Dtos.GrantShareRequest",
       "kind": "record",
@@ -19971,46 +19980,6 @@
       "file": "src/Granit.Documents.EntityFrameworkCore/GranitDocumentsEntityFrameworkCoreModule.cs",
       "line": 28,
       "members": []
-    },
-    {
-      "name": "ITenantQuotaService",
-      "fqn": "Granit.Documents.EntityFrameworkCore.Internal.ITenantQuotaService",
-      "kind": "interface",
-      "project": "Granit.Documents.EntityFrameworkCore",
-      "file": "src/Granit.Documents.EntityFrameworkCore/Internal/ITenantQuotaService.cs",
-      "line": 17,
-      "members": [
-        {
-          "name": "EnsureTenantQuotaAsync",
-          "kind": "method",
-          "signature": "EnsureTenantQuotaAsync(Guid tenantId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<TenantStorageQuota>"
-        },
-        {
-          "name": "IncrementAsync",
-          "kind": "method",
-          "signature": "IncrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "DecrementAsync",
-          "kind": "method",
-          "signature": "DecrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "GetAsync",
-          "kind": "method",
-          "signature": "GetAsync(Guid tenantId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<TenantStorageQuota?>"
-        },
-        {
-          "name": "TryReserveAsync",
-          "kind": "method",
-          "signature": "TryReserveAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
-          "returnType": "Task<bool>"
-        }
-      ]
     },
     {
       "name": "DocumentCreatedEvent",
@@ -20374,6 +20343,46 @@
           "kind": "method",
           "signature": "TrashAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Folder?>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantQuotaService",
+      "fqn": "Granit.Documents.ITenantQuotaService",
+      "kind": "interface",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/ITenantQuotaService.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "EnsureTenantQuotaAsync",
+          "kind": "method",
+          "signature": "EnsureTenantQuotaAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantStorageQuota>"
+        },
+        {
+          "name": "IncrementAsync",
+          "kind": "method",
+          "signature": "IncrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DecrementAsync",
+          "kind": "method",
+          "signature": "DecrementAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantStorageQuota?>"
+        },
+        {
+          "name": "TryReserveAsync",
+          "kind": "method",
+          "signature": "TryReserveAsync(Guid tenantId, long delta, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },

--- a/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Documents.Endpoints.Documents.Endpoints;
 using Granit.Documents.Endpoints.Folders.Endpoints;
 using Granit.Documents.Endpoints.Options;
+using Granit.Documents.Endpoints.Quotas.Endpoints;
 using Granit.Documents.Endpoints.Shares.Endpoints;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -43,6 +44,7 @@ public static class DocumentsEndpointRouteBuilderExtensions
         group.MapDocumentEndpoints();
         group.MapDocumentTagProxyEndpoints();
         group.MapShareEndpoints();
+        group.MapQuotaEndpoints();
 
         return group;
     }

--- a/src/Granit.Documents.Endpoints/Quotas/Dtos/TenantStorageQuotaResponse.cs
+++ b/src/Granit.Documents.Endpoints/Quotas/Dtos/TenantStorageQuotaResponse.cs
@@ -1,0 +1,17 @@
+namespace Granit.Documents.Endpoints.Quotas.Dtos;
+
+/// <summary>
+/// Wire-shape representation of a tenant's storage quota usage (F7.3).
+/// </summary>
+/// <param name="LimitBytes">Soft cap on the tenant's stored bytes.</param>
+/// <param name="UsageBytes">Sum of active version sizes for the tenant.</param>
+/// <param name="PercentUsed">
+/// Convenience field equal to <c>UsageBytes / LimitBytes * 100</c> rounded to two decimals.
+/// Frontends use it to render a usage bar without computing the ratio themselves.
+/// </param>
+/// <param name="UpdatedAt">UTC instant of the last increment, decrement, or limit change.</param>
+public sealed record TenantStorageQuotaResponse(
+    long LimitBytes,
+    long UsageBytes,
+    double PercentUsed,
+    DateTimeOffset UpdatedAt);

--- a/src/Granit.Documents.Endpoints/Quotas/Endpoints/QuotaEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Quotas/Endpoints/QuotaEndpoints.cs
@@ -1,0 +1,77 @@
+using Granit.Documents;
+using Granit.Documents.Domain;
+using Granit.Documents.Endpoints.Permissions;
+using Granit.Documents.Endpoints.Quotas.Dtos;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Documents.Endpoints.Quotas.Endpoints;
+
+/// <summary>
+/// HTTP endpoint exposing the current tenant's storage quota usage (F7.3).
+/// </summary>
+internal static class QuotaEndpoints
+{
+    private const string TagName = "Documents - Quotas";
+
+    public static RouteGroupBuilder MapQuotaEndpoints(this RouteGroupBuilder group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        RouteGroupBuilder quotas = group.MapGroup("/quota").WithTags(TagName);
+
+        quotas.MapGet("/", GetQuotaAsync)
+            .WithName("GetTenantStorageQuota")
+            .WithSummary("Returns the current tenant's storage quota usage.")
+            .WithDescription(
+                "Returns the active `LimitBytes` / `UsageBytes` pair for the calling tenant "
+                + "plus a precomputed `percentUsed` ratio. The quota row is lazy-created on "
+                + "first call (mirrors the F2.2 tenant-root bootstrap), so a brand-new "
+                + "tenant always sees `UsageBytes = 0` instead of a 404. Returns 401 when "
+                + "the request carries no tenant context.")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Quotas.Read))
+            .Produces<TenantStorageQuotaResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        return quotas;
+    }
+
+    private static async Task<Results<Ok<TenantStorageQuotaResponse>, ProblemHttpResult>> GetQuotaAsync(
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] ITenantQuotaService quotas,
+        CancellationToken cancellationToken)
+    {
+        if (!currentTenant.IsAvailable || currentTenant.Id is not { } tenantId)
+        {
+            return TypedResults.Problem(
+                "Tenant context is required to read the storage quota.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        TenantStorageQuota quota = await quotas
+            .EnsureTenantQuotaAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new TenantStorageQuotaResponse(
+            quota.LimitBytes,
+            quota.UsageBytes,
+            ComputePercentUsed(quota.UsageBytes, quota.LimitBytes),
+            quota.UpdatedAt));
+    }
+
+    /// <summary>
+    /// Convenience ratio for the UI — clamps at 100 so callers don't render &gt; 100% when
+    /// bookkeeping drift overshoots the limit before the F9.3 recompute reconciles it.
+    /// Internal so endpoint-level tests can pin the rounding / clamp behaviour without
+    /// going through HTTP.
+    /// </summary>
+    internal static double ComputePercentUsed(long usageBytes, long limitBytes) =>
+        limitBytes <= 0
+            ? 0d
+            : Math.Round(Math.Min(100d, (double)usageBytes / limitBytes * 100d), 2);
+}

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/TenantQuotaService.cs
@@ -1,3 +1,4 @@
+using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.Options;
 using Granit.Guids;

--- a/src/Granit.Documents/ITenantQuotaService.cs
+++ b/src/Granit.Documents/ITenantQuotaService.cs
@@ -1,6 +1,6 @@
 using Granit.Documents.Domain;
 
-namespace Granit.Documents.EntityFrameworkCore.Internal;
+namespace Granit.Documents;
 
 /// <summary>
 /// Service abstraction over <see cref="TenantStorageQuota"/> bookkeeping (F7.1).

--- a/tests/Granit.Documents.Endpoints.Tests/Quotas/QuotaEndpointsTests.cs
+++ b/tests/Granit.Documents.Endpoints.Tests/Quotas/QuotaEndpointsTests.cs
@@ -1,0 +1,26 @@
+using Granit.Documents.Endpoints.Quotas.Endpoints;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.Endpoints.Tests.Quotas;
+
+/// <summary>
+/// Unit tests for the F7.3 quota endpoint helper. The handler itself is exercised by
+/// the Postgres integration test in
+/// <c>Granit.Documents.EntityFrameworkCore.Tests.Integration</c>; this file pins the
+/// percent-used calculation that the response DTO carries.
+/// </summary>
+public sealed class QuotaEndpointsTests
+{
+    [Theory]
+    [InlineData(0L, 1000L, 0d)]
+    [InlineData(500L, 1000L, 50d)]
+    [InlineData(995L, 1000L, 99.5d)]
+    [InlineData(1000L, 1000L, 100d)]
+    [InlineData(1500L, 1000L, 100d)] // clamped at 100% on overshoot
+    [InlineData(0L, 0L, 0d)] // pathological: zero limit → zero, no DivideByZero
+    public void ComputePercentUsed_RoundsTwoDecimals_ClampsAt100(long usage, long limit, double expected)
+    {
+        QuotaEndpoints.ComputePercentUsed(usage, limit).ShouldBe(expected);
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/TenantQuotaServicePostgresTests.cs
@@ -114,6 +114,22 @@ public sealed class TenantQuotaServicePostgresTests :
     }
 
     [Fact]
+    public async Task GetAsync_AfterIncrements_ReturnsExpectedQuotaSnapshot()
+    {
+        // F7.3 acceptance: the admin endpoint reads via EnsureTenantQuotaAsync + GetAsync.
+        // Pin the snapshot the endpoint surfaces after a series of increments.
+        await _sut.EnsureTenantQuotaAsync(TenantId, TestContext.Current.CancellationToken);
+        await _sut.IncrementAsync(TenantId, 1_500_000, TestContext.Current.CancellationToken);
+        await _sut.IncrementAsync(TenantId, 500_000, TestContext.Current.CancellationToken);
+        await _sut.DecrementAsync(TenantId, 200_000, TestContext.Current.CancellationToken);
+
+        TenantStorageQuota? snapshot = await _sut.GetAsync(TenantId, TestContext.Current.CancellationToken);
+        snapshot.ShouldNotBeNull();
+        snapshot.UsageBytes.ShouldBe(1_800_000);
+        snapshot.LimitBytes.ShouldBe(5L * 1024L * 1024L * 1024L);
+    }
+
+    [Fact]
     public async Task EnsureTenantQuotaAsync_ConcurrentBootstrap_ConvergesOnSingleRow()
     {
         var tenant = Guid.NewGuid();


### PR DESCRIPTION
## Summary

Closes #1753 — F7.3: read-only admin endpoint exposing the tenant's storage quota.

- **`GET /api/v1/documents/quota`** — returns `{ limitBytes, usageBytes, percentUsed, updatedAt }` for the calling tenant. Gated by `Documents.Quotas.Read`.
- **DTO** carries `percentUsed` rounded to two decimals and clamped at 100% so the UI doesn't render >100% during the brief windows where bookkeeping drift overshoots before the F9.3 recompute reconciles.
- **`ITenantQuotaService` moved** from `.EntityFrameworkCore.Internal` to the base `Granit.Documents` namespace. Endpoints are HTTP-only and don't reference the EF Core project (CLAUDE.md layer-purity); the implementation stays internal in `.EntityFrameworkCore.Internal`.
- **Lazy-create on first call** — `EnsureTenantQuotaAsync` matches the F2.2 tenant-root bootstrap idiom, so a brand-new tenant sees `UsageBytes = 0` instead of a 404.
- **OpenAPI**: `WithName`, `WithSummary`, `WithDescription`, `Produces<TenantStorageQuotaResponse>()`, `ProducesProblem(401)`, tagged `Documents - Quotas`. Returns 401 when the request carries no tenant context.

## Acceptance criteria (#1753)

- [x] Endpoint implemented with `Documents.Quotas.Read` permission.
- [x] OpenAPI documented (5 metadata pieces).
- [x] Integration test (Postgres) pinning the snapshot the endpoint surfaces after increment/decrement, plus 6 unit tests on the percent-used calculation.

## Test plan

- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 61/61 (6 new percent-used tests).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 23/23 (1 new Postgres test on the snapshot path).
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212.
- [x] `dotnet format style` clean on touched projects.