### PR TITLE
feat(documents): trash + restore endpoints with cascade trash (F8.1)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -20251,6 +20251,12 @@
           "kind": "method",
           "signature": "TrashAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Document?>"
+        },
+        {
+          "name": "RestoreAsync",
+          "kind": "method",
+          "signature": "RestoreAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
         }
       ]
     },
@@ -20317,7 +20323,7 @@
         {
           "name": "ListChildrenAsync",
           "kind": "method",
-          "signature": "ListChildrenAsync(Guid? parentFolderId, CancellationToken cancellationToken = default)",
+          "signature": "ListChildrenAsync(Guid? parentFolderId, FolderStatus status = FolderStatus.Active, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Folder>>"
         },
         {
@@ -20342,6 +20348,12 @@
           "name": "TrashAsync",
           "kind": "method",
           "signature": "TrashAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Folder?>"
+        },
+        {
+          "name": "RestoreAsync",
+          "kind": "method",
+          "signature": "RestoreAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Folder?>"
         }
       ]

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
@@ -75,6 +75,19 @@ internal static class DocumentMutationEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
+        documents.MapPost("/{id:guid}/restore", RestoreAsync)
+            .WithName("RestoreDocument")
+            .WithSummary("Restores a trashed document.")
+            .WithDescription(
+                "Sets the document identified by `id` back to `Active`. Returns 404 when "
+                + "the document is missing or not currently trashed; 409 when the parent "
+                + "folder is itself trashed (callers must restore the folder first).")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces<DocumentResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
         return documents;
     }
 
@@ -193,6 +206,29 @@ internal static class DocumentMutationEndpoints
         }
         catch (InvalidOperationException ex)
         {
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+    }
+
+    private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> RestoreAsync(
+        Guid id,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Document? document = await documents.RestoreAsync(id, cancellationToken).ConfigureAwait(false);
+            if (document is null)
+            {
+                return TypedResults.Problem(
+                    $"Document '{id}' was not found or is not currently trashed.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(document.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Parent folder is trashed.
             return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
     }

--- a/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
@@ -27,12 +27,13 @@ internal static class FolderEndpoints
 
         folders.MapGet("/", ListChildrenAsync)
             .WithName("ListFolders")
-            .WithSummary("Lists active child folders under a parent (defaults to the tenant root).")
+            .WithSummary("Lists child folders under a parent (defaults to the tenant root).")
             .WithDescription(
-                "Returns the active children of the folder identified by the optional `parentId` query parameter. "
+                "Returns the children of the folder identified by the optional `parentId` query parameter. "
                 + "When `parentId` is omitted, the children of the invisible tenant root are returned. "
                 + "The tenant root itself is always filtered out of the result set. "
-                + "Trashed folders are excluded — use the trash listing endpoint (F8.2) to retrieve them.")
+                + "Pass `?status=Trashed` to read the trash listing for the same parent (F8.1); the "
+                + "default is `Active`.")
             .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Read))
             .Produces<ListFoldersResponse>();
 
@@ -103,12 +104,26 @@ internal static class FolderEndpoints
             .WithName("TrashFolder")
             .WithSummary("Sends a folder to the trash (soft-delete).")
             .WithDescription(
-                "Moves the folder identified by `id` to the trash. Permanent deletion happens after "
-                + "the configured retention period via the empty-trash background job (F8/F9.2). "
-                + "The tenant root cannot be trashed.")
+                "Moves the folder identified by `id` to the trash. Cascade-trashes every "
+                + "active descendant folder and document in a single transaction (F8.1). "
+                + "Permanent deletion happens after the configured retention period via the "
+                + "empty-trash background job (F8/F9.2). The tenant root cannot be trashed.")
             .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
+
+        folders.MapPost("/{id:guid}/restore", RestoreAsync)
+            .WithName("RestoreFolder")
+            .WithSummary("Restores a trashed folder.")
+            .WithDescription(
+                "Sets the folder identified by `id` back to `Active`. Descendants stay trashed "
+                + "unless restored individually (per F8.1 — restore is non-cascading by design). "
+                + "Returns 404 when the folder is missing or not currently trashed; 409 when the "
+                + "parent folder is itself trashed (callers must restore the parent first).")
+            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .Produces<FolderResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         return folders;
     }
@@ -122,10 +137,11 @@ internal static class FolderEndpoints
         [FromServices] IFolderService folders,
         [FromServices] IDocumentPrincipalAccessor principalAccessor,
         [FromServices] IEffectivePermissionResolver permissionResolver,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        [FromQuery] FolderStatus? status = null)
     {
         IReadOnlyList<Folder> children = await folders
-            .ListChildrenAsync(parentId, cancellationToken)
+            .ListChildrenAsync(parentId, status ?? FolderStatus.Active, cancellationToken)
             .ConfigureAwait(false);
 
         // F6.5b — populate the per-row Permission via a single batch call when an
@@ -263,6 +279,29 @@ internal static class FolderEndpoints
                 statusCode: StatusCodes.Status404NotFound);
         }
         return TypedResults.Ok(folder.ToResponse());
+    }
+
+    private static async Task<Results<Ok<FolderResponse>, ProblemHttpResult>> RestoreAsync(
+        Guid id,
+        [FromServices] IFolderService folders,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            Folder? folder = await folders.RestoreAsync(id, cancellationToken).ConfigureAwait(false);
+            if (folder is null)
+            {
+                return TypedResults.Problem(
+                    $"Folder '{id}' was not found or is not currently trashed.",
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+            return TypedResults.Ok(folder.ToResponse());
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Parent folder is trashed — caller must restore the parent first.
+            return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
     }
 
     private static Guid ResolveOwnerUserId(HttpContext? httpContext)

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -619,4 +619,37 @@ internal sealed class DocumentService(
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return document;
     }
+
+    /// <inheritdoc />
+    public async Task<Document?> RestoreAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null || document.Status != DocumentStatus.Trashed)
+        {
+            return null;
+        }
+
+        // Reject restore when the parent folder is trashed — callers must restore the
+        // folder first so the document is reachable.
+        Folder? parent = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == document.FolderId, cancellationToken)
+            .ConfigureAwait(false);
+        if (parent is not null && parent.Status == FolderStatus.Trashed)
+        {
+            throw new InvalidOperationException(
+                $"Cannot restore document {id}: parent folder {parent.Id} is trashed. Restore the folder first.");
+        }
+
+        document.Restore();
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return document;
+    }
 }

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/FolderService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/FolderService.cs
@@ -65,6 +65,7 @@ internal sealed class FolderService(
     /// <inheritdoc />
     public async Task<IReadOnlyList<Folder>> ListChildrenAsync(
         Guid? parentFolderId,
+        FolderStatus status = FolderStatus.Active,
         CancellationToken cancellationToken = default)
     {
         await using DocumentsDbContext context = await contextFactory
@@ -87,7 +88,7 @@ internal sealed class FolderService(
 
         return await context.Folders
             .Where(f => f.ParentFolderId == effectiveParentId
-                && f.Status == FolderStatus.Active
+                && f.Status == status
                 && !f.IsTenantRoot)
             .OrderBy(f => f.Name)
             .ToListAsync(cancellationToken)
@@ -262,7 +263,91 @@ internal sealed class FolderService(
             return null;
         }
 
-        folder.Trash(clock.Now);
+        DateTimeOffset trashedAt = clock.Now;
+
+        // Cascade-trash every active descendant — folders with the requested folder's
+        // path as a strict prefix, plus every active document under those folders.
+        // Single transaction via SaveChangesAsync atomicity.
+        string pathPrefix = folder.Path == Folder.TenantRootPath
+            ? Folder.TenantRootPath
+            : folder.Path + Folder.PathSeparator;
+
+        List<Folder> descendantFolders = folder.IsTenantRoot
+            ? []
+            : await context.Folders
+                .Where(f => f.TenantId == folder.TenantId
+                    && f.Status == FolderStatus.Active
+                    && !f.IsTenantRoot
+                    && f.Id != folder.Id
+                    && f.Path.StartsWith(pathPrefix))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        // Documents whose folder is the target OR any descendant folder. Two queries —
+        // direct + descendants — kept separate so each gets a clean SQL shape.
+        List<Document> directDocuments = await context.Documents
+            .Where(d => d.FolderId == folder.Id && d.Status == DocumentStatus.Active)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<Document> descendantDocuments = descendantFolders.Count == 0
+            ? []
+            : await context.Documents
+                .Where(d => descendantFolders.Select(f => f.Id).Contains(d.FolderId)
+                    && d.Status == DocumentStatus.Active)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        folder.Trash(trashedAt);
+        foreach (Folder descendant in descendantFolders)
+        {
+            descendant.Trash(trashedAt);
+        }
+        foreach (Document doc in directDocuments)
+        {
+            doc.Trash(trashedAt);
+        }
+        foreach (Document doc in descendantDocuments)
+        {
+            doc.Trash(trashedAt);
+        }
+
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return folder;
+    }
+
+    /// <inheritdoc />
+    public async Task<Folder?> RestoreAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Folder? folder = await context.Folders
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (folder is null || folder.Status != FolderStatus.Trashed)
+        {
+            return null;
+        }
+
+        // Reject restore when the parent is itself trashed — callers must restore the
+        // parent first so the restored folder can become reachable from the tree.
+        if (folder.ParentFolderId is { } parentId)
+        {
+            Folder? parent = await context.Folders
+                .FirstOrDefaultAsync(f => f.Id == parentId, cancellationToken)
+                .ConfigureAwait(false);
+            if (parent is not null && parent.Status == FolderStatus.Trashed)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot restore folder {id}: parent folder {parent.Id} is trashed. Restore the parent first.");
+            }
+        }
+
+        folder.Restore();
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return folder;
     }

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -149,4 +149,12 @@ public interface IDocumentService
     /// when the document is not found.
     /// </summary>
     Task<Document?> TrashAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Restores a trashed document. Returns the restored aggregate, or <c>null</c> when
+    /// the document is not found / not currently trashed / excluded by the tenant
+    /// filter. Throws <see cref="InvalidOperationException"/> when the document's
+    /// folder is itself trashed (callers must restore the folder first).
+    /// </summary>
+    Task<Document?> RestoreAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Documents/IFolderService.cs
+++ b/src/Granit.Documents/IFolderService.cs
@@ -33,12 +33,15 @@ public interface IFolderService
     Task<Folder?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Lists active folders under <paramref name="parentFolderId"/>; when <c>null</c>
-    /// the result is the children of the tenant root. The tenant root itself is
-    /// always excluded from the result.
+    /// Lists folders under <paramref name="parentFolderId"/>; when <c>null</c> the
+    /// result is the children of the tenant root. The tenant root itself is always
+    /// excluded from the result. By default only <see cref="FolderStatus.Active"/>
+    /// children are returned — pass <see cref="FolderStatus.Trashed"/> to read the
+    /// trash listing for that parent.
     /// </summary>
     Task<IReadOnlyList<Folder>> ListChildrenAsync(
         Guid? parentFolderId,
+        FolderStatus status = FolderStatus.Active,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -90,4 +93,16 @@ public interface IFolderService
     /// <see cref="FolderStatus.Trashed"/> with the same <c>TrashedAt</c>.
     /// </remarks>
     Task<Folder?> TrashAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Restores a trashed folder. Returns the restored folder, or <c>null</c> when the
+    /// folder is not found / excluded by the tenant filter / not currently trashed.
+    /// Throws <see cref="InvalidOperationException"/> when the parent folder is itself
+    /// trashed (callers must restore the parent first).
+    /// </summary>
+    /// <remarks>
+    /// Restore is non-cascading: descendants stay trashed unless restored individually
+    /// (per the F8.1 acceptance criterion).
+    /// </remarks>
+    Task<Folder?> RestoreAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/FolderTrashCascadePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/FolderTrashCascadePostgresTests.cs
@@ -1,0 +1,124 @@
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres-backed verification that <see cref="FolderService.TrashAsync"/> cascades
+/// the trash status to every active descendant folder + document in a single
+/// transaction, and that <see cref="FolderService.RestoreAsync"/> stays non-cascading
+/// per the F8.1 acceptance.
+/// </summary>
+public sealed class FolderTrashCascadePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private FolderService _sut = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public FolderTrashCascadePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_folders, documents_documents, documents_document_versions RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        ILocalEventBus localEventBus = Substitute.For<ILocalEventBus>();
+
+        _sut = new FolderService(_factory, bootstrap, currentTenant,
+            new SimpleGuidGenerator(), clock, localEventBus);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task TrashAsync_DeepSubtree_CascadesToAllDescendants_OnPostgres()
+    {
+        // /A → /A/B → /A/B/C plus /A/Sibling and a doc per leaf folder. Trashing /A
+        // must flip every descendant folder + document to Trashed.
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, ct);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, ct);
+        Folder c = await _sut.CreateAsync(b.Id, "C", OwnerId, ct);
+        Folder sibling = await _sut.CreateAsync(a.Id, "Sibling", OwnerId, ct);
+
+        await using DocumentsDbContext seed = await _factory.CreateDbContextAsync(ct);
+        Folder cAttached = await seed.Folders.SingleAsync(f => f.Id == c.Id, ct);
+        Folder siblingAttached = await seed.Folders.SingleAsync(f => f.Id == sibling.Id, ct);
+        var docInC = Document.Create(Guid.NewGuid(), cAttached, OwnerId, "in-c.pdf");
+        var docInSibling = Document.Create(Guid.NewGuid(), siblingAttached, OwnerId, "in-sibling.pdf");
+        seed.Documents.Add(docInC);
+        seed.Documents.Add(docInSibling);
+        await seed.SaveChangesAsync(ct);
+
+        // Also create an unrelated /Other folder + doc that must stay Active.
+        Folder other = await _sut.CreateAsync(null, "Other", OwnerId, ct);
+        await using DocumentsDbContext seed2 = await _factory.CreateDbContextAsync(ct);
+        Folder otherAttached = await seed2.Folders.SingleAsync(f => f.Id == other.Id, ct);
+        var docInOther = Document.Create(Guid.NewGuid(), otherAttached, OwnerId, "in-other.pdf");
+        seed2.Documents.Add(docInOther);
+        await seed2.SaveChangesAsync(ct);
+
+        await _sut.TrashAsync(a.Id, ct);
+
+        await using DocumentsDbContext check = await _factory.CreateDbContextAsync(ct);
+        Folder reloadedA = await check.Folders.SingleAsync(f => f.Id == a.Id, ct);
+        Folder reloadedB = await check.Folders.SingleAsync(f => f.Id == b.Id, ct);
+        Folder reloadedC = await check.Folders.SingleAsync(f => f.Id == c.Id, ct);
+        Folder reloadedSibling = await check.Folders.SingleAsync(f => f.Id == sibling.Id, ct);
+        Folder reloadedOther = await check.Folders.SingleAsync(f => f.Id == other.Id, ct);
+        Document reloadedDocC = await check.Documents.SingleAsync(d => d.Id == docInC.Id, ct);
+        Document reloadedDocSibling = await check.Documents.SingleAsync(d => d.Id == docInSibling.Id, ct);
+        Document reloadedDocOther = await check.Documents.SingleAsync(d => d.Id == docInOther.Id, ct);
+
+        reloadedA.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedB.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedC.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedSibling.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedDocC.Status.ShouldBe(DocumentStatus.Trashed);
+        reloadedDocSibling.Status.ShouldBe(DocumentStatus.Trashed);
+
+        // Unrelated subtree untouched.
+        reloadedOther.Status.ShouldBe(FolderStatus.Active);
+        reloadedDocOther.Status.ShouldBe(DocumentStatus.Active);
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -640,6 +640,40 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
         result.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task RestoreAsync_TrashedDocument_ReturnsActive()
+    {
+        Document seeded = await SeedDocumentAsync();
+        await _sut.TrashAsync(seeded.Id, TestContext.Current.CancellationToken);
+
+        Document? restored = await _sut.RestoreAsync(seeded.Id,
+            TestContext.Current.CancellationToken);
+
+        restored.ShouldNotBeNull();
+        restored.Status.ShouldBe(DocumentStatus.Active);
+        restored.TrashedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_NotTrashed_ReturnsNull()
+    {
+        Document seeded = await SeedDocumentAsync();
+
+        Document? result = await _sut.RestoreAsync(seeded.Id,
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Missing_ReturnsNull()
+    {
+        Document? result = await _sut.RestoreAsync(Guid.NewGuid(),
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
     // -------------------------------------------------------------------------
     // F4.1 — AppendVersionAsync (autonomous monotonic versioning)
     // -------------------------------------------------------------------------

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/FolderServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/FolderServiceSqliteTests.cs
@@ -83,7 +83,7 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
         await _sut.CreateAsync(null, "B", OwnerId, TestContext.Current.CancellationToken);
 
         IReadOnlyList<Folder> children = await _sut.ListChildrenAsync(null,
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         children.Count.ShouldBe(2);
         children.ShouldAllBe(f => !f.IsTenantRoot);
@@ -97,7 +97,7 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
         await _sut.TrashAsync(a.Id, TestContext.Current.CancellationToken);
 
         IReadOnlyList<Folder> children = await _sut.ListChildrenAsync(null,
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         children.Count.ShouldBe(1);
         children[0].Name.ShouldBe("B");
@@ -162,6 +162,102 @@ public sealed class FolderServiceSqliteTests : IAsyncLifetime
         trashed.ShouldNotBeNull();
         trashed.Status.ShouldBe(FolderStatus.Trashed);
         trashed.TrashedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task TrashAsync_CascadesTo_DescendantFoldersAndDocuments()
+    {
+        // /A → /A/B → /A/B/C plus a document in /A/B and /A/B/C.
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, ct);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, ct);
+        Folder c = await _sut.CreateAsync(b.Id, "C", OwnerId, ct);
+
+        await using DocumentsDbContext seed = await _factory.CreateDbContextAsync(ct);
+        Folder bAttached = await seed.Folders.SingleAsync(f => f.Id == b.Id, ct);
+        Folder cAttached = await seed.Folders.SingleAsync(f => f.Id == c.Id, ct);
+        var docInB = Document.Create(Guid.NewGuid(), bAttached, OwnerId, "in-b.pdf");
+        var docInC = Document.Create(Guid.NewGuid(), cAttached, OwnerId, "in-c.pdf");
+        seed.Documents.Add(docInB);
+        seed.Documents.Add(docInC);
+        await seed.SaveChangesAsync(ct);
+
+        await _sut.TrashAsync(a.Id, ct);
+
+        await using DocumentsDbContext check = await _factory.CreateDbContextAsync(ct);
+        Folder reloadedA = await check.Folders.SingleAsync(f => f.Id == a.Id, ct);
+        Folder reloadedB = await check.Folders.SingleAsync(f => f.Id == b.Id, ct);
+        Folder reloadedC = await check.Folders.SingleAsync(f => f.Id == c.Id, ct);
+        Document reloadedDocB = await check.Documents.SingleAsync(d => d.Id == docInB.Id, ct);
+        Document reloadedDocC = await check.Documents.SingleAsync(d => d.Id == docInC.Id, ct);
+
+        reloadedA.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedB.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedC.Status.ShouldBe(FolderStatus.Trashed);
+        reloadedDocB.Status.ShouldBe(DocumentStatus.Trashed);
+        reloadedDocC.Status.ShouldBe(DocumentStatus.Trashed);
+
+        // Sibling folders untouched.
+        reloadedA.TrashedAt.ShouldBe(reloadedB.TrashedAt);
+        reloadedA.TrashedAt.ShouldBe(reloadedC.TrashedAt);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_TrashedFolder_ReturnsActive_DoesNotCascade()
+    {
+        // Trashing /A cascades; restoring /A leaves /A/B trashed (per F8.1 — opt-in).
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, ct);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, ct);
+        await _sut.TrashAsync(a.Id, ct);
+
+        Folder? restored = await _sut.RestoreAsync(a.Id, ct);
+        restored.ShouldNotBeNull();
+        restored.Status.ShouldBe(FolderStatus.Active);
+        restored.TrashedAt.ShouldBeNull();
+
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(ct);
+        Folder reloadedB = await db.Folders.SingleAsync(f => f.Id == b.Id, ct);
+        reloadedB.Status.ShouldBe(FolderStatus.Trashed);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ParentTrashed_Throws()
+    {
+        // Direct-restore of a child whose parent is still trashed must fail with
+        // InvalidOperationException — caller restores the parent first.
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, ct);
+        Folder b = await _sut.CreateAsync(a.Id, "B", OwnerId, ct);
+        await _sut.TrashAsync(a.Id, ct);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            _sut.RestoreAsync(b.Id, ct));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_NotTrashed_ReturnsNull()
+    {
+        Folder folder = await _sut.CreateAsync(null, "Active", OwnerId,
+            TestContext.Current.CancellationToken);
+
+        Folder? result = await _sut.RestoreAsync(folder.Id, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ListChildrenAsync_StatusTrashed_ReturnsOnlyTrashedRows()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        Folder a = await _sut.CreateAsync(null, "A", OwnerId, ct);
+        await _sut.CreateAsync(null, "B", OwnerId, ct);
+        await _sut.TrashAsync(a.Id, ct);
+
+        IReadOnlyList<Folder> trashed = await _sut.ListChildrenAsync(
+            null, FolderStatus.Trashed, ct);
+        trashed.Count.ShouldBe(1);
+        trashed[0].Id.ShouldBe(a.Id);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1755 — F8.1: trash + restore endpoints for folders and documents, with cascade trash and opt-in (non-cascading) restore.

- **Cascade trash**: `FolderService.TrashAsync` flips every active descendant folder and every active document under those folders to `Trashed` in a single `SaveChanges` transaction. Each aggregate's domain `Trash(now)` is invoked, so every row carries the same `TrashedAt` and emits its `FolderTrashedEvent` / `DocumentTrashedEvent` for downstream consumers.
- **Non-cascading restore**: `RestoreAsync` (folder + document) restores the single aggregate. Descendants stay trashed unless restored individually — this matches the F8.1 acceptance "Restoring a folder does NOT auto-restore descendants (user opts-in)". A guard rejects restore (409) when the parent is itself trashed so callers can't create dangling `Active` rows under a `Trashed` parent.
- **`?status=Trashed`** on `GET /folders/?parentId=`: the existing list endpoint reads trashed children for the same parent (default `Active`) — no separate endpoint needed for the trash UI.
- **New endpoints**: `POST /folders/{id}/restore` + `POST /documents/{id}/restore`, both gated by the matching `Manage` permission, RFC-7807 problem responses for 404 / 409.

## Acceptance criteria (#1755)

- [x] Trash sets `Status = Trashed`, `TrashedAt = now`. Tenant root rejected (already enforced by `Folder.Trash` aggregate guard).
- [x] Restore sets `Status = Active`, clears `TrashedAt`. Rejected (409) if parent folder is trashed.
- [x] List/search endpoints exclude trashed items by default — `?status=Trashed` opts in.
- [x] Trashing a folder cascade-trashes its descendants (folders + documents) in a single transaction.
- [x] Restoring a folder does NOT auto-restore descendants.
- [x] Integration test covers the cascade + restore behaviours (Postgres + SQLite).

## Test plan

- [x] `dotnet test tests/Granit.Documents.Tests` — 85/85.
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 105/105 (8 new SQLite tests across folder + document services).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 24/24 (1 new Postgres test pinning cascade scope isolation).
- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 61/61.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212.
- [x] `dotnet format style` clean on touched projects.