### PR TITLE
fix(docs): broken Granit.BlobStorage link in ADR-052

### DIFF
--- a/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/052-documents-module.md
@@ -439,7 +439,7 @@ These are tracked in the Epic and resolved during implementation; they do not bl
 
 ## Cross-references
 
-- [Granit.BlobStorage reference](/dotnet/reference/modules/blob-storage) — composed primitive.
+- [Granit.BlobStorage reference](/dotnet/data/blob-storage/) — composed primitive.
 - ADR-017 — DDD aggregate / value-object strategy. `Document` and `Folder` follow the aggregate-root rules (private setters, `Create()` factory, `AddDomainEvent()`).
 - ADR-020 — Declarative definitions placement. `DocumentQueryDefinition`, `DocumentExportDefinition`, `MetricDefinition` live in the base `Granit.Documents` module.
 - ADR-040 — Three-tier metadata. `Document` and `Folder` ship with their own `EntityDefinition` (Tier A) for OData and admin UI exposure.


### PR DESCRIPTION
## Summary

Cloudflare Pages build (and \`npx astro build\`) failed on the link validator: ADR-052's cross-references section pointed at \`/dotnet/reference/modules/blob-storage\`, a legacy path that no longer exists in the docs tree. The current path is \`/dotnet/data/blob-storage/\`.

## Test plan

- [x] \`npx astro build\` from \`docs-site/\` — \"All internal links are valid.\" → 465 pages built.