### PR TITLE
feat(documents): trash list + permanent delete (F8.2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19576,6 +19576,24 @@
       ]
     },
     {
+      "name": "TrashedDocumentPage",
+      "fqn": "Granit.Documents.Domain.TrashedDocumentPage",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/TrashedDocumentPage.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TrashedDocumentRow",
+      "fqn": "Granit.Documents.Domain.TrashedDocumentRow",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/TrashedDocumentPage.cs",
+      "line": 17,
+      "members": []
+    },
+    {
       "name": "AppendVersionRequest",
       "fqn": "Granit.Documents.Endpoints.Documents.Dtos.AppendVersionRequest",
       "kind": "record",
@@ -19657,6 +19675,15 @@
       "members": []
     },
     {
+      "name": "ListTrashedDocumentsResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.ListTrashedDocumentsResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/TrashedDocumentResponse.cs",
+      "line": 24,
+      "members": []
+    },
+    {
       "name": "MoveDocumentRequest",
       "fqn": "Granit.Documents.Endpoints.Documents.Dtos.MoveDocumentRequest",
       "kind": "record",
@@ -19672,6 +19699,15 @@
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Documents/Dtos/RenameDocumentRequest.cs",
       "line": 18,
+      "members": []
+    },
+    {
+      "name": "TrashedDocumentResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.TrashedDocumentResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/TrashedDocumentResponse.cs",
+      "line": 15,
       "members": []
     },
     {
@@ -20018,6 +20054,15 @@
       "members": []
     },
     {
+      "name": "DocumentPermanentlyDeletedEvent",
+      "fqn": "Granit.Documents.Events.DocumentPermanentlyDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentPermanentlyDeletedEvent.cs",
+      "line": 18,
+      "members": []
+    },
+    {
       "name": "DocumentRenamedEvent",
       "fqn": "Granit.Documents.Events.DocumentRenamedEvent",
       "kind": "record",
@@ -20257,6 +20302,18 @@
           "kind": "method",
           "signature": "RestoreAsync(Guid id, CancellationToken cancellationToken = default)",
           "returnType": "Task<Document?>"
+        },
+        {
+          "name": "PermanentlyDeleteAsync",
+          "kind": "method",
+          "signature": "PermanentlyDeleteAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Document?>"
+        },
+        {
+          "name": "ListTrashedAsync",
+          "kind": "method",
+          "signature": "ListTrashedAsync(int skip, int take, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TrashedDocumentPage>"
         }
       ]
     },

--- a/src/Granit.Documents.Endpoints/Documents/Dtos/TrashedDocumentResponse.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Dtos/TrashedDocumentResponse.cs
@@ -1,0 +1,28 @@
+namespace Granit.Documents.Endpoints.Documents.Dtos;
+
+/// <summary>Wire-shape row in the F8.2 trash listing.</summary>
+/// <param name="Id">Document identifier.</param>
+/// <param name="FolderId">Folder the document was in when it was trashed.</param>
+/// <param name="Name">User-facing display name.</param>
+/// <param name="OwnerUserId">Document owner.</param>
+/// <param name="TrashedAt">UTC instant the document was sent to the trash.</param>
+/// <param name="DaysUntilPermanentDeletion">
+/// Number of whole days remaining before the empty-trash background job (F9.2)
+/// permanently deletes the row, derived from <see cref="TrashedAt"/> +
+/// <c>GranitDocumentsOptions.TrashRetentionDays</c>. Negative values are clamped at zero
+/// — past-due rows are awaiting the next cleanup run.
+/// </param>
+public sealed record TrashedDocumentResponse(
+    Guid Id,
+    Guid FolderId,
+    string Name,
+    Guid OwnerUserId,
+    DateTimeOffset TrashedAt,
+    int DaysUntilPermanentDeletion);
+
+/// <summary>Wire-shape response for <c>GET /documents/trash</c>.</summary>
+public sealed record ListTrashedDocumentsResponse(
+    IReadOnlyList<TrashedDocumentResponse> Documents,
+    long TotalCount,
+    int Skip,
+    int Take);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -1,15 +1,19 @@
 using Granit.BlobStorage;
+using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Dtos;
 using Granit.Documents.Endpoints.Documents.Mapping;
 using Granit.Documents.Endpoints.Permissions;
 using Granit.Documents.Exceptions;
+using Granit.Documents.Options;
+using Granit.Timing;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Documents.Endpoints.Documents.Endpoints;
 
@@ -89,6 +93,18 @@ internal static class DocumentEndpoints
                 "permission", DocumentsPermissions.Documents.Read))
             .Produces<ListDocumentVersionsResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
+
+        documents.MapGet("/trash", ListTrashedAsync)
+            .WithName("ListTrashedDocuments")
+            .WithSummary("Lists trashed documents for the current tenant (F8.2).")
+            .WithDescription(
+                "Returns a paged slice of trashed documents ordered by `TrashedAt` "
+                + "descending. Each row carries `daysUntilPermanentDeletion`, derived from "
+                + "the trash retention window (`GranitDocumentsOptions.TrashRetentionDays`, "
+                + "default 30 days). Defaults are `skip=0` and `take=50` (max 200).")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Read))
+            .Produces<ListTrashedDocumentsResponse>();
 
         documents.MapDocumentMutationEndpoints();
 
@@ -213,6 +229,39 @@ internal static class DocumentEndpoints
             statusCode: StatusCodes.Status403Forbidden,
             type: "https://granit.dev/problems/quota-exceeded",
             title: "Tenant storage quota exceeded");
+
+    private static async Task<Ok<ListTrashedDocumentsResponse>> ListTrashedAsync(
+        [FromServices] IDocumentService documents,
+        [FromServices] IClock clock,
+        [FromServices] IOptions<GranitDocumentsOptions> options,
+        CancellationToken cancellationToken,
+        [FromQuery] int? skip = null,
+        [FromQuery] int? take = null)
+    {
+        const int DefaultTake = 50;
+        const int MaxTake = 200;
+
+        int effectiveSkip = Math.Max(0, skip ?? 0);
+        int effectiveTake = Math.Clamp(take ?? DefaultTake, 1, MaxTake);
+
+        TrashedDocumentPage page = await documents
+            .ListTrashedAsync(effectiveSkip, effectiveTake, cancellationToken)
+            .ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        int retentionDays = options.Value.TrashRetentionDays;
+
+        TrashedDocumentResponse[] mapped = [.. page.Documents.Select(d =>
+        {
+            DateTimeOffset deletionAt = d.TrashedAt.AddDays(retentionDays);
+            int daysLeft = Math.Max(0, (int)Math.Ceiling((deletionAt - now).TotalDays));
+            return new TrashedDocumentResponse(
+                d.Id, d.FolderId, d.Name, d.OwnerUserId, d.TrashedAt, daysLeft);
+        })];
+
+        return TypedResults.Ok(new ListTrashedDocumentsResponse(
+            mapped, page.TotalCount, effectiveSkip, effectiveTake));
+    }
 
     private static async Task<Results<Ok<ListDocumentVersionsResponse>, ProblemHttpResult>> ListVersionsAsync(
         Guid id,

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
@@ -88,6 +88,22 @@ internal static class DocumentMutationEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
+        documents.MapDelete("/{id:guid}/permanent", PermanentlyDeleteAsync)
+            .WithName("PermanentlyDeleteDocument")
+            .WithSummary("Permanently deletes a trashed document (F8.2).")
+            .WithDescription(
+                "Soft-deletes every version's `BlobDescriptor` (the bytes are removed; "
+                + "the audit row is retained per `Granit.BlobStorage`'s 3-year retention), "
+                + "decrements the tenant's storage quota by the released bytes, and "
+                + "promotes the document to `Status = PermanentlyDeleted` (tombstone for "
+                + "the GDPR / ISO 27001 audit trail). Emits `DocumentPermanentlyDeletedEvent`. "
+                + "Returns 204 on success, 404 when the document is missing or not "
+                + "currently trashed.")
+            .RequireAuthorization(p => p.RequireClaim(
+                "permission", DocumentsPermissions.Documents.Manage))
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return documents;
     }
 
@@ -208,6 +224,23 @@ internal static class DocumentMutationEndpoints
         {
             return TypedResults.Problem(ex.Message, statusCode: StatusCodes.Status409Conflict);
         }
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> PermanentlyDeleteAsync(
+        Guid id,
+        [FromServices] IDocumentService documents,
+        CancellationToken cancellationToken)
+    {
+        Document? document = await documents
+            .PermanentlyDeleteAsync(id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null)
+        {
+            return TypedResults.Problem(
+                $"Document '{id}' was not found or is not currently trashed.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        return TypedResults.NoContent();
     }
 
     private static async Task<Results<Ok<DocumentResponse>, ProblemHttpResult>> RestoreAsync(

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -652,4 +652,90 @@ internal sealed class DocumentService(
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return document;
     }
+
+    /// <inheritdoc />
+    public async Task<Document?> PermanentlyDeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Document? document = await context.Documents
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (document is null || document.Status != DocumentStatus.Trashed)
+        {
+            return null;
+        }
+
+        // Snapshot every version before mutation — soft-delete each blob via
+        // BlobStorage, sum the bytes for the quota release.
+        List<DocumentVersion> versions = await context.DocumentVersions
+            .Where(v => v.DocumentId == document.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        long releasedBytes = versions.Sum(v => v.SizeBytes);
+
+        foreach (DocumentVersion version in versions)
+        {
+            // BlobStorage.DeleteAsync transitions the descriptor to Deleted and physically
+            // removes the S3 object; the audit row is retained per BlobStorage's own
+            // retention policy. Idempotent: re-running is a no-op on already-deleted blobs.
+            await blobStorage
+                .DeleteAsync(
+                    ContainerName,
+                    version.BlobDescriptorId,
+                    deletionReason: $"Granit.Documents permanent delete of document {document.Id}",
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        document.PermanentlyDelete(releasedBytes, clock.Now);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (releasedBytes > 0 && currentTenant.IsAvailable && currentTenant.Id is { } tid)
+        {
+            await quotas.DecrementAsync(tid, releasedBytes, cancellationToken).ConfigureAwait(false);
+        }
+
+        return document;
+    }
+
+    /// <inheritdoc />
+    public async Task<TrashedDocumentPage> ListTrashedAsync(
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        IQueryable<Document> query = context.Documents
+            .Where(d => d.Status == DocumentStatus.Trashed);
+
+        long totalCount = await query.LongCountAsync(cancellationToken).ConfigureAwait(false);
+
+        // Materialise the trashed set then sort + page in memory: SQLite cannot translate
+        // ORDER BY on DateTimeOffset, and the trashed set is bounded by the retention
+        // window so the in-memory cost is negligible. Postgres would happily sort the
+        // DateTimeOffset directly, but keeping the pipeline provider-agnostic avoids a
+        // fork in the service for what is fundamentally a trash bin (not a hot path).
+        List<TrashedDocumentRow> all = await query
+            .Select(d => new TrashedDocumentRow(
+                d.Id, d.FolderId, d.Name, d.OwnerUserId, d.TrashedAt!.Value))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<TrashedDocumentRow> rows = [.. all
+            .OrderByDescending(r => r.TrashedAt)
+            .ThenBy(r => r.Id)
+            .Skip(skip)
+            .Take(take)];
+
+        return new TrashedDocumentPage(rows, totalCount);
+    }
 }

--- a/src/Granit.Documents/Domain/Document.cs
+++ b/src/Granit.Documents/Domain/Document.cs
@@ -248,6 +248,34 @@ public sealed class Document : AggregateRoot, IMultiTenant, IEmitEntityLifecycle
         AddDomainEvent(new DocumentRestoredEvent(Id, TenantId));
     }
 
+    /// <summary>
+    /// Promotes a trashed document to <see cref="DocumentStatus.PermanentlyDeleted"/>
+    /// (F8.2). The aggregate row stays for the GDPR / ISO 27001 audit trail; the bytes
+    /// are transitioned to <c>BlobStatus.Deleted</c> by the service layer.
+    /// </summary>
+    /// <param name="releasedBytes">
+    /// Sum of <see cref="DocumentVersion.SizeBytes"/> released by this deletion — used by
+    /// the emitted <see cref="DocumentPermanentlyDeletedEvent"/> to drive the F7 quota
+    /// decrement downstream consumers may want to react to.
+    /// </param>
+    /// <param name="deletedAt">UTC instant the deletion is recorded.</param>
+    /// <exception cref="InvalidOperationException">
+    /// When the document is not currently trashed (only trashed documents can be
+    /// permanently deleted; active documents must be trashed first).
+    /// </exception>
+    public void PermanentlyDelete(long releasedBytes, DateTimeOffset deletedAt)
+    {
+        if (Status != DocumentStatus.Trashed)
+        {
+            throw new InvalidOperationException(
+                $"Document {Id} cannot be permanently deleted (status: {Status}). Trash it first.");
+        }
+
+        Status = DocumentStatus.PermanentlyDeleted;
+        RowVersion++;
+        AddDomainEvent(new DocumentPermanentlyDeletedEvent(Id, TenantId, deletedAt, releasedBytes));
+    }
+
     private void ThrowIfNotActive(string operation)
     {
         if (Status != DocumentStatus.Active)

--- a/src/Granit.Documents/Domain/TrashedDocumentPage.cs
+++ b/src/Granit.Documents/Domain/TrashedDocumentPage.cs
@@ -1,0 +1,22 @@
+namespace Granit.Documents.Domain;
+
+/// <summary>
+/// Paged slice of trashed documents returned by
+/// <see cref="IDocumentService.ListTrashedAsync"/> (F8.2). Carries a snapshot of every row
+/// the endpoint exposes including <see cref="TrashedAt"/> so the response can compute the
+/// retention countdown.
+/// </summary>
+public sealed record TrashedDocumentPage(
+    IReadOnlyList<TrashedDocumentRow> Documents,
+    long TotalCount);
+
+/// <summary>
+/// Domain-level row for a trashed document — the API DTO maps over this and adds the
+/// computed <c>daysUntilPermanentDeletion</c>.
+/// </summary>
+public sealed record TrashedDocumentRow(
+    Guid Id,
+    Guid FolderId,
+    string Name,
+    Guid OwnerUserId,
+    DateTimeOffset TrashedAt);

--- a/src/Granit.Documents/Events/DocumentPermanentlyDeletedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentPermanentlyDeletedEvent.cs
@@ -1,0 +1,22 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a trashed <c>Document</c> is permanently deleted (F8.2). The aggregate row
+/// stays as a tombstone (<c>Status = PermanentlyDeleted</c>) for the GDPR / ISO 27001
+/// audit trail; the bytes have been transitioned to <c>BlobStatus.Deleted</c> via
+/// <c>BlobStorage</c>.
+/// </summary>
+/// <param name="DocumentId">Identifier of the document that was permanently deleted.</param>
+/// <param name="TenantId">Identifier of the tenant the document belonged to.</param>
+/// <param name="DeletedAt">UTC instant the permanent deletion was recorded.</param>
+/// <param name="ReleasedBytes">
+/// Sum of <c>DocumentVersion.SizeBytes</c> across the document's active versions, decremented
+/// from the tenant's storage quota by the same operation.
+/// </param>
+public sealed record DocumentPermanentlyDeletedEvent(
+    Guid DocumentId,
+    Guid? TenantId,
+    DateTimeOffset DeletedAt,
+    long ReleasedBytes) : IDomainEvent;

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -157,4 +157,23 @@ public interface IDocumentService
     /// folder is itself trashed (callers must restore the folder first).
     /// </summary>
     Task<Document?> RestoreAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently deletes a trashed document (F8.2). Soft-deletes every
+    /// <c>DocumentVersion</c>'s <c>BlobDescriptor</c> through
+    /// <see cref="IBlobStorage.DeleteAsync"/> (the bytes are removed; the audit row
+    /// stays for the configured retention), decrements the tenant's storage quota, and
+    /// promotes the document to <c>Status = PermanentlyDeleted</c>. Returns the deleted
+    /// aggregate, or <c>null</c> when not found / not trashed.
+    /// </summary>
+    Task<Document?> PermanentlyDeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a paged slice of the tenant's trashed documents (F8.2), ordered by
+    /// <c>TrashedAt</c> descending so the most recently trashed appear first.
+    /// </summary>
+    Task<TrashedDocumentPage> ListTrashedAsync(
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/PermanentDeletePostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/PermanentDeletePostgresTests.cs
@@ -1,0 +1,141 @@
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.Documents;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Options;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Postgres-backed verification of the F8.2 permanent-delete + trash-list flow on top
+/// of the real ITenantQuotaService. The IBlobStorage dependency stays substituted —
+/// we're pinning the EF Core / quota interaction, not the cloud-side delete.
+/// </summary>
+public sealed class PermanentDeletePostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private DocumentService _sut = null!;
+    private TenantQuotaService _quotas = null!;
+    private IBlobStorage _blobStorage = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public PermanentDeletePostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_folders, documents_documents, documents_document_versions, documents_tenant_storage_quotas RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        IOptions<GranitDocumentsOptions> opts = Microsoft.Extensions.Options.Options.Create(
+            new GranitDocumentsOptions { DefaultTenantQuotaBytes = 5L * 1024L * 1024L * 1024L });
+
+        _quotas = new TenantQuotaService(_factory, new SimpleGuidGenerator(), clock, opts);
+
+        _blobStorage = Substitute.For<IBlobStorage>();
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => BlobDescriptor.Create(
+                (Guid)ci[1], TenantId, DocumentService.ContainerName,
+                $"docs/{(Guid)ci[1]:N}",
+                new BlobUploadRequest("f.pdf", "application/pdf", 1_000_000),
+                DateTimeOffset.UtcNow));
+        _blobStorage.ConfirmUploadAsync(
+                DocumentService.ContainerName, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "application/pdf",
+                SizeBytes: 4096, RejectionReason: null));
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        ILocalEventBus localEventBus = Substitute.For<ILocalEventBus>();
+
+        _sut = new DocumentService(
+            _factory, bootstrap, _blobStorage, currentTenant,
+            new SimpleGuidGenerator(), clock, localEventBus, metrics, _quotas);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task PermanentlyDeleteAsync_TrashedDocument_DeletesBlob_DecrementsQuota_OnPostgres()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+
+        // Upload (FinalizeUpload reserves+releases through the real quota service) →
+        // trash → permanent delete.
+        Document doc = await _sut.FinalizeUploadAsync(
+            Guid.NewGuid(), folderId: null, OwnerId, "F.pdf", null, null, ct);
+        TenantStorageQuota? afterUpload = await _quotas.GetAsync(TenantId, ct);
+        afterUpload.ShouldNotBeNull();
+        afterUpload.UsageBytes.ShouldBe(4096);
+
+        await _sut.TrashAsync(doc.Id, ct);
+        await _sut.PermanentlyDeleteAsync(doc.Id, ct);
+
+        // Quota fully released back to zero.
+        TenantStorageQuota? afterDelete = await _quotas.GetAsync(TenantId, ct);
+        afterDelete.ShouldNotBeNull();
+        afterDelete.UsageBytes.ShouldBe(0);
+
+        // Blob descriptor delete propagated.
+        await _blobStorage.Received(1).DeleteAsync(
+            DocumentService.ContainerName,
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            ct);
+
+        // Document row stays as a tombstone.
+        await using DocumentsDbContext db = await _factory.CreateDbContextAsync(ct);
+        Document tombstone = await db.Documents.SingleAsync(d => d.Id == doc.Id, ct);
+        tombstone.Status.ShouldBe(DocumentStatus.PermanentlyDeleted);
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+}

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Internal/DocumentServiceSqliteTests.cs
@@ -127,7 +127,7 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
                 IsValid: true,
                 Status: BlobStatus.Valid,
                 VerifiedContentType: "application/pdf",
-                SizeBytes: 1_234_567,
+                SizeBytes: 100,
                 RejectionReason: null));
 
         Document doc = await _sut.FinalizeUploadAsync(
@@ -147,7 +147,7 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
             .SingleAsync(v => v.DocumentId == doc.Id, TestContext.Current.CancellationToken);
         version.VersionNumber.ShouldBe(1);
         version.BlobDescriptorId.ShouldBe(blobId);
-        version.SizeBytes.ShouldBe(1_234_567);
+        version.SizeBytes.ShouldBe(100);
         version.ContentType.ShouldBe("application/pdf");
         version.CommitMessage.ShouldBe("Initial");
         version.Id.ShouldBe(doc.CurrentVersionId!.Value);
@@ -672,6 +672,96 @@ public sealed class DocumentServiceSqliteTests : IAsyncLifetime
             TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PermanentlyDeleteAsync_Trashed_DeletesBlobs_DecrementsQuota_PromotesStatus()
+    {
+        // Seed via FinalizeUpload (single version, 100 bytes) → trash → permanent delete.
+        Document seeded = await SeedDocumentAsync();
+        await using DocumentsDbContext lookupDb = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Guid blobId = (await lookupDb.DocumentVersions
+                .SingleAsync(v => v.DocumentId == seeded.Id, TestContext.Current.CancellationToken))
+            .BlobDescriptorId;
+        await _sut.TrashAsync(seeded.Id, TestContext.Current.CancellationToken);
+
+        // Track the quota decrement + blob delete by re-wiring substitutes locally.
+        ITenantQuotaService quotas = Substitute.For<ITenantQuotaService>();
+        quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(true);
+        tenant.Id.Returns(TenantId);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        var sut = new DocumentService(
+            _factory, _bootstrap, _blobStorage, tenant,
+            new SimpleGuidGenerator(), clock, _localEventBus, metrics, quotas);
+
+        Document? deleted = await sut.PermanentlyDeleteAsync(
+            seeded.Id, TestContext.Current.CancellationToken);
+
+        deleted.ShouldNotBeNull();
+        deleted.Status.ShouldBe(DocumentStatus.PermanentlyDeleted);
+
+        // Blob delete propagated through to BlobStorage.DeleteAsync.
+        await _blobStorage.Received(1).DeleteAsync(
+            DocumentService.ContainerName,
+            blobId,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+
+        // Quota decrement matches the version's SizeBytes (100 from SeedDocumentAsync).
+        await quotas.Received(1).DecrementAsync(TenantId, 100, Arg.Any<CancellationToken>());
+
+        // The aggregate event is asserted at domain level — emission of domain events
+        // through the local bus depends on the SaveChanges interceptor wiring which is
+        // out of scope for this unit slice (covered by the Folder domain tests). The
+        // service-level assertions above (status promotion + blob delete + quota
+        // decrement) are the F8.2 behavioural surface.
+        _ = seeded;
+    }
+
+    [Fact]
+    public async Task PermanentlyDeleteAsync_Active_ReturnsNull()
+    {
+        // Active document — not trashed → service returns null without touching blobs.
+        Document seeded = await SeedDocumentAsync();
+
+        Document? result = await _sut.PermanentlyDeleteAsync(
+            seeded.Id, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await _blobStorage.DidNotReceive().DeleteAsync(
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListTrashedAsync_OrdersByTrashedAtDescending_AndPages()
+    {
+        Document a = await SeedDocumentAsync(name: "a.pdf");
+        Document b = await SeedDocumentAsync(name: "b.pdf");
+        Document c = await SeedDocumentAsync(name: "c.pdf");
+        await _sut.TrashAsync(a.Id, TestContext.Current.CancellationToken);
+        await _sut.TrashAsync(b.Id, TestContext.Current.CancellationToken);
+        await _sut.TrashAsync(c.Id, TestContext.Current.CancellationToken);
+
+        TrashedDocumentPage page = await _sut.ListTrashedAsync(
+            skip: 0, take: 2, TestContext.Current.CancellationToken);
+
+        page.TotalCount.ShouldBe(3);
+        page.Documents.Count.ShouldBe(2);
+        // SQLite stores DateTimeOffset as text — order-by-desc on identical timestamps
+        // falls back to the secondary order key (Id), so we don't pin which two come back
+        // beyond their count + the total.
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Documents.Tests/Domain/DocumentTests.cs
+++ b/tests/Granit.Documents.Tests/Domain/DocumentTests.cs
@@ -293,4 +293,47 @@ public sealed class DocumentTests
 
         Should.Throw<InvalidOperationException>(() => doc.Restore());
     }
+
+    [Fact]
+    public void PermanentlyDelete_FromTrash_BecomesTombstone_AndEmitsEvent()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        doc.Trash(now);
+
+        doc.PermanentlyDelete(releasedBytes: 4096, deletedAt: now.AddSeconds(1));
+
+        doc.Status.ShouldBe(DocumentStatus.PermanentlyDeleted);
+        Granit.Documents.Events.DocumentPermanentlyDeletedEvent ev = doc.DomainEvents
+            .OfType<Granit.Documents.Events.DocumentPermanentlyDeletedEvent>()
+            .ShouldHaveSingleItem();
+        ev.ReleasedBytes.ShouldBe(4096);
+        ev.DeletedAt.ShouldBe(now.AddSeconds(1));
+    }
+
+    [Fact]
+    public void PermanentlyDelete_Active_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+
+        Should.Throw<InvalidOperationException>(() =>
+            doc.PermanentlyDelete(0, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void PermanentlyDelete_AlreadyPermanentlyDeleted_Throws()
+    {
+        Folder root = NewRoot();
+        Folder folder = NewFolder(root, "F");
+        var doc = Document.Create(Guid.NewGuid(), folder, OwnerId, "F.pdf");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        doc.Trash(now);
+        doc.PermanentlyDelete(0, now);
+
+        Should.Throw<InvalidOperationException>(() => doc.PermanentlyDelete(0, now));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1756 — F8.2: trash listing + permanent delete with quota release and blob soft-delete.

- **`GET /api/v1/documents/trash`** — paged listing of trashed documents for the calling tenant. Each row carries `daysUntilPermanentDeletion` derived from `TrashedAt + GranitDocumentsOptions.TrashRetentionDays` so the UI renders the retention countdown without re-deriving it. Default page size 50 (max 200) — matches the versions list endpoint convention.
- **`DELETE /api/v1/documents/{id}/permanent`** — admin-only hard delete. Soft-deletes every version's `BlobDescriptor` through `IBlobStorage.DeleteAsync` (the S3 object is removed; the audit row stays per BlobStorage's 3-year retention), decrements the tenant's storage quota by the released bytes, and promotes the document to `Status = PermanentlyDeleted` as a tombstone for the GDPR / ISO 27001 audit trail.
- **`Document.PermanentlyDelete`** domain method emits the new `DocumentPermanentlyDeletedEvent` (carries `ReleasedBytes`). Mirrors the F8.1 trashed-only guard semantics.
- **`IDocumentService.PermanentlyDeleteAsync`** + **`ListTrashedAsync`** (paged). `ListTrashedAsync` materialises the bounded set then sorts / pages in memory — SQLite cannot translate `ORDER BY` on `DateTimeOffset` and the trash bin is small enough to make this provider-agnostic without a fork.

## Acceptance criteria (#1756)

- [x] Trash list endpoint paged, includes `daysUntilPermanentDeletion`.
- [x] Permanent delete endpoint with `Documents.Documents.Manage` permission.
- [x] Permanent delete emits `DocumentPermanentlyDeletedEvent`, decrements quota, soft-deletes the BlobDescriptor (per BlobStorage's 3-year retention policy).
- [x] Integration tests (Postgres end-to-end + SQLite unit slices).

## Test plan

- [x] `dotnet test tests/Granit.Documents.Tests` — 88/88 (3 new domain tests on `Document.PermanentlyDelete`).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests` — 108/108 (3 new SQLite service tests).
- [x] `dotnet test tests/Granit.Documents.EntityFrameworkCore.Tests.Integration` — 25/25 (1 new Postgres test pinning end-to-end quota release).
- [x] `dotnet test tests/Granit.Documents.Endpoints.Tests` — 61/61.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 212/212.
- [x] `dotnet format style` clean on touched projects.