### PR TITLE
docs(blog): three new articles for May 2026

### DIFF
--- a/docs-site/src/content/docs/blog/5-ef-core-mistakes-that-kill-performance.md
+++ b/docs-site/src/content/docs/blog/5-ef-core-mistakes-that-kill-performance.md
@@ -1,0 +1,203 @@
+---
+title: "5 EF Core Mistakes That Kill Performance (and How to Fix Them)"
+date: 2026-05-03
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - persistence
+  - performance
+description: "From accidental client evaluation to N+1 queries and tracked reads, these are the five EF Core anti-patterns that turn 50 ms endpoints into 5-second ones — and the exact fix for each."
+excerpt: >
+  From accidental client evaluation to N+1 queries and tracked reads, these are
+  the five EF Core anti-patterns that turn 50 ms endpoints into 5-second ones —
+  and the exact fix for each.
+---
+
+EF Core 10 is fast. The framework rewrites your LINQ into solid SQL, batches inserts, and ships query splitting out of the box. None of that helps if your code asks it to do the wrong thing. Ninety percent of the "EF Core is slow" tickets I see are five mistakes repeated under different names.
+
+Here they are, with the diagnostic and the fix.
+
+## 1. Returning a `List<T>` from a query that should stream
+
+```csharp title="ExportEndpoint.cs — Bad"
+var invoices = await db.Invoices
+    .Where(i => i.TenantId == tenantId)
+    .ToListAsync(ct); // 250k rows materialized into memory
+
+foreach (var invoice in invoices)
+{
+    await writer.WriteAsync(invoice, ct);
+}
+```
+
+`ToListAsync()` allocates the entire result set, plus change-tracker entries, plus navigation graph stubs. On a CSV export of 250k rows you've just moved 400 MB through GC for no reason.
+
+```csharp title="ExportEndpoint.cs — Good"
+var stream = db.Invoices
+    .AsNoTracking()
+    .Where(i => i.TenantId == tenantId)
+    .AsAsyncEnumerable();
+
+await foreach (var invoice in stream.WithCancellation(ct))
+{
+    await writer.WriteAsync(invoice, ct);
+}
+```
+
+`AsAsyncEnumerable()` reads rows from the open `DbDataReader` one at a time. Memory stays flat regardless of result size. Add `AsNoTracking()` because you are not modifying anything — that alone removes the change-tracker overhead.
+
+**Rule of thumb:** if the result set could plausibly grow past a few thousand rows, stream it. `ToListAsync()` is for known-bounded sets.
+
+## 2. Tracked queries on read paths
+
+```csharp title="GetInvoice.cs — Bad"
+var invoice = await db.Invoices
+    .Include(i => i.Lines)
+    .FirstOrDefaultAsync(i => i.Id == id, ct);
+
+return invoice is null
+    ? Results.NotFound()
+    : Results.Ok(invoice.ToResponse());
+```
+
+EF Core tracked the entity, hashed each property into the change tracker, and built navigation fixups. You then projected to a response and threw the entity away. Pure waste.
+
+```csharp title="GetInvoice.cs — Good"
+var response = await db.Invoices
+    .AsNoTracking()
+    .Where(i => i.Id == id)
+    .Select(i => new InvoiceResponse(
+        i.Id,
+        i.Number,
+        i.IssuedAt,
+        i.Lines.Select(l => new LineResponse(l.Description, l.Amount)).ToList()))
+    .FirstOrDefaultAsync(ct);
+
+return response is null ? Results.NotFound() : Results.Ok(response);
+```
+
+Two wins:
+
+- `AsNoTracking()` skips change tracking entirely — measurably cheaper on hot paths.
+- `Select` projection generates a single SQL statement that reads only the columns the response needs. The `Include` you removed was returning 25 columns you never used.
+
+Granit nudges you toward this with the [`Never return EF entities`](/blog/never-return-ef-entities/) rule. The performance gain is real; the API contract benefit is bigger.
+
+## 3. The N+1 hidden behind a `foreach`
+
+```csharp title="OrderListEndpoint.cs — Bad"
+var orders = await db.Orders.ToListAsync(ct);
+
+foreach (var order in orders)
+{
+    order.LatestPaymentStatus = await db.Payments
+        .Where(p => p.OrderId == order.Id)
+        .OrderByDescending(p => p.PaidAt)
+        .Select(p => p.Status)
+        .FirstOrDefaultAsync(ct); // One query per order — N+1
+}
+```
+
+This pattern hides in services, mappers, and AutoMapper post-processors. With 500 orders you fire 501 SQL round trips. Database CPU is fine; your app waits on network latency 500 times.
+
+```csharp title="OrderListEndpoint.cs — Good"
+var orders = await db.Orders
+    .AsNoTracking()
+    .Select(o => new OrderResponse(
+        o.Id,
+        o.Number,
+        o.Payments
+            .OrderByDescending(p => p.PaidAt)
+            .Select(p => p.Status)
+            .FirstOrDefault()))
+    .ToListAsync(ct);
+```
+
+One query. EF Core translates the inner `Select`/`OrderByDescending`/`FirstOrDefault` into a correlated subquery (or a window function on PostgreSQL). The execution plan is the database's job, not yours.
+
+**Diagnostic:** turn on `QueryDiagnosticsBehavior` or `LogTo(Console.WriteLine, LogLevel.Information)` in dev. Any time you see the same parameterized query repeat with different IDs, you have an N+1.
+
+## 4. Accidentally evaluating filters in C\#
+
+```csharp title="UserSearch.cs — Bad"
+var matches = await db.Users
+    .Where(u => NormalizeEmail(u.Email) == NormalizeEmail(query)) // Client eval!
+    .ToListAsync(ct);
+```
+
+`NormalizeEmail` is a C# method. EF Core cannot translate it to SQL, so on EF Core 3+ this throws `InvalidOperationException: could not be translated`. Many teams "fix" it by calling `.AsEnumerable()` first — which silently pulls **the entire `Users` table** into memory and runs the filter in C#.
+
+```csharp title="UserSearch.cs — Good"
+var normalized = NormalizeEmail(query);
+
+var matches = await db.Users
+    .Where(u => u.NormalizedEmail == normalized) // Server-side, indexed
+    .AsNoTracking()
+    .ToListAsync(ct);
+```
+
+Two practical fixes:
+
+- **Persist the normalized form.** Add a `NormalizedEmail` column, populate it on save, index it. Filter on the column.
+- **Or use a translatable function.** `EF.Functions.Like`, `EF.Functions.ILike`, `string.StartsWith` are all translated. Custom methods are not.
+
+If you must transform user input, do it once outside the query and pass the result as a parameter — never inside the lambda.
+
+## 5. `SaveChangesAsync` in a loop
+
+```csharp title="ImportJob.cs — Bad"
+foreach (var row in csvRows)
+{
+    db.Invoices.Add(MapToInvoice(row));
+    await db.SaveChangesAsync(ct); // 50,000 round trips
+}
+```
+
+Every `SaveChangesAsync` is a transaction commit. On 50k rows you have 50k commits, 50k flushes, and 50k WAL writes. The slow part is not EF Core — it's Postgres durability.
+
+```csharp title="ImportJob.cs — Good"
+const int batchSize = 1000;
+
+for (int i = 0; i < csvRows.Count; i += batchSize)
+{
+    var batch = csvRows.Skip(i).Take(batchSize).Select(MapToInvoice);
+    db.Invoices.AddRange(batch);
+    await db.SaveChangesAsync(ct);
+    db.ChangeTracker.Clear(); // Drop tracked entities before next batch
+}
+```
+
+Three details:
+
+- **Batch.** EF Core 10 already groups inserts into multi-row `INSERT` statements when the provider supports it. One `SaveChangesAsync` per 1000 rows commits one transaction per 1000 rows.
+- **Clear the tracker.** Without it the change tracker grows unbounded across batches; performance degrades quadratically as it scans more entries on each save.
+- **For 100k+ rows, skip EF Core.** Use `COPY` (Npgsql), `SqlBulkCopy` (SQL Server), or a dedicated bulk insert library. EF Core is for typed CRUD, not ETL.
+
+## Bonus: measure before you change anything
+
+EF Core ships diagnostics. Use them:
+
+```csharp
+optionsBuilder.LogTo(
+    Console.WriteLine,
+    [DbLoggerCategory.Database.Command.Name],
+    LogLevel.Information);
+```
+
+Or hook OpenTelemetry: `Npgsql.NpgsqlActivitySource` and `Microsoft.EntityFrameworkCore` traces show every command, parameter set, and duration. You will spot a tracked-read and an N+1 in five minutes of looking at a real trace.
+
+## Key takeaways
+
+- **Stream large reads** with `AsAsyncEnumerable()` instead of materializing with `ToListAsync()`.
+- **Project to response records** with `AsNoTracking()` — skip both change tracking and over-fetching.
+- **Watch for N+1** in any `foreach` that hits the database; collapse into one query with subqueries or projections.
+- **Never client-evaluate filters.** Persist normalized columns or use translatable EF functions.
+- **Batch and clear** when bulk-inserting; for ETL workloads bypass EF Core entirely.
+
+## Further reading
+
+- [Persistence overview](/dotnet/data/persistence/)
+- [Isolated DbContext per module](/blog/isolated-dbcontext-per-module/)
+- [Never return your EF entities from an API](/blog/never-return-ef-entities/)
+- [Don't mock the database — use Testcontainers](/blog/dont-mock-the-database-use-testcontainers/)

--- a/docs-site/src/content/docs/blog/adding-authentication-with-keycloak-in-granit.mdx
+++ b/docs-site/src/content/docs/blog/adding-authentication-with-keycloak-in-granit.mdx
@@ -1,0 +1,228 @@
+---
+title: "Adding Authentication with Keycloak in Granit"
+date: 2026-05-06
+authors:
+  - jfmeyers
+tags:
+  - tutorial
+  - security
+  - api
+description: "Wire Keycloak JWT Bearer authentication into a Granit API in five minutes — claims transformation, role mapping, back-channel logout, and an Admin authorization policy, all from one DependsOn."
+excerpt: >
+  Wire Keycloak JWT Bearer authentication into a Granit API in five minutes —
+  claims transformation, role mapping, back-channel logout, and an Admin
+  authorization policy, all from one DependsOn.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Keycloak is the default open-source identity provider for self-hosted .NET deployments. The JWT structure it issues, however, does not look like an ASP.NET Core developer expects: roles live in `realm_access.roles` or `resource_access.{client}.roles`, never in the `role` claim. The `name` claim is the human-readable display name, not a stable identifier. Without translation, `[Authorize(Roles = "admin")]` returns 403 even with a valid admin token.
+
+`Granit.Authentication.JwtBearer.Keycloak` is the thin module that handles this. One `[DependsOn]`, one config block — JWT validation, claims transformation, back-channel logout, and an `Admin` policy all wire up. This article walks through the full setup.
+
+## What you get
+
+- **JWT Bearer validation** against your Keycloak realm's discovery document.
+- **Claims transformation** — `realm_access.roles` and `resource_access.{ClientId}.roles` mapped to `ClaimTypes.Role` so `[Authorize(Roles = "admin")]` works.
+- **NameClaimType = `preferred_username`** — `User.Identity.Name` returns the Keycloak username instead of the GUID `sub`.
+- **Back-channel logout** — when a session is revoked at Keycloak, your API rejects the token immediately.
+- **Pluggable role source** — switch between realm and client roles via a single config key.
+
+## The Keycloak side
+
+You need three things in your realm:
+
+1. A **client** for your API (`my-backend` in the examples below). Set `Access Type: confidential` if you'll need a client secret, otherwise `bearer-only`.
+2. The **realm or client roles** your API will check (`admin`, `doctor`, `support`...).
+3. **Role assignments** for your test users.
+
+If you also have a public client (SPA, mobile app), configure it separately to obtain tokens — the API itself only validates them.
+
+## Wire it into your Granit module
+
+```csharp title="AppModule.cs"
+[DependsOn(typeof(GranitAuthenticationJwtBearerKeycloakModule))]
+public sealed class AppModule : GranitModule
+{
+    public override void OnApplicationInitialization(
+        ApplicationInitializationContext context)
+    {
+        context.App.UseAuthentication();
+        context.App.UseAuthorization();
+
+        // Optional: enables OIDC back-channel logout
+        context.App.MapGranitBackChannelLogout();
+    }
+}
+```
+
+That is the entire C# setup. The module declares `[DependsOn(GranitAuthenticationJwtBearerModule)]` itself, so the generic JWT Bearer middleware is registered transitively.
+
+## Configure the realm
+
+```json title="appsettings.json"
+{
+  "Authentication": {
+    "Authority": "https://keycloak.example.com/realms/clinic",
+    "Audience": "my-backend",
+    "RequireHttpsMetadata": true,
+    "BackChannelLogout": {
+      "Enabled": true,
+      "EndpointPath": "/auth/back-channel-logout",
+      "SessionRevocationTtl": "01:00:00"
+    }
+  },
+  "Keycloak": {
+    "Authority": "https://keycloak.example.com/realms/clinic",
+    "ClientId": "my-backend",
+    "RoleClaimsSource": "realm_access"
+  }
+}
+```
+
+The `Keycloak` section overrides the generic JWT Bearer values via `PostConfigure<JwtBearerOptions>`. You can keep both blocks or set everything under `Keycloak` — the module reads from there at resolution time.
+
+| Key                    | Purpose                                                |
+| ---------------------- | ------------------------------------------------------ |
+| `Authority`            | OIDC issuer URL — the realm endpoint                   |
+| `ClientId`             | Keycloak client name — defaults the audience           |
+| `Audience`             | Expected `aud` claim (defaults to `ClientId`)          |
+| `RoleClaimsSource`     | `realm_access` (default) or `resource_access`          |
+| `RequireHttpsMetadata` | Set to `false` only for local dev with HTTP Keycloak   |
+
+:::caution
+Never store `ClientSecret` in plain text. Granit integrates with HashiCorp Vault and AWS Secrets Manager — point the value at a secret reference (`vault:secret/data/keycloak#client-secret`) and let the configuration layer resolve it at startup.
+:::
+
+## What the claims transformation does
+
+A typical Keycloak access token payload looks like this:
+
+```json
+{
+  "sub": "8f45a91b-3c12-4f6d-a5e0-3c9c1e1f0a44",
+  "preferred_username": "alice@clinic.example.com",
+  "realm_access": {
+    "roles": ["admin", "doctor"]
+  },
+  "resource_access": {
+    "my-backend": {
+      "roles": ["manage-patients"]
+    }
+  }
+}
+```
+
+`KeycloakClaimsTransformation` runs on every authenticated request. It reads the JSON `realm_access.roles` array (or `resource_access.{ClientId}.roles` if you set `RoleClaimsSource = "resource_access"`) and emits one `ClaimTypes.Role` per entry:
+
+```csharp
+// After transformation, the principal carries:
+new Claim(ClaimTypes.Role, "admin")
+new Claim(ClaimTypes.Role, "doctor")
+new Claim(ClaimTypes.Role, "manage-patients") // if RoleClaimsSource = resource_access
+```
+
+The standard ASP.NET Core authorization stack now works:
+
+```csharp title="PatientEndpoints.cs"
+patients.MapGet("/", ListPatientsAsync)
+    .RequireAuthorization() // Any authenticated user
+    .WithName("ListPatients");
+
+patients.MapDelete("/{id:guid}", DeletePatientAsync)
+    .RequireAuthorization(policy => policy.RequireRole("admin"))
+    .WithName("DeletePatient");
+```
+
+## Realm roles vs client roles — which to use?
+
+| Source            | When                                                              | Trade-off                                                    |
+| ----------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| `realm_access`    | Roles meaningful across the whole realm (e.g. `admin`, `support`) | Simpler, but every API in the realm sees the same role names |
+| `resource_access` | Roles scoped to one API (e.g. `manage-patients` on `my-backend`)  | Better isolation, more administrative work in Keycloak       |
+
+For multi-API realms, **prefer `resource_access`**. It scopes role names to your client, so a `manage-patients` role on the clinic API does not collide with a `manage-patients` role on a billing API.
+
+## Reading the current user
+
+`Granit.Authentication.JwtBearer` registers `ICurrentUserService` — a clean abstraction over `IHttpContextAccessor` that you inject anywhere:
+
+```csharp title="AuditService.cs"
+public class AuditService(ICurrentUserService currentUser, IClock clock)
+{
+    public AuditEntry Capture(string action)
+    {
+        return new AuditEntry
+        {
+            UserId = currentUser.UserId,           // sub claim
+            UserName = currentUser.UserName,        // preferred_username
+            Roles = currentUser.Roles.ToArray(),    // ClaimTypes.Role values
+            OccurredAt = clock.Now,
+            Action = action,
+        };
+    }
+}
+```
+
+Tests substitute `ICurrentUserService` with a fake — no `HttpContext` plumbing.
+
+## Back-channel logout — closing the gap
+
+Token expiry is not enough. If an admin revokes a user at the Keycloak admin console, that user's token remains valid until it expires, sometimes 30 minutes later. For regulated environments (healthcare, finance), that gap is unacceptable.
+
+OIDC defines [back-channel logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) for exactly this. Keycloak POSTs a signed logout token to your API; you record the revoked session in distributed cache and reject any subsequent token bound to it.
+
+Granit ships the endpoint and the validation:
+
+```csharp
+context.App.MapGranitBackChannelLogout();
+```
+
+This wires `POST /auth/back-channel-logout` (anonymous — Keycloak calls it directly), validates the logout token signature against the realm JWKS, extracts the `sid` claim, and stores it in `IDistributedCache` for `SessionRevocationTtl`. The JWT Bearer events handler checks this cache on every authenticated request and returns 401 for revoked sessions.
+
+In the Keycloak admin console, configure your client's **Backchannel Logout URL** to `https://your-api.example.com/auth/back-channel-logout`.
+
+## Try it locally
+
+The fastest path to a working setup:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:25.0 start-dev
+```
+
+Open `http://localhost:8080`, create a realm `clinic`, a client `my-backend`, a role `admin`, and a user with that role. Then point your API at it:
+
+```json
+{
+  "Authentication": {
+    "Authority": "http://localhost:8080/realms/clinic",
+    "Audience": "my-backend",
+    "RequireHttpsMetadata": false
+  },
+  "Keycloak": {
+    "Authority": "http://localhost:8080/realms/clinic",
+    "ClientId": "my-backend"
+  }
+}
+```
+
+Grab a token from `/realms/clinic/protocol/openid-connect/token` (Direct Access Grants) and call your API with `Authorization: Bearer <token>`. Roles flow through, `[Authorize(Roles = "admin")]` works, and `User.Identity.Name` is the Keycloak username.
+
+## Key takeaways
+
+- One `[DependsOn(typeof(GranitAuthenticationJwtBearerKeycloakModule))]` registers JWT Bearer, claims transformation, and the audit-friendly `ICurrentUserService`.
+- `realm_access.roles` and `resource_access.{ClientId}.roles` map to `ClaimTypes.Role` automatically — `[Authorize(Roles = "...")]` just works.
+- `NameClaimType = "preferred_username"` makes `User.Identity.Name` the Keycloak username.
+- Back-channel logout closes the token-revocation gap; enable it for any compliance-sensitive deployment.
+- Switching to Entra ID, Cognito, or Google Cloud is a one-line change — the surrounding code stays identical.
+
+## Further reading
+
+- [Authentication overview](/dotnet/security/authentication/)
+- [OIDC client primitives](/dotnet/security/authentication-oidc/)
+- [Authorization and permissions](/dotnet/security/authorization/)
+- [Identity module](/dotnet/security/identity/)
+- [API keys for service-to-service](/dotnet/security/api-keys/)

--- a/docs-site/src/content/docs/blog/multi-channel-notifications-dotnet.mdx
+++ b/docs-site/src/content/docs/blog/multi-channel-notifications-dotnet.mdx
@@ -1,0 +1,277 @@
+---
+title: "Multi-Channel Notifications in .NET: Email, SMS, Push, SignalR, and More"
+date: 2026-05-01
+authors:
+  - jfmeyers
+tags:
+  - tutorial
+  - notifications
+  - real-time
+  - architecture
+description: "One PublishAsync call, seven delivery channels. How Granit fans out a notification to email, SMS, WhatsApp, mobile push, web push, SignalR, and SSE without rewriting your domain code."
+excerpt: >
+  One PublishAsync call, seven delivery channels. How Granit fans out a single
+  notification to email, SMS, WhatsApp, mobile push, web push, SignalR, and SSE
+  without rewriting your domain code.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+A user uploads a 4 GB export. When it finishes, you want to: send them an email with the download link, ping their browser tab so the spinner disappears, push a notification to their phone if the tab is closed, and SMS them if the export failed and they configured an SLA escalation. That is **four channels, one event**. Most .NET teams end up with four `if` branches, four configuration blocks, four retry policies, four sets of templates, and zero observability across them.
+
+`Granit.Notifications` exists to collapse this into a single `INotificationPublisher.PublishAsync()` call. The fan-out engine reads the user's preferences, resolves their contact info, dispatches to every registered channel in parallel, and records every delivery attempt in an immutable audit trail. This article walks through the architecture, the seven built-in channels, and how to add your own.
+
+## The fan-out architecture
+
+Domain code does not know about email, SMS, or sockets. It publishes a `NotificationDefinition` — a typed record that names the event, carries data, and declares which channels are eligible. The engine takes it from there.
+
+```mermaid
+flowchart LR
+    D[Domain code<br/>PublishAsync] --> E[Fan-out engine]
+    E --> P[User preferences]
+    E --> R[IRecipientResolver]
+    P --> F[Channel filter]
+    R --> F
+    F --> InApp
+    F --> Email
+    F --> SMS
+    F --> WhatsApp
+    F --> MobilePush
+    F --> WebPush
+    F --> SignalR
+    F --> SSE
+    InApp --> A[Audit trail]
+    Email --> A
+    SMS --> A
+    WhatsApp --> A
+    MobilePush --> A
+    WebPush --> A
+    SignalR --> A
+    SSE --> A
+
+    style E fill:#4a9eff,color:#fff,stroke-width:2px
+    style F fill:#2ecc71,color:#fff
+    style A fill:#f39c12,color:#fff
+```
+
+Three things matter:
+
+- **Channels are loosely coupled.** They register through `INotificationChannel`. Unregistered channels are silently skipped with a warning log — the framework degrades gracefully rather than crashing.
+- **Preferences gate delivery.** The user said "no SMS for low-priority alerts"? The filter strips SMS before it reaches the channel.
+- **Every attempt is recorded.** ISO 27001 auditors want proof you tried to notify; the engine writes a row per channel, per recipient, per outcome.
+
+## The seven built-in channels
+
+| Channel | Constant | Provider |
+| --------- | ---------- | ---------- |
+| In-app inbox | `NotificationChannels.InApp` | Built-in |
+| Email | `NotificationChannels.Email` | SMTP, SendGrid, Brevo, AWS SES, Azure Communication Services, Scaleway |
+| SMS | `NotificationChannels.Sms` | Twilio, Brevo, AWS SNS, Azure Communication Services |
+| WhatsApp | `NotificationChannels.WhatsApp` | Twilio, Brevo |
+| Mobile Push | `NotificationChannels.MobilePush` | Firebase Cloud Messaging, AWS SNS, Azure Notification Hubs |
+| Web Push (W3C) | `NotificationChannels.Push` | VAPID-signed (RFC 8030/8291/8292) |
+| SignalR | `NotificationChannels.SignalR` | Built-in hub + Redis backplane |
+| Server-Sent Events | `NotificationChannels.Sse` | Native .NET 10 SSE |
+
+Provider selection uses **Keyed Services**. You ask for `IEmailSender` keyed `"Brevo"` and the right implementation resolves at runtime — no `if (provider == "Brevo")` switches anywhere in the framework.
+
+## Setting up production-grade notifications
+
+```csharp title="AppModule.cs"
+[DependsOn(typeof(GranitNotificationsWolverineModule))]
+[DependsOn(typeof(GranitNotificationsEntityFrameworkCoreModule))]
+public sealed class AppModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Persistence — replaces in-memory defaults
+        context.Builder.AddGranitNotificationsEntityFrameworkCore(
+            opts => opts.UseNpgsql(context.Configuration
+                .GetConnectionString("Notifications")));
+
+        // Email via Brevo (also handles SMS + WhatsApp under one API key)
+        context.Services.AddGranitNotificationsBrevo();
+        context.Services.AddGranitNotificationsEmail(opts => opts.Provider = "Brevo");
+        context.Services.AddGranitNotificationsSms(opts => opts.Provider = "Brevo");
+        context.Services.AddGranitNotificationsWhatsApp(opts => opts.Provider = "Brevo");
+
+        // Mobile push via FCM
+        context.Services.AddGranitNotificationsMobilePush();
+        context.Services.AddGranitNotificationsMobilePushGoogleFcm();
+
+        // Real-time browser delivery
+        context.Services.AddGranitNotificationsSignalR(
+            context.Configuration.GetConnectionString("Redis")!);
+
+        // Inbox + preferences endpoints
+        context.Services.AddGranitNotificationsEndpoints();
+    }
+
+    public override void OnApplicationInitialization(
+        ApplicationInitializationContext context)
+    {
+        context.App.MapGranitNotifications();
+        context.App.MapHub<NotificationHub>("/hubs/notifications");
+    }
+}
+```
+
+You added one provider package per channel. That's the entire wiring.
+
+## Defining a notification
+
+Each `*.Notifications` package owns one or more `NotificationDefinition` singletons. The pattern is consistent across every Granit module that emits user-facing events.
+
+```csharp title="ExportReadyNotification.cs"
+public sealed class ExportReadyNotification : NotificationDefinition
+{
+    public static readonly ExportReadyNotification Instance = new();
+
+    public override string Name => "documents.export_ready";
+
+    public override IReadOnlyList<string> SupportedChannels =>
+        [NotificationChannels.InApp,
+         NotificationChannels.Email,
+         NotificationChannels.SignalR,
+         NotificationChannels.MobilePush];
+
+    public override NotificationPriority Priority => NotificationPriority.Normal;
+}
+```
+
+The `Name` is `snake_case` and namespaced — it is how preferences and templates are looked up. The `SupportedChannels` list declares the menu; per-user preferences pick from it.
+
+## Publishing — one call, seven possible deliveries
+
+```csharp title="ExportCompletedHandler.cs"
+public class ExportCompletedHandler(INotificationPublisher publisher)
+{
+    public async Task Handle(
+        ExportCompletedEvent evt,
+        CancellationToken ct)
+    {
+        await publisher.PublishAsync(new NotificationRequest
+        {
+            Definition = ExportReadyNotification.Instance,
+            RecipientUserId = evt.UserId,
+            Data = new Dictionary<string, object?>
+            {
+                ["FileName"] = evt.FileName,
+                ["DownloadUrl"] = evt.DownloadUrl,
+                ["ExpiresAt"] = evt.ExpiresAt,
+            },
+        }, ct).ConfigureAwait(false);
+    }
+}
+```
+
+That single call:
+
+1. Looks up the user's `RecipientInfo` via your `IRecipientResolver`.
+2. Filters channels by user preferences (the user disabled SMS? skipped).
+3. Renders the email template (with the `FileName` / `DownloadUrl` substituted).
+4. Pushes a SignalR message if the user is connected.
+5. Sends an FCM push to every registered device token for that user.
+6. Persists an in-app inbox entry.
+7. Writes seven `NotificationDelivery` rows — one per channel — with status, timestamp, error message, and attempt number.
+
+## Durable dispatch with Wolverine
+
+In-process `Channel<T>` dispatch is fine for development. In production you want **at-least-once delivery survival across crashes**. `Granit.Notifications.Wolverine` wires the publisher to the Wolverine outbox: the request is committed to the same database transaction as your domain change, then Wolverine picks it up, fans out to channels, and applies exponential backoff on transient failures.
+
+```csharp
+[DependsOn(typeof(GranitNotificationsWolverineModule))]
+public class AppModule : GranitModule { }
+```
+
+The handler signature does not change. Whether you run in-memory or behind an outbox is a deployment concern, not a domain concern.
+
+## Connecting your user model
+
+Granit does not know who your users are. Your application implements `IRecipientResolver` once:
+
+```csharp title="AppRecipientResolver.cs"
+public sealed class AppRecipientResolver(AppDbContext db) : IRecipientResolver
+{
+    public async Task<RecipientInfo?> ResolveAsync(
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await db.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == Guid.Parse(userId), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (user is null) return null;
+
+        return new RecipientInfo
+        {
+            UserId = userId,
+            Email = user.Email,
+            PhoneNumber = user.PhoneNumberE164,
+            PreferredCulture = user.Culture, // BCP 47 — drives template selection
+            DisplayName = user.FullName,
+        };
+    }
+}
+```
+
+`PreferredCulture` is the hook that makes localization automatic — Granit ships templates in 17 cultures and selects the right one per recipient.
+
+## Adding a custom channel
+
+The framework covers email/SMS/push/real-time. Some teams need Microsoft Teams, Slack, or a corporate paging system. The contract is one method:
+
+```csharp title="TeamsNotificationChannel.cs"
+public sealed class TeamsNotificationChannel(
+    IRecipientResolver resolver,
+    IHttpClientFactory httpClientFactory)
+    : INotificationChannel
+{
+    public string Name => "Teams";
+
+    public async Task SendAsync(
+        NotificationDeliveryContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var recipient = await resolver
+            .ResolveAsync(context.RecipientUserId, cancellationToken)
+            .ConfigureAwait(false);
+        if (recipient?.Email is null) return;
+
+        var http = httpClientFactory.CreateClient("Teams");
+        // POST to the Microsoft Graph chatMessage endpoint...
+    }
+}
+
+// Register
+services.AddSingleton<INotificationChannel, TeamsNotificationChannel>();
+```
+
+Add `"Teams"` to a definition's `SupportedChannels`, ship a template, done. The audit trail picks up the new channel for free.
+
+## What you get for free
+
+- **Templating.** HTML templates are embedded resources; per-tenant overrides live in the database. The `<title>` tag becomes the email subject — no `Subject` field to forget.
+- **Localization.** 17 cultures (14 base + 3 regional). Templates ship as `.html` / `.fr.html` / `.de.html`. Recipients with `PreferredCulture = "fr-CA"` get the closest match.
+- **Backoff and retry.** Wolverine outbox dispatch retries transient channel failures without re-running domain logic.
+- **Preferences.** A REST endpoint exposes per-user, per-notification, per-channel toggles. The fan-out engine respects them.
+- **Compliance.** Every delivery attempt is recorded. ISO 27001 audit ready out of the box. PII in audit rows is governed by the same erasure rules as the rest of your data via `Granit.Notifications.Privacy`.
+
+## Key takeaways
+
+- One `INotificationPublisher.PublishAsync()` call fans out to all eligible channels, filtered by user preferences.
+- Channels are loosely coupled — register only what you ship, swap providers via Keyed Services.
+- `IRecipientResolver` is the only interface your app must implement; the rest is conventions.
+- `Granit.Notifications.Wolverine` upgrades in-process dispatch to durable outbox-backed delivery without changing handler code.
+- Adding a custom channel is one class and one DI registration.
+
+## Further reading
+
+- [Notifications overview](/dotnet/infrastructure/notifications/)
+- [Notification channels](/dotnet/infrastructure/notifications/channels/)
+- [Email channel](/dotnet/infrastructure/notifications/email-channel/)
+- [SMS, push and real-time channels](/dotnet/infrastructure/notifications/sms-push-realtime/)
+- [Fan-out engine](/dotnet/infrastructure/notifications/fan-out-engine/)
+- [Wolverine integration](/dotnet/infrastructure/notifications/wolverine-integration/)
+- [SSE vs SignalR vs WebSockets](/blog/sse-vs-signalr-vs-websockets/)


### PR DESCRIPTION
## Summary

Three new blog articles for the Granit docs site:

- **Multi-Channel Notifications in .NET: Email, SMS, Push, SignalR, and More** — published 2026-05-01. Long-form tutorial with Mermaid fan-out diagram, walking through the 7 built-in channels, `INotificationPublisher`, Wolverine outbox dispatch, `IRecipientResolver`, and a custom-channel example.
- **5 EF Core Mistakes That Kill Performance (and How to Fix Them)** — published 2026-05-03. Best-practice format covering streaming vs `ToListAsync`, tracked reads on read paths, hidden N+1, accidental client evaluation, and `SaveChangesAsync` in loops.
- **Adding Authentication with Keycloak in Granit** — published 2026-05-06. Tutorial covering `GranitAuthenticationJwtBearerKeycloakModule`, claims transformation (`realm_access` vs `resource_access`), `ICurrentUserService`, back-channel logout, and a local Docker walkthrough.

All APIs verified against source (`Granit.Notifications.*`, `Granit.Authentication.JwtBearer.Keycloak`).

## Test plan

- [x] `npx astro build` — 0 errors, all internal links valid (470 pages built)
- [x] `npx markdownlint-cli2` — 0 errors on the three new files
- [ ] Visual review of rendered pages on the deployed preview
- [ ] Confirm the three posts appear on the blog index in the right date order