### PR TITLE
perf(parties,subscriptions): AsSplitQuery on multi-collection Includes

### DIFF
--- a/src/Granit.Parties.Deduplication.BackgroundJobs/Services/PartyDuplicateScanService.cs
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/Services/PartyDuplicateScanService.cs
@@ -92,6 +92,7 @@ internal sealed class PartyDuplicateScanService(
             .Include(p => p.Emails)
             .Include(p => p.Phones)
             .Take(TenantPartyCap + 1)
+            .AsSplitQuery()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         if (parties.Count > TenantPartyCap)

--- a/src/Granit.Parties.Deduplication/Internal/DefaultPartyDuplicateDetector.cs
+++ b/src/Granit.Parties.Deduplication/Internal/DefaultPartyDuplicateDetector.cs
@@ -66,6 +66,7 @@ internal sealed class DefaultPartyDuplicateDetector(
             .Include(x => x.Emails)
             .Include(x => x.Phones)
             .Take(TenantScanCap + 1)
+            .AsSplitQuery()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         if (tenantParties.Count > TenantScanCap)

--- a/src/Granit.Parties.Deduplication/Internal/Tier3WeightedScorer.cs
+++ b/src/Granit.Parties.Deduplication/Internal/Tier3WeightedScorer.cs
@@ -54,6 +54,7 @@ internal sealed class Tier3WeightedScorer(IDbContextFactory<PartiesDbContext> co
             .Include(p => p.Emails)
             .Include(p => p.Phones)
             .Include(p => p.Addresses)
+            .AsSplitQuery()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         var byId = loaded.ToDictionary(p => p.Id);

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartyResolver.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfDefaultPartyResolver.cs
@@ -37,6 +37,7 @@ internal sealed class EfDefaultPartyResolver(
             .Include(c => c.Emails)
             .Include(c => c.Phones)
             .Include(c => c.ExternalMappings)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(
                 c => c.TenantId == null
                   && c.ExternalMappings.Any(m =>

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyQueryableSource.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyQueryableSource.cs
@@ -25,7 +25,8 @@ internal sealed class EfPartyQueryableSource(
             .Include(c => c.Addresses)
             .Include(c => c.Emails)
             .Include(c => c.Phones)
-            .Include(c => c.ExternalMappings);
+            .Include(c => c.ExternalMappings)
+            .AsSplitQuery();
 
     public void Dispose() => _context.Dispose();
 }

--- a/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyStore.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/Internal/EfPartyStore.cs
@@ -41,6 +41,7 @@ internal sealed class EfPartyStore(
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
                 .Include(c => c.ExternalMappings)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(c => c.Id == id.Value, cancellationToken),
             cancellationToken);
 
@@ -56,6 +57,7 @@ internal sealed class EfPartyStore(
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
                 .Include(c => c.ExternalMappings)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(
                     c => c.ExternalMappings.Any(m =>
                         m.ProviderName == providerName && m.ExternalId == externalId),
@@ -76,6 +78,7 @@ internal sealed class EfPartyStore(
                 .Include(c => c.Emails)
                 .Include(c => c.Phones)
                 .Include(c => c.ExternalMappings)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(c => c.UserId == userId, cancellationToken),
             cancellationToken);
     }

--- a/src/Granit.Parties.Mergeable/Internal/PartyMergeableAggregateAdapter.cs
+++ b/src/Granit.Parties.Mergeable/Internal/PartyMergeableAggregateAdapter.cs
@@ -35,6 +35,7 @@ internal sealed class PartyMergeableAggregateAdapter(
             .Include(p => p.Emails)
             .Include(p => p.Phones)
             .Include(p => p.ExternalMappings)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(p => p.Id == id, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanReader.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanReader.cs
@@ -38,6 +38,7 @@ internal sealed class EfPlanReader(
         ReadAsync(async db => await db.Plans
             .Include(p => p.Prices)
             .Include(p => p.ExternalMappings)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(
                 p => p.ExternalMappings.Any(m => m.ProviderName == providerName && m.ExternalId == externalId),
                 cancellationToken)


### PR DESCRIPTION
## Summary

- Adds `.AsSplitQuery()` to 10 EF Core query chains that include ≥2 collection navigations, silencing `MultipleCollectionIncludeWarning` and removing cartesian explosion on Party aggregates.
- Pure perf fix — no API change, no behaviour change. Each query target is either a single-row lookup (`FirstOrDefaultAsync`) or a bounded batch scan; no inter-query consistency dependency.

### Why now

Worst-case Party load (4 collections: Addresses + Emails + Phones + ExternalMappings) materialised up to 5×5×5×10 = 1 250 rows per single entity under `SingleQuery`. The dedup background scan amplified this across up to 5 000 parties/tenant — orders of magnitude of unnecessary network and materialisation cost.

### Sites changed

| File | Notes |
|------|-------|
| `EfPartyStore` | 3 read methods (`GetById/Ext/User`) |
| `EfDefaultPartyResolver` | tenant-default lookup |
| `EfPartyQueryableSource` | feeds `IQueryableSource<Party>` for QueryEngine |
| `PartyMergeableAggregateAdapter.LoadAsync` | merge orchestrator load |
| `Tier3WeightedScorer` | up to 50 candidates × 3 collections |
| `DefaultPartyDuplicateDetector.ScanTenantAsync` | up to 5000 parties × 2 collections |
| `PartyDuplicateScanService.ScanTenantAsync` | idem |
| `EfPlanReader.GetByExternalIdAsync` | Plans (Prices + ExternalMappings) |

## Follow-ups (separate PRs)

1. **Dedup scan projection** — load `PartyDraftRow` directly via `Select`, avoid hydrating full `Party` aggregates (with audit fields, soft-delete fields, canonicalisation fields…) just to extract `Email.Address` and `Phone.Number`. Big perf win on the nightly job.
2. **Read-only Party endpoints** — project to `PartyResponse` via `IQueryable<Party>` instead of round-tripping through `IPartyReader.GetByIdAsync` (which loads the full aggregate for write paths).

## Test plan

- [x] `dotnet build` business + saas shards (Release) — clean
- [x] `dotnet format --verify-no-changes` business shard — clean
- [x] Unit tests: Parties.EntityFrameworkCore (95), Parties.Deduplication (14), Parties.Deduplication.BackgroundJobs (4), Parties.Mergeable (5), Subscriptions.EntityFrameworkCore (41) — all green
- [ ] CI integration shard (real Postgres) — not run locally