### PR TITLE
perf(parties.dedup): project tenant scans to scalar rows

### DIFF
--- a/src/Granit.Parties.Deduplication.BackgroundJobs/Services/PartyDuplicateScanService.cs
+++ b/src/Granit.Parties.Deduplication.BackgroundJobs/Services/PartyDuplicateScanService.cs
@@ -86,37 +86,55 @@ internal sealed class PartyDuplicateScanService(
         // remain filtered out — we don't surface duplicates of merged-out aggregates.
         using IDisposable _ = dataFilter.Disable<IMultiTenant>();
 
-        List<Party> parties = await db.Parties
+        // Project directly to the scalars consumed by detector.FindCandidatesAsync —
+        // hydrating full Party aggregates just to read e.Address / ph.Number on every
+        // PartyEmail / PartyPhone row is wasteful at 5000 parties per tenant per night.
+        var rows = await db.Parties
             .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .Where(p => p.TenantId == tenantId)
-            .Include(p => p.Emails)
-            .Include(p => p.Phones)
+            .Select(p => new
+            {
+                p.Id,
+                p.TenantId,
+                p.Kind,
+                p.Name,
+                p.TaxId,
+                Emails = p.Emails.Select(e => e.Address).ToList(),
+                Phones = p.Phones.Select(ph => ph.Number).ToList(),
+            })
             .Take(TenantPartyCap + 1)
             .AsSplitQuery()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-        if (parties.Count > TenantPartyCap)
+        if (rows.Count > TenantPartyCap)
         {
             logger.LogWarning(
                 "Tenant {TenantId} has more than {Cap} parties; scan truncated. "
                 + "Paginated incremental scan is a follow-up enhancement.",
                 tenantId, TenantPartyCap);
-            parties = parties.Take(TenantPartyCap).ToList();
+            rows = rows.Take(TenantPartyCap).ToList();
         }
 
         int upserted = 0;
-        foreach (Party party in parties)
+        foreach (var row in rows)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            PartyDraft draft = ToDraft(party);
+            PartyDraft draft = new(
+                TenantId: row.TenantId,
+                Kind: row.Kind,
+                Name: row.Name,
+                TaxId: row.TaxId,
+                Emails: row.Emails,
+                Phones: row.Phones);
+
             IReadOnlyList<DuplicateCandidate> candidates =
                 await detector.FindCandidatesAsync(draft, cancellationToken).ConfigureAwait(false);
 
             // Filter out the self-match before we hand the list to the sink. The sink also
             // guards against this, but eliminating it here keeps the metrics accurate.
             var nonSelf = candidates
-                .Where(c => c.CandidateId.Value != party.Id)
+                .Where(c => c.CandidateId.Value != row.Id)
                 .ToList();
 
             if (nonSelf.Count == 0)
@@ -124,7 +142,7 @@ internal sealed class PartyDuplicateScanService(
                 continue;
             }
 
-            upserted += await sink.UpsertAsync(nonSelf, party.Id, tenantId, cancellationToken)
+            upserted += await sink.UpsertAsync(nonSelf, row.Id, tenantId, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -132,12 +150,4 @@ internal sealed class PartyDuplicateScanService(
         metrics.RecordScanDuration(tenantId, stopwatch.Elapsed);
         return upserted;
     }
-
-    private static PartyDraft ToDraft(Party party) => new(
-        TenantId: party.TenantId,
-        Kind: party.Kind,
-        Name: party.Name,
-        TaxId: party.TaxId,
-        Emails: [.. party.Emails.Select(e => e.Address)],
-        Phones: [.. party.Phones.Select(p => p.Number)]);
 }

--- a/src/Granit.Parties.Deduplication/Internal/DefaultPartyDuplicateDetector.cs
+++ b/src/Granit.Parties.Deduplication/Internal/DefaultPartyDuplicateDetector.cs
@@ -60,22 +60,34 @@ internal sealed class DefaultPartyDuplicateDetector(
         // active so tombstoned losers don't show up as candidates.
         using IDisposable _ = dataFilter.Disable<IMultiTenant>();
 
-        List<Party> tenantParties = await db.Parties
+        // Project directly to the scalars consumed by FindCandidatesAsync — loading the
+        // full Party aggregate (with audit / soft-delete / canonicalisation columns on
+        // every PartyEmail and PartyPhone row) only to read e.Address / ph.Number is
+        // wasteful at 5000 parties × N children scale.
+        var rows = await db.Parties
             .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
             .Where(p => p.TenantId == tenantId)
-            .Include(x => x.Emails)
-            .Include(x => x.Phones)
+            .Select(p => new
+            {
+                p.Id,
+                p.TenantId,
+                p.Kind,
+                p.Name,
+                p.TaxId,
+                Emails = p.Emails.Select(e => e.Address).ToList(),
+                Phones = p.Phones.Select(ph => ph.Number).ToList(),
+            })
             .Take(TenantScanCap + 1)
             .AsSplitQuery()
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-        if (tenantParties.Count > TenantScanCap)
+        if (rows.Count > TenantScanCap)
         {
             logger.LogWarning(
                 "Tenant {TenantId} has more than {Cap} parties; ScanTenantAsync truncated. "
                 + "Drive large-tenant scans through the background job (#1300) instead.",
                 tenantId, TenantScanCap);
-            tenantParties = tenantParties.Take(TenantScanCap).ToList();
+            rows = rows.Take(TenantScanCap).ToList();
         }
 
         // Each pair is counted ONCE: the lower-id endpoint reports the match, the higher-
@@ -84,24 +96,31 @@ internal sealed class DefaultPartyDuplicateDetector(
         // deterministic, which keeps the count reproducible across re-runs.
         HashSet<(Guid Lower, Guid Higher)> uniquePairs = new();
 
-        foreach (Party party in tenantParties)
+        foreach (var row in rows)
         {
-            PartyDraft draft = ToDraft(party);
+            PartyDraft draft = new(
+                TenantId: row.TenantId,
+                Kind: row.Kind,
+                Name: row.Name,
+                TaxId: row.TaxId,
+                Emails: row.Emails,
+                Phones: row.Phones);
+
             IReadOnlyList<DuplicateCandidate> hits =
                 await FindCandidatesAsync(draft, cancellationToken).ConfigureAwait(false);
 
             foreach (DuplicateCandidate hit in hits)
             {
                 Guid candidate = hit.CandidateId.Value;
-                if (candidate == party.Id)
+                if (candidate == row.Id)
                 {
                     // Self-match — every party is its own deterministic dup. Skip.
                     continue;
                 }
 
-                (Guid lower, Guid higher) = candidate.CompareTo(party.Id) < 0
-                    ? (candidate, party.Id)
-                    : (party.Id, candidate);
+                (Guid lower, Guid higher) = candidate.CompareTo(row.Id) < 0
+                    ? (candidate, row.Id)
+                    : (row.Id, candidate);
 
                 uniquePairs.Add((lower, higher));
             }
@@ -109,14 +128,6 @@ internal sealed class DefaultPartyDuplicateDetector(
 
         return uniquePairs.Count;
     }
-
-    private static PartyDraft ToDraft(Party party) => new(
-        TenantId: party.TenantId,
-        Kind: party.Kind,
-        Name: party.Name,
-        TaxId: party.TaxId,
-        Emails: [.. party.Emails.Select(e => e.Address)],
-        Phones: [.. party.Phones.Select(p => p.Number)]);
 
     /// <summary>
     /// Merges Tier-1 and Tier-3 outputs into a single ranked list keyed by candidate id.


### PR DESCRIPTION
## Summary

Follow-up to #1944. The two nightly tenant scans no longer hydrate full `Party` aggregates just to extract `e.Address` / `ph.Number` — they project directly to the scalars needed by `FindCandidatesAsync`.

## Context

`DefaultPartyDuplicateDetector.ScanTenantAsync` and `PartyDuplicateScanService.ScanTenantAsync` (BG job, runs daily) iterate up to 5 000 parties per tenant. Each iteration only ever reads:

- `party.Id, TenantId, Kind, Name, TaxId`
- `party.Emails.Select(e => e.Address)`
- `party.Phones.Select(p => p.Number)`

…which were extracted into a `PartyDraft` then thrown away (private `ToDraft(Party)` helper, duplicated in both files).

Previously the SQL hydrated ~30 columns per `PartyEmail` (Address, CanonicalEmail, CanonicalEmailHash, IsPrimary, IsVerified, all audit/soft-delete/tenant/concurrency columns) and the same on `PartyPhone`, plus the full `Party` row.

## Change

Anonymous-type projection + `AsSplitQuery()`:

```csharp
.Select(p => new {
    p.Id, p.TenantId, p.Kind, p.Name, p.TaxId,
    Emails = p.Emails.Select(e => e.Address).ToList(),
    Phones = p.Phones.Select(ph => ph.Number).ToList(),
})
.Take(TenantPartyCap + 1)
.AsSplitQuery()
.ToListAsync(ct);
```

EF emits 3 small queries (root + `WHERE PartyId IN (...)` for each scalar collection). The `new PartyDraft(...)` construction is inlined next to its consumer; the now-redundant `ToDraft` helper is removed from both classes.

## Why this is safe

- Pure read path — no mutation, no domain invariants.
- `PartyDraft` is a flat record (no domain behaviour); identical values feed `FindCandidatesAsync`.
- Standard EF Core projection idiom; `Mergeable.Tests.Integration` (18/18 on Postgres testcontainer) confirms the split-query infra from #1944 works on Npgsql.

## Out of scope (future)

- `Tier3WeightedScorer` is bounded to 50 candidates and uses 4 collections including `Addresses.Value.{Line1,PostalCode}` and the canonical email/phone fields — its read shape would need either projecting to a richer custom row or a small refactor of `BestEmailPartial` / `AnyPhoneSubscriberMatch` to take scalars. AsSplitQuery from #1944 already removes the cartesian explosion there; deferring projection.
- The `private static ToDraft(Party)` helpers were duplicated across 2 packages — both are now removed since the call site can build `PartyDraft` inline. Sharing via `InternalsVisibleTo` would be net-negative for ~10 lines.

## Test plan

- [x] `dotnet build` Release on `Granit.Parties.Deduplication` + `.BackgroundJobs` — clean
- [x] `dotnet format --verify-no-changes` on both — clean
- [x] Unit tests: `Granit.Parties.Deduplication.Tests` (14/14, exercises `ScanTenantAsync` against InMemory provider), `Granit.Parties.Deduplication.BackgroundJobs.Tests` (4/4)
- [x] Integration smoke: `Granit.Parties.Mergeable.Tests.Integration` (18/18 against Postgres testcontainer) — validates split-query path on Npgsql
- [ ] CI integration shard