### PR TITLE
test(browsing): F4 — architecture tests for Granit.Browsing

### DIFF
--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -68,6 +68,8 @@
       "src/Granit.BlobStorage.Proxy/Granit.BlobStorage.Proxy.csproj",
       "src/Granit.BlobStorage.S3/Granit.BlobStorage.S3.csproj",
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
+      "src/Granit.Browsing.Playwright/Granit.Browsing.Playwright.csproj",
+      "src/Granit.Browsing.PuppeteerSharp/Granit.Browsing.PuppeteerSharp.csproj",
       "src/Granit.Browsing/Granit.Browsing.csproj",
       "src/Granit.Caching.StackExchangeRedis/Granit.Caching.StackExchangeRedis.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",

--- a/tests/Granit.ArchitectureTests/BrowsingArchitectureTests.cs
+++ b/tests/Granit.ArchitectureTests/BrowsingArchitectureTests.cs
@@ -1,0 +1,181 @@
+using System.Xml.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Architecture rules pinning the <c>Granit.Browsing</c> abstraction-then-provider
+/// shape (epic #1936). Mirrors the discipline already enforced on <c>Granit.Imaging</c>
+/// and <c>Granit.BlobStorage</c>.
+/// </summary>
+public sealed class BrowsingArchitectureTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// Only the PuppeteerSharp provider package and its test harness may reference the
+    /// <c>PuppeteerSharp</c> NuGet directly. Every other consumer (e.g.
+    /// <c>Granit.DocumentGeneration.Pdf</c>) routes through the <c>Granit.Browsing</c>
+    /// abstraction. Pinning this rule prevents the historical
+    /// "everyone imports PuppeteerSharp" anti-pattern from creeping back.
+    /// </summary>
+    [Fact]
+    public void Only_Granit_Browsing_PuppeteerSharp_should_reference_PuppeteerSharp_directly() =>
+        AssertExclusiveProviderReference(
+            packageId: "PuppeteerSharp",
+            allowedProjects:
+            [
+                "Granit.Browsing.PuppeteerSharp",
+                "Granit.Browsing.PuppeteerSharp.Tests",
+            ]);
+
+    /// <summary>
+    /// Only the Playwright provider package and its test harness may reference the
+    /// <c>Microsoft.Playwright</c> NuGet directly.
+    /// </summary>
+    [Fact]
+    public void Only_Granit_Browsing_Playwright_should_reference_Microsoft_Playwright_directly() =>
+        AssertExclusiveProviderReference(
+            packageId: "Microsoft.Playwright",
+            allowedProjects:
+            [
+                "Granit.Browsing.Playwright",
+                "Granit.Browsing.Playwright.Tests",
+            ]);
+
+    /// <summary>
+    /// The base <c>Granit.Browsing</c> package must not reference any provider impl —
+    /// it would invert the abstraction-then-provider direction and force every consumer
+    /// to drag the provider's dependencies (Chromium binaries) into the build graph.
+    /// </summary>
+    [Fact]
+    public void Granit_Browsing_base_should_not_reference_provider_packages()
+    {
+        string csprojPath = Path.Join(
+            RepoRoot, "src", "Granit.Browsing", "Granit.Browsing.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected {csprojPath} to exist.");
+
+        var doc = XDocument.Load(csprojPath);
+        IEnumerable<string> projectRefs = doc.Descendants("ProjectReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty);
+
+        IEnumerable<string> providerRefs = projectRefs
+            .Where(r => r.Contains("Granit.Browsing.PuppeteerSharp", StringComparison.Ordinal)
+                     || r.Contains("Granit.Browsing.Playwright", StringComparison.Ordinal));
+
+        providerRefs.ShouldBeEmpty(
+            "Granit.Browsing (base abstraction) must not reference provider impls. " +
+            "Move the consumer to the provider package or invert the dependency.");
+    }
+
+    /// <summary>
+    /// Every <c>Granit.Browsing.*</c> provider package must reference the base
+    /// <c>Granit.Browsing</c> contract. Without this reference, the provider is
+    /// implementing a parallel surface and consumers can't hot-swap providers.
+    /// </summary>
+    [Theory]
+    [InlineData("Granit.Browsing.PuppeteerSharp")]
+    [InlineData("Granit.Browsing.Playwright")]
+    public void Provider_package_should_reference_Granit_Browsing(string providerProjectName)
+    {
+        string csprojPath = Path.Join(
+            RepoRoot, "src", providerProjectName, $"{providerProjectName}.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected {csprojPath} to exist.");
+
+        var doc = XDocument.Load(csprojPath);
+        bool referencesBase = doc.Descendants("ProjectReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty)
+            .Any(r => r.Contains("Granit.Browsing.csproj", StringComparison.Ordinal)
+                  || r.EndsWith("/Granit.Browsing/Granit.Browsing.csproj", StringComparison.Ordinal)
+                  || r.EndsWith(@"\Granit.Browsing\Granit.Browsing.csproj", StringComparison.Ordinal));
+
+        referencesBase.ShouldBeTrue(
+            $"{providerProjectName} must reference the base Granit.Browsing contract.");
+    }
+
+    /// <summary>
+    /// Every public type in <c>Granit.Browsing.Capabilities</c> whose name ends with
+    /// <c>Capability</c> must be an interface. The convention keeps capability discovery
+    /// uniform — consumers inject <c>I*Capability</c>, providers implement them.
+    /// </summary>
+    [Fact]
+    public void Capability_named_types_in_Granit_Browsing_Capabilities_should_be_interfaces()
+    {
+        System.Reflection.Assembly browsingAssembly = typeof(Granit.Browsing.IHeadlessBrowser).Assembly;
+        IEnumerable<Type> capabilityTypes = browsingAssembly.GetExportedTypes()
+            .Where(t => t.Namespace == "Granit.Browsing.Capabilities"
+                     && t.Name.EndsWith("Capability", StringComparison.Ordinal));
+
+        IEnumerable<string> nonInterfaces = capabilityTypes
+            .Where(t => !t.IsInterface)
+            .Select(t => t.FullName!);
+
+        nonInterfaces.ShouldBeEmpty(
+            "Types ending in 'Capability' in Granit.Browsing.Capabilities must be interfaces. " +
+            "Move concrete impls to providers (Granit.Browsing.PuppeteerSharp.Internal, " +
+            "Granit.Browsing.Playwright.Internal) and rename the offending types.");
+    }
+
+    private static void AssertExclusiveProviderReference(
+        string packageId,
+        IReadOnlyList<string> allowedProjects)
+    {
+        List<string> violators = [];
+
+        foreach (string csproj in EnumerateRepoCsproj())
+        {
+            string projectName = Path.GetFileNameWithoutExtension(csproj);
+            if (allowedProjects.Contains(projectName))
+            {
+                continue;
+            }
+
+            var doc = XDocument.Load(csproj);
+            bool references = doc.Descendants("PackageReference")
+                .Any(e => string.Equals(
+                    e.Attribute("Include")?.Value, packageId, StringComparison.Ordinal));
+
+            if (references)
+            {
+                violators.Add(projectName);
+            }
+        }
+
+        violators.ShouldBeEmpty(
+            $"Only {string.Join(" / ", allowedProjects)} may reference the {packageId} NuGet directly. " +
+            $"Other consumers must route through Granit.Browsing's IHeadlessBrowser + capability interfaces. " +
+            $"Violators: {string.Join(", ", violators)}");
+    }
+
+    private static IEnumerable<string> EnumerateRepoCsproj()
+    {
+        foreach (string root in (string[])["src", "tests"])
+        {
+            string dir = Path.Join(RepoRoot, root);
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+            foreach (string csproj in Directory.EnumerateFiles(dir, "*.csproj", SearchOption.AllDirectories))
+            {
+                yield return csproj;
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(BrowsingArchitectureTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -101,6 +101,9 @@
     <ProjectReference Include="..\..\src\Granit.BlobStorage.GoogleCloud\Granit.BlobStorage.GoogleCloud.csproj" />
     <ProjectReference Include="..\..\src\Granit.BlobStorage.Proxy\Granit.BlobStorage.Proxy.csproj" />
     <ProjectReference Include="..\..\src\Granit.BlobStorage.S3\Granit.BlobStorage.S3.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Browsing\Granit.Browsing.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Browsing.PuppeteerSharp\Granit.Browsing.PuppeteerSharp.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Browsing.Playwright\Granit.Browsing.Playwright.csproj" />
     <ProjectReference Include="..\..\src\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\..\src\Granit.Caching.StackExchangeRedis\Granit.Caching.StackExchangeRedis.csproj" />
     <ProjectReference Include="..\..\src\Granit.Catalog\Granit.Catalog.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1207,8 +1207,8 @@
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "pOd+UhZ3X8xfwKDlgAzowUJNjp8VYVmOHZm++vCd0kq1HZ0zK3mNo2yRXjYgv7Ik/Xi43fmJfND2PLEsQSALCg=="
+        "resolved": "5.0.0",
+        "contentHash": "dMkqfy2el8A8/I76n2Hi1oBFEbG1SfxD2l5nhwXV3XjlnOmwxJlQbYpJH4W51odnU9sARCSAgv7S3CyAFMkpYg=="
       },
       "System.Composition": {
         "type": "Transitive",
@@ -1344,6 +1344,11 @@
           "Microsoft.Data.SqlClient": "6.1.3",
           "Weasel.Core": "8.15.1"
         }
+      },
+      "WebDriverBiDi": {
+        "type": "Transitive",
+        "resolved": "0.0.49",
+        "contentHash": "KXTJjGny4f4yO+HJGMMgX+qaWqweQvcrtMQPkUw+lw2nUQpJV0VfE3oW4t25bgXOq62cdE9yVEVSjssKRBa98A=="
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
@@ -1999,6 +2004,20 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )"
+        }
+      },
+      "granit.browsing.playwright": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Browsing": "[0.1.0-dev, )",
+          "Microsoft.Playwright": "[1.*, )"
+        }
+      },
+      "granit.browsing.puppeteersharp": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Browsing": "[0.1.0-dev, )",
+          "PuppeteerSharp": "[24.*, )"
         }
       },
       "granit.caching": {
@@ -4943,6 +4962,16 @@
         "resolved": "3.0.1",
         "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
       },
+      "Microsoft.Playwright": {
+        "type": "CentralTransitive",
+        "requested": "[1.*, )",
+        "resolved": "1.59.0",
+        "contentHash": "igqHbZMmXI6cYNPg1X1o5/51U3CQp83lvvov/d/zmus2wlG1LjvpEL6i1Jx51pRahPtSyppvwq+ZoBfxeSjiew==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "System.ComponentModel.Annotations": "5.0.0"
+        }
+      },
       "MimeKit": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
@@ -5131,6 +5160,16 @@
         "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
         "dependencies": {
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "PuppeteerSharp": {
+        "type": "CentralTransitive",
+        "requested": "[24.*, )",
+        "resolved": "24.42.0",
+        "contentHash": "t019+FnCRx4aH9bTRqwcDrhjqcuJ3+Da3ijmYw/dmH/3UzPbcdhjRxESG725Kz6o1W0sL5AjPRQwwo0n/cX1Uw==",
+        "dependencies": {
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
+          "WebDriverBiDi": "0.0.49"
         }
       },
       "Scalar.AspNetCore": {


### PR DESCRIPTION
Closes #1940
Closes EPIC #1936 (final feature of the Granit.Browsing roll-out)

## Summary

Pins the abstraction-then-provider discipline introduced by EPIC #1936 into the architecture-test suite. Mirrors the boundary discipline already enforced on `Granit.Imaging` and `Granit.BlobStorage`.

## Tests added

| Test | Rule |
| --- | --- |
| `Only_Granit_Browsing_PuppeteerSharp_should_reference_PuppeteerSharp_directly` | Only the PuppeteerSharp provider package + its tests may take a `PuppeteerSharp` `PackageReference`. Every other consumer routes through `Granit.Browsing`. |
| `Only_Granit_Browsing_Playwright_should_reference_Microsoft_Playwright_directly` | Same rule on the Playwright side. |
| `Granit_Browsing_base_should_not_reference_provider_packages` | The base abstraction must not depend on its providers — the dependency direction is fixed. |
| `Provider_package_should_reference_Granit_Browsing` (theory: PuppeteerSharp + Playwright) | Every provider package MUST reference the base contract. Without it, the provider would implement a parallel surface and consumers couldn't hot-swap. |
| `Capability_named_types_in_Granit_Browsing_Capabilities_should_be_interfaces` | Every public type in `Granit.Browsing.Capabilities` whose name ends with `Capability` must be an interface. Keeps capability discovery uniform — consumers inject `I*Capability`, providers implement them. |

## Test plan

- [x] `Granit.ArchitectureTests` — 218/218 pass (212 + 6 new)
- [x] Build clean across the test project after adding the three Browsing `ProjectReference`s

## EPIC #1936 wrap-up

After this PR, the Granit.Browsing epic is fully delivered:

- F1 #1937 — base package (merged in #1942)
- F2 #1938 + F5 #1941 + Phase B Playwright provider — merged
- F3 #1939 — `Granit.DocumentGeneration.Pdf` refactored onto the abstraction — merged
- F4 #1940 — this PR