### PR TITLE
refactor(modules)!: align module class names with assembly names

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7784,11 +7784,11 @@
       "members": []
     },
     {
-      "name": "GranitApiKeysBackgroundJobsModule",
-      "fqn": "Granit.Authentication.ApiKeys.BackgroundJobs.GranitApiKeysBackgroundJobsModule",
+      "name": "GranitAuthenticationApiKeysBackgroundJobsModule",
+      "fqn": "Granit.Authentication.ApiKeys.BackgroundJobs.GranitAuthenticationApiKeysBackgroundJobsModule",
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.BackgroundJobs",
-      "file": "src/Granit.Authentication.ApiKeys.BackgroundJobs/GranitApiKeysBackgroundJobsModule.cs",
+      "file": "src/Granit.Authentication.ApiKeys.BackgroundJobs/GranitAuthenticationApiKeysBackgroundJobsModule.cs",
       "line": 18,
       "members": [
         {
@@ -8515,11 +8515,11 @@
       ]
     },
     {
-      "name": "GranitApiKeysNotificationsModule",
-      "fqn": "Granit.Authentication.ApiKeys.Notifications.GranitApiKeysNotificationsModule",
+      "name": "GranitAuthenticationApiKeysNotificationsModule",
+      "fqn": "Granit.Authentication.ApiKeys.Notifications.GranitAuthenticationApiKeysNotificationsModule",
       "kind": "class",
       "project": "Granit.Authentication.ApiKeys.Notifications",
-      "file": "src/Granit.Authentication.ApiKeys.Notifications/GranitApiKeysNotificationsModule.cs",
+      "file": "src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs",
       "line": 27,
       "members": [
         {
@@ -27863,11 +27863,11 @@
       ]
     },
     {
-      "name": "GranitHttpSecurityModule",
-      "fqn": "Granit.Http.SecurityHeaders.GranitHttpSecurityModule",
+      "name": "GranitHttpSecurityHeadersModule",
+      "fqn": "Granit.Http.SecurityHeaders.GranitHttpSecurityHeadersModule",
       "kind": "class",
       "project": "Granit.Http.SecurityHeaders",
-      "file": "src/Granit.Http.SecurityHeaders/GranitHttpSecurityModule.cs",
+      "file": "src/Granit.Http.SecurityHeaders/GranitHttpSecurityHeadersModule.cs",
       "line": 32,
       "members": [
         {

--- a/docs-site/src/content/docs/dotnet/security/api-keys.mdx
+++ b/docs-site/src/content/docs/dotnet/security/api-keys.mdx
@@ -247,8 +247,8 @@ stamp.
     typeof(GranitAuthenticationApiKeysModule),
     typeof(GranitAuthenticationApiKeysEntityFrameworkCoreModule),
     typeof(GranitAuthenticationApiKeysEndpointsModule),
-    typeof(GranitApiKeysBackgroundJobsModule),       // optional — daily scanner
-    typeof(GranitApiKeysNotificationsModule))]       // optional — email + in-app
+    typeof(GranitAuthenticationApiKeysBackgroundJobsModule),       // optional — daily scanner
+    typeof(GranitAuthenticationApiKeysNotificationsModule))]       // optional — email + in-app
 public sealed class AppModule : GranitModule { }
 ```
 

--- a/src/Granit.Authentication.ApiKeys.BackgroundJobs/GranitAuthenticationApiKeysBackgroundJobsModule.cs
+++ b/src/Granit.Authentication.ApiKeys.BackgroundJobs/GranitAuthenticationApiKeysBackgroundJobsModule.cs
@@ -15,7 +15,7 @@ namespace Granit.Authentication.ApiKeys.BackgroundJobs;
 [DependsOn(
     typeof(GranitAuthenticationApiKeysModule),
     typeof(GranitBackgroundJobsModule))]
-public sealed class GranitApiKeysBackgroundJobsModule : GranitModule
+public sealed class GranitAuthenticationApiKeysBackgroundJobsModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context) =>

--- a/src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs
+++ b/src/Granit.Authentication.ApiKeys.Notifications/GranitAuthenticationApiKeysNotificationsModule.cs
@@ -24,7 +24,7 @@ namespace Granit.Authentication.ApiKeys.Notifications;
     typeof(GranitAuthenticationApiKeysModule),
     typeof(GranitNotificationsAbstractionsModule),
     typeof(GranitTemplatingModule))]
-public sealed class GranitApiKeysNotificationsModule : GranitModule
+public sealed class GranitAuthenticationApiKeysNotificationsModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
@@ -32,7 +32,7 @@ public sealed class GranitApiKeysNotificationsModule : GranitModule
         // Ship the embedded HTML templates for every API-keys notification.
         // Apps can override any of them at runtime through the Granit.Templating
         // admin API (DB-backed resolver runs at higher priority than the embedded one).
-        context.Services.AddEmbeddedTemplates(typeof(GranitApiKeysNotificationsModule).Assembly);
+        context.Services.AddEmbeddedTemplates(typeof(GranitAuthenticationApiKeysNotificationsModule).Assembly);
 
         // Layout glob — covers all snake_case "apikeys.*" notification names. The host
         // application registers the actual `Layout.Email` template; if absent, templates

--- a/src/Granit.Http.SecurityHeaders/GranitHttpSecurityHeadersModule.cs
+++ b/src/Granit.Http.SecurityHeaders/GranitHttpSecurityHeadersModule.cs
@@ -29,7 +29,7 @@ namespace Granit.Http.SecurityHeaders;
 /// <b>after</b> exception handling and <b>before</b> routing.
 /// </para>
 /// </remarks>
-public sealed class GranitHttpSecurityModule : GranitModule
+public sealed class GranitHttpSecurityHeadersModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context) =>

--- a/src/bundles/Granit.Bundle.Essentials/GranitBuilderEssentialsExtensions.cs
+++ b/src/bundles/Granit.Bundle.Essentials/GranitBuilderEssentialsExtensions.cs
@@ -26,7 +26,7 @@ public static class GranitBuilderEssentialsExtensions
         builder.AddModule<GranitPersistenceEntityFrameworkCoreModule>();
         builder.AddModule<GranitObservabilityModule>();
         builder.AddModule<GranitHttpExceptionHandlingModule>();
-        builder.AddModule<GranitHttpSecurityModule>();
+        builder.AddModule<GranitHttpSecurityHeadersModule>();
         builder.AddModule<GranitDiagnosticsModule>();
         return builder;
     }

--- a/tests/Granit.ArchitectureTests/ModuleConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ModuleConventionTests.cs
@@ -1,7 +1,9 @@
+using System.Reflection;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent;
 using ArchUnitNET.xUnit;
 using Granit.Modularity;
+using Shouldly;
 using Xunit;
 using static ArchUnitNET.Fluent.ArchRuleDefinition;
 
@@ -39,5 +41,57 @@ public sealed class ModuleConventionTests
             .Because("module naming convention: Granit*Module");
 
         rule.Check(Architecture);
+    }
+
+    /// <summary>
+    /// Names that intentionally diverge from the assembly-derived form (too long otherwise).
+    /// Each entry MUST carry an inline justification.
+    /// </summary>
+    private static readonly HashSet<string> ModuleNameExemptions = new(StringComparer.Ordinal)
+    {
+        // "AzureCommunicationServices" → "Acs": full name is too long for ergonomic use.
+        "GranitNotificationsSmsAcsModule",
+    };
+
+    [Fact]
+    public void Module_class_name_should_match_assembly_name()
+    {
+        List<string> violations = [];
+
+        // Architecture loading (static ctor of GranitArchitecture) has already pulled
+        // every Granit.*.dll into the AppDomain via Assembly.LoadFrom.
+        _ = Architecture;
+
+        IEnumerable<Type> moduleTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.GetName().Name?.StartsWith("Granit.", StringComparison.Ordinal) == true)
+            .SelectMany(a =>
+            {
+                try { return a.GetExportedTypes(); }
+                catch (ReflectionTypeLoadException ex) { return ex.Types.OfType<Type>(); }
+            })
+            .Where(t => t is { IsClass: true, IsAbstract: false } &&
+                        typeof(GranitModule).IsAssignableFrom(t));
+
+        foreach (Type module in moduleTypes)
+        {
+            string assemblyName = module.Assembly.GetName().Name!;
+            if (!assemblyName.StartsWith("Granit.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string expected = assemblyName.Replace(".", string.Empty) + "Module";
+            if (module.Name == expected || ModuleNameExemptions.Contains(module.Name))
+            {
+                continue;
+            }
+
+            violations.Add($"{module.FullName} (assembly {assemblyName}) → expected '{expected}'");
+        }
+
+        violations.ShouldBeEmpty(
+            "GranitModule class names must equal '<AssemblyNameWithoutDots>Module' " +
+            "so [DependsOn], AddModule<>, and OpenAPI tags stay predictable. " +
+            "Add to ModuleNameExemptions only when the derived name is unreasonably long.");
     }
 }

--- a/tests/Granit.Authentication.ApiKeys.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Notifications.Tests/Templates/EmbeddedTemplatesTests.cs
@@ -28,7 +28,7 @@ public sealed class EmbeddedTemplatesTests
     [MemberData(nameof(ExpectedTemplates))]
     public void EachExpectedTemplate_IsEmbeddedInTheAssembly(string suffix)
     {
-        Assembly assembly = typeof(GranitApiKeysNotificationsModule).Assembly;
+        Assembly assembly = typeof(GranitAuthenticationApiKeysNotificationsModule).Assembly;
         string assemblyName = assembly.GetName().Name!;
         string fullResourceName = $"{assemblyName}.{suffix}";
 
@@ -43,7 +43,7 @@ public sealed class EmbeddedTemplatesTests
     [MemberData(nameof(ExpectedTemplates))]
     public void EachExpectedTemplate_IsNotEmpty(string suffix)
     {
-        Assembly assembly = typeof(GranitApiKeysNotificationsModule).Assembly;
+        Assembly assembly = typeof(GranitAuthenticationApiKeysNotificationsModule).Assembly;
         string fullResourceName = $"{assembly.GetName().Name}.{suffix}";
 
         using Stream? stream = assembly.GetManifestResourceStream(fullResourceName);
@@ -61,7 +61,7 @@ public sealed class EmbeddedTemplatesTests
     [MemberData(nameof(ExpectedTemplates))]
     public void NoTemplate_ReferencesAnySecretField(string suffix)
     {
-        Assembly assembly = typeof(GranitApiKeysNotificationsModule).Assembly;
+        Assembly assembly = typeof(GranitAuthenticationApiKeysNotificationsModule).Assembly;
         string fullResourceName = $"{assembly.GetName().Name}.{suffix}";
 
         using Stream? stream = assembly.GetManifestResourceStream(fullResourceName);

--- a/tests/Granit.Http.SecurityHeaders.Tests/GranitHttpSecurityHeadersModuleTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/GranitHttpSecurityHeadersModuleTests.cs
@@ -11,15 +11,15 @@ using Xunit;
 
 namespace Granit.Http.SecurityHeaders.Tests;
 
-public sealed class GranitHttpSecurityModuleTests
+public sealed class GranitHttpSecurityHeadersModuleTests
 {
     [Fact]
-    public void GranitHttpSecurityModule_IsGranitModule() =>
-        typeof(GranitHttpSecurityModule).IsAssignableTo(typeof(GranitModule)).ShouldBeTrue();
+    public void GranitHttpSecurityHeadersModule_IsGranitModule() =>
+        typeof(GranitHttpSecurityHeadersModule).IsAssignableTo(typeof(GranitModule)).ShouldBeTrue();
 
     [Fact]
-    public void GranitHttpSecurityModule_IsSealed() =>
-        typeof(GranitHttpSecurityModule).IsSealed.ShouldBeTrue();
+    public void GranitHttpSecurityHeadersModule_IsSealed() =>
+        typeof(GranitHttpSecurityHeadersModule).IsSealed.ShouldBeTrue();
 
     // -------------------------------------------------------------------------
     // Kestrel Server header


### PR DESCRIPTION
## Summary

Three `GranitModule` subclasses had names that diverged from their assembly name, breaking the predictability of `[DependsOn]`, `AddModule<>`, and OpenAPI tags.

| Assembly | Before | After |
|---|---|---|
| `Granit.Http.SecurityHeaders` | `GranitHttpSecurityModule` | `GranitHttpSecurityHeadersModule` |
| `Granit.Authentication.ApiKeys.Notifications` | `GranitApiKeysNotificationsModule` | `GranitAuthenticationApiKeysNotificationsModule` |
| `Granit.Authentication.ApiKeys.BackgroundJobs` | `GranitApiKeysBackgroundJobsModule` | `GranitAuthenticationApiKeysBackgroundJobsModule` |

Adds `ModuleConventionTests.Module_class_name_should_match_assembly_name` to lock the rule. `GranitNotificationsSmsAcsModule` is exempted via an inline-justified `ModuleNameExemptions` set (full Azure Communication Services name is unwieldy).

## Breaking change

Pre-1.0 framework — clean break, no `[Obsolete]` graduation. Consumers referencing the old class names must update.

## Test plan

- [x] `dotnet build` clean on the 4 affected `src/` projects + 2 test projects
- [x] `dotnet test tests/Granit.ArchitectureTests --filter ModuleConventionTests` — 3 passed
- [x] `dotnet format style/whitespace` clean
- [ ] CI green