### PR TITLE
fix(odata-exposure): disambiguate endpoint names between host and tenant feeds

### DIFF
--- a/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.ODataExposure/Extensions/ODataExposureEndpointRouteBuilderExtensions.cs
@@ -430,7 +430,12 @@ public static class ODataExposureEndpointRouteBuilderExtensions
             .WithODataResult()
             .WithODataOptions(opts => opts.SetMaxTop(descriptor.MaxTop));
 
-        route.WithName($"OData{descriptor.EntitySetName}List")
+        // Tenant-feed name stays `OData{Set}List` (no breaking change). Host-feed
+        // gains a `Host` segment so an entity exposed on both feeds (e.g. canonical
+        // User aggregate, ADR-051) does not collide on the globally-unique endpoint
+        // name registry.
+        string feedSegment = descriptor.FeedKind == ODataFeedKind.Host ? "Host" : string.Empty;
+        route.WithName($"OData{feedSegment}{descriptor.EntitySetName}List")
              .WithSummary($"Returns the {descriptor.EntitySetName} EntitySet, filtered by the framework's tenant + soft-delete pipeline.")
              .WithDescription($"OData v4 endpoint for the {descriptor.EntitySetName} set. Supports $filter, $select, $top, $skip, $orderby. Tenant and soft-delete filters are applied BEFORE any user $filter — the OData query never bypasses framework access control. Per-set caps: MaxTop={descriptor.MaxTop}, PageSize={descriptor.PageSize}, $count={(descriptor.CountEnabled ? "enabled" : "disabled")}, $expand={(descriptor.ExpandWhitelist is null or { Count: 0 } ? "disabled" : string.Join(",", descriptor.ExpandWhitelist))}.")
              .Produces(StatusCodes.Status200OK)

--- a/tests/Granit.Http.ODataExposure.Tests/EndpointNameCollisionTests.cs
+++ b/tests/Granit.Http.ODataExposure.Tests/EndpointNameCollisionTests.cs
@@ -1,0 +1,138 @@
+using Granit.Authorization;
+using Granit.DataExchange.Export;
+using Granit.Domain;
+using Granit.Entities;
+using Granit.Http.ODataExposure.Extensions;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.RateLimiting.Extensions;
+using Granit.RateLimiting.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ODataExposure.Tests;
+
+/// <summary>
+/// Regression: an entity legitimately exposed on BOTH the tenant-feed and the
+/// host-feed (e.g. the canonical User aggregate per ADR-051 — tenant-scope read
+/// for self-service, host-scope cross-tenant read for compliance) must not
+/// collide on the globally-unique endpoint name registry. The tenant-feed name
+/// stays <c>OData{Set}List</c> (no breaking change for existing apps); the
+/// host-feed gets a <c>Host</c> segment.
+/// </summary>
+public sealed class EndpointNameCollisionTests
+{
+    [Fact]
+    public void SameEntitySetName_OnBothFeeds_DoesNotCollide()
+    {
+        using WebApplication app = BuildApp();
+
+        // Mount "Users" on both feeds — pre-fix, this threw
+        // InvalidOperationException("Duplicate endpoint name 'ODataUsersList'…").
+        app.MapGranitODataEndpoints("/api/v1/odata", opts =>
+            opts.EntitySet<User, UserQueryDefinition>("Users")
+                .RequirePermission("OData.Test.Users.Read")
+                .DisableExpand());
+
+        Should.NotThrow(() =>
+            app.MapGranitODataHostEndpoints("/api/v1/odata/host", opts =>
+                opts.EntitySet<User, UserQueryDefinition>("Users")
+                    .RequirePermission("OData.Test.Users.Host.Read")
+                    .AcknowledgeCrossTenantExposure(q => q)
+                    .DisableExpand()));
+
+        HashSet<string> endpointNames =
+        [
+            .. ((IEndpointRouteBuilder)app).DataSources
+                .SelectMany(s => s.Endpoints)
+                .Select(e => e.Metadata.GetMetadata<Microsoft.AspNetCore.Routing.EndpointNameMetadata>()?.EndpointName)
+                .OfType<string>(),
+        ];
+
+        endpointNames.ShouldContain("ODataUsersList");
+        endpointNames.ShouldContain("ODataHostUsersList");
+    }
+
+    private static WebApplication BuildApp()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+        builder.Services.AddSingleton<IPermissionChecker>(Substitute.For<IPermissionChecker>());
+        builder.Services.AddSingleton(Substitute.For<IQueryableSource<User>>());
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<User>>());
+        builder.Services.AddSingleton<QueryDefinition<User>>(new UserQueryDefinition());
+        builder.Services.AddSingleton<IEntityDefinitionDescriptor>(new UserEntityDefinition());
+        builder.Services.AddSingleton<IExportDefinitionDescriptor>(new UserExportDefinition());
+
+        // Host-feed validator looks up the required permission and checks
+        // MultiTenancySides.Host — stub a provider with the two permissions
+        // referenced by the test.
+        builder.Services.AddSingleton<IPermissionDefinitionManager>(
+            new StubPermissionDefinitionManager
+            {
+                ["OData.Test.Users.Read"] = MultiTenancySides.Tenant,
+                ["OData.Test.Users.Host.Read"] = MultiTenancySides.Host,
+            });
+
+        builder.Services.AddGranitODataExposure();
+        builder.Services.AddGranitRateLimiting(o =>
+        {
+            o.Enabled = true;
+            o.Policies[ODataExposureEndpointRouteBuilderExtensions.RateLimitPolicyName] =
+                new RateLimitPolicyOptions { PermitLimit = 1000, Window = TimeSpan.FromMinutes(1) };
+            o.Policies[ODataExposureEndpointRouteBuilderExtensions.HostRateLimitPolicyName] =
+                new RateLimitPolicyOptions { PermitLimit = 1000, Window = TimeSpan.FromMinutes(1) };
+        });
+
+        return builder.Build();
+    }
+
+    private sealed class StubPermissionDefinitionManager : IPermissionDefinitionManager
+    {
+        private readonly Dictionary<string, PermissionDefinition> _definitions = [];
+
+        public MultiTenancySides this[string name]
+        {
+            set => _definitions[name] = new PermissionDefinition(name, DisplayName: null, GroupName: "Test", value);
+        }
+
+        public bool Exists(string name) => _definitions.ContainsKey(name);
+        public PermissionDefinition? Find(string name) => _definitions.GetValueOrDefault(name);
+        public IReadOnlyList<PermissionDefinition> GetAll() => [.. _definitions.Values];
+        public IReadOnlyList<PermissionGroup> GetGroups() => [];
+    }
+
+    public sealed class User : IMultiTenant
+    {
+        public Guid Id { get; init; }
+        public Guid? TenantId { get; set; }
+        public string Email { get; init; } = string.Empty;
+    }
+
+    public sealed class UserQueryDefinition : QueryDefinition<User>
+    {
+        public override string Name => "Test.Users";
+        protected override void Configure(QueryDefinitionBuilder<User> builder) =>
+            builder.Column(u => u.Email, c => c.Filterable());
+    }
+
+    public sealed class UserEntityDefinition : EntityDefinition<User>
+    {
+        public override string Name => "Test.User";
+        protected override void Configure(EntityDefinitionBuilder<User> builder) =>
+            builder.Query<UserQueryDefinition>().Export<UserExportDefinition>();
+    }
+
+    public sealed class UserExportDefinition : ExportDefinition<User>
+    {
+        public override string Name => "Test.UserExport";
+        protected override void Configure(ExportDefinitionBuilder<User> builder) =>
+            builder.Field(u => u.Email);
+    }
+}


### PR DESCRIPTION
## Summary

- An entity exposed on both the tenant-feed and the host-feed (e.g. canonical User aggregate per ADR-051) collided on the globally-unique Minimal API endpoint name registry: both routes were named `OData{Set}List`, triggering `InvalidOperationException: Duplicate endpoint name 'ODataUsersList'` at host startup.
- Host-feed route names now carry a `Host` segment (`ODataHostUsersList`). Tenant-feed names are unchanged — no breaking change for apps that reference `OData{Set}List` by name.
- `$metadata` and service-document op names were already differentiated; no extra fix needed there.

Reproduced on `granit-fx/granit-showcase-dotnet` PR #50.

## Test plan

- [x] New regression test [EndpointNameCollisionTests.cs](tests/Granit.Http.ODataExposure.Tests/EndpointNameCollisionTests.cs) mounts the same EntitySet name on both feeds and asserts `ODataUsersList` + `ODataHostUsersList` coexist.
- [x] Full `Granit.Http.ODataExposure.Tests` suite green (44/44).
- [x] `dotnet format --verify-no-changes` clean on the modified src + test projects.
- [ ] CI api-data shard green.