### PR TITLE
fix(documents-asset-metadata): wire up Endpoints package missed by F17.3 squash

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -207,6 +207,7 @@
         "tests/Granit.Documents.Notifications.Tests",
         "tests/Granit.Documents.AssetMetadata.Tests",
         "tests/Granit.Documents.AssetMetadata.EntityFrameworkCore.Tests",
+        "tests/Granit.Documents.AssetMetadata.Endpoints.Tests",
         "tests/Granit.Documents.Renditions.BackgroundJobs.Tests",
         "tests/Granit.Documents.Renditions.Endpoints.Tests",
         "tests/Granit.Documents.Renditions.Imaging.Tests",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7199,6 +7199,15 @@
       ]
     },
     {
+      "name": "AuditEntityChangeSummaryResponse",
+      "fqn": "Granit.Auditing.Dtos.AuditEntityChangeSummaryResponse",
+      "kind": "record",
+      "project": "Granit.Auditing",
+      "file": "src/Granit.Auditing/Dtos/AuditEntityChangeSummaryResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "AuditEntryResponse",
       "fqn": "Granit.Auditing.Dtos.AuditEntryResponse",
       "kind": "record",
@@ -7854,7 +7863,7 @@
       "kind": "class",
       "project": "Granit.Auditing",
       "file": "src/Granit.Auditing/Queries/AuditEntityChangeQueryDefinition.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "Name",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -162,6 +162,7 @@
     <Project Path="src/Granit.Documents.Renditions.EntityFrameworkCore/Granit.Documents.Renditions.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Documents.AssetMetadata/Granit.Documents.AssetMetadata.csproj" />
     <Project Path="src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Granit.Documents.AssetMetadata.EntityFrameworkCore.csproj" />
+    <Project Path="src/Granit.Documents.AssetMetadata.Endpoints/Granit.Documents.AssetMetadata.Endpoints.csproj" />
     <Project Path="src/Granit.Documents.Renditions/Granit.Documents.Renditions.csproj" />
     <Project Path="src/Granit.Documents/Granit.Documents.csproj" />
     <Project Path="src/Granit.Features.Endpoints/Granit.Features.Endpoints.csproj" />
@@ -552,6 +553,7 @@
     <Project Path="tests/Granit.Documents.Notifications.Tests/Granit.Documents.Notifications.Tests.csproj" />
     <Project Path="tests/Granit.Documents.AssetMetadata.Tests/Granit.Documents.AssetMetadata.Tests.csproj" />
     <Project Path="tests/Granit.Documents.AssetMetadata.EntityFrameworkCore.Tests/Granit.Documents.AssetMetadata.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.Documents.AssetMetadata.Endpoints.Tests/Granit.Documents.AssetMetadata.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Documents.Renditions.BackgroundJobs.Tests/Granit.Documents.Renditions.BackgroundJobs.Tests.csproj" />
     <Project Path="tests/Granit.Documents.Renditions.Endpoints.Tests/Granit.Documents.Renditions.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Documents.Renditions.Imaging.Tests/Granit.Documents.Renditions.Imaging.Tests.csproj" />

--- a/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Extensions/AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Extensions/AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -29,6 +29,7 @@ public static class AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtens
 
         builder.Services.AddGranitDbContext<AssetMetadataDbContext>(configure);
         builder.Services.TryAddScoped<IAssetMetadataStore, AssetMetadataStore>();
+        builder.Services.TryAddScoped<IAssetMetadataService, AssetMetadataService>();
 
         return builder;
     }


### PR DESCRIPTION
## Summary

The squash-merge of #1989 dropped three follow-up files that are required to actually wire the new `Granit.Documents.AssetMetadata.Endpoints` package into the solution and DI graph:

- `Granit.slnx` — project not added to the solution
- `.github/test-shards.json` — `Granit.Documents.AssetMetadata.Endpoints.Tests` not registered in the `infrastructure` shard, so CI silently skips it
- `AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions` — `IAssetMetadataService` had no DI registration, so endpoint injection fails at runtime

Regenerated `infrastructure.slnf` / `src-only.slnf` from the updated manifest.

## Test plan

- [x] `Granit.slnx` includes the new project
- [x] `dotnet build .github/shard-filters/infrastructure.slnf` clean
- [x] `IAssetMetadataService` resolves at runtime