### PR TITLE
fix(openapi): BFF tag casing + audit-entity-changes DTO projection

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -21095,6 +21095,24 @@
       ]
     },
     {
+      "name": "DocumentListPage",
+      "fqn": "Granit.Documents.Domain.DocumentListPage",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/DocumentListPage.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DocumentListSort",
+      "fqn": "Granit.Documents.Domain.DocumentListSort",
+      "kind": "enum",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Domain/DocumentListPage.cs",
+      "line": 21,
+      "members": []
+    },
+    {
       "name": "DocumentShare",
       "fqn": "Granit.Documents.Domain.DocumentShare",
       "kind": "class",
@@ -21311,6 +21329,15 @@
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Documents/Dtos/ListDocumentVersionsResponse.cs",
       "line": 12,
+      "members": []
+    },
+    {
+      "name": "ListDocumentsResponse",
+      "fqn": "Granit.Documents.Endpoints.Documents.Dtos.ListDocumentsResponse",
+      "kind": "record",
+      "project": "Granit.Documents.Endpoints",
+      "file": "src/Granit.Documents.Endpoints/Documents/Dtos/ListDocumentsResponse.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -22029,6 +22056,12 @@
           "kind": "method",
           "signature": "ListTrashedAsync(int skip, int take, CancellationToken cancellationToken = default)",
           "returnType": "Task<TrashedDocumentPage>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(Guid? folderId, DocumentStatus status, int skip, int take, DocumentListSort sort, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentListPage>"
         }
       ]
     },

--- a/src/Granit.Auditing/Dtos/AuditEntityChangeSummaryResponse.cs
+++ b/src/Granit.Auditing/Dtos/AuditEntityChangeSummaryResponse.cs
@@ -1,0 +1,21 @@
+using Granit.Auditing.Domain;
+
+namespace Granit.Auditing.Dtos;
+
+/// <summary>
+/// Summary projection of an <see cref="AuditEntityChange"/> for list/query endpoints.
+/// </summary>
+/// <remarks>
+/// Returned by the query engine when <c>MapGranitQuery&lt;AuditEntityChange&gt;</c> is
+/// mounted with <c>AuditEntityChangeQueryDefinition</c>. Property-level diffs are
+/// deliberately excluded from the list view — they are exposed via the parent
+/// <c>AuditEntry</c> detail endpoint. <c>PropertyChangeCount</c> is computed
+/// server-side via a SQL subquery on <c>AuditPropertyChange</c>.
+/// </remarks>
+public sealed record AuditEntityChangeSummaryResponse(
+    Guid Id,
+    Guid AuditEntryId,
+    string EntityType,
+    string EntityId,
+    AuditChangeType ChangeType,
+    int PropertyChangeCount);

--- a/src/Granit.Auditing/Queries/AuditEntityChangeQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntityChangeQueryDefinition.cs
@@ -1,4 +1,5 @@
 using Granit.Auditing.Domain;
+using Granit.Auditing.Dtos;
 using Granit.QueryEngine;
 
 namespace Granit.Auditing.Queries;
@@ -22,6 +23,13 @@ public sealed class AuditEntityChangeQueryDefinition : QueryDefinition<AuditEnti
             .Column(e => e.ChangeType, c => c.Label("Change Type").LabelKey("Auditing.Columns.ChangeType").Filterable().Sortable())
             .GlobalSearch(e => e.EntityType, e => e.EntityId)
             .DefaultSort("-auditEntryId")
-            .DefaultPageSize(25);
+            .DefaultPageSize(25)
+            .ProjectTo(e => new AuditEntityChangeSummaryResponse(
+                e.Id,
+                e.AuditEntryId,
+                e.EntityType,
+                e.EntityId,
+                e.ChangeType,
+                e.PropertyChanges.Count));
     }
 }

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -77,7 +77,7 @@ public static class BffEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(groupPrefix)
-            .WithTags($"BFF - {frontend.Name}");
+            .WithTags($"BFF - {ToTagSuffix(frontend.Name)}");
 
         group.MapLoginEndpoints(frontend);
         group.MapLogoutEndpoints(frontend);
@@ -145,6 +145,11 @@ public static class BffEndpointRouteBuilderExtensions
         .ExcludeFromDescription()
         .AllowAnonymous();
     }
+
+    private static string ToTagSuffix(string name) =>
+        string.IsNullOrEmpty(name)
+            ? name
+            : char.ToUpperInvariant(name[0]) + name[1..];
 
     internal static string GetContentType(string path) =>
         Path.GetExtension(path).ToLowerInvariant() switch


### PR DESCRIPTION
## Summary

Two OpenAPI convention fixes surfaced by an audit of `/openapi/v1.json` on the Granit Showcase API.

### 1. BFF tag casing — `Granit.Bff.Endpoints`

`BffEndpointRouteBuilderExtensions.MapFrontendEndpoints` interpolated `frontend.Name` directly into the tag (`$"BFF - {frontend.Name}"`). Since `Name` is also the routing key (idiomatically lowercase: `"app"`, `"host"`), tags came out as `BFF - app` / `BFF - host`, violating the documented `Module - SubGroup` Title Case rule (`CLAUDE.md §OpenAPI tags`).

Fix: a small `ToTagSuffix` helper capitalizes the first letter when composing the tag, leaving the route key untouched. → `BFF - App`, `BFF - Host`.

### 2. `audit-entity-changes` returns the EF entity — `Granit.Auditing`

Reported by the showcase React client: `GET /api/v1/auditing/audit-entity-changes` exposes `PagedResult<AuditEntityChange>` (domain entity) instead of a Response DTO, unlike the sibling `audit-entries` endpoint which returns `PagedResult<AuditEntryResponse>`.

Root cause: `AuditEntityChangeQueryDefinition` declares columns but never calls `.ProjectTo(...)`, so the QueryEngine falls back to the entity type.

Fix: new flat DTO `AuditEntityChangeSummaryResponse` (Id, AuditEntryId, EntityType, EntityId, ChangeType enum, PropertyChangeCount via SQL subquery) in `Granit.Auditing/Dtos/`, plus a `.ProjectTo(...)` call in the query definition. Mirrors the `AuditEntryQueryDefinition` / `AuditEntryResponse` pattern exactly. The existing nested `AuditEntityChangeResponse` (used by the detail endpoint with full property diffs) is unchanged.

## Test plan

- [x] `dotnet build src/Granit.Auditing` — 0/0
- [x] `dotnet build src/Granit.Auditing.Endpoints` — 0/0
- [x] `dotnet build src/Granit.Bff.Endpoints` — 0/0
- [x] `dotnet test tests/Granit.Auditing.Tests` — 88 passed
- [x] `dotnet test tests/Granit.Auditing.Endpoints.Tests` — 33 passed
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 109 passed
- [x] `dotnet format style --verify-no-changes` clean on both source folders
- [ ] Showcase: restart and confirm `/openapi/v1.json` now shows `BFF - App` / `BFF - Host` tags and `PagedResultOfAuditEntityChangeSummaryResponse` schema on `/api/v1/auditing/audit-entity-changes`.