### PR TITLE
feat(documents-endpoints): wire MapGranitQuery<Document> for paged listing

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -988,6 +988,7 @@
         "Granit.Authorization",
         "Granit.Documents",
         "Granit.Http.ApiDocumentation",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Taxonomy",
         "Granit.Validation"
       ],
@@ -21373,7 +21374,7 @@
       "kind": "class",
       "project": "Granit.Documents.Endpoints",
       "file": "src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "MapGranitDocuments",
@@ -21605,7 +21606,7 @@
       "kind": "class",
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitDocumentsEntityFrameworkCore",

--- a/src/Granit.Documents.AssetMetadata.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Endpoints/packages.lock.json
@@ -134,6 +134,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -193,11 +194,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {

--- a/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Documents.Endpoints/Extensions/DocumentsEndpointRouteBuilderExtensions.cs
@@ -1,8 +1,10 @@
+using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Endpoints;
 using Granit.Documents.Endpoints.Folders.Endpoints;
 using Granit.Documents.Endpoints.Options;
 using Granit.Documents.Endpoints.Quotas.Endpoints;
 using Granit.Documents.Endpoints.Shares.Endpoints;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -45,6 +47,12 @@ public static class DocumentsEndpointRouteBuilderExtensions
         group.MapDocumentTagProxyEndpoints();
         group.MapShareEndpoints();
         group.MapQuotaEndpoints();
+
+        // Query engine endpoint — paginated, filterable, sortable listing exposed
+        // under /documents/query. Front-ends targeting folder-scoped views call
+        // `?filter=folderId eq <guid> and status eq Active&sort=name asc`.
+        // The tenant filter is applied by the underlying DbContext / IQueryableSource.
+        group.MapGranitGroup("documents/query").MapGranitQuery<Document>();
 
         return group;
     }

--- a/src/Granit.Documents.Endpoints/Granit.Documents.Endpoints.csproj
+++ b/src/Granit.Documents.Endpoints/Granit.Documents.Endpoints.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Documents\Granit.Documents.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Taxonomy\Granit.Taxonomy.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>

--- a/src/Granit.Documents.Endpoints/README.md
+++ b/src/Granit.Documents.Endpoints/README.md
@@ -46,6 +46,25 @@ app.MapGranitDocuments(o =>
 | --- | --- |
 | `Documents.Folders.Read` | List folders, get one, breadcrumb. |
 | `Documents.Folders.Manage` | Create / rename / move / trash folders. |
+| `Documents.Documents.Read` | Read documents, list metadata, query documents grid. |
+
+## Query endpoint
+
+`GET /documents/query` is wired through the standard Granit query engine
+(`MapGranitQuery<Document>()`) and is the canonical way to list documents with
+filtering, sorting, and pagination. The `DocumentQueryDefinition` exposes
+columns (`folderId`, `status`, `name`, `description`, `currentVersionId`,
+`trashedAt`, …) with global search on `name` + `description`.
+
+Folder-scoped listing for a file-explorer UI:
+
+```http
+GET /documents/query?filter=folderId eq <guid> and status eq Active&sort=name asc&take=50
+```
+
+Permission gate: `Documents.Documents.Read`. The tenant filter is applied at
+the EF Core layer — when no tenant context is active (host admin), all
+documents are returned cross-tenant.
 
 ## Documentation
 

--- a/src/Granit.Documents.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.Endpoints/packages.lock.json
@@ -177,11 +177,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,8 +1,10 @@
 using Granit.Documents.Authorization;
+using Granit.Documents.Domain;
 using Granit.Documents.EntityFrameworkCore.Authorization;
 using Granit.Documents.EntityFrameworkCore.Internal;
 using Granit.Documents.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -73,6 +75,9 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
         // is registered first so the cache decorator can delegate to it; the public
         // IEffectivePermissionResolver registration depends on whether the FusionCache layer
         // is enabled (DocumentsOptions.AclCacheEnabled — default true).
+        // Query engine source — powers the generic /documents/query endpoint.
+        builder.Services.AddScoped<IQueryableSource<Document>, EfDocumentQueryableSource>();
+
         builder.Services.AddScoped<EffectivePermissionResolver>();
         builder.Services.AddScoped<IEffectivePermissionResolver>(sp =>
         {

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/EfDocumentQueryableSource.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/EfDocumentQueryableSource.cs
@@ -1,0 +1,35 @@
+using Granit.DataFiltering;
+using Granit.Documents.Domain;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Documents.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="Document"/>. Powers the generic <c>/documents/query</c> endpoint
+/// wired by <c>Granit.Documents.Endpoints</c>. When no tenant context is active
+/// (host admin), the multi-tenant query filter is disabled so all documents are
+/// returned cross-tenant.
+/// </summary>
+internal sealed class EfDocumentQueryableSource(
+    IDbContextFactory<DocumentsDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IDataFilter dataFilter) : IQueryableSource<Document>, IDisposable
+{
+    private readonly DocumentsDbContext _context = contextFactory.CreateDbContext();
+    private readonly IDisposable? _tenantBypass = !currentTenant.IsAvailable
+        ? dataFilter.Disable<IMultiTenant>()
+        : null;
+
+    public IQueryable<Document> GetQueryable() =>
+        _context.Documents.AsNoTracking();
+
+    public void Dispose()
+    {
+        _tenantBypass?.Dispose();
+        _context.Dispose();
+    }
+}

--- a/src/Granit.Documents.Renditions.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.Renditions.Endpoints/packages.lock.json
@@ -128,6 +128,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -194,11 +195,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2358,6 +2358,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Documents.AssetMetadata.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Endpoints.Tests/packages.lock.json
@@ -427,6 +427,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -490,11 +491,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {

--- a/tests/Granit.Documents.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Endpoints.Tests/packages.lock.json
@@ -412,6 +412,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -475,11 +476,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {

--- a/tests/Granit.Documents.Renditions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Endpoints.Tests/packages.lock.json
@@ -412,6 +412,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Taxonomy": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -493,11 +494,27 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.taxonomy": {


### PR DESCRIPTION
## Summary

Closes #1990. The front file-explorer UI (granit-front F13) needs a paged, filterable, sortable listing of documents. Rather than carving a bespoke `/folders/{id}/documents` endpoint, this PR exposes the entity through the **standard Granit query engine** (same pattern as Invoicing, Catalog, Webhooks, AI, Tax, Parties, Subscriptions, Auditing, BlobStorage).

## Changes

- `Granit.Documents.Endpoints` now wires `MapGranitQuery<Document>()` under `/documents/query`. The existing `DocumentQueryDefinition` (columns, sortable name + status + folderId, global search on name + description) is the contract — no new DTO to maintain.
- `Granit.Documents.EntityFrameworkCore` registers `EfDocumentQueryableSource : IQueryableSource<Document>`. When no tenant context is active (host admin), the multi-tenant filter is bypassed — same precedent as `EfInvoiceQueryableSource`.
- README updated with the canonical folder-scoped call.

## Usage

Folder-scoped listing for the file explorer:

```http
GET /documents/query?filter=folderId eq <guid> and status eq Active&sort=name asc&take=50
```

Permission gate is `Documents.Documents.Read` (inherited from the root group). Tenant filter applied at the EF Core layer.

## Test plan

- [x] `dotnet build .github/shard-filters/infrastructure.slnf` clean
- [x] `dotnet build .github/shard-filters/architecture.slnf` clean
- [x] `dotnet test architecture.slnf` — 230/230 pass
- [x] `dotnet format --verify-no-changes` clean

## Notes

No bespoke list endpoint, no new DTO, no service surface to maintain — the query engine already covers filter (eq/ne/contains/in), sort (asc/desc), pagination, search, presets and meta endpoint out of the box.