### PR TITLE
fix(http-security): public ctor on DefaultUrlSafetyValidator for DI activation

### DIFF
--- a/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
+++ b/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
@@ -17,7 +17,7 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
     private readonly IDnsResolver _resolver;
     private readonly TimeProvider _timeProvider;
 
-    internal DefaultUrlSafetyValidator(
+    public DefaultUrlSafetyValidator(
         IOptions<UrlSafetyOptions> options,
         IDnsResolver resolver,
         TimeProvider timeProvider)


### PR DESCRIPTION
## Problem

Hosts wiring `Granit.Http.Security` with `ServiceProviderOptions.ValidateOnBuild = true` (default in .NET 10 / Aspire) crash at boot:

```
A suitable constructor for type
'Granit.Http.Security.Internal.DefaultUrlSafetyValidator' could not be
located. Ensure the type is concrete and services are registered for
all parameters of a public constructor.
```

Reported from `granit-fx/granit-showcase-dotnet` PR #50.

## Root cause

`UrlSafetyServiceCollectionExtensions.cs:34` registers the validator via:

```csharp
services.TryAddSingleton<IUrlSafetyValidator, DefaultUrlSafetyValidator>();
```

This form resolves to `CallSiteFactory.CreateConstructorCallSite`, which only enumerates **public** constructors. `DefaultUrlSafetyValidator`'s ctor was declared `internal`, so DI's reflection step found no candidate and failed validation.

Every other `internal sealed` service in Granit uses primary constructors — those generate a `public` ctor at the IL level, hiding the gotcha. Only this type carried an explicit `internal` ctor.

## Fix

Promote the constructor to `public`. The class stays `internal sealed`, so:

- No new public API surface — `internal` types are not instantiable from outside the assembly regardless of ctor visibility.
- Strictly additive change.

## Audit

Grep'd every other `internal sealed class` with an explicit `internal` ctor in `src/Granit.*/Internal/`. The two other matches (`ApiKeyCurrentUserService`, `MagickNetImagePipeline`) are activated by factory code, not by DI — no fix needed.

## Test plan

- [x] Build clean
- [ ] Integration smoke (Showcase PR #50 will validate the boot path)