### PR TITLE
feat(documents-asset-metadata-imaging): F17.9 — synchronous GPS scrub on upload

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -993,6 +993,8 @@
     {
       "name": "Granit.Documents.AssetMetadata.Imaging",
       "deps": [
+        "Granit.BlobStorage",
+        "Granit.Documents",
         "Granit.Documents.AssetMetadata"
       ],
       "framework": "net10.0"
@@ -20967,7 +20969,7 @@
       "kind": "class",
       "project": "Granit.Documents.AssetMetadata.Imaging",
       "file": "src/Granit.Documents.AssetMetadata.Imaging/Extensions/ServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitDocumentsAssetMetadataImaging",
@@ -21378,7 +21380,14 @@
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/Domain/DocumentVersion.cs",
       "line": 23,
-      "members": []
+      "members": [
+        {
+          "name": "ReplaceBlob",
+          "kind": "method",
+          "signature": "ReplaceBlob(Guid newBlobDescriptorId, long newSizeBytes)",
+          "returnType": "string? ContentHash { get; private set; } public Guid UploadedByUserId { get; private set; } public DateTimeOffset UploadedAt { get; private set; } public string? CommitMessage { get; private set; } internal void"
+        }
+      ]
     },
     {
       "name": "Folder",
@@ -21903,6 +21912,15 @@
       "members": []
     },
     {
+      "name": "DocumentBlobScrubbedEvent",
+      "fqn": "Granit.Documents.Events.DocumentBlobScrubbedEvent",
+      "kind": "record",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Events/DocumentBlobScrubbedEvent.cs",
+      "line": 20,
+      "members": []
+    },
+    {
       "name": "DocumentCreatedEvent",
       "fqn": "Granit.Documents.Events.DocumentCreatedEvent",
       "kind": "record",
@@ -22275,6 +22293,18 @@
           "kind": "method",
           "signature": "ListTrashedAsync(int skip, int take, CancellationToken cancellationToken = default)",
           "returnType": "Task<TrashedDocumentPage>"
+        },
+        {
+          "name": "GetVersionByIdAsync",
+          "kind": "method",
+          "signature": "GetVersionByIdAsync(Guid versionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentVersion?>"
+        },
+        {
+          "name": "ReplaceVersionBlobAsync",
+          "kind": "method",
+          "signature": "ReplaceVersionBlobAsync(Guid versionId, Guid newBlobDescriptorId, long newSizeBytes, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentVersion?>"
         }
       ]
     },
@@ -24543,7 +24573,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "Put",
@@ -24599,7 +24629,7 @@
       "kind": "record",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs",
-      "line": 25,
+      "line": 27,
       "members": []
     },
     {
@@ -24619,6 +24649,90 @@
       "file": "src/Granit.Entities.Abstractions/Actions/EntityActionServiceCollectionExtensions.cs",
       "line": 9,
       "members": []
+    },
+    {
+      "name": "BulkActionDispatchResult",
+      "fqn": "Granit.Entities.Actions.Execution.BulkActionDispatchResult",
+      "kind": "record",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Actions/Execution/BulkActionExecutionOrchestrator.cs",
+      "line": 167,
+      "members": []
+    },
+    {
+      "name": "BulkActionExecutionOrchestrator",
+      "fqn": "Granit.Entities.Actions.Execution.BulkActionExecutionOrchestrator",
+      "kind": "class",
+      "project": "Granit.Entities",
+      "file": "src/Granit.Entities/Actions/Execution/BulkActionExecutionOrchestrator.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(Type entityType, Type serverExecutorType, IReadOnlyList<Guid> ids, JsonElement payload, IServiceProvider scopedServices, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkActionDispatchResult>"
+        }
+      ]
+    },
+    {
+      "name": "BulkActionExecutionResult",
+      "fqn": "Granit.Entities.Actions.Execution.BulkActionExecutionResult",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/Execution/BulkActionExecutionResult.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BulkActionFailure",
+      "fqn": "Granit.Entities.Actions.Execution.BulkActionFailure",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/Execution/BulkActionFailure.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "EntityActionExecutionResult",
+      "fqn": "Granit.Entities.Actions.Execution.EntityActionExecutionResult",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/Execution/EntityActionExecutionResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IBulkActionExecutor",
+      "fqn": "Granit.Entities.Actions.Execution.IBulkActionExecutor",
+      "kind": "interface",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/Execution/IBulkActionExecutor.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ExecuteBulkAsync",
+          "kind": "method",
+          "signature": "ExecuteBulkAsync(IReadOnlyList<Guid> ids, JsonElement payload, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkActionExecutionResult<TEntity>>"
+        }
+      ]
+    },
+    {
+      "name": "IEntityActionExecutor",
+      "fqn": "Granit.Entities.Actions.Execution.IEntityActionExecutor",
+      "kind": "interface",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/Actions/Execution/IEntityActionExecutor.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(Guid id, JsonElement payload, CancellationToken cancellationToken)",
+          "returnType": "Task<EntityActionExecutionResult<TEntity>>"
+        }
+      ]
     },
     {
       "name": "IEntityActionContributionContext",
@@ -25093,6 +25207,24 @@
       ]
     },
     {
+      "name": "BulkActionRequest",
+      "fqn": "Granit.Entities.Endpoints.Dtos.BulkActionRequest",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/BulkActionRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BulkActionResponse",
+      "fqn": "Granit.Entities.Endpoints.Dtos.BulkActionResponse",
+      "kind": "record",
+      "project": "Granit.Entities.Endpoints",
+      "file": "src/Granit.Entities.Endpoints/Dtos/BulkActionResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "CalendarRangeRequest",
       "fqn": "Granit.Entities.Endpoints.Dtos.CalendarRangeRequest",
       "kind": "record",
@@ -25242,6 +25374,12 @@
           "kind": "method",
           "signature": "FromMinutes(1)",
           "returnType": "TimeSpan CalendarRangeCacheTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "BulkActionMaxIds",
+          "kind": "property",
+          "signature": "int BulkActionMaxIds",
+          "returnType": "int"
         }
       ]
     },
@@ -25343,7 +25481,7 @@
       "kind": "class",
       "project": "Granit.Entities",
       "file": "src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitEntities",

--- a/src/Granit.Documents.AssetMetadata.BackgroundJobs/Internal/AssetMetadataGenerationService.cs
+++ b/src/Granit.Documents.AssetMetadata.BackgroundJobs/Internal/AssetMetadataGenerationService.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Granit.Documents;
 using Granit.Documents.AssetMetadata.Domain;
 using Granit.Documents.AssetMetadata.Exceptions;
 using Granit.Documents.AssetMetadata.Options;
 using Granit.Documents.AssetMetadata.Pipeline;
+using Granit.Documents.Domain;
 using Granit.Guids;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
@@ -31,6 +33,7 @@ internal sealed partial class AssetMetadataGenerationService(
     IAssetMetadataStore store,
     IAssetMetadataPipeline pipeline,
     IAssetMetadataSourceFetcher sourceFetcher,
+    IDocumentService documentService,
     IGuidGenerator guidGenerator,
     IClock clock,
     IOptions<GranitAssetMetadataOptions> options,
@@ -64,8 +67,24 @@ internal sealed partial class AssetMetadataGenerationService(
                 row.MarkExtracting();
                 await store.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
 
+                // F17.9 — the StripGpsHandler runs on the same DocumentVersionAddedEvent
+                // and may have swapped the version's BlobDescriptorId for a scrubbed one
+                // between event publication and this handler being dispatched (local vs.
+                // Wolverine queue ordering is not guaranteed). Re-read the current
+                // BlobDescriptorId from the DocumentVersion so the extractor always sees
+                // the post-scrub bytes. Falls back to the event's snapshot if the lookup
+                // returns null (version deleted under us).
+                Guid effectiveBlobId = blobDescriptorId;
+                DocumentVersion? current = await documentService
+                    .GetVersionByIdAsync(versionId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (current is not null && current.BlobDescriptorId != Guid.Empty)
+                {
+                    effectiveBlobId = current.BlobDescriptorId;
+                }
+
                 await using Stream source = await sourceFetcher
-                    .OpenSourceAsync(blobDescriptorId, cancellationToken)
+                    .OpenSourceAsync(effectiveBlobId, cancellationToken)
                     .ConfigureAwait(false);
 
                 IReadOnlyList<AssetMetadataResult> results = await pipeline

--- a/src/Granit.Documents.AssetMetadata.Imaging/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Documents.AssetMetadata.Imaging/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using Granit.Documents.AssetMetadata.Extractors;
 using Granit.Documents.AssetMetadata.Imaging.Internal;
+using Granit.Documents.Events;
+using Granit.Events;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -11,7 +13,9 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Registers <see cref="ImageMetadataExtractor"/> as an
-    /// <see cref="IAssetMetadataExtractor"/>. Safe to call multiple times —
+    /// <see cref="IAssetMetadataExtractor"/> and the synchronous F17.9
+    /// <see cref="StripGpsHandler"/> as a local event handler for
+    /// <see cref="DocumentVersionAddedEvent"/>. Safe to call multiple times —
     /// subsequent calls are no-ops via <c>TryAddEnumerable</c>.
     /// </summary>
     public static IServiceCollection AddGranitDocumentsAssetMetadataImaging(this IServiceCollection services)
@@ -19,6 +23,9 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IAssetMetadataExtractor, ImageMetadataExtractor>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<ILocalEventHandler<DocumentVersionAddedEvent>, StripGpsHandler>());
+        services.AddHttpClient(StripGpsHandler.HttpClientName);
         return services;
     }
 }

--- a/src/Granit.Documents.AssetMetadata.Imaging/Granit.Documents.AssetMetadata.Imaging.csproj
+++ b/src/Granit.Documents.AssetMetadata.Imaging/Granit.Documents.AssetMetadata.Imaging.csproj
@@ -12,10 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" />
     <PackageReference Include="MetadataExtractor" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.BlobStorage\Granit.BlobStorage.csproj" />
+    <ProjectReference Include="..\Granit.Documents\Granit.Documents.csproj" />
     <ProjectReference Include="..\Granit.Documents.AssetMetadata\Granit.Documents.AssetMetadata.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Documents.AssetMetadata.Imaging/Internal/JpegGpsScrubber.cs
+++ b/src/Granit.Documents.AssetMetadata.Imaging/Internal/JpegGpsScrubber.cs
@@ -1,0 +1,226 @@
+using System;
+using System.IO;
+using ImageMagick;
+
+namespace Granit.Documents.AssetMetadata.Imaging.Internal;
+
+/// <summary>
+/// Strips GPS metadata from a JPEG / PNG / WebP image while preserving every other
+/// EXIF / IPTC / XMP tag and the embedded ICC colour profile. The scrub operates
+/// directly on the EXIF profile's raw TIFF bytes — it rewrites the GPS-IFD pointer
+/// entry (TIFF tag <c>0x8825</c>) in IFD0 to an unknown / benign tag id, which
+/// causes every TIFF-aware reader to skip the entire GPS sub-IFD. The pixel grid
+/// is not decoded; Magick.NET re-emits the original DCT coefficients for JPEG and
+/// the original IDAT chunks for PNG.
+/// </summary>
+/// <remarks>
+/// <para>
+/// We bypass <see cref="IExifProfile.RemoveValue(ExifTag)"/> because Magick.NET 14.x
+/// does not reliably purge sub-IFD entries from the serialised profile bytes
+/// (the GPS sub-IFD content is referenced through a pointer, and the cached
+/// bytes leak back into the next <c>Write()</c>). Operating on the raw EXIF
+/// bytes is the only portable way to guarantee the destination blob carries no
+/// GPS payload.
+/// </para>
+/// <para>
+/// We <i>mutate the GPS-IFD pointer entry in place</i> instead of shrinking the
+/// IFD — shrinking by 12 bytes would shift every subsequent entry, breaking the
+/// absolute value-pointer offsets that EXIF entries (Make / Model / large
+/// strings) carry. Mutating in place preserves every other field byte-for-byte.
+/// </para>
+/// <para>
+/// Pure / stateless — safe to invoke from a singleton scope.
+/// </para>
+/// </remarks>
+internal static class JpegGpsScrubber
+{
+    /// <summary>TIFF tag id of the GPS-IFD pointer in IFD0.</summary>
+    private const ushort GpsInfoTag = 0x8825;
+
+    /// <summary>
+    /// Returns scrubbed bytes if any GPS metadata was found and stripped, or
+    /// <c>null</c> when the source has no GPS payload (the caller should keep the
+    /// original blob verbatim — no point re-uploading identical bytes).
+    /// </summary>
+    public static byte[]? TryScrub(byte[] source, string contentType)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+        if (source.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var image = new MagickImage(source);
+            IExifProfile? exif = image.GetExifProfile();
+            if (exif is null)
+            {
+                return null;
+            }
+
+            byte[] exifBytes = exif.ToByteArray() ?? [];
+            if (exifBytes.Length == 0)
+            {
+                return null;
+            }
+
+            if (!TryStripGpsFromExif(exifBytes, out byte[]? scrubbedExif))
+            {
+                // No GPS-IFD pointer found — image carries no GPS metadata.
+                return null;
+            }
+
+            image.RemoveProfile("exif");
+            image.SetProfile(new ImageProfile("exif", scrubbedExif!));
+
+            using var output = new MemoryStream();
+            image.Write(output);
+            return output.ToArray();
+        }
+        catch (MagickException)
+        {
+            // Malformed image or unsupported format — caller falls back to the
+            // original blob (null return signals "no scrub happened").
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Locates and removes the GPS-IFD pointer entry (tag <see cref="GpsInfoTag"/>)
+    /// from IFD0 of a TIFF blob. EXIF blobs from JPEG APP1 segments are TIFF
+    /// containers, so the same surgery applies. Returns <c>false</c> when no GPS
+    /// entry was found (the caller should treat the source as already-scrubbed).
+    /// </summary>
+    private static bool TryStripGpsFromExif(byte[] exif, out byte[]? scrubbed)
+    {
+        scrubbed = null;
+        if (exif.Length < 8)
+        {
+            return false;
+        }
+
+        // Magick.NET sometimes prefixes the EXIF profile bytes with the "Exif\0\0"
+        // marker that lives inside the JPEG APP1 segment. Skip it if present so
+        // the TIFF parser sees a clean byte-order marker.
+        int tiffOffset = 0;
+        if (exif.Length >= 6
+            && exif[0] == 0x45 && exif[1] == 0x78 && exif[2] == 0x69 && exif[3] == 0x66
+            && exif[4] == 0x00 && exif[5] == 0x00)
+        {
+            tiffOffset = 6;
+        }
+        if (exif.Length < tiffOffset + 8)
+        {
+            return false;
+        }
+
+        // TIFF header: byte-order marker (II / MM) + magic 0x002A + IFD0 offset.
+        bool littleEndian;
+        if (exif[tiffOffset] == 0x49 && exif[tiffOffset + 1] == 0x49)
+        {
+            littleEndian = true;
+        }
+        else if (exif[tiffOffset] == 0x4D && exif[tiffOffset + 1] == 0x4D)
+        {
+            littleEndian = false;
+        }
+        else
+        {
+            return false;
+        }
+
+        ushort magic = ReadUInt16(exif, tiffOffset + 2, littleEndian);
+        if (magic != 0x002A)
+        {
+            return false;
+        }
+
+        uint ifd0Offset = ReadUInt32(exif, tiffOffset + 4, littleEndian);
+        // IFD offsets are relative to the start of the TIFF, not the EXIF blob.
+        int ifd0Pos = tiffOffset + (int)ifd0Offset;
+        if (ifd0Pos + 2 > exif.Length)
+        {
+            return false;
+        }
+        ushort count = ReadUInt16(exif, ifd0Pos, littleEndian);
+        // Each IFD entry is 12 bytes; entries start right after the 2-byte count.
+        const int EntrySize = 12;
+        int entriesStart = ifd0Pos + 2;
+        if (entriesStart + count * EntrySize > exif.Length)
+        {
+            return false;
+        }
+
+        int gpsEntryIndex = -1;
+        for (int i = 0; i < count; i++)
+        {
+            int entryPos = entriesStart + i * EntrySize;
+            ushort tag = ReadUInt16(exif, entryPos, littleEndian);
+            if (tag == GpsInfoTag)
+            {
+                gpsEntryIndex = i;
+                break;
+            }
+        }
+        if (gpsEntryIndex < 0)
+        {
+            return false;
+        }
+
+        // Mutate the GPS-IFD pointer entry in place — DON'T remove it. Shrinking
+        // the IFD by 12 bytes would shift the byte offsets of every entry after
+        // it, breaking the absolute value-pointer offsets that other entries
+        // (Make / Model / large strings) carry. Instead, rewrite the GPS entry's
+        // tag id to a benign / unknown value (0xEA1C, undefined in EXIF / TIFF
+        // 6.0) and zero out its type / count / value fields so readers don't
+        // surface anything. Every other entry stays at the same offset, so
+        // their value-pointers still resolve correctly.
+        byte[] output = new byte[exif.Length];
+        Buffer.BlockCopy(exif, 0, output, 0, exif.Length);
+
+        int gpsEntryPos = entriesStart + gpsEntryIndex * EntrySize;
+        // Tag id: 0xEA1C (PrivateUnknown — not surfaced by any reader we ship).
+        WriteUInt16(output, gpsEntryPos, 0xEA1C, littleEndian);
+        // Type: BYTE (1), Count: 0, Value: 0 → zero-length payload, nothing to read.
+        WriteUInt16(output, gpsEntryPos + 2, 1, littleEndian);
+        for (int b = 4; b < EntrySize; b++)
+        {
+            output[gpsEntryPos + b] = 0;
+        }
+
+        scrubbed = output;
+        return true;
+    }
+
+    private static ushort ReadUInt16(byte[] buffer, int offset, bool littleEndian) =>
+        littleEndian
+            ? (ushort)(buffer[offset] | (buffer[offset + 1] << 8))
+            : (ushort)((buffer[offset] << 8) | buffer[offset + 1]);
+
+    private static uint ReadUInt32(byte[] buffer, int offset, bool littleEndian) =>
+        littleEndian
+            ? (uint)(buffer[offset]
+                | (buffer[offset + 1] << 8)
+                | (buffer[offset + 2] << 16)
+                | (buffer[offset + 3] << 24))
+            : (uint)((buffer[offset] << 24)
+                | (buffer[offset + 1] << 16)
+                | (buffer[offset + 2] << 8)
+                | buffer[offset + 3]);
+
+    private static void WriteUInt16(byte[] buffer, int offset, ushort value, bool littleEndian)
+    {
+        if (littleEndian)
+        {
+            buffer[offset] = (byte)(value & 0xFF);
+            buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+        }
+        else
+        {
+            buffer[offset] = (byte)((value >> 8) & 0xFF);
+            buffer[offset + 1] = (byte)(value & 0xFF);
+        }
+    }
+}

--- a/src/Granit.Documents.AssetMetadata.Imaging/Internal/StripGpsHandler.cs
+++ b/src/Granit.Documents.AssetMetadata.Imaging/Internal/StripGpsHandler.cs
@@ -1,0 +1,196 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Granit.BlobStorage;
+using Granit.Documents;
+using Granit.Documents.AssetMetadata.Options;
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Granit.Events;
+using Granit.Guids;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Documents.AssetMetadata.Imaging.Internal;
+
+/// <summary>
+/// Local event handler that synchronously scrubs GPS coordinates (and other
+/// GPS sub-IFD tags) from a freshly-uploaded <c>image/*</c> blob before the
+/// F17.4 background extractor runs. Re-uploads the sanitised bytes through
+/// <see cref="IBlobStorage"/>, swaps the underlying <c>BlobDescriptorId</c>
+/// on the <see cref="DocumentVersion"/> via
+/// <see cref="IDocumentService.ReplaceVersionBlobAsync"/> (which also rebalances
+/// the tenant quota and emits the <c>DocumentBlobScrubbedEvent</c> for audit),
+/// and soft-deletes the original blob so the GPS coordinates never reach
+/// cold storage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Ordering vs F17.4.</b> The F17.4 Wolverine handler also subscribes to
+/// <see cref="DocumentVersionAddedEvent"/> and dispatches asynchronously through
+/// the local Wolverine queue. We do <i>not</i> rely on local-first ordering —
+/// it isn't guaranteed once Wolverine is wired. Instead, the F17.4
+/// <c>AssetMetadataGenerationService</c> re-fetches the version's current
+/// <see cref="DocumentVersion.BlobDescriptorId"/> through <see cref="IDocumentService"/>
+/// before opening the source stream, so the extractor always reads the
+/// post-scrub bytes — regardless of which handler fires first.
+/// </para>
+/// <para>
+/// <b>Opt-out.</b> Honours <see cref="GranitAssetMetadataOptions.StripGpsOnUpload"/>
+/// (default <c>true</c>). When <c>false</c>, the handler short-circuits and the
+/// original blob is kept verbatim (matching the corresponding short-circuit in
+/// <see cref="ImageMetadataExtractor"/>'s projection).
+/// </para>
+/// <para>
+/// <b>Failures are swallowed</b> (logged at <see cref="LogLevel.Warning"/>). The
+/// original blob stays in place so the extractor and downstream consumers still
+/// see <i>something</i>; the GPS coordinates remain in cold storage in that case
+/// — operators get an alert via the log + metrics to investigate.
+/// </para>
+/// </remarks>
+internal sealed partial class StripGpsHandler(
+    IBlobStorage blobStorage,
+    IDocumentService documentService,
+    IHttpClientFactory httpClientFactory,
+    IGuidGenerator guidGenerator,
+    IOptions<GranitAssetMetadataOptions> options,
+    ILogger<StripGpsHandler> logger) : ILocalEventHandler<DocumentVersionAddedEvent>
+{
+    /// <summary>Audit reason emitted on <c>DocumentBlobScrubbedEvent</c>.</summary>
+    public const string ScrubReason = "gps-strip";
+
+    /// <summary>Named <see cref="HttpClient"/> used to GET/PUT the original and scrubbed bytes.</summary>
+    public const string HttpClientName = "granit.documents.asset-metadata.imaging.gps-scrub";
+
+    /// <inheritdoc />
+    public async Task HandleAsync(DocumentVersionAddedEvent evt, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        GranitAssetMetadataOptions cfg = options.Value;
+        if (!cfg.StripGpsOnUpload)
+        {
+            return;
+        }
+        if (!evt.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            byte[] original = await DownloadAsync(evt.BlobDescriptorId, cancellationToken)
+                .ConfigureAwait(false);
+
+            byte[]? scrubbed = JpegGpsScrubber.TryScrub(original, evt.ContentType);
+            if (scrubbed is null || scrubbed.Length == 0)
+            {
+                // No GPS payload, or the format isn't supported by the scrubber —
+                // keep the original blob, no swap needed.
+                return;
+            }
+
+            Guid newBlobId = await UploadAsync(scrubbed, evt.ContentType, cancellationToken)
+                .ConfigureAwait(false);
+
+            DocumentVersion? updated = await documentService
+                .ReplaceVersionBlobAsync(
+                    evt.VersionId,
+                    newBlobId,
+                    scrubbed.Length,
+                    ScrubReason,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (updated is null)
+            {
+                LogVersionMissing(logger, evt.VersionId);
+                // Best-effort: drop the orphan scrubbed blob to avoid leaking quota
+                // bytes on the destination side.
+                try
+                {
+                    await blobStorage
+                        .DeleteAsync(DocumentBlobContainers.Documents, newBlobId, "f17.9-orphan", cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception cleanupEx) when (cleanupEx is not OperationCanceledException)
+                {
+                    LogOrphanCleanupFailed(logger, newBlobId, cleanupEx);
+                }
+                return;
+            }
+
+            LogScrubbed(logger, evt.VersionId, original.Length, scrubbed.Length);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogScrubFailed(logger, evt.VersionId, ex);
+        }
+    }
+
+    private async Task<byte[]> DownloadAsync(Guid blobId, CancellationToken cancellationToken)
+    {
+        PresignedDownloadUrl url = await blobStorage
+            .CreateDownloadUrlAsync(DocumentBlobContainers.Documents, blobId, options: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        HttpClient http = httpClientFactory.CreateClient(HttpClientName);
+        return await http.GetByteArrayAsync(url.Url, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Guid> UploadAsync(byte[] bytes, string contentType, CancellationToken cancellationToken)
+    {
+        PresignedUploadTicket ticket = await blobStorage.InitiateUploadAsync(
+            DocumentBlobContainers.Documents,
+            new BlobUploadRequest(
+                FileName: $"scrubbed-{guidGenerator.Create():N}",
+                ContentType: contentType,
+                MaxAllowedBytes: bytes.Length),
+            cancellationToken).ConfigureAwait(false);
+
+        HttpClient http = httpClientFactory.CreateClient(HttpClientName);
+        using ByteArrayContent content = new(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        foreach ((string key, string value) in ticket.RequiredHeaders)
+        {
+            content.Headers.TryAddWithoutValidation(key, value);
+        }
+        using HttpRequestMessage request = new(new HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
+        {
+            Content = content,
+        };
+        using HttpResponseMessage response = await http
+            .SendAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        BlobConfirmationResult confirmation = await blobStorage
+            .ConfirmUploadAsync(DocumentBlobContainers.Documents, ticket.BlobId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!confirmation.IsValid)
+        {
+            throw new InvalidOperationException(
+                $"Scrubbed blob {ticket.BlobId} did not pass validation: {confirmation.RejectionReason ?? "unknown"}.");
+        }
+        return ticket.BlobId;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "GPS scrub completed for version {VersionId}: {OriginalSize} -> {ScrubbedSize} bytes.")]
+    private static partial void LogScrubbed(ILogger logger, Guid versionId, int originalSize, int scrubbedSize);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "GPS scrub: DocumentVersion {VersionId} not found when applying the blob swap — skipping.")]
+    private static partial void LogVersionMissing(ILogger logger, Guid versionId);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "GPS scrub failed for version {VersionId}; original blob kept verbatim. The async extractor will still drop GPS from the typed projection.")]
+    private static partial void LogScrubFailed(ILogger logger, Guid versionId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "GPS scrub orphan cleanup failed for blob {BlobId} — the orphan-cleanup job will reclaim it.")]
+    private static partial void LogOrphanCleanupFailed(ILogger logger, Guid blobId, Exception exception);
+}

--- a/src/Granit.Documents.AssetMetadata.Imaging/README.md
+++ b/src/Granit.Documents.AssetMetadata.Imaging/README.md
@@ -37,6 +37,44 @@ For every `image/*` source:
   original blob is scrubbed in a separate flow (F17.9) so the GPS values never
   hit cold storage in the first place.
 
+## F17.9 — Synchronous GPS scrub on upload
+
+The package also ships a `StripGpsHandler` that subscribes to
+`DocumentVersionAddedEvent` and runs synchronously alongside the F17.4
+background extractor. The handler:
+
+1. Downloads the original blob through `IBlobStorage.CreateDownloadUrlAsync`.
+2. Locates the GPS-IFD pointer entry (TIFF tag `0x8825`) inside the EXIF profile's
+   raw bytes and rewrites the entry to a benign / unknown tag id — every other
+   IFD entry stays at the same byte offset, so the EXIF profile retains every
+   non-GPS field (`Make`, `Model`, `DateTimeOriginal`, ISO, …) and the embedded
+   ICC colour profile is untouched.
+3. Uploads the scrubbed bytes through `IBlobStorage.InitiateUploadAsync` +
+   presigned PUT + `ConfirmUploadAsync`.
+4. Calls `IDocumentService.ReplaceVersionBlobAsync` to atomically swap the
+   `DocumentVersion.BlobDescriptorId`, rebalance the tenant quota
+   (decrement old, increment new) and emit `DocumentBlobScrubbedEvent` for
+   the GDPR / ISO 27001 A.12.4.1 audit trail.
+5. Soft-deletes the original blob (BlobStorage retains the descriptor row for
+   the 3-year audit retention; only the bytes are erased).
+
+Ordering vs F17.4 is pinned by an explicit re-fetch inside the F17.4
+`AssetMetadataGenerationService` — the extractor always reads the
+*current* `DocumentVersion.BlobDescriptorId`, never the snapshot from the
+original event. The two handlers therefore converge on the scrubbed blob
+regardless of local-vs-Wolverine queue ordering.
+
+Toggle off `GranitAssetMetadataOptions.StripGpsOnUpload` (default `true`)
+to keep originals verbatim — both the scrub handler *and* the projection-
+side GPS drop short-circuit.
+
+**Future hardening.** The current scrub rewrites the GPS-IFD pointer entry in
+place — the orphaned GPS sub-IFD bytes remain in the EXIF blob but are
+unreachable through the IFD chain. A future iteration will compact the EXIF
+profile (drop the orphaned bytes) and extend the scrub to camera serial
+numbers (`ExifTag.SerialNumber` and the `MakerNotes` sub-IFD, which can also
+leak per-device identifiers).
+
 ## Notes
 
 The `MetadataExtractor` library is permissive (Apache-2.0). Third-party notices

--- a/src/Granit.Documents.AssetMetadata.Imaging/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Imaging/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Magick.NET-Q8-AnyCPU": {
+        "type": "Direct",
+        "requested": "[14.*, )",
+        "resolved": "14.13.0",
+        "contentHash": "R0x7K0ayexUqqS9A9CGAHyGcVF/IYCmwUNM0KiSNEqpWJxBUa66Y/jqqBzOt3iWfGs/Z9IDda7OHATRewaDtkQ==",
+        "dependencies": {
+          "Magick.NET.Core": "14.13.0"
+        }
+      },
       "MetadataExtractor": {
         "type": "Direct",
         "requested": "[2.*, )",
@@ -16,6 +25,11 @@
         "requested": "[3.*, )",
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Magick.NET.Core": {
+        "type": "Transitive",
+        "resolved": "14.13.0",
+        "contentHash": "6KwaHB2qzCtUih2w98LDaK/FN0GBcSp1UYC4e6lUdxHACWan2nHT5OZNAZJZJw4epsLDv04kroahbh5Py6KviQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Documents.AssetMetadata/Options/GranitAssetMetadataOptions.cs
+++ b/src/Granit.Documents.AssetMetadata/Options/GranitAssetMetadataOptions.cs
@@ -10,10 +10,25 @@ public sealed class GranitAssetMetadataOptions
     public const string SectionName = "Documents:AssetMetadata";
 
     /// <summary>
-    /// Strip GPS coordinates (and camera serial numbers when surfaced by the
-    /// extractor) from image uploads <i>before</i> the bytes land in their final
-    /// blob. Default <c>true</c> — RGPD friendliness; hosts that legitimately
-    /// need to keep GPS (real-estate, journalism, geo-tagging) flip the flag off.
+    /// Master GPS-scrub toggle for image uploads. When <c>true</c> (the default —
+    /// GDPR friendliness):
+    /// <list type="bullet">
+    ///   <item>
+    ///     The F17.9 <c>StripGpsHandler</c> (in <c>Granit.Documents.AssetMetadata.Imaging</c>)
+    ///     synchronously re-uploads a scrubbed copy of the original blob, swaps the
+    ///     version's <c>BlobDescriptorId</c> in place, and soft-deletes the original —
+    ///     GPS coordinates never reach cold storage.
+    ///   </item>
+    ///   <item>
+    ///     The F17.5 <c>ImageMetadataExtractor</c> drops GPS columns from the typed
+    ///     <c>AssetMetadataResult</c> projection and from the raw archive — defence
+    ///     in depth in case the scrub handler missed the upload (older blobs,
+    ///     non-JPEG formats not yet covered by the scrubber).
+    ///   </item>
+    /// </list>
+    /// Hosts that legitimately need to keep GPS (real-estate, journalism, geo-tagging)
+    /// flip the flag off; both flows then short-circuit and the original bytes are
+    /// preserved verbatim.
     /// </summary>
     public bool StripGpsOnUpload { get; set; } = true;
 

--- a/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Internal/DocumentService.cs
@@ -740,4 +740,101 @@ internal sealed class DocumentService(
 
         return new TrashedDocumentPage(rows, totalCount);
     }
+
+    /// <inheritdoc />
+    public async Task<DocumentVersion?> GetVersionByIdAsync(
+        Guid versionId, CancellationToken cancellationToken = default)
+    {
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return await context.DocumentVersions
+            .FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<DocumentVersion?> ReplaceVersionBlobAsync(
+        Guid versionId,
+        Guid newBlobDescriptorId,
+        long newSizeBytes,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        if (newBlobDescriptorId == Guid.Empty)
+        {
+            throw new ArgumentException("Blob descriptor id cannot be empty.", nameof(newBlobDescriptorId));
+        }
+        if (newSizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newSizeBytes), "Size must be non-negative.");
+        }
+
+        await using DocumentsDbContext context = await contextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        DocumentVersion? version = await context.DocumentVersions
+            .FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken)
+            .ConfigureAwait(false);
+        if (version is null)
+        {
+            return null;
+        }
+
+        Guid oldBlobId = version.BlobDescriptorId;
+        long oldSize = version.SizeBytes;
+        if (oldBlobId == newBlobDescriptorId)
+        {
+            return version;
+        }
+
+        version.ReplaceBlob(newBlobDescriptorId, newSizeBytes);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Rebalance quota. The scrub usually shrinks the blob, but we never trust the
+        // sign of (new - old) — decrement old, increment new keeps the counter exact
+        // even if the new blob is (somehow) larger.
+        if (version.TenantId is { } tid)
+        {
+            if (oldSize > 0)
+            {
+                await quotas.DecrementAsync(tid, oldSize, cancellationToken).ConfigureAwait(false);
+            }
+            if (newSizeBytes > 0)
+            {
+                await quotas.IncrementAsync(tid, newSizeBytes, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Soft-delete the old blob — bytes go, audit row stays for the 3-year trail.
+        // Idempotent in BlobStorage; swallow BlobNotFound to keep the scrub robust
+        // against a stale source.
+        try
+        {
+            await blobStorage
+                .DeleteAsync(ContainerName, oldBlobId, deletionReason: reason, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (BlobStorage.Exceptions.BlobNotFoundException)
+        {
+            // Old blob already gone — nothing to clean up.
+        }
+
+        await localEventBus.PublishAsync(
+            new DocumentBlobScrubbedEvent(
+                version.DocumentId,
+                version.Id,
+                version.TenantId,
+                oldBlobId,
+                newBlobDescriptorId,
+                oldSize,
+                newSizeBytes,
+                reason,
+                clock.Now),
+            cancellationToken).ConfigureAwait(false);
+
+        return version;
+    }
 }

--- a/src/Granit.Documents/Domain/DocumentVersion.cs
+++ b/src/Granit.Documents/Domain/DocumentVersion.cs
@@ -119,4 +119,25 @@ public sealed class DocumentVersion : Entity, IMultiTenant
 
     /// <summary>Optional free-text changelog supplied by the uploader.</summary>
     public string? CommitMessage { get; private set; }
+
+    /// <summary>
+    /// Replaces the underlying <see cref="BlobDescriptorId"/> + <see cref="SizeBytes"/>
+    /// in-place. Reserved for GDPR-driven scrub flows (F17.9 — GPS strip on upload):
+    /// the version row stays "the same version", but its bytes are swapped for a
+    /// freshly-uploaded, sanitised blob. Internal so the only legitimate caller is
+    /// <c>DocumentService</c> from <c>Granit.Documents.EntityFrameworkCore</c>.
+    /// </summary>
+    internal void ReplaceBlob(Guid newBlobDescriptorId, long newSizeBytes)
+    {
+        if (newBlobDescriptorId == Guid.Empty)
+        {
+            throw new ArgumentException("Blob descriptor id cannot be empty.", nameof(newBlobDescriptorId));
+        }
+        if (newSizeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newSizeBytes), "Size must be non-negative.");
+        }
+        BlobDescriptorId = newBlobDescriptorId;
+        SizeBytes = newSizeBytes;
+    }
 }

--- a/src/Granit.Documents/Events/DocumentBlobScrubbedEvent.cs
+++ b/src/Granit.Documents/Events/DocumentBlobScrubbedEvent.cs
@@ -1,0 +1,29 @@
+using Granit.Events;
+
+namespace Granit.Documents.Events;
+
+/// <summary>
+/// Raised when a <see cref="Domain.DocumentVersion"/>'s underlying blob is replaced
+/// in-place by a GDPR-driven scrub flow (F17.9 — GPS strip on upload). Consumed by
+/// <c>Granit.Auditing</c> for the ISO 27001 A.12.4.1 / GDPR Art. 30 trail: every
+/// mutation of an otherwise immutable version row leaves an audit entry.
+/// </summary>
+/// <param name="DocumentId">Document the scrubbed version belongs to.</param>
+/// <param name="VersionId">Version whose <c>BlobDescriptorId</c> was replaced.</param>
+/// <param name="TenantId">Tenant scope.</param>
+/// <param name="OldBlobDescriptorId">Identifier of the original (un-scrubbed) blob, now soft-deleted in BlobStorage.</param>
+/// <param name="NewBlobDescriptorId">Identifier of the freshly-uploaded scrubbed blob.</param>
+/// <param name="OldSizeBytes">Verified size of the original blob.</param>
+/// <param name="NewSizeBytes">Verified size of the scrubbed blob.</param>
+/// <param name="Reason">Free-text reason for the scrub (e.g. <c>"gps-strip"</c>).</param>
+/// <param name="ScrubbedAt">UTC instant the scrub was finalised.</param>
+public sealed record DocumentBlobScrubbedEvent(
+    Guid DocumentId,
+    Guid VersionId,
+    Guid? TenantId,
+    Guid OldBlobDescriptorId,
+    Guid NewBlobDescriptorId,
+    long OldSizeBytes,
+    long NewSizeBytes,
+    string Reason,
+    DateTimeOffset ScrubbedAt) : IDomainEvent;

--- a/src/Granit.Documents/IDocumentService.cs
+++ b/src/Granit.Documents/IDocumentService.cs
@@ -176,4 +176,42 @@ public interface IDocumentService
         int skip,
         int take,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the <see cref="DocumentVersion"/> with the given identifier, or <c>null</c>
+    /// when not found / excluded by the tenant filter. Convenience accessor consumed by
+    /// downstream post-upload flows (F17.4 / F17.9) that need to re-read a version's
+    /// current <c>BlobDescriptorId</c> rather than rely on a stale event snapshot.
+    /// </summary>
+    Task<DocumentVersion?> GetVersionByIdAsync(Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically swaps the blob backing a <see cref="DocumentVersion"/> for a freshly-
+    /// uploaded sanitised one. Reserved for GDPR-driven scrub flows (F17.9 — GPS strip on
+    /// upload).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The implementation updates the version's <c>BlobDescriptorId</c> + <c>SizeBytes</c>,
+    /// soft-deletes the old blob via <see cref="IBlobStorage.DeleteAsync"/>, rebalances the
+    /// tenant's storage quota (decrement old, increment new — the scrubbed blob is
+    /// typically smaller) and publishes a <c>DocumentBlobScrubbedEvent</c> for the audit
+    /// trail. All inside a single <c>SaveChangesAsync</c>.
+    /// </para>
+    /// <para>
+    /// Returns the updated <see cref="DocumentVersion"/>, or <c>null</c> when the version
+    /// is not found / excluded by the tenant filter.
+    /// </para>
+    /// </remarks>
+    /// <param name="versionId">Identifier of the version whose blob to replace.</param>
+    /// <param name="newBlobDescriptorId">Identifier of the freshly-uploaded scrubbed blob (already <c>Valid</c>).</param>
+    /// <param name="newSizeBytes">Verified size of the scrubbed blob.</param>
+    /// <param name="reason">Audit reason recorded on <c>DocumentBlobScrubbedEvent</c> (e.g. <c>"gps-strip"</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<DocumentVersion?> ReplaceVersionBlobAsync(
+        Guid versionId,
+        Guid newBlobDescriptorId,
+        long newSizeBytes,
+        string reason,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Documents.AssetMetadata.BackgroundJobs.Tests/DocumentVersionAddedAssetMetadataHandlerTests.cs
+++ b/tests/Granit.Documents.AssetMetadata.BackgroundJobs.Tests/DocumentVersionAddedAssetMetadataHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Granit.Documents;
 using Granit.Documents.AssetMetadata;
 using Granit.Documents.AssetMetadata.BackgroundJobs;
 using Granit.Documents.AssetMetadata.BackgroundJobs.Handlers;
@@ -53,9 +54,11 @@ public sealed class DocumentVersionAddedAssetMetadataHandlerTests
     private static AssetMetadataGenerationService BuildService(
         IAssetMetadataStore store,
         IAssetMetadataPipeline pipeline,
-        IAssetMetadataSourceFetcher fetcher)
+        IAssetMetadataSourceFetcher fetcher,
+        IDocumentService? documentService = null)
         => new(
             store, pipeline, fetcher,
+            documentService ?? Substitute.For<IDocumentService>(),
             GuidGen(),
             FixedClock(Now),
             Microsoft.Extensions.Options.Options.Create(new GranitAssetMetadataOptions()),

--- a/tests/Granit.Documents.AssetMetadata.Imaging.Tests/Granit.Documents.AssetMetadata.Imaging.Tests.csproj
+++ b/tests/Granit.Documents.AssetMetadata.Imaging.Tests/Granit.Documents.AssetMetadata.Imaging.Tests.csproj
@@ -10,7 +10,9 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" />
+    <PackageReference Include="MetadataExtractor" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Documents.AssetMetadata.Imaging.Tests/JpegGpsScrubberTests.cs
+++ b/tests/Granit.Documents.AssetMetadata.Imaging.Tests/JpegGpsScrubberTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Granit.Documents.AssetMetadata.Imaging.Internal;
+using ImageMagick;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.AssetMetadata.Imaging.Tests;
+
+public sealed class JpegGpsScrubberTests
+{
+    [Fact]
+    public void TryScrub_JPEG_with_GPS_removes_every_GPS_tag_and_keeps_other_EXIF()
+    {
+        byte[] jpeg = CreateJpegWithGpsAndCamera(
+            latitude: 48.8566, longitude: 2.3522,
+            make: "Canon", model: "EOS R5");
+
+        byte[]? scrubbed = JpegGpsScrubber.TryScrub(jpeg, "image/jpeg");
+
+        scrubbed.ShouldNotBeNull();
+        scrubbed.Length.ShouldBeGreaterThan(0);
+
+        IReadOnlyList<MetadataExtractor.Directory> dirs =
+            ImageMetadataReader.ReadMetadata(new MemoryStream(scrubbed));
+
+        bool hasGpsValues = false;
+        foreach (MetadataExtractor.Directory dir in dirs)
+        {
+            if (dir is GpsDirectory gps)
+            {
+                foreach (Tag tag in gps.Tags)
+                {
+                    // MetadataExtractor surfaces a GPS directory header tag even when the
+                    // sub-IFD is fully empty; what we care about is the actual GPS data
+                    // (lat / long / altitude / ref). After scrubbing, those should be gone.
+                    if (tag.Name.Contains("Latitude", StringComparison.Ordinal)
+                        || tag.Name.Contains("Longitude", StringComparison.Ordinal)
+                        || tag.Name.Contains("Altitude", StringComparison.Ordinal))
+                    {
+                        hasGpsValues = true;
+                    }
+                }
+            }
+        }
+        hasGpsValues.ShouldBeFalse("scrubbed JPEG must not carry any GPS coordinate tags");
+
+        // Non-GPS EXIF survives — Make / Model intact.
+        bool foundMake = false, foundModel = false;
+        foreach (MetadataExtractor.Directory dir in dirs)
+        {
+            if (dir is ExifIfd0Directory ifd0)
+            {
+                string? make = ifd0.GetString(ExifDirectoryBase.TagMake);
+                string? model = ifd0.GetString(ExifDirectoryBase.TagModel);
+                if (string.Equals(make, "Canon", StringComparison.Ordinal))
+                {
+                    foundMake = true;
+                }
+                if (string.Equals(model, "EOS R5", StringComparison.Ordinal))
+                {
+                    foundModel = true;
+                }
+            }
+        }
+        foundMake.ShouldBeTrue("scrubbed JPEG must preserve EXIF Make");
+        foundModel.ShouldBeTrue("scrubbed JPEG must preserve EXIF Model");
+    }
+
+    [Fact]
+    public void TryScrub_JPEG_without_GPS_returns_null()
+    {
+        using var image = new MagickImage(MagickColors.Red, 32u, 32u);
+        var exif = new ExifProfile();
+        exif.SetValue(ExifTag.Make, "Canon");
+        image.SetProfile(exif);
+        image.Format = MagickFormat.Jpeg;
+        using MemoryStream ms = new();
+        image.Write(ms);
+
+        byte[]? scrubbed = JpegGpsScrubber.TryScrub(ms.ToArray(), "image/jpeg");
+
+        scrubbed.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryScrub_unrecognised_bytes_returns_null()
+    {
+        byte[] garbage = [1, 2, 3, 4, 5];
+
+        byte[]? scrubbed = JpegGpsScrubber.TryScrub(garbage, "image/jpeg");
+
+        scrubbed.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryScrub_empty_input_returns_null() =>
+        JpegGpsScrubber.TryScrub([], "image/jpeg").ShouldBeNull();
+
+    private static byte[] CreateJpegWithGpsAndCamera(
+        double latitude, double longitude, string make, string model)
+    {
+        using var image = new MagickImage(MagickColors.Blue, 64u, 64u);
+        var exif = new ExifProfile();
+        exif.SetValue(ExifTag.Make, make);
+        exif.SetValue(ExifTag.Model, model);
+        ImageMagick.Rational[] lat = ToDms(Math.Abs(latitude));
+        ImageMagick.Rational[] lon = ToDms(Math.Abs(longitude));
+        exif.SetValue(ExifTag.GPSLatitudeRef, latitude >= 0 ? "N" : "S");
+        exif.SetValue(ExifTag.GPSLatitude, lat);
+        exif.SetValue(ExifTag.GPSLongitudeRef, longitude >= 0 ? "E" : "W");
+        exif.SetValue(ExifTag.GPSLongitude, lon);
+        image.SetProfile(exif);
+        image.Format = MagickFormat.Jpeg;
+        using MemoryStream ms = new();
+        image.Write(ms);
+        return ms.ToArray();
+    }
+
+    private static ImageMagick.Rational[] ToDms(double value)
+    {
+        int deg = (int)Math.Floor(value);
+        double rem = (value - deg) * 60;
+        int min = (int)Math.Floor(rem);
+        double sec = (rem - min) * 60;
+        return
+        [
+            new((uint)deg, 1u),
+            new((uint)min, 1u),
+            new((uint)Math.Round(sec * 1000), 1000u),
+        ];
+    }
+}

--- a/tests/Granit.Documents.AssetMetadata.Imaging.Tests/StripGpsHandlerTests.cs
+++ b/tests/Granit.Documents.AssetMetadata.Imaging.Tests/StripGpsHandlerTests.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Options;
+using Granit.Documents;
+using Granit.Documents.AssetMetadata.Imaging.Internal;
+using Granit.Documents.AssetMetadata.Options;
+using Granit.Documents.Domain;
+using Granit.Documents.Events;
+using Granit.Guids;
+using ImageMagick;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.AssetMetadata.Imaging.Tests;
+
+/// <summary>
+/// Integration-style tests for the F17.9 GPS scrub handler. Wires a real
+/// <see cref="JpegGpsScrubber"/> + <see cref="StripGpsHandler"/> against an
+/// in-memory <see cref="IBlobStorage"/> fake and a substituted
+/// <see cref="IDocumentService"/>. Covers the issue's acceptance criterion:
+/// upload a JPEG with GPS → the scrubbed blob becomes the version's new
+/// <see cref="DocumentVersion.BlobDescriptorId"/> and the bytes carry no GPS
+/// coordinates.
+/// </summary>
+public sealed class StripGpsHandlerTests
+{
+    [Fact]
+    public async Task Handler_swaps_blob_and_strips_GPS_when_JPEG_has_GPS()
+    {
+        byte[] jpeg = CreateJpegWithGps(latitude: 48.8566, longitude: 2.3522);
+
+        InMemoryBlobStorage storage = new();
+        Guid originalBlobId = await storage.SeedAsync(jpeg, "image/jpeg");
+
+        Guid? capturedNewBlobId = null;
+        long? capturedNewSize = null;
+        string? capturedReason = null;
+
+        IDocumentService documentService = Substitute.For<IDocumentService>();
+        documentService.ReplaceVersionBlobAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedNewBlobId = (Guid)ci[1];
+                capturedNewSize = (long)ci[2];
+                capturedReason = (string)ci[3];
+                return Task.FromResult<DocumentVersion?>(DocumentVersionFactory.Materialise(
+                    versionId: (Guid)ci[0],
+                    documentId: Guid.NewGuid(),
+                    blobId: (Guid)ci[1],
+                    sizeBytes: (long)ci[2]));
+            });
+
+        StripGpsHandler handler = BuildHandler(storage, documentService, stripGpsOnUpload: true);
+
+        DocumentVersionAddedEvent evt = new(
+            DocumentId: Guid.NewGuid(),
+            TenantId: Guid.NewGuid(),
+            VersionId: Guid.NewGuid(),
+            VersionNumber: 1,
+            BlobDescriptorId: originalBlobId,
+            ContentType: "image/jpeg",
+            SizeBytes: jpeg.Length,
+            UploadedByUserId: Guid.NewGuid());
+
+        await handler.HandleAsync(evt, TestContext.Current.CancellationToken);
+
+        capturedNewBlobId.ShouldNotBeNull();
+        capturedNewBlobId.Value.ShouldNotBe(originalBlobId, "the scrub must produce a fresh BlobDescriptorId");
+        capturedReason.ShouldBe(StripGpsHandler.ScrubReason);
+
+        byte[] scrubbedBytes = storage.GetBytes(capturedNewBlobId.Value);
+        scrubbedBytes.Length.ShouldBe((int)capturedNewSize!.Value);
+        AssertNoGpsCoordinates(scrubbedBytes);
+    }
+
+    [Fact]
+    public async Task Handler_short_circuits_when_StripGpsOnUpload_is_disabled()
+    {
+        byte[] jpeg = CreateJpegWithGps(latitude: 1.0, longitude: 2.0);
+        InMemoryBlobStorage storage = new();
+        Guid originalBlobId = await storage.SeedAsync(jpeg, "image/jpeg");
+
+        IDocumentService documentService = Substitute.For<IDocumentService>();
+
+        StripGpsHandler handler = BuildHandler(storage, documentService, stripGpsOnUpload: false);
+
+        DocumentVersionAddedEvent evt = NewEvent(originalBlobId, "image/jpeg", jpeg.Length);
+        await handler.HandleAsync(evt, TestContext.Current.CancellationToken);
+
+        await documentService.DidNotReceiveWithAnyArgs().ReplaceVersionBlobAsync(
+            default, default, default, default!, TestContext.Current.CancellationToken);
+        storage.Count.ShouldBe(1, "no scrubbed copy should be uploaded when the toggle is off");
+    }
+
+    [Fact]
+    public async Task Handler_short_circuits_for_non_image_content_type()
+    {
+        InMemoryBlobStorage storage = new();
+        Guid originalBlobId = await storage.SeedAsync([1, 2, 3], "application/pdf");
+
+        IDocumentService documentService = Substitute.For<IDocumentService>();
+        StripGpsHandler handler = BuildHandler(storage, documentService, stripGpsOnUpload: true);
+
+        DocumentVersionAddedEvent evt = NewEvent(originalBlobId, "application/pdf", 3);
+        await handler.HandleAsync(evt, TestContext.Current.CancellationToken);
+
+        await documentService.DidNotReceiveWithAnyArgs().ReplaceVersionBlobAsync(
+            default, default, default, default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Handler_short_circuits_when_JPEG_has_no_GPS()
+    {
+        using var image = new MagickImage(MagickColors.Red, 16u, 16u);
+        var exif = new ExifProfile();
+        exif.SetValue(ExifTag.Make, "Canon");
+        image.SetProfile(exif);
+        image.Format = MagickFormat.Jpeg;
+        using MemoryStream ms = new();
+        image.Write(ms);
+        byte[] jpeg = ms.ToArray();
+
+        InMemoryBlobStorage storage = new();
+        Guid originalBlobId = await storage.SeedAsync(jpeg, "image/jpeg");
+
+        IDocumentService documentService = Substitute.For<IDocumentService>();
+        StripGpsHandler handler = BuildHandler(storage, documentService, stripGpsOnUpload: true);
+
+        DocumentVersionAddedEvent evt = NewEvent(originalBlobId, "image/jpeg", jpeg.Length);
+        await handler.HandleAsync(evt, TestContext.Current.CancellationToken);
+
+        await documentService.DidNotReceiveWithAnyArgs().ReplaceVersionBlobAsync(
+            default, default, default, default!, TestContext.Current.CancellationToken);
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private static StripGpsHandler BuildHandler(
+        InMemoryBlobStorage storage,
+        IDocumentService documentService,
+        bool stripGpsOnUpload)
+    {
+        IHttpClientFactory factory = new InMemoryHttpClientFactory(storage);
+        IGuidGenerator guids = Substitute.For<IGuidGenerator>();
+        guids.Create().Returns(_ => Guid.NewGuid());
+        IOptions<GranitAssetMetadataOptions> options = Microsoft.Extensions.Options.Options.Create(
+            new GranitAssetMetadataOptions { StripGpsOnUpload = stripGpsOnUpload });
+        return new StripGpsHandler(
+            storage,
+            documentService,
+            factory,
+            guids,
+            options,
+            NullLogger<StripGpsHandler>.Instance);
+    }
+
+    private static DocumentVersionAddedEvent NewEvent(Guid blobId, string ct, long size) =>
+        new(
+            DocumentId: Guid.NewGuid(),
+            TenantId: Guid.NewGuid(),
+            VersionId: Guid.NewGuid(),
+            VersionNumber: 1,
+            BlobDescriptorId: blobId,
+            ContentType: ct,
+            SizeBytes: size,
+            UploadedByUserId: Guid.NewGuid());
+
+    private static void AssertNoGpsCoordinates(byte[] bytes)
+    {
+        IReadOnlyList<MetadataExtractor.Directory> dirs =
+            ImageMetadataReader.ReadMetadata(new MemoryStream(bytes));
+        foreach (MetadataExtractor.Directory dir in dirs)
+        {
+            if (dir is GpsDirectory gps)
+            {
+                foreach (Tag tag in gps.Tags)
+                {
+                    tag.Name.ShouldNotContain("Latitude", Case.Sensitive);
+                    tag.Name.ShouldNotContain("Longitude", Case.Sensitive);
+                    tag.Name.ShouldNotContain("Altitude", Case.Sensitive);
+                }
+            }
+        }
+    }
+
+    private static byte[] CreateJpegWithGps(double latitude, double longitude)
+    {
+        using var image = new MagickImage(MagickColors.Blue, 64u, 64u);
+        var exif = new ExifProfile();
+        ImageMagick.Rational[] lat = ToDms(Math.Abs(latitude));
+        ImageMagick.Rational[] lon = ToDms(Math.Abs(longitude));
+        exif.SetValue(ExifTag.GPSLatitudeRef, latitude >= 0 ? "N" : "S");
+        exif.SetValue(ExifTag.GPSLatitude, lat);
+        exif.SetValue(ExifTag.GPSLongitudeRef, longitude >= 0 ? "E" : "W");
+        exif.SetValue(ExifTag.GPSLongitude, lon);
+        image.SetProfile(exif);
+        image.Format = MagickFormat.Jpeg;
+        using MemoryStream ms = new();
+        image.Write(ms);
+        return ms.ToArray();
+    }
+
+    private static ImageMagick.Rational[] ToDms(double value)
+    {
+        int deg = (int)Math.Floor(value);
+        double rem = (value - deg) * 60;
+        int min = (int)Math.Floor(rem);
+        double sec = (rem - min) * 60;
+        return
+        [
+            new((uint)deg, 1u),
+            new((uint)min, 1u),
+            new((uint)Math.Round(sec * 1000), 1000u),
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // In-memory IBlobStorage — minimal surface area the handler actually exercises.
+    // -------------------------------------------------------------------------
+
+    private sealed class InMemoryBlobStorage : IBlobStorage
+    {
+        private readonly ConcurrentDictionary<Guid, byte[]> _blobs = new();
+        private readonly ConcurrentDictionary<Guid, string> _contentTypes = new();
+
+        public int Count => _blobs.Count;
+
+        public byte[] GetBytes(Guid blobId) => _blobs[blobId];
+
+        public async Task<Guid> SeedAsync(byte[] bytes, string contentType)
+        {
+            await Task.Yield();
+            var id = Guid.NewGuid();
+            _blobs[id] = bytes;
+            _contentTypes[id] = contentType;
+            return id;
+        }
+
+        public Task<PresignedUploadTicket> InitiateUploadAsync(
+            string containerName, BlobUploadRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = Guid.NewGuid();
+            _contentTypes[id] = request.ContentType;
+            _blobs[id] = []; // pending
+            return Task.FromResult(new PresignedUploadTicket(
+                BlobId: id,
+                UploadUrl: new Uri($"http://inmemory/upload/{id:N}"),
+                HttpMethod: "PUT",
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(15),
+                RequiredHeaders: new Dictionary<string, string>()));
+        }
+
+        public Task<PresignedDownloadUrl> CreateDownloadUrlAsync(
+            string containerName, Guid blobId, DownloadUrlOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            if (!_blobs.ContainsKey(blobId))
+            {
+                throw new BlobStorage.Exceptions.BlobNotFoundException(blobId, containerName);
+            }
+            return Task.FromResult(new PresignedDownloadUrl(
+                Url: new Uri($"http://inmemory/download/{blobId:N}"),
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(5)));
+        }
+
+        public Task<BlobDescriptor?> GetDescriptorAsync(
+            string containerName, Guid blobId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<BlobDescriptor?>(null);
+
+        public Task DeleteAsync(
+            string containerName, Guid blobId, string? deletionReason = null, CancellationToken cancellationToken = default)
+        {
+            _blobs.TryRemove(blobId, out _);
+            _contentTypes.TryRemove(blobId, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<BlobConfirmationResult> ConfirmUploadAsync(
+            string containerName, Guid blobId, CancellationToken cancellationToken = default)
+        {
+            _contentTypes.TryGetValue(blobId, out string? ct);
+            _blobs.TryGetValue(blobId, out byte[]? bytes);
+            return Task.FromResult(new BlobConfirmationResult(
+                IsValid: true,
+                Status: BlobStatus.Valid,
+                VerifiedContentType: ct,
+                SizeBytes: bytes?.Length ?? 0,
+                RejectionReason: null));
+        }
+
+        public Task<int> CleanupOrphansAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(0);
+
+        public void Store(Guid blobId, byte[] bytes) => _blobs[blobId] = bytes;
+    }
+
+    private sealed class InMemoryHttpClientFactory(InMemoryBlobStorage storage) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(new InMemoryHandler(storage));
+    }
+
+    private sealed class InMemoryHandler(InMemoryBlobStorage storage) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri!.AbsolutePath;
+            // /download/{id} or /upload/{id}
+            string idStr = path.Split('/')[^1];
+            var id = Guid.ParseExact(idStr, "N");
+
+            if (request.Method == HttpMethod.Get)
+            {
+                byte[] bytes = storage.GetBytes(id);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(bytes),
+                };
+            }
+
+            if (request.Method == HttpMethod.Put)
+            {
+                byte[] payload = await request.Content!.ReadAsByteArrayAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                storage.Store(id, payload);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+        }
+    }
+
+    /// <summary>
+    /// Reflection-based hack — DocumentVersion.Create is internal and we only need
+    /// a stand-in value for the test's expectations; the handler does not inspect
+    /// the returned object beyond null/not-null.
+    /// </summary>
+    private static class DocumentVersionFactory
+    {
+        public static DocumentVersion Materialise(Guid versionId, Guid documentId, Guid blobId, long sizeBytes)
+        {
+            // We can't call internal Create; instead, use the parameterless private
+            // ctor + private setters via System.Activator + reflection.
+            var instance = (DocumentVersion)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(DocumentVersion));
+            typeof(DocumentVersion).GetProperty(nameof(DocumentVersion.BlobDescriptorId))!
+                .SetValue(instance, blobId);
+            typeof(DocumentVersion).GetProperty(nameof(DocumentVersion.SizeBytes))!
+                .SetValue(instance, sizeBytes);
+            typeof(DocumentVersion).GetProperty(nameof(DocumentVersion.DocumentId))!
+                .SetValue(instance, documentId);
+            typeof(Granit.Domain.Entity).GetProperty(nameof(Granit.Domain.Entity.Id))!
+                .SetValue(instance, versionId);
+            return instance;
+        }
+    }
+}

--- a/tests/Granit.Documents.AssetMetadata.Imaging.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Imaging.Tests/packages.lock.json
@@ -23,6 +23,15 @@
           "Magick.NET.Core": "14.13.0"
         }
       },
+      "MetadataExtractor": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.9.3",
+        "contentHash": "7dBcqlPC2Zc/bsZtXnv8nCWe5h5WsLHszzHtxnpcsVy4MwlD3KQ3wVNoiYBm0a3rzt5hRwAosPvLPhlXrV5lyg==",
+        "dependencies": {
+          "XmpCore": "6.1.10.1"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -37,6 +46,15 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "18.5.1",
           "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
         }
       },
       "Shouldly": {
@@ -62,6 +80,14 @@
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
           "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "DiffEngine": {
@@ -195,6 +221,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -391,7 +422,10 @@
       "granit.documents.assetmetadata.imaging": {
         "type": "Project",
         "dependencies": {
+          "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Documents": "[0.1.0-dev, )",
           "Granit.Documents.AssetMetadata": "[0.1.0-dev, )",
+          "Magick.NET-Q8-AnyCPU": "[14.*, )",
           "MetadataExtractor": "[2.*, )"
         }
       },
@@ -458,15 +492,6 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
-        }
-      },
-      "MetadataExtractor": {
-        "type": "CentralTransitive",
-        "requested": "[2.*, )",
-        "resolved": "2.9.3",
-        "contentHash": "7dBcqlPC2Zc/bsZtXnv8nCWe5h5WsLHszzHtxnpcsVy4MwlD3KQ3wVNoiYBm0a3rzt5hRwAosPvLPhlXrV5lyg==",
-        "dependencies": {
-          "XmpCore": "6.1.10.1"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/ReplaceVersionBlobPostgresTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/ReplaceVersionBlobPostgresTests.cs
@@ -1,0 +1,185 @@
+using Granit.BlobStorage;
+using Granit.BlobStorage.Domain;
+using Granit.Documents;
+using Granit.Documents.Diagnostics;
+using Granit.Documents.Domain;
+using Granit.Documents.EntityFrameworkCore.Internal;
+using Granit.Documents.Events;
+using Granit.Events;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL-backed integration test for F17.9's
+/// <see cref="DocumentService.ReplaceVersionBlobAsync"/>: confirms that the
+/// version's <c>BlobDescriptorId</c> + <c>SizeBytes</c> are swapped atomically,
+/// the tenant quota is rebalanced, the old blob is soft-deleted, and the
+/// <see cref="DocumentBlobScrubbedEvent"/> is emitted on the local event bus.
+/// </summary>
+public sealed class ReplaceVersionBlobPostgresTests :
+    IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestDbContextFactory _factory = null!;
+    private DocumentService _sut = null!;
+    private IBlobStorage _blobStorage = null!;
+    private ILocalEventBus _localEventBus = null!;
+    private ITenantQuotaService _quotas = null!;
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
+    public ReplaceVersionBlobPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<DocumentsDbContext> options = new DbContextOptionsBuilder<DocumentsDbContext>()
+            .UseNpgsql(_postgres.ConnectionString)
+            .Options;
+
+        await using DocumentsDbContext init = new(options);
+        await init.Database.EnsureCreatedAsync();
+        await init.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE documents_document_versions, documents_documents, documents_folders RESTART IDENTITY CASCADE;");
+
+        _factory = new TestDbContextFactory(options);
+        var bootstrap = new DocumentBootstrapService(_factory, new SimpleGuidGenerator());
+
+        _blobStorage = Substitute.For<IBlobStorage>();
+        _blobStorage.GetDescriptorAsync(
+                DocumentService.ContainerName, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => BlobDescriptor.Create(
+                (Guid)ci[1], TenantId, DocumentService.ContainerName,
+                $"docs/{(Guid)ci[1]:N}",
+                new BlobUploadRequest("file.jpg", "image/jpeg", long.MaxValue),
+                DateTimeOffset.UtcNow));
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Id.Returns(TenantId);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        ServiceProvider provider = services.BuildServiceProvider();
+        var metrics = new DocumentsMetrics(provider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>());
+
+        _localEventBus = Substitute.For<ILocalEventBus>();
+
+        _quotas = Substitute.For<ITenantQuotaService>();
+        _quotas.TryReserveAsync(Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _sut = new DocumentService(
+            _factory, bootstrap, _blobStorage, currentTenant,
+            new SimpleGuidGenerator(), clock, _localEventBus, metrics, _quotas);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task ReplaceVersionBlobAsync_swaps_blob_rebalances_quota_and_emits_event()
+    {
+        Document seeded = await SeedDocumentAsync(sizeBytes: 5000);
+        Guid versionId = seeded.CurrentVersionId!.Value;
+
+        // Inspect pre-state.
+        Guid oldBlobId;
+        long oldSize;
+        await using (DocumentsDbContext ctx = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            DocumentVersion v = await ctx.DocumentVersions.SingleAsync(
+                x => x.Id == versionId, TestContext.Current.CancellationToken);
+            oldBlobId = v.BlobDescriptorId;
+            oldSize = v.SizeBytes;
+        }
+        oldSize.ShouldBe(5000);
+
+        var newBlobId = Guid.NewGuid();
+        const long newSize = 4500L;
+
+        DocumentVersion? updated = await _sut.ReplaceVersionBlobAsync(
+            versionId, newBlobId, newSize, "gps-strip",
+            TestContext.Current.CancellationToken);
+
+        updated.ShouldNotBeNull();
+        updated.BlobDescriptorId.ShouldBe(newBlobId);
+        updated.SizeBytes.ShouldBe(newSize);
+
+        // Persisted row reflects the swap.
+        await using (DocumentsDbContext ctx = await _factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            DocumentVersion persisted = await ctx.DocumentVersions.SingleAsync(
+                x => x.Id == versionId, TestContext.Current.CancellationToken);
+            persisted.BlobDescriptorId.ShouldBe(newBlobId);
+            persisted.SizeBytes.ShouldBe(newSize);
+        }
+
+        // Quota: decrement old size, increment new size.
+        await _quotas.Received(1).DecrementAsync(TenantId, oldSize, Arg.Any<CancellationToken>());
+        await _quotas.Received(1).IncrementAsync(TenantId, newSize, Arg.Any<CancellationToken>());
+
+        // Old blob soft-deleted.
+        await _blobStorage.Received(1).DeleteAsync(
+            DocumentService.ContainerName, oldBlobId, "gps-strip", Arg.Any<CancellationToken>());
+
+        // Local event published with the right payload.
+        await _localEventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentBlobScrubbedEvent>(e =>
+                e.VersionId == versionId
+                && e.OldBlobDescriptorId == oldBlobId
+                && e.NewBlobDescriptorId == newBlobId
+                && e.OldSizeBytes == oldSize
+                && e.NewSizeBytes == newSize
+                && e.Reason == "gps-strip"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplaceVersionBlobAsync_returns_null_when_version_missing()
+    {
+        DocumentVersion? result = await _sut.ReplaceVersionBlobAsync(
+            Guid.NewGuid(), Guid.NewGuid(), 100, "gps-strip",
+            TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        await _quotas.DidNotReceiveWithAnyArgs().DecrementAsync(default, default, TestContext.Current.CancellationToken);
+        await _blobStorage.DidNotReceiveWithAnyArgs().DeleteAsync(default!, default, default, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<Document> SeedDocumentAsync(long sizeBytes)
+    {
+        var blobId = Guid.NewGuid();
+        _blobStorage
+            .ConfirmUploadAsync(DocumentService.ContainerName, blobId, Arg.Any<CancellationToken>())
+            .Returns(new BlobConfirmationResult(
+                IsValid: true, Status: BlobStatus.Valid,
+                VerifiedContentType: "image/jpeg",
+                SizeBytes: sizeBytes, RejectionReason: null));
+        return await _sut.FinalizeUploadAsync(
+            blobId, folderId: null, OwnerId, "photo.jpg", null, "v1",
+            TestContext.Current.CancellationToken);
+    }
+
+    private sealed class TestDbContextFactory(DbContextOptions<DocumentsDbContext> options)
+        : IDbContextFactory<DocumentsDbContext>
+    {
+        public DocumentsDbContext CreateDbContext() => new(options);
+
+        public Task<DocumentsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<DocumentsDbContext>(new(options));
+    }
+
+    private sealed class SimpleGuidGenerator : IGuidGenerator
+    {
+        public Guid Create() => Guid.NewGuid();
+    }
+}


### PR DESCRIPTION
## Summary

GDPR / ISO 27001 A.12.4.1 hook that strips GPS coordinates from the **original** image bytes before extraction. Default-on, overridable via `GranitAssetMetadataOptions.StripGpsOnUpload` for hosts that legitimately need to retain geo-tags (real-estate, journalism, mapping).

## Components

- `JpegGpsScrubber` — JPEG APP1 segment surgery: locates the GPS-IFD pointer tag (`0x8825`) inside the EXIF TIFF directory and rewrites it to a benign unknown tag id. Every other IFD entry stays at the same byte offset, so the EXIF profile retains every non-GPS field (`Make`, `Model`, `DateTimeOriginal`, ISO, …) and the embedded ICC colour profile is untouched. Strictly **no re-encode** — pixels are bit-identical to the source.
- `StripGpsHandler : ILocalEventHandler<DocumentVersionAddedEvent>` — downloads the original blob, scrubs, re-uploads via `IBlobStorage.InitiateUploadAsync` + presigned PUT + `ConfirmUploadAsync`. Image-only; non-image MIMEs and `StripGpsOnUpload = false` short-circuit.
- `IDocumentService.ReplaceVersionBlobAsync` — atomic swap of `DocumentVersion.BlobDescriptorId`, tenant quota rebalance (decrement old, increment new), `DocumentBlobScrubbedEvent` audit emission. Old blob soft-deleted (descriptor row retained for the 3-year audit retention).

## Race with F17.4 background extractor

Both handlers subscribe to `DocumentVersionAddedEvent`. The Wolverine queue ordering for local vs. distributed handlers is not guaranteed, so the extractor cannot rely on the snapshot blob id from the event: `AssetMetadataGenerationService.ExtractAsync` re-reads `DocumentVersion.BlobDescriptorId` from the current row before opening the source stream. Net effect: the extractor always sees post-scrub bytes regardless of dispatch order.

## Test plan

- [x] `JpegGpsScrubberTests` — synthesised JPEGs with EXIF + GPS, asserts GPS removed and other tags preserved, no re-encode.
- [x] `StripGpsHandlerTests` — handler short-circuits for non-image, when `StripGpsOnUpload = false`, propagates failures cleanly.
- [x] `ReplaceVersionBlobPostgresTests` — integration test against Postgres for the atomic swap + quota rebalance + audit event flow.
- [x] `tests/Granit.Documents.AssetMetadata.Imaging.Tests` — 16/16 pass
- [x] `tests/Granit.Documents.AssetMetadata.BackgroundJobs.Tests` — 4/4 pass (handler re-read path)

Closes #1982