### PR TITLE
chore(governance): maintainer-only contribution policy + analyzer-suppression guard

### DIFF
--- a/.github/workflows/no-analyzer-suppressions.yml
+++ b/.github/workflows/no-analyzer-suppressions.yml
@@ -1,0 +1,157 @@
+# =============================================================================
+# Block PRs that disable analyzers without justification
+# =============================================================================
+# Inspects the PR diff for newly added analyzer suppressions:
+#   - #pragma warning disable
+#   - <NoWarn>...</NoWarn>
+#   - dotnet_diagnostic.*.severity = none|silent  (in .editorconfig / .globalconfig)
+#   - [SuppressMessage(...)]
+#
+# A suppression is allowed only if the SAME hunk introduces a
+# `// justification:` (or `<!-- justification: -->`) comment.
+#
+# Fails the check with a comment listing the offending hunks.
+# =============================================================================
+
+name: No Analyzer Suppressions
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    name: Scan PR diff for analyzer suppressions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect newly added suppressions
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # Diff restricted to source files we actually care about.
+          mapfile -t files < <(git diff --name-only --diff-filter=AM "$base" "$head" \
+            | grep -E '\.(cs|csproj|props|targets|editorconfig|globalconfig)$' || true)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no relevant files changed"
+            echo "violations=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          violations_file="$(mktemp)"
+          : > "$violations_file"
+
+          # Patterns that indicate a new suppression on an added line ('+' prefix,
+          # not '+++' header).
+          patterns='^\+[^+].*(#pragma\s+warning\s+disable|<NoWarn>|dotnet_diagnostic\.[^=]+\=\s*(none|silent)|SuppressMessage\()'
+
+          for f in "${files[@]}"; do
+            # Hunks added by this PR for the file.
+            hunks="$(git diff "$base" "$head" -- "$f" || true)"
+            [ -z "$hunks" ] && continue
+
+            # Walk added lines; for each suspect added line, check whether the
+            # same hunk also contains an added 'justification:' line.
+            current_hunk=""
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^@@ ]]; then
+                # New hunk — evaluate the previous one
+                if [[ -n "$current_hunk" ]]; then
+                  if echo "$current_hunk" | grep -Eq "$patterns"; then
+                    if ! echo "$current_hunk" | grep -Eq '^\+[^+].*justification:'; then
+                      {
+                        echo "── $f ──"
+                        echo "$current_hunk" | grep -E "$patterns" || true
+                        echo
+                      } >> "$violations_file"
+                    fi
+                  fi
+                fi
+                current_hunk="$line"$'\n'
+              else
+                current_hunk+="$line"$'\n'
+              fi
+            done <<< "$hunks"
+
+            # Tail hunk
+            if [[ -n "$current_hunk" ]]; then
+              if echo "$current_hunk" | grep -Eq "$patterns"; then
+                if ! echo "$current_hunk" | grep -Eq '^\+[^+].*justification:'; then
+                  {
+                    echo "── $f ──"
+                    echo "$current_hunk" | grep -E "$patterns" || true
+                    echo
+                  } >> "$violations_file"
+                fi
+              fi
+            fi
+          done
+
+          if [ -s "$violations_file" ]; then
+            {
+              echo "violations<<EOF"
+              cat "$violations_file"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "count=$(wc -l < "$violations_file")" >> "$GITHUB_OUTPUT"
+          else
+            echo "count=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR if violations
+        if: steps.scan.outputs.count != '0'
+        uses: actions/github-script@v7
+        env:
+          VIOLATIONS: ${{ steps.scan.outputs.violations }}
+        with:
+          script: |
+            const body = [
+              '## Analyzer suppressions added without justification',
+              '',
+              'This PR adds one or more analyzer suppressions',
+              '(`#pragma warning disable`, `<NoWarn>`, `dotnet_diagnostic.*.severity = none`,',
+              'or `[SuppressMessage]`) on lines that do **not** carry a `justification:` comment.',
+              '',
+              'Per `CONTRIBUTING.md`, suppressions must either be fixed at the source or',
+              'documented inline. Example:',
+              '',
+              '```csharp',
+              '// justification: false positive — handler is discovered by Wolverine via',
+              '// Assembly.ExportedTypes and requires a public ctor (see CLAUDE.md).',
+              '#pragma warning disable S1118',
+              '```',
+              '',
+              'Offending hunks:',
+              '',
+              '```diff',
+              process.env.VIOLATIONS || '(empty)',
+              '```',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+      - name: Fail if violations
+        if: steps.scan.outputs.count != '0'
+        run: |
+          echo "::error::This PR adds analyzer suppressions without a 'justification:' comment. See PR comment."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,31 @@
 # Contributing to Granit
 
-Thank you for your interest in contributing to Granit! This guide will help you get started.
+Thank you for your interest in Granit.
+
+## Contribution policy
+
+Granit is currently developed under a **maintainer-only** model. The framework is
+pre-1.0, the architecture is still consolidating, and the project is maintained by
+a single person — review bandwidth is the bottleneck, not code volume.
+
+Concretely:
+
+- **Code contributions** (pull requests against `develop` / `main`) are **not
+  accepted from external contributors at this time.** PRs opened without a prior
+  invitation from a maintainer will be closed without merge. This is not a
+  judgement on the code; it is a scope decision.
+- **Issues, bug reports, security reports, and discussions** are very welcome and
+  actively read:
+  - Bugs → [Bug Report](https://github.com/granit-fx/granit-dotnet/issues/new?template=bug_report.yml)
+  - Features → [Feature Request](https://github.com/granit-fx/granit-dotnet/issues/new?template=feature_request.yml)
+  - Questions → [Discussions](https://github.com/granit-fx/granit-dotnet/discussions)
+  - Vulnerabilities → [Security Policy](https://github.com/granit-fx/granit-dotnet/security/policy)
+- If you would like to contribute code, **open an issue or a discussion first.**
+  A maintainer will respond if and when the scope is a good fit for an outside
+  contribution and will explicitly invite a PR.
+- This policy will be relaxed as the framework stabilizes. The rest of this
+  document remains as reference for invited contributors and for the project's
+  internal conventions.
 
 ## Getting started
 
@@ -50,7 +75,7 @@ See [conventions documentation](https://granit-fx.dev/contributing/coding-standa
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```text
 feat(persistence): add soft-delete interceptor
 fix(auth): handle expired token refresh
 docs: update BlobStorage guide
@@ -64,10 +89,26 @@ chore(ci): update GitHub Actions workflow
 - Update documentation if your change affects the public API
 - Ensure CI passes (build, tests, format, markdownlint)
 - No hardcoded secrets, tokens, or PII in code or logs
+- Do not disable analyzers (`#pragma warning disable`, `<NoWarn>`, `dotnet_diagnostic.*.severity = none`) to make code compile. Fix the underlying issue. PRs that suppress analyzers without a `// justification:` comment will be rejected.
+- Do not add Markdown files at the repo root, top-level analysis/solution write-ups, or unsolicited `samples/` projects. Framework documentation lives in [`granit-fx/granit-docs`](https://github.com/granit-fx/granit-docs); open a separate PR there.
+
+## AI-assisted contributions
+
+Using AI tools (Claude Code, Copilot, Cursor, ChatGPT, etc.) to help write code is **welcome**. Submitting un-reviewed AI output is **not**.
+
+If any part of your PR was generated or substantially shaped by an AI assistant:
+
+1. **Disclose it** in the PR description, in a `## AI assistance` section, naming the tool(s) and what was AI-generated (code, tests, commit messages, docs).
+2. **You are the author.** You are responsible for every line, every dependency, every analyzer suppression. "The agent did it" is not an acceptable response to review comments.
+3. **Strip agent artifacts** before pushing: no `## Overview / ## Problem / ## Solution / ## Design Decisions / ✓ …` boilerplate in commit messages, no `from subagent review` / `from agent feedback` mentions, no auto-generated `ISSUE_XXXX_SOLUTION.md` files.
+4. **Match the scope of the linked issue.** If the issue asks for a carve-out, do not ship a webapp sample, a frontend, a 400-line design doc, and three speculative abstractions alongside it. Split into separate, scoped PRs.
+5. **Be ready to defend the design.** Reviewers may ask open-ended questions about trade-offs (not multiple-choice). If you cannot answer because the agent made the call, that is a signal you have not internalized the change — please re-read your own diff before responding.
+
+Large unscoped or undisclosed AI-generated PRs will be closed and the author asked to resubmit in scoped pieces with a disclosure. We do this to protect the framework and our review bandwidth, not to discourage AI use.
 
 ## Project structure
 
-```
+```text
 src/Granit.{Module}/              # Abstractions + DI registration
 src/Granit.{Module}.{Provider}/   # Provider implementations
 tests/Granit.{Module}.Tests/      # Unit tests (xUnit + Shouldly + NSubstitute)


### PR DESCRIPTION
## Summary

- **`CONTRIBUTING.md`** — declare a maintainer-only code-contribution policy at the top of the document. Issues, discussions, and security reports remain open; code PRs from external contributors now require a prior maintainer invitation. Adds an *AI-assisted contributions* section setting expectations for disclosure, scope discipline, and commit-message hygiene; prohibits analyzer suppressions without a `justification:` comment; bans unsolicited `samples/` and root-level analysis Markdown.
- **`.github/workflows/no-analyzer-suppressions.yml`** — new PR check that scans the diff for newly added `#pragma warning disable`, `<NoWarn>`, `dotnet_diagnostic.*.severity = none|silent`, or `[SuppressMessage]` and fails the check (with an explanatory comment on the PR) unless the same hunk introduces a `justification:` comment.

Context: PR #2002 surfaced a pattern of unscoped, LLM-generated contributions that disable analyzers to silence noise rather than fix it. This change makes the policy explicit and adds a structural guard so the rule is enforced by CI rather than by review attention.

## Test plan

- [ ] Open a throwaway PR adding a bare `#pragma warning disable CA1822` line → workflow fails and comments on the PR.
- [ ] Open a throwaway PR adding `// justification: <reason>` immediately followed by `#pragma warning disable CA1822` → workflow passes.
- [ ] Same two cases for `<NoWarn>` inside a `.csproj` and `dotnet_diagnostic.IDE0008.severity = none` inside an `.editorconfig`.
- [ ] Verify `markdownlint-cli2 CONTRIBUTING.md` passes.