### PR TITLE
feat(entities): server-side bulk action surface (#1822)

### DIFF
--- a/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionBuilder.cs
@@ -1,3 +1,5 @@
+using Granit.Entities.Actions.Execution;
+
 namespace Granit.Entities.Actions;
 
 /// <summary>
@@ -30,6 +32,7 @@ public sealed class EntityActionBuilder<TEntity>
     private bool _showOnCalendarTile;
     private bool _showOnListHeader;
     private bool _showOnSelection;
+    private Type? _serverExecutorType;
 
     // RouteBase composition state — populated by verb shortcuts (Post / Put / Delete /
     // Patch / Get / Download). At Build() time, if no explicit URL was supplied via
@@ -324,6 +327,28 @@ public sealed class EntityActionBuilder<TEntity>
         return this;
     }
 
+    /// <summary>
+    /// Opts the action into server-side execution (ADR-056). Flags
+    /// <see cref="EntityActionDescriptor.RequiresServerExecution"/> on the
+    /// descriptor and captures <typeparamref name="TExecutor"/> as
+    /// <see cref="EntityActionDescriptor.ServerExecutorType"/> so the bulk
+    /// endpoint can resolve it through DI.
+    /// </summary>
+    /// <remarks>
+    /// The builder does NOT register the executor in DI — hosts add it
+    /// explicitly via <c>services.AddScoped&lt;TExecutor&gt;()</c> (and optionally
+    /// <c>services.AddScoped&lt;IBulkActionExecutor&lt;TEntity&gt;, TExecutor&gt;()</c>
+    /// when the executor implements the bulk-friendly variant). The archi test
+    /// <c>ServerExecutorRegistrationTests</c> enforces the registration shape.
+    /// </remarks>
+    /// <typeparam name="TExecutor">Implementation of <see cref="IEntityActionExecutor{TEntity}"/>.</typeparam>
+    public EntityActionBuilder<TEntity> ServerExecutor<TExecutor>()
+        where TExecutor : class, IEntityActionExecutor<TEntity>
+    {
+        _serverExecutorType = typeof(TExecutor);
+        return this;
+    }
+
     internal EntityActionDescriptor Build()
     {
         string? resolvedUrl = ResolveUrl();
@@ -382,7 +407,9 @@ public sealed class EntityActionBuilder<TEntity>
             ShowOnGalleryCard: _showOnGalleryCard,
             ShowOnCalendarTile: _showOnCalendarTile,
             ShowOnListHeader: _showOnListHeader,
-            ShowOnSelection: _showOnSelection);
+            ShowOnSelection: _showOnSelection,
+            RequiresServerExecution: _serverExecutorType is not null,
+            ServerExecutorType: _serverExecutorType);
     }
 
     private string? ResolveUrl()

--- a/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/EntityActionDescriptor.cs
@@ -22,6 +22,8 @@ namespace Granit.Entities.Actions;
 /// <param name="ShowOnCalendarTile">When <see langword="true"/>, the action also appears as a compact icon-button on the source entity's calendar tile. Off by default — calendar tiles are smaller than kanban cards so curate carefully.</param>
 /// <param name="ShowOnListHeader">When <see langword="true"/>, the action is pinned on the list-page header (above the list / kanban / gallery / calendar tabs), not on individual rows. Use for entity-scope actions like <c>Import</c>, <c>Export</c>, <c>BulkArchive</c> — the URL template must NOT carry a <c>{id}</c> placeholder since no row is selected. Mirrors Odoo's top-of-list action bar.</param>
 /// <param name="ShowOnSelection">When <see langword="true"/>, the action is exposed on the selection-bar dropdown that appears above the list when at least one row is selected (Odoo's "Action ▼"). Same row URL as the per-row action — the renderer fires N parallel requests, substituting <c>{id}</c> per selected row (concurrency-capped client-side). Mutually exclusive with <see cref="ShowOnListHeader"/>: header actions are entity-scope and cannot also be selection-scope.</param>
+/// <param name="RequiresServerExecution">When <see langword="true"/>, the action runs through the framework's bulk endpoint <c>POST /api/entities/{name}/bulk/{action}</c> and a registered <see cref="Granit.Entities.Actions.Execution.IEntityActionExecutor{TEntity}"/> implementation (ADR-056). Flipped on by <c>EntityActionBuilder{TEntity}.ServerExecutor&lt;TExecutor&gt;()</c>.</param>
+/// <param name="ServerExecutorType">CLR type of the <see cref="Granit.Entities.Actions.Execution.IEntityActionExecutor{TEntity}"/> captured by <c>.ServerExecutor&lt;TExecutor&gt;()</c>. <see langword="null"/> when the action is purely declarative. Stored as <see cref="Type"/> because heterogeneous actions live in one descriptor list.</param>
 public sealed record EntityActionDescriptor(
     string Name,
     EntityActionKind Kind,
@@ -38,4 +40,6 @@ public sealed record EntityActionDescriptor(
     bool ShowOnGalleryCard = false,
     bool ShowOnCalendarTile = false,
     bool ShowOnListHeader = false,
-    bool ShowOnSelection = false);
+    bool ShowOnSelection = false,
+    bool RequiresServerExecution = false,
+    Type? ServerExecutorType = null);

--- a/src/Granit.Entities.Abstractions/Actions/Execution/BulkActionExecutionResult.cs
+++ b/src/Granit.Entities.Abstractions/Actions/Execution/BulkActionExecutionResult.cs
@@ -1,0 +1,16 @@
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// Aggregate outcome of <see cref="IBulkActionExecutor{TEntity}.ExecuteBulkAsync"/>
+/// or the framework's per-row loop fallback. Carries both the affected entities
+/// (so the framework can emit a single
+/// <see cref="Granit.Events.EntityBulkUpdatedEvent{TEntity}"/>) and the structured
+/// failure list (so the caller can re-issue against rejected rows).
+/// </summary>
+/// <typeparam name="TEntity">The entity type.</typeparam>
+/// <param name="AffectedEntities">Post-save entities for the rows the executor accepted. Empty when nothing succeeded.</param>
+/// <param name="Failures">One entry per rejected row.</param>
+public sealed record BulkActionExecutionResult<TEntity>(
+    IReadOnlyList<TEntity> AffectedEntities,
+    IReadOnlyList<BulkActionFailure> Failures)
+    where TEntity : class;

--- a/src/Granit.Entities.Abstractions/Actions/Execution/BulkActionFailure.cs
+++ b/src/Granit.Entities.Abstractions/Actions/Execution/BulkActionFailure.cs
@@ -1,0 +1,10 @@
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// One per-row failure reported by a bulk action run. UX-friendly partial
+/// success — the renderer can highlight the failed rows and let the user
+/// retry against them.
+/// </summary>
+/// <param name="Id">Primary key of the row that was rejected.</param>
+/// <param name="Reason">Human-readable failure reason (e.g. <c>"NotFound"</c>, <c>"InvariantViolated"</c>, <c>"AccessDenied"</c>). Free-form on purpose — executors localise as needed.</param>
+public sealed record BulkActionFailure(Guid Id, string Reason);

--- a/src/Granit.Entities.Abstractions/Actions/Execution/EntityActionExecutionResult.cs
+++ b/src/Granit.Entities.Abstractions/Actions/Execution/EntityActionExecutionResult.cs
@@ -1,0 +1,14 @@
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// Per-row outcome of <see cref="IEntityActionExecutor{TEntity}.ExecuteAsync"/>.
+/// Exactly one of <see cref="AffectedEntity"/> / <see cref="FailureReason"/> is
+/// non-<see langword="null"/> on a well-behaved implementation.
+/// </summary>
+/// <typeparam name="TEntity">The entity type.</typeparam>
+/// <param name="AffectedEntity">Post-save entity when the row succeeded; <see langword="null"/> on failure.</param>
+/// <param name="FailureReason">Human-readable failure reason (forwarded into <see cref="BulkActionFailure.Reason"/>); <see langword="null"/> on success.</param>
+public sealed record EntityActionExecutionResult<TEntity>(
+    TEntity? AffectedEntity,
+    string? FailureReason)
+    where TEntity : class;

--- a/src/Granit.Entities.Abstractions/Actions/Execution/IBulkActionExecutor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/Execution/IBulkActionExecutor.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// Optional bulk-friendly counterpart to <see cref="IEntityActionExecutor{TEntity}"/>
+/// (ADR-056 §Q4). When registered, the bulk endpoint dispatches the whole list
+/// in one call (e.g. one <c>UPDATE … WHERE Id IN (…)</c>). When missing, the
+/// framework's <c>BulkActionExecutionOrchestrator</c> loops the per-row executor
+/// — same observable behaviour, N queries.
+/// </summary>
+/// <typeparam name="TEntity">The entity the action targets.</typeparam>
+public interface IBulkActionExecutor<TEntity>
+    where TEntity : class
+{
+    /// <summary>
+    /// Executes the action against the rows identified by <paramref name="ids"/>.
+    /// </summary>
+    /// <param name="ids">Primary keys of the targeted rows. Always non-empty; the framework guards an empty input.</param>
+    /// <param name="payload">Free-form JSON payload supplied by the caller.</param>
+    /// <param name="cancellationToken">Request cancellation token.</param>
+    /// <returns>
+    /// The set of affected (post-save) entities plus a structured per-row failure
+    /// list. Hosts MUST return one failure per missing / rejected id so the caller
+    /// can re-issue against the failed rows.
+    /// </returns>
+    Task<BulkActionExecutionResult<TEntity>> ExecuteBulkAsync(
+        IReadOnlyList<Guid> ids,
+        JsonElement payload,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Entities.Abstractions/Actions/Execution/IEntityActionExecutor.cs
+++ b/src/Granit.Entities.Abstractions/Actions/Execution/IEntityActionExecutor.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// Server-side execution surface for one entity action (ADR-056). Implementations
+/// mutate a single row identified by its primary key and return the post-save
+/// entity so the framework can emit a single batched
+/// <see cref="Granit.Events.EntityBulkUpdatedEvent{TEntity}"/> for the run.
+/// </summary>
+/// <typeparam name="TEntity">The entity the action targets. Must match the
+/// <c>EntityDefinition{TEntity}</c>'s entity type.</typeparam>
+/// <remarks>
+/// <para>
+/// Executors are resolved scoped per request (the typical implementation needs
+/// a <c>DbContext</c>). Hosts register the executor explicitly via
+/// <c>services.AddScoped&lt;TExecutor&gt;()</c>; the framework does not auto-register
+/// it — the fluent <c>.ServerExecutor&lt;TExecutor&gt;()</c> builder only captures the
+/// type on the descriptor.
+/// </para>
+/// <para>
+/// Row addressing is by <see cref="Guid"/> id — the executor owns the load,
+/// including tenant / soft-delete / Named-Query-Filter application via the
+/// host's <c>DbContext</c>. Rows the executor cannot find or chooses to
+/// reject for row-level visibility reasons (defense in depth) must be
+/// reported back through <see cref="EntityActionExecutionResult{TEntity}.FailureReason"/>.
+/// </para>
+/// </remarks>
+public interface IEntityActionExecutor<TEntity>
+    where TEntity : class
+{
+    /// <summary>
+    /// Executes the action against the row identified by <paramref name="id"/>.
+    /// Returns the post-save entity on success and <see langword="null"/> with a
+    /// <see cref="EntityActionExecutionResult{TEntity}.FailureReason"/> when the
+    /// row was rejected (not found, permission denied, invariant violated, …).
+    /// </summary>
+    /// <param name="id">Primary key of the targeted row.</param>
+    /// <param name="payload">Free-form JSON payload supplied by the caller. May be <see cref="JsonElement.ValueKind"/> <c>Undefined</c> when the action takes no parameters.</param>
+    /// <param name="cancellationToken">Request cancellation token.</param>
+    Task<EntityActionExecutionResult<TEntity>> ExecuteAsync(
+        Guid id,
+        JsonElement payload,
+        CancellationToken cancellationToken);
+}

--- a/src/Granit.Entities.Endpoints/Dtos/BulkActionRequest.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/BulkActionRequest.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Request body for <c>POST /api/entities/{name}/bulk/{action}</c>.
+/// </summary>
+/// <param name="Ids">Primary keys of the rows to act upon. Must be non-empty.</param>
+/// <param name="Payload">Free-form JSON payload forwarded verbatim to the registered <c>IEntityActionExecutor&lt;TEntity&gt;</c>. Pass an empty object <c>{}</c> when the action takes no parameters.</param>
+public sealed record BulkActionRequest(IReadOnlyList<Guid> Ids, JsonElement Payload);

--- a/src/Granit.Entities.Endpoints/Dtos/BulkActionResponse.cs
+++ b/src/Granit.Entities.Endpoints/Dtos/BulkActionResponse.cs
@@ -1,0 +1,10 @@
+using Granit.Entities.Actions.Execution;
+
+namespace Granit.Entities.Endpoints.Dtos;
+
+/// <summary>
+/// Response body for <c>POST /api/entities/{name}/bulk/{action}</c>.
+/// </summary>
+/// <param name="Affected">Number of rows the executor accepted.</param>
+/// <param name="Failures">Per-row failures reported by the executor. Empty when every row succeeded.</param>
+public sealed record BulkActionResponse(int Affected, IReadOnlyList<BulkActionFailure> Failures);

--- a/src/Granit.Entities.Endpoints/Endpoints/BulkActionEndpoint.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/BulkActionEndpoint.cs
@@ -1,0 +1,115 @@
+using System.Security.Claims;
+using Granit.Authorization;
+using Granit.Entities.Actions;
+using Granit.Entities.Actions.Execution;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Internal;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Entities.Endpoints.Endpoints;
+
+/// <summary>
+/// <c>POST /api/entities/{name}/bulk/{action}</c> — synchronous bulk runner for
+/// any entity action that opted into server-side execution via
+/// <c>.ServerExecutor&lt;TExecutor&gt;()</c> (ADR-056, story #1822). One round-trip
+/// in, one batched <see cref="Granit.Events.EntityBulkUpdatedEvent{TEntity}"/>
+/// out, per-row failure isolation.
+/// </summary>
+internal static class BulkActionEndpoint
+{
+    /// <summary>
+    /// Mounts the bulk-action route on the entity-endpoint group.
+    /// </summary>
+    public static RouteGroupBuilder MapBulkActionEndpoint(this RouteGroupBuilder group)
+    {
+        group.MapPost("/{name}/bulk/{action}", HandleAsync)
+            .WithName("PostEntityBulkAction")
+            .WithSummary("Executes a registered entity action against the supplied rows in one round-trip.")
+            .WithDescription("Resolves the entity definition and the named action, gates the call through the action's RequiresPermission (defense in depth), then dispatches the run via the framework's BulkActionExecutionOrchestrator. Hosts wire a scoped IEntityActionExecutor<TEntity> per action; an optional IBulkActionExecutor<TEntity> shortcut lets the executor batch the work (one UPDATE … WHERE Id IN (…) call). Per-row failures are returned in the response payload; the call itself returns HTTP 200 whenever the bulk surface accepted the request. One EntityBulkUpdatedEvent<TEntity> is emitted via ILocalEventBus when at least one row succeeded and the entity implements IEmitEntityLifecycleEvents.")
+            .Produces<BulkActionResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Ok<BulkActionResponse>, ProblemHttpResult>> HandleAsync(
+        string name,
+        string action,
+        BulkActionRequest request,
+        [FromServices] IEntityDefinitionRegistry registry,
+        [FromServices] BulkActionExecutionOrchestrator orchestrator,
+        [FromServices] IPermissionChecker permissionChecker,
+        HttpContext httpContext,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Resolve the entity definition.
+        IEntityDefinitionDescriptor? definitionRef = registry.GetByName(name);
+        if (definitionRef is null)
+        {
+            return TypedResults.Problem(
+                detail: $"No EntityDefinition is registered with name '{name}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        EntityDefinitionDescriptor descriptor = definitionRef.Descriptor;
+
+        // 2. Resolve the action by name.
+        EntityActionDescriptor? actionDescriptor = descriptor.Actions
+            .FirstOrDefault(a => string.Equals(a.Name, action, StringComparison.Ordinal));
+
+        if (actionDescriptor is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Entity '{name}' has no action named '{action}'.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        // 3. Reject actions that did not opt into server-side execution. The
+        //    selection-bar renderer still uses the per-row URL for those.
+        if (!actionDescriptor.RequiresServerExecution || actionDescriptor.ServerExecutorType is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Action '{action}' on entity '{name}' is declarative — it does not opt into server-side execution via .ServerExecutor<>().",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        // 4. Permission gate inherits from the action's RequiresPermission.
+        //    Defense in depth: row-level visibility is the executor's job.
+        if (actionDescriptor.RequiresPermission is { } permission)
+        {
+            bool granted = await permissionChecker
+                .IsGrantedAsync(permission, cancellationToken)
+                .ConfigureAwait(false);
+            if (!granted)
+            {
+                return TypedResults.Problem(
+                    detail: $"You do not have permission '{permission}' required by action '{action}'.",
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+        }
+
+        // 5. Dispatch the run. The orchestrator picks IBulkActionExecutor<T>
+        //    when registered, otherwise loops the per-row executor.
+        BulkActionDispatchResult result = await orchestrator
+            .DispatchAsync(
+                entityType: descriptor.EntityType,
+                serverExecutorType: actionDescriptor.ServerExecutorType,
+                ids: request.Ids,
+                payload: request.Payload,
+                scopedServices: httpContext.RequestServices,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok(new BulkActionResponse(result.Affected, result.Failures));
+    }
+}

--- a/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
+++ b/src/Granit.Entities.Endpoints/Endpoints/EntitiesEndpoints.cs
@@ -42,6 +42,7 @@ internal static class EntitiesEndpoints
 
         group.MapRelationAggregatesEndpoint();
         group.MapCalendarRangeEndpoint();
+        group.MapBulkActionEndpoint();
 
         return group;
     }

--- a/src/Granit.Entities.Endpoints/Options/EntitiesEndpointsOptions.cs
+++ b/src/Granit.Entities.Endpoints/Options/EntitiesEndpointsOptions.cs
@@ -40,4 +40,11 @@ public sealed class EntitiesEndpointsOptions
     /// across requests with the same security context and the same window.
     /// </summary>
     public TimeSpan CalendarRangeCacheTtl { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Maximum number of <c>ids</c> accepted by <c>POST /api/entities/{name}/bulk/{action}</c>
+    /// in a single request. Synchronous bulks larger than this should run through
+    /// <c>Granit.DataExchange.Import</c> (background-job-backed) instead. Default 1000.
+    /// </summary>
+    public int BulkActionMaxIds { get; set; } = 1000;
 }

--- a/src/Granit.Entities.Endpoints/Validators/BulkActionRequestValidator.cs
+++ b/src/Granit.Entities.Endpoints/Validators/BulkActionRequestValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using Granit.Entities.Endpoints.Dtos;
+using Granit.Entities.Endpoints.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Entities.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="BulkActionRequest"/> — non-empty <c>Ids</c> capped at
+/// <see cref="EntitiesEndpointsOptions.BulkActionMaxIds"/> entries. Error
+/// messages use framework error codes so the 18-culture
+/// localization manager picks them up.
+/// </summary>
+internal sealed class BulkActionRequestValidator : AbstractValidator<BulkActionRequest>
+{
+    public BulkActionRequestValidator(IOptions<EntitiesEndpointsOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        int maxIds = options.Value.BulkActionMaxIds;
+
+        RuleFor(x => x.Ids)
+            .NotEmpty();
+
+        RuleFor(x => x.Ids.Count)
+            .LessThanOrEqualTo(maxIds)
+            .When(x => x.Ids is not null);
+    }
+}

--- a/src/Granit.Entities/Actions/Execution/BulkActionExecutionOrchestrator.cs
+++ b/src/Granit.Entities/Actions/Execution/BulkActionExecutionOrchestrator.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using System.Text.Json;
+using Granit.Domain;
+using Granit.Entities.Actions.Execution;
+using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Entities.Actions.Execution;
+
+/// <summary>
+/// Type-erased dispatcher between the bulk endpoint (non-generic, knows the
+/// entity by name → CLR type) and the generic
+/// <see cref="IEntityActionExecutor{TEntity}"/> / <see cref="IBulkActionExecutor{TEntity}"/>
+/// surface (ADR-056). Resolves the executor through DI, dispatches the run,
+/// then emits exactly one <see cref="EntityBulkUpdatedEvent{TEntity}"/> via
+/// <see cref="ILocalEventBus"/> when the entity implements
+/// <see cref="IEmitEntityLifecycleEvents"/>.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton — owns no per-request state. All scoped
+/// resolution goes through the <see cref="IServiceProvider"/> handed in
+/// per call (the endpoint forwards <c>HttpContext.RequestServices</c>).
+/// </remarks>
+public sealed partial class BulkActionExecutionOrchestrator(ILogger<BulkActionExecutionOrchestrator> logger)
+{
+    private static readonly MethodInfo DispatchGenericMethod = typeof(BulkActionExecutionOrchestrator)
+        .GetMethod(nameof(DispatchGenericAsync), BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException(
+            "BulkActionExecutionOrchestrator.DispatchGenericAsync method not found via reflection.");
+
+    /// <summary>
+    /// Resolves the executor for <paramref name="entityType"/> and dispatches the
+    /// run. The caller (the bulk endpoint) is responsible for permission gating
+    /// and request-shape validation — this method is purely the dispatch seam.
+    /// </summary>
+    /// <param name="entityType">CLR type of the targeted entity (from the registry).</param>
+    /// <param name="serverExecutorType">CLR type of the registered per-row executor (from the descriptor).</param>
+    /// <param name="ids">Primary keys to act upon. Guaranteed non-empty by the endpoint.</param>
+    /// <param name="payload">Caller-supplied JSON payload, forwarded verbatim.</param>
+    /// <param name="scopedServices">Per-request <see cref="IServiceProvider"/>.</param>
+    /// <param name="cancellationToken">Request cancellation token.</param>
+    /// <returns>
+    /// The framework-level outcome — <see cref="BulkActionDispatchResult.Affected"/>
+    /// counts the rows the executor accepted, <see cref="BulkActionDispatchResult.Failures"/>
+    /// carries the per-row reasons.
+    /// </returns>
+    public Task<BulkActionDispatchResult> DispatchAsync(
+        Type entityType,
+        Type serverExecutorType,
+        IReadOnlyList<Guid> ids,
+        JsonElement payload,
+        IServiceProvider scopedServices,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+        ArgumentNullException.ThrowIfNull(serverExecutorType);
+        ArgumentNullException.ThrowIfNull(ids);
+        ArgumentNullException.ThrowIfNull(scopedServices);
+
+        MethodInfo closed = DispatchGenericMethod.MakeGenericMethod(entityType);
+        return (Task<BulkActionDispatchResult>)closed.Invoke(
+            this,
+            [serverExecutorType, ids, payload, scopedServices, cancellationToken])!;
+    }
+
+    private async Task<BulkActionDispatchResult> DispatchGenericAsync<TEntity>(
+        Type serverExecutorType,
+        IReadOnlyList<Guid> ids,
+        JsonElement payload,
+        IServiceProvider scopedServices,
+        CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        BulkActionExecutionResult<TEntity> result;
+
+        // Prefer the bulk-friendly executor when registered — one query, one save.
+        IBulkActionExecutor<TEntity>? bulk = scopedServices.GetService<IBulkActionExecutor<TEntity>>();
+        if (bulk is not null)
+        {
+            result = await bulk.ExecuteBulkAsync(ids, payload, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // Fallback: loop the per-row executor. Same observable contract;
+            // N queries instead of one.
+            object executorInstance = scopedServices.GetRequiredService(serverExecutorType);
+            if (executorInstance is not IEntityActionExecutor<TEntity> executor)
+            {
+                throw new InvalidOperationException(
+                    $"Server executor '{serverExecutorType.FullName}' does not implement "
+                    + $"IEntityActionExecutor<{typeof(TEntity).Name}>. Check the .ServerExecutor<>() "
+                    + "declaration on the action.");
+            }
+
+            List<TEntity> affected = new(ids.Count);
+            List<BulkActionFailure> failures = [];
+            foreach (Guid id in ids)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                EntityActionExecutionResult<TEntity> row = await executor
+                    .ExecuteAsync(id, payload, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (row.AffectedEntity is { } entity)
+                {
+                    affected.Add(entity);
+                }
+                else
+                {
+                    failures.Add(new BulkActionFailure(id, row.FailureReason ?? "Unspecified"));
+                }
+            }
+
+            result = new BulkActionExecutionResult<TEntity>(affected, failures);
+        }
+
+        // Emit the batched lifecycle event when the entity opted in. Entities
+        // outside the IEmitEntityLifecycleEvents constraint silently skip — the
+        // ADR documents this as a non-fatal manifest / persistence mismatch.
+        if (result.AffectedEntities.Count > 0 && typeof(IEmitEntityLifecycleEvents).IsAssignableFrom(typeof(TEntity)))
+        {
+            ILocalEventBus? eventBus = scopedServices.GetService<ILocalEventBus>();
+            if (eventBus is null)
+            {
+                LogNoEventBus(logger, typeof(TEntity).FullName ?? typeof(TEntity).Name);
+            }
+            else
+            {
+                // Activate the open-generic EntityBulkUpdatedEvent<TLifecycle>
+                // through reflection: TEntity satisfies the lifecycle marker but
+                // the generic constraint sits on a different type parameter.
+                Type lifecycleEventType = typeof(EntityBulkUpdatedEvent<>).MakeGenericType(typeof(TEntity));
+                object evt = Activator.CreateInstance(lifecycleEventType, result.AffectedEntities)!;
+                await PublishViaReflectionAsync(eventBus, evt, lifecycleEventType, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return new BulkActionDispatchResult(
+            Affected: result.AffectedEntities.Count,
+            Failures: result.Failures);
+    }
+
+    private static Task PublishViaReflectionAsync(
+        ILocalEventBus bus, object evt, Type eventType, CancellationToken cancellationToken)
+    {
+        MethodInfo open = typeof(ILocalEventBus).GetMethod(nameof(ILocalEventBus.PublishAsync))!;
+        MethodInfo closed = open.MakeGenericMethod(eventType);
+        return (Task)closed.Invoke(bus, [evt, cancellationToken])!;
+    }
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Debug,
+        Message = "Bulk action affected rows for entity '{Entity}' but no ILocalEventBus is registered; skipping EntityBulkUpdatedEvent emission.")]
+    private static partial void LogNoEventBus(ILogger logger, string entity);
+}
+
+/// <summary>
+/// Framework-level outcome of <see cref="BulkActionExecutionOrchestrator.DispatchAsync"/>.
+/// Mirrors the public <c>BulkActionResponse</c> shape exposed by the endpoint
+/// but stays in the base module — the endpoint layer maps it to its DTO.
+/// </summary>
+/// <param name="Affected">Number of rows the executor accepted.</param>
+/// <param name="Failures">Per-row failures reported by the executor.</param>
+public sealed record BulkActionDispatchResult(
+    int Affected,
+    IReadOnlyList<BulkActionFailure> Failures);

--- a/src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs
+++ b/src/Granit.Entities/Extensions/EntitiesServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.Entities.Actions.Execution;
 using Granit.Entities.Diagnostics;
 using Granit.Entities.Internal;
 using Granit.Entities.Options;
@@ -42,6 +43,7 @@ public static class EntitiesServiceCollectionExtensions
         }
 
         services.TryAddSingleton<IEntityDefinitionRegistry, EntityDefinitionRegistry>();
+        services.TryAddSingleton<BulkActionExecutionOrchestrator>();
         services.AddHostedService<IntegrityCheckRunner>();
 
         // Default Layer-4 customization applier (ADR-053 §5) — no-op until the

--- a/tests/Granit.ArchitectureTests/ServerExecutorRegistrationTests.cs
+++ b/tests/Granit.ArchitectureTests/ServerExecutorRegistrationTests.cs
@@ -1,0 +1,63 @@
+using Granit.ArchitectureTests.Internal;
+using Granit.Entities;
+using Granit.Entities.Actions;
+using Granit.Entities.Actions.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Enforces story #1822 / ADR-056: every <see cref="EntityActionDescriptor"/>
+/// with <see cref="EntityActionDescriptor.RequiresServerExecution"/> set MUST
+/// declare a <see cref="EntityActionDescriptor.ServerExecutorType"/> that
+/// implements <see cref="IEntityActionExecutor{TEntity}"/> for the entity's CLR
+/// type. The matching descriptor type is captured by the
+/// <c>EntityActionBuilder&lt;TEntity&gt;.ServerExecutor&lt;TExecutor&gt;()</c> fluent
+/// extension; the archi test catches drift if a contributor pokes the
+/// descriptor through a different path.
+/// </summary>
+public sealed class ServerExecutorRegistrationTests
+{
+    [Fact]
+    public void Every_server_executed_action_must_declare_a_matching_IEntityActionExecutor_implementation()
+    {
+        List<IEntityDefinitionDescriptor> entities = EntityDefinitionScan.ScanEntityDefinitions();
+
+        List<string> violations = [];
+
+        foreach (IEntityDefinitionDescriptor entity in entities)
+        {
+            EntityDefinitionDescriptor descriptor = entity.Descriptor;
+            foreach (EntityActionDescriptor action in descriptor.Actions)
+            {
+                if (!action.RequiresServerExecution)
+                {
+                    continue;
+                }
+
+                if (action.ServerExecutorType is null)
+                {
+                    violations.Add(
+                        $"Action '{action.Name}' on entity '{descriptor.Name}' has RequiresServerExecution=true "
+                        + "but ServerExecutorType is null. Use .ServerExecutor<TExecutor>() on the action builder.");
+                    continue;
+                }
+
+                Type expectedInterface = typeof(IEntityActionExecutor<>).MakeGenericType(descriptor.EntityType);
+                if (!expectedInterface.IsAssignableFrom(action.ServerExecutorType))
+                {
+                    violations.Add(
+                        $"Action '{action.Name}' on entity '{descriptor.Name}' declares ServerExecutorType "
+                        + $"'{action.ServerExecutorType.FullName}' which does not implement "
+                        + $"IEntityActionExecutor<{descriptor.EntityType.Name}>. Fix the .ServerExecutor<>() type "
+                        + "or align the executor's generic argument with the entity type.");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "ADR-056 / story #1822: every server-executed action must ship a registered IEntityActionExecutor<TEntity> "
+            + "for the matching entity type. Violations:\n" + string.Join("\n", violations));
+    }
+}

--- a/tests/Granit.Entities.Tests/Actions/EntityActionBuilderServerExecutorTests.cs
+++ b/tests/Granit.Entities.Tests/Actions/EntityActionBuilderServerExecutorTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Granit.Entities.Actions;
+using Granit.Entities.Actions.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Tests.Actions;
+
+public sealed class EntityActionBuilderServerExecutorTests
+{
+    private sealed class Widget { }
+
+    private sealed class WidgetExecutor : IEntityActionExecutor<Widget>
+    {
+        public Task<EntityActionExecutionResult<Widget>> ExecuteAsync(
+            Guid id, JsonElement payload, CancellationToken cancellationToken) =>
+            Task.FromResult(new EntityActionExecutionResult<Widget>(new Widget(), null));
+    }
+
+    [Fact]
+    public void ServerExecutor_flags_descriptor_and_captures_type()
+    {
+        var b = new EntityDefinitionBuilder<Widget>();
+        b.RouteBase("/api/widgets");
+        b.Action("archive", a => a
+            .Post("archive")
+            .RequiresPermission("Widgets.Widgets.Manage")
+            .ServerExecutor<WidgetExecutor>());
+
+        EntityDefinitionDescriptor d = b.Build("Test.Widget");
+        EntityActionDescriptor action = d.Actions.ShouldHaveSingleItem();
+        action.RequiresServerExecution.ShouldBeTrue();
+        action.ServerExecutorType.ShouldBe(typeof(WidgetExecutor));
+    }
+
+    [Fact]
+    public void Descriptor_defaults_to_declarative_action()
+    {
+        var b = new EntityDefinitionBuilder<Widget>();
+        b.RouteBase("/api/widgets");
+        b.Action("legacy", a => a.Post("legacy"));
+
+        EntityActionDescriptor action = b.Build("Test.Widget").Actions.ShouldHaveSingleItem();
+        action.RequiresServerExecution.ShouldBeFalse();
+        action.ServerExecutorType.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Entities.Tests/Actions/Execution/BulkActionExecutionOrchestratorTests.cs
+++ b/tests/Granit.Entities.Tests/Actions/Execution/BulkActionExecutionOrchestratorTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using Granit.Domain;
+using Granit.Entities.Actions.Execution;
+using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Entities.Tests.Actions.Execution;
+
+public sealed class BulkActionExecutionOrchestratorTests
+{
+    private sealed class Widget : IEmitEntityLifecycleEvents
+    {
+        public Guid Id { get; init; }
+    }
+
+    private sealed class Gadget
+    {
+        public Guid Id { get; init; }
+    }
+
+    private sealed class PerRowExecutor(Dictionary<Guid, EntityActionExecutionResult<Widget>> outcomes)
+        : IEntityActionExecutor<Widget>
+    {
+        public List<Guid> Calls { get; } = [];
+
+        public Task<EntityActionExecutionResult<Widget>> ExecuteAsync(
+            Guid id, JsonElement payload, CancellationToken cancellationToken)
+        {
+            Calls.Add(id);
+            return Task.FromResult(outcomes[id]);
+        }
+    }
+
+    private sealed class BulkExecutor : IBulkActionExecutor<Widget>
+    {
+        public IReadOnlyList<Guid>? CapturedIds { get; private set; }
+
+        public Task<BulkActionExecutionResult<Widget>> ExecuteBulkAsync(
+            IReadOnlyList<Guid> ids, JsonElement payload, CancellationToken cancellationToken)
+        {
+            CapturedIds = ids;
+            return Task.FromResult(new BulkActionExecutionResult<Widget>(
+                AffectedEntities: [.. ids.Select(i => new Widget { Id = i })],
+                Failures: []));
+        }
+    }
+
+    private sealed class GadgetExecutor : IEntityActionExecutor<Gadget>
+    {
+        public Task<EntityActionExecutionResult<Gadget>> ExecuteAsync(
+            Guid id, JsonElement payload, CancellationToken cancellationToken) =>
+            Task.FromResult(new EntityActionExecutionResult<Gadget>(new Gadget { Id = id }, FailureReason: null));
+    }
+
+    private sealed class RecordingBus : ILocalEventBus
+    {
+        public List<object> Published { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            Published.Add(localEvent);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task PerRow_loop_aggregates_successes_and_failures()
+    {
+        var ok1 = Guid.NewGuid();
+        var ok2 = Guid.NewGuid();
+        var bad = Guid.NewGuid();
+
+        var e1 = new Widget { Id = ok1 };
+        var e2 = new Widget { Id = ok2 };
+
+        var executor = new PerRowExecutor(new()
+        {
+            [ok1] = new EntityActionExecutionResult<Widget>(e1, null),
+            [ok2] = new EntityActionExecutionResult<Widget>(e2, null),
+            [bad] = new EntityActionExecutionResult<Widget>(null, "NotFound"),
+        });
+        RecordingBus bus = new();
+
+        ServiceCollection services = new();
+        services.AddSingleton(executor);
+        services.AddSingleton<ILocalEventBus>(bus);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        BulkActionExecutionOrchestrator orchestrator = new(NullLogger<BulkActionExecutionOrchestrator>.Instance);
+        BulkActionDispatchResult result = await orchestrator.DispatchAsync(
+            typeof(Widget), typeof(PerRowExecutor),
+            [ok1, ok2, bad],
+            default,
+            sp,
+            CancellationToken.None);
+
+        result.Affected.ShouldBe(2);
+        BulkActionFailure failure = result.Failures.ShouldHaveSingleItem();
+        failure.Id.ShouldBe(bad);
+        failure.Reason.ShouldBe("NotFound");
+        executor.Calls.Count.ShouldBe(3);
+
+        // Lifecycle bus saw exactly one batched event.
+        bus.Published.Count.ShouldBe(1);
+        EntityBulkUpdatedEvent<Widget> evt = bus.Published[0].ShouldBeOfType<EntityBulkUpdatedEvent<Widget>>();
+        evt.Entities.Select(x => x.Id).ShouldBe([ok1, ok2]);
+    }
+
+    [Fact]
+    public async Task Prefers_bulk_executor_when_registered()
+    {
+        BulkExecutor bulk = new();
+        PerRowExecutor perRow = new(new());
+
+        ServiceCollection services = new();
+        services.AddSingleton<IBulkActionExecutor<Widget>>(bulk);
+        services.AddSingleton(perRow);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        Guid[] ids = [Guid.NewGuid(), Guid.NewGuid()];
+        BulkActionExecutionOrchestrator orchestrator = new(NullLogger<BulkActionExecutionOrchestrator>.Instance);
+
+        BulkActionDispatchResult result = await orchestrator.DispatchAsync(
+            typeof(Widget), typeof(PerRowExecutor), ids, default, sp, CancellationToken.None);
+
+        result.Affected.ShouldBe(2);
+        result.Failures.ShouldBeEmpty();
+        bulk.CapturedIds.ShouldBe(ids);
+        perRow.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Skips_lifecycle_event_when_entity_does_not_emit_lifecycle_events()
+    {
+        GadgetExecutor executor = new();
+        RecordingBus bus = new();
+
+        ServiceCollection services = new();
+        services.AddSingleton(executor);
+        services.AddSingleton<ILocalEventBus>(bus);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        BulkActionExecutionOrchestrator orchestrator = new(NullLogger<BulkActionExecutionOrchestrator>.Instance);
+        BulkActionDispatchResult result = await orchestrator.DispatchAsync(
+            typeof(Gadget), typeof(GadgetExecutor),
+            [Guid.NewGuid()], default, sp, CancellationToken.None);
+
+        result.Affected.ShouldBe(1);
+        bus.Published.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Skips_event_when_no_lifecycle_bus_registered()
+    {
+        Widget e = new() { Id = Guid.NewGuid() };
+        PerRowExecutor executor = new(new()
+        {
+            [e.Id] = new EntityActionExecutionResult<Widget>(e, null),
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton(executor);
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        BulkActionExecutionOrchestrator orchestrator = new(NullLogger<BulkActionExecutionOrchestrator>.Instance);
+        // No throw, no event — just a successful result.
+        BulkActionDispatchResult result = await orchestrator.DispatchAsync(
+            typeof(Widget), typeof(PerRowExecutor), [e.Id], default, sp, CancellationToken.None);
+
+        result.Affected.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `IEntityActionExecutor<TEntity>` / `IBulkActionExecutor<TEntity>` contracts (pure abstractions) and the orchestrator that dispatches one or many rows against them.
- Wires `EntityActionBuilder<T>.ServerExecutor<TExecutor>()` so an action opts into server-side execution and surfaces the executor type on the descriptor.
- Mounts `POST /api/entities/{name}/bulk/{action}` — synchronous, permission-gated, per-row failure isolation, batched `EntityBulkUpdatedEvent<TEntity>` emission via `ILocalEventBus`.
- Architecture test guarantees every action with `RequiresServerExecution = true` resolves to a registered `IEntityActionExecutor<T>`.

## Design decisions

- **Per-row failure isolation** — `BulkActionResponse.Failures[]` reports rejected rows individually; the endpoint returns 200 as long as the dispatch surface accepted the request. Atomic semantics stay opt-in inside the host executor via an explicit UoW. UX-friendly default; atomicity would have been too brittle for selection-bar workflows.
- **Framework emits the lifecycle event** — executor responsibility is mutate + return touched rows; the orchestrator emits exactly one `EntityBulkUpdatedEvent<T>` per run, feeding the D1/D2 invalidator (#1793 / #1794).
- **Executor lifecycle: scoped** — typical implementations need a `DbContext`. The fluent `.ServerExecutor<>()` only captures the type; the host registers the executor explicitly (`AddScoped<TExecutor>()`).
- **Bulk shortcut is optional** — when `IBulkActionExecutor<T>` is registered the orchestrator uses it (one query, one save); otherwise it loops the per-row executor with the same observable contract.

ADR-056 documenting these calls will land in a separate `granit-docs` PR.

## Test plan

- [x] `dotnet build` on the 5 affected `src` / `tests` projects (all clean, zero warnings)
- [x] `dotnet test tests/Granit.Entities.Tests` — 22 passed (6 new across the executor surface)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter ~ServerExecutor` — 1 passed
- [x] `dotnet format --verify-no-changes` on each modified project — clean
- [ ] CI: business + api-data + architecture shards green
- [ ] ADR-056 PR on `granit-docs` (follow-up)

Closes #1822
Refs #1510 #1794