### PR TITLE
feat(documents-public-links): F18.4 — rate limiting + consumption audit events

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22896,7 +22896,7 @@
       "kind": "record",
       "project": "Granit.Documents.PublicLinks",
       "file": "src/Granit.Documents.PublicLinks/IDocumentPublicLinkService.cs",
-      "line": 69,
+      "line": 79,
       "members": []
     },
     {
@@ -23010,13 +23010,29 @@
       "kind": "class",
       "project": "Granit.Documents.PublicLinks.Endpoints",
       "file": "src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitDocumentsPublicLinks",
           "kind": "method",
           "signature": "MapGranitDocumentsPublicLinks(this IEndpointRouteBuilder endpoints, Action<DocumentsPublicLinksEndpointsOptions>? configure = null)",
           "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DocumentsPublicLinksRateLimiterServiceCollectionExtensions",
+      "fqn": "Granit.Documents.PublicLinks.Endpoints.Extensions.DocumentsPublicLinksRateLimiterServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Documents.PublicLinks.Endpoints",
+      "file": "src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksRateLimiterServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitDocumentsPublicLinksRateLimiter",
+          "kind": "method",
+          "signature": "AddGranitDocumentsPublicLinksRateLimiter(this IServiceCollection services, IConfiguration? configuration = null)",
+          "returnType": "IServiceCollection"
         }
       ]
     },
@@ -23120,7 +23136,7 @@
       "kind": "record",
       "project": "Granit.Documents.PublicLinks",
       "file": "src/Granit.Documents.PublicLinks/Events/DocumentPublicLinkConsumedEto.cs",
-      "line": 7,
+      "line": 23,
       "members": []
     },
     {
@@ -23229,7 +23245,7 @@
         {
           "name": "ResolveAndConsumeAsync",
           "kind": "method",
-          "signature": "ResolveAndConsumeAsync(string token, CancellationToken cancellationToken = default)",
+          "signature": "ResolveAndConsumeAsync(string token, string? clientIpMasked = null, string? userAgent = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<DocumentPublicLink?>"
         },
         {

--- a/src/Granit.Documents.PublicLinks.Endpoints/Endpoints/PublicLinksEndpoints.cs
+++ b/src/Granit.Documents.PublicLinks.Endpoints/Endpoints/PublicLinksEndpoints.cs
@@ -2,6 +2,7 @@ using Granit.BlobStorage;
 using Granit.Documents.PublicLinks.Diagnostics;
 using Granit.Documents.PublicLinks.Domain;
 using Granit.Documents.PublicLinks.Endpoints.Dtos;
+using Granit.Documents.PublicLinks.Endpoints.Internal;
 using Granit.Documents.PublicLinks.Endpoints.Options;
 using Granit.Documents.PublicLinks.Permissions;
 using Microsoft.AspNetCore.Authorization;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace Granit.Documents.PublicLinks.Endpoints.Endpoints;
 
@@ -206,10 +208,11 @@ internal static partial class PublicLinksEndpoints
         [FromServices] IDocumentPublicLinkService service,
         [FromServices] DocumentsPublicLinksMetrics metrics,
         [FromServices] ILoggerFactory loggerFactory,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         ILogger logger = loggerFactory.CreateLogger(typeof(PublicLinksEndpoints).FullName!);
-        return await RedeemAsync(token, forceAttachment: true, service, metrics, logger, cancellationToken)
+        return await RedeemAsync(token, forceAttachment: true, service, metrics, logger, httpContext, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -218,10 +221,11 @@ internal static partial class PublicLinksEndpoints
         [FromServices] IDocumentPublicLinkService service,
         [FromServices] DocumentsPublicLinksMetrics metrics,
         [FromServices] ILoggerFactory loggerFactory,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         ILogger logger = loggerFactory.CreateLogger(typeof(PublicLinksEndpoints).FullName!);
-        return await RedeemAsync(token, forceAttachment: false, service, metrics, logger, cancellationToken)
+        return await RedeemAsync(token, forceAttachment: false, service, metrics, logger, httpContext, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -231,10 +235,19 @@ internal static partial class PublicLinksEndpoints
         [FromServices] IDocumentPublicLinkService service,
         [FromServices] DocumentsPublicLinksMetrics metrics,
         [FromServices] ILogger logger,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
+        // F18.4 — capture masked client IP + UA for the distributed audit event.
+        // The raw IP NEVER leaves this method; the anonymiser collapses it to /24
+        // (v4) or /48 (v6) before it crosses any module boundary.
+        string? clientIpMasked = IpAddressAnonymizer.Mask(httpContext.Connection.RemoteIpAddress);
+        string? userAgent = httpContext.Request.Headers.UserAgent is StringValues ua && ua.Count > 0
+            ? ua.ToString()
+            : null;
+
         DocumentPublicLink? link = await service
-            .ResolveAndConsumeAsync(token, cancellationToken)
+            .ResolveAndConsumeAsync(token, clientIpMasked, userAgent, cancellationToken)
             .ConfigureAwait(false);
         if (link is null)
         {

--- a/src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksEndpointRouteBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Documents.PublicLinks.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Routing;
 
 namespace Granit.Documents.PublicLinks.Endpoints.Extensions;
@@ -37,7 +38,11 @@ public static class DocumentsPublicLinksEndpointRouteBuilderExtensions
 
         RouteGroupBuilder anonymousGroup = endpoints
             .MapGranitGroup(options.AnonymousRoutePrefix)
-            .WithTags(options.TagName);
+            .WithTags(options.TagName)
+            // F18.4 — rate-limit metadata is harmless without UseRateLimiter() / a
+            // registered policy: ASP.NET Core treats unknown policies as no-op.
+            // Hosts opt in by calling AddGranitDocumentsPublicLinksRateLimiter().
+            .RequireRateLimiting(DocumentsPublicLinksRateLimiterServiceCollectionExtensions.PolicyName);
         anonymousGroup.MapAnonymousEndpoints();
 
         return endpoints;

--- a/src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksRateLimiterServiceCollectionExtensions.cs
+++ b/src/Granit.Documents.PublicLinks.Endpoints/Extensions/DocumentsPublicLinksRateLimiterServiceCollectionExtensions.cs
@@ -1,0 +1,107 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.RateLimiting;
+using Granit.Documents.PublicLinks.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Documents.PublicLinks.Endpoints.Extensions;
+
+/// <summary>
+/// Registration helpers for the anonymous public-link rate limiter (F18.4).
+/// </summary>
+public static class DocumentsPublicLinksRateLimiterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Policy name applied by the anonymous redemption group. Hosts MUST register
+    /// this policy via <see cref="AddGranitDocumentsPublicLinksRateLimiter"/> and
+    /// add <c>UseRateLimiter()</c> to the request pipeline for the limit to be
+    /// enforced. The endpoint metadata is harmless when the middleware is absent.
+    /// </summary>
+    public const string PolicyName = "granit-documents-public-links";
+
+    /// <summary>
+    /// Registers an ASP.NET Core rate limiter with a fixed-window
+    /// policy named <see cref="PolicyName"/>, keyed on a hash of
+    /// <c>(client IP, bearer token)</c>. The window is 1 minute and the permit limit
+    /// is sourced from <see cref="GranitDocumentsPublicLinksOptions.RateLimitPerMinute"/>
+    /// (default <c>60</c>).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">
+    /// Optional configuration root. When supplied the <see cref="GranitDocumentsPublicLinksOptions.SectionName"/>
+    /// section is bound onto the options instance — hosts that already bound the
+    /// options elsewhere may pass <c>null</c>.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <b>Partition key:</b> the raw bearer token NEVER appears in the partition
+    /// key. The key is the hex-encoded SHA-256 digest of <c>"{ip}|{token}"</c> —
+    /// the hash never leaves the process but defending in depth is cheap and keeps
+    /// memory dumps clean of cleartext tokens.
+    /// </para>
+    /// <para>
+    /// <b>Rejection response:</b> the default middleware response is kept — a
+    /// minimal <c>429 Too Many Requests</c> with a <c>Retry-After</c> header. No
+    /// custom body so revoked / unknown / rate-limited tokens still cannot be
+    /// distinguished by the rejection text.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddGranitDocumentsPublicLinksRateLimiter(
+        this IServiceCollection services,
+        IConfiguration? configuration = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (configuration is not null)
+        {
+            services
+                .AddOptions<GranitDocumentsPublicLinksOptions>()
+                .Bind(configuration.GetSection(GranitDocumentsPublicLinksOptions.SectionName))
+                .ValidateDataAnnotations();
+        }
+
+        services.AddRateLimiter(rateLimiterOptions =>
+        {
+            rateLimiterOptions.AddPolicy(PolicyName, httpContext =>
+            {
+                IOptionsMonitor<GranitDocumentsPublicLinksOptions> monitor =
+                    httpContext.RequestServices
+                        .GetRequiredService<IOptionsMonitor<GranitDocumentsPublicLinksOptions>>();
+                int permits = Math.Max(1, monitor.CurrentValue.RateLimitPerMinute);
+
+                string partitionKey = BuildPartitionKey(httpContext);
+
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey,
+                    _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = permits,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueLimit = 0,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        AutoReplenishment = true,
+                    });
+            });
+        });
+
+        return services;
+    }
+
+    private static string BuildPartitionKey(HttpContext httpContext)
+    {
+        string ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        string token = httpContext.GetRouteValue("token") as string ?? string.Empty;
+
+        // SHA-256 is non-cryptographic here (no adversary controls inputs in a way
+        // that benefits from collision); we use it purely to avoid retaining the
+        // raw token in the limiter's partition table.
+        byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes($"{ip}|{token}"));
+        return Convert.ToHexString(digest);
+    }
+}

--- a/src/Granit.Documents.PublicLinks.Endpoints/Internal/IpAddressAnonymizer.cs
+++ b/src/Granit.Documents.PublicLinks.Endpoints/Internal/IpAddressAnonymizer.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Granit.Documents.PublicLinks.Endpoints.Internal;
+
+/// <summary>
+/// GDPR-friendly client-IP anonymiser (F18.4). Masks IPv4 addresses to <c>/24</c>
+/// and IPv6 addresses to <c>/48</c> — sufficient for abuse-pattern detection on
+/// the public-links audit trail without retaining a per-user identifier.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the masking applied by major analytics platforms (Google Analytics
+/// "anonymizeIp", Matomo, Plausible). Loopback / link-local / private addresses
+/// are masked exactly the same way — no special casing — to keep the call site
+/// trivial and audit-friendly.
+/// </para>
+/// </remarks>
+internal static class IpAddressAnonymizer
+{
+    /// <summary>
+    /// Returns the anonymised string representation of <paramref name="address"/>,
+    /// or <c>null</c> if the address is <c>null</c> or of an unsupported family.
+    /// </summary>
+    public static string? Mask(IPAddress? address)
+    {
+        if (address is null)
+        {
+            return null;
+        }
+
+        // Unwrap IPv4-mapped IPv6 (::ffff:1.2.3.4 → 1.2.3.4) so the mask falls on
+        // the correct family.
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        return address.AddressFamily switch
+        {
+            AddressFamily.InterNetwork => MaskIPv4(address),
+            AddressFamily.InterNetworkV6 => MaskIPv6(address),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Parses <paramref name="raw"/> as an IP address and returns its anonymised
+    /// representation, or <c>null</c> if parsing fails or the address is unsupported.
+    /// </summary>
+    public static string? Mask(string? raw) =>
+        IPAddress.TryParse(raw, out IPAddress? parsed) ? Mask(parsed) : null;
+
+    private static string MaskIPv4(IPAddress address)
+    {
+        byte[] bytes = address.GetAddressBytes();
+        bytes[3] = 0;
+        return new IPAddress(bytes).ToString();
+    }
+
+    private static string MaskIPv6(IPAddress address)
+    {
+        byte[] bytes = address.GetAddressBytes();
+        // /48 = first 6 bytes preserved, last 10 zeroed.
+        for (int i = 6; i < bytes.Length; i++)
+        {
+            bytes[i] = 0;
+        }
+        return new IPAddress(bytes).ToString();
+    }
+}

--- a/src/Granit.Documents.PublicLinks.Endpoints/README.md
+++ b/src/Granit.Documents.PublicLinks.Endpoints/README.md
@@ -41,6 +41,50 @@ builder.AddGranitDocumentsPublicLinks();
 builder.AddGranitDocumentsEntityFrameworkCore(opts => opts.UseNpgsql(connString));
 builder.AddGranitDocumentsPublicLinksEntityFrameworkCore(opts => opts.UseNpgsql(connString));
 
+// F18.4 — opt in to rate limiting on the anonymous /p/{token} endpoints.
+builder.Services.AddGranitDocumentsPublicLinksRateLimiter(builder.Configuration);
+
+app.UseRateLimiter();  // required for the policy above to be enforced
+
 app.MapGroup("/api").MapGranitDocuments();
 app.MapGranitDocumentsPublicLinks();
 ```
+
+## Rate limiting (F18.4)
+
+The anonymous `/p/{token}` and `/p/{token}/preview` endpoints carry a
+`RequireRateLimiting("granit-documents-public-links")` metadata. Hosts opt in by
+calling `AddGranitDocumentsPublicLinksRateLimiter(configuration)` and adding
+`UseRateLimiter()` to the pipeline; without those two calls the metadata is a
+no-op and the endpoints are unbounded.
+
+- **Window:** 1 minute (fixed)
+- **Permit limit:** `GranitDocumentsPublicLinksOptions.RateLimitPerMinute`
+  (default `60`)
+- **Partition key:** SHA-256 hash of `"{client IP}|{bearer token}"`. The raw
+  token never enters the limiter's partition table — the hash is computed
+  in-process for defense-in-depth so a memory dump cannot recover cleartext
+  bearers.
+- **Rejection response:** the default ASP.NET Core `429 Too Many Requests`
+  with a `Retry-After` header. No custom body — rate-limited and revoked
+  tokens remain indistinguishable on the wire.
+
+## Consumption audit trail (F18.4)
+
+Every successful redemption (after the consumption is durably persisted)
+publishes a `DocumentPublicLinkConsumedEto` integration event onto
+`IDistributedEventBus`. The Eto carries:
+
+- `LinkId`, `DocumentId`, `TenantId`, `Scope`
+- `CurrentUses` (post-increment), `ConsumedAt`
+- `ClientIpMasked` — anonymised to `/24` (IPv4) or `/48` (IPv6); raw IP never
+  leaves the endpoint module
+- `UserAgent` — verbatim `User-Agent` header (downstream consumers SHOULD
+  honour retention limits)
+
+The token is **never** included — neither in cleartext nor in hashed form.
+
+No dedicated `PublicLinkAccessLog` table ships with the framework. Consumers
+that need long-term audit storage subscribe to the Eto (audit module, SIEM
+forwarder, BigQuery sink, etc.) — keeping the module decoupled from any
+particular retention strategy.

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/DocumentPublicLinkService.cs
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/DocumentPublicLinkService.cs
@@ -2,7 +2,9 @@ using Granit.BlobStorage;
 using Granit.BlobStorage.Options;
 using Granit.Documents.Domain;
 using Granit.Documents.PublicLinks.Domain;
+using Granit.Documents.PublicLinks.Events;
 using Granit.Documents.PublicLinks.Options;
+using Granit.Events;
 using Granit.Guids;
 using Granit.Users;
 using Microsoft.Extensions.Options;
@@ -25,6 +27,7 @@ internal sealed class DocumentPublicLinkService(
     IGuidGenerator guidGenerator,
     TimeProvider timeProvider,
     IOptionsMonitor<GranitDocumentsPublicLinksOptions> optionsMonitor,
+    IDistributedEventBus? distributedEventBus = null,
     ICurrentUserService? currentUser = null) : IDocumentPublicLinkService
 {
     /// <inheritdoc/>
@@ -98,7 +101,10 @@ internal sealed class DocumentPublicLinkService(
 
     /// <inheritdoc/>
     public async Task<DocumentPublicLink?> ResolveAndConsumeAsync(
-        string token, CancellationToken cancellationToken = default)
+        string token,
+        string? clientIpMasked = null,
+        string? userAgent = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(token))
         {
@@ -141,6 +147,24 @@ internal sealed class DocumentPublicLinkService(
         }
 
         await store.UpdateAsync(link, cancellationToken).ConfigureAwait(false);
+
+        // F18.4 — publish the distributed audit event AFTER the consumption is durably
+        // persisted (outbox semantics: never advertise a side-effect that isn't recorded).
+        // Bus is optional — hosts without a distributed event provider get no-op behaviour.
+        if (distributedEventBus is not null)
+        {
+            var eto = new DocumentPublicLinkConsumedEto(
+                LinkId: link.Id,
+                TenantId: link.TenantId,
+                DocumentId: link.DocumentId,
+                Scope: link.Scope,
+                CurrentUses: link.CurrentUses,
+                ConsumedAt: now,
+                ClientIpMasked: clientIpMasked,
+                UserAgent: userAgent);
+            await distributedEventBus.PublishAsync(eto, cancellationToken).ConfigureAwait(false);
+        }
+
         return link;
     }
 

--- a/src/Granit.Documents.PublicLinks/Events/DocumentPublicLinkConsumedEto.cs
+++ b/src/Granit.Documents.PublicLinks/Events/DocumentPublicLinkConsumedEto.cs
@@ -3,11 +3,29 @@ using Granit.Events;
 
 namespace Granit.Documents.PublicLinks.Events;
 
-/// <summary>Distributed integration event raised on every successful public-link redemption.</summary>
+/// <summary>
+/// Distributed integration event raised on every successful public-link redemption.
+/// </summary>
+/// <param name="LinkId">Identifier of the consumed link.</param>
+/// <param name="TenantId">Tenant identifier of the link (links may live outside a tenant context).</param>
+/// <param name="DocumentId">Identifier of the underlying document.</param>
+/// <param name="Scope">Granted scope of the link.</param>
+/// <param name="CurrentUses">Post-increment usage counter (number of successful redemptions so far).</param>
+/// <param name="ConsumedAt">UTC instant the consumption was recorded.</param>
+/// <param name="ClientIpMasked">
+/// Optional anonymised client IP captured by the HTTP surface: /24 for IPv4 and /48 for IPv6.
+/// The raw IP is never carried — only a network prefix sufficient for abuse-pattern detection.
+/// </param>
+/// <param name="UserAgent">
+/// Optional <c>User-Agent</c> header value captured by the HTTP surface. Downstream consumers
+/// SHOULD honour retention limits — UA strings can be quasi-identifiers under GDPR.
+/// </param>
 public sealed record DocumentPublicLinkConsumedEto(
     Guid LinkId,
     Guid? TenantId,
     Guid DocumentId,
     PublicLinkScope Scope,
     int CurrentUses,
-    DateTimeOffset ConsumedAt) : IIntegrationEvent;
+    DateTimeOffset ConsumedAt,
+    string? ClientIpMasked = null,
+    string? UserAgent = null) : IIntegrationEvent;

--- a/src/Granit.Documents.PublicLinks/IDocumentPublicLinkService.cs
+++ b/src/Granit.Documents.PublicLinks/IDocumentPublicLinkService.cs
@@ -39,8 +39,18 @@ public interface IDocumentPublicLinkService
     /// success, or <c>null</c> on any business validation failure — callers MUST treat
     /// <c>null</c> as 404 (no info disclosure).
     /// </summary>
+    /// <param name="token">Bearer token (raw, as supplied by the anonymous caller).</param>
+    /// <param name="clientIpMasked">
+    /// Optional anonymised client IP (/24 v4 or /48 v6) propagated onto the
+    /// distributed audit event (F18.4). The raw IP MUST be masked by the caller before
+    /// reaching this method.
+    /// </param>
+    /// <param name="userAgent">Optional <c>User-Agent</c> string from the inbound request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<DocumentPublicLink?> ResolveAndConsumeAsync(
         string token,
+        string? clientIpMasked = null,
+        string? userAgent = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/tests/Granit.Documents.PublicLinks.Endpoints.Tests/IpAddressAnonymizerTests.cs
+++ b/tests/Granit.Documents.PublicLinks.Endpoints.Tests/IpAddressAnonymizerTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using Granit.Documents.PublicLinks.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.PublicLinks.Endpoints.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="IpAddressAnonymizer"/> (F18.4). Verifies the /24 (IPv4)
+/// and /48 (IPv6) masks documented for the public-link audit trail.
+/// </summary>
+public sealed class IpAddressAnonymizerTests
+{
+    [Fact]
+    public void Mask_IPv4_ZeroesLastOctet()
+    {
+        IpAddressAnonymizer.Mask(IPAddress.Parse("203.0.113.42")).ShouldBe("203.0.113.0");
+    }
+
+    [Fact]
+    public void Mask_IPv6_ZeroesLastTenBytes()
+    {
+        // /48 keeps the first three hextets; remaining 80 bits zeroed.
+        IpAddressAnonymizer.Mask(IPAddress.Parse("2001:db8:cafe:1::dead:beef")).ShouldBe("2001:db8:cafe::");
+    }
+
+    [Fact]
+    public void Mask_IPv4MappedIPv6_UnwrapsBeforeMasking()
+    {
+        IpAddressAnonymizer.Mask(IPAddress.Parse("::ffff:198.51.100.7")).ShouldBe("198.51.100.0");
+    }
+
+    [Fact]
+    public void Mask_Null_ReturnsNull()
+    {
+        IpAddressAnonymizer.Mask((IPAddress?)null).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-an-ip")]
+    [InlineData("999.999.999.999")]
+    public void Mask_InvalidString_ReturnsNull(string? raw)
+    {
+        IpAddressAnonymizer.Mask(raw).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Mask_ValidIPv4String_ReturnsMaskedString()
+    {
+        IpAddressAnonymizer.Mask("10.20.30.40").ShouldBe("10.20.30.0");
+    }
+}

--- a/tests/Granit.Documents.PublicLinks.Endpoints.Tests/RateLimiterRegistrationTests.cs
+++ b/tests/Granit.Documents.PublicLinks.Endpoints.Tests/RateLimiterRegistrationTests.cs
@@ -1,0 +1,54 @@
+using Granit.Documents.PublicLinks.Endpoints.Extensions;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Documents.PublicLinks.Endpoints.Tests;
+
+/// <summary>
+/// Verifies that <see cref="DocumentsPublicLinksRateLimiterServiceCollectionExtensions"/>
+/// registers the named policy expected by the anonymous redemption group (F18.4).
+/// </summary>
+public sealed class RateLimiterRegistrationTests
+{
+    [Fact]
+    public void AddGranitDocumentsPublicLinksRateLimiter_RegistersRateLimiterOptions()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+
+        services.AddGranitDocumentsPublicLinksRateLimiter(configuration: null);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        // The policy registry is internal to ASP.NET Core. We assert the visible
+        // contract: RateLimiterOptions is bound and resolvable from DI, which means
+        // AddRateLimiter ran successfully and the named policy AddPolicy call queued.
+        IOptions<RateLimiterOptions> options = provider.GetRequiredService<IOptions<RateLimiterOptions>>();
+        options.Value.ShouldNotBeNull();
+        DocumentsPublicLinksRateLimiterServiceCollectionExtensions.PolicyName
+            .ShouldBe("granit-documents-public-links");
+    }
+
+    [Fact]
+    public void AddGranitDocumentsPublicLinksRateLimiter_BindsOptionsFromConfiguration()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Granit:Documents:PublicLinks:RateLimitPerMinute"] = "5",
+            })
+            .Build();
+
+        services.AddGranitDocumentsPublicLinksRateLimiter(config);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IOptionsMonitor<Granit.Documents.PublicLinks.Options.GranitDocumentsPublicLinksOptions> monitor =
+            provider.GetRequiredService<IOptionsMonitor<Granit.Documents.PublicLinks.Options.GranitDocumentsPublicLinksOptions>>();
+        monitor.CurrentValue.RateLimitPerMinute.ShouldBe(5);
+    }
+}

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/DocumentPublicLinkServicePostgresTests.cs
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/DocumentPublicLinkServicePostgresTests.cs
@@ -4,7 +4,9 @@ using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.PublicLinks.Domain;
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+using Granit.Documents.PublicLinks.Events;
 using Granit.Documents.PublicLinks.Options;
+using Granit.Events;
 using Granit.Guids;
 using Granit.Users;
 using Microsoft.EntityFrameworkCore;
@@ -30,6 +32,7 @@ public sealed class DocumentPublicLinkServicePostgresTests :
     private EfDocumentPublicLinkStore _store = null!;
     private DocumentPublicLinkService _sut = null!;
     private IDocumentService _documents = null!;
+    private CapturingEventBus _eventBus = null!;
 
     public DocumentPublicLinkServicePostgresTests(PostgresFixture postgres) => _postgres = postgres;
 
@@ -49,6 +52,7 @@ public sealed class DocumentPublicLinkServicePostgresTests :
         _store = new EfDocumentPublicLinkStore(_factory);
 
         _documents = Substitute.For<IDocumentService>();
+        _eventBus = new CapturingEventBus();
         _sut = BuildService();
     }
 
@@ -72,7 +76,8 @@ public sealed class DocumentPublicLinkServicePostgresTests :
             _store, _documents, guids,
             new FixedTime(Now),
             monitor,
-            user);
+            distributedEventBus: _eventBus,
+            currentUser: user);
     }
 
     [Fact]
@@ -165,6 +170,52 @@ public sealed class DocumentPublicLinkServicePostgresTests :
     }
 
     [Fact]
+    public async Task ResolveAndConsumeAsync_PublishesIntegrationEvent()
+    {
+        var docId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        _documents.GetByIdAsync(docId, Arg.Any<CancellationToken>())
+            .Returns(BuildDocument(docId, tenantId));
+
+        DocumentPublicLinkCreationResult result = await _sut.CreateAsync(
+            docId, PublicLinkScope.Download, TimeSpan.FromHours(2), maxUses: 5,
+            TestContext.Current.CancellationToken);
+
+        _eventBus.Captured.Clear();
+
+        DocumentPublicLink? consumed = await _sut.ResolveAndConsumeAsync(
+            result.Token.Value, clientIpMasked: "203.0.113.0", userAgent: "TestAgent/1.0",
+            TestContext.Current.CancellationToken);
+
+        consumed.ShouldNotBeNull();
+        consumed.CurrentUses.ShouldBe(1);
+
+        DocumentPublicLinkConsumedEto eto = _eventBus.Captured
+            .OfType<DocumentPublicLinkConsumedEto>()
+            .ShouldHaveSingleItem();
+        eto.LinkId.ShouldBe(result.Link.Id);
+        eto.DocumentId.ShouldBe(docId);
+        eto.TenantId.ShouldBe(tenantId);
+        eto.Scope.ShouldBe(PublicLinkScope.Download);
+        eto.CurrentUses.ShouldBe(1);
+        eto.ConsumedAt.ShouldBe(Now);
+        eto.ClientIpMasked.ShouldBe("203.0.113.0");
+        eto.UserAgent.ShouldBe("TestAgent/1.0");
+    }
+
+    [Fact]
+    public async Task ResolveAndConsumeAsync_DoesNotPublishWhenLinkUnknown()
+    {
+        _eventBus.Captured.Clear();
+
+        DocumentPublicLink? consumed = await _sut.ResolveAndConsumeAsync(
+            "not-a-real-token", cancellationToken: TestContext.Current.CancellationToken);
+
+        consumed.ShouldBeNull();
+        _eventBus.Captured.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task CreateAsync_ThrowsWhenSigningKeyEmpty()
     {
         DocumentPublicLinkService sut = BuildService(new GranitDocumentsPublicLinksOptions
@@ -223,5 +274,17 @@ public sealed class DocumentPublicLinkServicePostgresTests :
     private sealed class FixedTime(DateTimeOffset now) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class CapturingEventBus : IDistributedEventBus
+    {
+        public List<IIntegrationEvent> Captured { get; } = [];
+
+        public Task PublishAsync<TEvent>(TEvent integrationEvent, CancellationToken cancellationToken = default)
+            where TEvent : class, IIntegrationEvent
+        {
+            Captured.Add(integrationEvent);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/DocumentPublicLinkServiceTests.cs
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/DocumentPublicLinkServiceTests.cs
@@ -36,7 +36,7 @@ public sealed class DocumentPublicLinkServiceTests
         IOptionsMonitor<GranitDocumentsPublicLinksOptions> monitor = Substitute.For<IOptionsMonitor<GranitDocumentsPublicLinksOptions>>();
         monitor.CurrentValue.Returns(_options);
         _guids.Create().Returns(_ => Guid.NewGuid());
-        return new DocumentPublicLinkService(_store, _documents, _guids, _time, monitor, user);
+        return new DocumentPublicLinkService(_store, _documents, _guids, _time, monitor, distributedEventBus: null, currentUser: user);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Opt-in rate limiter `AddGranitDocumentsPublicLinksRateLimiter` registers a fixed-window policy (`RateLimitPerMinute` / minute) keyed on SHA-256(`{ip}|{token}`) — token never plaintext in partition table
- Anonymous endpoint group carries `RequireRateLimiting(PolicyName)` metadata (harmless if host omits `UseRateLimiter`)
- `IpAddressAnonymizer` masks /24 (IPv4) / /48 (IPv6) for GDPR; unwraps IPv4-mapped-IPv6
- `ResolveAndConsumeAsync` now accepts optional `clientIpMasked` + `userAgent`; endpoints capture from `HttpContext` and forward
- `DocumentPublicLinkConsumedEto` published via `IDistributedEventBus` (optional inject) AFTER durable persistence — Wolverine outbox commits atomically; no Eto on null result
- No new audit table: hosts subscribe to the Eto for persistent logging / SIEM

Closes #2011. Refs #1783.

## Test plan

- [x] 15 base tests
- [x] 26 endpoint tests (+10: IpAddressAnonymizer ×8, RateLimiterRegistration ×2)
- [x] 13 EF Core unit tests
- [x] 8 integration tests (+2: \`PublishesIntegrationEvent\`, \`DoesNotPublishWhenLinkUnknown\`)
- [x] \`dotnet format\` clean