### PR TITLE
fix(query-engine): orphan PagedResult $refs in OpenAPI components

### DIFF
--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -278,13 +278,20 @@ public static class QueryEndpointRouteBuilderExtensions
             && concrete.Content is not null
             && concrete.Content.TryGetValue("application/json", out OpenApiMediaType? media))
         {
-            // Trigger registration in components.schemas. The returned IOpenApiSchema is the
-            // concrete schema (not a reference) — for OneOf to serialize as $ref we must
-            // construct OpenApiSchemaReference explicitly. Without this, both PagedResult and
-            // GroupedResult are inlined in the response, duplicating ~5KB per query endpoint
-            // and leaving 16 orphan *Of* schemas in components.
-            await context.GetOrCreateSchemaAsync(pagedResultType, null, cancellationToken).ConfigureAwait(false);
-            await context.GetOrCreateSchemaAsync(groupedResultType, null, cancellationToken).ConfigureAwait(false);
+            // GetOrCreateSchemaAsync returns the concrete schema but does NOT reliably
+            // persist it in components.schemas when the same response status has two
+            // .Produces<>() entries — ASP.NET Core dedups at status code, so only the
+            // second (GroupedResult) reaches the schema collector. We register both
+            // explicitly so OneOf $refs resolve and codegen tools don't break.
+            IOpenApiSchema pagedSchema = await context
+                .GetOrCreateSchemaAsync(pagedResultType, null, cancellationToken)
+                .ConfigureAwait(false);
+            IOpenApiSchema groupedSchema = await context
+                .GetOrCreateSchemaAsync(groupedResultType, null, cancellationToken)
+                .ConfigureAwait(false);
+
+            EnsureRegisteredInComponents(context.Document, pagedResultType, pagedSchema);
+            EnsureRegisteredInComponents(context.Document, groupedResultType, groupedSchema);
 
             media.Schema = new OpenApiSchema
             {
@@ -296,6 +303,23 @@ public static class QueryEndpointRouteBuilderExtensions
                 Description = "PagedResult when groupBy is absent; GroupedResult otherwise.",
             };
         }
+    }
+
+    private static void EnsureRegisteredInComponents(
+        OpenApiDocument? document,
+        Type type,
+        IOpenApiSchema schema)
+    {
+        if (document is null || schema is OpenApiSchemaReference)
+        {
+            return;
+        }
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
+
+        string id = GetSchemaReferenceId(type);
+        document.Components.Schemas.TryAdd(id, schema);
     }
 
     /// <summary>

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/Granit.QueryEngine.AspNetCore.Tests.Integration.csproj
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/Granit.QueryEngine.AspNetCore.Tests.Integration.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <!-- Exclude from dotnet test in CI unit-test job (no ASP.NET TestServer needed). -->
     <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointOpenApiSchemaTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/QueryEndpointOpenApiSchemaTests.cs
@@ -1,0 +1,161 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Granit.MultiTenancy;
+using Granit.QueryEngine.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.AspNetCore.Tests.Integration;
+
+/// <summary>
+/// Regression tests for the OpenAPI document produced by <c>MapGranitQuery</c>.
+///
+/// The query endpoint declares two <c>Produces&lt;&gt;</c> calls at status 200
+/// (<c>PagedResult&lt;T&gt;</c> and <c>GroupedResult&lt;T&gt;</c>) and rewrites
+/// the response schema to a <c>oneOf</c> of <c>$ref</c>s. ASP.NET Core's schema
+/// collector dedups by status code, so historically only the second type
+/// (GroupedResult) ended up in <c>components.schemas</c>, leaving the PagedResult
+/// <c>$ref</c> orphan and breaking codegen clients. Both wrappers must now be
+/// present in components.schemas and every <c>$ref</c> emitted by the document
+/// must resolve.
+/// </summary>
+public sealed class QueryEndpointOpenApiSchemaTests
+{
+    [Fact]
+    public async Task NonProjectedQuery_RegistersBothPagedAndGroupedSchemas()
+    {
+        await using WebApplication app = await BuildAppAsync(projected: false);
+
+        JsonDocument doc = await FetchOpenApiAsync(app);
+
+        JsonElement schemas = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("schemas");
+
+        schemas.TryGetProperty("PagedResultOfTestProduct", out _).ShouldBeTrue(
+            "PagedResult<TestProduct> must be registered in components.schemas");
+        schemas.TryGetProperty("GroupedResultOfTestProduct", out _).ShouldBeTrue(
+            "GroupedResult<TestProduct> must be registered in components.schemas");
+    }
+
+    [Fact]
+    public async Task ProjectedQuery_RegistersBothPagedAndGroupedSchemas()
+    {
+        await using WebApplication app = await BuildAppAsync(projected: true);
+
+        JsonDocument doc = await FetchOpenApiAsync(app);
+
+        JsonElement schemas = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("schemas");
+
+        schemas.TryGetProperty("PagedResultOfTestProductDto", out _).ShouldBeTrue(
+            "PagedResult<TestProductDto> must be registered in components.schemas");
+        schemas.TryGetProperty("GroupedResultOfTestProductDto", out _).ShouldBeTrue(
+            "GroupedResult<TestProductDto> must be registered in components.schemas");
+    }
+
+    [Fact]
+    public async Task QueryEndpoint_EmitsNoOrphanRefs()
+    {
+        await using WebApplication app = await BuildAppAsync(projected: true);
+
+        JsonDocument doc = await FetchOpenApiAsync(app);
+
+        var declared = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("schemas")
+            .EnumerateObject()
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<string> orphans = [];
+        CollectOrphanRefs(doc.RootElement, declared, orphans);
+
+        orphans.ShouldBeEmpty(
+            $"every $ref must resolve in components.schemas; orphans: {string.Join(", ", orphans)}");
+    }
+
+    private static async Task<WebApplication> BuildAppAsync(bool projected)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddOpenApi();
+
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<TestProduct>>());
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
+        if (projected)
+        {
+            builder.Services.AddSingleton<QueryDefinition<TestProduct>, ProjectedTestProductQueryDefinition>();
+        }
+        else
+        {
+            builder.Services.AddSingleton<QueryDefinition<TestProduct>, TestProductQueryDefinition>();
+        }
+
+        WebApplication app = builder.Build();
+        app.MapOpenApi();
+        app.MapGranitQuery<TestProduct>(
+            _ => Array.Empty<TestProduct>().AsQueryable(),
+            "/api/products");
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<JsonDocument> FetchOpenApiAsync(WebApplication app)
+    {
+        HttpClient client = app.GetTestClient();
+        HttpResponseMessage response = await client.GetAsync(
+            "/openapi/v1.json", TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        Stream stream = await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken);
+        return await JsonDocument.ParseAsync(stream, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private static void CollectOrphanRefs(JsonElement node, HashSet<string> declared, List<string> orphans)
+    {
+        switch (node.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (JsonProperty prop in node.EnumerateObject())
+                {
+                    if (prop.NameEquals("$ref") && prop.Value.ValueKind == JsonValueKind.String)
+                    {
+                        string? value = prop.Value.GetString();
+                        if (value is not null && value.StartsWith("#/components/schemas/", StringComparison.Ordinal))
+                        {
+                            string id = value["#/components/schemas/".Length..];
+                            if (!declared.Contains(id) && !orphans.Contains(id))
+                            {
+                                orphans.Add(id);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        CollectOrphanRefs(prop.Value, declared, orphans);
+                    }
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (JsonElement item in node.EnumerateArray())
+                {
+                    CollectOrphanRefs(item, declared, orphans);
+                }
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1992 — the React showcase still couldn't run `pnpm api:generate` because 16 query-engine endpoints emitted `$ref: #/components/schemas/PagedResultOf<T>` while only the `GroupedResultOf<T>` sibling was actually registered in `components.schemas`.

### Root cause

`MapGranitQuery` declares two `Produces<>` calls at status 200 (`PagedResult<T>` and `GroupedResult<T>`) and rewrites the response schema to a `oneOf` of `$ref`s in an operation transformer. ASP.NET Core's schema collector dedups response metadata by status code, so only the second `Produces` (GroupedResult) reaches the components collector. The `GetOrCreateSchemaAsync` call in the transformer returns the concrete schema but doesn't reliably persist it in `document.Components.Schemas` from that hook point — leaving Paged as an orphan `$ref` and breaking codegen tools.

Endpoints that happened to "work" (e.g. `audit-entries`, `api-keys`) only did so because a sibling custom endpoint independently declared `.Produces<PagedResult<XxxResponse>>()` outside the QueryEngine machinery.

### Fix

In `DescribeQueryEndpointAsync`, after `GetOrCreateSchemaAsync` returns the concrete schema, explicitly add it to `context.Document.Components.Schemas` if missing (skip if the result is already an `OpenApiSchemaReference`, which means it was already registered upstream). Both wrappers are now guaranteed to land in components for every query endpoint.

### Regression test

New `QueryEndpointOpenApiSchemaTests` in `Granit.QueryEngine.AspNetCore.Tests.Integration`:

- Builds a minimal `WebApplication` with `AddOpenApi()` and `MapGranitQuery<T>()`.
- Fetches `/openapi/v1.json`.
- Asserts both `PagedResultOf<T>` and `GroupedResultOf<T>` exist in components (entity-typed AND projected-DTO variants).
- Walks every node, collects `$ref: #/components/schemas/...`, and fails on any orphan.

Verified that reverting the framework fix flips all three test cases to fail — the test catches the exact regression we just fixed, not adjacent breakage.

## Test plan

- [x] `dotnet build src/Granit.QueryEngine.AspNetCore` — 0/0
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests` — 48 passed
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests.Integration --filter QueryEndpointOpenApiSchemaTests` — 3 passed
- [x] Regression guard verified: reverting the framework change makes all 3 new tests fail.
- [x] `dotnet format style --verify-no-changes` clean on touched files.
- [ ] Showcase: after merge, restart and confirm `/openapi/v1.json` ships the 16 missing `PagedResultOf*` component entries — unblocks `pnpm api:generate` on `granit-showcase-admin-react`.