### PR TITLE
fix(persistence): tenant-isolated DbContext registration for 7 modules + dual-scope schema defaults

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5247,12 +5247,12 @@
       "kind": "class",
       "project": "Granit.Activities.EntityFrameworkCore",
       "file": "src/Granit.Activities.EntityFrameworkCore/Extensions/ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitActivitiesEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitActivitiesEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitActivitiesEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -12677,12 +12677,12 @@
       "kind": "class",
       "project": "Granit.BlobStorage.EntityFrameworkCore",
       "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitBlobStorageEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitBlobStorageEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitBlobStorageEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -18142,7 +18142,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.EntityFrameworkCore",
       "file": "src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs",
-      "line": 13,
+      "line": 21,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -20873,12 +20873,12 @@
       "kind": "class",
       "project": "Granit.Documents.AssetMetadata.EntityFrameworkCore",
       "file": "src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Extensions/AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDocumentsAssetMetadataEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitDocumentsAssetMetadataEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitDocumentsAssetMetadataEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -21933,12 +21933,12 @@
       "kind": "class",
       "project": "Granit.Documents.EntityFrameworkCore",
       "file": "src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitDocumentsEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitDocumentsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitDocumentsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -23180,12 +23180,12 @@
       "kind": "class",
       "project": "Granit.Documents.PublicLinks.EntityFrameworkCore",
       "file": "src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitDocumentsPublicLinksEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitDocumentsPublicLinksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitDocumentsPublicLinksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -23754,12 +23754,12 @@
       "kind": "class",
       "project": "Granit.Documents.Renditions.EntityFrameworkCore",
       "file": "src/Granit.Documents.Renditions.EntityFrameworkCore/Extensions/RenditionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDocumentsRenditionsEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitDocumentsRenditionsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitDocumentsRenditionsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -42318,7 +42318,7 @@
       "kind": "class",
       "project": "Granit.Notifications.EntityFrameworkCore",
       "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs",
-      "line": 21,
+      "line": 27,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -46894,7 +46894,7 @@
       "kind": "class",
       "project": "Granit.Parties.EntityFrameworkCore",
       "file": "src/Granit.Parties.EntityFrameworkCore/GranitPartiesDbProperties.cs",
-      "line": 6,
+      "line": 12,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -60999,12 +60999,12 @@
       "kind": "class",
       "project": "Granit.Taxonomy.EntityFrameworkCore",
       "file": "src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitTaxonomyEntityFrameworkCore",
           "kind": "method",
-          "signature": "AddGranitTaxonomyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "signature": "AddGranitTaxonomyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureShared, Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null, Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null, Action<TenantSchemaOptions>? configureTenantSchema = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]
@@ -61818,7 +61818,7 @@
       "kind": "class",
       "project": "Granit.Templating.EntityFrameworkCore",
       "file": "src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs",
-      "line": 13,
+      "line": 21,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -63345,7 +63345,7 @@
       "kind": "class",
       "project": "Granit.Timeline.EntityFrameworkCore",
       "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs",
-      "line": 13,
+      "line": 21,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -66509,7 +66509,7 @@
       "kind": "class",
       "project": "Granit.Webhooks.EntityFrameworkCore",
       "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs",
-      "line": 21,
+      "line": 27,
       "members": [
         {
           "name": "DbTablePrefix",

--- a/src/Granit.Activities.EntityFrameworkCore/Extensions/ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Activities.EntityFrameworkCore/Extensions/ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Activities.EntityFrameworkCore.Internal;
 using Granit.Activities.Persistence;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -13,21 +14,34 @@ namespace Granit.Activities.EntityFrameworkCore.Extensions;
 public static class ActivitiesEntityFrameworkCoreHostApplicationBuilderExtensions
 {
     /// <summary>
-    /// Registers the isolated <see cref="ActivitiesDbContext"/> via
-    /// <c>AddGranitDbContext</c> (which wires audit + soft-delete + lifecycle
-    /// interceptors automatically).
+    /// Registers <see cref="ActivitiesDbContext"/> via <c>AddGranitIsolatedDbContext</c>.
     /// </summary>
+    /// <remarks>
+    /// Activities is a tenant-only module. The active <c>TenantIsolationStrategy</c>
+    /// (<c>SharedDatabase</c>, <c>DatabasePerTenant</c>, <c>SchemaPerTenant</c>) is honored
+    /// and the audit + soft-delete + lifecycle interceptors are wired automatically.
+    /// </remarks>
     /// <param name="builder">The host application builder.</param>
-    /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitActivitiesEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<ActivitiesDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<ActivitiesDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
         builder.Services.AddScoped<IActivityReader, EfCoreActivityReader>();
         builder.Services.AddScoped<IActivityWriter, EfCoreActivityWriter>();
         return builder;

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,9 +18,12 @@ public static class BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensio
     /// Registers EF Core persistence for Granit blob storage.
     /// </summary>
     /// <remarks>
-    /// Registers <see cref="BlobStorageDbContext"/> via
-    /// <c>AddGranitDbContext</c> (<c>IDbContextFactory</c> with interceptor DI)
+    /// <para>
+    /// Registers <see cref="BlobStorageDbContext"/> via <c>AddGranitIsolatedDbContext</c>
     /// and binds <see cref="IBlobDescriptorStore"/> to <c>EfBlobDescriptorStore</c>.
+    /// BlobStorage is tenant-only: descriptors are isolated per tenant through the active
+    /// <c>TenantIsolationStrategy</c>.
+    /// </para>
     /// <para>
     /// <see cref="AuditedEntityInterceptor"/> is added automatically when
     /// <c>Granit.Persistence</c> is configured, enabling the ISO 27001 3-year audit trail.
@@ -29,13 +33,26 @@ public static class BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensio
     /// </para>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
-    /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitBlobStorageEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
-        builder.Services.AddGranitDbContext<BlobStorageDbContext>(configure);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureShared);
+
+        builder.Services.AddGranitIsolatedDbContext<BlobStorageDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
 
         builder.Services.AddScoped<EfBlobDescriptorStore>();
         builder.Services.AddScoped<IBlobDescriptorStore>(sp => sp.GetRequiredService<EfBlobDescriptorStore>());

--- a/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs
@@ -6,9 +6,17 @@ namespace Granit.DataExchange.EntityFrameworkCore;
 /// Provides configurable table-naming properties for the DataExchange EF Core module.
 /// </summary>
 /// <remarks>
+/// <para>
+/// DataExchange is a <b>dual-scope</b> module: it serves both host-admin operations
+/// (cross-tenant export/import for platform administrators) and tenant-scoped operations.
+/// Tables live in the <b>host schema</b> and tenant isolation is enforced via the
+/// <c>TenantId</c> row-level query filter (with <c>EfStoreBase</c> bypass for host context).
+/// </para>
+/// <para>
 /// <b>Important:</b> Set these properties at application startup, before
 /// <c>ConfigureServices</c> completes. EF Core caches the compiled model
 /// after first use — later mutations have no effect.
+/// </para>
 /// </remarks>
 public static class GranitDataExchangeDbProperties
 {
@@ -21,12 +29,14 @@ public static class GranitDataExchangeDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for DataExchange tables. Falls back to
+    /// <see cref="GranitDbDefaults.HostDbSchema"/>, then <see cref="GranitDbDefaults.DbSchema"/>
+    /// when not explicitly set — DataExchange tables intentionally live in the host schema
+    /// (row-level multi-tenancy via <c>TenantId</c> filter).
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Extensions/AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Extensions/AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Granit.Documents.AssetMetadata.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -17,17 +18,37 @@ public static class AssetMetadataEntityFrameworkCoreHostApplicationBuilderExtens
     /// <c>DocumentPermanentlyDeletedEvent</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Registers <see cref="AssetMetadataDbContext"/> via <c>AddGranitIsolatedDbContext</c>
+    /// — AssetMetadata is a tenant-only satellite of Documents and inherits the same
+    /// per-tenant isolation strategy.
+    /// </para>
+    /// <para>
     /// Should be called after <c>AddGranitDocumentsEntityFrameworkCore</c> so the
     /// parent documents <c>DbContext</c> and events are already wired.
+    /// </para>
     /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitDocumentsAssetMetadataEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<AssetMetadataDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<AssetMetadataDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
         builder.Services.TryAddScoped<IAssetMetadataStore, AssetMetadataStore>();
         builder.Services.TryAddScoped<IAssetMetadataService, AssetMetadataService>();
 

--- a/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.EntityFrameworkCore/Extensions/DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Documents.EntityFrameworkCore.Authorization;
 using Granit.Documents.EntityFrameworkCore.Internal;
 using Granit.Documents.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,27 +23,43 @@ public static class DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Registers the isolated <c>DocumentsDbContext</c> via <c>AddGranitDbContext</c>
-    /// (<see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/> with interceptor
-    /// DI), which automatically wires <c>AuditedEntityInterceptor</c> and
-    /// <c>SoftDeleteInterceptor</c> when <c>Granit.Persistence</c> is configured, enabling the
-    /// ISO 27001 3-year audit trail and GDPR-compatible soft-delete out of the box.
+    /// Registers <see cref="DocumentsDbContext"/> via <c>AddGranitIsolatedDbContext</c>, which
+    /// wires the active <c>TenantIsolationStrategy</c> (<c>SharedDatabase</c>,
+    /// <c>DatabasePerTenant</c>, <c>SchemaPerTenant</c>) and the
+    /// <see cref="TenantSchemaConnectionInterceptor"/> for per-tenant schema routing. Audit
+    /// (<c>AuditedEntityInterceptor</c>) and soft-delete (<c>SoftDeleteInterceptor</c>)
+    /// interceptors are wired automatically.
+    /// </para>
+    /// <para>
+    /// Documents is a tenant-only module: all entities are <c>IMultiTenant</c> and isolated
+    /// per tenant. Provide <paramref name="configureSchemaPerTenant"/> when the host runs in
+    /// <c>SchemaPerTenant</c> mode.
     /// </para>
     /// <para>
     /// Must be called after <see cref="DocumentsServiceCollectionExtensions.AddGranitDocuments"/>.
     /// </para>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
-    /// <param name="configure">EF Core <see cref="DbContextOptionsBuilder"/> configuration (provider + connection string).</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy (provider + connection string).</param>
+    /// <param name="configureDatabasePerTenant">Optional EF Core options for the database-per-tenant strategy.</param>
+    /// <param name="configureSchemaPerTenant">Optional EF Core options for the schema-per-tenant strategy.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning (prefix, naming).</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitDocumentsEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<DocumentsDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<DocumentsDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
 
         // Tenant-root bootstrap (F2.2): scoped so the per-instance memoisation cache lives
         // for the duration of one request only. Concurrency-safe via the partial unique

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -16,18 +17,38 @@ public static class DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilde
     /// <see cref="DocumentsPublicLinksDbContext"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Registers <see cref="DocumentsPublicLinksDbContext"/> via
+    /// <c>AddGranitIsolatedDbContext</c> — public links are tenant-scoped and inherit the
+    /// active multi-tenancy isolation strategy.
+    /// </para>
+    /// <para>
     /// Should be called after <c>AddGranitDocumentsEntityFrameworkCore</c> so the
     /// parent documents <c>DbContext</c> and <see cref="IDocumentService"/>
     /// implementation are already wired.
+    /// </para>
     /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitDocumentsPublicLinksEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<DocumentsPublicLinksDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<DocumentsPublicLinksDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
         builder.Services.TryAddScoped<IDocumentPublicLinkStore, EfDocumentPublicLinkStore>();
         builder.Services.TryAddScoped<IDocumentPublicLinkService, DocumentPublicLinkService>();
 

--- a/src/Granit.Documents.Renditions.EntityFrameworkCore/Extensions/RenditionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.Renditions.EntityFrameworkCore/Extensions/RenditionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Granit.Documents.Renditions.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -16,18 +17,37 @@ public static class RenditionsEntityFrameworkCoreHostApplicationBuilderExtension
     /// and wires the cascade handler on <c>DocumentPermanentlyDeletedEvent</c>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Registers <see cref="RenditionsDbContext"/> via <c>AddGranitIsolatedDbContext</c>
+    /// — renditions are tenant-scoped and inherit the active multi-tenancy isolation strategy.
+    /// </para>
+    /// <para>
     /// Must be called after <c>AddGranitDocumentsEntityFrameworkCore</c> so that
     /// <c>ITenantQuotaService</c> is registered — this module decrements the
     /// rendition counter through it on cascade.
+    /// </para>
     /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitDocumentsRenditionsEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<RenditionsDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<RenditionsDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
         builder.Services.TryAddScoped<IRenditionStore, RenditionStore>();
         builder.Services.TryAddScoped<IRenditionService, RenditionService>();
 

--- a/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
@@ -7,6 +7,12 @@ namespace Granit.Notifications.EntityFrameworkCore;
 /// </summary>
 /// <remarks>
 /// <para>
+/// Notifications is a <b>dual-scope</b> module: host-defined notification channels and
+/// templates coexist with tenant-scoped subscriptions, preferences, and delivery logs.
+/// Tables live in the <b>host schema</b> and tenant isolation is enforced via the
+/// <c>TenantId</c> row-level query filter (with <c>EfStoreBase</c> bypass for host context).
+/// </para>
+/// <para>
 /// These properties control the table prefix and schema used by all entity configurations
 /// in <c>Granit.Notifications.EntityFrameworkCore</c>. Both the internal
 /// <c>NotificationsDbContext</c> and the host's <c>Configure*Module()</c> call read

--- a/src/Granit.Parties.EntityFrameworkCore/GranitPartiesDbProperties.cs
+++ b/src/Granit.Parties.EntityFrameworkCore/GranitPartiesDbProperties.cs
@@ -3,6 +3,12 @@ using Granit.Persistence.EntityFrameworkCore;
 namespace Granit.Parties.EntityFrameworkCore;
 
 /// <summary>Table-naming properties for the Parties EF Core module.</summary>
+/// <remarks>
+/// Parties is a <b>dual-scope</b> module: it backs SaaS billing (the tenant itself is a
+/// <c>Party</c> referenced by <c>Subscription.PartyId</c>) and tenant-scoped CRM data.
+/// Tables live in the <b>host schema</b> and tenant isolation is enforced via the
+/// <c>TenantId</c> row-level query filter (with <c>EfStoreBase</c> bypass for host context).
+/// </remarks>
 public static class GranitPartiesDbProperties
 {
     /// <summary>Table prefix. Default: <c>"parties_"</c>.</summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -266,4 +266,38 @@ public static class PersistenceTenantExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Non-generic overload of <see cref="AddGranitIsolatedDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder{TContext}}, Action{DbContextOptionsBuilder{TContext}, string}?, Action{DbContextOptionsBuilder{TContext}}?, Action{TenantSchemaOptions}?)"/>
+    /// for use with <c>internal</c> <see cref="DbContext"/> types, whose generic
+    /// <see cref="DbContextOptionsBuilder{TContext}"/> would otherwise leak into the public
+    /// extension method signature.
+    /// </summary>
+    /// <typeparam name="TContext">The <see cref="DbContext"/> to register (may be internal).</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGranitIsolatedDbContext<TContext>(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(configureShared);
+
+        return services.AddGranitIsolatedDbContext<TContext>(
+            configureShared: opts => configureShared(opts),
+            configureDatabasePerTenant: configureDatabasePerTenant is null
+                ? null
+                : (opts, cs) => configureDatabasePerTenant(opts, cs),
+            configureSchemaPerTenant: configureSchemaPerTenant is null
+                ? null
+                : opts => configureSchemaPerTenant(opts),
+            configureTenantSchema: configureTenantSchema);
+    }
 }

--- a/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Taxonomy.EntityFrameworkCore/Extensions/TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.Taxonomy.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,19 +16,34 @@ public static class TaxonomyEntityFrameworkCoreHostApplicationBuilderExtensions
     /// Registers EF Core persistence for <c>Granit.Taxonomy</c>.
     /// </summary>
     /// <remarks>
-    /// Wires the isolated <see cref="TaxonomyDbContext"/> via <c>AddGranitDbContext</c>
-    /// (interceptor DI for audit / soft-delete) and registers the EF Core-backed
-    /// <c>ITagService</c>. Must be called after
-    /// <c>services.AddGranitTaxonomy()</c>.
+    /// <para>
+    /// Wires <see cref="TaxonomyDbContext"/> via <c>AddGranitIsolatedDbContext</c>
+    /// — Taxonomy is tenant-only and inherits the active multi-tenancy isolation strategy
+    /// (audit + soft-delete interceptors wired automatically).
+    /// </para>
+    /// <para>Must be called after <c>services.AddGranitTaxonomy()</c>.</para>
     /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureShared">EF Core options for the shared-database strategy.</param>
+    /// <param name="configureDatabasePerTenant">Optional database-per-tenant configuration.</param>
+    /// <param name="configureSchemaPerTenant">Optional schema-per-tenant configuration.</param>
+    /// <param name="configureTenantSchema">Optional <see cref="TenantSchemaOptions"/> tuning.</param>
+    /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitTaxonomyEntityFrameworkCore(
         this IHostApplicationBuilder builder,
-        Action<DbContextOptionsBuilder> configure)
+        Action<DbContextOptionsBuilder> configureShared,
+        Action<DbContextOptionsBuilder, string>? configureDatabasePerTenant = null,
+        Action<DbContextOptionsBuilder>? configureSchemaPerTenant = null,
+        Action<TenantSchemaOptions>? configureTenantSchema = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureShared);
 
-        builder.Services.AddGranitDbContext<TaxonomyDbContext>(configure);
+        builder.Services.AddGranitIsolatedDbContext<TaxonomyDbContext>(
+            configureShared,
+            configureDatabasePerTenant,
+            configureSchemaPerTenant,
+            configureTenantSchema);
         builder.Services.AddScoped<ITagService, TagService>();
         builder.Services.AddScoped<ITagAssignmentService, TagAssignmentService>();
         builder.Services.AddScoped<ITagSearchService, TagSearchService>();

--- a/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
@@ -6,9 +6,17 @@ namespace Granit.Templating.EntityFrameworkCore;
 /// Provides configurable table-naming properties for the Templating EF Core module.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Templating is a <b>dual-scope</b> module: system templates shipped by the host coexist
+/// with tenant-defined overrides. Tables live in the <b>host schema</b> and tenant
+/// isolation is enforced via the <c>TenantId</c> row-level query filter (with
+/// <c>EfStoreBase</c> bypass for host context).
+/// </para>
+/// <para>
 /// <b>Important:</b> Set these properties at application startup, before
 /// <c>ConfigureServices</c> completes. EF Core caches the compiled model
 /// after first use — later mutations have no effect.
+/// </para>
 /// </remarks>
 public static class GranitTemplatingDbProperties
 {

--- a/src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs
@@ -6,9 +6,17 @@ namespace Granit.Timeline.EntityFrameworkCore;
 /// Provides configurable table-naming properties for the Timeline EF Core module.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Timeline is a <b>dual-scope</b> module: it captures a platform-wide activity stream
+/// across tenants for host-admin observability as well as tenant-scoped activity feeds.
+/// Tables live in the <b>host schema</b> and tenant isolation is enforced via the
+/// <c>TenantId</c> row-level query filter (with <c>EfStoreBase</c> bypass for host context).
+/// </para>
+/// <para>
 /// <b>Important:</b> Set these properties at application startup, before
 /// <c>ConfigureServices</c> completes. EF Core caches the compiled model
 /// after first use — later mutations have no effect.
+/// </para>
 /// </remarks>
 public static class GranitTimelineDbProperties
 {
@@ -21,12 +29,14 @@ public static class GranitTimelineDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for Timeline tables. Falls back to
+    /// <see cref="GranitDbDefaults.HostDbSchema"/>, then <see cref="GranitDbDefaults.DbSchema"/>
+    /// when not explicitly set — Timeline tables intentionally live in the host schema
+    /// (row-level multi-tenancy via <c>TenantId</c> filter).
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs
@@ -7,6 +7,12 @@ namespace Granit.Webhooks.EntityFrameworkCore;
 /// </summary>
 /// <remarks>
 /// <para>
+/// Webhooks is a <b>dual-scope</b> module: platform subscriptions (host admins observing
+/// tenant events) coexist with tenant-defined webhooks. Tables live in the <b>host schema</b>
+/// and tenant isolation is enforced via the <c>TenantId</c> row-level query filter (with
+/// <c>EfStoreBase</c> bypass for host context).
+/// </para>
+/// <para>
 /// These properties control the table prefix and schema used by all entity configurations
 /// in <c>Granit.Webhooks.EntityFrameworkCore</c>. Both the internal
 /// <c>WebhooksDbContext</c> and the host's <c>Configure*Module()</c> call read
@@ -29,12 +35,14 @@ public static class GranitWebhooksDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for Webhooks tables. Falls back to
+    /// <see cref="GranitDbDefaults.HostDbSchema"/>, then <see cref="GranitDbDefaults.DbSchema"/>
+    /// when not explicitly set — Webhooks tables intentionally live in the host schema
+    /// (row-level multi-tenancy via <c>TenantId</c> filter).
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -212,6 +212,15 @@ public sealed partial class IsolatedDbContextTests
                     continue;
                 }
 
+                // Skip matches inside single-line comments (// ...). XML doc (///) is
+                // already excluded by the regex lookbehind.
+                int lineStart = content.LastIndexOf('\n', Math.Max(0, match.Index - 1)) + 1;
+                string lineUpToMatch = content[lineStart..match.Index];
+                if (lineUpToMatch.Contains("//", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 // The DbContext's project must contain a Configure*Module() ModelBuilder
                 // extension method so that host applications can include the module's
                 // entity configurations in their own DbContext and generate migrations.
@@ -278,9 +287,10 @@ public sealed partial class IsolatedDbContextTests
     private static partial Regex OnModelCreatingOverride();
 
     /// <summary>
-    /// Captures the type argument from <c>AddGranitDbContext&lt;SomeDbContext&gt;</c>.
+    /// Captures the type argument from <c>AddGranitDbContext&lt;SomeDbContext&gt;</c>
+    /// or <c>AddGranitIsolatedDbContext&lt;SomeDbContext&gt;</c>.
     /// Excludes XML doc / comment lines (starts with whitespace + "///").
     /// </summary>
-    [GeneratedRegex(@"(?<!///.*)\bAddGranitDbContext<(\w+)>")]
+    [GeneratedRegex(@"(?<!///.*)\bAddGranit(?:Isolated)?DbContext<(\w+)>")]
     private static partial Regex AddGranitDbContextCall();
 }

--- a/tests/Granit.Notifications.Analytics.Tests/GranitNotificationsAnalyticsModuleTests.cs
+++ b/tests/Granit.Notifications.Analytics.Tests/GranitNotificationsAnalyticsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitNotificationsAnalyticsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

Fixes a systemic bug surfaced while wiring F13.1 (Showcase Documents integration, granit-dotnet#1774). 13 \`Granit.*.EntityFrameworkCore\` modules were registering their DbContext via \`AddGranitDbContext\` (non-isolated). For modules with strict per-tenant isolation, runtime queries opened Postgres connections with \`search_path = public\` and failed with \`42P01\` against per-tenant schemas — observable in showcase via \`relation "documents_folders" does not exist\`.

Investigation split the 13 candidates into two correct patterns:

### Tenant-only — now `AddGranitIsolatedDbContext` (7 modules)

| Module | DbContext |
|---|---|
| Documents | DocumentsDbContext |
| Documents.AssetMetadata | AssetMetadataDbContext |
| Documents.PublicLinks | DocumentsPublicLinksDbContext |
| Documents.Renditions | RenditionsDbContext |
| Taxonomy | TaxonomyDbContext |
| Activities | ActivitiesDbContext |
| BlobStorage | BlobStorageDbContext |

Each \`AddGranit{X}EntityFrameworkCore\` signature gains optional \`configureDatabasePerTenant\` / \`configureSchemaPerTenant\` / \`configureTenantSchema\` callbacks alongside the existing \`configure\` (now \`configureShared\`). \`TenantSchemaConnectionInterceptor\` now wires for SchemaPerTenant deployments.

### Dual-scope — default schema to \`HostDbSchema\` (6 modules)

| Module | Host-scope use case |
|---|---|
| Parties | SaaS billing (tenant-as-Party for \`Subscription.PartyId\`) |
| Timeline | Platform-wide activity stream |
| Templating | System templates vs tenant overrides |
| Webhooks | Platform subscriptions vs tenant-defined |
| Notifications | Host channels/templates vs tenant instances |
| DataExchange | Cross-tenant export/import for platform admins |

\`*DbProperties.DbSchema\` getter falls back to \`GranitDbDefaults.HostDbSchema\` instead of \`GranitDbDefaults.DbSchema\` so dual-scope tables land in host schema by default — the showcase's existing manual pin for DataExchange can be deleted. XmlDoc on each module now describes the row-level dual-scope design explicitly.

### Other

- Architecture test \`AddGranitDbContext_should_have_matching_ConfigureModule_extension\` widened to match \`AddGranit(?:Isolated)?DbContext<...>\`
- Drive-by fix on \`GranitNotificationsAnalyticsModuleTests\` (\`DependedModules\` → \`DependedTypes\`) that was blocking the infra shard
- Added a non-generic \`AddGranitIsolatedDbContext\` overload accepting \`Action<DbContextOptionsBuilder>\` so internal-sealed DbContexts can keep their encapsulation
- Templating + Notifications keep their custom \`AddDbContextFactory\` because their interceptors are not registered as \`IInterceptor\` (canonicalization would silently drop them)
- Verified \`UseGranitInterceptors(sp)\` is wired in all 3 isolated factories — no audit/soft-delete regression

## Breaking change

The 7 tenant-only modules require new call-site shapes. Pre-1.0 — no \`[Obsolete]\` shim. Showcase follow-up PR will update its 7 call sites and delete the DataExchange schema-pin workaround.

## Test plan

- [x] \`dotnet build .github/shard-filters/infrastructure.slnf\` — green
- [x] \`dotnet build .github/shard-filters/business.slnf\` — green
- [x] \`dotnet test tests/Granit.ArchitectureTests\` — 248/248
- [x] Unit tests for Documents/BlobStorage/Activities/Taxonomy EF Core — 181/181
- [x] \`dotnet format --verify-no-changes\` clean