### PR TITLE
fix(satellite-tests): use DependedTypes property name on DependsOnAttribute

### DIFF
--- a/tests/Granit.BlobStorage.Analytics.Tests/GranitBlobStorageAnalyticsModuleTests.cs
+++ b/tests/Granit.BlobStorage.Analytics.Tests/GranitBlobStorageAnalyticsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitBlobStorageAnalyticsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }

--- a/tests/Granit.BlobStorage.Dashboards.Tests/GranitBlobStorageDashboardsModuleTests.cs
+++ b/tests/Granit.BlobStorage.Dashboards.Tests/GranitBlobStorageDashboardsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitBlobStorageDashboardsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }

--- a/tests/Granit.Identity.Federated.Analytics.Tests/GranitIdentityFederatedAnalyticsModuleTests.cs
+++ b/tests/Granit.Identity.Federated.Analytics.Tests/GranitIdentityFederatedAnalyticsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitIdentityFederatedAnalyticsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }

--- a/tests/Granit.Webhooks.Analytics.Tests/GranitWebhooksAnalyticsModuleTests.cs
+++ b/tests/Granit.Webhooks.Analytics.Tests/GranitWebhooksAnalyticsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitWebhooksAnalyticsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }

--- a/tests/Granit.Webhooks.Dashboards.Tests/GranitWebhooksDashboardsModuleTests.cs
+++ b/tests/Granit.Webhooks.Dashboards.Tests/GranitWebhooksDashboardsModuleTests.cs
@@ -25,6 +25,6 @@ public sealed class GranitWebhooksDashboardsModuleTests
             .FirstOrDefault();
 
         attr.ShouldNotBeNull("Satellite modules must declare their framework host and analytics-abstractions dependencies.");
-        attr!.DependedModules.ShouldNotBeEmpty();
+        attr!.DependedTypes.ShouldNotBeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

CI hotfix for PR #2020. The skeleton smoke tests I generated for the 6 observability satellite modules referenced a non-existent `DependedModules` property on `DependsOnAttribute` — the actual property is `DependedTypes`. CI caught it on the full rebuild; my local validation missed it because the test assemblies were cached from before the generator script ran.

## Fix

Bulk rename `DependedModules` → `DependedTypes` in 5 satellite test files. The Notifications.Analytics test file was already correct at HEAD.

## Validation

- All 5 satellite test projects build green.
- 12/12 smoke tests pass locally.

## Test plan

- [x] `dotnet build` on the 6 satellite test projects
- [x] `dotnet test --no-build` on the 6 satellite test projects (12/12 passing)
- [ ] CI on api-data, security, infrastructure shards