### PR TITLE
ci(codeql): scan src-only.slnf, exclude tests from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: Granit CodeQL config
+
+# Granit's threat model targets production code only. Test projects produce
+# high-noise findings (fixture credentials, "injectable" SQL in helpers,
+# unsafe deserialization in stubs) with no security value, so we exclude
+# them from analysis. Build is also restricted to src-only.slnf to halve
+# tracer/compile time.
+paths-ignore:
+  - tests/**
+  - '**/*.Tests/**'
+  - '**/*.Tests.Integration/**'
+  - '**/*.ArchitectureTests/**'
+  - scripts/**
+  - docs/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,14 +229,15 @@ jobs:
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: csharp
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Build for CodeQL
-        run: dotnet build -c $CONFIGURATION -p:SkipIntegrationTests=true
+      - name: Build for CodeQL (src only)
+        run: dotnet build .github/shard-filters/src-only.slnf -c $CONFIGURATION -p:SkipIntegrationTests=true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4


### PR DESCRIPTION
## Summary

- Restrict the CodeQL `Build for CodeQL` step to `.github/shard-filters/src-only.slnf` (380 src projects) instead of the full solution (~520 projects including ~134 test projects).
- Add `.github/codeql/codeql-config.yml` with `paths-ignore` for `tests/**`, `scripts/**`, `docs/**` as a defense-in-depth result filter.

## Why

The CodeQL job was building the entire solution. Test projects nearly double the tracer/compile time and produce high-noise findings (fixture credentials, "injectable" SQL in helpers, unsafe deserialization in stubs) with no security value — Granit's threat model targets production code only.

Expected gain: ~40–50% wall time on the `codeql` job.

## Test plan

- [ ] CI green on this PR
- [ ] `codeql` job completes faster than baseline on `develop`
- [ ] CodeQL alerts on the PR (if any) come only from `src/**`