### PR TITLE
fix(rate-limiting-tests): add missing AddLogging to InMemory store resolution test

### DIFF
--- a/tests/Granit.RateLimiting.Tests/RateLimitingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.RateLimiting.Tests/RateLimitingServiceCollectionExtensionsTests.cs
@@ -113,6 +113,7 @@ public sealed class RateLimitingServiceCollectionExtensionsTests
     public void AddGranitRateLimiting_WithoutRedis_ResolvesInMemoryCounterStore()
     {
         ServiceCollection services = CreateServices();
+        services.AddLogging();
 
         services.AddGranitRateLimiting(opts =>
         {


### PR DESCRIPTION
## Summary

Fixes the `Test process crashed with exit code 134` failure currently blocking the **api-data** shard on develop (and downstream PRs).

## Root cause

`Granit.RateLimiting.Tests.RateLimitingServiceCollectionExtensionsTests.AddGranitRateLimiting_WithoutRedis_ResolvesInMemoryCounterStore` builds a `ServiceProvider` without registering `Microsoft.Extensions.Logging`. The `InMemoryRateLimitCounterStore` factory registered by `AddGranitRateLimiting` resolves `ILogger<InMemoryRateLimitCounterStore>` to emit the in-memory fallback warning (added in PR #708, March 2026):

```csharp
services.TryAddSingleton<InMemoryRateLimitCounterStore>(sp =>
{
    if (!s_inMemoryWarningLogged)
    {
        s_inMemoryWarningLogged = true;
        RateLimitingLog.LogInMemoryFallback(
            sp.GetRequiredService<ILogger<InMemoryRateLimitCounterStore>>());
    }
    ...
});
```

When `ILogger<>` isn't registered, `GetRequiredService<>` throws `InvalidOperationException`, the test fails, and xunit's worker process aborts with **SIGABRT (exit 134)** during teardown — surfacing as `[FATAL ERROR] Xunit.Sdk.TestPipelineException` + `Catastrophic failure: Test process crashed`.

The bug was previously masked by the `s_inMemoryWarningLogged` static flag — once another test in the same shard set it to `true`, the factory skipped the `GetRequiredService<ILogger<>>` path. Recent test-ordering changes in the api-data shard caused this test to run first, exposing the bug.

## Fix

Add `services.AddLogging()` to the failing test, mirroring the sibling test `AddGranitRateLimiting_RegistersTenantPartitionedRateLimiter` (line 134) which already does this.

## Validation

- Repro confirmed locally: full `dotnet test .github/shard-filters/api-data.slnf -c Release --collect:"XPlat Code Coverage"` reproduces the exit-134 crash before the fix.
- After fix: targeted test passes; full shard run pending CI.

## Test plan

- [x] `dotnet build tests/Granit.RateLimiting.Tests -c Release`
- [x] `dotnet test tests/Granit.RateLimiting.Tests --filter AddGranitRateLimiting_WithoutRedis` → Passed 1/1
- [ ] CI on api-data shard