### PR TITLE
ci(codeql): switch to build-mode none to skip rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,15 +229,8 @@ jobs:
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: csharp
+          build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Build for CodeQL (src only)
-        run: dotnet build .github/shard-filters/src-only.slnf -c $CONFIGURATION -p:SkipIntegrationTests=true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4


### PR DESCRIPTION
## Summary

- Set `build-mode: none` on `codeql-action/init` for C#
- Remove the now-redundant `Setup .NET` + `Build for CodeQL` steps

## Why

CodeQL's C# extractor historically required a full `dotnet build` because its tracer hooks `csc` invocations to capture sources and resolve references. The `build` job already does this — the CodeQL job was rebuilding the same code purely so the tracer could observe it (binaries from another job cannot be reused).

Since CodeQL 2.16, `build-mode: none` parses C# directly without compilation. GitHub now recommends it as the default for C#.

## Trade-off

- ✅ ~70-80% wall time saved on the `codeql` job (no more compile)
- ✅ No more duplicate build
- ✅ Structural queries (hardcoded creds, weak crypto, path traversal, unsafe deserialization, XSS, SQLi) keep full precision
- ⚠️ Advanced dataflow through cross-project generics / inference may see minor false negatives — acceptable for a framework where coverage breadth matters more than dataflow depth

## Test plan

- [ ] CI green
- [ ] `codeql` job completes in a fraction of previous time
- [ ] CodeQL alerts on Security tab remain comparable on a follow-up run against `develop`