### PR TITLE
ci(codeql): shadow nuget.config to silence unreachable feed warning

### DIFF
--- a/.github/codeql/nuget.config
+++ b/.github/codeql/nuget.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  CodeQL-only NuGet config. The root nuget.config declares an auth-gated
+  GitHub Packages feed for downstream consumers of Granit; CodeQL's
+  build-mode "none" restore does not have a token and emits an
+  "unreachable NuGet feed" warning. All Granit.* packages are
+  ProjectReferences within this repo, so dropping that feed for CodeQL
+  has no effect on type resolution.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Shadow the repo nuget.config with a CodeQL-only variant that drops the
+      # auth-gated `Granit GitHub` feed. All Granit.* packages are ProjectReferences
+      # in this repo, so no resolution is lost — and we silence the "unreachable
+      # NuGet feed" warning emitted by build-mode: none.
+      - name: CodeQL-only NuGet config
+        run: cp .github/codeql/nuget.config nuget.config
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:


### PR DESCRIPTION
## Summary

- Add `.github/codeql/nuget.config` (nuget.org only)
- Copy it over the root `nuget.config` as the first step of the `codeql` job

## Why

After switching CodeQL to `build-mode: none` (#2026), the job emits:

> Found unreachable NuGet feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.

The unreachable feed is `Granit GitHub` (`https://nuget.pkg.github.com/granit-fx/index.json`), which is auth-gated. CodeQL's no-build restore has no token.

This repo IS `granit-dotnet` — every `Granit.*` reference here is a `ProjectReference`, never resolved through NuGet. The GitHub Packages feed exists only for downstream consumers of the framework. Dropping it for the CodeQL job has zero effect on type resolution and silences the warning.

## Test plan

- [ ] `codeql` job warning is gone on this PR
- [ ] CodeQL findings remain comparable to previous runs (no spurious "missing type" alerts)