### PR TITLE
fix(persistence): infinite recursion in AddGranitIsolatedDbContext non-generic overload

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -290,14 +290,18 @@ public static class PersistenceTenantExtensions
     {
         ArgumentNullException.ThrowIfNull(configureShared);
 
+        // Explicit lambda parameter types disambiguate overload resolution: an untyped
+        // `opts => configureShared(opts)` re-binds to *this* non-generic overload
+        // (DbContextOptionsBuilder matches) instead of the generic one we want, causing
+        // infinite recursion → stack overflow → SIGABRT.
         return services.AddGranitIsolatedDbContext<TContext>(
-            configureShared: opts => configureShared(opts),
+            configureShared: (DbContextOptionsBuilder<TContext> opts) => configureShared(opts),
             configureDatabasePerTenant: configureDatabasePerTenant is null
                 ? null
-                : (opts, cs) => configureDatabasePerTenant(opts, cs),
+                : (DbContextOptionsBuilder<TContext> opts, string cs) => configureDatabasePerTenant(opts, cs),
             configureSchemaPerTenant: configureSchemaPerTenant is null
                 ? null
-                : opts => configureSchemaPerTenant(opts),
+                : (DbContextOptionsBuilder<TContext> opts) => configureSchemaPerTenant(opts),
             configureTenantSchema: configureTenantSchema);
     }
 }


### PR DESCRIPTION
## Summary

Stops a stack overflow introduced by PR #2021. The non-generic \`AddGranitIsolatedDbContext\` overload added in #2021 forwarded to the generic one with implicitly-typed wrapper lambdas (\`opts => configureShared(opts)\`). C# overload resolution preferred the **non-generic** candidate (its \`Action<DbContextOptionsBuilder>\` matches the lambda body without conversion), so the forwarding call recursed into itself → stack overflow → SIGABRT (exit 134).

CI on \`d97fca05d\` and subsequent commits surfaced this on
\`DefaultTenantSchemaProviderCachingTests.GetSchemaNameAsync_InvalidConventionValue_ThrowsInvalidOperationException\`
(and would crash any test resolving an isolated DbContext).

## Fix

Explicit lambda parameter types (\`DbContextOptionsBuilder<TContext>\`) force overload resolution to unambiguously dispatch to the generic overload.

## Test plan

- [x] \`dotnet build src/Granit.Persistence.EntityFrameworkCore\` — green
- [x] Inspection: comment added at call site explaining the trap