### PR TITLE
ci(fuzz): opt fuzz workflows into Node.js 24

### DIFF
--- a/.github/workflows/cifuzz-batch.yml
+++ b/.github/workflows/cifuzz-batch.yml
@@ -40,6 +40,7 @@ jobs:
       FUZZ_SECONDS: 3600
       DOTNET_NOLOGO: 'true'
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cifuzz-pr.yml
+++ b/.github/workflows/cifuzz-pr.yml
@@ -44,6 +44,7 @@ jobs:
       FUZZ_SECONDS: 300
       DOTNET_NOLOGO: 'true'
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

GitHub-hosted runners deprecate Node.js 20 on **2026-06-02** (forced cutover) and remove it on **2026-09-16**. The fuzz workflows currently emit a deprecation warning on every run because `actions/checkout@v4`, `actions/setup-dotnet@v4`, and `actions/upload-artifact@v4` still ship on Node 20.

Until these actions release v5 with native Node 24, opt the fuzz jobs into Node 24 now via the documented env switch:

```yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
```

Applied at the job level in both `cifuzz-pr.yml` and `cifuzz-batch.yml`.

## Why only the fuzz workflows

This PR scopes the opt-in to the two files I own in the recent fuzz work. Other workflows in this repo are out of scope here — they should each be handled when their owners pass through.

Ref: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>

## Test plan

- [ ] Next PR run on either fuzz workflow no longer emits the Node 20 deprecation warning
- [ ] All matrix shards still succeed end-to-end