### PR TITLE
refactor(documents): apply audit findings across Documents module families

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -962,6 +962,7 @@
         "Granit",
         "Granit.Analytics",
         "Granit.BlobStorage",
+        "Granit.Caching",
         "Granit.DataExchange.Abstractions",
         "Granit.Localization",
         "Granit.QueryEngine.Abstractions",
@@ -21231,6 +21232,40 @@
       ]
     },
     {
+      "name": "AclCacheInvalidationHandler",
+      "fqn": "Granit.Documents.Authorization.AclCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Authorization/AclCacheInvalidationHandler.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DocumentShareGrantedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DocumentShareRevokedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FolderPathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FolderTreePathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "DocumentPrincipal",
       "fqn": "Granit.Documents.Authorization.DocumentPrincipal",
       "kind": "record",
@@ -21894,40 +21929,6 @@
       "members": []
     },
     {
-      "name": "AclCacheInvalidationHandler",
-      "fqn": "Granit.Documents.EntityFrameworkCore.Authorization.AclCacheInvalidationHandler",
-      "kind": "class",
-      "project": "Granit.Documents.EntityFrameworkCore",
-      "file": "src/Granit.Documents.EntityFrameworkCore/Authorization/AclCacheInvalidationHandler.cs",
-      "line": 30,
-      "members": [
-        {
-          "name": "HandleAsync",
-          "kind": "method",
-          "signature": "HandleAsync(DocumentShareGrantedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        },
-        {
-          "name": "HandleAsync",
-          "kind": "method",
-          "signature": "HandleAsync(DocumentShareRevokedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        },
-        {
-          "name": "HandleAsync",
-          "kind": "method",
-          "signature": "HandleAsync(FolderPathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        },
-        {
-          "name": "HandleAsync",
-          "kind": "method",
-          "signature": "HandleAsync(FolderTreePathChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
       "name": "DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Documents.EntityFrameworkCore.Extensions.DocumentsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
@@ -22213,28 +22214,12 @@
       ]
     },
     {
-      "name": "DocumentsServiceCollectionExtensions",
-      "fqn": "Granit.Documents.Extensions.DocumentsServiceCollectionExtensions",
-      "kind": "class",
-      "project": "Granit.Documents",
-      "file": "src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs",
-      "line": 21,
-      "members": [
-        {
-          "name": "AddGranitDocuments",
-          "kind": "method",
-          "signature": "AddGranitDocuments(this IServiceCollection services, Action<GranitDocumentsOptions>? configure = null)",
-          "returnType": "IServiceCollection"
-        }
-      ]
-    },
-    {
       "name": "GranitDocumentsModule",
       "fqn": "Granit.Documents.GranitDocumentsModule",
       "kind": "class",
       "project": "Granit.Documents",
       "file": "src/Granit.Documents/GranitDocumentsModule.cs",
-      "line": 28,
+      "line": 30,
       "members": []
     },
     {
@@ -23054,22 +23039,6 @@
       ]
     },
     {
-      "name": "PublicLinkTokenFactory",
-      "fqn": "Granit.Documents.PublicLinks.Domain.PublicLinkTokenFactory",
-      "kind": "class",
-      "project": "Granit.Documents.PublicLinks",
-      "file": "src/Granit.Documents.PublicLinks/Domain/PublicLinkToken.cs",
-      "line": 43,
-      "members": [
-        {
-          "name": "GenerateRandom",
-          "kind": "method",
-          "signature": "GenerateRandom()",
-          "returnType": "PublicLinkToken"
-        }
-      ]
-    },
-    {
       "name": "CreatePublicLinkRequest",
       "fqn": "Granit.Documents.PublicLinks.Endpoints.Dtos.CreatePublicLinkRequest",
       "kind": "record",
@@ -23180,7 +23149,7 @@
       "kind": "class",
       "project": "Granit.Documents.PublicLinks.EntityFrameworkCore",
       "file": "src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDocumentsPublicLinksEntityFrameworkCore",
@@ -23291,7 +23260,7 @@
       "kind": "class",
       "project": "Granit.Documents.PublicLinks",
       "file": "src/Granit.Documents.PublicLinks/Extensions/ServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitDocumentsPublicLinks",
@@ -23604,50 +23573,6 @@
       ]
     },
     {
-      "name": "RenditionsActivitySource",
-      "fqn": "Granit.Documents.Renditions.Diagnostics.RenditionsActivitySource",
-      "kind": "class",
-      "project": "Granit.Documents.Renditions",
-      "file": "src/Granit.Documents.Renditions/Diagnostics/RenditionsActivitySource.cs",
-      "line": 6,
-      "members": [
-        {
-          "name": "new",
-          "kind": "method",
-          "signature": "new(Name)",
-          "returnType": "ActivitySource Source ="
-        }
-      ]
-    },
-    {
-      "name": "RenditionsMetrics",
-      "fqn": "Granit.Documents.Renditions.Diagnostics.RenditionsMetrics",
-      "kind": "class",
-      "project": "Granit.Documents.Renditions",
-      "file": "src/Granit.Documents.Renditions/Diagnostics/RenditionsMetrics.cs",
-      "line": 10,
-      "members": [
-        {
-          "name": "RecordFailed",
-          "kind": "method",
-          "signature": "RecordFailed(string? tenantId, string sourceContentType, string targetContentType, string errorType)",
-          "returnType": "void"
-        },
-        {
-          "name": "RecordOnDemandServed",
-          "kind": "method",
-          "signature": "RecordOnDemandServed(string? tenantId, string targetContentType, string renditionType)",
-          "returnType": "void"
-        },
-        {
-          "name": "RecordGenerationDuration",
-          "kind": "method",
-          "signature": "RecordGenerationDuration(string sourceContentType, string targetContentType, string provider, TimeSpan duration)",
-          "returnType": "void"
-        }
-      ]
-    },
-    {
       "name": "DocumentRenditionContainers",
       "fqn": "Granit.Documents.Renditions.DocumentRenditionContainers",
       "kind": "class",
@@ -23702,7 +23627,7 @@
       "kind": "record",
       "project": "Granit.Documents.Renditions.Endpoints",
       "file": "src/Granit.Documents.Renditions.Endpoints/Dtos/RenditionResponse.cs",
-      "line": 25,
+      "line": 26,
       "members": []
     },
     {
@@ -23711,7 +23636,7 @@
       "kind": "record",
       "project": "Granit.Documents.Renditions.Endpoints",
       "file": "src/Granit.Documents.Renditions.Endpoints/Dtos/RenditionResponse.cs",
-      "line": 33,
+      "line": 34,
       "members": []
     },
     {
@@ -23720,7 +23645,7 @@
       "kind": "record",
       "project": "Granit.Documents.Renditions.Endpoints",
       "file": "src/Granit.Documents.Renditions.Endpoints/Dtos/RenditionResponse.cs",
-      "line": 7,
+      "line": 8,
       "members": []
     },
     {
@@ -23811,7 +23736,7 @@
       "kind": "class",
       "project": "Granit.Documents.Renditions.EntityFrameworkCore",
       "file": "src/Granit.Documents.Renditions.EntityFrameworkCore/Internal/DocumentPermanentlyDeletedRenditionHandler.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "HandleAsync",
@@ -23854,7 +23779,7 @@
       "kind": "class",
       "project": "Granit.Documents.Renditions",
       "file": "src/Granit.Documents.Renditions/Extensions/ServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitDocumentsRenditions",
@@ -68833,6 +68758,22 @@
       "file": "src/Granit.Workspaces.Abstractions/WorkspaceSectionDescriptor.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "DocumentsServiceCollectionExtensions",
+      "fqn": "Microsoft.Extensions.DependencyInjection.DocumentsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Documents",
+      "file": "src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitDocuments",
+          "kind": "method",
+          "signature": "AddGranitDocuments(this IServiceCollection services, Action<GranitDocumentsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
     }
   ]
 }

--- a/src/Granit.Documents.AssetMetadata.AudioVideo/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.AudioVideo/packages.lock.json
@@ -154,6 +154,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.BackgroundJobs/Handlers/DocumentVersionAddedAssetMetadataHandler.cs
+++ b/src/Granit.Documents.AssetMetadata.BackgroundJobs/Handlers/DocumentVersionAddedAssetMetadataHandler.cs
@@ -11,7 +11,7 @@ namespace Granit.Documents.AssetMetadata.BackgroundJobs.Handlers;
 /// <see cref="IAssetMetadataGenerationService"/> — the handler stays a thin
 /// wrapper so the orchestration logic remains testable in isolation.
 /// </summary>
-public partial class DocumentVersionAddedAssetMetadataHandler
+public sealed partial class DocumentVersionAddedAssetMetadataHandler
 {
     /// <summary>Wolverine-style entry point. Public + static per framework convention.</summary>
     public static Task HandleAsync(

--- a/src/Granit.Documents.AssetMetadata.BackgroundJobs/Internal/AssetMetadataGenerationService.cs
+++ b/src/Granit.Documents.AssetMetadata.BackgroundJobs/Internal/AssetMetadataGenerationService.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.Documents;
+using Granit.Documents.AssetMetadata.Diagnostics;
 using Granit.Documents.AssetMetadata.Domain;
 using Granit.Documents.AssetMetadata.Exceptions;
 using Granit.Documents.AssetMetadata.Options;
@@ -36,6 +38,7 @@ internal sealed partial class AssetMetadataGenerationService(
     IDocumentService documentService,
     IGuidGenerator guidGenerator,
     IClock clock,
+    AssetMetadataMetrics metrics,
     IOptions<GranitAssetMetadataOptions> options,
     ILogger<AssetMetadataGenerationService> logger) : IAssetMetadataGenerationService, IDisposable
 {
@@ -87,13 +90,17 @@ internal sealed partial class AssetMetadataGenerationService(
                     .OpenSourceAsync(effectiveBlobId, cancellationToken)
                     .ConfigureAwait(false);
 
+                string? tenantTag = tenantId?.ToString();
+                var sw = Stopwatch.StartNew();
                 IReadOnlyList<AssetMetadataResult> results = await pipeline
                     .ExtractAsync(source, sourceContentType, cancellationToken)
                     .ConfigureAwait(false);
+                metrics.RecordExtractionDuration(tenantTag, "pipeline", sw.Elapsed.TotalMilliseconds);
 
                 foreach (AssetMetadataResult result in results)
                 {
                     row.ApplyExtraction(result);
+                    metrics.RecordExtracted(tenantTag, sourceContentType, result.ExtractorName);
                 }
 
                 row.MarkReady(clock.Now);
@@ -105,12 +112,14 @@ internal sealed partial class AssetMetadataGenerationService(
             {
                 row.MarkFailed(ex.Message, clock.Now);
                 await store.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                metrics.RecordFailed(tenantId?.ToString(), sourceContentType, ex.ExtractorName, nameof(AssetMetadataExtractionException));
                 LogFailed(logger, row.Id, sourceContentType, ex.Message);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 row.MarkFailed(ex.Message, clock.Now);
                 await store.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                metrics.RecordFailed(tenantId?.ToString(), sourceContentType, extractor: "pipeline", errorType: ex.GetType().Name);
                 LogFailedUnexpected(logger, row.Id, sourceContentType, ex);
             }
         }

--- a/src/Granit.Documents.AssetMetadata.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.BackgroundJobs/packages.lock.json
@@ -162,6 +162,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.Endpoints/Endpoints/AssetMetadataEndpoints.cs
+++ b/src/Granit.Documents.AssetMetadata.Endpoints/Endpoints/AssetMetadataEndpoints.cs
@@ -5,6 +5,7 @@ using Granit.Documents.AssetMetadata.Domain;
 using Granit.Documents.AssetMetadata.Endpoints.Dtos;
 using Granit.Documents.AssetMetadata.Endpoints.Mapping;
 using Granit.Documents.Permissions;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -29,7 +30,7 @@ internal static class AssetMetadataEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder documents = group.MapGroup("/documents/{id:guid}").WithTags(TagName);
+        RouteGroupBuilder documents = group.MapGranitGroup("/documents/{id:guid}").WithTags(TagName);
 
         documents.MapGet("/metadata", GetForCurrentVersionAsync)
             .WithName("GetDocumentAssetMetadata")
@@ -39,8 +40,7 @@ internal static class AssetMetadataEndpoints
                 + "plus the verbatim extractor payload under `rawMetadata`. Returns 404 when "
                 + "the document is missing, excluded by the tenant filter, or extraction has "
                 + "not yet completed for the current version.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<AssetMetadataResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -52,8 +52,7 @@ internal static class AssetMetadataEndpoints
                 + "identifier. Useful for audit trails or comparing metadata between revisions. "
                 + "Returns 404 when the document or version is missing, the version does not "
                 + "belong to the supplied document, or no metadata row has been produced yet.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<AssetMetadataResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 

--- a/src/Granit.Documents.AssetMetadata.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Endpoints/packages.lock.json
@@ -117,6 +117,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Internal/DocumentPermanentlyDeletedAssetMetadataHandler.cs
+++ b/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/Internal/DocumentPermanentlyDeletedAssetMetadataHandler.cs
@@ -17,7 +17,7 @@ namespace Granit.Documents.AssetMetadata.EntityFrameworkCore.Internal;
 /// module stays unaware of asset-metadata (clean dependency direction; mirrors
 /// the rendition handler).
 /// </remarks>
-public class DocumentPermanentlyDeletedAssetMetadataHandler
+public sealed partial class DocumentPermanentlyDeletedAssetMetadataHandler
 {
     /// <summary>Wolverine-style handler entry point. Public + static per framework convention.</summary>
     public static async Task HandleAsync(
@@ -32,12 +32,7 @@ public class DocumentPermanentlyDeletedAssetMetadataHandler
         LogCascade(logger, evt.DocumentId);
     }
 
-    private static readonly Action<ILogger, Guid, Exception?> LogCascadeMessage =
-        LoggerMessage.Define<Guid>(
-            LogLevel.Information,
-            new EventId(1, nameof(DocumentPermanentlyDeletedAssetMetadataHandler)),
-            "Granit.Documents.AssetMetadata cascaded permanent-delete: dropped rows for document {DocumentId}.");
-
-    private static void LogCascade(ILogger logger, Guid documentId) =>
-        LogCascadeMessage(logger, documentId, null);
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Granit.Documents.AssetMetadata cascaded permanent-delete: dropped rows for document {DocumentId}.")]
+    private static partial void LogCascade(ILogger logger, Guid documentId);
 }

--- a/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.EntityFrameworkCore/packages.lock.json
@@ -215,6 +215,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.Imaging/Internal/StripGpsHandler.cs
+++ b/src/Granit.Documents.AssetMetadata.Imaging/Internal/StripGpsHandler.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Granit.BlobStorage;
 using Granit.Documents;
+using Granit.Documents.AssetMetadata.Diagnostics;
 using Granit.Documents.AssetMetadata.Options;
 using Granit.Documents.Domain;
 using Granit.Documents.Events;
@@ -56,6 +57,7 @@ internal sealed partial class StripGpsHandler(
     IDocumentService documentService,
     IHttpClientFactory httpClientFactory,
     IGuidGenerator guidGenerator,
+    AssetMetadataMetrics metrics,
     IOptions<GranitAssetMetadataOptions> options,
     ILogger<StripGpsHandler> logger) : ILocalEventHandler<DocumentVersionAddedEvent>
 {
@@ -123,6 +125,7 @@ internal sealed partial class StripGpsHandler(
                 return;
             }
 
+            metrics.RecordGpsScrubbed(evt.TenantId?.ToString(), evt.ContentType);
             LogScrubbed(logger, evt.VersionId, original.Length, scrubbed.Length);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Granit.Documents.AssetMetadata.Imaging/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Imaging/packages.lock.json
@@ -176,6 +176,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.Office/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Office/packages.lock.json
@@ -170,6 +170,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata.Pdf/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata.Pdf/packages.lock.json
@@ -154,6 +154,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.AssetMetadata/Granit.Documents.AssetMetadata.csproj
+++ b/src/Granit.Documents.AssetMetadata/Granit.Documents.AssetMetadata.csproj
@@ -17,7 +17,6 @@
     <InternalsVisibleTo Include="Granit.Documents.AssetMetadata.Imaging" />
     <InternalsVisibleTo Include="Granit.Documents.AssetMetadata.Pdf" />
     <InternalsVisibleTo Include="Granit.Documents.AssetMetadata.Office" />
-    <InternalsVisibleTo Include="Granit.Documents.AssetMetadata.Media" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Documents.AssetMetadata/Pipeline/AssetMetadataPipeline.cs
+++ b/src/Granit.Documents.AssetMetadata/Pipeline/AssetMetadataPipeline.cs
@@ -17,7 +17,6 @@ namespace Granit.Documents.AssetMetadata.Pipeline;
 /// </summary>
 internal sealed partial class AssetMetadataPipeline(
     IEnumerable<IAssetMetadataExtractor> extractors,
-    AssetMetadataMetrics metrics,
     ILogger<AssetMetadataPipeline> logger) : IAssetMetadataPipeline
 {
     /// <inheritdoc />
@@ -49,14 +48,12 @@ internal sealed partial class AssetMetadataPipeline(
                 AssetMetadataActivitySource.ExtractorExtract);
             hopSpan?.SetTag("extractor", extractor.Name);
 
-            var sw = Stopwatch.StartNew();
             try
             {
                 AssetMetadataResult result = await extractor
                     .ExtractAsync(source, sourceContentType, cancellationToken)
                     .ConfigureAwait(false);
                 results.Add(result);
-                metrics.RecordExtractionDuration(tenantId: null, extractor.Name, sw.Elapsed.TotalMilliseconds);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Granit.Documents.AssetMetadata/packages.lock.json
+++ b/src/Granit.Documents.AssetMetadata/packages.lock.json
@@ -148,6 +148,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.BackgroundJobs/Jobs/EmptyTrashHandler.cs
+++ b/src/Granit.Documents.BackgroundJobs/Jobs/EmptyTrashHandler.cs
@@ -1,7 +1,7 @@
 namespace Granit.Documents.BackgroundJobs.Jobs;
 
 /// <summary>Handler for <see cref="EmptyTrashJob"/> (F9.2).</summary>
-public class EmptyTrashHandler
+public sealed class EmptyTrashHandler
 {
     public static Task HandleAsync(
         EmptyTrashJob _,

--- a/src/Granit.Documents.BackgroundJobs/Jobs/OrphanDocumentCleanupHandler.cs
+++ b/src/Granit.Documents.BackgroundJobs/Jobs/OrphanDocumentCleanupHandler.cs
@@ -1,7 +1,7 @@
 namespace Granit.Documents.BackgroundJobs.Jobs;
 
 /// <summary>Handler for <see cref="OrphanDocumentCleanupJob"/> (F9.1).</summary>
-public class OrphanDocumentCleanupHandler
+public sealed class OrphanDocumentCleanupHandler
 {
     public static Task HandleAsync(
         OrphanDocumentCleanupJob _,

--- a/src/Granit.Documents.BackgroundJobs/Jobs/QuotaRecomputeHandler.cs
+++ b/src/Granit.Documents.BackgroundJobs/Jobs/QuotaRecomputeHandler.cs
@@ -1,7 +1,7 @@
 namespace Granit.Documents.BackgroundJobs.Jobs;
 
 /// <summary>Handler for <see cref="QuotaRecomputeJob"/> (F9.3).</summary>
-public class QuotaRecomputeHandler
+public sealed class QuotaRecomputeHandler
 {
     public static Task HandleAsync(
         QuotaRecomputeJob _,

--- a/src/Granit.Documents.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Documents.BackgroundJobs/packages.lock.json
@@ -162,6 +162,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentEndpoints.cs
@@ -7,7 +7,7 @@ using Granit.Documents.Exceptions;
 using Granit.Documents.Options;
 using Granit.Documents.Permissions;
 using Granit.Timing;
-using Microsoft.AspNetCore.Authorization;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -29,7 +29,7 @@ internal static class DocumentEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder documents = group.MapGroup("/documents").WithTags(TagName);
+        RouteGroupBuilder documents = group.MapGranitGroup("/documents").WithTags(TagName);
 
         documents.MapPost("/upload-ticket", RequestUploadTicketAsync)
             .WithName("RequestDocumentUploadTicket")
@@ -39,8 +39,7 @@ internal static class DocumentEndpoints
                 + "bytes directly to the configured cloud provider (no proxying through the API), "
                 + "then calls POST /documents/finalize with the returned blobId. Tickets expire "
                 + "after the BlobStorage-configured TTL (default 15 minutes).")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<UploadTicketResponse>()
             .ProducesValidationProblem();
 
@@ -53,8 +52,7 @@ internal static class DocumentEndpoints
                 + "DocumentVersion under the requested folder (or the tenant root when "
                 + "folderId is omitted). Returns 422 when the blob fails validation, 404 when "
                 + "the target folder is missing.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -72,8 +70,7 @@ internal static class DocumentEndpoints
                 + "(DocumentId, VersionNumber) protect concurrent uploaders. Returns 422 "
                 + "when the blob fails validation or the document is trashed; 404 when the "
                 + "document is missing or excluded by the tenant filter.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentVersionResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -89,8 +86,7 @@ internal static class DocumentEndpoints
                 + "is flagged via `isCurrent: true`. Use `?skip=` and `?take=` to page; "
                 + "defaults are skip=0, take=50 (max 200). Returns 404 when the document "
                 + "is missing or excluded by the tenant filter.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<ListDocumentVersionsResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -102,8 +98,7 @@ internal static class DocumentEndpoints
                 + "descending. Each row carries `daysUntilPermanentDeletion`, derived from "
                 + "the trash retention window (`GranitDocumentsOptions.TrashRetentionDays`, "
                 + "default 30 days). Defaults are `skip=0` and `take=50` (max 200).")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<ListTrashedDocumentsResponse>();
 
         documents.MapDocumentMutationEndpoints();
@@ -119,8 +114,7 @@ internal static class DocumentEndpoints
                 + "the ISO 27001 audit trail and increments granit.documents.download.count. "
                 + "Returns 404 when the document or version is not found, 409 when the document "
                 + "is trashed or has no current version yet.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<DownloadUrlResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentMutationEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Documents.Dtos;
 using Granit.Documents.Endpoints.Documents.Mapping;
 using Granit.Documents.Permissions;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -29,8 +30,7 @@ internal static class DocumentMutationEndpoints
                 "Returns the document identified by `id`, including its current version "
                 + "pointer and folder placement. 404 when the document is not found or "
                 + "excluded by the tenant filter.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<DocumentResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -42,8 +42,7 @@ internal static class DocumentMutationEndpoints
                 + "to drop the description (sending an empty string sets a non-null empty "
                 + "value, which is rarely what callers want). 404 when the document is "
                 + "missing; 409 when the document is trashed.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
@@ -56,8 +55,7 @@ internal static class DocumentMutationEndpoints
                 "Moves the document identified by `id` under `newFolderId` (or under the "
                 + "tenant root when omitted). Cross-tenant moves and moves into trashed or "
                 + "missing folders surface as 409 Conflict.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
@@ -69,8 +67,7 @@ internal static class DocumentMutationEndpoints
                 "Moves the document identified by `id` to the trash. Permanent deletion "
                 + "happens after the configured retention period via the empty-trash "
                 + "background job (F8 / F9.2). Already-trashed documents surface as 409.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
@@ -82,8 +79,7 @@ internal static class DocumentMutationEndpoints
                 "Sets the document identified by `id` back to `Active`. Returns 404 when "
                 + "the document is missing or not currently trashed; 409 when the parent "
                 + "folder is itself trashed (callers must restore the folder first).")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
@@ -99,8 +95,7 @@ internal static class DocumentMutationEndpoints
                 + "the GDPR / ISO 27001 audit trail). Emits `DocumentPermanentlyDeletedEvent`. "
                 + "Returns 204 on success, 404 when the document is missing or not "
                 + "currently trashed.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);
 

--- a/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentTagProxyEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Documents/Endpoints/DocumentTagProxyEndpoints.cs
@@ -4,6 +4,7 @@ using Granit.Documents.Endpoints.Documents.Dtos;
 using Granit.Documents.Permissions;
 using Granit.Taxonomy;
 using Granit.Taxonomy.Domain;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -28,7 +29,7 @@ internal static class DocumentTagProxyEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder tags = group.MapGroup("/documents/{id:guid}/tags").WithTags(TagName);
+        RouteGroupBuilder tags = group.MapGranitGroup("/documents/{id:guid}/tags").WithTags(TagName);
 
         tags.MapGet("/", ListTagsAsync)
             .WithName("ListDocumentTags")
@@ -38,8 +39,7 @@ internal static class DocumentTagProxyEndpoints
                 + "with TargetType = Granit.Documents.Domain.Document. The canonical store "
                 + "lives in Taxonomy; this endpoint is purely a UX shortcut on the "
                 + "Documents surface. Permission: Documents.Documents.Read.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<ListDocumentTagsResponse>();
 
         tags.MapPost("/{tagId:guid}", AssignTagAsync)
@@ -49,8 +49,7 @@ internal static class DocumentTagProxyEndpoints
                 "Idempotent assignment: re-posting the same (document, tag) pair returns the "
                 + "existing row instead of creating a duplicate. Delegates to "
                 + "Granit.Taxonomy's TagAssignmentService. Permission: Documents.Documents.Manage.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces<DocumentTagAssignmentResponse>(StatusCodes.Status201Created)
             .Produces<DocumentTagAssignmentResponse>(StatusCodes.Status200OK);
 
@@ -61,8 +60,7 @@ internal static class DocumentTagProxyEndpoints
                 "Deletes the (document, tag) assignment row. Returns 404 when no row matches "
                 + "(typically because the tag was never assigned, or has already been removed). "
                 + "Permission: Documents.Documents.Manage.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Manage))
+            .RequireAuthorization(DocumentsPermissions.Documents.Manage)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -109,7 +107,7 @@ internal static class DocumentTagProxyEndpoints
             : TypedResults.Ok(response);
     }
 
-    private static async Task<Results<NoContent, NotFound>> UnassignTagAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult>> UnassignTagAsync(
         Guid id,
         Guid tagId,
         [FromServices] ITagAssignmentService service,
@@ -118,7 +116,11 @@ internal static class DocumentTagProxyEndpoints
         bool deleted = await service
             .UnassignAsync(tagId, DocumentTargetType, id, cancellationToken)
             .ConfigureAwait(false);
-        return deleted ? TypedResults.NoContent() : TypedResults.NotFound();
+        return deleted
+            ? TypedResults.NoContent()
+            : TypedResults.Problem(
+                detail: $"Tag assignment '{tagId}' on document '{id}' was not found.",
+                statusCode: StatusCodes.Status404NotFound);
     }
 
     private static Guid ExtractUserId(ClaimsPrincipal user)

--- a/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Folders/Endpoints/FolderEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Folders.Dtos;
 using Granit.Documents.Endpoints.Folders.Mapping;
 using Granit.Documents.Permissions;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -23,7 +24,7 @@ internal static class FolderEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder folders = group.MapGroup("/folders").WithTags(TagName);
+        RouteGroupBuilder folders = group.MapGranitGroup("/folders").WithTags(TagName);
 
         folders.MapGet("/", ListChildrenAsync)
             .WithName("ListFolders")
@@ -34,7 +35,7 @@ internal static class FolderEndpoints
                 + "The tenant root itself is always filtered out of the result set. "
                 + "Pass `?status=Trashed` to read the trash listing for the same parent (F8.1); the "
                 + "default is `Active`.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Read))
+            .RequireAuthorization(DocumentsPermissions.Folders.Read)
             .Produces<ListFoldersResponse>();
 
         folders.MapGet("/{id:guid}", GetByIdAsync)
@@ -45,7 +46,7 @@ internal static class FolderEndpoints
                 + "Returns 404 when the folder does not exist or when the caller's tenant filter "
                 + "excludes it. The tenant root itself is also returned as 404 because it is not "
                 + "user-visible.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Read))
+            .RequireAuthorization(DocumentsPermissions.Folders.Read)
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -57,7 +58,7 @@ internal static class FolderEndpoints
                 + "tenant root) down to and including the folder identified by `id`. The invisible "
                 + "tenant root is excluded from the chain so the client never has to know about it. "
                 + "Returns 404 when the folder does not exist or is the tenant root.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Read))
+            .RequireAuthorization(DocumentsPermissions.Folders.Read)
             .Produces<FolderBreadcrumbResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -69,7 +70,7 @@ internal static class FolderEndpoints
                 + "folder is created directly under the invisible tenant root, which is auto-bootstrapped "
                 + "on first access for the tenant. The folder name is validated against length, the "
                 + "reserved path separator '/', and parent-scoped uniqueness.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .RequireAuthorization(DocumentsPermissions.Folders.Manage)
             .Produces<FolderResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem();
 
@@ -80,7 +81,7 @@ internal static class FolderEndpoints
                 "Renames the folder identified by `id`. The materialised path is recomputed atomically. "
                 + "Descendant paths are updated by the move-folder endpoint (F2.4) — rename does not "
                 + "modify descendants. The tenant root cannot be renamed.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .RequireAuthorization(DocumentsPermissions.Folders.Manage)
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem();
@@ -95,7 +96,7 @@ internal static class FolderEndpoints
                 + "UPDATE within the same transaction. Cycles, cross-tenant moves, and moves "
                 + "under a trashed or descendant target are rejected. The tenant root cannot "
                 + "be moved.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .RequireAuthorization(DocumentsPermissions.Folders.Manage)
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
@@ -108,7 +109,7 @@ internal static class FolderEndpoints
                 + "active descendant folder and document in a single transaction (F8.1). "
                 + "Permanent deletion happens after the configured retention period via the "
                 + "empty-trash background job (F8/F9.2). The tenant root cannot be trashed.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .RequireAuthorization(DocumentsPermissions.Folders.Manage)
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -120,7 +121,7 @@ internal static class FolderEndpoints
                 + "unless restored individually (per F8.1 — restore is non-cascading by design). "
                 + "Returns 404 when the folder is missing or not currently trashed; 409 when the "
                 + "parent folder is itself trashed (callers must restore the parent first).")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Folders.Manage))
+            .RequireAuthorization(DocumentsPermissions.Folders.Manage)
             .Produces<FolderResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);

--- a/src/Granit.Documents.Endpoints/Quotas/Endpoints/QuotaEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Quotas/Endpoints/QuotaEndpoints.cs
@@ -3,6 +3,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Quotas.Dtos;
 using Granit.Documents.Permissions;
 using Granit.MultiTenancy;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -23,7 +24,7 @@ internal static class QuotaEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder quotas = group.MapGroup("/quota").WithTags(TagName);
+        RouteGroupBuilder quotas = group.MapGranitGroup("/quota").WithTags(TagName);
 
         quotas.MapGet("/", GetQuotaAsync)
             .WithName("GetTenantStorageQuota")
@@ -34,9 +35,8 @@ internal static class QuotaEndpoints
                 + "first call (mirrors the F2.2 tenant-root bootstrap), so a brand-new "
                 + "tenant always sees `UsageBytes = 0` instead of a 404. Returns 401 when "
                 + "the request carries no tenant context.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Quotas.Read))
-            .Produces<TenantStorageQuotaResponse>()
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .RequireAuthorization(DocumentsPermissions.Quotas.Read)
+            .Produces<TenantStorageQuotaResponse>();
 
         return quotas;
     }

--- a/src/Granit.Documents.Endpoints/Shares/Endpoints/ShareEndpoints.cs
+++ b/src/Granit.Documents.Endpoints/Shares/Endpoints/ShareEndpoints.cs
@@ -2,6 +2,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Endpoints.Shares.Dtos;
 using Granit.Documents.Endpoints.Shares.Mapping;
 using Granit.Documents.Permissions;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -34,7 +35,7 @@ internal static class ShareEndpoints
 
         // Folder share endpoints — nested under /folders/{folderId}/shares.
         RouteGroupBuilder folderShares = group
-            .MapGroup("/folders/{folderId:guid}/shares")
+            .MapGranitGroup("/folders/{folderId:guid}/shares")
             .WithTags(TagName);
 
         folderShares.MapGet("/", ListFolderSharesAsync)
@@ -45,7 +46,7 @@ internal static class ShareEndpoints
                 + "creation time. Expired grants are excluded. The path-based inheritance "
                 + "(F6.4) is not flattened in this listing — callers see only grants directly "
                 + "attached to this folder.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Read))
+            .RequireAuthorization(DocumentsPermissions.Shares.Read)
             .Produces<ListSharesResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -57,14 +58,14 @@ internal static class ShareEndpoints
                 + "When `isDefault` is true (the default), the grant inherits to descendants "
                 + "via the path-based effective-permission resolver introduced by F6.4 — F6.1 "
                 + "only persists the flag.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .RequireAuthorization(DocumentsPermissions.Shares.Manage)
             .Produces<ShareResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem();
 
         // Document share endpoints — nested under /documents/{documentId}/shares.
         RouteGroupBuilder documentShares = group
-            .MapGroup("/documents/{documentId:guid}/shares")
+            .MapGranitGroup("/documents/{documentId:guid}/shares")
             .WithTags(TagName);
 
         documentShares.MapGet("/", ListDocumentSharesAsync)
@@ -75,7 +76,7 @@ internal static class ShareEndpoints
                 + "by creation time. Expired grants are excluded. Inherited grants from the "
                 + "document's parent folder are not included — see the F6.5 effective ACL "
                 + "field on document list responses for the resolved view.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Read))
+            .RequireAuthorization(DocumentsPermissions.Shares.Read)
             .Produces<ListSharesResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -85,13 +86,13 @@ internal static class ShareEndpoints
             .WithDescription(
                 "Creates a `DocumentShare` row targeting the document identified by "
                 + "`documentId`. The `isDefault` flag is ignored for document shares.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .RequireAuthorization(DocumentsPermissions.Shares.Manage)
             .Produces<ShareResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesValidationProblem();
 
         // Top-level revoke endpoint — share id is globally unique inside a tenant.
-        RouteGroupBuilder shares = group.MapGroup("/shares").WithTags(TagName);
+        RouteGroupBuilder shares = group.MapGranitGroup("/shares").WithTags(TagName);
 
         shares.MapDelete("/{id:guid}", RevokeAsync)
             .WithName("RevokeShare")
@@ -100,7 +101,7 @@ internal static class ShareEndpoints
                 "Deletes the share row identified by `id` and emits `DocumentShareRevokedEvent` "
                 + "for downstream cache invalidation (F6.3). Returns 404 when the share does "
                 + "not exist or is excluded by the tenant filter.")
-            .RequireAuthorization(p => p.RequireClaim("permission", DocumentsPermissions.Shares.Manage))
+            .RequireAuthorization(DocumentsPermissions.Shares.Manage)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);
 

--- a/src/Granit.Documents.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.Endpoints/packages.lock.json
@@ -117,6 +117,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Documents.EntityFrameworkCore/packages.lock.json
@@ -206,6 +206,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Notifications/Handlers/DocumentShareRevokedHandler.cs
+++ b/src/Granit.Documents.Notifications/Handlers/DocumentShareRevokedHandler.cs
@@ -10,7 +10,7 @@ namespace Granit.Documents.Notifications.Handlers;
 /// for <see cref="ShareGranteeType.User"/> grants — see
 /// <see cref="DocumentSharedHandler"/> for the role/group rationale.
 /// </summary>
-public class DocumentShareRevokedHandler
+public sealed class DocumentShareRevokedHandler
 {
     public static async Task HandleAsync(
         DocumentShareRevokedEvent evt,

--- a/src/Granit.Documents.Notifications/Handlers/DocumentSharedHandler.cs
+++ b/src/Granit.Documents.Notifications/Handlers/DocumentSharedHandler.cs
@@ -11,7 +11,7 @@ namespace Granit.Documents.Notifications.Handlers;
 /// responsibility (the recipient list depends on the role/group resolution layer
 /// which is not in scope for the framework).
 /// </summary>
-public class DocumentSharedHandler
+public sealed class DocumentSharedHandler
 {
     public static async Task HandleAsync(
         DocumentShareGrantedEvent evt,

--- a/src/Granit.Documents.Notifications/packages.lock.json
+++ b/src/Granit.Documents.Notifications/packages.lock.json
@@ -148,6 +148,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.PublicLinks.Endpoints/Endpoints/PublicLinksEndpoints.cs
+++ b/src/Granit.Documents.PublicLinks.Endpoints/Endpoints/PublicLinksEndpoints.cs
@@ -54,8 +54,7 @@ internal static partial class PublicLinksEndpoints
                 + "after this response. `ttlDays` is clamped down to the configured maximum; "
                 + "`maxUses` falls back to the configured default when omitted. Returns 422 "
                 + "when the document is missing or excluded by the tenant filter.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPublicLinksPermissions.PublicLinks.Create))
+            .RequireAuthorization(DocumentsPublicLinksPermissions.PublicLinks.Create)
             .Produces<CreatePublicLinkResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem();
@@ -67,8 +66,7 @@ internal static partial class PublicLinksEndpoints
                 "Idempotency is not enforced: revoking an already-revoked link returns 422. "
                 + "The optional `reason` is persisted on the aggregate and surfaced on the "
                 + "audit trail (DocumentPublicLinkRevokedEvent / Eto).")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPublicLinksPermissions.PublicLinks.Revoke))
+            .RequireAuthorization(DocumentsPublicLinksPermissions.PublicLinks.Revoke)
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
 
@@ -80,8 +78,7 @@ internal static partial class PublicLinksEndpoints
                 + "omitted — the bearer is only ever shown at creation time. Returns an "
                 + "empty array when the document has no links (or does not exist for the "
                 + "current tenant).")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPublicLinksPermissions.PublicLinks.Read))
+            .RequireAuthorization(DocumentsPublicLinksPermissions.PublicLinks.Read)
             .Produces<IReadOnlyList<PublicLinkResponse>>();
 
         return group;
@@ -105,7 +102,8 @@ internal static partial class PublicLinksEndpoints
                 + "are indistinguishable on the wire.")
             .AllowAnonymous()
             .Produces(StatusCodes.Status302Found)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapGet("/{token}/preview", PreviewAsync)
             .WithName("RedeemDocumentPublicLinkPreview")
@@ -117,7 +115,8 @@ internal static partial class PublicLinksEndpoints
                 + "preview the bytes inline. EVERY failure path returns 404 with no body.")
             .AllowAnonymous()
             .Produces(StatusCodes.Status302Found)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }
@@ -170,8 +169,8 @@ internal static partial class PublicLinksEndpoints
         [FromServices] IDocumentPublicLinkService service,
         [FromServices] DocumentsPublicLinksMetrics metrics,
         [FromServices] ILoggerFactory loggerFactory,
-        CancellationToken cancellationToken,
-        RevokePublicLinkRequest? request = null)
+        RevokePublicLinkRequest? request,
+        CancellationToken cancellationToken)
     {
         ILogger logger = loggerFactory.CreateLogger(typeof(PublicLinksEndpoints).FullName!);
         try

--- a/src/Granit.Documents.PublicLinks.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.PublicLinks.Endpoints/packages.lock.json
@@ -123,6 +123,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Extensions/DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+using Granit.Documents.PublicLinks.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
@@ -50,7 +51,6 @@ public static class DocumentsPublicLinksEntityFrameworkCoreHostApplicationBuilde
             configureSchemaPerTenant,
             configureTenantSchema);
         builder.Services.TryAddScoped<IDocumentPublicLinkStore, EfDocumentPublicLinkStore>();
-        builder.Services.TryAddScoped<IDocumentPublicLinkService, DocumentPublicLinkService>();
 
         return builder;
     }

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Granit.Documents.PublicLinks.EntityFrameworkCore.csproj
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Granit.Documents.PublicLinks.EntityFrameworkCore.csproj
@@ -15,8 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/EfDocumentPublicLinkStore.cs
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/EfDocumentPublicLinkStore.cs
@@ -1,4 +1,5 @@
 using Granit.Documents.PublicLinks.Domain;
+using Granit.Documents.PublicLinks.Internal;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.Documents.PublicLinks.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Documents.PublicLinks.EntityFrameworkCore/packages.lock.json
@@ -33,25 +33,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.7",
-        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Primitives": "10.0.7"
-        }
-      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -225,6 +206,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
@@ -413,6 +395,25 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",

--- a/src/Granit.Documents.PublicLinks/Domain/PublicLinkToken.cs
+++ b/src/Granit.Documents.PublicLinks/Domain/PublicLinkToken.cs
@@ -40,7 +40,7 @@ public sealed class PublicLinkToken : SingleValueObject<string>
 /// the host's signing key (a pepper, sourced from Vault and held in
 /// <c>GranitDocumentsPublicLinksOptions.SigningKey</c>).
 /// </summary>
-public static class PublicLinkTokenFactory
+internal static class PublicLinkTokenFactory
 {
     /// <summary>Mints a fresh random token (32 bytes, URL-safe base64, no padding).</summary>
     public static PublicLinkToken GenerateRandom()

--- a/src/Granit.Documents.PublicLinks/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Documents.PublicLinks/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Documents.PublicLinks.Diagnostics;
+using Granit.Documents.PublicLinks.Internal;
 using Granit.Documents.PublicLinks.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -30,6 +31,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.TryAddSingleton<DocumentsPublicLinksMetrics>();
+        services.TryAddScoped<IDocumentPublicLinkService, DocumentPublicLinkService>();
         return services;
     }
 }

--- a/src/Granit.Documents.PublicLinks/Granit.Documents.PublicLinks.csproj
+++ b/src/Granit.Documents.PublicLinks/Granit.Documents.PublicLinks.csproj
@@ -10,6 +10,7 @@
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.Tests" />
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration" />
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.Endpoints" />
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.Endpoints.Tests" />
     <InternalsVisibleTo Include="Granit.Documents.PublicLinks.BackgroundJobs" />

--- a/src/Granit.Documents.PublicLinks/Internal/DocumentPublicLinkService.cs
+++ b/src/Granit.Documents.PublicLinks/Internal/DocumentPublicLinkService.cs
@@ -9,10 +9,10 @@ using Granit.Guids;
 using Granit.Users;
 using Microsoft.Extensions.Options;
 
-namespace Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+namespace Granit.Documents.PublicLinks.Internal;
 
 /// <summary>
-/// EF Core-backed <see cref="IDocumentPublicLinkService"/>. Composes
+/// Default <see cref="IDocumentPublicLinkService"/>. Composes
 /// <see cref="IDocumentService"/> (to honour the parent tenant filter / trash
 /// status at creation time) with <see cref="IDocumentPublicLinkStore"/>.
 /// </summary>

--- a/src/Granit.Documents.PublicLinks/Internal/IDocumentPublicLinkStore.cs
+++ b/src/Granit.Documents.PublicLinks/Internal/IDocumentPublicLinkStore.cs
@@ -1,6 +1,6 @@
 using Granit.Documents.PublicLinks.Domain;
 
-namespace Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+namespace Granit.Documents.PublicLinks.Internal;
 
 /// <summary>Persistence surface for <see cref="DocumentPublicLink"/> rows.</summary>
 internal interface IDocumentPublicLinkStore

--- a/src/Granit.Documents.PublicLinks/Options/GranitDocumentsPublicLinksOptions.cs
+++ b/src/Granit.Documents.PublicLinks/Options/GranitDocumentsPublicLinksOptions.cs
@@ -24,8 +24,10 @@ public sealed class GranitDocumentsPublicLinksOptions
     /// HMAC pepper used to hash bearer tokens at rest. Sourced from Vault via
     /// <c>Granit.Configuration.Vault</c>. The empty default is intentional: hosts
     /// that fail to configure the key are rejected at startup by the
-    /// <see cref="ValidateAttribute"/>-style validator.
+    /// <see cref="ValidateAttribute"/>-style validator. Minimum length is 32 bytes
+    /// (HMAC-SHA256 block size) to reject anaemic peppers at startup.
     /// </summary>
+    [MinLength(32)]
     public byte[] SigningKey { get; set; } = [];
 
     /// <summary>

--- a/src/Granit.Documents.PublicLinks/packages.lock.json
+++ b/src/Granit.Documents.PublicLinks/packages.lock.json
@@ -148,6 +148,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.BackgroundJobs/Handlers/DocumentVersionAddedRenditionsHandler.cs
+++ b/src/Granit.Documents.Renditions.BackgroundJobs/Handlers/DocumentVersionAddedRenditionsHandler.cs
@@ -13,7 +13,7 @@ namespace Granit.Documents.Renditions.BackgroundJobs.Handlers;
 /// the rendition targets via <see cref="IRenditionTypePolicy"/> and delegates the
 /// per-rendition generation to <see cref="RenditionGenerationService"/>.
 /// </summary>
-public partial class DocumentVersionAddedRenditionsHandler
+public sealed partial class DocumentVersionAddedRenditionsHandler
 {
     /// <summary>Wolverine-style handler entry point. Public + static per framework convention.</summary>
     public static async Task HandleAsync(

--- a/src/Granit.Documents.Renditions.BackgroundJobs/Internal/RenditionGenerationService.cs
+++ b/src/Granit.Documents.Renditions.BackgroundJobs/Internal/RenditionGenerationService.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.Documents.Renditions.BackgroundJobs.Policies;
+using Granit.Documents.Renditions.Diagnostics;
 using Granit.Documents.Renditions.Domain;
 using Granit.Documents.Renditions.Exceptions;
 using Granit.Documents.Renditions.Options;
@@ -37,6 +39,7 @@ internal sealed partial class RenditionGenerationService(
     IGuidGenerator guidGenerator,
     IClock clock,
     IOptions<GranitRenditionsOptions> options,
+    RenditionsMetrics metrics,
     ILogger<RenditionGenerationService> logger) : IRenditionGenerationService, IDisposable
 {
     private readonly SemaphoreSlim _gate = new(options.Value.MaxConcurrentGenerations);
@@ -63,6 +66,10 @@ internal sealed partial class RenditionGenerationService(
                 return;
             }
 
+            string? tenantTag = tenantId?.ToString();
+            var sw = Stopwatch.StartNew();
+            using Activity? activity = RenditionsActivitySource.Source.StartActivity(
+                RenditionsActivitySource.PipelineExecute);
             try
             {
                 row.MarkGenerating();
@@ -89,18 +96,23 @@ internal sealed partial class RenditionGenerationService(
                         .ConfigureAwait(false);
                 }
 
+                sw.Stop();
+                metrics.RecordGenerated(tenantTag, sourceContentType, target.TargetContentType, target.Type.ToString());
+                metrics.RecordGenerationDuration(sourceContentType, target.TargetContentType, "pipeline", sw.Elapsed);
                 LogGenerated(logger, row.Id, target.Type, target.TargetContentType, result.Content.Length);
             }
             catch (RenditionPipelineException ex)
             {
                 row.MarkFailed(ex.Message, clock.Now);
                 await renditionStore.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                metrics.RecordFailed(tenantTag, sourceContentType, target.TargetContentType, nameof(RenditionPipelineException));
                 LogFailed(logger, row.Id, target.Type, target.TargetContentType, ex.Message);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 row.MarkFailed(ex.Message, clock.Now);
                 await renditionStore.UpdateAsync(row, cancellationToken).ConfigureAwait(false);
+                metrics.RecordFailed(tenantTag, sourceContentType, target.TargetContentType, ex.GetType().Name);
                 LogFailedUnexpected(logger, row.Id, target.Type, target.TargetContentType, ex);
             }
         }

--- a/src/Granit.Documents.Renditions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Documents.Renditions.BackgroundJobs/packages.lock.json
@@ -162,6 +162,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.Endpoints/Dtos/RenditionResponse.cs
+++ b/src/Granit.Documents.Renditions.Endpoints/Dtos/RenditionResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Granit.Documents.Renditions.Domain;
 
 namespace Granit.Documents.Renditions.Endpoints.Dtos;
@@ -25,7 +26,7 @@ public sealed record RenditionResponse(
 public sealed record ListRenditionsResponse(
     Guid DocumentId,
     Guid DocumentVersionId,
-    System.Collections.Generic.IReadOnlyList<RenditionResponse> Renditions);
+    IReadOnlyList<RenditionResponse> Renditions);
 
 /// <summary>HTTP shape returned by the rendition download endpoint.</summary>
 /// <param name="Url">Short-lived presigned URL the caller can use to fetch the rendition bytes directly from blob storage.</param>

--- a/src/Granit.Documents.Renditions.Endpoints/Endpoints/RenditionEndpoints.cs
+++ b/src/Granit.Documents.Renditions.Endpoints/Endpoints/RenditionEndpoints.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.BlobStorage;
@@ -7,6 +8,7 @@ using Granit.Documents.Renditions;
 using Granit.Documents.Renditions.Domain;
 using Granit.Documents.Renditions.Endpoints.Dtos;
 using Granit.Documents.Renditions.Endpoints.Mapping;
+using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -29,7 +31,7 @@ internal static class RenditionEndpoints
     {
         ArgumentNullException.ThrowIfNull(group);
 
-        RouteGroupBuilder renditions = group.MapGroup("/documents/{id:guid}/renditions").WithTags(TagName);
+        RouteGroupBuilder renditions = group.MapGranitGroup("/documents/{id:guid}/renditions").WithTags(TagName);
 
         renditions.MapGet("", ListAsync)
             .WithName("ListDocumentRenditions")
@@ -38,8 +40,7 @@ internal static class RenditionEndpoints
                 "Returns each rendition row (any status — including Pending and Failed) so the "
                 + "UI can render placeholders or surface errors. Ordered by Type then Format. "
                 + "Returns 404 when the document is not found or has no current version.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<ListRenditionsResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -54,8 +55,7 @@ internal static class RenditionEndpoints
                 + "is missing or no rendition of the requested Type / Format is yet in Ready "
                 + "status — on-demand synchronous generation is deferred to a follow-up; "
                 + "until then callers retry once the F16.4 background job completes.")
-            .RequireAuthorization(p => p.RequireClaim(
-                "permission", DocumentsPermissions.Documents.Read))
+            .RequireAuthorization(DocumentsPermissions.Documents.Read)
             .Produces<RenditionDownloadUrlResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -71,7 +71,7 @@ internal static class RenditionEndpoints
         [FromServices] IRenditionService service,
         CancellationToken cancellationToken)
     {
-        System.Collections.Generic.IReadOnlyList<DocumentRendition>? rows =
+        IReadOnlyList<DocumentRendition>? rows =
             await service.ListAsync(id, cancellationToken).ConfigureAwait(false);
         if (rows is null)
         {

--- a/src/Granit.Documents.Renditions.Endpoints/packages.lock.json
+++ b/src/Granit.Documents.Renditions.Endpoints/packages.lock.json
@@ -117,6 +117,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.EntityFrameworkCore/Extensions/RenditionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Documents.Renditions.EntityFrameworkCore/Extensions/RenditionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -49,7 +49,6 @@ public static class RenditionsEntityFrameworkCoreHostApplicationBuilderExtension
             configureSchemaPerTenant,
             configureTenantSchema);
         builder.Services.TryAddScoped<IRenditionStore, RenditionStore>();
-        builder.Services.TryAddScoped<IRenditionService, RenditionService>();
 
         return builder;
     }

--- a/src/Granit.Documents.Renditions.EntityFrameworkCore/Internal/DocumentPermanentlyDeletedRenditionHandler.cs
+++ b/src/Granit.Documents.Renditions.EntityFrameworkCore/Internal/DocumentPermanentlyDeletedRenditionHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.BlobStorage;
@@ -21,7 +22,7 @@ namespace Granit.Documents.Renditions.EntityFrameworkCore.Internal;
 /// Lives in the renditions EFC package so the parent <c>Granit.Documents</c> module
 /// stays unaware of the renditions surface (clean dependency direction).
 /// </remarks>
-public class DocumentPermanentlyDeletedRenditionHandler
+public sealed partial class DocumentPermanentlyDeletedRenditionHandler
 {
     /// <summary>Wolverine-style handler entry point. Public + static per framework convention.</summary>
     public static async Task HandleAsync(
@@ -32,7 +33,7 @@ public class DocumentPermanentlyDeletedRenditionHandler
         ILogger<DocumentPermanentlyDeletedRenditionHandler> logger,
         CancellationToken cancellationToken)
     {
-        System.Collections.Generic.IReadOnlyList<DocumentRendition> renditions = await renditionStore
+        IReadOnlyList<DocumentRendition> renditions = await renditionStore
             .ListForDocumentAsync(evt.DocumentId, cancellationToken)
             .ConfigureAwait(false);
 
@@ -68,13 +69,10 @@ public class DocumentPermanentlyDeletedRenditionHandler
         LogCascade(logger, renditions.Count, releasedBytes, evt.DocumentId);
     }
 
-    private static readonly Action<ILogger, int, long, Guid, Exception?> LogCascadeMessage =
-        LoggerMessage.Define<int, long, Guid>(
-            LogLevel.Information,
-            new EventId(1, nameof(DocumentPermanentlyDeletedRenditionHandler)),
-            "Granit.Documents.Renditions cascaded permanent-delete: dropped {Count} rendition(s) (~{ReleasedBytes} bytes) for document {DocumentId}.");
-
-    private static void LogCascade(ILogger logger, int count, long releasedBytes, Guid documentId) =>
-        LogCascadeMessage(logger, count, releasedBytes, documentId, null);
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "Granit.Documents.Renditions cascaded permanent-delete: dropped {Count} rendition(s) (~{ReleasedBytes} bytes) for document {DocumentId}.")]
+    private static partial void LogCascade(ILogger logger, int count, long releasedBytes, Guid documentId);
 }
 

--- a/src/Granit.Documents.Renditions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Documents.Renditions.EntityFrameworkCore/packages.lock.json
@@ -215,6 +215,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.Imaging/Internal/InlineThumbnailHandler.cs
+++ b/src/Granit.Documents.Renditions.Imaging/Internal/InlineThumbnailHandler.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.BlobStorage;
@@ -31,7 +33,7 @@ namespace Granit.Documents.Renditions.Imaging.Internal;
 internal sealed partial class InlineThumbnailHandler(
     IImageProcessor processor,
     IBlobStorage blobStorage,
-    System.Net.Http.IHttpClientFactory httpClientFactory,
+    IHttpClientFactory httpClientFactory,
     IRenditionStore renditionStore,
     ITenantQuotaService quotas,
     IGuidGenerator guidGenerator,
@@ -102,7 +104,7 @@ internal sealed partial class InlineThumbnailHandler(
             .CreateDownloadUrlAsync(DocumentBlobContainers.Documents, sourceBlobId, options: null, cancellationToken)
             .ConfigureAwait(false);
 
-        System.Net.Http.HttpClient http = httpClientFactory.CreateClient(HttpClientName);
+        HttpClient http = httpClientFactory.CreateClient(HttpClientName);
         await using Stream source = await http.GetStreamAsync(url.Url, cancellationToken).ConfigureAwait(false);
 
         ImageFormat outputFormat = ResolveFormat(thumb.Format);
@@ -128,19 +130,19 @@ internal sealed partial class InlineThumbnailHandler(
                 MaxAllowedBytes: bytes.Length),
             cancellationToken).ConfigureAwait(false);
 
-        System.Net.Http.HttpClient http = httpClientFactory.CreateClient(HttpClientName);
-        using System.Net.Http.ByteArrayContent content = new(bytes);
-        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+        HttpClient http = httpClientFactory.CreateClient(HttpClientName);
+        using ByteArrayContent content = new(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
         foreach ((string key, string value) in ticket.RequiredHeaders)
         {
             content.Headers.TryAddWithoutValidation(key, value);
         }
-        using System.Net.Http.HttpRequestMessage request = new(
-            new System.Net.Http.HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
+        using HttpRequestMessage request = new(
+            new HttpMethod(ticket.HttpMethod), ticket.UploadUrl)
         {
             Content = content,
         };
-        using System.Net.Http.HttpResponseMessage response = await http
+        using HttpResponseMessage response = await http
             .SendAsync(request, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/src/Granit.Documents.Renditions.Imaging/packages.lock.json
+++ b/src/Granit.Documents.Renditions.Imaging/packages.lock.json
@@ -148,6 +148,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.Office/packages.lock.json
+++ b/src/Granit.Documents.Renditions.Office/packages.lock.json
@@ -148,6 +148,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions.Pdf/packages.lock.json
+++ b/src/Granit.Documents.Renditions.Pdf/packages.lock.json
@@ -164,6 +164,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents.Renditions/Diagnostics/RenditionsActivitySource.cs
+++ b/src/Granit.Documents.Renditions/Diagnostics/RenditionsActivitySource.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Granit.Documents.Renditions.Diagnostics;
 
 /// <summary>Central <see cref="ActivitySource"/> for Granit.Documents.Renditions distributed tracing.</summary>
-public static class RenditionsActivitySource
+internal static class RenditionsActivitySource
 {
     /// <summary>The name of the renditions <see cref="ActivitySource"/>.</summary>
     public const string Name = "Granit.Documents.Renditions";

--- a/src/Granit.Documents.Renditions/Diagnostics/RenditionsMetrics.cs
+++ b/src/Granit.Documents.Renditions/Diagnostics/RenditionsMetrics.cs
@@ -7,7 +7,7 @@ namespace Granit.Documents.Renditions.Diagnostics;
 /// <summary>
 /// OpenTelemetry metrics for the renditions module. Meter: <c>Granit.Documents.Renditions</c>.
 /// </summary>
-public sealed class RenditionsMetrics
+internal sealed class RenditionsMetrics
 {
     /// <summary>Meter name.</summary>
     public const string MeterName = "Granit.Documents.Renditions";

--- a/src/Granit.Documents.Renditions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Documents.Renditions/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Granit.Documents.Renditions.Diagnostics;
+using Granit.Documents.Renditions.Internal;
 using Granit.Documents.Renditions.Options;
 using Granit.Documents.Renditions.Pipeline;
 using Granit.Documents.Renditions.Providers;
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<RenditionsMetrics>();
         services.TryAddSingleton<IRenditionPipeline, RenditionPipeline>();
+        services.TryAddScoped<IRenditionService, RenditionService>();
 
         return services;
     }

--- a/src/Granit.Documents.Renditions/Internal/RenditionService.cs
+++ b/src/Granit.Documents.Renditions/Internal/RenditionService.cs
@@ -8,7 +8,7 @@ using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.Renditions.Domain;
 
-namespace Granit.Documents.Renditions.EntityFrameworkCore.Internal;
+namespace Granit.Documents.Renditions.Internal;
 
 /// <summary>
 /// EF Core-backed <see cref="IRenditionService"/>. Composes <see cref="IDocumentService"/>

--- a/src/Granit.Documents.Renditions/packages.lock.json
+++ b/src/Granit.Documents.Renditions/packages.lock.json
@@ -164,6 +164,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/src/Granit.Documents/Authorization/AclCacheInvalidationHandler.cs
+++ b/src/Granit.Documents/Authorization/AclCacheInvalidationHandler.cs
@@ -2,7 +2,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.Events;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.Documents.EntityFrameworkCore.Authorization;
+namespace Granit.Documents.Authorization;
 
 /// <summary>
 /// Wolverine message handlers that invalidate the F6.3 effective-ACL cache when share
@@ -27,7 +27,7 @@ namespace Granit.Documents.EntityFrameworkCore.Authorization;
 /// </list>
 /// </para>
 /// </remarks>
-public class AclCacheInvalidationHandler
+public sealed class AclCacheInvalidationHandler
 {
     /// <summary>Invalidates entries that depended on the share's target.</summary>
     public static Task HandleAsync(

--- a/src/Granit.Documents/Authorization/AclCacheKeys.cs
+++ b/src/Granit.Documents/Authorization/AclCacheKeys.cs
@@ -1,9 +1,7 @@
 using System.Globalization;
 using System.Security.Cryptography;
-using System.Text;
-using Granit.Documents.Authorization;
 
-namespace Granit.Documents.EntityFrameworkCore.Authorization;
+namespace Granit.Documents.Authorization;
 
 /// <summary>
 /// Centralised cache-key and tag construction for the F6.3 effective-ACL cache layer.

--- a/src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs
+++ b/src/Granit.Documents/Extensions/DocumentsServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
-namespace Granit.Documents.Extensions;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Extensions for registering Granit.Documents module services.

--- a/src/Granit.Documents/Granit.Documents.csproj
+++ b/src/Granit.Documents/Granit.Documents.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Analytics\Granit.Analytics.csproj" />
     <ProjectReference Include="..\Granit.BlobStorage\Granit.BlobStorage.csproj" />
+    <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Localization\Granit.Localization.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />

--- a/src/Granit.Documents/GranitDocumentsModule.cs
+++ b/src/Granit.Documents/GranitDocumentsModule.cs
@@ -1,4 +1,5 @@
 using Granit.BlobStorage;
+using Granit.Caching;
 using Granit.Modularity;
 using Granit.Taxonomy;
 
@@ -17,12 +18,13 @@ namespace Granit.Documents;
 /// </para>
 /// <para>
 /// Phase 1 ships only the scaffolding declared in
-/// <see cref="Extensions.DocumentsServiceCollectionExtensions.AddGranitDocuments(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action{Options.GranitDocumentsOptions}?)"/>.
+/// <see cref="Microsoft.Extensions.DependencyInjection.DocumentsServiceCollectionExtensions.AddGranitDocuments(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action{Options.GranitDocumentsOptions}?)"/>.
 /// Domain types, endpoints, and persistence are introduced in subsequent stories
 /// of the tracking Epic.
 /// </para>
 /// </remarks>
 [DependsOn(
     typeof(GranitBlobStorageModule),
+    typeof(GranitCachingModule),
     typeof(GranitTaxonomyModule))]
 public sealed class GranitDocumentsModule : GranitModule;

--- a/tests/Granit.Documents.AssetMetadata.AudioVideo.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.AudioVideo.Tests/packages.lock.json
@@ -358,6 +358,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.BackgroundJobs.Tests/packages.lock.json
@@ -394,6 +394,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Endpoints.Tests/packages.lock.json
@@ -401,6 +401,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.EntityFrameworkCore.Tests/packages.lock.json
@@ -482,6 +482,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.Imaging.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Imaging.Tests/packages.lock.json
@@ -408,6 +408,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.Office.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Office.Tests/packages.lock.json
@@ -371,6 +371,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.Pdf.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Pdf.Tests/packages.lock.json
@@ -358,6 +358,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.AssetMetadata.Tests/packages.lock.json
+++ b/tests/Granit.Documents.AssetMetadata.Tests/packages.lock.json
@@ -380,6 +380,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Documents.BackgroundJobs.Tests/packages.lock.json
@@ -394,6 +394,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Endpoints.Tests/packages.lock.json
@@ -401,6 +401,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -488,6 +488,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/AclCacheKeysTests.cs
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/Authorization/AclCacheKeysTests.cs
@@ -1,5 +1,4 @@
 using Granit.Documents.Authorization;
-using Granit.Documents.EntityFrameworkCore.Authorization;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.Documents.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Documents.EntityFrameworkCore.Tests/packages.lock.json
@@ -493,6 +493,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Notifications.Tests/packages.lock.json
@@ -380,6 +380,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.PublicLinks.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.PublicLinks.Endpoints.Tests/packages.lock.json
@@ -413,6 +413,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/DocumentPublicLinkServicePostgresTests.cs
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/DocumentPublicLinkServicePostgresTests.cs
@@ -5,6 +5,7 @@ using Granit.Documents.Domain;
 using Granit.Documents.PublicLinks.Domain;
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
 using Granit.Documents.PublicLinks.Events;
+using Granit.Documents.PublicLinks.Internal;
 using Granit.Documents.PublicLinks.Options;
 using Granit.Events;
 using Granit.Guids;

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -488,6 +488,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
@@ -507,9 +508,7 @@
           "Granit.Documents.PublicLinks": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.entities.abstractions": {

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/DocumentPublicLinkServiceTests.cs
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/DocumentPublicLinkServiceTests.cs
@@ -4,6 +4,7 @@ using Granit.Documents;
 using Granit.Documents.Domain;
 using Granit.Documents.PublicLinks.Domain;
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+using Granit.Documents.PublicLinks.Internal;
 using Granit.Documents.PublicLinks.Options;
 using Granit.Guids;
 using Granit.Users;

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/EfDocumentPublicLinkStoreSqliteTests.cs
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/EfDocumentPublicLinkStoreSqliteTests.cs
@@ -1,5 +1,6 @@
 using Granit.Documents.PublicLinks.Domain;
 using Granit.Documents.PublicLinks.EntityFrameworkCore.Internal;
+using Granit.Documents.PublicLinks.Internal;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Shouldly;

--- a/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Documents.PublicLinks.EntityFrameworkCore.Tests/packages.lock.json
@@ -482,6 +482,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
@@ -501,9 +502,7 @@
           "Granit.Documents.PublicLinks": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.entities.abstractions": {

--- a/tests/Granit.Documents.PublicLinks.Tests/packages.lock.json
+++ b/tests/Granit.Documents.PublicLinks.Tests/packages.lock.json
@@ -386,6 +386,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.BackgroundJobs.Tests/packages.lock.json
@@ -394,6 +394,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Endpoints.Tests/packages.lock.json
@@ -401,6 +401,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.EntityFrameworkCore.Tests/packages.lock.json
@@ -482,6 +482,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.Imaging.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Imaging.Tests/packages.lock.json
@@ -380,6 +380,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.Office.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Office.Tests/packages.lock.json
@@ -380,6 +380,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.Pdf.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Pdf.Tests/packages.lock.json
@@ -396,6 +396,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Renditions.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Renditions.Tests/packages.lock.json
@@ -380,6 +380,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.Documents.Tests/GranitDocumentsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Documents.Tests/GranitDocumentsServiceCollectionExtensionsTests.cs
@@ -1,6 +1,5 @@
 using Granit.Documents.Diagnostics;
 using Granit.Documents.Domain;
-using Granit.Documents.Extensions;
 using Granit.Documents.Options;
 using Granit.Taxonomy.Registration;
 using Microsoft.Extensions.Configuration;

--- a/tests/Granit.Documents.Tests/packages.lock.json
+++ b/tests/Granit.Documents.Tests/packages.lock.json
@@ -434,6 +434,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Analytics": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Cross-family sweeps and targeted fixes from a `/audit` pass on all `Granit.Documents.*` submodules (4 families, 23 src projects). Mechanical and architectural findings only — design-level findings are deferred (see follow-up list below).

## Changes by severity

### BREAKING (1)
- **PublicLinks**: add `ProducesProblem(429)` to anonymous redemption endpoints (`RedeemDownload`, `RedeemPreview`). They are rate-limited but the SDK had no typed branch for 429.

### ARCHITECTURE — Layer purity (5 file moves)
| From | To | Reason |
|---|---|---|
| `Granit.Documents.EntityFrameworkCore/Authorization/AclCacheKeys.cs` | `Granit.Documents/Authorization/` | Pure string helpers, no EF Core |
| `Granit.Documents.EntityFrameworkCore/Authorization/AclCacheInvalidationHandler.cs` | `Granit.Documents/Authorization/` | Pure FusionCache + Wolverine, no EF Core |
| `Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/DocumentPublicLinkService.cs` | `Granit.Documents.PublicLinks/Internal/` | Pure orchestration |
| `Granit.Documents.PublicLinks.EntityFrameworkCore/Internal/IDocumentPublicLinkStore.cs` | `Granit.Documents.PublicLinks/Internal/` | Interface follows the service |
| `Granit.Documents.Renditions.EntityFrameworkCore/Internal/RenditionService.cs` | `Granit.Documents.Renditions/Internal/` | Pure orchestration |

Adds `Granit.Caching` ref + `[DependsOn(GranitCachingModule)]` on `Granit.Documents` for the AclCache code path. Drops unused `Microsoft.Extensions.Options` / `Logging.Abstractions` package refs from `Granit.Documents.PublicLinks.EntityFrameworkCore.csproj`.

### CONVENTION sweeps (all 4 families)
- **Permission policy form**: every `RequireAuthorization(p => p.RequireClaim("permission", X))` → `RequireAuthorization(X)`. Lets the framework permission policy provider do its job (caching, hierarchical grants).
- **Sub-groups**: `MapGroup(...)` → `MapGranitGroup(...)` so auto-validation flows down.
- **ProblemDetails contract**: `DocumentTagProxyEndpoints.UnassignTagAsync` `TypedResults.NotFound()` → `TypedResults.Problem(404)`.
- **Namespace standardisation**: `AddGranitDocuments` moved to `Microsoft.Extensions.DependencyInjection` namespace.
- **Wolverine handler visibility**: `public class` → `public sealed (partial) class` on all touched handlers. Hand-rolled `LoggerMessage.Define<>` → `[LoggerMessage]` source-gen.
- **PublicLinks security**: `PublicLinkTokenFactory` public → internal. `[MinLength(32)]` on `SigningKey` (fail-fast on weak Vault pepper). `CancellationToken` reordered to last param in `RevokeAsync`.
- **Renditions**: `RenditionsMetrics` / `RenditionsActivitySource` public → internal (matches other Granit modules).

### CONVENTION — Metric wiring
- **AssetMetadata**: wire `RecordExtracted` / `RecordFailed` / `RecordGpsScrubbed` / `RecordExtractionDuration` with real `tenant_id` tag (previously dead counters, hardcoded `null` tenant tag).
- **Renditions**: inject `RenditionsMetrics` into `RenditionGenerationService`; emit `RecordGenerated` / `RecordFailed` / `RecordGenerationDuration` and start an `Activity` span around the pipeline call.

### CLEANUP
- Drop dead `InternalsVisibleTo` to `Granit.Documents.AssetMetadata.Media` (package was renamed to `.AudioVideo` before merge).
- Update 3 test usings broken by the PublicLinks namespace move.

## Build & format
- **Source**: 0 errors, 0 warnings on all 4 module families (per-project build verified).
- **Tests**: 6 affected test projects build clean (incl. PublicLinks EFC tests + Integration).
- **Format**: `dotnet format --verify-no-changes` clean on all touched projects.

## Test plan
- [ ] CI green on the `infrastructure` shard (unit tests).
- [ ] CI green on `integration` shard (PublicLinks integration tests use Postgres).
- [ ] Architecture tests pass (layer-purity moves change project layout).
- [ ] OpenAPI smoke check on a host that wires Documents endpoints (verify `429` shows on `/public-links/{token}/download` and `/preview`).
- [ ] Manual verification that `RequireAuthorization(string)` correctly resolves through the framework permission policy provider in a sample app (sanity check the sweep).
- [ ] Spot-check that `AssetMetadata` extraction emits per-tenant metrics in dev (look for `granit.documents.asset_metadata.extracted.count` with `tenant_id` tag).

## Deferred to follow-up PRs

Audit findings intentionally NOT included (design or scope concerns):
- `CachedEffectivePermissionResolver` layer-purity move — requires exposing `EffectivePermissionResolver` + `DocumentResolutionResult` as public API.
- `IConcurrencyAware` on `DocumentPublicLink` / `DocumentRendition` (race-condition hardening).
- `ExtractionTimeout` option wiring in AssetMetadata pipeline.
- Encryption at rest for raw EXIF/IPTC metadata (GDPR/ISO 27001).
- Rename `Granit.Documents.Renditions.BackgroundJobs` → `.Wolverine` (no `IBackgroundJob` records inside).
- `BackgroundJob` for expired PublicLink pruning.
- Bind `EndpointsOptions` from configuration in PublicLinks + Renditions.
- PII-strip option for raw asset metadata (author/copyright fields).
- `HttpAssetMetadataSourceFetcher` resilience policy (Polly).

## Origin

Generated from a 4-agent parallel `/audit` pass; fixes applied by 4 parallel `--fix` agents per family. All changes manually verified before commit.