### PR TITLE
ci(codeql): parallelize analysis across all cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,15 +232,24 @@ jobs:
       - name: CodeQL-only NuGet config
         run: cp .github/codeql/nuget.config nuget.config
 
+      # GitHub-hosted ubuntu-latest = 4 cores / 16 GB. CodeQL defaults to 1 thread
+      # and a conservative RAM budget; on a ~380-project C# codebase the analyse
+      # phase otherwise takes ~21 min. threads: 0 = use all cores; ram leaves ~3 GB
+      # headroom for the OS and the extractor.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: csharp
           build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
+          threads: 0
+          ram: 13000
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        with:
+          threads: 0
+          ram: 13000
 
   # ---------------------------------------------------------------------------
   # ANALYSIS


### PR DESCRIPTION
## Summary

- Pass `threads: 0` and `ram: 13000` to both `codeql-action/init` and `codeql-action/analyze`

## Why

Baseline timings on `develop` after #2024 + #2026 + #2027:

| Step | Duration |
| ---- | -------- |
| Initialize CodeQL | 16 s |
| **Perform CodeQL Analysis** | **20 min 57 s** |
| Total codeql job | 21 min |

CodeQL defaults to a single thread on GitHub-hosted runners (`ubuntu-latest` = 4 vCPU / 16 GB), so 3 cores sit idle for the entire analyse phase. `threads: 0` tells CodeQL to use every available core; `ram: 13000` raises the heap budget from the default (~6 GB) while leaving ~3 GB for the OS and extractor.

Expected gain: **-40 to -60% on the analyse step** → total job ~10-12 min, down from 21 min (and 49 min before this PR series).

## Test plan

- [ ] `codeql` job total time noticeably lower than `develop` baseline
- [ ] No OOM in the analyse step
- [ ] CodeQL findings remain comparable