### PR TITLE
docs(scripts): note shared-infra paths needed for granit-business extraction

### DIFF
--- a/scripts/list-business-paths.sh
+++ b/scripts/list-business-paths.sh
@@ -11,6 +11,26 @@
 #   - src/Granit.Entities.Abstractions    (declarative contracts: EntityDefinition, builders)
 #   - tests/Granit.Entities.Abstractions.Tests
 #
+# IMPORTANT — additional paths the extraction must include but which STAY in
+# granit-dotnet (so they are NOT emitted by this script — concatenate manually
+# when feeding `git filter-repo --paths-from-file`):
+#
+#   Root build/infra :  .claude .editorconfig .github .gitignore .gitleaks.toml
+#                       .husky .markdownlint-cli2.jsonc .markdownlint.json
+#                       .markdownlintignore .semgrepignore .slnf .vscode
+#                       BannedSymbols.txt CHANGELOG.md CLAUDE.md
+#                       CODE_OF_CONDUCT.md CONTRIBUTING.md
+#                       Directory.Build.props Directory.Packages.props
+#                       Granit.slnx LICENSE NOTICE README.md SECURITY.md
+#                       THIRD-PARTY-NOTICES.md coverage.runsettings
+#                       dotnet-tools.json global.json nuget.config scripts
+#   Tests-root config :  tests/Directory.Build.props  tests/xunit.runner.json
+#   Shared assets :      assets/granit-icon-64.png
+#
+# Discovered missing during the first extraction (May 2026) — without them,
+# the new granit-business repo can't build: tests can't resolve junit logger
+# or xunit.runner.json, pack fails on missing PackageIcon asset, etc.
+#
 # Usage:
 #   scripts/list-business-paths.sh                 # human-readable list
 #   scripts/list-business-paths.sh --filter-repo   # emit `--path X` lines


### PR DESCRIPTION
## Summary

Add docstring to [scripts/list-business-paths.sh](scripts/list-business-paths.sh) listing the shared-infrastructure paths that the granit-business extraction must include but which this script intentionally doesn't emit (because they STAY in granit-dotnet during Phase 3b-3 cleanup).

Discovered during the first real extraction (May 2026) on https://gitlab.digitaldynamics.be/digital-dynamics/granit-fx/granit-business — without these files the new repo can't build:
- `tests/Directory.Build.props` → `JunitXml.TestLogger` missing in CI, tests can't emit reports
- `tests/xunit.runner.json` → parallelization default reverts, slower test runs
- `assets/granit-icon-64.png` → `dotnet pack` fails with `Could not find a part of the path '...assets'` because `Directory.Build.props` references it as `PackageIcon`
- Root config bundle (`Directory.Build.props`, `nuget.config`, `Granit.slnx`, `.github`, `scripts`, `.husky`, etc.) → without them filter-repo strips everything outside the listed business module paths

Script logic & output unchanged — only the docstring grows. Phase 3b-3's `git rm -r` loop still gets the same business-only path list it expects.

## Test plan
- [x] `bash scripts/list-business-paths.sh --count` still emits 259
- [x] Script output unchanged (diff shows only comment additions)