### PR TITLE
refactor(analyzers): enforce CA1305/CA1848/CA1873 across framework

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17360,7 +17360,7 @@
       "kind": "class",
       "project": "Granit.Features",
       "file": "src/Granit.Features/Definitions/FeatureGroupDefinition.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "Name",
@@ -19232,7 +19232,7 @@
       "kind": "class",
       "project": "Granit.Http.Idempotency",
       "file": "src/Granit.Http.Idempotency/Diagnostics/IdempotencyMetrics.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "RecordLockConflict",
@@ -19722,7 +19722,7 @@
       "kind": "class",
       "project": "Granit.Http.Resilience",
       "file": "src/Granit.Http.Resilience/Diagnostics/HttpResilienceMetrics.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "RecordCircuitBreakerStateChanged",
@@ -30382,7 +30382,7 @@
       "kind": "class",
       "project": "Granit.Observability",
       "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitObservability",
@@ -34700,7 +34700,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/LegalAgreements/Domain/LegalDocument.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "Create",
@@ -36791,7 +36791,7 @@
       "kind": "class",
       "project": "Granit.RateLimiting",
       "file": "src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {
@@ -39147,7 +39147,7 @@
       "kind": "class",
       "project": "Granit.Templating.Scriban",
       "file": "src/Granit.Templating.Scriban/Exceptions/TemplateParseException.cs",
-      "line": 8,
+      "line": 9,
       "members": [
         {
           "name": "TemplateParseException",
@@ -42816,7 +42816,7 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Diagnostics/WebhooksMetrics.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "RecordDeliverySucceeded",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <NuGetAuditLevel>moderate</NuGetAuditLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <NoWarn>CA1848;CA1873;CA1707;CA1305;CA1861;CS1591;CS1574;CS1734</NoWarn>
+    <NoWarn>CA1707;CA1861;CS1591;CS1574;CS1734</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- NuGet lock files: résolution locale, mode verrouillé en CI -->
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Granit.Auditing/Internal/Services/AuditingCleanupWorker.cs
+++ b/src/Granit.Auditing/Internal/Services/AuditingCleanupWorker.cs
@@ -74,7 +74,7 @@ internal sealed partial class AuditingCleanupWorker(
                 metrics.RecordPurged(totalPurged, category.ToString(), tenantId: null);
             }
 
-            LogCategoryPurged(category.ToString(), totalPurged, cutoff);
+            LogCategoryPurged(category, totalPurged, cutoff);
         }
     }
 
@@ -84,7 +84,7 @@ internal sealed partial class AuditingCleanupWorker(
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Audit log cleanup '{Category}': purged {Count} entries (cutoff: {Cutoff})")]
-    private partial void LogCategoryPurged(string category, long count, DateTimeOffset cutoff);
+    private partial void LogCategoryPurged(AuditCategory category, long count, DateTimeOffset cutoff);
 
     [LoggerMessage(Level = LogLevel.Error,
         Message = "Audit log cleanup failed")]

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -163,7 +163,11 @@ internal static partial class BffLoginEndpoints
         }
 #pragma warning restore GRSEC003
 
-        LogLoginRedirect(logger, bffOptions.Authority.ToString(), frontend.Name);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string authority = bffOptions.Authority.ToString();
+            LogLoginRedirect(logger, authority, frontend.Name);
+        }
 
         return TypedResults.Redirect(authorizeUrl);
     }
@@ -268,7 +272,11 @@ internal static partial class BffLoginEndpoints
             .ConfigureAwait(false);
 
         metrics.RecordLogin(null);
-        LogLoginSuccess(logger, BffSessionEndpoints.MaskSessionId(sessionId), frontend.Name);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string maskedSessionId = BffSessionEndpoints.MaskSessionId(sessionId);
+            LogLoginSuccess(logger, maskedSessionId, frontend.Name);
+        }
 
         // Redirect to the original URL the user requested, or fall back to the configured post-login path
         string redirectUrl = !string.IsNullOrEmpty(pkceState.ReturnUrl)

--- a/src/Granit.Bff.Endpoints/Endpoints/BffSessionEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffSessionEndpoints.cs
@@ -147,7 +147,11 @@ internal static partial class BffSessionEndpoints
         }
 
         await tokenStore.RemoveAsync(frontend.Name, targetSessionId, cancellationToken).ConfigureAwait(false);
-        LogSessionRevoked(logger, MaskSessionId(targetSessionId), frontend.Name);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string maskedSessionId = MaskSessionId(targetSessionId);
+            LogSessionRevoked(logger, maskedSessionId, frontend.Name);
+        }
 
         return TypedResults.NoContent();
     }

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -128,7 +128,11 @@ public sealed partial class BffTokenInjectionMiddleware
                 await tokenStore.StoreAsync(frontend.Name, sessionId, tokens, context.RequestAborted)
                     .ConfigureAwait(false);
                 metrics.RecordTokenRefresh(null);
-                LogTokenRefreshed(logger, MaskSessionId(sessionId), frontend.Name);
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    string maskedSessionId = MaskSessionId(sessionId);
+                    LogTokenRefreshed(logger, maskedSessionId, frontend.Name);
+                }
                 context.Response.Headers["X-Bff-Session-Refreshed"] = "true";
             }
             else

--- a/src/Granit.Bff.Yarp/Internal/BffTokenInjectionTransform.cs
+++ b/src/Granit.Bff.Yarp/Internal/BffTokenInjectionTransform.cs
@@ -97,7 +97,11 @@ internal sealed partial class BffTokenInjectionTransform(
                     .ConfigureAwait(false);
 
                 metrics.RecordTokenRefresh(null);
-                LogTokenRefreshed(logger, MaskSessionId(sessionId), frontend.Name);
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    string maskedSessionId = MaskSessionId(sessionId);
+                    LogTokenRefreshed(logger, maskedSessionId, frontend.Name);
+                }
 
                 // Signal to the SPA that the session was refreshed
                 httpContext.Response.Headers["X-Bff-Session-Refreshed"] = "true";

--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightHeadlessBrowser.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightHeadlessBrowser.cs
@@ -378,9 +378,9 @@ internal sealed partial class PlaywrightHeadlessBrowser : IHeadlessBrowser, IHea
                 _ => _playwright.Chromium,
             };
 
-            LogStartingBrowser(opts.Engine.ToString());
+            LogStartingBrowser(opts.Engine);
             _browser = await type.LaunchAsync(launch).ConfigureAwait(false);
-            LogBrowserStarted(opts.Engine.ToString());
+            LogBrowserStarted(opts.Engine);
         }
         finally
         {
@@ -435,10 +435,10 @@ internal sealed partial class PlaywrightHeadlessBrowser : IHeadlessBrowser, IHea
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Granit.Browsing.Playwright launching {Engine} (headless)...")]
-    private partial void LogStartingBrowser(string engine);
+    private partial void LogStartingBrowser(BrowserEngine engine);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Granit.Browsing.Playwright {Engine} launched.")]
-    private partial void LogBrowserStarted(string engine);
+    private partial void LogBrowserStarted(BrowserEngine engine);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Granit.Browsing.Playwright failed to dispose a stale browser handle.")]
     private partial void LogDisposeFailure(Exception exception);

--- a/src/Granit.Browsing/Internal/SimpleObservable.cs
+++ b/src/Granit.Browsing/Internal/SimpleObservable.cs
@@ -12,7 +12,7 @@ namespace Granit.Browsing.Internal;
 /// Extensions. Subscriber exceptions are logged (or swallowed when no logger is wired)
 /// and never propagate to other subscribers or the producer.
 /// </summary>
-internal sealed class SimpleObservable<T> : IObservable<T>
+internal sealed partial class SimpleObservable<T> : IObservable<T>
 {
     private ImmutableList<IObserver<T>> _observers = ImmutableList<IObserver<T>>.Empty;
     private readonly ILogger? _logger;
@@ -47,10 +47,17 @@ internal sealed class SimpleObservable<T> : IObservable<T>
             }
             catch (Exception ex)
             {
-                _logger?.LogDebug(ex, "Subscriber threw while handling observable value.");
+                if (_logger is not null)
+                {
+                    LogSubscriberThrew(_logger, ex);
+                }
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Subscriber threw while handling observable value.")]
+    private static partial void LogSubscriberThrew(ILogger logger, Exception ex);
 
     private sealed class Subscription : IDisposable
     {

--- a/src/Granit.Browsing/Pages/RequestRouter.cs
+++ b/src/Granit.Browsing/Pages/RequestRouter.cs
@@ -32,7 +32,7 @@ namespace Granit.Browsing.Pages;
 /// request. Sandbox rules ALWAYS evaluate first — no user code can widen them.
 /// </para>
 /// </remarks>
-internal sealed class RequestRouter : IRequestRouter
+internal sealed partial class RequestRouter : IRequestRouter
 {
     private readonly IBrowserSandboxProfile _sandbox;
     private readonly IUrlSafetyValidator _urlSafety;
@@ -143,7 +143,7 @@ internal sealed class RequestRouter : IRequestRouter
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "User route handler threw; defaulting to Continue.");
+                LogUserHandlerThrew(_logger, ex);
             }
         }
 
@@ -195,10 +195,18 @@ internal sealed class RequestRouter : IRequestRouter
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Failed to publish BrowserUrlNavigatedEvent on sandbox block.");
+                LogPublishFailed(_logger, ex);
             }
         }
 
         return RouteDecision.Abort(errorCode: reason);
     }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "User route handler threw; defaulting to Continue.")]
+    private static partial void LogUserHandlerThrew(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Failed to publish BrowserUrlNavigatedEvent on sandbox block.")]
+    private static partial void LogPublishFailed(ILogger logger, Exception ex);
 }

--- a/src/Granit.Browsing/Pool/HeadlessBrowserDrainCoordinator.cs
+++ b/src/Granit.Browsing/Pool/HeadlessBrowserDrainCoordinator.cs
@@ -10,7 +10,7 @@ namespace Granit.Browsing.Pool;
 /// Bounds <see cref="IHeadlessBrowserPool.DrainAsync"/> so a misbehaving page handle can
 /// never block a graceful shutdown indefinitely. Closes VULN-200.
 /// </summary>
-internal sealed class HeadlessBrowserDrainCoordinator
+internal sealed partial class HeadlessBrowserDrainCoordinator
 {
     private readonly BrowsingMetrics _metrics;
     private readonly ILogger<HeadlessBrowserDrainCoordinator> _logger;
@@ -48,10 +48,7 @@ internal sealed class HeadlessBrowserDrainCoordinator
         catch (TimeoutException)
         {
             _metrics.RecordPoolDrainTimeout(browser.EngineName);
-            _logger.LogWarning(
-                "Headless browser pool drain timed out after {Timeout}; forcing disposal of {Engine}.",
-                timeout,
-                browser.EngineName);
+            LogDrainTimeout(_logger, timeout, browser.EngineName);
 
             if (browser is IAsyncDisposable disposable)
             {
@@ -59,4 +56,8 @@ internal sealed class HeadlessBrowserDrainCoordinator
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Headless browser pool drain timed out after {Timeout}; forcing disposal of {Engine}.")]
+    private static partial void LogDrainTimeout(ILogger logger, TimeSpan timeout, string engine);
 }

--- a/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
+++ b/src/Granit.Browsing/Pool/PrivilegedFlagGuard.cs
@@ -27,7 +27,7 @@ namespace Granit.Browsing.Pool;
 /// <c>USER=app</c>, but that is outside our threat model.
 /// </para>
 /// </remarks>
-public static class PrivilegedFlagGuard
+public static partial class PrivilegedFlagGuard
 {
     /// <summary>Environment variable that must be set to <c>"1"</c> to opt in.</summary>
     public const string OptInEnvVar = "GRANIT_BROWSING_ALLOW_NO_SANDBOX";
@@ -89,12 +89,7 @@ public static class PrivilegedFlagGuard
 
         if (optedIn && inContainer && nonRoot)
         {
-            logger.LogWarning(
-                "Privileged browser flag '{Flag}' permitted: container={Container}, nonRoot={NonRoot}, optIn={OptIn}.",
-                offendingArg ?? "DisableSandbox",
-                inContainer,
-                nonRoot,
-                optedIn);
+            LogPrivilegedFlagPermitted(logger, offendingArg ?? "DisableSandbox", inContainer, nonRoot, optedIn);
             return;
         }
 
@@ -102,6 +97,11 @@ public static class PrivilegedFlagGuard
             SandboxViolationKind.PrivilegedFlagRefused,
             $"Privileged browser flag '{offendingArg ?? "DisableSandbox"}' refused (container={inContainer}, nonRoot={nonRoot}, optIn={optedIn}). Set {OptInEnvVar}=1 in a non-root container to allow.");
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Privileged browser flag '{Flag}' permitted: container={Container}, nonRoot={NonRoot}, optIn={OptIn}.")]
+    private static partial void LogPrivilegedFlagPermitted(
+        ILogger logger, string flag, bool container, bool nonRoot, bool optIn);
 }
 
 /// <summary>Pluggable probe for container / privilege detection — enables unit tests.</summary>

--- a/src/Granit.Browsing/Pool/TenantAwareHeadlessBrowser.cs
+++ b/src/Granit.Browsing/Pool/TenantAwareHeadlessBrowser.cs
@@ -29,7 +29,7 @@ namespace Granit.Browsing.Pool;
 /// <see cref="IHeadlessBrowserPool"/> in F8 / F9.
 /// </para>
 /// </remarks>
-public sealed class TenantAwareHeadlessBrowser : IHeadlessBrowser
+public sealed partial class TenantAwareHeadlessBrowser : IHeadlessBrowser
 {
     private readonly IHeadlessBrowser _inner;
     private readonly ICurrentTenant _currentTenant;
@@ -102,10 +102,14 @@ public sealed class TenantAwareHeadlessBrowser : IHeadlessBrowser
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Failed to publish BrowserPageAcquiredEvent.");
+                LogPublishFailed(_logger, ex);
             }
         }
 
         return page;
     }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Failed to publish BrowserPageAcquiredEvent.")]
+    private static partial void LogPublishFailed(ILogger logger, Exception ex);
 }

--- a/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
+++ b/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Granit.AI;
@@ -150,7 +151,7 @@ internal sealed partial class AISemanticMappingService(
         sb.AppendLine("""- "target": exact target property path""");
         sb.AppendLine("""- "score": confidence score 0.0 to 1.0""");
         sb.AppendLine();
-        sb.Append($"Only include confident matches (score >= {minConfidenceScore:F1}). ");
+        sb.Append(CultureInfo.InvariantCulture, $"Only include confident matches (score >= {minConfidenceScore:F1}). ");
         sb.AppendLine("Return [] if no good matches found.");
         sb.AppendLine("Return ONLY the JSON array, no markdown fences or extra text.");
 

--- a/src/Granit.Features/Definitions/FeatureGroupDefinition.cs
+++ b/src/Granit.Features/Definitions/FeatureGroupDefinition.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.Features.ValueTypes;
 
 namespace Granit.Features.Definitions;
@@ -71,7 +72,7 @@ public sealed class FeatureGroupDefinition
     {
         _features.Add(new FeatureDefinition(
             name,
-            defaultValue.ToString(),
+            defaultValue.ToString(CultureInfo.InvariantCulture),
             FeatureValueType.Numeric)
         {
             DisplayName = displayName,

--- a/src/Granit.Http.Bulkhead/TenantPartitionedBulkhead.cs
+++ b/src/Granit.Http.Bulkhead/TenantPartitionedBulkhead.cs
@@ -119,7 +119,11 @@ public sealed class TenantPartitionedBulkhead(
         string? matchedRole = _options.BypassRoles.FirstOrDefault(currentUser.IsInRole);
         if (matchedRole is not null)
         {
-            BulkheadLog.LogBypassApplied(logger, policyName, $"Role:{matchedRole}", currentUser.UserId);
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                string reason = $"Role:{matchedRole}";
+                BulkheadLog.LogBypassApplied(logger, policyName, reason, currentUser.UserId);
+            }
             return true;
         }
 

--- a/src/Granit.Http.Idempotency/Diagnostics/IdempotencyMetrics.cs
+++ b/src/Granit.Http.Idempotency/Diagnostics/IdempotencyMetrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 
 namespace Granit.Http.Idempotency.Diagnostics;
 
@@ -56,7 +57,7 @@ public sealed class IdempotencyMetrics
         _responsesReplayed.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
-            { "status_code", statusCode.ToString() },
+            { "status_code", statusCode.ToString(CultureInfo.InvariantCulture) },
         });
 
     public void RecordHashMismatch(string? tenantId) =>

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -127,7 +128,7 @@ internal sealed partial class IdempotencyMiddleware(
             // return 409 + Retry-After so the client retries in a window where
             // we can re-acquire cleanly. Preserves the at-most-once guarantee.
             int retryAfter = (int)_opts.InProgressTtl.TotalSeconds;
-            context.Response.Headers.RetryAfter = retryAfter.ToString();
+            context.Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
             LogRaceCondition(_logger, redisKey);
             await WriteProblemAsync(context, StatusCodes.Status409Conflict,
                 "Idempotency Race",
@@ -153,7 +154,7 @@ internal sealed partial class IdempotencyMiddleware(
         if (entry.State == IdempotencyState.InProgress)
         {
             int retryAfter = (int)_opts.InProgressTtl.TotalSeconds;
-            context.Response.Headers.RetryAfter = retryAfter.ToString();
+            context.Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
             await WriteProblemAsync(context, StatusCodes.Status409Conflict,
                 "Request In Progress",
                 $"A request with this idempotency key is already being processed. Retry after {retryAfter}s.").ConfigureAwait(false);

--- a/src/Granit.Http.Resilience/Diagnostics/HttpResilienceMetrics.cs
+++ b/src/Granit.Http.Resilience/Diagnostics/HttpResilienceMetrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 
 namespace Granit.Http.Resilience.Diagnostics;
 
@@ -37,7 +38,7 @@ public sealed class HttpResilienceMetrics
         {
             { "tenant_id", tenantId ?? "global" },
             { "client_name", clientName },
-            { "attempt_number", attemptNumber.ToString() },
+            { "attempt_number", attemptNumber.ToString(CultureInfo.InvariantCulture) },
         });
 
     public void RecordCircuitBreakerStateChanged(string? tenantId, string clientName, string state) =>

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -925,7 +925,11 @@ internal sealed partial class EntraIdIdentityProvider(
             ?? throw new InvalidOperationException("Entra ID did not return a user ID after creation.");
 
         activity?.SetTag(IdentityEntraIdActivitySource.TagUserId, createdUserId);
-        LogUserCreated(LogRedaction.Username(user.Username), createdUserId);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(user.Username);
+            LogUserCreated(redactedUsername, createdUserId);
+        }
 
         var createdIdentityUser = new FederatedIdentityUser(
             createdUserId,
@@ -1090,11 +1094,19 @@ internal sealed partial class EntraIdIdentityProvider(
 
         if (response.IsSuccessStatusCode)
         {
-            LogCredentialVerificationSucceeded(LogRedaction.Username(username));
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                string redactedUsername = LogRedaction.Username(username);
+                LogCredentialVerificationSucceeded(redactedUsername);
+            }
             return true;
         }
 
-        LogCredentialVerificationFailed(LogRedaction.Username(username), (int)response.StatusCode);
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            string redactedUsername = LogRedaction.Username(username);
+            LogCredentialVerificationFailed(redactedUsername, (int)response.StatusCode);
+        }
         return false;
     }
 

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -834,7 +834,11 @@ internal sealed partial class KeycloakIdentityProvider(
                 .ConfigureAwait(false);
         }
 
-        LogUserCreated(LogRedaction.Username(user.Username), createdUserId);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(user.Username);
+            LogUserCreated(redactedUsername, createdUserId);
+        }
 
         metrics.RecordOperationCompleted(null, "create_user", ProviderName, "created");
         metrics.RecordOperationDuration(null, "create_user", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
@@ -1104,11 +1108,19 @@ internal sealed partial class KeycloakIdentityProvider(
 
         if (response.IsSuccessStatusCode)
         {
-            LogCredentialVerificationSucceeded(LogRedaction.Username(username));
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                string redactedUsername = LogRedaction.Username(username);
+                LogCredentialVerificationSucceeded(redactedUsername);
+            }
             return true;
         }
 
-        LogCredentialVerificationFailed(LogRedaction.Username(username), (int)response.StatusCode);
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            string redactedUsername = LogRedaction.Username(username);
+            LogCredentialVerificationFailed(redactedUsername, (int)response.StatusCode);
+        }
         return false;
     }
 

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
@@ -289,7 +289,7 @@ internal sealed partial class AspNetPasskeyService(
 
             await userManager.AddOrUpdatePasskeyAsync(user, updated).ConfigureAwait(false);
 
-            Log.AssertionCompleted(logger, user.Id.ToString());
+            Log.AssertionCompleted(logger, user.Id);
             return new GranitPasskeyAssertionResult(Succeeded: true, UserId: user.Id.ToString());
         }
         catch (Fido2VerificationException ex)
@@ -418,7 +418,7 @@ internal sealed partial class AspNetPasskeyService(
         public static partial void PasskeyDeleted(ILogger logger, string userId, Guid passkeyId);
 
         [LoggerMessage(Level = LogLevel.Information, Message = "Passkey assertion completed for user {UserId}")]
-        public static partial void AssertionCompleted(ILogger logger, string userId);
+        public static partial void AssertionCompleted(ILogger logger, Guid userId);
 
         [LoggerMessage(Level = LogLevel.Warning, Message = "Passkey assertion failed: {Reason}")]
         public static partial void AssertionFailed(ILogger logger, string reason);

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -138,7 +138,11 @@ internal sealed partial class GranitRoleOrchestrator(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogAtomicPathUnavailable(logger, $"host factory failed: {ex.GetType().Name}");
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                string reason = $"host factory failed: {ex.GetType().Name}";
+                LogAtomicPathUnavailable(logger, reason);
+            }
             return AtomicResolution.NotAtomic;
         }
 

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TotpService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TotpService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Granit.Identity.Local.Services;
@@ -93,7 +94,7 @@ internal sealed class TotpService(
                        | (hash[offset + 3] & 0xFF);
 
         int otp = binaryCode % CodeModulus;
-        return otp.ToString().PadLeft(CodeDigits, '0');
+        return otp.ToString(CultureInfo.InvariantCulture).PadLeft(CodeDigits, '0');
     }
 #pragma warning restore CA5350
 

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -150,7 +150,7 @@ internal static partial class AccountLoginEndpoints
 
         if (result.Succeeded)
         {
-            LogLoginSuccess(logger, user.Id.ToString());
+            LogLoginSuccess(logger, user.Id);
             metrics?.RecordAuthenticationSuccess(null, "password");
 
             return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
@@ -158,14 +158,14 @@ internal static partial class AccountLoginEndpoints
 
         if (result.RequiresTwoFactor)
         {
-            LogLoginTwoFactor(logger, user.Id.ToString());
+            LogLoginTwoFactor(logger, user.Id);
             return TypedResults.Ok(new AccountLoginResponse(
                 Succeeded: false, RequiresTwoFactor: true));
         }
 
         if (result.IsLockedOut)
         {
-            LogLoginLockedOut(logger, user.Id.ToString());
+            LogLoginLockedOut(logger, user.Id);
             metrics?.RecordAuthenticationFailure(null, "account_locked");
 
             await PublishAccountLockedAsync(httpContext, userManager, user, cancellationToken)
@@ -180,7 +180,7 @@ internal static partial class AccountLoginEndpoints
 
         if (result.IsNotAllowed)
         {
-            LogLoginNotAllowed(logger, user.Id.ToString());
+            LogLoginNotAllowed(logger, user.Id);
             metrics?.RecordAuthenticationFailure(null, "email_not_confirmed");
 
             return TypedResults.Problem(
@@ -272,7 +272,7 @@ internal static partial class AccountLoginEndpoints
             LocalIdentity? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
                 .ConfigureAwait(false);
 
-            LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
+            LogLoginLockedOut(logger, lockedUser?.Id ?? Guid.Empty);
             metrics?.RecordAuthenticationFailure(null, "account_locked");
 
             if (lockedUser is not null)
@@ -394,16 +394,16 @@ internal static partial class AccountLoginEndpoints
     // ──── Source-generated log messages ────
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Headless login: user {UserId} authenticated successfully")]
-    private static partial void LogLoginSuccess(ILogger logger, string userId);
+    private static partial void LogLoginSuccess(ILogger logger, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Headless login: user {UserId} requires two-factor authentication")]
-    private static partial void LogLoginTwoFactor(ILogger logger, string userId);
+    private static partial void LogLoginTwoFactor(ILogger logger, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: user {UserId} is locked out")]
-    private static partial void LogLoginLockedOut(ILogger logger, string userId);
+    private static partial void LogLoginLockedOut(ILogger logger, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: user {UserId} sign-in not allowed")]
-    private static partial void LogLoginNotAllowed(ILogger logger, string userId);
+    private static partial void LogLoginNotAllowed(ILogger logger, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: failed for '{Login}' — {Reason}")]
     private static partial void LogLoginFailed(ILogger logger, string login, string reason);

--- a/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
+++ b/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
@@ -53,7 +53,11 @@ internal sealed partial class BrevoNotificationProvider(
             "smtp/email", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync("smtp/email", response, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient);
+        }
     }
 
     /// <inheritdoc />
@@ -74,7 +78,11 @@ internal sealed partial class BrevoNotificationProvider(
             "transactionalSMS/sms", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync("transactionalSMS/sms", response, cancellationToken).ConfigureAwait(false);
 
-        LogSmsSent(LogRedaction.Phone(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Phone(message.To);
+            LogSmsSent(redactedRecipient);
+        }
     }
 
     /// <inheritdoc />
@@ -95,7 +103,11 @@ internal sealed partial class BrevoNotificationProvider(
             "whatsapp/sendTemplate", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync("whatsapp/sendTemplate", response, cancellationToken).ConfigureAwait(false);
 
-        LogWhatsAppSent(LogRedaction.Phone(message.To), message.TemplateName);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Phone(message.To);
+            LogWhatsAppSent(redactedRecipient, message.TemplateName);
+        }
     }
 
     /// <summary>

--- a/src/Granit.Notifications.Email.AwsSes/Internal/AwsSesEmailSender.cs
+++ b/src/Granit.Notifications.Email.AwsSes/Internal/AwsSesEmailSender.cs
@@ -70,7 +70,11 @@ internal sealed partial class AwsSesEmailSender(
         using IAwsSesTransport transport = _transportFactory();
         await transport.SendEmailAsync(request, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To), ses.Region);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient, ses.Region);
+        }
     }
 
     private static List<MessageHeader>? BuildMessageHeaders(IReadOnlyDictionary<string, string>? headers)

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
@@ -63,7 +63,11 @@ internal sealed partial class AcsEmailSender(
 
         await transport.SendAsync(acsMessage, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ACS email sent to {RedactedRecipient}")]

--- a/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
+++ b/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
@@ -59,7 +59,11 @@ internal sealed partial class ScalewayEmailSender(
             "emails", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient);
+        }
     }
 
     /// <summary>

--- a/src/Granit.Notifications.Email.SendGrid/Internal/SendGridEmailSender.cs
+++ b/src/Granit.Notifications.Email.SendGrid/Internal/SendGridEmailSender.cs
@@ -60,7 +60,11 @@ internal sealed partial class SendGridEmailSender(
             "mail/send", payload, JsonOptions, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient);
+        }
     }
 
     /// <summary>

--- a/src/Granit.Notifications.Email.Smtp/Internal/MailKitEmailSender.cs
+++ b/src/Granit.Notifications.Email.Smtp/Internal/MailKitEmailSender.cs
@@ -76,7 +76,11 @@ internal sealed partial class MailKitEmailSender(
         await client.SendAsync(mimeMessage, cancellationToken).ConfigureAwait(false);
         await client.DisconnectAsync(quit: true, cancellationToken).ConfigureAwait(false);
 
-        LogEmailSent(LogRedaction.Email(message.To), smtp.Host, smtp.Port);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Email(message.To);
+            LogEmailSent(redactedRecipient, smtp.Host, smtp.Port);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SMTP email sent to {RedactedRecipient} via {Host}:{Port}")]

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
@@ -98,7 +98,11 @@ internal sealed partial class GoogleFcmMobilePushSender(
             response.EnsureSuccessStatusCode();
         }
 
-        LogMessageSent(LogRedaction.Token(token), projectId);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedToken = LogRedaction.Token(token);
+            LogMessageSent(redactedToken, projectId);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "FCM push sent to token {RedactedToken} for project {ProjectId}")]

--- a/src/Granit.Notifications.Sms.AwsSns/Internal/AwsSnsSmsSender.cs
+++ b/src/Granit.Notifications.Sms.AwsSns/Internal/AwsSnsSmsSender.cs
@@ -67,7 +67,11 @@ internal sealed partial class AwsSnsSmsSender(
             .PublishAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        LogSmsSent(LogRedaction.Phone(message.To), response.MessageId);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Phone(message.To);
+            LogSmsSent(redactedRecipient, response.MessageId);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SNS SMS sent to {RedactedRecipient}, messageId={MessageId}")]

--- a/src/Granit.Notifications.Sms.AzureCommunicationServices/Internal/AcsSmsSender.cs
+++ b/src/Granit.Notifications.Sms.AzureCommunicationServices/Internal/AcsSmsSender.cs
@@ -36,11 +36,19 @@ internal sealed partial class AcsSmsSender(
 
         if (result.Successful)
         {
-            LogSmsSent(LogRedaction.Phone(message.To), result.MessageId);
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                string redactedRecipient = LogRedaction.Phone(message.To);
+                LogSmsSent(redactedRecipient, result.MessageId);
+            }
         }
         else
         {
-            LogSmsFailed(LogRedaction.Phone(message.To), result.ErrorMessage);
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                string redactedRecipient = LogRedaction.Phone(message.To);
+                LogSmsFailed(redactedRecipient, result.ErrorMessage);
+            }
         }
     }
 

--- a/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
+++ b/src/Granit.Notifications.Twilio/Internal/TwilioNotificationProvider.cs
@@ -37,7 +37,11 @@ internal sealed partial class TwilioNotificationProvider(
             endpoint, content, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(endpoint, response, cancellationToken).ConfigureAwait(false);
 
-        LogSmsSent(LogRedaction.Phone(message.To));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Phone(message.To);
+            LogSmsSent(redactedRecipient);
+        }
     }
 
     /// <inheritdoc />
@@ -62,7 +66,11 @@ internal sealed partial class TwilioNotificationProvider(
             endpoint, content, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(endpoint, response, cancellationToken).ConfigureAwait(false);
 
-        LogWhatsAppSent(LogRedaction.Phone(message.To), message.TemplateName);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedRecipient = LogRedaction.Phone(message.To);
+            LogWhatsAppSent(redactedRecipient, message.TemplateName);
+        }
     }
 
     /// <summary>

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.Diagnostics;
 using Granit.Observability.Options;
 using Microsoft.Extensions.Configuration;
@@ -83,7 +84,8 @@ public static class ObservabilityServiceCollectionExtensions
                 .Enrich.WithProperty("ServiceVersion", options.ServiceVersion)
                 .Enrich.WithProperty("Environment", options.Environment)
                 .WriteTo.Console(
-                    outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}")
+                    outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext} {Message:lj}{NewLine}{Exception}",
+                    formatProvider: CultureInfo.InvariantCulture)
                 .WriteTo.OpenTelemetry(otel =>
                 {
                     otel.Endpoint = options.OtlpEndpoint;

--- a/src/Granit.Oidc.TokenManagement/Handlers/ClientCredentialsTokenHandler.cs
+++ b/src/Granit.Oidc.TokenManagement/Handlers/ClientCredentialsTokenHandler.cs
@@ -64,7 +64,11 @@ internal sealed partial class ClientCredentialsTokenHandler(
         // On 401 Unauthorized, invalidate the cached token and retry once
         if (response.StatusCode is HttpStatusCode.Unauthorized)
         {
-            LogUnauthorizedRetry(ClientName, request.RequestUri?.ToString() ?? "unknown");
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                string requestUri = request.RequestUri?.ToString() ?? "unknown";
+                LogUnauthorizedRetry(ClientName, requestUri);
+            }
 
             await tokenCache.RemoveTokenAsync(ClientName, cancellationToken).ConfigureAwait(false);
             accessToken = await AcquireTokenAsync(options, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -189,7 +189,7 @@ internal static partial class ConnectAuthorizationEndpoints
             .ConfigureAwait(false);
         principal.SetAuthorizationId(authorizationId);
 
-        LogAuthorizationGranted(logger, user.Id.ToString(), request.ClientId!);
+        LogAuthorizationGranted(logger, user.Id, request.ClientId!);
 
         string? tenantId = requestTenant is { IsAvailable: true } ? requestTenant.Id?.ToString() : null;
         OpenIddictMetrics metrics = context.RequestServices.GetRequiredService<OpenIddictMetrics>();
@@ -214,5 +214,5 @@ internal static partial class ConnectAuthorizationEndpoints
     private static partial void LogUserNotFound(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Authorization granted for subject '{Subject}' to client '{ClientId}'")]
-    private static partial void LogAuthorizationGranted(ILogger logger, string subject, string clientId);
+    private static partial void LogAuthorizationGranted(ILogger logger, Guid subject, string clientId);
 }

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -131,7 +131,11 @@ internal static partial class ConnectTokenEndpoints
             string grantType = request.GrantType!;
             metrics.RecordTokenIssued(tenantId, grantType);
             metrics.RecordAuthenticationSuccess(tenantId, grantType);
-            LogTokenIssued(logger, user.Id.ToString(), grantType);
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                string userSubject = user.Id.ToString();
+                LogTokenIssued(logger, userSubject, grantType);
+            }
 
             return Results.SignIn(principal,
                 authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);

--- a/src/Granit.OpenIddict/Services/DefaultTotpService.cs
+++ b/src/Granit.OpenIddict/Services/DefaultTotpService.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Granit.Identity.Local.Services;
@@ -89,7 +90,7 @@ internal sealed class DefaultTotpService(IClock clock) : ITotpService
                        | (hash[offset + 3] & 0xFF);
 
         int otp = binaryCode % CodeModulus;
-        return otp.ToString().PadLeft(CodeDigits, '0');
+        return otp.ToString(CultureInfo.InvariantCulture).PadLeft(CodeDigits, '0');
     }
 #pragma warning restore CA5350
 

--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -37,7 +37,7 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// </remarks>
 /// <typeparam name="TEntity">The entity type (must inherit <see cref="Entity"/>).</typeparam>
 /// <typeparam name="TContext">The isolated <see cref="DbContext"/> type.</typeparam>
-public abstract class EfStoreBase<TEntity, TContext>
+public abstract partial class EfStoreBase<TEntity, TContext>
     where TEntity : Entity
     where TContext : DbContext
 {
@@ -170,23 +170,27 @@ public abstract class EfStoreBase<TEntity, TContext>
     }
 
     private void LogUnsignaledCrossTenantQuery(string entity) =>
-        _logger.LogWarning(
-            "Unsignaled cross-tenant query on {Entity}: ICurrentTenant.IsAvailable=false and "
-            + "no host-access signal was set on the request. This signals a tenant-context "
-            + "loss between request entry and the data layer. Investigate the call-site or "
-            + "mark the endpoint with .AllowHostAccess() if the bypass is intentional.",
-            entity);
+        LogUnsignaledCrossTenantQueryCore(_logger, entity);
 
     private void LogHostEndpointCrossTenantQuery(string entity) =>
-        _logger.LogInformation(
-            "Host-endpoint cross-tenant query on {Entity}: served via .AllowHostAccess() route.",
-            entity);
+        LogHostEndpointCrossTenantQueryCore(_logger, entity);
 
     private void LogExplicitCrossTenantQuery(
         string entity, string callerMember, string callerFile, int callerLine) =>
-        _logger.LogInformation(
-            "Explicit cross-tenant query on {Entity} from {CallerMember} ({CallerFile}:{CallerLine}).",
-            entity, callerMember, callerFile, callerLine);
+        LogExplicitCrossTenantQueryCore(_logger, entity, callerMember, callerFile, callerLine);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Unsignaled cross-tenant query on {Entity}: ICurrentTenant.IsAvailable=false and no host-access signal was set on the request. This signals a tenant-context loss between request entry and the data layer. Investigate the call-site or mark the endpoint with .AllowHostAccess() if the bypass is intentional.")]
+    private static partial void LogUnsignaledCrossTenantQueryCore(ILogger logger, string entity);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Host-endpoint cross-tenant query on {Entity}: served via .AllowHostAccess() route.")]
+    private static partial void LogHostEndpointCrossTenantQueryCore(ILogger logger, string entity);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Explicit cross-tenant query on {Entity} from {CallerMember} ({CallerFile}:{CallerLine}).")]
+    private static partial void LogExplicitCrossTenantQueryCore(
+        ILogger logger, string entity, string callerMember, string callerFile, int callerLine);
 
     // ── Read helpers ────────────────────────────────────────────────────
 

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalDocumentPublicationService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Events;
@@ -50,7 +51,7 @@ internal sealed class LegalDocumentPublicationService(
         // Archive the old version (dispatches LegalAgreementObsoleteEto via domain event).
         if (currentPublished is not null)
         {
-            currentPublished.Archive(draft.Version.ToString());
+            currentPublished.Archive(draft.Version.ToString(CultureInfo.InvariantCulture));
         }
 
         // Publish the new version.

--- a/src/Granit.Privacy/LegalAgreements/Domain/LegalDocument.cs
+++ b/src/Granit.Privacy/LegalAgreements/Domain/LegalDocument.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.Domain;
 using Granit.Privacy.LegalAgreements.Events;
 using Granit.Workflow.Domain;
@@ -125,7 +126,7 @@ public sealed class LegalDocument : VersionedWorkflowEntity, IMultiTenant, IWork
         SetLifecycleStatus(WorkflowLifecycleStatus.Archived);
 
         AddDistributedEvent(new LegalAgreementObsoleteEto(
-            DocumentId, Version.ToString(), newVersion));
+            DocumentId, Version.ToString(CultureInfo.InvariantCulture), newVersion));
     }
 
     private void EnsureDraft()

--- a/src/Granit.Privacy/LegalAgreements/Internal/CompositeLegalDocumentRegistry.cs
+++ b/src/Granit.Privacy/LegalAgreements/Internal/CompositeLegalDocumentRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using Granit.Privacy.LegalAgreements.Domain;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -69,7 +70,7 @@ internal sealed class CompositeLegalDocumentRegistry(
         {
             _cache[doc.DocumentId] = new LegalDocumentDefinition(
                 doc.DocumentId,
-                doc.Version.ToString(),
+                doc.Version.ToString(CultureInfo.InvariantCulture),
                 doc.DisplayName);
         }
 

--- a/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
+++ b/src/Granit.QueryEngine.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Granit.AI;
@@ -138,7 +139,7 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
             foreach (FilterableField field in metadata.FilterableFields)
             {
                 string operators = string.Join(", ", field.Operators.Select(static op => op.ToString().ToLowerInvariant()));
-                sb.AppendLine($"  - {field.Name} (type: {field.Type}, operators: {operators})");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  - {field.Name} (type: {field.Type}, operators: {operators})");
             }
 
             sb.AppendLine();
@@ -151,7 +152,7 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
 
             foreach (SortableField field in metadata.SortableFields)
             {
-                sb.AppendLine($"  - {field.Name}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  - {field.Name}");
             }
 
             sb.AppendLine("Sort format: comma-separated field names. Prefix with - for descending (e.g. \"-createdAt,lastName\").");
@@ -165,7 +166,7 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
 
             foreach (QuickFilterMeta qf in metadata.QuickFilters)
             {
-                sb.AppendLine($"  - \"{qf.Name}\" (label: {qf.Label})");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  - \"{qf.Name}\" (label: {qf.Label})");
             }
 
             sb.AppendLine();
@@ -179,7 +180,7 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
             foreach (DateFilterMeta df in metadata.DateFilters)
             {
                 string periods = string.Join(", ", df.AvailablePeriods.Select(static p => p.ToString()));
-                sb.AppendLine($"  - {df.Name} (periods: {periods})");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  - {df.Name} (periods: {periods})");
             }
 
             sb.AppendLine();
@@ -192,14 +193,14 @@ internal sealed partial class LlmNaturalLanguageQueryTranslator(
 
             foreach (GroupByField field in metadata.GroupByFields)
             {
-                sb.AppendLine($"  - {field.Name}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  - {field.Name}");
             }
 
             sb.AppendLine();
         }
 
         sb.AppendLine("Filter key format: \"fieldName.operator\" (e.g. \"status.eq\", \"amount.gte\", \"name.contains\").");
-        sb.AppendLine($"Current date: {clock.Now:yyyy-MM-dd}. Use this for relative date references (\"this week\", \"last month\").");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"Current date: {clock.Now:yyyy-MM-dd}. Use this for relative date references (\"this week\", \"last month\").");
         sb.AppendLine();
         sb.AppendLine("Rules:");
         sb.AppendLine("- Return ONLY valid JSON, no explanation.");

--- a/src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs
+++ b/src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.RateLimiting.Abstractions;
 using Granit.RateLimiting.Exceptions;
 using Microsoft.AspNetCore.Builder;
@@ -34,7 +35,7 @@ public static class RateLimitEndpointExtensions
 
             if (result is { IsAllowed: false })
             {
-                context.HttpContext.Response.Headers[HeaderNames.RetryAfter] = ((int)Math.Ceiling(result.RetryAfter.TotalSeconds)).ToString();
+                context.HttpContext.Response.Headers[HeaderNames.RetryAfter] = ((int)Math.Ceiling(result.RetryAfter.TotalSeconds)).ToString(CultureInfo.InvariantCulture);
 
                 return TypedResults.Problem(
                     detail: "Too many requests. Please retry later.",
@@ -52,8 +53,8 @@ public static class RateLimitEndpointExtensions
             {
                 context.HttpContext.Response.OnStarting(() =>
                 {
-                    context.HttpContext.Response.Headers["X-RateLimit-Limit"] = result.Limit.ToString();
-                    context.HttpContext.Response.Headers["X-RateLimit-Remaining"] = result.Remaining.ToString();
+                    context.HttpContext.Response.Headers["X-RateLimit-Limit"] = result.Limit.ToString(CultureInfo.InvariantCulture);
+                    context.HttpContext.Response.Headers["X-RateLimit-Remaining"] = result.Remaining.ToString(CultureInfo.InvariantCulture);
                     return Task.CompletedTask;
                 });
             }

--- a/src/Granit.Templating.Scriban/Exceptions/TemplateParseException.cs
+++ b/src/Granit.Templating.Scriban/Exceptions/TemplateParseException.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Scriban.Parsing;
 
 namespace Granit.Templating.Scriban.Exceptions;
@@ -26,7 +27,7 @@ public sealed class TemplateParseException : Exception
         sb.AppendLine("Failed to parse Scriban template. Errors:");
         foreach (LogMessage error in errors)
         {
-            sb.AppendLine($"  [{error.Type}] {error.Span}: {error.Message}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"  [{error.Type}] {error.Span}: {error.Message}");
         }
         return sb.ToString();
     }

--- a/src/Granit.Templating.Scriban/GlobalContexts/NowGlobalContext.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/NowGlobalContext.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Granit.Templating.GlobalContext;
 using Granit.Timing;
 
@@ -35,13 +36,13 @@ internal sealed class NowGlobalContext(IClock clock) : ITemplateGlobalContext
         DateTimeOffset now = _clock.Now;
         return new
         {
-            date = now.ToString("dd/MM/yyyy"),
-            datetime = now.ToString("dd/MM/yyyy HH:mm"),
-            iso = now.ToString("O"),
-            year = now.Year.ToString("D4"),
-            month = now.Month.ToString("D2"),
-            day = now.Day.ToString("D2"),
-            time = now.ToString("HH:mm"),
+            date = now.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+            datetime = now.ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture),
+            iso = now.ToString("O", CultureInfo.InvariantCulture),
+            year = now.Year.ToString("D4", CultureInfo.InvariantCulture),
+            month = now.Month.ToString("D2", CultureInfo.InvariantCulture),
+            day = now.Day.ToString("D2", CultureInfo.InvariantCulture),
+            time = now.ToString("HH:mm", CultureInfo.InvariantCulture),
         };
     }
 }

--- a/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Granit.AI;
@@ -180,7 +181,7 @@ internal sealed partial class LlmTimelineAnomalyDetector(
         {
             // VULN-002: Pseudonymize PII — never send AuthorName ([SensitiveData]) to external LLM
             string author = entry.AuthorId is { Length: >= 8 } id ? $"User-{id[..8]}" : "System";
-            sb.AppendLine($"- [{entry.OccurredAt:u}] ({entry.EntryType}) {author}: {entry.Body}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- [{entry.OccurredAt:u}] ({entry.EntryType}) {author}: {entry.Body}");
         }
 
         pb.AppendUserTextBlock("Timeline entries (newest first)", sb.ToString());

--- a/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Granit.AI;
 using Granit.MultiTenancy;
@@ -201,7 +202,7 @@ internal sealed partial class LlmTimelineSummarizer(
         {
             // VULN-002: Pseudonymize PII — never send AuthorName ([SensitiveData]) to external LLM
             string author = entry.AuthorId is { Length: >= 8 } id ? $"User-{id[..8]}" : "System";
-            sb.AppendLine($"- [{entry.OccurredAt:u}] ({entry.EntryType}) {author}: {entry.Body}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- [{entry.OccurredAt:u}] ({entry.EntryType}) {author}: {entry.Body}");
         }
 
         pb.AppendUserTextBlock("Timeline entries (newest first)", sb.ToString());

--- a/src/Granit.Validation.Europe/Internal/FrenchRibAlgorithm.cs
+++ b/src/Granit.Validation.Europe/Internal/FrenchRibAlgorithm.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Granit.Validation.Europe.Internal;
 
 /// <summary>
@@ -66,10 +68,10 @@ internal static class FrenchRibAlgorithm
             return false;
         }
 
-        long bank = long.Parse(bankStr);
-        long branch = long.Parse(branchStr);
-        long account = long.Parse(accountDigits);
-        int providedKey = int.Parse(keyStr);
+        long bank = long.Parse(bankStr, CultureInfo.InvariantCulture);
+        long branch = long.Parse(branchStr, CultureInfo.InvariantCulture);
+        long account = long.Parse(accountDigits, CultureInfo.InvariantCulture);
+        int providedKey = int.Parse(keyStr, CultureInfo.InvariantCulture);
 
         long remainder = (89L * bank + 15L * branch + 3L * account) % 97;
         int expectedKey = remainder == 0 ? 97 : (int)(97 - remainder);

--- a/src/Granit.Vault.Aws/Services/AwsSecretsCredentialProvider.cs
+++ b/src/Granit.Vault.Aws/Services/AwsSecretsCredentialProvider.cs
@@ -117,7 +117,11 @@ internal sealed partial class AwsSecretsCredentialProvider(
         _store.Apply(username, password);
         _versionId = response.VersionId;
 
-        LogCredentialsObtained(LogRedaction.Username(username), _versionId);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(username);
+            LogCredentialsObtained(redactedUsername, _versionId);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting AWS Secrets Manager credential manager")]

--- a/src/Granit.Vault.Azure/Services/AzureSecretsCredentialProvider.cs
+++ b/src/Granit.Vault.Azure/Services/AzureSecretsCredentialProvider.cs
@@ -111,7 +111,11 @@ internal sealed partial class AzureSecretsCredentialProvider(
         _store.Apply(username, password);
         _version = secret.Properties.Version ?? string.Empty;
 
-        LogCredentialsObtained(LogRedaction.Username(username), _version);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(username);
+            LogCredentialsObtained(redactedUsername, _version);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting Azure Key Vault Secrets credential manager")]

--- a/src/Granit.Vault.GoogleCloud/Services/SecretManagerCredentialProvider.cs
+++ b/src/Granit.Vault.GoogleCloud/Services/SecretManagerCredentialProvider.cs
@@ -65,7 +65,11 @@ internal sealed partial class SecretManagerCredentialProvider(
         SecretVersionName secretVersionName = new(
             _options.ProjectId, _options.DatabaseSecretName, "latest");
 
-        LogObtainingCredentials(secretVersionName.ToString());
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string secretName = secretVersionName.ToString();
+            LogObtainingCredentials(secretName);
+        }
 
         using System.Diagnostics.Activity? activity = VaultGoogleCloudActivitySource.Source.StartActivity(
             VaultGoogleCloudActivitySource.Operations.SecretsObtain);
@@ -115,7 +119,11 @@ internal sealed partial class SecretManagerCredentialProvider(
         _store.Apply(username, password);
         _versionName = response.Name;
 
-        LogCredentialsObtained(LogRedaction.Username(username), _versionName);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(username);
+            LogCredentialsObtained(redactedUsername, _versionName);
+        }
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting Secret Manager credential manager")]

--- a/src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs
+++ b/src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs
@@ -74,7 +74,11 @@ internal sealed partial class VaultCredentialLeaseManager(
         _leaseId = secret.LeaseId;
         _leaseDurationSeconds = secret.LeaseDurationSeconds;
 
-        LogCredentialsObtained(logger, LogRedaction.Username(secret.Data.Username), _leaseDurationSeconds);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string redactedUsername = LogRedaction.Username(secret.Data.Username);
+            LogCredentialsObtained(logger, redactedUsername, _leaseDurationSeconds);
+        }
     }
 
     private async Task RenewLeaseAsync(CancellationToken cancellationToken)

--- a/src/Granit.Webhooks/Diagnostics/WebhooksMetrics.cs
+++ b/src/Granit.Webhooks/Diagnostics/WebhooksMetrics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 
 namespace Granit.Webhooks.Diagnostics;
 
@@ -66,14 +67,14 @@ public sealed class WebhooksMetrics
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEventType, eventType },
-            { "http_status", httpStatus?.ToString() ?? "timeout" },
+            { "http_status", httpStatus?.ToString(CultureInfo.InvariantCulture) ?? "timeout" },
         });
 
     public void RecordSubscriptionSuspended(string? tenantId, int httpStatus) =>
         _subscriptionsSuspended.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
-            { "http_status", httpStatus.ToString() },
+            { "http_status", httpStatus.ToString(CultureInfo.InvariantCulture) },
         });
 
     public void RecordDeliveryDuration(string? tenantId, string eventType, string status, TimeSpan duration) =>

--- a/src/Granit/Modularity/GranitApplication.cs
+++ b/src/Granit/Modularity/GranitApplication.cs
@@ -104,15 +104,20 @@ public sealed partial class GranitApplication
 
     private void LogModuleList(ServiceConfigurationContext context)
     {
+        int enabledCount = 0;
         foreach (ModuleDescriptor module in _modules)
         {
             bool enabled = module.Instance.IsEnabled(context);
             module.IsEnabled = enabled;
+            if (enabled)
+            {
+                enabledCount++;
+            }
             string status = enabled ? "OK" : "DISABLED";
             LogModuleLoaded(module.ModuleType.Name, status);
         }
 
-        LogModuleSummary(_modules.Count, _modules.Count(m => m.IsEnabled));
+        LogModuleSummary(_modules.Count, enabledCount);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Granit module {ModuleName} [{Status}]")]

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,10 @@
     <IsPackable>false</IsPackable>
     <!-- Granit analyzers target production code — test projects legitimately use
          Guid.NewGuid(), DateTimeOffset.UtcNow, and test secrets for setup/assertions. -->
-    <NoWarn>$(NoWarn);GRSEC001;GRSEC002;GRSEC003;GRSEC004;GREF001;RS0030</NoWarn>
+    <!-- CA1305/CA1848/CA1873 are enforced in src/ but relaxed in tests:
+         test code intentionally uses culture-sensitive ToString and inline log calls
+         for readability — perf and locale concerns don't apply to test setup. -->
+    <NoWarn>$(NoWarn);GRSEC001;GRSEC002;GRSEC003;GRSEC004;GREF001;RS0030;CA1305;CA1848;CA1873</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Removes `CA1305`, `CA1848`, `CA1873` from the global `<NoWarn>` in `Directory.Build.props` and fixes every resulting violation in `src/`. This aligns granit-dotnet with granit-business, which refuses to propagate these suppressions.

- **CA1305** (IFormatProvider): ~34 sites — every server-side `ToString`/`Parse`/`string.Format` now uses `CultureInfo.InvariantCulture` (multi-tenant 18-locale framework — never locale-dependent server-side). No `intentional` overrides needed.
- **CA1848** (LoggerMessage source-gen): ~15 host classes migrated to `[LoggerMessage]` partial methods. Matches the existing repo convention (`[LoggerMessage]` is canonical per CLAUDE.md).
- **CA1873** (deferred expensive log args): ~45 sites — hoisted expensive expressions (redactions, `ToString` on aggregates) into local variables inside `if (logger.IsEnabled(...))` blocks. Wrapping alone was insufficient; the analyzer required hoisting.

Tests are exempted via `tests/Directory.Build.props` `NoWarn` (mirroring the existing `GRSEC*`/`GREF001` relaxation pattern) — test code intentionally uses culture-sensitive `ToString` and inline `LogXxx` calls for readability.

Modules touched (67 files): Granit, Granit.Browsing(.Playwright), Granit.Entities, Granit.Persistence.EntityFrameworkCore, Granit.Workspaces, Granit.Auditing, Granit.Identity.Local(.AspNetIdentity, .Endpoints), Granit.Identity.Federated.{EntraId, Keycloak}, Granit.Bff.{Endpoints, Yarp}, all Granit.Notifications.* (Email/SMS/MobilePush incl. Twilio/Brevo), all Granit.Vault.* providers, Granit.Tax.{Builtin, Stripe}, Granit.OpenIddict(.Endpoints), Granit.Oidc.TokenManagement, Granit.Privacy(.EntityFrameworkCore), Granit.Payments.SepaDirectDebit.*, Granit.QueryEngine.AI, Granit.Timeline.AI, Granit.DataExchange.AI, Granit.Templating.Scriban, Granit.Validation.Europe, Granit.RateLimiting, Granit.Webhooks, Granit.Http.{Idempotency, Resilience, Bulkhead}, Granit.Observability, Granit.Features, Granit.Metering.EntityFrameworkCore, Granit.Parties.Deduplication(.BackgroundJobs).

`CA1707`, `CA1861`, `CS1591`, `CS1574`, `CS1734` remain in the global `NoWarn` — separate debate.

## Test plan

- [x] `dotnet build .github/shard-filters/src-only.slnf` — green
- [x] All 7 CI shards build green (`api-data`, `business`, `core-ai`, `infrastructure`, `saas`, `security`, `integration`)
- [x] `dotnet test .github/shard-filters/architecture.slnf` — 248 passed, 0 failed
- [ ] Full CI run on PR