### PR TITLE
refactor(notifications): convert email content templates to MJML

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44317,7 +44317,7 @@
       "kind": "enum",
       "project": "Granit.Workflow",
       "file": "src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs",
-      "line": 6,
+      "line": 8,
       "members": []
     },
     {

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.expiring_soon.fr.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.expiring_soon.fr.html
@@ -1,17 +1,19 @@
 <title>Clé d'API expirant dans {{ model.days_until_expiry }} jour(s) : {{ model.key_name }}</title>
-<p>Bonjour,</p>
-<p>Une de vos clés d'API approche de son expiration. Planifiez la rotation dès maintenant — dès qu'elle expire, tous les appelants qui l'utilisent cessent d'être authentifiés et vos intégrations en aval se cassent silencieusement.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Nom</td><td><strong>{{ model.key_name }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Type</td><td><code>{{ model.key_type }}</code></td></tr>
-  <tr><td style="color: #4b5563;">Expire le</td><td><strong>{{ model.expires_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Jours restants</td><td><strong>{{ model.days_until_expiry }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Référence</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #b45309; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Faire tourner la clé</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration. La rotation produit une nouvelle valeur ; révoquez l'ancienne une fois les intégrations basculées.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Besoin d'aide ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Bonjour,</p>
+  <p>Une de vos clés d'API approche de son expiration. Planifiez la rotation dès maintenant — dès qu'elle expire, tous les appelants qui l'utilisent cessent d'être authentifiés et vos intégrations en aval se cassent silencieusement.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Nom</td><td style="padding: 6px 0;"><strong>{{ model.key_name }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Type</td><td style="padding: 6px 0;"><code>{{ model.key_type }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Expire le</td><td style="padding: 6px 0;"><strong>{{ model.expires_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Jours restants</td><td style="padding: 6px 0;"><strong>{{ model.days_until_expiry }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Référence</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#b45309" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Faire tourner la clé</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration. La rotation produit une nouvelle valeur ; révoquez l'ancienne une fois les intégrations basculées.</p>
+  {{- if app.support_email }}
+  <p>Besoin d'aide ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.expiring_soon.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.expiring_soon.html
@@ -1,17 +1,19 @@
 <title>API key expires in {{ model.days_until_expiry }} day(s): {{ model.key_name }}</title>
-<p>Hi,</p>
-<p>One of your API keys is approaching expiration. Plan rotation now — once the key expires, every caller using it stops being authenticated and your downstream integrations break silently.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Name</td><td><strong>{{ model.key_name }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Type</td><td><code>{{ model.key_type }}</code></td></tr>
-  <tr><td style="color: #4b5563;">Expires</td><td><strong>{{ model.expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Days remaining</td><td><strong>{{ model.days_until_expiry }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Reference</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #b45309; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Rotate the key</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">For your security, the key value is never sent by email — it was shown once at creation time inside the admin panel. Rotating produces a new value; revoke the old one once integrations have been switched over.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Need help? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Hi,</p>
+  <p>One of your API keys is approaching expiration. Plan rotation now — once the key expires, every caller using it stops being authenticated and your downstream integrations break silently.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Name</td><td style="padding: 6px 0;"><strong>{{ model.key_name }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Type</td><td style="padding: 6px 0;"><code>{{ model.key_type }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Expires</td><td style="padding: 6px 0;"><strong>{{ model.expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Days remaining</td><td style="padding: 6px 0;"><strong>{{ model.days_until_expiry }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Reference</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#b45309" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Rotate the key</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>For your security, the key value is never sent by email — it was shown once at creation time inside the admin panel. Rotating produces a new value; revoke the old one once integrations have been switched over.</p>
+  {{- if app.support_email }}
+  <p>Need help? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.new_key_issued.fr.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.new_key_issued.fr.html
@@ -1,15 +1,17 @@
 <title>Nouvelle clé d'API émise : {{ model.key_name }}</title>
-<p>Bonjour,</p>
-<p>Une nouvelle clé d'API vient d'être émise dans votre tenant. Vérifiez que cette opération est attendue — une émission inattendue peut révéler un compte administrateur compromis ou un processus non autorisé.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Nom</td><td><strong>{{ model.key_name }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Type</td><td><code>{{ model.key_type }}</code></td></tr>
-  <tr><td style="color: #4b5563;">Référence</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Vérifier la clé</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Cette opération n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Bonjour,</p>
+  <p>Une nouvelle clé d'API vient d'être émise dans votre tenant. Vérifiez que cette opération est attendue — une émission inattendue peut révéler un compte administrateur compromis ou un processus non autorisé.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Nom</td><td style="padding: 6px 0;"><strong>{{ model.key_name }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Type</td><td style="padding: 6px 0;"><code>{{ model.key_type }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Référence</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Vérifier la clé</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration.</p>
+  {{- if app.support_email }}
+  <p>Cette opération n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.new_key_issued.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.new_key_issued.html
@@ -1,15 +1,17 @@
 <title>New API key issued: {{ model.key_name }}</title>
-<p>Hi,</p>
-<p>A new API key has been issued in your tenant. Confirm this provisioning is expected — out-of-band issuance can indicate a compromised admin account or an unauthorised workflow.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Name</td><td><strong>{{ model.key_name }}</strong></td></tr>
-  <tr><td style="color: #4b5563;">Type</td><td><code>{{ model.key_type }}</code></td></tr>
-  <tr><td style="color: #4b5563;">Reference</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Review the key</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">For your security, the key value itself is never sent by email — it was shown once at creation time inside the admin panel.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Did not expect this? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Hi,</p>
+  <p>A new API key has been issued in your tenant. Confirm this provisioning is expected — out-of-band issuance can indicate a compromised admin account or an unauthorised workflow.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Name</td><td style="padding: 6px 0;"><strong>{{ model.key_name }}</strong></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Type</td><td style="padding: 6px 0;"><code>{{ model.key_type }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Reference</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Review the key</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>For your security, the key value itself is never sent by email — it was shown once at creation time inside the admin panel.</p>
+  {{- if app.support_email }}
+  <p>Did not expect this? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.revoked.fr.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.revoked.fr.html
@@ -1,12 +1,14 @@
 <title>Clé d'API révoquée</title>
-<p>Bonjour,</p>
-<p>Une clé d'API vient d'être révoquée et n'est plus acceptée par la couche d'authentification. Si cette révocation n'était pas attendue, déclenchez votre procédure de réponse à incident : une révocation hors du cycle normal de rotation peut révéler une compromission ou une action administrateur non autorisée.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Référence</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Vérifier la clé</a>
-</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Cette révocation n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Bonjour,</p>
+  <p>Une clé d'API vient d'être révoquée et n'est plus acceptée par la couche d'authentification. Si cette révocation n'était pas attendue, déclenchez votre procédure de réponse à incident : une révocation hors du cycle normal de rotation peut révéler une compromission ou une action administrateur non autorisée.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Référence</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Vérifier la clé</mj-button>
+{{- if app.support_email }}
+<mj-text font-size="13px" color="#4b5563">
+  <p>Cette révocation n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+</mj-text>
+{{- end }}

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.revoked.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.revoked.html
@@ -1,12 +1,14 @@
 <title>API key revoked</title>
-<p>Hi,</p>
-<p>An API key has been revoked and is no longer accepted by the authentication layer. If this revocation was not expected, follow your incident-response procedure: a revocation outside of normal rotation cadence may indicate a compromise or unauthorised admin action.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Reference</td><td><code>{{ model.key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Review the key</a>
-</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Did not expect this revocation? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Hi,</p>
+  <p>An API key has been revoked and is no longer accepted by the authentication layer. If this revocation was not expected, follow your incident-response procedure: a revocation outside of normal rotation cadence may indicate a compromise or unauthorised admin action.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Reference</td><td style="padding: 6px 0;"><code>{{ model.key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.key_id }}">Review the key</mj-button>
+{{- if app.support_email }}
+<mj-text font-size="13px" color="#4b5563">
+  <p>Did not expect this revocation? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+</mj-text>
+{{- end }}

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.rotation_completed.fr.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.rotation_completed.fr.html
@@ -1,14 +1,16 @@
 <title>Clé d'API renouvelée</title>
-<p>Bonjour,</p>
-<p>Une clé d'API vient d'être renouvelée. L'ancienne clé restera acceptée pendant la période de grâce configurée — assurez-vous que tous les consommateurs ont migré vers la nouvelle clé avant l'expiration de cette fenêtre.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Ancienne clé</td><td><code>{{ model.old_key_id }}</code></td></tr>
-  <tr><td style="color: #4b5563;">Nouvelle clé</td><td><code>{{ model.new_key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.new_key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ouvrir la nouvelle clé</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Cette rotation n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Bonjour,</p>
+  <p>Une clé d'API vient d'être renouvelée. L'ancienne clé restera acceptée pendant la période de grâce configurée — assurez-vous que tous les consommateurs ont migré vers la nouvelle clé avant l'expiration de cette fenêtre.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Ancienne clé</td><td style="padding: 6px 0;"><code>{{ model.old_key_id }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Nouvelle clé</td><td style="padding: 6px 0;"><code>{{ model.new_key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.new_key_id }}">Ouvrir la nouvelle clé</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pour des raisons de sécurité, la valeur de la clé n'est jamais transmise par e-mail — elle n'a été affichée qu'une seule fois, à la création, dans le panneau d'administration.</p>
+  {{- if app.support_email }}
+  <p>Cette rotation n'était pas prévue ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.rotation_completed.html
+++ b/src/Granit.Authentication.ApiKeys.Notifications/Templates/apikeys.rotation_completed.html
@@ -1,14 +1,16 @@
 <title>API key rotated</title>
-<p>Hi,</p>
-<p>An API key has been rotated. The previous key will remain accepted during the configured grace period — make sure every consumer has migrated to the new key before that window closes.</p>
-<table cellpadding="6" cellspacing="0" style="margin: 16px 0; font-size: 14px; border-collapse: collapse;">
-  <tr><td style="color: #4b5563;">Previous key</td><td><code>{{ model.old_key_id }}</code></td></tr>
-  <tr><td style="color: #4b5563;">New key</td><td><code>{{ model.new_key_id }}</code></td></tr>
-</table>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/api-keys/{{ model.new_key_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Open the new key</a>
-</p>
-<p style="font-size: 13px; color: #4b5563;">For your security, the key value itself is never sent by email — it was shown once at creation time inside the admin panel.</p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Did not expect this rotation? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Hi,</p>
+  <p>An API key has been rotated. The previous key will remain accepted during the configured grace period — make sure every consumer has migrated to the new key before that window closes.</p>
+</mj-text>
+<mj-table css-class="apikey-details">
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">Previous key</td><td style="padding: 6px 0;"><code>{{ model.old_key_id }}</code></td></tr>
+  <tr><td style="color: #4b5563; padding: 6px 12px 6px 0;">New key</td><td style="padding: 6px 0;"><code>{{ model.new_key_id }}</code></td></tr>
+</mj-table>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/api-keys/{{ model.new_key_id }}">Open the new key</mj-button>
+<mj-text font-size="13px" color="#4b5563">
+  <p>For your security, the key value itself is never sent by email — it was shown once at creation time inside the admin panel.</p>
+  {{- if app.support_email }}
+  <p>Did not expect this rotation? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+  {{- end }}
+</mj-text>

--- a/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.fr.html
+++ b/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.fr.html
@@ -1,14 +1,18 @@
 <title>Tâche récurrente en échec : {{ model.job_name }}</title>
-<p>Bonjour,</p>
-<p>La tâche récurrente <strong><code>{{ model.job_name }}</code></strong> a échoué lors de <strong>{{ model.consecutive_failure_count }}</strong> exécutions consécutives et risque d'être suspendue automatiquement. Les traitements critiques pour les SLA (rapports de conformité, clôtures de facturation) risquent de s'interrompre si la cause n'est pas identifiée rapidement.</p>
-{{ if model.last_error_message }}
-<p>Dernière erreur remontée par l'exécuteur :</p>
-<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
-{{ end }}
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ouvrir les diagnostics</a>
-</p>
-<p>Référence : <code>{{ model.job_id }}</code></p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Besoin d'aide ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Bonjour,</p>
+  <p>La tâche récurrente <strong><code>{{ model.job_name }}</code></strong> a échoué lors de <strong>{{ model.consecutive_failure_count }}</strong> exécutions consécutives et risque d'être suspendue automatiquement. Les traitements critiques pour les SLA (rapports de conformité, clôtures de facturation) risquent de s'interrompre si la cause n'est pas identifiée rapidement.</p>
+  {{- if model.last_error_message }}
+  <p>Dernière erreur remontée par l'exécuteur :</p>
+  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
+  {{- end }}
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}">Ouvrir les diagnostics</mj-button>
+<mj-text>
+  <p>Référence : <code>{{ model.job_id }}</code></p>
+</mj-text>
+{{- if app.support_email }}
+<mj-text font-size="13px" color="#4b5563">
+  <p>Besoin d'aide ? Contactez <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+</mj-text>
+{{- end }}

--- a/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.html
+++ b/src/Granit.BackgroundJobs.Notifications/Templates/jobs.recurring_failing.html
@@ -1,14 +1,18 @@
 <title>Recurring job failing: {{ model.job_name }}</title>
-<p>Hi,</p>
-<p>The recurring job <strong><code>{{ model.job_name }}</code></strong> has failed <strong>{{ model.consecutive_failure_count }}</strong> consecutive runs and is at risk of being automatically paused. SLA-critical batches (compliance reports, billing rollups) may stop progressing if this is not investigated promptly.</p>
-{{ if model.last_error_message }}
-<p>Last error reported by the runner:</p>
-<pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
-{{ end }}
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Open job diagnostics</a>
-</p>
-<p>Reference: <code>{{ model.job_id }}</code></p>
-{{ if app.support_email }}
-<p style="font-size: 13px; color: #4b5563;">Need help? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
-{{ end }}
+<mj-text>
+  <p>Hi,</p>
+  <p>The recurring job <strong><code>{{ model.job_name }}</code></strong> has failed <strong>{{ model.consecutive_failure_count }}</strong> consecutive runs and is at risk of being automatically paused. SLA-critical batches (compliance reports, billing rollups) may stop progressing if this is not investigated promptly.</p>
+  {{- if model.last_error_message }}
+  <p>Last error reported by the runner:</p>
+  <pre style="background-color: #f3f4f6; border-left: 4px solid #dc2626; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; color: #111827;">{{ model.last_error_message | html.escape }}</pre>
+  {{- end }}
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ app.base_url }}/admin/jobs/{{ model.job_id }}">Open job diagnostics</mj-button>
+<mj-text>
+  <p>Reference: <code>{{ model.job_id }}</code></p>
+</mj-text>
+{{- if app.support_email }}
+<mj-text font-size="13px" color="#4b5563">
+  <p>Need help? Contact <a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a>.</p>
+</mj-text>
+{{- end }}

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.cs.html
@@ -1,13 +1,15 @@
-<p>Dobrý den,</p>
+<mj-text>
+  <p>Dobrý den,</p>
 <p>Váš účet <strong>{{ model.email | html.escape }}</strong> byl uzamčen po <strong>{{ model.failed_attempts }}</strong> po sobě jdoucích neúspěšných pokusech o přihlášení.</p>
 <p>Jedná se o bezpečnostní opatření k ochraně vašeho účtu. Uzamčení vyprší <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y v %H:%M UTC' }}</strong>.</p>
 <p>Pokud tyto pokusy o přihlášení nebyly provedeny vámi, můžete si obnovit heslo a okamžitě odemknout svůj účet:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Obnovit moje heslo</a>
-</p>
-<p>Pokud jste tyto pokusy neprovedli a nechcete podnikat žádné kroky, uzamčení vyprší automaticky.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do svého prohlížeče:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Obnovit moje heslo</mj-button>
+<mj-text>
+  <p>Pokud jste tyto pokusy neprovedli a nechcete podnikat žádné kroky, uzamčení vyprší automaticky.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do svého prohlížeče:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.de.html
@@ -1,13 +1,15 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Ihr Konto <strong>{{ model.email | html.escape }}</strong> wurde nach <strong>{{ model.failed_attempts }}</strong> aufeinanderfolgenden fehlgeschlagenen Anmeldeversuchen gesperrt.</p>
 <p>Dies ist eine Sicherheitsmaßnahme zum Schutz Ihres Kontos. Die Sperre wird am <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y um %H:%M UTC' }}</strong> aufgehoben.</p>
 <p>Wenn diese Anmeldeversuche nicht von Ihnen stammten, können Sie Ihr Passwort zurücksetzen, um Ihr Konto sofort zu entsperren:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Passwort zurücksetzen</a>
-</p>
-<p>Wenn Sie diese Versuche nicht unternommen haben und keine Maßnahmen ergreifen möchten, wird die Sperre automatisch aufgehoben.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Falls die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Passwort zurücksetzen</mj-button>
+<mj-text>
+  <p>Wenn Sie diese Versuche nicht unternommen haben und keine Maßnahmen ergreifen möchten, wird die Sperre automatisch aufgehoben.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Falls die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.es.html
@@ -1,13 +1,15 @@
-<p>Hola,</p>
+<mj-text>
+  <p>Hola,</p>
 <p>Su cuenta <strong>{{ model.email | html.escape }}</strong> ha sido bloqueada después de <strong>{{ model.failed_attempts }}</strong> intentos de inicio de sesión fallidos consecutivos.</p>
 <p>Esta es una medida de seguridad para proteger su cuenta. El bloqueo expirará el <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y a las %H:%M UTC' }}</strong>.</p>
 <p>Si estos intentos de inicio de sesión no fueron realizados por usted, puede restablecer su contraseña para desbloquear su cuenta de inmediato:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Restablecer mi contraseña</a>
-</p>
-<p>Si no realizó estos intentos y prefiere no tomar medidas, el bloqueo expirará automáticamente.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Restablecer mi contraseña</mj-button>
+<mj-text>
+  <p>Si no realizó estos intentos y prefiere no tomar medidas, el bloqueo expirará automáticamente.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.fr.html
@@ -1,13 +1,15 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Votre compte <strong>{{ model.email | html.escape }}</strong> a été verrouillé après <strong>{{ model.failed_attempts }}</strong> tentatives de connexion échouées consécutives.</p>
 <p>Il s'agit d'une mesure de sécurité pour protéger votre compte. Le verrouillage expirera le <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</strong>.</p>
 <p>Si ces tentatives de connexion n'ont pas été effectuées par vous, vous pouvez réinitialiser votre mot de passe pour déverrouiller immédiatement votre compte :</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Réinitialiser mon mot de passe</a>
-</p>
-<p>Si vous n'avez pas effectué ces tentatives et préférez ne pas agir, le verrouillage expirera automatiquement.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Réinitialiser mon mot de passe</mj-button>
+<mj-text>
+  <p>Si vous n'avez pas effectué ces tentatives et préférez ne pas agir, le verrouillage expirera automatiquement.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.hi.html
@@ -1,13 +1,15 @@
-<p>नमस्ते,</p>
+<mj-text>
+  <p>नमस्ते,</p>
 <p>आपका खाता <strong>{{ model.email | html.escape }}</strong> लगातार <strong>{{ model.failed_attempts }}</strong> असफल लॉगिन प्रयासों के बाद लॉक कर दिया गया है।</p>
 <p>यह आपके खाते की सुरक्षा के लिए एक सुरक्षा उपाय है। लॉकआउट <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y को %H:%M UTC' }}</strong> पर समाप्त होगा।</p>
 <p>यदि ये लॉगिन प्रयास आपने नहीं किए थे, तो आप अपना पासवर्ड रीसेट करके अपने खाते को तुरंत अनलॉक कर सकते हैं:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा पासवर्ड रीसेट करें</a>
-</p>
-<p>यदि आपने ये प्रयास नहीं किए और कोई कार्रवाई नहीं करना चाहते, तो लॉकआउट स्वचालित रूप से समाप्त हो जाएगा।</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  यदि बटन काम नहीं करता है, तो निम्नलिखित लिंक को कॉपी करके अपने ब्राउज़र में पेस्ट करें:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">मेरा पासवर्ड रीसेट करें</mj-button>
+<mj-text>
+  <p>यदि आपने ये प्रयास नहीं किए और कोई कार्रवाई नहीं करना चाहते, तो लॉकआउट स्वचालित रूप से समाप्त हो जाएगा।</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>यदि बटन काम नहीं करता है, तो निम्नलिखित लिंक को कॉपी करके अपने ब्राउज़र में पेस्ट करें:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.html
@@ -1,13 +1,16 @@
-<p>Hi,</p>
-<p>Your account <strong>{{ model.email | html.escape }}</strong> has been locked after <strong>{{ model.failed_attempts }}</strong> consecutive failed login attempts.</p>
-<p>This is a security measure to protect your account. The lockout will expire on <strong>{{ model.lockout_expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>.</p>
-<p>If these login attempts were not made by you, you can reset your password to immediately unlock your account:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reset my password</a>
-</p>
-<p>If you didn't make these attempts and prefer not to take action, the lockout will expire automatically.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  If the button doesn't work, copy and paste the following link into your browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+<title>Your account has been locked</title>
+<mj-text>
+  <p>Hi,</p>
+  <p>Your account <strong>{{ model.email | html.escape }}</strong> has been locked after <strong>{{ model.failed_attempts }}</strong> consecutive failed login attempts.</p>
+  <p>This is a security measure to protect your account. The lockout will expire on <strong>{{ model.lockout_expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>.</p>
+  <p>If these login attempts were not made by you, you can reset your password to immediately unlock your account:</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Reset my password</mj-button>
+<mj-text>
+  <p>If you didn't make these attempts and prefer not to take action, the lockout will expire automatically.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>If the button doesn't work, copy and paste the following link into your browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.it.html
@@ -1,13 +1,15 @@
-<p>Ciao,</p>
+<mj-text>
+  <p>Ciao,</p>
 <p>Il tuo account <strong>{{ model.email | html.escape }}</strong> è stato bloccato dopo <strong>{{ model.failed_attempts }}</strong> tentativi di accesso consecutivi falliti.</p>
 <p>Questa è una misura di sicurezza per proteggere il tuo account. Il blocco scadrà il <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y alle %H:%M UTC' }}</strong>.</p>
 <p>Se questi tentativi di accesso non sono stati effettuati da te, puoi reimpostare la password per sbloccare immediatamente il tuo account:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reimposta la mia password</a>
-</p>
-<p>Se non hai effettuato questi tentativi e preferisci non agire, il blocco scadrà automaticamente.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Reimposta la mia password</mj-button>
+<mj-text>
+  <p>Se non hai effettuato questi tentativi e preferisci non agire, il blocco scadrà automaticamente.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ja.html
@@ -1,13 +1,15 @@
-<p>こんにちは、</p>
+<mj-text>
+  <p>こんにちは、</p>
 <p>アカウント <strong>{{ model.email | html.escape }}</strong> は、連続 <strong>{{ model.failed_attempts }}</strong> 回のログイン失敗によりロックされました。</p>
 <p>これはアカウントを保護するためのセキュリティ対策です。ロックは <strong>{{ model.lockout_expires_at | date.to_string '%Y年%m月%d日 %H:%M UTC' }}</strong> に解除されます。</p>
 <p>これらのログイン試行が身に覚えのないものである場合は、パスワードをリセットしてアカウントを即座にロック解除できます：</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">パスワードをリセット</a>
-</p>
-<p>これらの試行を行っておらず、対応を希望しない場合、ロックは自動的に解除されます。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">パスワードをリセット</mj-button>
+<mj-text>
+  <p>これらの試行を行っておらず、対応を希望しない場合、ロックは自動的に解除されます。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ko.html
@@ -1,13 +1,15 @@
-<p>안녕하세요,</p>
+<mj-text>
+  <p>안녕하세요,</p>
 <p>계정 <strong>{{ model.email | html.escape }}</strong>이(가) 연속 <strong>{{ model.failed_attempts }}</strong>회 로그인 실패 후 잠겼습니다.</p>
 <p>이는 계정을 보호하기 위한 보안 조치입니다. 잠금은 <strong>{{ model.lockout_expires_at | date.to_string '%Y년 %m월 %d일 %H:%M UTC' }}</strong>에 해제됩니다.</p>
 <p>이러한 로그인 시도가 본인의 것이 아닌 경우, 비밀번호를 재설정하여 계정을 즉시 잠금 해제할 수 있습니다:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">비밀번호 재설정</a>
-</p>
-<p>이러한 시도를 하지 않았으며 조치를 취하지 않으려면 잠금이 자동으로 해제됩니다.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  버튼이 작동하지 않으면 다음 링크를 복사하여 브라우저에 붙여넣으세요:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">비밀번호 재설정</mj-button>
+<mj-text>
+  <p>이러한 시도를 하지 않았으며 조치를 취하지 않으려면 잠금이 자동으로 해제됩니다.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>버튼이 작동하지 않으면 다음 링크를 복사하여 브라우저에 붙여넣으세요:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.nl.html
@@ -1,13 +1,15 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Uw account <strong>{{ model.email | html.escape }}</strong> is vergrendeld na <strong>{{ model.failed_attempts }}</strong> opeenvolgende mislukte aanmeldpogingen.</p>
 <p>Dit is een beveiligingsmaatregel om uw account te beschermen. De vergrendeling verloopt op <strong>{{ model.lockout_expires_at | date.to_string '%d-%m-%Y om %H:%M UTC' }}</strong>.</p>
 <p>Als deze aanmeldpogingen niet door u zijn gedaan, kunt u uw wachtwoord opnieuw instellen om uw account onmiddellijk te ontgrendelen:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Wachtwoord opnieuw instellen</a>
-</p>
-<p>Als u deze pogingen niet hebt gedaan en liever geen actie onderneemt, verloopt de vergrendeling automatisch.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Wachtwoord opnieuw instellen</mj-button>
+<mj-text>
+  <p>Als u deze pogingen niet hebt gedaan en liever geen actie onderneemt, verloopt de vergrendeling automatisch.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pl.html
@@ -1,13 +1,15 @@
-<p>Witaj,</p>
+<mj-text>
+  <p>Witaj,</p>
 <p>Twoje konto <strong>{{ model.email | html.escape }}</strong> zostało zablokowane po <strong>{{ model.failed_attempts }}</strong> kolejnych nieudanych próbach logowania.</p>
 <p>Jest to środek bezpieczeństwa mający na celu ochronę Twojego konta. Blokada wygaśnie <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y o %H:%M UTC' }}</strong>.</p>
 <p>Jeśli te próby logowania nie zostały wykonane przez Ciebie, możesz zresetować hasło, aby natychmiast odblokować swoje konto:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zresetuj moje hasło</a>
-</p>
-<p>Jeśli nie wykonałeś tych prób i wolisz nie podejmować działań, blokada wygaśnie automatycznie.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Zresetuj moje hasło</mj-button>
+<mj-text>
+  <p>Jeśli nie wykonałeś tych prób i wolisz nie podejmować działań, blokada wygaśnie automatycznie.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt-BR.html
@@ -1,13 +1,15 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Sua conta <strong>{{ model.email | html.escape }}</strong> foi bloqueada após <strong>{{ model.failed_attempts }}</strong> tentativas consecutivas de login malsucedidas.</p>
 <p>Esta é uma medida de segurança para proteger sua conta. O bloqueio expirará em <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y às %H:%M UTC' }}</strong>.</p>
 <p>Se essas tentativas de login não foram feitas por você, você pode redefinir sua senha para desbloquear sua conta imediatamente:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Redefinir minha senha</a>
-</p>
-<p>Se você não fez essas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Redefinir minha senha</mj-button>
+<mj-text>
+  <p>Se você não fez essas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt.html
@@ -1,13 +1,15 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>A sua conta <strong>{{ model.email | html.escape }}</strong> foi bloqueada após <strong>{{ model.failed_attempts }}</strong> tentativas de início de sessão falhadas consecutivas.</p>
 <p>Esta é uma medida de segurança para proteger a sua conta. O bloqueio expirará em <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y às %H:%M UTC' }}</strong>.</p>
 <p>Se estas tentativas de início de sessão não foram feitas por si, pode repor a sua palavra-passe para desbloquear imediatamente a sua conta:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Repor a minha palavra-passe</a>
-</p>
-<p>Se não fez estas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Repor a minha palavra-passe</mj-button>
+<mj-text>
+  <p>Se não fez estas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.sv.html
@@ -1,13 +1,15 @@
-<p>Hej,</p>
+<mj-text>
+  <p>Hej,</p>
 <p>Ditt konto <strong>{{ model.email | html.escape }}</strong> har låsts efter <strong>{{ model.failed_attempts }}</strong> på varandra följande misslyckade inloggningsförsök.</p>
 <p>Detta är en säkerhetsåtgärd för att skydda ditt konto. Låsningen upphör <strong>{{ model.lockout_expires_at | date.to_string '%Y-%m-%d kl. %H:%M UTC' }}</strong>.</p>
 <p>Om dessa inloggningsförsök inte gjordes av dig kan du återställa ditt lösenord för att omedelbart låsa upp ditt konto:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Återställ mitt lösenord</a>
-</p>
-<p>Om du inte gjorde dessa försök och föredrar att inte vidta åtgärder kommer låsningen att upphöra automatiskt.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Återställ mitt lösenord</mj-button>
+<mj-text>
+  <p>Om du inte gjorde dessa försök och föredrar att inte vidta åtgärder kommer låsningen att upphöra automatiskt.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.tr.html
@@ -1,13 +1,15 @@
-<p>Merhaba,</p>
+<mj-text>
+  <p>Merhaba,</p>
 <p>Hesabınız <strong>{{ model.email | html.escape }}</strong>, art arda <strong>{{ model.failed_attempts }}</strong> başarısız giriş denemesinden sonra kilitlendi.</p>
 <p>Bu, hesabınızı korumaya yönelik bir güvenlik önlemidir. Kilitleme <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y saat %H:%M UTC' }}</strong> tarihinde sona erecektir.</p>
 <p>Bu giriş denemeleri sizin tarafınızdan yapılmadıysa, hesabınızı hemen açmak için parolanızı sıfırlayabilirsiniz:</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Parolamı sıfırla</a>
-</p>
-<p>Bu denemeleri yapmadıysanız ve işlem yapmak istemiyorsanız, kilitleme otomatik olarak sona erecektir.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Düğme çalışmıyorsa, aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Parolamı sıfırla</mj-button>
+<mj-text>
+  <p>Bu denemeleri yapmadıysanız ve işlem yapmak istemiyorsanız, kilitleme otomatik olarak sona erecektir.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Düğme çalışmıyorsa, aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.zh.html
@@ -1,13 +1,15 @@
-<p>您好，</p>
+<mj-text>
+  <p>您好，</p>
 <p>您的账户 <strong>{{ model.email | html.escape }}</strong> 在连续 <strong>{{ model.failed_attempts }}</strong> 次登录失败后已被锁定。</p>
 <p>这是保护您账户的安全措施。锁定将于 <strong>{{ model.lockout_expires_at | date.to_string '%Y年%m月%d日 %H:%M UTC' }}</strong> 解除。</p>
 <p>如果这些登录尝试不是您本人所为，您可以重置密码以立即解锁您的账户：</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">重置我的密码</a>
-</p>
-<p>如果您未进行这些尝试且不想采取措施，锁定将自动解除。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  如果按钮无法使用，请将以下链接复制并粘贴到您的浏览器中：<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">重置我的密码</mj-button>
+<mj-text>
+  <p>如果您未进行这些尝试且不想采取措施，锁定将自动解除。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>如果按钮无法使用，请将以下链接复制并粘贴到您的浏览器中：<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeAlert.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeAlert.html
@@ -1,3 +1,4 @@
+<title>Email change request for your account</title>
 <p>Hi,</p>
 <p>A request was made to change the email address on your account from <strong>{{ model.email | html.escape }}</strong> to <strong>{{ model.new_email | html.escape }}</strong>.</p>
 <p>If you initiated this change, a confirmation email was sent to the new address.</p>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.cs.html
@@ -1,11 +1,13 @@
-<p>Dobrý den,</p>
+<mj-text>
+  <p>Dobrý den,</p>
 <p>Potvrďte prosím, že <strong>{{ model.new_email | html.escape }}</strong> je vaše nová e-mailová adresa.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potvrdit nový e-mail</a>
-</p>
-<p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>. Pokud jste o tuto změnu nežádali, můžete tento e-mail ignorovat.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Potvrdit nový e-mail</mj-button>
+<mj-text>
+  <p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>. Pokud jste o tuto změnu nežádali, můžete tento e-mail ignorovat.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.de.html
@@ -1,11 +1,13 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Bitte bestätigen Sie, dass <strong>{{ model.new_email | html.escape }}</strong> Ihre neue E-Mail-Adresse ist.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Neue E-Mail bestätigen</a>
-</p>
-<p>Dieser Link läuft in <strong>24 Stunden</strong> ab. Wenn Sie diese Änderung nicht angefordert haben, können Sie diese E-Mail ignorieren.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Neue E-Mail bestätigen</mj-button>
+<mj-text>
+  <p>Dieser Link läuft in <strong>24 Stunden</strong> ab. Wenn Sie diese Änderung nicht angefordert haben, können Sie diese E-Mail ignorieren.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.es.html
@@ -1,11 +1,13 @@
-<p>Hola,</p>
+<mj-text>
+  <p>Hola,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> es su nueva dirección de correo electrónico.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar nuevo correo electrónico</a>
-</p>
-<p>Este enlace caduca en <strong>24 horas</strong>. Si no solicitó este cambio, puede ignorar este correo electrónico.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar nuevo correo electrónico</mj-button>
+<mj-text>
+  <p>Este enlace caduca en <strong>24 horas</strong>. Si no solicitó este cambio, puede ignorar este correo electrónico.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr-CA.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr-CA.html
@@ -1,11 +1,13 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Veuillez confirmer que <strong>{{ model.new_email | html.escape }}</strong> est votre nouvelle adresse courriel.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer le nouveau courriel</a>
-</p>
-<p>Ce lien expire dans <strong>24 heures</strong>. Si vous n'avez pas demandé cette modification, vous pouvez ignorer ce courriel en toute sécurité.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmer le nouveau courriel</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>24 heures</strong>. Si vous n'avez pas demandé cette modification, vous pouvez ignorer ce courriel en toute sécurité.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr.html
@@ -1,11 +1,13 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Veuillez confirmer que <strong>{{ model.new_email | html.escape }}</strong> est votre nouvelle adresse e-mail.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer le nouvel e-mail</a>
-</p>
-<p>Ce lien expire dans <strong>24 heures</strong>. Si vous n'avez pas demandé cette modification, vous pouvez ignorer cet e-mail en toute sécurité.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmer le nouvel e-mail</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>24 heures</strong>. Si vous n'avez pas demandé cette modification, vous pouvez ignorer cet e-mail en toute sécurité.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.hi.html
@@ -1,11 +1,13 @@
-<p>नमस्ते,</p>
+<mj-text>
+  <p>नमस्ते,</p>
 <p>कृपया पुष्टि करें कि <strong>{{ model.new_email | html.escape }}</strong> आपका नया ईमेल पता है।</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">नया ईमेल पुष्टि करें</a>
-</p>
-<p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा। यदि आपने यह परिवर्तन नहीं किया, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं।</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">नया ईमेल पुष्टि करें</mj-button>
+<mj-text>
+  <p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा। यदि आपने यह परिवर्तन नहीं किया, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं।</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.html
@@ -1,11 +1,14 @@
-<p>Hi,</p>
-<p>Please confirm that <strong>{{ model.new_email | html.escape }}</strong> is your new email address.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirm new email</a>
-</p>
-<p>This link expires in <strong>24 hours</strong>. If you did not request this change, you can safely ignore this email.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  If the button doesn't work, copy and paste the following link into your browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+<title>Confirm your new email address</title>
+<mj-text>
+  <p>Hi,</p>
+  <p>Please confirm that <strong>{{ model.new_email | html.escape }}</strong> is your new email address.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirm new email</mj-button>
+<mj-text>
+  <p>This link expires in <strong>24 hours</strong>. If you did not request this change, you can safely ignore this email.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>If the button doesn't work, copy and paste the following link into your browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.it.html
@@ -1,11 +1,13 @@
-<p>Ciao,</p>
+<mj-text>
+  <p>Ciao,</p>
 <p>Conferma che <strong>{{ model.new_email | html.escape }}</strong> è il tuo nuovo indirizzo e-mail.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Conferma nuovo e-mail</a>
-</p>
-<p>Questo link scade tra <strong>24 ore</strong>. Se non hai richiesto questa modifica, puoi ignorare questa e-mail.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Conferma nuovo e-mail</mj-button>
+<mj-text>
+  <p>Questo link scade tra <strong>24 ore</strong>. Se non hai richiesto questa modifica, puoi ignorare questa e-mail.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ja.html
@@ -1,11 +1,13 @@
-<p>こんにちは、</p>
+<mj-text>
+  <p>こんにちは、</p>
 <p><strong>{{ model.new_email | html.escape }}</strong> が新しいメールアドレスであることを確認してください。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">新しいメールを確認</a>
-</p>
-<p>このリンクは <strong>24 時間</strong>で有効期限が切れます。この変更をリクエストしていない場合は、このメールを無視してください。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">新しいメールを確認</mj-button>
+<mj-text>
+  <p>このリンクは <strong>24 時間</strong>で有効期限が切れます。この変更をリクエストしていない場合は、このメールを無視してください。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ko.html
@@ -1,11 +1,13 @@
-<p>안녕하세요,</p>
+<mj-text>
+  <p>안녕하세요,</p>
 <p><strong>{{ model.new_email | html.escape }}</strong>이(가) 새 이메일 주소임을 확인해 주세요.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">새 이메일 확인</a>
-</p>
-<p>이 링크는 <strong>24시간</strong> 후에 만료됩니다. 이 변경을 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">새 이메일 확인</mj-button>
+<mj-text>
+  <p>이 링크는 <strong>24시간</strong> 후에 만료됩니다. 이 변경을 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.nl.html
@@ -1,11 +1,13 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Bevestig dat <strong>{{ model.new_email | html.escape }}</strong> uw nieuwe e-mailadres is.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Nieuw e-mailadres bevestigen</a>
-</p>
-<p>Deze link vervalt over <strong>24 uur</strong>. Als u deze wijziging niet heeft aangevraagd, kunt u deze e-mail veilig negeren.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Nieuw e-mailadres bevestigen</mj-button>
+<mj-text>
+  <p>Deze link vervalt over <strong>24 uur</strong>. Als u deze wijziging niet heeft aangevraagd, kunt u deze e-mail veilig negeren.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pl.html
@@ -1,11 +1,13 @@
-<p>Witaj,</p>
+<mj-text>
+  <p>Witaj,</p>
 <p>Potwierdź, że <strong>{{ model.new_email | html.escape }}</strong> to Twój nowy adres e-mail.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potwierdź nowy e-mail</a>
-</p>
-<p>Ten link wygasa za <strong>24 godziny</strong>. Jeśli nie prosiłeś o tę zmianę, możesz zignorować tę wiadomość.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Potwierdź nowy e-mail</mj-button>
+<mj-text>
+  <p>Ten link wygasa za <strong>24 godziny</strong>. Jeśli nie prosiłeś o tę zmianę, możesz zignorować tę wiadomość.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt-BR.html
@@ -1,11 +1,13 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> é seu novo endereço de e-mail.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar novo e-mail</a>
-</p>
-<p>Este link expira em <strong>24 horas</strong>. Se você não solicitou essa alteração, pode ignorar este e-mail com segurança.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar novo e-mail</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>24 horas</strong>. Se você não solicitou essa alteração, pode ignorar este e-mail com segurança.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt.html
@@ -1,11 +1,13 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> é o seu novo endereço de e-mail.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar novo e-mail</a>
-</p>
-<p>Este link expira em <strong>24 horas</strong>. Se não solicitou esta alteração, pode ignorar este e-mail com segurança.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar novo e-mail</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>24 horas</strong>. Se não solicitou esta alteração, pode ignorar este e-mail com segurança.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.sv.html
@@ -1,11 +1,13 @@
-<p>Hej,</p>
+<mj-text>
+  <p>Hej,</p>
 <p>Vänligen bekräfta att <strong>{{ model.new_email | html.escape }}</strong> är din nya e-postadress.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Bekräfta ny e-post</a>
-</p>
-<p>Denna länk upphör att gälla om <strong>24 timmar</strong>. Om du inte begärde denna ändring kan du ignorera detta e-postmeddelande.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Bekräfta ny e-post</mj-button>
+<mj-text>
+  <p>Denna länk upphör att gälla om <strong>24 timmar</strong>. Om du inte begärde denna ändring kan du ignorera detta e-postmeddelande.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.tr.html
@@ -1,11 +1,13 @@
-<p>Merhaba,</p>
+<mj-text>
+  <p>Merhaba,</p>
 <p>Lütfen <strong>{{ model.new_email | html.escape }}</strong> adresinin yeni e-posta adresiniz olduğunu doğrulayın.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Yeni e-postayı doğrula</a>
-</p>
-<p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir. Bu değişikliği talep etmediyseniz bu e-postayı güvenle yok sayabilirsiniz.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Yeni e-postayı doğrula</mj-button>
+<mj-text>
+  <p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir. Bu değişikliği talep etmediyseniz bu e-postayı güvenle yok sayabilirsiniz.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.zh.html
@@ -1,11 +1,13 @@
-<p>您好，</p>
+<mj-text>
+  <p>您好，</p>
 <p>请确认 <strong>{{ model.new_email | html.escape }}</strong> 是您的新电子邮件地址。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">确认新邮箱</a>
-</p>
-<p>此链接将在 <strong>24 小时</strong>后过期。如果您未请求此更改，可以放心忽略此邮件。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">确认新邮箱</mj-button>
+<mj-text>
+  <p>此链接将在 <strong>24 小时</strong>后过期。如果您未请求此更改，可以放心忽略此邮件。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.cs.html
@@ -1,11 +1,13 @@
-<p>Dobrý den,</p>
+<mj-text>
+  <p>Dobrý den,</p>
 <p>Potvrďte prosím svou e-mailovou adresu <strong>{{ model.email | html.escape }}</strong> pro aktivaci účtu.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potvrdit můj e-mail</a>
-</p>
-<p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Potvrdit můj e-mail</mj-button>
+<mj-text>
+  <p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.de.html
@@ -1,11 +1,13 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Bitte bestätigen Sie Ihre E-Mail-Adresse <strong>{{ model.email | html.escape }}</strong>, um Ihr Konto zu aktivieren.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Meine E-Mail bestätigen</a>
-</p>
-<p>Dieser Link läuft in <strong>24 Stunden</strong> ab.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Meine E-Mail bestätigen</mj-button>
+<mj-text>
+  <p>Dieser Link läuft in <strong>24 Stunden</strong> ab.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.es.html
@@ -1,11 +1,13 @@
-<p>Hola,</p>
+<mj-text>
+  <p>Hola,</p>
 <p>Confirme su dirección de correo electrónico <strong>{{ model.email | html.escape }}</strong> para activar su cuenta.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar mi correo electrónico</a>
-</p>
-<p>Este enlace caduca en <strong>24 horas</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar mi correo electrónico</mj-button>
+<mj-text>
+  <p>Este enlace caduca en <strong>24 horas</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr-CA.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr-CA.html
@@ -1,11 +1,13 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Veuillez confirmer votre adresse courriel <strong>{{ model.email | html.escape }}</strong> pour activer votre compte.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer mon courriel</a>
-</p>
-<p>Ce lien expire dans <strong>24 heures</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmer mon courriel</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>24 heures</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr.html
@@ -1,11 +1,13 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Veuillez confirmer votre adresse e-mail <strong>{{ model.email | html.escape }}</strong> pour activer votre compte.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer mon e-mail</a>
-</p>
-<p>Ce lien expire dans <strong>24 heures</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmer mon e-mail</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>24 heures</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.hi.html
@@ -1,11 +1,13 @@
-<p>नमस्ते,</p>
+<mj-text>
+  <p>नमस्ते,</p>
 <p>कृपया अपना खाता सक्रिय करने के लिए अपना ईमेल पता <strong>{{ model.email | html.escape }}</strong> पुष्टि करें।</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा ईमेल पुष्टि करें</a>
-</p>
-<p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा।</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">मेरा ईमेल पुष्टि करें</mj-button>
+<mj-text>
+  <p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा।</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.html
@@ -1,11 +1,14 @@
-<p>Hi,</p>
-<p>Please confirm your email address <strong>{{ model.email | html.escape }}</strong> to activate your account.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirm my email</a>
-</p>
-<p>This link expires in <strong>24 hours</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  If the button doesn't work, copy and paste the following link into your browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+<title>Confirm your email address</title>
+<mj-text>
+  <p>Hi,</p>
+  <p>Please confirm your email address <strong>{{ model.email | html.escape }}</strong> to activate your account.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirm my email</mj-button>
+<mj-text>
+  <p>This link expires in <strong>24 hours</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>If the button doesn't work, copy and paste the following link into your browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.it.html
@@ -1,11 +1,13 @@
-<p>Ciao,</p>
+<mj-text>
+  <p>Ciao,</p>
 <p>Conferma il tuo indirizzo e-mail <strong>{{ model.email | html.escape }}</strong> per attivare il tuo account.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Conferma la mia e-mail</a>
-</p>
-<p>Questo link scade tra <strong>24 ore</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Conferma la mia e-mail</mj-button>
+<mj-text>
+  <p>Questo link scade tra <strong>24 ore</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ja.html
@@ -1,11 +1,13 @@
-<p>こんにちは、</p>
+<mj-text>
+  <p>こんにちは、</p>
 <p>アカウントを有効にするために、メールアドレス <strong>{{ model.email | html.escape }}</strong> を確認してください。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">メールを確認</a>
-</p>
-<p>このリンクは <strong>24 時間</strong>で有効期限が切れます。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">メールを確認</mj-button>
+<mj-text>
+  <p>このリンクは <strong>24 時間</strong>で有効期限が切れます。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ko.html
@@ -1,11 +1,13 @@
-<p>안녕하세요,</p>
+<mj-text>
+  <p>안녕하세요,</p>
 <p>계정을 활성화하려면 이메일 주소 <strong>{{ model.email | html.escape }}</strong>을(를) 확인해 주세요.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">이메일 확인</a>
-</p>
-<p>이 링크는 <strong>24시간</strong> 후에 만료됩니다.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">이메일 확인</mj-button>
+<mj-text>
+  <p>이 링크는 <strong>24시간</strong> 후에 만료됩니다.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.nl.html
@@ -1,11 +1,13 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Bevestig uw e-mailadres <strong>{{ model.email | html.escape }}</strong> om uw account te activeren.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mijn e-mail bevestigen</a>
-</p>
-<p>Deze link vervalt over <strong>24 uur</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Mijn e-mail bevestigen</mj-button>
+<mj-text>
+  <p>Deze link vervalt over <strong>24 uur</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pl.html
@@ -1,11 +1,13 @@
-<p>Witaj,</p>
+<mj-text>
+  <p>Witaj,</p>
 <p>Potwierdź swój adres e-mail <strong>{{ model.email | html.escape }}</strong>, aby aktywować swoje konto.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potwierdź mój e-mail</a>
-</p>
-<p>Ten link wygasa za <strong>24 godziny</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Potwierdź mój e-mail</mj-button>
+<mj-text>
+  <p>Ten link wygasa za <strong>24 godziny</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt-BR.html
@@ -1,11 +1,13 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Confirme seu endereço de e-mail <strong>{{ model.email | html.escape }}</strong> para ativar sua conta.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar meu e-mail</a>
-</p>
-<p>Este link expira em <strong>24 horas</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar meu e-mail</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>24 horas</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt.html
@@ -1,11 +1,13 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Confirme o seu endereço de e-mail <strong>{{ model.email | html.escape }}</strong> para ativar a sua conta.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar o meu e-mail</a>
-</p>
-<p>Este link expira em <strong>24 horas</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Confirmar o meu e-mail</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>24 horas</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.sv.html
@@ -1,11 +1,13 @@
-<p>Hej,</p>
+<mj-text>
+  <p>Hej,</p>
 <p>Vänligen bekräfta din e-postadress <strong>{{ model.email | html.escape }}</strong> för att aktivera ditt konto.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Bekräfta min e-post</a>
-</p>
-<p>Denna länk upphör att gälla om <strong>24 timmar</strong>.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">Bekräfta min e-post</mj-button>
+<mj-text>
+  <p>Denna länk upphör att gälla om <strong>24 timmar</strong>.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.tr.html
@@ -1,11 +1,13 @@
-<p>Merhaba,</p>
+<mj-text>
+  <p>Merhaba,</p>
 <p>Hesabınızı etkinleştirmek için lütfen <strong>{{ model.email | html.escape }}</strong> e-posta adresinizi doğrulayın.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">E-postamı doğrula</a>
-</p>
-<p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">E-postamı doğrula</mj-button>
+<mj-text>
+  <p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.zh.html
@@ -1,11 +1,13 @@
-<p>您好，</p>
+<mj-text>
+  <p>您好，</p>
 <p>请确认您的电子邮件地址 <strong>{{ model.email | html.escape }}</strong> 以激活您的账户。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">确认我的电子邮件</a>
-</p>
-<p>此链接将在 <strong>24 小时</strong>后过期。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
-  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>
-</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.confirm_link }}">确认我的电子邮件</mj-button>
+<mj-text>
+  <p>此链接将在 <strong>24 小时</strong>后过期。</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
+  <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.ImpersonationAlert.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.ImpersonationAlert.html
@@ -1,3 +1,4 @@
+<title>Administrator access to your account</title>
 <p>Hi,</p>
 <p>An administrator{{ if model.impersonator_display_name != "" }} (<strong>{{ model.impersonator_display_name | html.escape }}</strong>){{ end }} accessed your account on <strong>{{ model.occurred_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>.</p>
 <p>This is a standard administrative action permitted by your organization's security policy. All actions performed during this session are logged and attributed to the administrator.</p>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordChanged.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordChanged.html
@@ -1,3 +1,4 @@
+<title>Your password has been changed</title>
 <p>Hi,</p>
 <p>The password for your account <strong>{{ model.email | html.escape }}</strong> was changed.</p>
 <p>If you made this change, no further action is needed.</p>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.cs.html
@@ -1,12 +1,14 @@
-<p>Dobrý den,</p>
+<mj-text>
+  <p>Dobrý den,</p>
 <p>Obdrželi jsme žádost o obnovení hesla k účtu spojenému s adresou <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Obnovit mé heslo</a>
-</p>
-<p>Platnost tohoto odkazu vyprší za <strong>15 minut</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Obnovit mé heslo</mj-button>
+<mj-text>
+  <p>Platnost tohoto odkazu vyprší za <strong>15 minut</strong>.</p>
 <p>Pokud jste o obnovení hesla nežádali, můžete tento e-mail ignorovat. Vaše heslo nebude změněno.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.de.html
@@ -1,12 +1,14 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>Wir haben eine Anfrage erhalten, das Passwort für das Konto zu zurücksetzen, das mit <strong>{{ model.email | html.escape }}</strong> verknüpft ist.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mein Passwort zurücksetzen</a>
-</p>
-<p>Dieser Link läuft in <strong>15 Minuten</strong> ab.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Mein Passwort zurücksetzen</mj-button>
+<mj-text>
+  <p>Dieser Link läuft in <strong>15 Minuten</strong> ab.</p>
 <p>Wenn Sie keine Passwortzurücksetzung angefordert haben, können Sie diese E-Mail ignorieren. Ihr Passwort wird nicht geändert.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.es.html
@@ -1,12 +1,14 @@
-<p>Hola,</p>
+<mj-text>
+  <p>Hola,</p>
 <p>Hemos recibido una solicitud para restablecer la contraseña de la cuenta asociada a <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Restablecer mi contraseña</a>
-</p>
-<p>Este enlace caduca en <strong>15 minutos</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Restablecer mi contraseña</mj-button>
+<mj-text>
+  <p>Este enlace caduca en <strong>15 minutos</strong>.</p>
 <p>Si no solicitó un restablecimiento de contraseña, puede ignorar este correo electrónico. Su contraseña no será modificada.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr-CA.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr-CA.html
@@ -1,12 +1,14 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Nous avons reçu une demande de réinitialisation du mot de passe pour le compte associé à <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Réinitialiser mon mot de passe</a>
-</p>
-<p>Ce lien expire dans <strong>15 minutes</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Réinitialiser mon mot de passe</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>15 minutes</strong>.</p>
 <p>Si vous n'avez pas demandé de réinitialisation de mot de passe, vous pouvez ignorer ce courriel en toute sécurité. Votre mot de passe ne sera pas modifié.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr.html
@@ -1,12 +1,14 @@
-<p>Bonjour,</p>
+<mj-text>
+  <p>Bonjour,</p>
 <p>Nous avons reçu une demande de réinitialisation du mot de passe pour le compte associé à <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Réinitialiser mon mot de passe</a>
-</p>
-<p>Ce lien expire dans <strong>15 minutes</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Réinitialiser mon mot de passe</mj-button>
+<mj-text>
+  <p>Ce lien expire dans <strong>15 minutes</strong>.</p>
 <p>Si vous n'avez pas demandé de réinitialisation de mot de passe, vous pouvez ignorer cet e-mail en toute sécurité. Votre mot de passe ne sera pas modifié.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.hi.html
@@ -1,12 +1,14 @@
-<p>नमस्ते,</p>
+<mj-text>
+  <p>नमस्ते,</p>
 <p>हमें <strong>{{ model.email | html.escape }}</strong> से जुड़े खाते का पासवर्ड रीसेट करने का अनुरोध प्राप्त हुआ है।</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा पासवर्ड रीसेट करें</a>
-</p>
-<p>यह लिंक <strong>15 मिनट</strong> में समाप्त हो जाएगा।</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">मेरा पासवर्ड रीसेट करें</mj-button>
+<mj-text>
+  <p>यह लिंक <strong>15 मिनट</strong> में समाप्त हो जाएगा।</p>
 <p>यदि आपने पासवर्ड रीसेट का अनुरोध नहीं किया, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं। आपका पासवर्ड नहीं बदला जाएगा।</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.html
@@ -1,12 +1,15 @@
-<p>Hi,</p>
-<p>We received a request to reset the password for the account associated with <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reset my password</a>
-</p>
-<p>This link expires in <strong>15 minutes</strong>.</p>
-<p>If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  If the button doesn't work, copy and paste the following link into your browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+<title>Reset your password</title>
+<mj-text>
+  <p>Hi,</p>
+  <p>We received a request to reset the password for the account associated with <strong>{{ model.email | html.escape }}</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Reset my password</mj-button>
+<mj-text>
+  <p>This link expires in <strong>15 minutes</strong>.</p>
+  <p>If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>If the button doesn't work, copy and paste the following link into your browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.it.html
@@ -1,12 +1,14 @@
-<p>Ciao,</p>
+<mj-text>
+  <p>Ciao,</p>
 <p>Abbiamo ricevuto una richiesta di reimpostazione della password per l'account associato a <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reimposta la mia password</a>
-</p>
-<p>Questo link scade tra <strong>15 minuti</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Reimposta la mia password</mj-button>
+<mj-text>
+  <p>Questo link scade tra <strong>15 minuti</strong>.</p>
 <p>Se non hai richiesto la reimpostazione della password, puoi ignorare questa e-mail. La tua password non verrà modificata.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ja.html
@@ -1,12 +1,14 @@
-<p>こんにちは、</p>
+<mj-text>
+  <p>こんにちは、</p>
 <p><strong>{{ model.email | html.escape }}</strong> に関連付けられたアカウントのパスワードリセットリクエストを受け取りました。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">パスワードをリセット</a>
-</p>
-<p>このリンクは <strong>15 分</strong>で有効期限が切れます。</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">パスワードをリセット</mj-button>
+<mj-text>
+  <p>このリンクは <strong>15 分</strong>で有効期限が切れます。</p>
 <p>パスワードリセットをリクエストしていない場合は、このメールを無視してください。パスワードは変更されません。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ko.html
@@ -1,12 +1,14 @@
-<p>안녕하세요,</p>
+<mj-text>
+  <p>안녕하세요,</p>
 <p><strong>{{ model.email | html.escape }}</strong>과(와) 연결된 계정의 비밀번호 재설정 요청을 받았습니다.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">비밀번호 재설정</a>
-</p>
-<p>이 링크는 <strong>15분</strong> 후에 만료됩니다.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">비밀번호 재설정</mj-button>
+<mj-text>
+  <p>이 링크는 <strong>15분</strong> 후에 만료됩니다.</p>
 <p>비밀번호 재설정을 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다. 비밀번호는 변경되지 않습니다.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.nl.html
@@ -1,12 +1,14 @@
-<p>Hallo,</p>
+<mj-text>
+  <p>Hallo,</p>
 <p>We hebben een verzoek ontvangen om het wachtwoord opnieuw in te stellen voor het account gekoppeld aan <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mijn wachtwoord opnieuw instellen</a>
-</p>
-<p>Deze link vervalt over <strong>15 minuten</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Mijn wachtwoord opnieuw instellen</mj-button>
+<mj-text>
+  <p>Deze link vervalt over <strong>15 minuten</strong>.</p>
 <p>Als u geen wachtwoordherstel heeft aangevraagd, kunt u deze e-mail veilig negeren. Uw wachtwoord wordt niet gewijzigd.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pl.html
@@ -1,12 +1,14 @@
-<p>Witaj,</p>
+<mj-text>
+  <p>Witaj,</p>
 <p>Otrzymaliśmy prośbę o zresetowanie hasła do konta powiązanego z adresem <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zresetuj moje hasło</a>
-</p>
-<p>Ten link wygasa za <strong>15 minut</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Zresetuj moje hasło</mj-button>
+<mj-text>
+  <p>Ten link wygasa za <strong>15 minut</strong>.</p>
 <p>Jeśli nie prosiłeś o zresetowanie hasła, możesz zignorować tę wiadomość. Twoje hasło nie zostanie zmienione.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt-BR.html
@@ -1,12 +1,14 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Recebemos uma solicitação para redefinir a senha da conta associada a <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Redefinir minha senha</a>
-</p>
-<p>Este link expira em <strong>15 minutos</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Redefinir minha senha</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>15 minutos</strong>.</p>
 <p>Se você não solicitou a redefinição de senha, pode ignorar este e-mail com segurança. Sua senha não será alterada.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt.html
@@ -1,12 +1,14 @@
-<p>Olá,</p>
+<mj-text>
+  <p>Olá,</p>
 <p>Recebemos um pedido para repor a palavra-passe da conta associada a <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Repor a minha palavra-passe</a>
-</p>
-<p>Este link expira em <strong>15 minutos</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Repor a minha palavra-passe</mj-button>
+<mj-text>
+  <p>Este link expira em <strong>15 minutos</strong>.</p>
 <p>Se não solicitou a reposição da palavra-passe, pode ignorar este e-mail com segurança. A sua palavra-passe não será alterada.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.sv.html
@@ -1,12 +1,14 @@
-<p>Hej,</p>
+<mj-text>
+  <p>Hej,</p>
 <p>Vi har tagit emot en begäran om att återställa lösenordet för kontot kopplat till <strong>{{ model.email | html.escape }}</strong>.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Återställ mitt lösenord</a>
-</p>
-<p>Denna länk upphör att gälla om <strong>15 minuter</strong>.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Återställ mitt lösenord</mj-button>
+<mj-text>
+  <p>Denna länk upphör att gälla om <strong>15 minuter</strong>.</p>
 <p>Om du inte har begärt en lösenordsåterställning kan du ignorera detta e-postmeddelande. Ditt lösenord kommer inte att ändras.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.tr.html
@@ -1,12 +1,14 @@
-<p>Merhaba,</p>
+<mj-text>
+  <p>Merhaba,</p>
 <p><strong>{{ model.email | html.escape }}</strong> ile ilişkili hesabın parolasını sıfırlamak için bir istek aldık.</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Parolamı sıfırla</a>
-</p>
-<p>Bu bağlantı <strong>15 dakika</strong> içinde geçerliliğini yitirecektir.</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">Parolamı sıfırla</mj-button>
+<mj-text>
+  <p>Bu bağlantı <strong>15 dakika</strong> içinde geçerliliğini yitirecektir.</p>
 <p>Parola sıfırlama talebinde bulunmadıysanız bu e-postayı güvenle yok sayabilirsiniz. Parolanız değiştirilmeyecektir.</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.zh.html
@@ -1,12 +1,14 @@
-<p>您好，</p>
+<mj-text>
+  <p>您好，</p>
 <p>我们收到了重置与 <strong>{{ model.email | html.escape }}</strong> 关联的账户密码的请求。</p>
-<p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">重置我的密码</a>
-</p>
-<p>此链接将在 <strong>15 分钟</strong>后过期。</p>
+</mj-text>
+<mj-button background-color="#1d4ed8" color="#ffffff" font-size="15px" font-weight="bold" border-radius="6px" inner-padding="12px 28px" padding="32px 0" href="{{ model.reset_link }}">重置我的密码</mj-button>
+<mj-text>
+  <p>此链接将在 <strong>15 分钟</strong>后过期。</p>
 <p>如果您未请求重置密码，可以放心忽略此邮件。您的密码不会被更改。</p>
-<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
-<p style="font-size: 13px; color: #4b5563;">
-  如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
-  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>
-</p>
+</mj-text>
+<mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+<mj-text font-size="13px" color="#4b5563">
+  <p>如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
+  <a href="{{ model.reset_link }}">{{ model.reset_link }}</a></p>
+</mj-text>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.TwoFactorChanged.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.TwoFactorChanged.html
@@ -1,3 +1,4 @@
+<title>Two-factor authentication update</title>
 <p>Hi,</p>
 {{- if model.enabled }}
 <p>Two-factor authentication has been <strong>enabled</strong> on your account <strong>{{ model.email | html.escape }}</strong>.</p>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.Welcome.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.Welcome.html
@@ -1,3 +1,4 @@
+<title>Welcome to {{ app.name }}</title>
 <p>Hi,</p>
 <p>Your account has been created with the email <strong>{{ model.email | html.escape }}</strong>.</p>
 <p>You can now sign in and start exploring the platform.</p>

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -218,8 +218,8 @@ internal sealed partial class EmailNotificationChannel(
             if (rendered is TextRenderedContent textResult)
             {
                 Log.TemplateRendered(logger, templateName, context.Culture);
-                string? subject = ExtractTitleFromHtml(textResult.Html);
-                return new RenderedEmail(textResult.Html, subject);
+                (string? subject, string body) = ExtractAndStripTitle(textResult.Html);
+                return new RenderedEmail(body, subject);
             }
         }
         catch (Exception ex)
@@ -304,13 +304,23 @@ internal sealed partial class EmailNotificationChannel(
         dataDict["title"] = contentEmail.Subject
             ?? context.NotificationTypeName.Replace('.', ' ');
 
-        // Inject body as ExtraVariable for {{ body | raw }} in layout
+        // Detect MJML body fragment (starts with `<mj-`) vs plain HTML — layouts wrap HTML
+        // bodies in a default `<mj-section><mj-column><mj-text>` so author writes plain markup,
+        // and inject MJML bodies raw at the section level so authors can use `<mj-button>`,
+        // `<mj-table>`, etc.
+        bool bodyIsMjml = contentEmail.Html.AsSpan().TrimStart()
+            .StartsWith("<mj-", StringComparison.OrdinalIgnoreCase);
+
         TemplateDescriptor layoutWithBody = new()
         {
             Content = layoutDescriptor.Content,
             MimeType = layoutDescriptor.MimeType,
             RevisionId = layoutDescriptor.RevisionId,
-            ExtraVariables = new Dictionary<string, object> { ["body"] = contentEmail.Html },
+            ExtraVariables = new Dictionary<string, object>
+            {
+                ["body"] = contentEmail.Html,
+                ["body_is_mjml"] = bodyIsMjml,
+            },
         };
 
         try
@@ -325,8 +335,8 @@ internal sealed partial class EmailNotificationChannel(
 
             if (rendered is TextRenderedContent textResult)
             {
-                string? subject = ExtractTitleFromHtml(textResult.Html);
-                return new RenderedEmail(textResult.Html, subject);
+                // Subject was captured at content-render time; layout doesn't redefine it.
+                return new RenderedEmail(textResult.Html, contentEmail.Subject);
             }
         }
         catch (Exception ex)
@@ -383,26 +393,46 @@ internal sealed partial class EmailNotificationChannel(
     }
 
     /// <summary>
-    /// Extracts the content of the <c>&lt;title&gt;</c> tag from rendered HTML, if present.
-    /// Used as the email subject when a Scriban template provides it.
+    /// Extracts the content of the <c>&lt;title&gt;</c> tag from rendered HTML and returns
+    /// the body with that tag removed. Used so the title doesn't leak into the layout's
+    /// <c>&lt;mj-body&gt;</c> (where a raw <c>&lt;title&gt;</c> would either render as visible
+    /// text or be silently dropped by MJML), while the email subject is threaded explicitly.
     /// </summary>
-    private static string? ExtractTitleFromHtml(string html)
+    /// <returns>
+    /// <c>Title</c> is <see langword="null"/> when no <c>&lt;title&gt;</c> tag is present or
+    /// the tag is empty. <c>Body</c> is the input with the title tag (and the immediately
+    /// trailing newline, if any) stripped.
+    /// </returns>
+    private static (string? Title, string Body) ExtractAndStripTitle(string html)
     {
         int start = html.IndexOf("<title>", StringComparison.OrdinalIgnoreCase);
         if (start < 0)
         {
-            return null;
+            return (null, html);
         }
 
-        start += "<title>".Length;
-        int end = html.IndexOf("</title>", start, StringComparison.OrdinalIgnoreCase);
-        if (end < 0)
+        int contentStart = start + "<title>".Length;
+        int contentEnd = html.IndexOf("</title>", contentStart, StringComparison.OrdinalIgnoreCase);
+        if (contentEnd < 0)
         {
-            return null;
+            return (null, html);
         }
 
-        string title = html[start..end].Trim();
-        return string.IsNullOrEmpty(title) ? null : title;
+        string title = html[contentStart..contentEnd].Trim();
+        int after = contentEnd + "</title>".Length;
+
+        // Consume a single trailing newline so the body doesn't start with a blank line.
+        if (after < html.Length && html[after] == '\r')
+        {
+            after++;
+        }
+        if (after < html.Length && html[after] == '\n')
+        {
+            after++;
+        }
+
+        string body = html[..start] + html[after..];
+        return (string.IsNullOrEmpty(title) ? null : title, body);
     }
 
     /// <summary>

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -1,5 +1,6 @@
 <mjml>
   <mj-head>
+    <mj-title>{{ model.title }}</mj-title>
     <mj-attributes>
       <mj-all font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" />
       <mj-text font-size="16px" line-height="1.6" color="#374151" />
@@ -17,18 +18,27 @@
         {{- end }}
       </mj-column>
     </mj-section>
-    <!-- Body -->
+    <!-- Body — wrapped in a default section+column. Content provides either MJML children
+         (mj-text, mj-button, mj-table, mj-divider, ...) or plain HTML auto-wrapped in mj-text. -->
     <mj-section background-color="#ffffff" padding="32px">
       <mj-column>
+        {{- if body_is_mjml }}
+        {{ body }}
+        {{- else }}
         <mj-text>{{ body }}</mj-text>
-        {{- if app.base_url != "" }}
-        <mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
-        <mj-text align="center">
-          <a href="{{ app.base_url }}" style="color: #1d4ed8; text-decoration: underline; font-size: 14px;">{{ app.name }}</a>
-        </mj-text>
         {{- end }}
       </mj-column>
     </mj-section>
+    {{- if app.base_url != "" }}
+    <mj-section background-color="#ffffff" padding="0 32px 32px">
+      <mj-column>
+        <mj-divider border-color="#d1d5db" border-width="1px" padding="0 0 24px" />
+        <mj-text align="center">
+          <a href="{{ app.base_url }}" style="color: #1d4ed8; text-decoration: underline; font-size: 14px;">{{ app.name }}</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    {{- end }}
     <!-- Footer -->
     <mj-section background-color="#f3f4f6" padding="20px 32px" border-top="1px solid #d1d5db">
       <mj-column>

--- a/tests/Granit.Templating.Mjml.Tests/MjmlTransformerTests.cs
+++ b/tests/Granit.Templating.Mjml.Tests/MjmlTransformerTests.cs
@@ -154,6 +154,31 @@ public sealed class MjmlTransformerTests
     }
 
     [Fact]
+    public async Task Mjml_WithTable_RendersRows()
+    {
+        string mjml = """
+            <mjml>
+              <mj-body>
+                <mj-section>
+                  <mj-column>
+                    <mj-table>
+                      <tr><td>Name</td><td><strong>example</strong></td></tr>
+                      <tr><td>Reference</td><td><code>abc-123</code></td></tr>
+                    </mj-table>
+                  </mj-column>
+                </mj-section>
+              </mj-body>
+            </mjml>
+            """;
+
+        string result = await _sut.TransformAsync(mjml, DocumentFormat.Html, CancellationToken);
+
+        result.ShouldContain("example");
+        result.ShouldContain("abc-123");
+        result.ShouldContain("<table");
+    }
+
+    [Fact]
     public async Task Mjml_CaseInsensitive_DetectsMjmlTag()
     {
         string mjml = """


### PR DESCRIPTION
## Summary

- Refactor `EmailNotificationChannel` to strip `<title>` from rendered content before layout injection (so it never leaks into the MJML body) and thread the subject explicitly. Adds a `body_is_mjml` flag passed to the layout.
- Update `Layout.Email.html` with a dual-format body slot: HTML bodies auto-wrap in a default `<mj-text>` (back-compat with ~25 plain-HTML templates still in the tree); MJML fragments inject raw as children of `<mj-column>`, letting authors use `<mj-button>`, `<mj-table>`, `<mj-divider>` directly without repeating section/column boilerplate.
- Convert content templates that previously inlined `<table>`/styled buttons:
  - `apikeys.*` (4 templates × EN+FR) → `mj-table` + `mj-button`
  - `jobs.recurring_failing` (EN+FR) → `mj-button`
  - `Security.{AccountLocked, EmailChangeConfirmation, EmailConfirmation, PasswordReset}` (EN + 16 hand-translated locales each) → `mj-button` + `mj-divider`; locales transformed mechanically by a throw-away Python script, every translation preserved.
- Add `<title>` line to the 5 simpler Security templates (`EmailChangeAlert`, `ImpersonationAlert`, `PasswordChanged`, `TwoFactorChanged`, `Welcome`) so subject extraction stops falling back to the humanised type name.

## Test plan

- [x] `dotnet test Granit.Notifications.Email.Tests` — 75 passants
- [x] `dotnet test Granit.Authentication.ApiKeys.Notifications.Tests` — 37 passants
- [x] `dotnet test Granit.Identity.Local.Notifications.Tests` — 313 passants (incl. embedded-resource pinning + notification-type drift)
- [x] `dotnet test Granit.Templating.Mjml.Tests` — 15 passants (added `Mjml_WithTable_RendersRows` for the new `mj-table` primitive)
- [x] End-to-end render verification (Scriban → strip-title → layout-compose → `MjmlRenderer`) on 149 Security templates + 10 apikeys/jobs templates: 0 MJML errors, subjects extracted correctly, layout chrome (header/footer/base-url link) present in all outputs.
- [ ] Visual QA: trigger a real send in dev (e.g. `Security.PasswordReset` and `apikeys.expiring_soon`) and inspect rendering in Gmail / Outlook / Apple Mail.

## Templates intentionally left as plain HTML

These have no `<table>` and no styled button — they render fine via the new HTML auto-wrap path and don't benefit from MJML conversion:

- `Granit.Auditing.Notifications/auditing.anomaly_detected.{html,fr.html}`
- `Granit.Identity.Federated.Notifications/identity.{sync_failed,user_provisioning_removed,token_exchange_audit}.{html,fr.html}`

## Follow-ups (not in this PR)

- Non-EN locales of the 5 simpler Security templates (e.g. `Security.PasswordChanged.fr.html`) still have no `<title>`, so subjects fall back to humanised type name. Can be batched later by adding a single `<title>` line per file — no structural change.