### PR TITLE
fix(encryption): stop tripping IsolatedDbContext arch test on doc string

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -502,18 +502,14 @@
     {
       "name": "Granit.Browsing.Playwright",
       "deps": [
-        "Granit.Browsing",
-        "Granit.Http.Security",
-        "Granit.IO"
+        "Granit.Browsing"
       ],
       "framework": "net10.0"
     },
     {
       "name": "Granit.Browsing.PuppeteerSharp",
       "deps": [
-        "Granit.Browsing",
-        "Granit.Http.Security",
-        "Granit.IO"
+        "Granit.Browsing"
       ],
       "framework": "net10.0"
     },
@@ -4095,7 +4091,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/EvaluateAsyncStringInterpolationAnalyzer.cs",
-      "line": 36,
+      "line": 35,
       "members": [
         {
           "name": "SupportedDiagnostics",
@@ -11039,6 +11035,22 @@
       "file": "src/Granit.Browsing/Pages/RouteRequest.cs",
       "line": 13,
       "members": []
+    },
+    {
+      "name": "BrowsingPermissionDefinitionProvider",
+      "fqn": "Granit.Browsing.Permissions.BrowsingPermissionDefinitionProvider",
+      "kind": "class",
+      "project": "Granit.Browsing",
+      "file": "src/Granit.Browsing/Permissions/BrowsingPermissionDefinitionProvider.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DefinePermissions",
+          "kind": "method",
+          "signature": "DefinePermissions(IPermissionDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "BrowsingPermissions",

--- a/src/Granit.Encryption.EntityFrameworkCore/Extensions/ReEncryptionServiceCollectionExtensions.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Extensions/ReEncryptionServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ReEncryptionServiceCollectionExtensions
     /// <typeparam name="TContext">
     /// The <see cref="DbContext"/> that owns the entities to re-encrypt.
     /// An <see cref="IDbContextFactory{TContext}"/> must already be registered
-    /// (via <c>AddDbContextFactory&lt;TContext&gt;()</c>).
+    /// by the consuming module.
     /// </typeparam>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>


### PR DESCRIPTION
## Summary

`IsolatedDbContextTests.EfCore_extension_methods_should_use_interceptor_DI_pattern` does a plain-text scan of every `*.cs` under `*/Extensions/` for the literal `AddDbContextFactory` and demands a matching `ServiceLifetime.Scoped`. The xmldoc on `AddGranitEncryptionReEncryption` mentioned `AddDbContextFactory<TContext>()` to tell consumers what they had to register upstream — that mention alone was enough to trip the rule even though this file registers nothing with that overload.

Rephrased the doc to "by the consuming module"; behaviour unchanged.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests --filter "FullyQualifiedName~EfCore_extension_methods_should_use_interceptor_DI_pattern"` → passes
- [ ] CI green