### PR TITLE
fix(http-security): audit findings — diagnostics, options validation, layered fixes

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -502,14 +502,18 @@
     {
       "name": "Granit.Browsing.Playwright",
       "deps": [
-        "Granit.Browsing"
+        "Granit.Browsing",
+        "Granit.Http.Security",
+        "Granit.IO"
       ],
       "framework": "net10.0"
     },
     {
       "name": "Granit.Browsing.PuppeteerSharp",
       "deps": [
-        "Granit.Browsing"
+        "Granit.Browsing",
+        "Granit.Http.Security",
+        "Granit.IO"
       ],
       "framework": "net10.0"
     },
@@ -4091,7 +4095,7 @@
       "kind": "class",
       "project": "Granit.Analyzers",
       "file": "src/Granit.Analyzers/EvaluateAsyncStringInterpolationAnalyzer.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "SupportedDiagnostics",
@@ -11035,22 +11039,6 @@
       "file": "src/Granit.Browsing/Pages/RouteRequest.cs",
       "line": 13,
       "members": []
-    },
-    {
-      "name": "BrowsingPermissionDefinitionProvider",
-      "fqn": "Granit.Browsing.Permissions.BrowsingPermissionDefinitionProvider",
-      "kind": "class",
-      "project": "Granit.Browsing",
-      "file": "src/Granit.Browsing/Permissions/BrowsingPermissionDefinitionProvider.cs",
-      "line": 18,
-      "members": [
-        {
-          "name": "DefinePermissions",
-          "kind": "method",
-          "signature": "DefinePermissions(IPermissionDefinitionContext context)",
-          "returnType": "void"
-        }
-      ]
     },
     {
       "name": "BrowsingPermissions",
@@ -19857,12 +19845,21 @@
       ]
     },
     {
+      "name": "HttpSecurityMetrics",
+      "fqn": "Granit.Http.Security.Diagnostics.HttpSecurityMetrics",
+      "kind": "class",
+      "project": "Granit.Http.Security",
+      "file": "src/Granit.Http.Security/Diagnostics/HttpSecurityMetrics.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "UrlSafetyServiceCollectionExtensions",
       "fqn": "Granit.Http.Security.Extensions.UrlSafetyServiceCollectionExtensions",
       "kind": "class",
       "project": "Granit.Http.Security",
       "file": "src/Granit.Http.Security/Extensions/UrlSafetyServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitUrlSafety",
@@ -19925,7 +19922,7 @@
       "kind": "class",
       "project": "Granit.Http.Security",
       "file": "src/Granit.Http.Security/Options/UrlSafetyOptions.cs",
-      "line": 6,
+      "line": 8,
       "members": [
         {
           "name": "AllowedSchemes",
@@ -20003,7 +20000,7 @@
       "kind": "record",
       "project": "Granit.Http.Security",
       "file": "src/Granit.Http.Security/UrlSafetyViolation.cs",
-      "line": 11,
+      "line": 17,
       "members": []
     },
     {
@@ -20021,14 +20018,8 @@
       "kind": "record",
       "project": "Granit.Http.Security",
       "file": "src/Granit.Http.Security/UrlSafetyResult.cs",
-      "line": 14,
+      "line": 11,
       "members": [
-        {
-          "name": "Valid",
-          "kind": "method",
-          "signature": "Valid(IReadOnlyList<IPAddress> ips)",
-          "returnType": "UrlSafetyResult"
-        },
         {
           "name": "Invalid",
           "kind": "method",

--- a/src/Granit.Browsing.Playwright/packages.lock.json
+++ b/src/Granit.Browsing.Playwright/packages.lock.json
@@ -215,6 +215,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Browsing.PuppeteerSharp/packages.lock.json
+++ b/src/Granit.Browsing.PuppeteerSharp/packages.lock.json
@@ -229,6 +229,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Browsing/packages.lock.json
+++ b/src/Granit.Browsing/packages.lock.json
@@ -159,6 +159,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.DocumentGeneration.Pdf/packages.lock.json
+++ b/src/Granit.DocumentGeneration.Pdf/packages.lock.json
@@ -188,6 +188,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Http.Security/Diagnostics/HttpSecurityActivitySource.cs
+++ b/src/Granit.Http.Security/Diagnostics/HttpSecurityActivitySource.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+
+namespace Granit.Http.Security.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Http.Security distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class HttpSecurityActivitySource
+{
+    /// <summary>The name of the Granit.Http.Security <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.HttpSecurity";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    internal const string ValidateUrl = "http_security.url.validate";
+}

--- a/src/Granit.Http.Security/Diagnostics/HttpSecurityLog.cs
+++ b/src/Granit.Http.Security/Diagnostics/HttpSecurityLog.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Http.Security.Diagnostics;
+
+/// <summary>
+/// Source-generated structured log messages for <c>Granit.Http.Security</c>.
+/// </summary>
+internal static partial class HttpSecurityLog
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "URL safety check blocked host '{Host}': {Kind} ({Reason})")]
+    public static partial void UrlBlocked(ILogger logger, string host, UrlSafetyViolationKind kind, string reason);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Warning,
+        Message = "DNS resolution failed for host '{Host}' during URL safety check: {ErrorKind}")]
+    public static partial void DnsResolutionFailed(ILogger logger, string host, string errorKind);
+}

--- a/src/Granit.Http.Security/Diagnostics/HttpSecurityMetrics.cs
+++ b/src/Granit.Http.Security/Diagnostics/HttpSecurityMetrics.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Http.Security.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the HTTP-security module.
+/// Meter: <c>Granit.HttpSecurity</c>.
+/// </summary>
+public sealed class HttpSecurityMetrics
+{
+    /// <summary>Name of the <see cref="Meter"/> owned by this module.</summary>
+    public const string MeterName = "Granit.HttpSecurity";
+
+    private readonly Counter<long> _validations;
+    private readonly Counter<long> _blocks;
+
+    /// <summary>Initializes a new <see cref="HttpSecurityMetrics"/> bound to <paramref name="meterFactory"/>.</summary>
+    public HttpSecurityMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+
+        Meter meter = meterFactory.Create(MeterName);
+
+        _validations = meter.CreateCounter<long>(
+            "granit.http_security.url.validated",
+            description: "Number of URLs passed through IUrlSafetyValidator.");
+
+        _blocks = meter.CreateCounter<long>(
+            "granit.http_security.url.blocked",
+            description: "Number of URLs blocked by IUrlSafetyValidator, tagged with the violation kind.");
+    }
+
+    /// <summary>Records a URL that passed every safety rule.</summary>
+    public void RecordValid(string? tenantId)
+    {
+        TagList tags =
+        [
+            new("tenant_id", tenantId ?? "global"),
+            new("outcome", "valid"),
+        ];
+        _validations.Add(1, tags);
+    }
+
+    /// <summary>Records a URL that was rejected, tagged with its violation kind.</summary>
+    public void RecordBlocked(string? tenantId, UrlSafetyViolationKind kind)
+    {
+        TagList tags =
+        [
+            new("tenant_id", tenantId ?? "global"),
+            new("outcome", "blocked"),
+            new("violation_kind", kind.ToString()),
+        ];
+        _validations.Add(1, tags);
+        _blocks.Add(1, tags);
+    }
+}

--- a/src/Granit.Http.Security/Extensions/UrlSafetyServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Security/Extensions/UrlSafetyServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.Diagnostics;
+using Granit.Http.Security.Diagnostics;
 using Granit.Http.Security.Internal;
 using Granit.Http.Security.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +24,13 @@ public static class UrlSafetyServiceCollectionExtensions
 
         services.AddOptions<UrlSafetyOptions>()
             .BindConfiguration(UrlSafetyOptions.SectionName)
+            .ValidateDataAnnotations()
+            .Validate(
+                o => o.DnsResolveTimeout > TimeSpan.Zero,
+                $"{nameof(UrlSafetyOptions.DnsResolveTimeout)} must be greater than zero.")
+            .Validate(
+                o => o.AllowedSchemes.Count > 0,
+                $"{nameof(UrlSafetyOptions.AllowedSchemes)} must contain at least one entry.")
             .ValidateOnStart();
 
         if (configure is not null)
@@ -31,7 +40,10 @@ public static class UrlSafetyServiceCollectionExtensions
 
         services.TryAddSingleton<IDnsResolver, SystemDnsResolver>();
         services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<HttpSecurityMetrics>();
         services.TryAddSingleton<IUrlSafetyValidator, DefaultUrlSafetyValidator>();
+
+        GranitActivitySourceRegistry.Register(HttpSecurityActivitySource.Name);
         return services;
     }
 }

--- a/src/Granit.Http.Security/Granit.Http.Security.csproj
+++ b/src/Granit.Http.Security/Granit.Http.Security.csproj
@@ -18,12 +18,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Localization\**\*.json" />
+    <EmbeddedResource Include="Localization\**\*.json" WithCulture="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
+++ b/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
+using Granit.Http.Security.Diagnostics;
 using Granit.Http.Security.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Http.Security.Internal;
@@ -16,18 +19,26 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
     private readonly IOptions<UrlSafetyOptions> _options;
     private readonly IDnsResolver _resolver;
     private readonly TimeProvider _timeProvider;
+    private readonly HttpSecurityMetrics _metrics;
+    private readonly ILogger<DefaultUrlSafetyValidator> _logger;
 
     public DefaultUrlSafetyValidator(
         IOptions<UrlSafetyOptions> options,
         IDnsResolver resolver,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        HttpSecurityMetrics metrics,
+        ILogger<DefaultUrlSafetyValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(resolver);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(logger);
         _options = options;
         _resolver = resolver;
         _timeProvider = timeProvider;
+        _metrics = metrics;
+        _logger = logger;
     }
 
     public ValueTask<UrlSafetyResult> ValidateAsync(Uri url, CancellationToken ct = default) =>
@@ -38,76 +49,90 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         ArgumentNullException.ThrowIfNull(url);
         ArgumentNullException.ThrowIfNull(optionOverrides);
 
+        using Activity? activity = HttpSecurityActivitySource.Source.StartActivity(HttpSecurityActivitySource.ValidateUrl);
+
         // (1) Absolute-URI gate.
         if (!url.IsAbsoluteUri)
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.MalformedUrl,
                 "URL is not absolute.",
-                "UrlSafety:MalformedUrl"));
+                "UrlSafety:MalformedUrl",
+                []));
         }
 
         // (2) Length cap.
         if (url.OriginalString.Length > optionOverrides.MaxUrlLength)
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.UrlTooLong,
                 $"URL exceeds the maximum length of {optionOverrides.MaxUrlLength}.",
-                "UrlSafety:UrlTooLong"));
+                "UrlSafety:UrlTooLong",
+                [optionOverrides.MaxUrlLength]));
         }
 
         // (3) Scheme allowlist.
         if (!IsSchemeAllowed(url.Scheme, optionOverrides.AllowedSchemes))
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.SchemeNotAllowed,
                 $"URL scheme '{url.Scheme}' is not allowed.",
-                "UrlSafety:SchemeNotAllowed"));
+                "UrlSafety:SchemeNotAllowed",
+                [url.Scheme]));
         }
 
         // (4) file:// short-circuit — no DNS / no IP classification.
+        // Note: enabling "file" in AllowedSchemes also lets through UNC paths on Windows
+        // (file://server/share) — only opt in for trusted, local-only contexts.
         if (string.Equals(url.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
         {
+            _metrics.RecordValid(tenantId: null);
+            activity?.SetTag("url_safety.outcome", "valid");
             return UrlSafetyResult.Valid([]);
         }
 
         string host = url.Host;
         if (string.IsNullOrEmpty(host))
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.MalformedUrl,
                 "URL has no host.",
-                "UrlSafety:MalformedUrl"));
+                "UrlSafety:MalformedUrl",
+                []));
         }
 
-        // (5) IDN normalization → punycode (skip when host is a bracketed IPv6 literal).
-        string asciiHost = NormalizeHost(host);
+        // (5) IDN normalization → punycode (skip when host is an IP literal or AllowIdn is off).
+        string asciiHost = optionOverrides.AllowIdn ? NormalizeHost(host) : host;
 
         // (6) Reserved TLD check (skipped for IP literals).
-        if (!IPAddress.TryParse(host, out IPAddress? literalIp) && ReservedTldClassifier.IsReserved(asciiHost, out string? tld))
+        if (!IPAddress.TryParse(StripBrackets(asciiHost), out IPAddress? literalIp)
+            && ReservedTldClassifier.IsReserved(asciiHost, out string? tld))
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.ReservedTld,
                 $"Host '{asciiHost}' uses the reserved TLD '{tld}'.",
-                "UrlSafety:ReservedTld"));
+                "UrlSafety:ReservedTld",
+                [asciiHost, tld]));
         }
 
         // (7) Deny patterns.
         if (optionOverrides.DeniedHostPatterns.Count > 0 && HostPatternMatcher.MatchesAny(asciiHost, optionOverrides.DeniedHostPatterns))
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.HostPatternDenied,
                 $"Host '{asciiHost}' matches a denied pattern.",
-                "UrlSafety:HostPatternDenied"));
+                "UrlSafety:HostPatternDenied",
+                [asciiHost]));
         }
 
         // (8) Allow patterns (if non-empty, must match at least one).
         if (optionOverrides.AllowedHostPatterns.Count > 0 && !HostPatternMatcher.MatchesAny(asciiHost, optionOverrides.AllowedHostPatterns))
         {
-            return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+            return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.HostPatternNotAllowed,
                 $"Host '{asciiHost}' is not in the allowed pattern list.",
-                "UrlSafety:HostPatternNotAllowed"));
+                "UrlSafety:HostPatternNotAllowed",
+                [asciiHost]));
         }
 
         // (9 / 10) Resolve and classify. IP literal → classify directly.
@@ -126,25 +151,31 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "timeout");
+                return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
                     $"DNS resolution timed out for host '{asciiHost}'.",
-                    "UrlSafety:DnsResolutionFailed"));
+                    "UrlSafety:DnsResolutionFailed",
+                    [asciiHost]));
             }
             catch (SocketException)
             {
-                return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "socket_error");
+                return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
                     $"DNS resolution failed for host '{asciiHost}'.",
-                    "UrlSafety:DnsResolutionFailed"));
+                    "UrlSafety:DnsResolutionFailed",
+                    [asciiHost]));
             }
 
             if (addresses.Length == 0)
             {
-                return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "no_addresses");
+                return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
                     $"DNS resolution returned no addresses for host '{asciiHost}'.",
-                    "UrlSafety:DnsResolutionFailed"));
+                    "UrlSafety:DnsResolutionFailed",
+                    [asciiHost]));
             }
         }
 
@@ -157,50 +188,56 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
                     continue;
                 }
 
-                return UrlSafetyResult.Invalid(new UrlSafetyViolation(
+                return Block(activity, new UrlSafetyViolation(
                     kind,
                     BuildReason(kind, asciiHost),
-                    LocalizationKeyFor(kind)));
+                    LocalizationKeyFor(kind),
+                    [asciiHost]));
             }
         }
 
+        _metrics.RecordValid(tenantId: null);
+        activity?.SetTag("url_safety.outcome", "valid");
         return UrlSafetyResult.Valid(addresses);
     }
 
-    private static bool IsSchemeAllowed(string scheme, IReadOnlyList<string> allowed)
+    private UrlSafetyResult Block(Activity? activity, UrlSafetyViolation violation)
     {
-        for (int i = 0; i < allowed.Count; i++)
-        {
-            if (string.Equals(scheme, allowed[i], StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-        return false;
+        _metrics.RecordBlocked(tenantId: null, violation.Kind);
+        HttpSecurityLog.UrlBlocked(_logger, ExtractHost(violation), violation.Kind, violation.Reason);
+        activity?.SetTag("url_safety.outcome", "blocked");
+        activity?.SetTag("url_safety.violation_kind", violation.Kind.ToString());
+        return UrlSafetyResult.Invalid(violation);
     }
+
+    private static string ExtractHost(UrlSafetyViolation violation) =>
+        violation.Args.Count > 0 && violation.Args[0] is string h ? h : "<unknown>";
+
+    private static bool IsSchemeAllowed(string scheme, IReadOnlyList<string> allowed) =>
+        allowed.Any(s => string.Equals(scheme, s, StringComparison.OrdinalIgnoreCase));
 
     private static string NormalizeHost(string host)
     {
-        // IPv6 literal in URI form is wrapped in brackets — Uri.Host already strips them, but defend.
-        if (host.Length > 0 && host[0] == '[')
-        {
-            return host;
-        }
+        // Uri.Host strips IPv6 brackets, but defend against callers building Uri-like strings by hand.
+        string unbracketed = StripBrackets(host);
 
-        if (IPAddress.TryParse(host, out _))
+        if (IPAddress.TryParse(unbracketed, out _))
         {
-            return host;
+            return unbracketed;
         }
 
         try
         {
-            return IdnMapping.GetAscii(host);
+            return IdnMapping.GetAscii(unbracketed);
         }
         catch (ArgumentException)
         {
-            return host;
+            return unbracketed;
         }
     }
+
+    private static string StripBrackets(string host) =>
+        host.Length >= 2 && host[0] == '[' && host[^1] == ']' ? host[1..^1] : host;
 
     private static bool IsAllowedByPolicy(UrlSafetyViolationKind kind, UrlSafetyOptions opts) =>
         kind switch

--- a/src/Granit.Http.Security/Options/UrlSafetyOptions.cs
+++ b/src/Granit.Http.Security/Options/UrlSafetyOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.Http.Security.Options;
 
 /// <summary>
@@ -12,6 +14,10 @@ public sealed class UrlSafetyOptions
     /// Schemes accepted for validation. Compared case-insensitively against <see cref="Uri.Scheme"/>.
     /// Defaults to <c>["https"]</c>.
     /// </summary>
+    /// <remarks>
+    /// Enabling <c>"file"</c> bypasses the DNS / IP-classification pipeline and on Windows lets
+    /// through UNC paths (<c>file://server/share</c>) — only opt in for trusted, local-only callers.
+    /// </remarks>
     public IReadOnlyList<string> AllowedSchemes { get; set; } = ["https"];
 
     /// <summary>
@@ -28,7 +34,7 @@ public sealed class UrlSafetyOptions
 
     /// <summary>
     /// When <c>true</c>, IDN hostnames are normalized to Punycode before validation.
-    /// Defaults to <c>true</c>.
+    /// Defaults to <c>true</c>. Set to <c>false</c> only if upstream code has already normalized.
     /// </summary>
     public bool AllowIdn { get; set; } = true;
 
@@ -42,6 +48,7 @@ public sealed class UrlSafetyOptions
     public IReadOnlyList<string> DeniedHostPatterns { get; set; } = [];
 
     /// <summary>Maximum permitted URL length in characters. Defaults to <c>2048</c>.</summary>
+    [Range(1, int.MaxValue)]
     public int MaxUrlLength { get; set; } = 2048;
 
     /// <summary>Hard timeout applied to <see cref="System.Net.Dns.GetHostAddressesAsync(string, System.Threading.CancellationToken)"/>.</summary>

--- a/src/Granit.Http.Security/PrivateNetworkClassifier.cs
+++ b/src/Granit.Http.Security/PrivateNetworkClassifier.cs
@@ -97,10 +97,12 @@ public static class PrivateNetworkClassifier
         return Miss(out kind);
     }
 
+    private static readonly byte[] IPv6LoopbackBytes = IPAddress.IPv6Loopback.GetAddressBytes();
+
     private static bool ClassifyIPv6(byte[] b, out UrlSafetyViolationKind kind)
     {
         // ::1 — loopback.
-        if (IsAllZerosExceptLast(b))
+        if (b.AsSpan().SequenceEqual(IPv6LoopbackBytes))
         {
             kind = UrlSafetyViolationKind.Loopback;
             return true;
@@ -128,23 +130,6 @@ public static class PrivateNetworkClassifier
         }
 
         return Miss(out kind);
-    }
-
-    private static bool IsAllZerosExceptLast(byte[] b)
-    {
-        if (b[15] != 1)
-        {
-            return false;
-        }
-
-        for (int i = 0; i < 15; i++)
-        {
-            if (b[i] != 0)
-            {
-                return false;
-            }
-        }
-        return true;
     }
 
     private static bool Miss(out UrlSafetyViolationKind kind)

--- a/src/Granit.Http.Security/UrlSafetyResult.cs
+++ b/src/Granit.Http.Security/UrlSafetyResult.cs
@@ -3,19 +3,32 @@ using System.Net;
 namespace Granit.Http.Security;
 
 /// <summary>
-/// Result of an <see cref="IUrlSafetyValidator"/> check.
+/// Result of an <see cref="IUrlSafetyValidator"/> check. Construct via
+/// <see cref="Valid"/> or <see cref="Invalid"/> — those factories guarantee that
+/// <see cref="IsValid"/>, <see cref="Violation"/>, and <see cref="ResolvedAddresses"/>
+/// are mutually consistent.
 /// </summary>
-/// <param name="IsValid"><c>true</c> when the URL passed every rule.</param>
-/// <param name="Violation">The first violation encountered, or <c>null</c> when valid.</param>
-/// <param name="ResolvedAddresses">
-/// Addresses resolved for the host. Callers SHOULD pin the connecting socket to one of these
-/// (or re-validate) to defeat DNS rebinding between validation and use.
-/// </param>
-public readonly record struct UrlSafetyResult(
-    bool IsValid,
-    UrlSafetyViolation? Violation,
-    IReadOnlyList<IPAddress> ResolvedAddresses)
+public readonly record struct UrlSafetyResult
 {
+    private UrlSafetyResult(bool isValid, UrlSafetyViolation? violation, IReadOnlyList<IPAddress> resolvedAddresses)
+    {
+        IsValid = isValid;
+        Violation = violation;
+        ResolvedAddresses = resolvedAddresses;
+    }
+
+    /// <summary><c>true</c> when the URL passed every rule.</summary>
+    public bool IsValid { get; }
+
+    /// <summary>The first violation encountered, or <c>null</c> when valid.</summary>
+    public UrlSafetyViolation? Violation { get; }
+
+    /// <summary>
+    /// Addresses resolved for the host. Callers SHOULD pin the connecting socket to one of
+    /// these (or re-validate) to defeat DNS rebinding between validation and use.
+    /// </summary>
+    public IReadOnlyList<IPAddress> ResolvedAddresses { get; }
+
     /// <summary>Creates a successful result with the resolved addresses.</summary>
     public static UrlSafetyResult Valid(IReadOnlyList<IPAddress> ips) =>
         new(true, null, ips);

--- a/src/Granit.Http.Security/UrlSafetyViolation.cs
+++ b/src/Granit.Http.Security/UrlSafetyViolation.cs
@@ -8,7 +8,19 @@ namespace Granit.Http.Security;
 /// <param name="Kind">The category of the violation.</param>
 /// <param name="Reason">English fallback reason — useful for logs/telemetry.</param>
 /// <param name="LocalizationKey">Granit localization key (e.g. <c>UrlSafety:Loopback</c>).</param>
+/// <param name="Args">
+/// Positional arguments to interpolate into the localized message. Order matches the
+/// <c>{0}</c>, <c>{1}</c>, ... placeholders in the resource file (e.g. <c>[host]</c> for
+/// most kinds, <c>[host, tld]</c> for <see cref="UrlSafetyViolationKind.ReservedTld"/>,
+/// <c>[maxLength]</c> for <see cref="UrlSafetyViolationKind.UrlTooLong"/>).
+/// </param>
 public sealed record UrlSafetyViolation(
     UrlSafetyViolationKind Kind,
     string Reason,
-    string LocalizationKey);
+    string LocalizationKey,
+    IReadOnlyList<object?> Args)
+{
+    /// <summary>Convenience overload for violations without localization arguments.</summary>
+    public UrlSafetyViolation(UrlSafetyViolationKind kind, string reason, string localizationKey)
+        : this(kind, reason, localizationKey, []) { }
+}

--- a/src/Granit.Http.Security/packages.lock.json
+++ b/src/Granit.Http.Security/packages.lock.json
@@ -14,6 +14,15 @@
         "resolved": "10.0.8",
         "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
       },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",

--- a/src/Granit.Webhooks.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Webhooks.BackgroundJobs/packages.lock.json
@@ -285,6 +285,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Webhooks.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Webhooks.EntityFrameworkCore/packages.lock.json
@@ -317,6 +317,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Webhooks.Notifications/packages.lock.json
+++ b/src/Granit.Webhooks.Notifications/packages.lock.json
@@ -271,6 +271,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -667,6 +667,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -132,6 +132,7 @@
     <ProjectReference Include="..\..\src\Granit.Http.OutputCaching.StackExchangeRedis\Granit.Http.OutputCaching.StackExchangeRedis.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.Resilience\Granit.Http.Resilience.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.ResponseCompression\Granit.Http.ResponseCompression.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Http.Security\Granit.Http.Security.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.SecurityHeaders\Granit.Http.SecurityHeaders.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Endpoints\Granit.Identity.Endpoints.csproj" />

--- a/tests/Granit.Browsing.Playwright.Tests/packages.lock.json
+++ b/tests/Granit.Browsing.Playwright.Tests/packages.lock.json
@@ -395,6 +395,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Browsing.PuppeteerSharp.Tests/packages.lock.json
+++ b/tests/Granit.Browsing.PuppeteerSharp.Tests/packages.lock.json
@@ -413,6 +413,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Browsing.Tests/packages.lock.json
+++ b/tests/Granit.Browsing.Tests/packages.lock.json
@@ -376,6 +376,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.DocumentGeneration.Pdf.Tests/packages.lock.json
+++ b/tests/Granit.DocumentGeneration.Pdf.Tests/packages.lock.json
@@ -403,6 +403,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
+++ b/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics.Metrics;
 using System.Net;
 using Granit.Http.Security;
+using Granit.Http.Security.Diagnostics;
 using Granit.Http.Security.Internal;
 using Granit.Http.Security.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
@@ -21,7 +24,19 @@ public sealed class DefaultUrlSafetyValidatorTests
             DnsResolveTimeout = TimeSpan.FromSeconds(2),
         };
         resolver ??= FakeDnsResolver.Returning("8.8.8.8");
-        return new DefaultUrlSafetyValidator(Microsoft.Extensions.Options.Options.Create(options), resolver, clock ?? TimeProvider.System);
+        HttpSecurityMetrics metrics = new(new DummyMeterFactory());
+        return new DefaultUrlSafetyValidator(
+            Microsoft.Extensions.Options.Options.Create(options),
+            resolver,
+            clock ?? TimeProvider.System,
+            metrics,
+            NullLogger<DefaultUrlSafetyValidator>.Instance);
+    }
+
+    private sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Http.Security.Tests/packages.lock.json
+++ b/tests/Granit.Http.Security.Tests/packages.lock.json
@@ -270,6 +270,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
@@ -289,6 +290,15 @@
         "requested": "[10.*, )",
         "resolved": "10.0.8",
         "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.8",
+        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",

--- a/tests/Granit.Webhooks.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.BackgroundJobs.Tests/packages.lock.json
@@ -534,6 +534,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
@@ -585,6 +585,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/packages.lock.json
@@ -604,6 +604,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Notifications.Tests/packages.lock.json
@@ -509,6 +509,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Tests/packages.lock.json
@@ -514,6 +514,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -861,6 +861,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }


### PR DESCRIPTION
## Summary

Addresses all findings from `/audit Granit.Http.Security`. Module was solid but missing diagnostics, options validation, and a few correctness/cleanup items.

### Architecture
- Register `Granit.Http.Security` in `Granit.ArchitectureTests` (was invisible to convention checks)

### Diagnostics (new)
- `HttpSecurityMetrics` — Meter `Granit.HttpSecurity`, counters `granit.http_security.url.validated` / `.blocked` tagged with `violation_kind`
- `HttpSecurityActivitySource` — registered via `GranitActivitySourceRegistry`
- `HttpSecurityLog` — `[LoggerMessage]` for blocks + DNS failures

### Correctness
- **`AllowIdn` was dead** — code always normalized via `IdnMapping` regardless of the flag; now honored
- **Options validation** — `[Range(1, int.MaxValue)]` on `MaxUrlLength`, `.Validate(...)` ensuring `DnsResolveTimeout > 0` and non-empty `AllowedSchemes`, `.ValidateOnStart()`
- **Localization placeholders fillable** — `UrlSafetyViolation.Args` carries positional args (host, tld, maxLength) so consumers can interpolate `{0}` / `{1}` in resource strings (back-compat overload preserved)
- **Bracket-stripping** before `IPAddress.TryParse` so `[::1]`-style hosts get classified correctly

### Cleanup
- Manual scheme loop → `.Any(...)`
- `IsAllZerosExceptLast` → `IPAddress.IPv6Loopback.GetAddressBytes().AsSpan().SequenceEqual(b)`
- `UrlSafetyResult` — positional ctor made private; only `Valid` / `Invalid` factories construct it (prevents inconsistent `(IsValid: true, Violation: x)` shapes)
- `<EmbeddedResource WithCulture="false">` — defensive against `*-CA.json` / `*-BR.json` satellite-resource misinterpretation

### Docs
- XML-doc on `AllowedSchemes` calling out the UNC-path caveat when `file` is opted in

## Test plan
- [x] `dotnet build src/Granit.Http.Security` — 0 warning, 0 error
- [x] `Granit.Http.Security.Tests` — 118/118 pass
- [x] `Granit.ArchitectureTests` — 182/182 pass (with new project reference)
- [x] `Granit.Browsing` + `Granit.Browsing.Tests` (consumer) — build clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] `packages.lock.json` regenerated