### PR TITLE
fix: deep SSRF audit — Http.Security + Webhooks + PDF + Browsing

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -14974,7 +14974,7 @@
       "kind": "class",
       "project": "Granit.DocumentGeneration.Pdf",
       "file": "src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitDocumentGenerationPdf",
@@ -15054,6 +15054,12 @@
           "name": "RenderTimeoutMs",
           "kind": "property",
           "signature": "int RenderTimeoutMs",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxHtmlBytes",
+          "kind": "property",
+          "signature": "int MaxHtmlBytes",
           "returnType": "int"
         }
       ]
@@ -20040,7 +20046,7 @@
       "kind": "class",
       "project": "Granit.Http.Security",
       "file": "src/Granit.Http.Security/PrivateNetworkClassifier.cs",
-      "line": 23,
+      "line": 26,
       "members": [
         {
           "name": "IsBlocked",

--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightBrowserPage.cs
@@ -138,6 +138,15 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Defense-in-depth chain (VULN-101): the URL is validated pre-navigation by
+    /// <see cref="IUrlSafetyValidator"/>; sub-resource requests are intercepted by the
+    /// <see cref="RequestRouter"/> when <see cref="IBrowserSandboxProfile.BlockPrivateNetworks"/>
+    /// is set; the final URL is re-validated after navigation to defeat redirect chains
+    /// that land on a private address. Residual TOCTOU: Chromium's network stack re-resolves
+    /// DNS independently of the validator. For high-assurance scenarios, launch the engine
+    /// with <c>--host-resolver-rules=MAP &lt;host&gt; &lt;ip&gt;</c> via custom args.
+    /// </remarks>
     public async Task NavigateAsync(Uri url, BrowsingNavigationOptions? options = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -165,8 +174,28 @@ internal sealed partial class PlaywrightBrowserPage : IBrowserPage
             _maxRenderDuration,
             cancellationToken).ConfigureAwait(false);
 
+        // VULN-101 — re-validate the final URL (after redirects). Catches redirect chains
+        // landing on a hostname that resolves to a private IP at fetch time.
+        if (_sandbox.BlockPrivateNetworks
+            && Uri.TryCreate(_page.Url, UriKind.Absolute, out Uri? finalUrl)
+            && !UriEquals(finalUrl, url))
+        {
+            UrlSafetyResult finalSafety = await _urlValidator
+                .ValidateAsync(finalUrl, cancellationToken)
+                .ConfigureAwait(false);
+            if (!finalSafety.IsValid)
+            {
+                string reason = finalSafety.Violation?.Reason ?? "url_safety_violation_post_redirect";
+                await PublishNavigatedAsync(finalUrl, blocked: true, reason, cancellationToken).ConfigureAwait(false);
+                throw new SandboxViolationException(SandboxViolationKind.UrlSafetyViolation, reason);
+            }
+        }
+
         await PublishNavigatedAsync(url, blocked: false, reason: null, cancellationToken).ConfigureAwait(false);
     }
+
+    private static bool UriEquals(Uri a, Uri b) =>
+        string.Equals(a.AbsoluteUri, b.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public Task SetContentAsync(string html, BrowsingNavigationOptions? options = null, CancellationToken cancellationToken = default)

--- a/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
+++ b/src/Granit.Browsing.PuppeteerSharp/Internal/PuppeteerBrowserPage.cs
@@ -138,6 +138,15 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Defense-in-depth chain (VULN-101): the URL is validated pre-navigation by
+    /// <see cref="IUrlSafetyValidator"/>; sub-resource requests are intercepted by the
+    /// <see cref="RequestRouter"/> when <see cref="IBrowserSandboxProfile.BlockPrivateNetworks"/>
+    /// is set; the final URL is re-validated after navigation to defeat redirect chains
+    /// that land on a private address. Residual TOCTOU: Chromium's network stack re-resolves
+    /// DNS independently of the validator. For high-assurance scenarios, launch the engine
+    /// with <c>--host-resolver-rules=MAP &lt;host&gt; &lt;ip&gt;</c> via custom args.
+    /// </remarks>
     public async Task NavigateAsync(Uri url, BrowsingNavigationOptions? options = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -163,8 +172,28 @@ internal sealed partial class PuppeteerBrowserPage : IBrowserPage
             _maxRenderDuration,
             cancellationToken).ConfigureAwait(false);
 
+        // VULN-101 — re-validate the final URL (after redirects). Catches redirect chains
+        // landing on a hostname that resolves to a private IP at fetch time.
+        if (_sandbox.BlockPrivateNetworks
+            && Uri.TryCreate(_page.Url, UriKind.Absolute, out Uri? finalUrl)
+            && !UriEquals(finalUrl, url))
+        {
+            UrlSafetyResult finalSafety = await _urlValidator
+                .ValidateAsync(finalUrl, cancellationToken)
+                .ConfigureAwait(false);
+            if (!finalSafety.IsValid)
+            {
+                string reason = finalSafety.Violation?.Reason ?? "url_safety_violation_post_redirect";
+                await PublishNavigatedAsync(finalUrl, blocked: true, reason, cancellationToken).ConfigureAwait(false);
+                throw new SandboxViolationException(SandboxViolationKind.UrlSafetyViolation, reason);
+            }
+        }
+
         await PublishNavigatedAsync(url, blocked: false, reason: null, cancellationToken).ConfigureAwait(false);
     }
+
+    private static bool UriEquals(Uri a, Uri b) =>
+        string.Equals(a.AbsoluteUri, b.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public Task SetContentAsync(string html, BrowsingNavigationOptions? options = null, CancellationToken cancellationToken = default)

--- a/src/Granit.DocumentGeneration.Pdf/Diagnostics/PdfRenderingActivitySource.cs
+++ b/src/Granit.DocumentGeneration.Pdf/Diagnostics/PdfRenderingActivitySource.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+
+namespace Granit.DocumentGeneration.Pdf.Diagnostics;
+
+/// <summary>
+/// <see cref="ActivitySource"/> for the PDF rendering pipeline. Registered with
+/// <c>GranitActivitySourceRegistry</c> on module load.
+/// </summary>
+internal static class PdfRenderingActivitySource
+{
+    /// <summary>Name of the <see cref="ActivitySource"/>.</summary>
+    public const string Name = "Granit.DocumentGeneration.Pdf";
+
+    /// <summary>Operation name for the full HTML → PDF render.</summary>
+    public const string RenderPdf = "PdfRendering.Render";
+
+    public static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using Granit.Browsing;
 using Granit.Browsing.Capabilities;
+using Granit.Diagnostics;
+using Granit.DocumentGeneration.Pdf.Diagnostics;
 using Granit.DocumentGeneration.Pdf.Internal;
 using Granit.DocumentGeneration.Pdf.Options;
 using Granit.DocumentGeneration.Pipeline;
@@ -56,6 +58,7 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IDocumentRenderer, BrowsingPdfRenderer>();
 
+        GranitActivitySourceRegistry.Register(PdfRenderingActivitySource.Name);
         return services;
     }
 }

--- a/src/Granit.DocumentGeneration.Pdf/Internal/BrowsingPdfRenderer.cs
+++ b/src/Granit.DocumentGeneration.Pdf/Internal/BrowsingPdfRenderer.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Diagnostics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Granit.Browsing;
 using Granit.Browsing.Capabilities;
 using Granit.Browsing.Pages;
+using Granit.DocumentGeneration.Pdf.Diagnostics;
 using Granit.DocumentGeneration.Pdf.Options;
 using Granit.DocumentGeneration.Pipeline;
 using Granit.Templating.Keys;
@@ -41,7 +44,30 @@ internal sealed partial class BrowsingPdfRenderer(
         ArgumentNullException.ThrowIfNull(html);
 
         PdfRenderOptions opts = options.Value;
+
+        // VULN-305 — bound HTML size to protect the Chromium renderer process from OOM.
+        // Char count overestimates byte count when UTF-16 chars are ASCII (good) and underestimates
+        // for surrogate pairs (rare). Use ByteCount for a tight check.
+        int htmlByteLength = Encoding.UTF8.GetByteCount(html);
+        if (htmlByteLength > opts.MaxHtmlBytes)
+        {
+            throw new ArgumentException(
+                $"HTML payload of {htmlByteLength} bytes exceeds MaxHtmlBytes={opts.MaxHtmlBytes}.",
+                nameof(html));
+        }
+
+        // VULN-204 — header/footer templates are trusted strings from configuration. Validate that
+        // no remote-fetch primitive smuggled in; defense-in-depth against config-store compromise
+        // / tenant-controlled overrides (the page-level route-abort does not apply to Chromium's
+        // print-preview header/footer render context).
+        ValidateTrustedTemplate(opts.HeaderTemplate, nameof(opts.HeaderTemplate));
+        ValidateTrustedTemplate(opts.FooterTemplate, nameof(opts.FooterTemplate));
+
         var renderTimeout = TimeSpan.FromMilliseconds(opts.RenderTimeoutMs);
+
+        using Activity? activity = PdfRenderingActivitySource.Source.StartActivity(PdfRenderingActivitySource.RenderPdf);
+        activity?.SetTag("pdf.format", opts.PaperFormat);
+        activity?.SetTag("pdf.html_bytes", htmlByteLength);
 
         await using IBrowserPage page = await browser.AcquirePageAsync(
             new Granit.Browsing.Options.BrowserPageOptions
@@ -53,7 +79,9 @@ internal sealed partial class BrowsingPdfRenderer(
         // CWE-918: SetContentAsync injects HTML via the page's CDP / driver — no
         // outbound request needed. Block any request the document might still emit
         // (referenced fonts, images served from foreign hosts, …) by aborting every
-        // intercepted route.
+        // intercepted route. Note: route() does not intercept data:/blob:/about: schemes
+        // (no network) — combined with JavaScriptEnabled=false above, this leaves no
+        // user-controlled exfil primitive in the main page render.
         await page.RouteAsync(
             RoutePattern.Parse("**/*"),
             static (_, _) => ValueTask.FromResult(RouteDecision.Abort("blocked")),
@@ -80,21 +108,66 @@ internal sealed partial class BrowsingPdfRenderer(
             FooterTemplate = opts.FooterTemplate,
         };
 
-        byte[] pdfBytes = await pdfCapability
-            .RenderToPdfAsync(page, pdfOptions, cancellationToken)
-            .WaitAsync(renderTimeout, cancellationToken)
-            .ConfigureAwait(false);
+        try
+        {
+            byte[] pdfBytes = await pdfCapability
+                .RenderToPdfAsync(page, pdfOptions, cancellationToken)
+                .WaitAsync(renderTimeout, cancellationToken)
+                .ConfigureAwait(false);
 
-        LogPdfRendered(pdfBytes.Length, opts.PaperFormat);
-        return new DocumentResult(pdfBytes, DocumentFormat.Pdf);
+            activity?.SetTag("pdf.bytes", pdfBytes.Length);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            LogPdfRendered(pdfBytes.Length, opts.PaperFormat);
+            return new DocumentResult(pdfBytes, DocumentFormat.Pdf);
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Rejects header/footer templates that embed remote-fetch primitives. The templates are
+    /// trusted strings from configuration — this is defense-in-depth (config-store compromise,
+    /// tenant overrides). Chromium renders these in a separate print-preview context that
+    /// bypasses the main page's route filter.
+    /// </summary>
+    private static void ValidateTrustedTemplate(string? template, string fieldName)
+    {
+        if (string.IsNullOrEmpty(template))
+        {
+            return;
+        }
+
+        // Case-insensitive contains. We accept HTML structure freely; what we forbid is anything
+        // that would trigger an outbound fetch (img, script, link, iframe, object, source, video,
+        // audio, embed, srcset, CSS url(...), or a base href that re-targets the document).
+        ReadOnlySpan<string> forbidden =
+        [
+            "http://", "https://", "//",
+            "<script", "<iframe", "<object", "<embed",
+            "<img", "<link", "<source", "<video", "<audio", "<base",
+            "srcset", "url(",
+        ];
+
+        foreach (string needle in forbidden)
+        {
+            if (template.Contains(needle, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"{fieldName} contains '{needle}' which can trigger an outbound fetch. " +
+                    "PDF header/footer templates must not reference remote resources " +
+                    "(CSS-only content is supported — see XML/CSS-only templating).");
+            }
+        }
     }
 
     /// <summary>
     /// Resolves a paper format string (<c>"A4"</c>, <c>"Letter"</c>, …) to a
     /// <see cref="BrowsingPaperFormat"/>. Falls back to <see cref="BrowsingPaperFormat.A4"/>
-    /// for anything unrecognised — the abstraction set is intentionally smaller than
-    /// what some engines expose, so legacy <c>"A0"</c> / <c>"A6"</c> / <c>"Ledger"</c>
-    /// inputs collapse to the closest standard paper.
+    /// for anything unrecognised — <see cref="PdfRenderOptions.PaperFormat"/> is validated at
+    /// boot via <c>[AllowedValues]</c>, so this fallback only matters in tests / direct calls.
     /// </summary>
     internal static BrowsingPaperFormat ResolvePaperFormat(string format) =>
         format.ToUpperInvariant() switch

--- a/src/Granit.DocumentGeneration.Pdf/Options/PdfRenderOptions.cs
+++ b/src/Granit.DocumentGeneration.Pdf/Options/PdfRenderOptions.cs
@@ -18,9 +18,11 @@ public sealed class PdfRenderOptions
     public const string SectionName = "DocumentGeneration:Pdf";
 
     /// <summary>
-    /// Paper format (e.g. <c>"A4"</c>, <c>"A5"</c>, <c>"Letter"</c>). Default <c>"A4"</c>.
+    /// Paper format. Default <c>"A4"</c>. Accepted values (case-sensitive):
+    /// <c>"A3"</c>, <c>"A4"</c>, <c>"A5"</c>, <c>"Letter"</c>, <c>"Legal"</c>, <c>"Tabloid"</c>.
     /// </summary>
     [Required]
+    [AllowedValues("A3", "A4", "A5", "Letter", "Legal", "Tabloid")]
     public string PaperFormat { get; set; } = "A4";
 
     /// <summary>Whether to use landscape orientation. Default <see langword="false"/> (portrait).</summary>
@@ -60,4 +62,11 @@ public sealed class PdfRenderOptions
     /// </summary>
     [Range(1_000, 300_000)]
     public int RenderTimeoutMs { get; set; } = 30_000;
+
+    /// <summary>
+    /// Maximum size of the HTML payload (in bytes, UTF-8) accepted by the renderer.
+    /// Default <c>16 MiB</c>. Guards against Chromium-renderer-process OOM via oversized payloads.
+    /// </summary>
+    [Range(1_024, 256 * 1024 * 1024)]
+    public int MaxHtmlBytes { get; set; } = 16 * 1024 * 1024;
 }

--- a/src/Granit.Http.Security/Diagnostics/HttpSecurityMetrics.cs
+++ b/src/Granit.Http.Security/Diagnostics/HttpSecurityMetrics.cs
@@ -51,7 +51,6 @@ public sealed class HttpSecurityMetrics
             new("outcome", "blocked"),
             new("violation_kind", kind.ToString()),
         ];
-        _validations.Add(1, tags);
         _blocks.Add(1, tags);
     }
 }

--- a/src/Granit.Http.Security/Extensions/UrlSafetyServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Security/Extensions/UrlSafetyServiceCollectionExtensions.cs
@@ -26,8 +26,8 @@ public static class UrlSafetyServiceCollectionExtensions
             .BindConfiguration(UrlSafetyOptions.SectionName)
             .ValidateDataAnnotations()
             .Validate(
-                o => o.DnsResolveTimeout > TimeSpan.Zero,
-                $"{nameof(UrlSafetyOptions.DnsResolveTimeout)} must be greater than zero.")
+                o => o.DnsResolveTimeout > TimeSpan.Zero && o.DnsResolveTimeout <= TimeSpan.FromSeconds(30),
+                $"{nameof(UrlSafetyOptions.DnsResolveTimeout)} must be in (0, 30s].")
             .Validate(
                 o => o.AllowedSchemes.Count > 0,
                 $"{nameof(UrlSafetyOptions.AllowedSchemes)} must contain at least one entry.")

--- a/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
+++ b/src/Granit.Http.Security/Internal/DefaultUrlSafetyValidator.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using Granit.Http.Security.Diagnostics;
 using Granit.Http.Security.Options;
 using Granit.MultiTenancy;
@@ -21,8 +22,8 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
     private readonly IDnsResolver _resolver;
     private readonly TimeProvider _timeProvider;
     private readonly HttpSecurityMetrics _metrics;
-    private readonly ILogger<DefaultUrlSafetyValidator> _logger;
     private readonly ICurrentTenant? _currentTenant;
+    private readonly ILogger<DefaultUrlSafetyValidator> _logger;
 
     public DefaultUrlSafetyValidator(
         IOptions<UrlSafetyOptions> options,
@@ -41,12 +42,9 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         _resolver = resolver;
         _timeProvider = timeProvider;
         _metrics = metrics;
-        _logger = logger;
         _currentTenant = currentTenant;
+        _logger = logger;
     }
-
-    private string? CurrentTenantId =>
-        _currentTenant is { IsAvailable: true } t ? t.Id?.ToString("N") : null;
 
     public ValueTask<UrlSafetyResult> ValidateAsync(Uri url, CancellationToken ct = default) =>
         ValidateAsync(url, _options.Value, ct);
@@ -88,12 +86,29 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
                 [url.Scheme]));
         }
 
-        // (4) file:// short-circuit — no DNS / no IP classification.
-        // Note: enabling "file" in AllowedSchemes also lets through UNC paths on Windows
-        // (file://server/share) — only opt in for trusted, local-only contexts.
+        // (4) file:// — gated by AllowFileScheme AND empty authority (no UNC).
         if (string.Equals(url.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
         {
-            _metrics.RecordValid(CurrentTenantId);
+            if (!optionOverrides.AllowFileScheme)
+            {
+                return Block(activity, new UrlSafetyViolation(
+                    UrlSafetyViolationKind.SchemeNotAllowed,
+                    "The file scheme is disabled. Set UrlSafetyOptions.AllowFileScheme=true to opt in.",
+                    "UrlSafety:SchemeNotAllowed",
+                    [url.Scheme]));
+            }
+
+            if (!string.IsNullOrEmpty(url.Host))
+            {
+                // file://server/share — UNC path, triggers SMB egress and NTLM-relay on Windows.
+                return Block(activity, new UrlSafetyViolation(
+                    UrlSafetyViolationKind.SchemeNotAllowed,
+                    "UNC file:// paths are not allowed.",
+                    "UrlSafety:SchemeNotAllowed",
+                    [url.Scheme]));
+            }
+
+            RecordValid();
             activity?.SetTag("url_safety.outcome", "valid");
             return UrlSafetyResult.Valid([]);
         }
@@ -117,7 +132,7 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         {
             return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.ReservedTld,
-                $"Host '{asciiHost}' uses the reserved TLD '{tld}'.",
+                $"Host '{SanitizeForDisplay(asciiHost)}' uses the reserved TLD '{tld}'.",
                 "UrlSafety:ReservedTld",
                 [asciiHost, tld]));
         }
@@ -127,7 +142,7 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         {
             return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.HostPatternDenied,
-                $"Host '{asciiHost}' matches a denied pattern.",
+                $"Host '{SanitizeForDisplay(asciiHost)}' matches a denied pattern.",
                 "UrlSafety:HostPatternDenied",
                 [asciiHost]));
         }
@@ -137,7 +152,7 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         {
             return Block(activity, new UrlSafetyViolation(
                 UrlSafetyViolationKind.HostPatternNotAllowed,
-                $"Host '{asciiHost}' is not in the allowed pattern list.",
+                $"Host '{SanitizeForDisplay(asciiHost)}' is not in the allowed pattern list.",
                 "UrlSafety:HostPatternNotAllowed",
                 [asciiHost]));
         }
@@ -158,29 +173,29 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "timeout");
+                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "timeout");
                 return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution timed out for host '{asciiHost}'.",
+                    $"DNS resolution timed out for host '{SanitizeForDisplay(asciiHost)}'.",
                     "UrlSafety:DnsResolutionFailed",
                     [asciiHost]));
             }
             catch (SocketException)
             {
-                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "socket_error");
+                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "socket_error");
                 return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution failed for host '{asciiHost}'.",
+                    $"DNS resolution failed for host '{SanitizeForDisplay(asciiHost)}'.",
                     "UrlSafety:DnsResolutionFailed",
                     [asciiHost]));
             }
 
             if (addresses.Length == 0)
             {
-                HttpSecurityLog.DnsResolutionFailed(_logger, asciiHost, "no_addresses");
+                HttpSecurityLog.DnsResolutionFailed(_logger, SanitizeForDisplay(asciiHost), "no_addresses");
                 return Block(activity, new UrlSafetyViolation(
                     UrlSafetyViolationKind.DnsResolutionFailed,
-                    $"DNS resolution returned no addresses for host '{asciiHost}'.",
+                    $"DNS resolution returned no addresses for host '{SanitizeForDisplay(asciiHost)}'.",
                     "UrlSafety:DnsResolutionFailed",
                     [asciiHost]));
             }
@@ -197,21 +212,26 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
 
                 return Block(activity, new UrlSafetyViolation(
                     kind,
-                    BuildReason(kind, asciiHost),
+                    BuildReason(kind, SanitizeForDisplay(asciiHost)),
                     LocalizationKeyFor(kind),
                     [asciiHost]));
             }
         }
 
-        _metrics.RecordValid(CurrentTenantId);
+        RecordValid();
         activity?.SetTag("url_safety.outcome", "valid");
         return UrlSafetyResult.Valid(addresses);
     }
 
+    private string? CurrentTenantId() =>
+        _currentTenant is { IsAvailable: true, Id: { } id } ? id.ToString() : null;
+
+    private void RecordValid() => _metrics.RecordValid(CurrentTenantId());
+
     private UrlSafetyResult Block(Activity? activity, UrlSafetyViolation violation)
     {
-        _metrics.RecordBlocked(CurrentTenantId, violation.Kind);
-        HttpSecurityLog.UrlBlocked(_logger, ExtractHost(violation), violation.Kind, violation.Reason);
+        _metrics.RecordBlocked(CurrentTenantId(), violation.Kind);
+        HttpSecurityLog.UrlBlocked(_logger, SanitizeForDisplay(ExtractHost(violation)), violation.Kind, violation.Reason);
         activity?.SetTag("url_safety.outcome", "blocked");
         activity?.SetTag("url_safety.violation_kind", violation.Kind.ToString());
         return UrlSafetyResult.Invalid(violation);
@@ -246,6 +266,40 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
     private static string StripBrackets(string host) =>
         host.Length >= 2 && host[0] == '[' && host[^1] == ']' ? host[1..^1] : host;
 
+    /// <summary>
+    /// Strips Unicode control / format code points (e.g. U+202E RTL override) that could spoof
+    /// log entries. Replaces them with <c>?</c>.
+    /// </summary>
+    private static string SanitizeForDisplay(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        StringBuilder? sb = null;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            UnicodeCategory cat = CharUnicodeInfo.GetUnicodeCategory(c);
+            bool unsafeChar = char.IsControl(c)
+                || cat == UnicodeCategory.Format
+                || cat == UnicodeCategory.LineSeparator
+                || cat == UnicodeCategory.ParagraphSeparator;
+            if (unsafeChar)
+            {
+                sb ??= new StringBuilder(value.Length).Append(value, 0, i);
+                sb.Append('?');
+            }
+            else
+            {
+                sb?.Append(c);
+            }
+        }
+
+        return sb?.ToString() ?? value;
+    }
+
     private static bool IsAllowedByPolicy(UrlSafetyViolationKind kind, UrlSafetyOptions opts) =>
         kind switch
         {
@@ -261,6 +315,8 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         UrlSafetyViolationKind.LinkLocal => $"Host '{host}' resolves to a link-local address.",
         UrlSafetyViolationKind.MetadataEndpoint => $"Host '{host}' resolves to a cloud metadata endpoint.",
         UrlSafetyViolationKind.IPv6UniqueLocal => $"Host '{host}' resolves to an IPv6 unique-local address.",
+        UrlSafetyViolationKind.ReservedAddress => $"Host '{host}' resolves to a reserved (multicast / broadcast / future-use) address.",
+        UrlSafetyViolationKind.IPv6EmbeddedIPv4 => $"Host '{host}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive.",
         _ => $"Host '{host}' is blocked.",
     };
 
@@ -271,6 +327,8 @@ internal sealed class DefaultUrlSafetyValidator : IUrlSafetyValidator
         UrlSafetyViolationKind.LinkLocal => "UrlSafety:LinkLocal",
         UrlSafetyViolationKind.MetadataEndpoint => "UrlSafety:MetadataEndpoint",
         UrlSafetyViolationKind.IPv6UniqueLocal => "UrlSafety:IPv6UniqueLocal",
+        UrlSafetyViolationKind.ReservedAddress => "UrlSafety:ReservedAddress",
+        UrlSafetyViolationKind.IPv6EmbeddedIPv4 => "UrlSafety:IPv6EmbeddedIPv4",
         _ => "UrlSafety:HostBlocked",
     };
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/cs.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/cs.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/de.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/de.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "Die URL überschreitet die maximale Länge von {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' entspricht einem verweigerten Muster.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' steht nicht auf der Liste erlaubter Muster.",
-    "UrlSafety:DnsResolutionFailed": "DNS-Auflösung für Host '{0}' fehlgeschlagen."
+    "UrlSafety:DnsResolutionFailed": "DNS-Auflösung für Host '{0}' fehlgeschlagen.",
+    "UrlSafety:ReservedAddress": "Host '{0}' wird zu einer reservierten Adresse (Multicast / Broadcast / zukünftige Nutzung) aufgelöst.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' wird zu einer IPv6-Übergangsadresse mit sensibler eingebetteter IPv4 aufgelöst."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/en-GB.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/en-GB.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/en.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/en.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/es.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/es.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "La URL supera la longitud máxima de {0}.",
     "UrlSafety:HostPatternDenied": "El host '{0}' coincide con un patrón denegado.",
     "UrlSafety:HostPatternNotAllowed": "El host '{0}' no está en la lista de patrones permitidos.",
-    "UrlSafety:DnsResolutionFailed": "Falló la resolución DNS para el host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "Falló la resolución DNS para el host '{0}'.",
+    "UrlSafety:ReservedAddress": "El host '{0}' se resuelve a una dirección reservada (multicast / broadcast / uso futuro).",
+    "UrlSafety:IPv6EmbeddedIPv4": "El host '{0}' se resuelve a una dirección IPv6 de transición con IPv4 embebida sensible."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/fr-CA.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/fr-CA.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "L'URL dépasse la longueur maximale de {0}.",
     "UrlSafety:HostPatternDenied": "L'hôte '{0}' correspond à un motif refusé.",
     "UrlSafety:HostPatternNotAllowed": "L'hôte '{0}' n'est pas dans la liste des motifs autorisés.",
-    "UrlSafety:DnsResolutionFailed": "Échec de la résolution DNS pour l'hôte '{0}'."
+    "UrlSafety:DnsResolutionFailed": "Échec de la résolution DNS pour l'hôte '{0}'.",
+    "UrlSafety:ReservedAddress": "L'hôte '{0}' se résout vers une adresse réservée (multicast / broadcast / usage futur).",
+    "UrlSafety:IPv6EmbeddedIPv4": "L'hôte '{0}' se résout vers une adresse de transition IPv6 dont l'IPv4 embarquée est sensible."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/fr.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/fr.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "L'URL dépasse la longueur maximale de {0}.",
     "UrlSafety:HostPatternDenied": "L'hôte '{0}' correspond à un motif refusé.",
     "UrlSafety:HostPatternNotAllowed": "L'hôte '{0}' n'est pas dans la liste des motifs autorisés.",
-    "UrlSafety:DnsResolutionFailed": "Échec de la résolution DNS pour l'hôte '{0}'."
+    "UrlSafety:DnsResolutionFailed": "Échec de la résolution DNS pour l'hôte '{0}'.",
+    "UrlSafety:ReservedAddress": "L'hôte '{0}' se résout vers une adresse réservée (multicast / broadcast / usage futur).",
+    "UrlSafety:IPv6EmbeddedIPv4": "L'hôte '{0}' se résout vers une adresse de transition IPv6 dont l'IPv4 embarquée est sensible."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/hi.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/hi.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/it.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/it.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/ja.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/ja.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/ko.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/ko.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/nl.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/nl.json
@@ -13,6 +13,8 @@
     "UrlSafety:UrlTooLong": "URL overschrijdt de maximumlengte van {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' komt overeen met een geweigerd patroon.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' staat niet in de lijst met toegestane patronen.",
-    "UrlSafety:DnsResolutionFailed": "DNS-resolutie mislukt voor host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS-resolutie mislukt voor host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' wordt herleid naar een gereserveerd adres (multicast / broadcast / toekomstig gebruik).",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' wordt herleid naar een IPv6-overgangsadres met een gevoelige ingebedde IPv4."
   }
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/pl.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/pl.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/pt-BR.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/pt-BR.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/pt.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/pt.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/sv.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/sv.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/tr.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/tr.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Localization/HttpSecurity/zh.json
+++ b/src/Granit.Http.Security/Localization/HttpSecurity/zh.json
@@ -13,7 +13,9 @@
     "UrlSafety:UrlTooLong": "URL exceeds the maximum length of {0}.",
     "UrlSafety:HostPatternDenied": "Host '{0}' matches a denied pattern.",
     "UrlSafety:HostPatternNotAllowed": "Host '{0}' is not in the allowed pattern list.",
-    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'."
+    "UrlSafety:DnsResolutionFailed": "DNS resolution failed for host '{0}'.",
+    "UrlSafety:ReservedAddress": "Host '{0}' resolves to a reserved (multicast / broadcast / future-use) address.",
+    "UrlSafety:IPv6EmbeddedIPv4": "Host '{0}' resolves to an IPv6 transition address whose embedded IPv4 is sensitive."
   },
   "_meta": "EN fallback — pending translation"
 }

--- a/src/Granit.Http.Security/Options/UrlSafetyOptions.cs
+++ b/src/Granit.Http.Security/Options/UrlSafetyOptions.cs
@@ -53,4 +53,16 @@ public sealed class UrlSafetyOptions
 
     /// <summary>Hard timeout applied to <see cref="System.Net.Dns.GetHostAddressesAsync(string, System.Threading.CancellationToken)"/>.</summary>
     public TimeSpan DnsResolveTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// When <c>true</c>, the <c>file</c> scheme is accepted (in addition to being listed in
+    /// <see cref="AllowedSchemes"/>). Defaults to <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// Defense-in-depth: listing <c>"file"</c> in <see cref="AllowedSchemes"/> is not enough on its own;
+    /// callers must also flip this toggle. Configuration drift on a list is more likely than on a
+    /// typed boolean. When enabled, hosts on <c>file://</c> URIs (Windows UNC paths) are still rejected
+    /// to prevent NTLM-relay / SMB egress via <c>file://attacker/share</c>.
+    /// </remarks>
+    public bool AllowFileScheme { get; set; }
 }

--- a/src/Granit.Http.Security/PrivateNetworkClassifier.cs
+++ b/src/Granit.Http.Security/PrivateNetworkClassifier.cs
@@ -17,6 +17,9 @@ namespace Granit.Http.Security;
 ///   <c>fd00:ec2::254</c>, <c>fe80::a9fe:a9fe</c> (AWS IMDS / GCP / Azure)</item>
 ///   <item>Distinct <see cref="UrlSafetyViolationKind.Loopback"/>, <see cref="UrlSafetyViolationKind.LinkLocal"/>,
 ///   <see cref="UrlSafetyViolationKind.PrivateNetwork"/>, <see cref="UrlSafetyViolationKind.IPv6UniqueLocal"/></item>
+///   <item>Broadcast/multicast/reserved-future as <see cref="UrlSafetyViolationKind.ReservedAddress"/></item>
+///   <item>IPv6 transition forms (NAT64, 6to4, Teredo, IPv4-compatible) unwrapped and re-classified;
+///   if the embedded IPv4 is sensitive, reported as <see cref="UrlSafetyViolationKind.IPv6EmbeddedIPv4"/></item>
 ///   <item>IPv4-mapped-IPv6 unwrap then re-classify</item>
 /// </list>
 /// </remarks>
@@ -34,6 +37,10 @@ public static class PrivateNetworkClassifier
     // Azure/GCP link-local IPv6 metadata variant: fe80::a9fe:a9fe → 12 zero bytes then a9 fe a9 fe.
     private static readonly byte[] LinkLocalIPv6Metadata =
         [0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa9, 0xfe, 0xa9, 0xfe];
+
+    // NAT64 well-known prefix (RFC 6052): 64:ff9b:: → 00 64 ff 9b 00 00 00 00 00 00 00 00 + 4 bytes IPv4.
+    private static readonly byte[] Nat64Prefix =
+        [0x00, 0x64, 0xff, 0x9b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
     /// <summary>
     /// Returns <c>true</c> and the matching <paramref name="kind"/> when the address falls in a
@@ -81,16 +88,32 @@ public static class PrivateNetworkClassifier
 
         // 0.0.0.0/8 — "this network" / unspecified (RFC 1122).
         // 10.0.0.0/8 — private (RFC 1918).
-        // 100.64.0.0/10 — CGNAT (RFC 6598). 0x40 == 64, 0x7F == 127.
+        // 100.64.0.0/10 — CGNAT (RFC 6598).
         // 172.16.0.0/12 — private (RFC 1918).
         // 192.168.0.0/16 — private (RFC 1918).
+        // 192.0.0.0/24 — IETF protocol assignments (RFC 6890).
+        // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — TEST-NET-1/2/3 (RFC 5737).
+        // 198.18.0.0/15 — benchmarking (RFC 2544); often routed to internal taps.
         if (b[0] == 0
             || b[0] == 10
             || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
             || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
-            || (b[0] == 192 && b[1] == 168))
+            || (b[0] == 192 && b[1] == 168)
+            || (b[0] == 192 && b[1] == 0 && b[2] == 0)
+            || (b[0] == 192 && b[1] == 0 && b[2] == 2)
+            || (b[0] == 198 && b[1] == 51 && b[2] == 100)
+            || (b[0] == 203 && b[1] == 0 && b[2] == 113)
+            || (b[0] == 198 && (b[1] == 18 || b[1] == 19)))
         {
             kind = UrlSafetyViolationKind.PrivateNetwork;
+            return true;
+        }
+
+        // 224.0.0.0/4 — multicast (RFC 5771).
+        // 240.0.0.0/4 — reserved for future use (RFC 1112) including 255.255.255.255 limited broadcast.
+        if (b[0] >= 224)
+        {
+            kind = UrlSafetyViolationKind.ReservedAddress;
             return true;
         }
 
@@ -98,11 +121,20 @@ public static class PrivateNetworkClassifier
     }
 
     private static readonly byte[] IPv6LoopbackBytes = IPAddress.IPv6Loopback.GetAddressBytes();
+    private static readonly byte[] IPv6UnspecifiedBytes = IPAddress.IPv6Any.GetAddressBytes();
+    private static readonly byte[] Ipv6DocumentationPrefix = [0x20, 0x01, 0x0d, 0xb8]; // 2001:db8::/32
 
     private static bool ClassifyIPv6(byte[] b, out UrlSafetyViolationKind kind)
     {
         // ::1 — loopback.
         if (b.AsSpan().SequenceEqual(IPv6LoopbackBytes))
+        {
+            kind = UrlSafetyViolationKind.Loopback;
+            return true;
+        }
+
+        // :: — unspecified (equivalent of 0.0.0.0).
+        if (b.AsSpan().SequenceEqual(IPv6UnspecifiedBytes))
         {
             kind = UrlSafetyViolationKind.Loopback;
             return true;
@@ -129,7 +161,78 @@ public static class PrivateNetworkClassifier
             return true;
         }
 
+        // ff00::/8 — multicast (RFC 4291).
+        if (b[0] == 0xff)
+        {
+            kind = UrlSafetyViolationKind.ReservedAddress;
+            return true;
+        }
+
+        // 2001:db8::/32 — documentation (RFC 3849) — must never resolve.
+        if (b.AsSpan(0, 4).SequenceEqual(Ipv6DocumentationPrefix))
+        {
+            kind = UrlSafetyViolationKind.ReservedAddress;
+            return true;
+        }
+
+        // NAT64 well-known prefix 64:ff9b::/96 (RFC 6052) — last 4 bytes are an embedded IPv4.
+        if (b.AsSpan(0, 12).SequenceEqual(Nat64Prefix))
+        {
+            return ClassifyEmbeddedIPv4(b.AsSpan(12, 4), out kind);
+        }
+
+        // 6to4 — 2002::/16. Bytes 2..5 carry the IPv4 (RFC 3056).
+        if (b[0] == 0x20 && b[1] == 0x02)
+        {
+            return ClassifyEmbeddedIPv4(b.AsSpan(2, 4), out kind);
+        }
+
+        // Teredo — 2001::/32 (RFC 4380). Bytes 12..15 are the client IPv4 obfuscated by XOR 0xff.
+        if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && b[3] == 0x00)
+        {
+            Span<byte> teredoClient = stackalloc byte[4];
+            teredoClient[0] = (byte)(b[12] ^ 0xff);
+            teredoClient[1] = (byte)(b[13] ^ 0xff);
+            teredoClient[2] = (byte)(b[14] ^ 0xff);
+            teredoClient[3] = (byte)(b[15] ^ 0xff);
+            return ClassifyEmbeddedIPv4(teredoClient, out kind);
+        }
+
+        // ::a.b.c.d — IPv4-compatible IPv6 (deprecated, RFC 4291 §2.5.5.1). First 12 bytes are zero,
+        // last 4 are the IPv4. We already matched ::1 and :: above, so any other ::/96 with a non-zero
+        // tail is treated as embedded IPv4.
+        if (IsZero(b.AsSpan(0, 12)) && !IsZero(b.AsSpan(12, 4)))
+        {
+            return ClassifyEmbeddedIPv4(b.AsSpan(12, 4), out kind);
+        }
+
         return Miss(out kind);
+    }
+
+    private static bool ClassifyEmbeddedIPv4(ReadOnlySpan<byte> v4, out UrlSafetyViolationKind kind)
+    {
+        byte[] copy = [v4[0], v4[1], v4[2], v4[3]];
+        if (ClassifyIPv4(copy, out UrlSafetyViolationKind embedded))
+        {
+            kind = embedded == UrlSafetyViolationKind.MetadataEndpoint
+                ? UrlSafetyViolationKind.MetadataEndpoint
+                : UrlSafetyViolationKind.IPv6EmbeddedIPv4;
+            return true;
+        }
+
+        return Miss(out kind);
+    }
+
+    private static bool IsZero(ReadOnlySpan<byte> span)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] != 0)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static bool Miss(out UrlSafetyViolationKind kind)

--- a/src/Granit.Http.Security/ReservedTldClassifier.cs
+++ b/src/Granit.Http.Security/ReservedTldClassifier.cs
@@ -14,6 +14,13 @@ public static class ReservedTldClassifier
         "test",       // RFC 6761
         "example",    // RFC 6761
         "invalid",    // RFC 6761
+        "arpa",       // infrastructure TLD (RFC 3172, includes home.arpa per RFC 8375)
+        "alt",        // unmanaged alternative-namespace TLD (RFC 9476)
+        "intranet",   // ICANN SAC 113 — never delegated
+        "corp",       // ICANN SAC 113 — never delegated
+        "home",       // ICANN SAC 113 — never delegated
+        "lan",        // ICANN SAC 113 — never delegated
+        "private",    // ICANN SAC 113 — never delegated
     ];
 
     /// <summary>

--- a/src/Granit.Http.Security/UrlSafetyViolationKind.cs
+++ b/src/Granit.Http.Security/UrlSafetyViolationKind.cs
@@ -51,4 +51,17 @@ public enum UrlSafetyViolationKind
 
     /// <summary>DNS resolution failed or timed out.</summary>
     DnsResolutionFailed,
+
+    /// <summary>
+    /// The host resolves to a multicast / broadcast / reserved-for-future-use range that must never
+    /// originate outbound traffic (224.0.0.0/4, 240.0.0.0/4, 255.255.255.255, ff00::/8).
+    /// </summary>
+    ReservedAddress,
+
+    /// <summary>
+    /// The host resolves to an IPv6 transition / embedding form (NAT64 64:ff9b::/96, 6to4 2002::/16,
+    /// Teredo 2001::/32, or the deprecated IPv4-compatible <c>::a.b.c.d</c>) whose embedded IPv4 falls
+    /// in a sensitive range.
+    /// </summary>
+    IPv6EmbeddedIPv4,
 }

--- a/src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs
+++ b/src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs
@@ -52,7 +52,11 @@ public static class WebhookTargetUrlValidatorExtensions
 
         string host = uri.Host;
 
-        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+        // Reject any reserved / internal-only hostname (localhost, *.local, *.internal, *.corp, …).
+        // Catches `localhost`, `ip6-localhost`, `*.home.arpa`, etc. — anything that NotUseBlockedTld
+        // would also reject, but applied here pre-IP so that hostnames pointing at private
+        // addresses via /etc/hosts trip on the literal name too.
+        if (ReservedTldClassifier.IsReserved(host, out _))
         {
             return false;
         }

--- a/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
@@ -15,12 +15,22 @@ internal static class WebhookSsrfConnectCallback
         SocketsHttpConnectionContext context,
         CancellationToken cancellationToken)
     {
-        IPHostEntry entry = await Dns.GetHostEntryAsync(
-            context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
+        // Forward-only A/AAAA lookup — never GetHostEntryAsync, which also triggers a reverse-PTR
+        // lookup (slow, can hang on broken reverse zones, leaks internal hostnames over DNS).
+        IPAddress[] addresses = await Dns
+            .GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (addresses.Length == 0)
+        {
+            throw new HttpRequestException(
+                $"Webhook delivery blocked: DNS returned no addresses for " +
+                $"'{context.DnsEndPoint.Host}'.");
+        }
 
         // Validate ALL resolved IPs before connecting — a multi-homed host might mix
         // public and private addresses.
-        IPAddress? blocked = Array.Find(entry.AddressList, PrivateNetworkClassifier.IsBlocked);
+        IPAddress? blocked = Array.Find(addresses, PrivateNetworkClassifier.IsBlocked);
         if (blocked is not null)
         {
             throw new HttpRequestException(
@@ -29,7 +39,7 @@ internal static class WebhookSsrfConnectCallback
                 "are not permitted for webhook target URLs (SSRF protection).");
         }
 
-        // Connect to the first available address.
+        // Connect to one of the validated addresses (no further DNS).
         var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
         {
             NoDelay = true,
@@ -37,7 +47,7 @@ internal static class WebhookSsrfConnectCallback
 
         try
         {
-            await socket.ConnectAsync(entry.AddressList, context.DnsEndPoint.Port, cancellationToken)
+            await socket.ConnectAsync(addresses, context.DnsEndPoint.Port, cancellationToken)
                 .ConfigureAwait(false);
             return new NetworkStream(socket, ownsSocket: true);
         }

--- a/tests/Granit.ArchitectureTests/OutboundHttpSafetyTests.cs
+++ b/tests/Granit.ArchitectureTests/OutboundHttpSafetyTests.cs
@@ -1,0 +1,124 @@
+using System.Xml.Linq;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Architecture rules pinning the SSRF defense posture across the framework. These tests
+/// guard the layered defense (validator + connect-callback + reserved-IP classifier) against
+/// regressions when new modules emit outbound HTTP or webhook traffic.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item><b>R-SSRF-1:</b> any package emitting outbound user-controlled URLs MUST reference
+///   <c>Granit.Http.Security</c>.</item>
+///   <item><b>R-SSRF-3:</b> no source code may call <c>Dns.GetHostEntry</c> / <c>GetHostEntryAsync</c>
+///   (triggers reverse-PTR; use <c>GetHostAddressesAsync</c> instead).</item>
+/// </list>
+/// R-SSRF-2 (forbid raw <c>SocketsHttpHandler</c> without <c>ConnectCallback</c>) and R-SSRF-4
+/// (force <c>--host-resolver-rules</c> in browser launch args) are documented but not enforced
+/// here — pattern-matching them across the codebase produces too many false positives.
+/// </remarks>
+public sealed class OutboundHttpSafetyTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// R-SSRF-1 — packages that emit outbound user-controlled URLs must reference
+    /// <c>Granit.Http.Security</c>. The reference makes the SSRF blocklist and
+    /// <c>IUrlSafetyValidator</c> available without each consumer reinventing the rule set.
+    /// </summary>
+    /// <remarks>
+    /// Provider / endpoint sub-packages (<c>*.Playwright</c>, <c>*.PuppeteerSharp</c>,
+    /// <c>*.Endpoints</c>) inherit the reference transitively through their base package and are
+    /// not listed here.
+    /// </remarks>
+    [Theory]
+    [InlineData("Granit.Webhooks")]
+    [InlineData("Granit.Browsing")]
+    public void Outbound_user_url_packages_must_reference_Granit_Http_Security(string projectName)
+    {
+        string csprojPath = Path.Join(RepoRoot, "src", projectName, $"{projectName}.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected {csprojPath} to exist.");
+
+        var doc = XDocument.Load(csprojPath);
+        bool referenced = doc.Descendants("ProjectReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty)
+            .Any(r => r.Contains("Granit.Http.Security.csproj", StringComparison.Ordinal)
+                  && !r.Contains("Granit.Http.SecurityHeaders", StringComparison.Ordinal));
+
+        referenced.ShouldBeTrue(
+            $"{projectName} emits outbound user-controlled URLs and must reference Granit.Http.Security " +
+            $"so it can use IUrlSafetyValidator / PrivateNetworkClassifier instead of inventing local rules.");
+    }
+
+    /// <summary>
+    /// R-SSRF-3 — forbid <c>Dns.GetHostEntry</c> / <c>GetHostEntryAsync</c>. These also perform
+    /// a reverse-PTR lookup (slow, can hang on broken reverse zones, leaks internal hostnames over
+    /// DNS). Use <c>Dns.GetHostAddressesAsync(host, ct)</c> instead.
+    /// </summary>
+    [Fact]
+    public void No_source_should_call_Dns_GetHostEntry()
+    {
+        List<string> violations = [];
+
+        foreach (string csFile in EnumerateRepoCsFiles())
+        {
+            // Skip test code (allowed to call any DNS API for assertions / fakes).
+            if (csFile.Contains($"{Path.DirectorySeparatorChar}tests{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string content = File.ReadAllText(csFile);
+            if (content.Contains("Dns.GetHostEntry", StringComparison.Ordinal))
+            {
+                string rel = Path.GetRelativePath(RepoRoot, csFile);
+                violations.Add(rel);
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Dns.GetHostEntry / GetHostEntryAsync triggers reverse-PTR lookups (slow, leaky). " +
+            "Use Dns.GetHostAddressesAsync(host, ct) for forward-only A/AAAA resolution. " +
+            $"Violators: {string.Join(", ", violations)}");
+    }
+
+    private static IEnumerable<string> EnumerateRepoCsFiles()
+    {
+        foreach (string root in (string[])["src", "tests"])
+        {
+            string dir = Path.Join(RepoRoot, root);
+            if (!Directory.Exists(dir))
+            {
+                continue;
+            }
+            foreach (string cs in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                // Skip generated obj/bin output.
+                if (cs.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || cs.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                yield return cs;
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(OutboundHttpSafetyTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}

--- a/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
+++ b/tests/Granit.Http.Security.Tests/DefaultUrlSafetyValidatorTests.cs
@@ -118,9 +118,9 @@ public sealed class DefaultUrlSafetyValidatorTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task FileScheme_AllowedWhenInAllowlist_NoDnsCall()
+    public async Task FileScheme_AllowedWhenInAllowlistAndOptIn_NoDnsCall()
     {
-        UrlSafetyOptions opts = new() { AllowedSchemes = ["file"] };
+        UrlSafetyOptions opts = new() { AllowedSchemes = ["file"], AllowFileScheme = true };
         var resolver = FakeDnsResolver.Throws();
         DefaultUrlSafetyValidator v = Create(resolver, opts);
 
@@ -137,6 +137,32 @@ public sealed class DefaultUrlSafetyValidatorTests
         DefaultUrlSafetyValidator v = Create(options: opts);
 
         UrlSafetyResult result = await v.ValidateAsync(new Uri("file:///etc/passwd"), TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Violation!.Kind.ShouldBe(UrlSafetyViolationKind.SchemeNotAllowed);
+    }
+
+    // VULN-202 — defense in depth: listing "file" in AllowedSchemes is not enough on its own.
+    [Fact]
+    public async Task FileScheme_InAllowlistButOptOutFalse_StillRejected()
+    {
+        UrlSafetyOptions opts = new() { AllowedSchemes = ["file"], AllowFileScheme = false };
+        DefaultUrlSafetyValidator v = Create(options: opts);
+
+        UrlSafetyResult result = await v.ValidateAsync(new Uri("file:///etc/passwd"), TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Violation!.Kind.ShouldBe(UrlSafetyViolationKind.SchemeNotAllowed);
+    }
+
+    // VULN-202 — UNC file:// path triggers SMB egress on Windows; reject even when opted in.
+    [Fact]
+    public async Task FileScheme_UncPath_Rejected()
+    {
+        UrlSafetyOptions opts = new() { AllowedSchemes = ["file"], AllowFileScheme = true };
+        DefaultUrlSafetyValidator v = Create(options: opts);
+
+        UrlSafetyResult result = await v.ValidateAsync(new Uri("file://attacker.example.com/share"), TestContext.Current.CancellationToken);
 
         result.IsValid.ShouldBeFalse();
         result.Violation!.Kind.ShouldBe(UrlSafetyViolationKind.SchemeNotAllowed);

--- a/tests/Granit.Http.Security.Tests/PrivateNetworkClassifierTests.cs
+++ b/tests/Granit.Http.Security.Tests/PrivateNetworkClassifierTests.cs
@@ -104,4 +104,68 @@ public sealed class PrivateNetworkClassifierTests
     public void Classify_NullArgument_Throws() =>
         Should.Throw<ArgumentNullException>(() =>
             PrivateNetworkClassifier.Classify(null!, out _));
+
+    [Theory]
+    // VULN-200 — reserved ranges
+    [InlineData("224.0.0.1", UrlSafetyViolationKind.ReservedAddress)]          // multicast
+    [InlineData("239.255.255.255", UrlSafetyViolationKind.ReservedAddress)]    // multicast
+    [InlineData("240.0.0.0", UrlSafetyViolationKind.ReservedAddress)]          // reserved future
+    [InlineData("255.255.255.255", UrlSafetyViolationKind.ReservedAddress)]    // limited broadcast
+    [InlineData("192.0.0.1", UrlSafetyViolationKind.PrivateNetwork)]           // IETF assignments
+    [InlineData("192.0.2.1", UrlSafetyViolationKind.PrivateNetwork)]           // TEST-NET-1
+    [InlineData("198.51.100.1", UrlSafetyViolationKind.PrivateNetwork)]        // TEST-NET-2
+    [InlineData("203.0.113.1", UrlSafetyViolationKind.PrivateNetwork)]         // TEST-NET-3
+    [InlineData("198.18.0.1", UrlSafetyViolationKind.PrivateNetwork)]          // benchmark
+    [InlineData("198.19.255.254", UrlSafetyViolationKind.PrivateNetwork)]      // benchmark
+    [InlineData("::", UrlSafetyViolationKind.Loopback)]                        // unspecified
+    [InlineData("ff00::1", UrlSafetyViolationKind.ReservedAddress)]            // IPv6 multicast
+    [InlineData("ff02::1", UrlSafetyViolationKind.ReservedAddress)]            // all-nodes multicast
+    [InlineData("2001:db8::1", UrlSafetyViolationKind.ReservedAddress)]        // documentation
+    public void Classify_NewReservedRanges_Blocked(string ipText, UrlSafetyViolationKind expected)
+    {
+        var ip = IPAddress.Parse(ipText);
+
+        bool blocked = PrivateNetworkClassifier.Classify(ip, out UrlSafetyViolationKind kind);
+
+        blocked.ShouldBeTrue();
+        kind.ShouldBe(expected);
+    }
+
+    [Theory]
+    // VULN-100 — IPv6 transitional / embedded-IPv4 bypass primitives
+    // NAT64 64:ff9b::/96 wrapping loopback / IMDS / RFC1918
+    [InlineData("64:ff9b::7f00:1", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]      // → 127.0.0.1
+    [InlineData("64:ff9b::a9fe:a9fe", UrlSafetyViolationKind.MetadataEndpoint)]   // → 169.254.169.254
+    [InlineData("64:ff9b::a00:1", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]       // → 10.0.0.1
+    // 6to4 2002::/16 — bytes 2..5 encode the IPv4
+    [InlineData("2002:7f00:1::", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]        // → 127.0.0.1
+    [InlineData("2002:a9fe:a9fe::", UrlSafetyViolationKind.MetadataEndpoint)]     // → 169.254.169.254
+    // Teredo 2001::/32 — last 4 bytes XOR 0xff = client IPv4
+    // 0x80 0x00 0xff 0xfe ^ 0xff = 0x7f 0xff 0x00 0x01 = 127.255.0.1 (loopback /8)
+    [InlineData("2001:0:0:0:0:0:8000:fffe", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]
+    // IPv4-compatible IPv6 ::a.b.c.d
+    [InlineData("::127.0.0.1", UrlSafetyViolationKind.IPv6EmbeddedIPv4)]
+    [InlineData("::169.254.169.254", UrlSafetyViolationKind.MetadataEndpoint)]
+    public void Classify_IPv6TransitionalEmbeddedIPv4_Blocked(string ipText, UrlSafetyViolationKind expected)
+    {
+        var ip = IPAddress.Parse(ipText);
+
+        bool blocked = PrivateNetworkClassifier.Classify(ip, out UrlSafetyViolationKind kind);
+
+        blocked.ShouldBeTrue();
+        kind.ShouldBe(expected);
+    }
+
+    [Theory]
+    // 6to4 / NAT64 to a PUBLIC IPv4 — must remain unblocked
+    [InlineData("64:ff9b::808:808")]   // NAT64 → 8.8.8.8
+    [InlineData("2002:808:808::")]      // 6to4 → 8.8.8.8
+    public void Classify_IPv6TransitionalEmbeddedPublicIPv4_Allowed(string ipText)
+    {
+        var ip = IPAddress.Parse(ipText);
+
+        bool blocked = PrivateNetworkClassifier.Classify(ip, out _);
+
+        blocked.ShouldBeFalse();
+    }
 }

--- a/tests/Granit.Http.Security.Tests/ReservedTldClassifierTests.cs
+++ b/tests/Granit.Http.Security.Tests/ReservedTldClassifierTests.cs
@@ -15,6 +15,15 @@ public sealed class ReservedTldClassifierTests
     [InlineData("foo.test", "test")]
     [InlineData("example.com.example", "example")]
     [InlineData("missing.invalid", "invalid")]
+    // VULN-300 — newly added reserved TLDs
+    [InlineData("home.arpa", "arpa")]
+    [InlineData("0.0.127.in-addr.arpa", "arpa")]
+    [InlineData("foo.alt", "alt")]
+    [InlineData("svc.intranet", "intranet")]
+    [InlineData("dc1.corp", "corp")]
+    [InlineData("printer.home", "home")]
+    [InlineData("router.lan", "lan")]
+    [InlineData("ns.private", "private")]
     // Case-insensitive matching.
     [InlineData("PRINTER.LOCAL", "local")]
     [InlineData("Some.Internal", "internal")]


### PR DESCRIPTION
## Summary

Follow-up to the deep `/security` audit of `Granit.Http.Security`. Closes 16 audit findings across 4 modules and adds 2 architecture rules to prevent regressions. Split into 5 atomic commits, one per module.

### `Granit.Http.Security` (`33223d54e`)
- **VULN-100 (HIGH)** — `PrivateNetworkClassifier` now covers IPv6 transitionals (NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, Teredo `2001::/32`, IPv4-compatible `::a.b.c.d`) — closes the bypass where `64:ff9b::a9fe:a9fe` reaches AWS IMDS.
- **VULN-200 (MEDIUM)** — added IANA special-purpose ranges: `255.255.255.255`, `224.0.0.0/4`, `240.0.0.0/4`, `ff00::/8`, `::`, `2001:db8::/32`, TEST-NET-1/2/3, benchmark `198.18.0.0/15`, IETF `192.0.0.0/24`.
- **VULN-202 (MEDIUM)** — new `UrlSafetyOptions.AllowFileScheme` opt-in toggle so listing `"file"` in `AllowedSchemes` alone no longer enables LFI/UNC; UNC `file://` rejected unconditionally.
- **VULN-300 (LOW)** — `ReservedTldClassifier` extended with `arpa`, `alt`, `intranet`, `corp`, `home`, `lan`, `private` (RFC 3172, 9476, ICANN SAC 113).
- **VULN-301 (LOW)** — hostnames sanitized (control / format / RTL code points stripped) before logs and reason strings.
- **VULN-400/401/402 (INFO)** — `ICurrentTenant` wired for metric attribution, `RecordBlocked` no longer double-counts on the throughput counter, `DnsResolveTimeout` capped at 30s.
- 2 new `UrlSafetyViolationKind` values + 18-culture localization coverage.
- +27 new unit tests (152 total, all green).

### `Granit.Webhooks` (`586a40386`)
- **VULN-302/403 (LOW)** — `WebhookSsrfConnectCallback` switched from `Dns.GetHostEntryAsync` (reverse-PTR, slow, leaky) to `Dns.GetHostAddressesAsync` + explicit empty-`AddressList` rejection.
- **VULN-404 (INFO)** — endpoint validator uses `ReservedTldClassifier` instead of a single `"localhost"` string special-case.

### `Granit.DocumentGeneration.Pdf` (`2bb0ef062`)
- **VULN-204 (MEDIUM)** — `HeaderTemplate` / `FooterTemplate` validated at render time: reject `http(s)://`, `//`, `<script`, `<iframe`, `<img`, `<link`, `<source`, `<video`, `<audio`, `<object`, `<embed`, `<base`, `srcset`, `url(`. Closes the print-preview render-context exfil primitive bypassing the page's `RouteAsync` filter.
- **VULN-305 (LOW)** — new `PdfRenderOptions.MaxHtmlBytes` (default 16 MiB) bounds HTML before Chromium → no renderer-process OOM.
- **VULN-306 (LOW)** — `PaperFormat` gated by `[AllowedValues]` at boot; typos no longer fall back silently to A4.
- **VULN-407 (INFO)** — new `PdfRenderingActivitySource` (`Granit.DocumentGeneration.Pdf`), registered with `GranitActivitySourceRegistry`, tags renders with format / html_bytes / output bytes.

### `Granit.Browsing*` (`f5c90d6b3`)
- **VULN-101 (HIGH, partial)** — after `NavigateAsync`, re-validate `_page.Url` (post-redirect) when `BlockPrivateNetworks` is set. Catches redirect chains landing on a hostname resolving to a private IP at fetch time. xmldoc documents the **residual** TOCTOU (Chromium re-resolves DNS independently of the validator) and points high-assurance callers at `--host-resolver-rules` launch pinning.
- **VULN-203** — already correctly handled by both engines (`BlockPrivateNetworks` triggers `RequiresEagerInterception`). No-op, kept for traceability.

### `Granit.ArchitectureTests` (`c48a84a6f`)
- **R-SSRF-1** — `Granit.Webhooks` and `Granit.Browsing` must reference `Granit.Http.Security` (transitive coverage for `*.Endpoints` / `*.Playwright` / `*.PuppeteerSharp`).
- **R-SSRF-3** — no source-tree code may call `Dns.GetHostEntry*` (forward-only `GetHostAddressesAsync` required).
- R-SSRF-2 / R-SSRF-4 documented in xmldoc but not yet enforceable without richer AST queries.

## Residual risk

`VULN-101` is **partially mitigated** by classifier hardening, eager interception (already in place), and post-redirect re-validation. The pure TOCTOU between validator DNS and Chromium DNS persists — true closure requires per-context `--host-resolver-rules` launch pinning OR a `Route.FulfillAsync` proxy through Granit's safe `HttpClient`. Both are substantial features warranting their own design discussion / PR.

## Test plan

- [x] `Granit.Http.Security.Tests` — 152/152 (+27 new)
- [x] `Granit.Webhooks.Tests` + `Webhooks.Endpoints.Tests` — 250/250
- [x] `Granit.Browsing.Tests` — 96/96
- [x] `Granit.DocumentGeneration.Pdf.Tests` — 34/34
- [x] `Granit.ArchitectureTests` — 185/185 (incl. 3 new R-SSRF)
- [x] `dotnet format style` + `dotnet format whitespace` clean on all 6 touched packages
- [x] Build green on `api-data` shard (CI parity)
- [ ] CI green on all 8 shards (delegated)