### PR TITLE
fix(build): register Granit.Workspaces.Abstractions in slnx and shards

### DIFF
--- a/.github/shard-filters/api-data.slnf
+++ b/.github/shard-filters/api-data.slnf
@@ -86,6 +86,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Bff.Endpoints.Tests/Granit.Bff.Endpoints.Tests.csproj",
       "tests/Granit.Bff.Tests/Granit.Bff.Tests.csproj",

--- a/.github/shard-filters/application.slnf
+++ b/.github/shard-filters/application.slnf
@@ -61,6 +61,7 @@
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Analytics.Abstractions.Tests/Granit.Analytics.Abstractions.Tests.csproj",
       "tests/Granit.Dashboards.Abstractions.Tests/Granit.Dashboards.Abstractions.Tests.csproj",
@@ -97,7 +98,8 @@
       "tests/Granit.Workflow.Endpoints.Tests/Granit.Workflow.Endpoints.Tests.csproj",
       "tests/Granit.Workflow.EntityFrameworkCore.Tests/Granit.Workflow.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj",
-      "tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj"
+      "tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj",
+      "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj"
     ]
   }
 }

--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -252,6 +252,7 @@
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.ArchitectureTests.Abstractions/Granit.ArchitectureTests.Abstractions.csproj",
       "tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj"

--- a/.github/shard-filters/core-ai.slnf
+++ b/.github/shard-filters/core-ai.slnf
@@ -89,6 +89,7 @@
       "src/Granit.Workflow.AI/Granit.Workflow.AI.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",

--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -94,6 +94,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.BackgroundJobs.Endpoints.Tests/Granit.BackgroundJobs.Endpoints.Tests.csproj",
       "tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests.csproj",

--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -105,6 +105,7 @@
       "src/Granit.Vault/Granit.Vault.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Auditing.ConfigurationChanges.Tests/Granit.Auditing.ConfigurationChanges.Tests.csproj",
       "tests/Granit.Auditing.Endpoints.Tests/Granit.Auditing.Endpoints.Tests.csproj",

--- a/.github/shard-filters/src-only.slnf
+++ b/.github/shard-filters/src-only.slnf
@@ -253,6 +253,7 @@
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",

--- a/.slnf/application.slnf
+++ b/.slnf/application.slnf
@@ -74,6 +74,7 @@
       "src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj",
       "src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj",
       "tests/Granit.DataExchange.Abstractions.Tests/Granit.DataExchange.Abstractions.Tests.csproj",

--- a/.slnf/compliance.slnf
+++ b/.slnf/compliance.slnf
@@ -55,6 +55,7 @@
       "src/Granit.Validation/Granit.Validation.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Auditing.ConfigurationChanges.Tests/Granit.Auditing.ConfigurationChanges.Tests.csproj",
       "tests/Granit.Auditing.Endpoints.Tests/Granit.Auditing.Endpoints.Tests.csproj",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -151,6 +151,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",
@@ -294,7 +295,8 @@
       "tests/Granit.Wolverine.Postgresql.Tests/Granit.Wolverine.Postgresql.Tests.csproj",
       "tests/Granit.Wolverine.SqlServer.Tests.Integration/Granit.Wolverine.SqlServer.Tests.Integration.csproj",
       "tests/Granit.Wolverine.SqlServer.Tests/Granit.Wolverine.SqlServer.Tests.csproj",
-      "tests/Granit.Wolverine.Tests/Granit.Wolverine.Tests.csproj"
+      "tests/Granit.Wolverine.Tests/Granit.Wolverine.Tests.csproj",
+      "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj"
     ]
   }
 }

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -78,6 +78,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.BackgroundJobs.Endpoints.Tests/Granit.BackgroundJobs.Endpoints.Tests.csproj",
       "tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests.csproj",

--- a/.slnf/notifications.slnf
+++ b/.slnf/notifications.slnf
@@ -64,6 +64,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Notifications.AI.Tests/Granit.Notifications.AI.Tests.csproj",
       "tests/Granit.Notifications.Abstractions.Tests/Granit.Notifications.Abstractions.Tests.csproj",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -92,6 +92,7 @@
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "src/bundles/Granit.Bundle.Api/Granit.Bundle.Api.csproj",
       "src/bundles/Granit.Bundle.Essentials/Granit.Bundle.Essentials.csproj",
@@ -155,7 +156,8 @@
       "tests/Granit.Validation.Europe.Tests/Granit.Validation.Europe.Tests.csproj",
       "tests/Granit.Validation.NorthAmerica.Tests/Granit.Validation.NorthAmerica.Tests.csproj",
       "tests/Granit.Validation.Tests/Granit.Validation.Tests.csproj",
-      "tests/Granit.Validation.UnitedKingdom.Tests/Granit.Validation.UnitedKingdom.Tests.csproj"
+      "tests/Granit.Validation.UnitedKingdom.Tests/Granit.Validation.UnitedKingdom.Tests.csproj",
+      "tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj"
     ]
   }
 }

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -95,6 +95,7 @@
       "src/Granit.Vault/Granit.Vault.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
       "src/Granit.Workflow/Granit.Workflow.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Authentication.ApiKeys.BackgroundJobs.Tests/Granit.Authentication.ApiKeys.BackgroundJobs.Tests.csproj",
       "tests/Granit.Authentication.ApiKeys.Endpoints.Tests/Granit.Authentication.ApiKeys.Endpoints.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -164,6 +164,7 @@
     <Project Path="src/Granit.Workflow.EntityFrameworkCore/Granit.Workflow.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Workflow.Notifications/Granit.Workflow.Notifications.csproj" />
     <Project Path="src/Granit.Workflow/Granit.Workflow.csproj" />
+    <Project Path="src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj" />
   </Folder>
   <Folder Name="/src/Infrastructure/">
     <Project Path="src/Granit.BackgroundJobs.Endpoints/Granit.BackgroundJobs.Endpoints.csproj" />
@@ -448,6 +449,7 @@
     <Project Path="tests/Granit.Workflow.EntityFrameworkCore.Tests/Granit.Workflow.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj" />
     <Project Path="tests/Granit.Workflow.Tests/Granit.Workflow.Tests.csproj" />
+    <Project Path="tests/Granit.Workspaces.Abstractions.Tests/Granit.Workspaces.Abstractions.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Infrastructure/">
     <Project Path="tests/Granit.BackgroundJobs.Endpoints.Tests/Granit.BackgroundJobs.Endpoints.Tests.csproj" />

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -157,6 +157,7 @@
     <ProjectReference Include="..\..\src\Granit.Imaging\Granit.Imaging.csproj" />
     <ProjectReference Include="..\..\src\Granit.Imaging.AI\Granit.Imaging.AI.csproj" />
     <ProjectReference Include="..\..\src\Granit.Imaging.MagickNet\Granit.Imaging.MagickNet.csproj" />
+    <ProjectReference Include="..\..\src\Granit.IO\Granit.IO.csproj" />
     <ProjectReference Include="..\..\src\Granit.Localization\Granit.Localization.csproj" />
     <ProjectReference Include="..\..\src\Granit.Localization.AI\Granit.Localization.AI.csproj" />
     <ProjectReference Include="..\..\src\Granit.Localization.Endpoints\Granit.Localization.Endpoints.csproj" />


### PR DESCRIPTION
## Summary

- Register `src/Granit.Workspaces.Abstractions` + `tests/Granit.Workspaces.Abstractions.Tests` in `Granit.slnx` — same oversight as #2065 (Dashboards.Abstractions). Without this entry CI silently skipped the build and no NuGet was published.
- Regenerate `.github/shard-filters/*.slnf` via `scripts/generate-shard-filters.py`; update legacy `.slnf/*.slnf` consistently.
- Wire `Granit.IO` into `Granit.ArchitectureTests.csproj` — it was the only `src/` module net10 not covered by framework-wide convention tests.

## Why

Per the May 2026 business extraction (`8fb3637d2`), `Granit.Workspaces.Abstractions` is **retained in the framework** (contract consumed by granit-business via NuGet). The slnx adjustment for that retention was forgotten.

## Test plan

- [ ] CI builds the new project across all shards
- [ ] `Granit.Workspaces.Abstractions` NuGet published to GitHub Packages on merge
- [ ] Architecture tests now exercise `Granit.IO` types