### PR TITLE
feat(workspaces): wire IWorkspaceContributor across 11 missing .Endpoints modules

### DIFF
--- a/.github/shard-filters/integration.slnf
+++ b/.github/shard-filters/integration.slnf
@@ -59,6 +59,7 @@
       "src/Granit.Wolverine.SqlServer/Granit.Wolverine.SqlServer.csproj",
       "src/Granit.Wolverine/Granit.Wolverine.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.BackgroundJobs.Tests.Integration/Granit.BackgroundJobs.Tests.Integration.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29,7 +29,8 @@
         "Granit.AI",
         "Granit.Authorization",
         "Granit.QueryEngine.AspNetCore",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -568,7 +569,8 @@
         "Granit.Authorization",
         "Granit.DataExchange",
         "Granit.Guids",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -636,7 +638,8 @@
         "Granit.Authorization",
         "Granit.Diagnostics",
         "Granit.Http.ApiDocumentation",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -895,7 +898,8 @@
         "Granit.Identity",
         "Granit.QueryEngine",
         "Granit.QueryEngine.AspNetCore",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1049,7 +1053,8 @@
         "Granit.Http.SecurityHeaders",
         "Granit.Identity.Local",
         "Granit.Settings",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1198,7 +1203,8 @@
         "Granit.Guids",
         "Granit.Http.ApiDocumentation",
         "Granit.MultiTenancy",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1517,7 +1523,8 @@
         "Granit.OpenIddict",
         "Granit.OpenIddict.Server",
         "Granit.QueryEngine.Abstractions",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1751,7 +1758,8 @@
         "Granit.Authorization",
         "Granit.Scheduling",
         "Granit.QueryEngine.AspNetCore",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1836,7 +1844,8 @@
         "Granit.Http.ApiDocumentation",
         "Granit.Authorization",
         "Granit.Templating",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -1915,7 +1924,8 @@
         "Granit.Authorization",
         "Granit.Http.ApiDocumentation",
         "Granit.Timeline",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -2154,7 +2164,8 @@
         "Granit.Http.ApiDocumentation",
         "Granit.Authorization",
         "Granit.Workflow",
-        "Granit.Validation"
+        "Granit.Validation",
+        "Granit.Workspaces.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -2507,8 +2518,15 @@
       "kind": "class",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "AIEndpointsOptions",
@@ -11679,8 +11697,15 @@
       "kind": "class",
       "project": "Granit.DataExchange.Endpoints",
       "file": "src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs",
-      "line": 21,
-      "members": []
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "DataExchangeEndpointsOptions",
@@ -13777,8 +13802,15 @@
       "kind": "class",
       "project": "Granit.Diagnostics.Endpoints",
       "file": "src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs",
-      "line": 17,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "DiagnosticsEndpointsOptions",
@@ -19794,8 +19826,15 @@
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
       "file": "src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs",
-      "line": 29,
-      "members": []
+      "line": 33,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IdentityEndpointsOptions",
@@ -22225,7 +22264,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs",
-      "line": 26,
+      "line": 30,
       "members": [
         {
           "name": "ConfigureServices",
@@ -25961,8 +26000,15 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.Endpoints",
       "file": "src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs",
-      "line": 23,
-      "members": []
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "MultiTenancyEndpointsOptions",
@@ -30591,7 +30637,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 34,
+      "line": 38,
       "members": [
         {
           "name": "ConfigureServices",
@@ -36396,8 +36442,15 @@
       "kind": "class",
       "project": "Granit.Scheduling.Endpoints",
       "file": "src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs",
-      "line": 22,
-      "members": []
+      "line": 26,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "SchedulingEndpointsOptions",
@@ -37895,8 +37948,15 @@
       "kind": "class",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs",
-      "line": 27,
-      "members": []
+      "line": 31,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "TemplatingEndpointsOptions",
@@ -39420,8 +39480,15 @@
       "kind": "class",
       "project": "Granit.Timeline.Endpoints",
       "file": "src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs",
-      "line": 24,
-      "members": []
+      "line": 28,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "TimelineEndpointsOptions",
@@ -43634,7 +43701,7 @@
       "kind": "class",
       "project": "Granit.Workflow.Endpoints",
       "file": "src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs",
-      "line": 33,
+      "line": 37,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.slnf/ai.slnf
+++ b/.slnf/ai.slnf
@@ -34,6 +34,7 @@
       "src/Granit.Timing/Granit.Timing.csproj",
       "src/Granit.Validation/Granit.Validation.csproj",
       "src/Granit.Workflow.Abstractions/Granit.Workflow.Abstractions.csproj",
+      "src/Granit.Workspaces.Abstractions/Granit.Workspaces.Abstractions.csproj",
       "src/Granit/Granit.csproj",
       "tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj",
       "tests/Granit.AI.Endpoints.Tests/Granit.AI.Endpoints.Tests.csproj",

--- a/src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj
+++ b/src/Granit.AI.Endpoints/Granit.AI.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
+++ b/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
@@ -1,6 +1,9 @@
+using Granit.AI.Endpoints.Workspaces;
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.AI.Endpoints;
 
@@ -10,5 +13,11 @@ namespace Granit.AI.Endpoints;
 [DependsOn(
     typeof(GranitAIModule),
     typeof(GranitAuthorizationModule),
-    typeof(GranitQueryEngineAspNetCoreModule))]
-public sealed class GranitAIEndpointsModule : GranitModule;
+    typeof(GranitQueryEngineAspNetCoreModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitAIEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<AIWorkspaceContribution>();
+}

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/cs.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/cs.json
@@ -1,16 +1,19 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Pracovní prostor s názvem '{0}' již existuje.",
     "AI.Workspaces.Kind.Dynamic": "Dynamický",
     "AI.Workspaces.Kind.System": "Systémový",
-    "AI.Workspaces.Kind.System:Hint": "Systémové pracovní prostory jsou pouze pro čtení a nelze je upravovat ani mazat."
+    "AI.Workspaces.Kind.System:Hint": "Systémové pracovní prostory jsou pouze pro čtení a nelze je upravovat ani mazat.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Pracovní prostor s názvem '{0}' již existuje.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/de.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/de.json
@@ -1,16 +1,19 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Ein Arbeitsbereich mit dem Namen '{0}' existiert bereits.",
     "AI.Workspaces.Kind.Dynamic": "Dynamisch",
     "AI.Workspaces.Kind.System": "System",
-    "AI.Workspaces.Kind.System:Hint": "Systemarbeitsbereiche sind schreibgeschützt und können nicht geändert oder gelöscht werden."
+    "AI.Workspaces.Kind.System:Hint": "Systemarbeitsbereiche sind schreibgeschützt und können nicht geändert oder gelöscht werden.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Ein Arbeitsbereich mit dem Namen '{0}' existiert bereits.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/en-GB.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/en-GB.json
@@ -1,16 +1,19 @@
 {
   "culture": "en-GB",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "A workspace named '{0}' already exists.",
     "AI.Workspaces.Kind.Dynamic": "Dynamic",
     "AI.Workspaces.Kind.System": "System",
-    "AI.Workspaces.Kind.System:Hint": "System workspaces are read-only and cannot be modified or deleted."
+    "AI.Workspaces.Kind.System:Hint": "System workspaces are read-only and cannot be modified or deleted.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "A workspace named '{0}' already exists.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/en.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/en.json
@@ -1,16 +1,19 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "A workspace named '{0}' already exists.",
     "AI.Workspaces.Kind.Dynamic": "Dynamic",
     "AI.Workspaces.Kind.System": "System",
-    "AI.Workspaces.Kind.System:Hint": "System workspaces are read-only and cannot be modified or deleted."
+    "AI.Workspaces.Kind.System:Hint": "System workspaces are read-only and cannot be modified or deleted.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "A workspace named '{0}' already exists.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/es.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/es.json
@@ -1,16 +1,19 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Ya existe un espacio de trabajo con el nombre '{0}'.",
     "AI.Workspaces.Kind.Dynamic": "Dinámico",
     "AI.Workspaces.Kind.System": "Sistema",
-    "AI.Workspaces.Kind.System:Hint": "Los espacios de trabajo del sistema son de solo lectura y no se pueden modificar ni eliminar."
+    "AI.Workspaces.Kind.System:Hint": "Los espacios de trabajo del sistema son de solo lectura y no se pueden modificar ni eliminar.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Ya existe un espacio de trabajo con el nombre '{0}'.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr-CA.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr-CA.json
@@ -1,16 +1,19 @@
 {
   "culture": "fr-CA",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Un espace de travail nommé « {0} » existe déjà.",
     "AI.Workspaces.Kind.Dynamic": "Dynamique",
     "AI.Workspaces.Kind.System": "Système",
-    "AI.Workspaces.Kind.System:Hint": "Les espaces de travail système sont en lecture seule et ne peuvent pas être modifiés ou supprimés."
+    "AI.Workspaces.Kind.System:Hint": "Les espaces de travail système sont en lecture seule et ne peuvent pas être modifiés ou supprimés.",
+    "AIEndpoints:Workspace.Section": "IA",
+    "AIEndpoints:Workspace.Usage": "Consommation",
+    "AIEndpoints:Workspace.Workspaces": "Workspaces IA",
+    "AIEndpoints:Workspace:DuplicateName": "Un espace de travail nommé « {0} » existe déjà.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr.json
@@ -1,16 +1,19 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:AI": "IA",
-    "Permission:AI.Workspaces.Read": "Voir les espaces de travail IA",
-    "Permission:AI.Workspaces.Manage": "Gérer les espaces de travail IA (créer, modifier, supprimer)",
-    "Permission:AI.Usage.Read": "Voir les enregistrements d'utilisation IA",
-    "Permission:AI.Chat.Execute": "Exécuter des complétions de chat IA",
-    "Permission:AI.Embeddings.Execute": "Générer des embeddings IA",
-    "AIEndpoints:Workspace:SystemImmutable": "L'espace de travail système « {0} » ne peut pas être modifié ou supprimé.",
-    "AIEndpoints:Workspace:DuplicateName": "Un espace de travail nommé « {0} » existe déjà.",
     "AI.Workspaces.Kind.Dynamic": "Dynamique",
     "AI.Workspaces.Kind.System": "Système",
-    "AI.Workspaces.Kind.System:Hint": "Les espaces de travail système sont en lecture seule et ne peuvent pas être modifiés ou supprimés."
+    "AI.Workspaces.Kind.System:Hint": "Les espaces de travail système sont en lecture seule et ne peuvent pas être modifiés ou supprimés.",
+    "AIEndpoints:Workspace.Section": "IA",
+    "AIEndpoints:Workspace.Usage": "Consommation",
+    "AIEndpoints:Workspace.Workspaces": "Workspaces IA",
+    "AIEndpoints:Workspace:DuplicateName": "Un espace de travail nommé « {0} » existe déjà.",
+    "AIEndpoints:Workspace:SystemImmutable": "L'espace de travail système « {0} » ne peut pas être modifié ou supprimé.",
+    "Permission:AI.Chat.Execute": "Exécuter des complétions de chat IA",
+    "Permission:AI.Embeddings.Execute": "Générer des embeddings IA",
+    "Permission:AI.Usage.Read": "Voir les enregistrements d'utilisation IA",
+    "Permission:AI.Workspaces.Manage": "Gérer les espaces de travail IA (créer, modifier, supprimer)",
+    "Permission:AI.Workspaces.Read": "Voir les espaces de travail IA",
+    "PermissionGroup:AI": "IA"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/hi.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/hi.json
@@ -1,16 +1,19 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "AI वर्कस्पेस देखें",
-    "Permission:AI.Workspaces.Manage": "AI वर्कस्पेस प्रबंधित करें (बनाएँ, अपडेट करें, हटाएँ)",
-    "Permission:AI.Usage.Read": "AI उपयोग रिकॉर्ड देखें",
-    "Permission:AI.Chat.Execute": "AI चैट पूर्णता चलाएँ",
-    "Permission:AI.Embeddings.Execute": "AI एम्बेडिंग उत्पन्न करें",
-    "AIEndpoints:Workspace:SystemImmutable": "सिस्टम वर्कस्पेस '{0}' को संशोधित या हटाया नहीं जा सकता।",
-    "AIEndpoints:Workspace:DuplicateName": "'{0}' नाम का वर्कस्पेस पहले से मौजूद है।",
     "AI.Workspaces.Kind.Dynamic": "गतिशील",
     "AI.Workspaces.Kind.System": "सिस्टम",
-    "AI.Workspaces.Kind.System:Hint": "सिस्टम वर्कस्पेस केवल पठनीय हैं और उन्हें संशोधित या हटाया नहीं जा सकता।"
+    "AI.Workspaces.Kind.System:Hint": "सिस्टम वर्कस्पेस केवल पठनीय हैं और उन्हें संशोधित या हटाया नहीं जा सकता।",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "'{0}' नाम का वर्कस्पेस पहले से मौजूद है।",
+    "AIEndpoints:Workspace:SystemImmutable": "सिस्टम वर्कस्पेस '{0}' को संशोधित या हटाया नहीं जा सकता।",
+    "Permission:AI.Chat.Execute": "AI चैट पूर्णता चलाएँ",
+    "Permission:AI.Embeddings.Execute": "AI एम्बेडिंग उत्पन्न करें",
+    "Permission:AI.Usage.Read": "AI उपयोग रिकॉर्ड देखें",
+    "Permission:AI.Workspaces.Manage": "AI वर्कस्पेस प्रबंधित करें (बनाएँ, अपडेट करें, हटाएँ)",
+    "Permission:AI.Workspaces.Read": "AI वर्कस्पेस देखें",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/it.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/it.json
@@ -1,16 +1,19 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Esiste già un workspace con il nome '{0}'.",
     "AI.Workspaces.Kind.Dynamic": "Dinamico",
     "AI.Workspaces.Kind.System": "Sistema",
-    "AI.Workspaces.Kind.System:Hint": "I workspace di sistema sono in sola lettura e non possono essere modificati o eliminati."
+    "AI.Workspaces.Kind.System:Hint": "I workspace di sistema sono in sola lettura e non possono essere modificati o eliminati.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Esiste già un workspace con il nome '{0}'.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/ja.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/ja.json
@@ -1,16 +1,19 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "'{0}' という名前のワークスペースは既に存在します。",
     "AI.Workspaces.Kind.Dynamic": "動的",
     "AI.Workspaces.Kind.System": "システム",
-    "AI.Workspaces.Kind.System:Hint": "システムワークスペースは読み取り専用であり、変更または削除できません。"
+    "AI.Workspaces.Kind.System:Hint": "システムワークスペースは読み取り専用であり、変更または削除できません。",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "'{0}' という名前のワークスペースは既に存在します。",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/ko.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/ko.json
@@ -1,16 +1,19 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "'{0}' 이름의 워크스페이스가 이미 존재합니다.",
     "AI.Workspaces.Kind.Dynamic": "동적",
     "AI.Workspaces.Kind.System": "시스템",
-    "AI.Workspaces.Kind.System:Hint": "시스템 워크스페이스는 읽기 전용이며 수정하거나 삭제할 수 없습니다."
+    "AI.Workspaces.Kind.System:Hint": "시스템 워크스페이스는 읽기 전용이며 수정하거나 삭제할 수 없습니다.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "'{0}' 이름의 워크스페이스가 이미 존재합니다.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/nl.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/nl.json
@@ -1,16 +1,19 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Er bestaat al een werkruimte met de naam '{0}'.",
     "AI.Workspaces.Kind.Dynamic": "Dynamisch",
     "AI.Workspaces.Kind.System": "Systeem",
-    "AI.Workspaces.Kind.System:Hint": "Systeemwerkruimten zijn alleen-lezen en kunnen niet worden gewijzigd of verwijderd."
+    "AI.Workspaces.Kind.System:Hint": "Systeemwerkruimten zijn alleen-lezen en kunnen niet worden gewijzigd of verwijderd.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Er bestaat al een werkruimte met de naam '{0}'.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pl.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pl.json
@@ -1,16 +1,19 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Przestrzeń robocza o nazwie '{0}' już istnieje.",
     "AI.Workspaces.Kind.Dynamic": "Dynamiczny",
     "AI.Workspaces.Kind.System": "Systemowy",
-    "AI.Workspaces.Kind.System:Hint": "Systemowe przestrzenie robocze są tylko do odczytu i nie mogą być modyfikowane ani usuwane."
+    "AI.Workspaces.Kind.System:Hint": "Systemowe przestrzenie robocze są tylko do odczytu i nie mogą być modyfikowane ani usuwane.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Przestrzeń robocza o nazwie '{0}' już istnieje.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt-BR.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt-BR.json
@@ -1,16 +1,19 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Já existe um workspace com o nome '{0}'.",
     "AI.Workspaces.Kind.Dynamic": "Dinâmico",
     "AI.Workspaces.Kind.System": "Sistema",
-    "AI.Workspaces.Kind.System:Hint": "Os workspaces de sistema são somente leitura e não podem ser modificados ou excluídos."
+    "AI.Workspaces.Kind.System:Hint": "Os workspaces de sistema são somente leitura e não podem ser modificados ou excluídos.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Já existe um workspace com o nome '{0}'.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt.json
@@ -1,16 +1,19 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "Já existe um workspace com o nome '{0}'.",
     "AI.Workspaces.Kind.Dynamic": "Dinâmico",
     "AI.Workspaces.Kind.System": "Sistema",
-    "AI.Workspaces.Kind.System:Hint": "Os workspaces de sistema são somente leitura e não podem ser modificados ou eliminados."
+    "AI.Workspaces.Kind.System:Hint": "Os workspaces de sistema são somente leitura e não podem ser modificados ou eliminados.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "Já existe um workspace com o nome '{0}'.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/sv.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/sv.json
@@ -1,16 +1,19 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "En arbetsyta med namnet '{0}' finns redan.",
     "AI.Workspaces.Kind.Dynamic": "Dynamisk",
     "AI.Workspaces.Kind.System": "System",
-    "AI.Workspaces.Kind.System:Hint": "Systemarbetsytor är skrivskyddade och kan inte ändras eller tas bort."
+    "AI.Workspaces.Kind.System:Hint": "Systemarbetsytor är skrivskyddade och kan inte ändras eller tas bort.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "En arbetsyta med namnet '{0}' finns redan.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/tr.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/tr.json
@@ -1,16 +1,19 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "'{0}' adında bir çalışma alanı zaten mevcut.",
     "AI.Workspaces.Kind.Dynamic": "Dinamik",
     "AI.Workspaces.Kind.System": "Sistem",
-    "AI.Workspaces.Kind.System:Hint": "Sistem çalışma alanları salt okunurdur ve değiştirilemez veya silinemez."
+    "AI.Workspaces.Kind.System:Hint": "Sistem çalışma alanları salt okunurdur ve değiştirilemez veya silinemez.",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "'{0}' adında bir çalışma alanı zaten mevcut.",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
@@ -1,16 +1,19 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:AI": "AI",
-    "Permission:AI.Workspaces.Read": "View AI workspaces",
-    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
-    "Permission:AI.Usage.Read": "View AI usage records",
-    "Permission:AI.Chat.Execute": "Execute AI chat completions",
-    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
-    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "名为\"{0}\"的工作区已存在。",
     "AI.Workspaces.Kind.Dynamic": "动态",
     "AI.Workspaces.Kind.System": "系统",
-    "AI.Workspaces.Kind.System:Hint": "系统工作区为只读，无法修改或删除。"
+    "AI.Workspaces.Kind.System:Hint": "系统工作区为只读，无法修改或删除。",
+    "AIEndpoints:Workspace.Section": "AI",
+    "AIEndpoints:Workspace.Usage": "Usage",
+    "AIEndpoints:Workspace.Workspaces": "AI workspaces",
+    "AIEndpoints:Workspace:DuplicateName": "名为\"{0}\"的工作区已存在。",
+    "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
+    "Permission:AI.Chat.Execute": "Execute AI chat completions",
+    "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
+    "Permission:AI.Usage.Read": "View AI usage records",
+    "Permission:AI.Workspaces.Manage": "Manage AI workspaces (create, update, delete)",
+    "Permission:AI.Workspaces.Read": "View AI workspaces",
+    "PermissionGroup:AI": "AI"
   }
 }

--- a/src/Granit.AI.Endpoints/Workspaces/AIWorkspaceContribution.cs
+++ b/src/Granit.AI.Endpoints/Workspaces/AIWorkspaceContribution.cs
@@ -1,0 +1,28 @@
+using Granit.AI.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.AI.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts AI admin entries onto the
+/// <c>Granit.Framework.Integrations</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class AIWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Integrations)
+            .Section("ai", s => s
+                .DisplayKey("AIEndpoints:Workspace.Section")
+                .Order(10)
+                .Link("/ai/workspaces", i => i
+                    .DisplayKey("AIEndpoints:Workspace.Workspaces")
+                    .Icon("sparkles")
+                    .Order(0)
+                    .RequiresPermission(AIPermissions.Workspaces.Read))
+                .Link("/ai/usage", i => i
+                    .DisplayKey("AIEndpoints:Workspace.Usage")
+                    .Icon("chart-bar")
+                    .Order(1)
+                    .RequiresPermission(AIPermissions.Usage.Read)));
+}

--- a/src/Granit.AI.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Endpoints/packages.lock.json
@@ -168,6 +168,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Auditing.Endpoints/Workspaces/AuditingWorkspaceContribution.cs
+++ b/src/Granit.Auditing.Endpoints/Workspaces/AuditingWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class AuditingWorkspaceContribution : IWorkspaceContributor
             .Section("auditing", s => s
                 .DisplayKey("AuditingEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/audit-log", i => i
+                .Link("/audit-log", i => i
                     .DisplayKey("AuditingEndpoints:Workspace.Item")
                     .Icon("clipboard-list")
                     .Order(0)

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysWorkspaceContribution.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class ApiKeysWorkspaceContribution : IWorkspaceContributor
             .Section("api-keys", s => s
                 .DisplayKey("AuthenticationApiKeysEndpoints:Workspace.Section")
                 .Order(10)
-                .Link("/admin/api-keys", i => i
+                .Link("/api-keys", i => i
                     .DisplayKey("AuthenticationApiKeysEndpoints:Workspace.Item")
                     .Icon("key-round")
                     .Order(0)

--- a/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationWorkspaceContribution.cs
+++ b/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class AuthorizationWorkspaceContribution : IWorkspaceContributor
             .Section("authorization", s => s
                 .DisplayKey("AuthorizationEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/authorization/permissions", i => i
+                .Link("/authorization/permissions", i => i
                     .DisplayKey("AuthorizationEndpoints:Workspace.Definitions")
                     .Icon("key")
                     .Order(0)

--- a/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsWorkspaceContribution.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Workspaces/BackgroundJobsWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class BackgroundJobsWorkspaceContribution : IWorkspaceContributo
             .Section("background-jobs", s => s
                 .DisplayKey("BackgroundJobsEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/background-jobs", i => i
+                .Link("/background-jobs", i => i
                     .DisplayKey("BackgroundJobsEndpoints:Workspace.Item")
                     .Icon("clock")
                     .Order(0)

--- a/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageWorkspaceContribution.cs
+++ b/src/Granit.BlobStorage.Endpoints/Workspaces/BlobStorageWorkspaceContribution.cs
@@ -17,7 +17,7 @@ internal sealed class BlobStorageWorkspaceContribution : IWorkspaceContributor
             .Section("blob-storage", s => s
                 .DisplayKey("BlobStorageEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/blob-storage", i => i
+                .Link("/blob-storage", i => i
                     .DisplayKey("BlobStorageEndpoints:Workspace.Item")
                     .Icon("file")
                     .Order(0)

--- a/src/Granit.DataExchange.Endpoints/Granit.DataExchange.Endpoints.csproj
+++ b/src/Granit.DataExchange.Endpoints/Granit.DataExchange.Endpoints.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Granit.DataExchange\Granit.DataExchange.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
+++ b/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.DataExchange.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.DataExchange.Endpoints;
 
@@ -17,7 +20,11 @@ namespace Granit.DataExchange.Endpoints;
 [DependsOn(
     typeof(GranitAuthorizationModule),
     typeof(GranitDataExchangeModule),
-    typeof(GranitHttpApiDocumentationModule))]
+    typeof(GranitHttpApiDocumentationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
 public sealed class GranitDataExchangeEndpointsModule : GranitModule
 {
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<DataExchangeWorkspaceContribution>();
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/cs.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/cs.json
@@ -1,10 +1,13 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:DataExchange": "Výměna dat",
-    "Permission:DataExchange.Imports.Read": "Zobrazit historii a stav importů",
-    "Permission:DataExchange.Imports.Execute": "Spustit import dat (nahrání, mapování, provedení, reporty)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Spustit export dat (definice, provedení, stažení, předvolby)",
     "Permission:DataExchange.Exports.Read": "Zobrazit definice a historii exportů",
-    "Permission:DataExchange.Exports.Execute": "Spustit export dat (definice, provedení, stažení, předvolby)"
+    "Permission:DataExchange.Imports.Execute": "Spustit import dat (nahrání, mapování, provedení, reporty)",
+    "Permission:DataExchange.Imports.Read": "Zobrazit historii a stav importů",
+    "PermissionGroup:DataExchange": "Výměna dat"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/de.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/de.json
@@ -1,10 +1,13 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:DataExchange": "Datenaustausch",
-    "Permission:DataExchange.Imports.Read": "Importverlauf und Status anzeigen",
-    "Permission:DataExchange.Imports.Execute": "Datenimporte ausführen (Upload, Zuordnung, Ausführung, Berichte)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Datenexporte ausführen (Definitionen, Ausführung, Download, Voreinstellungen)",
     "Permission:DataExchange.Exports.Read": "Exportdefinitionen und Verlauf anzeigen",
-    "Permission:DataExchange.Exports.Execute": "Datenexporte ausführen (Definitionen, Ausführung, Download, Voreinstellungen)"
+    "Permission:DataExchange.Imports.Execute": "Datenimporte ausführen (Upload, Zuordnung, Ausführung, Berichte)",
+    "Permission:DataExchange.Imports.Read": "Importverlauf und Status anzeigen",
+    "PermissionGroup:DataExchange": "Datenaustausch"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/en-GB.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/en-GB.json
@@ -1,4 +1,8 @@
 {
   "culture": "en-GB",
-  "texts": {}
+  "texts": {
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange"
+  }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/en.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/en.json
@@ -1,10 +1,13 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:DataExchange": "Data Exchange",
-    "Permission:DataExchange.Imports.Read": "View data import history and status",
-    "Permission:DataExchange.Imports.Execute": "Execute data imports (upload, mapping, execution, reports)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Execute data exports (definitions, execution, download, presets)",
     "Permission:DataExchange.Exports.Read": "View data export definitions and history",
-    "Permission:DataExchange.Exports.Execute": "Execute data exports (definitions, execution, download, presets)"
+    "Permission:DataExchange.Imports.Execute": "Execute data imports (upload, mapping, execution, reports)",
+    "Permission:DataExchange.Imports.Read": "View data import history and status",
+    "PermissionGroup:DataExchange": "Data Exchange"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/es.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/es.json
@@ -1,10 +1,13 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:DataExchange": "Intercambio de datos",
-    "Permission:DataExchange.Imports.Read": "Ver historial y estado de importaciones",
-    "Permission:DataExchange.Imports.Execute": "Ejecutar importaciones de datos (carga, mapeo, ejecución, informes)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Ejecutar exportaciones de datos (definiciones, ejecución, descarga, presets)",
     "Permission:DataExchange.Exports.Read": "Ver definiciones e historial de exportaciones",
-    "Permission:DataExchange.Exports.Execute": "Ejecutar exportaciones de datos (definiciones, ejecución, descarga, presets)"
+    "Permission:DataExchange.Imports.Execute": "Ejecutar importaciones de datos (carga, mapeo, ejecución, informes)",
+    "Permission:DataExchange.Imports.Read": "Ver historial y estado de importaciones",
+    "PermissionGroup:DataExchange": "Intercambio de datos"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/fr-CA.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/fr-CA.json
@@ -1,4 +1,8 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Échange de données"
+  }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/fr.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/fr.json
@@ -1,10 +1,13 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:DataExchange": "Échange de données",
-    "Permission:DataExchange.Imports.Read": "Consulter l'historique et le statut des imports",
-    "Permission:DataExchange.Imports.Execute": "Exécuter des imports de données (upload, mapping, exécution, rapports)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Échange de données",
+    "Permission:DataExchange.Exports.Execute": "Exécuter des exports de données (définitions, exécution, téléchargement, presets)",
     "Permission:DataExchange.Exports.Read": "Consulter les définitions et l'historique des exports",
-    "Permission:DataExchange.Exports.Execute": "Exécuter des exports de données (définitions, exécution, téléchargement, presets)"
+    "Permission:DataExchange.Imports.Execute": "Exécuter des imports de données (upload, mapping, exécution, rapports)",
+    "Permission:DataExchange.Imports.Read": "Consulter l'historique et le statut des imports",
+    "PermissionGroup:DataExchange": "Échange de données"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/hi.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/hi.json
@@ -1,10 +1,13 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:DataExchange": "डेटा एक्सचेंज",
-    "Permission:DataExchange.Imports.Read": "डेटा आयात इतिहास और स्थिति देखें",
-    "Permission:DataExchange.Imports.Execute": "डेटा आयात करें (अपलोड, मैपिंग, निष्पादन, रिपोर्ट)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "डेटा निर्यात करें (परिभाषाएँ, निष्पादन, डाउनलोड, प्रीसेट)",
     "Permission:DataExchange.Exports.Read": "डेटा निर्यात परिभाषाएँ और इतिहास देखें",
-    "Permission:DataExchange.Exports.Execute": "डेटा निर्यात करें (परिभाषाएँ, निष्पादन, डाउनलोड, प्रीसेट)"
+    "Permission:DataExchange.Imports.Execute": "डेटा आयात करें (अपलोड, मैपिंग, निष्पादन, रिपोर्ट)",
+    "Permission:DataExchange.Imports.Read": "डेटा आयात इतिहास और स्थिति देखें",
+    "PermissionGroup:DataExchange": "डेटा एक्सचेंज"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/it.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/it.json
@@ -1,10 +1,13 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:DataExchange": "Scambio dati",
-    "Permission:DataExchange.Imports.Read": "Visualizzare cronologia e stato delle importazioni",
-    "Permission:DataExchange.Imports.Execute": "Eseguire importazioni di dati (caricamento, mappatura, esecuzione, rapporti)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Eseguire esportazioni di dati (definizioni, esecuzione, download, preset)",
     "Permission:DataExchange.Exports.Read": "Visualizzare definizioni e cronologia delle esportazioni",
-    "Permission:DataExchange.Exports.Execute": "Eseguire esportazioni di dati (definizioni, esecuzione, download, preset)"
+    "Permission:DataExchange.Imports.Execute": "Eseguire importazioni di dati (caricamento, mappatura, esecuzione, rapporti)",
+    "Permission:DataExchange.Imports.Read": "Visualizzare cronologia e stato delle importazioni",
+    "PermissionGroup:DataExchange": "Scambio dati"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/ja.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/ja.json
@@ -1,10 +1,13 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:DataExchange": "データ交換",
-    "Permission:DataExchange.Imports.Read": "インポート履歴とステータスの閲覧",
-    "Permission:DataExchange.Imports.Execute": "データインポートの実行（アップロード、マッピング、実行、レポート）",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "データエクスポートの実行（定義、実行、ダウンロード、プリセット）",
     "Permission:DataExchange.Exports.Read": "エクスポート定義と履歴の閲覧",
-    "Permission:DataExchange.Exports.Execute": "データエクスポートの実行（定義、実行、ダウンロード、プリセット）"
+    "Permission:DataExchange.Imports.Execute": "データインポートの実行（アップロード、マッピング、実行、レポート）",
+    "Permission:DataExchange.Imports.Read": "インポート履歴とステータスの閲覧",
+    "PermissionGroup:DataExchange": "データ交換"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/ko.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/ko.json
@@ -1,10 +1,13 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:DataExchange": "데이터 교환",
-    "Permission:DataExchange.Imports.Read": "가져오기 이력 및 상태 조회",
-    "Permission:DataExchange.Imports.Execute": "데이터 가져오기 실행 (업로드, 매핑, 실행, 보고서)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "데이터 내보내기 실행 (정의, 실행, 다운로드, 프리셋)",
     "Permission:DataExchange.Exports.Read": "내보내기 정의 및 이력 조회",
-    "Permission:DataExchange.Exports.Execute": "데이터 내보내기 실행 (정의, 실행, 다운로드, 프리셋)"
+    "Permission:DataExchange.Imports.Execute": "데이터 가져오기 실행 (업로드, 매핑, 실행, 보고서)",
+    "Permission:DataExchange.Imports.Read": "가져오기 이력 및 상태 조회",
+    "PermissionGroup:DataExchange": "데이터 교환"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/nl.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/nl.json
@@ -1,10 +1,13 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:DataExchange": "Gegevensuitwisseling",
-    "Permission:DataExchange.Imports.Read": "Importgeschiedenis en status bekijken",
-    "Permission:DataExchange.Imports.Execute": "Gegevensimports uitvoeren (upload, mapping, uitvoering, rapporten)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Gegevensexports uitvoeren (definities, uitvoering, download, presets)",
     "Permission:DataExchange.Exports.Read": "Exportdefinities en geschiedenis bekijken",
-    "Permission:DataExchange.Exports.Execute": "Gegevensexports uitvoeren (definities, uitvoering, download, presets)"
+    "Permission:DataExchange.Imports.Execute": "Gegevensimports uitvoeren (upload, mapping, uitvoering, rapporten)",
+    "Permission:DataExchange.Imports.Read": "Importgeschiedenis en status bekijken",
+    "PermissionGroup:DataExchange": "Gegevensuitwisseling"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pl.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pl.json
@@ -1,10 +1,13 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:DataExchange": "Wymiana danych",
-    "Permission:DataExchange.Imports.Read": "Przeglądanie historii i statusu importów",
-    "Permission:DataExchange.Imports.Execute": "Wykonywanie importu danych (przesyłanie, mapowanie, wykonanie, raporty)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Wykonywanie eksportu danych (definicje, wykonanie, pobieranie, szablony)",
     "Permission:DataExchange.Exports.Read": "Przeglądanie definicji i historii eksportów",
-    "Permission:DataExchange.Exports.Execute": "Wykonywanie eksportu danych (definicje, wykonanie, pobieranie, szablony)"
+    "Permission:DataExchange.Imports.Execute": "Wykonywanie importu danych (przesyłanie, mapowanie, wykonanie, raporty)",
+    "Permission:DataExchange.Imports.Read": "Przeglądanie historii i statusu importów",
+    "PermissionGroup:DataExchange": "Wymiana danych"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pt-BR.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pt-BR.json
@@ -1,4 +1,8 @@
 {
   "culture": "pt-BR",
-  "texts": {}
+  "texts": {
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange"
+  }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pt.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/pt.json
@@ -1,10 +1,13 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:DataExchange": "Troca de dados",
-    "Permission:DataExchange.Imports.Read": "Ver histórico e estado das importações",
-    "Permission:DataExchange.Imports.Execute": "Executar importações de dados (upload, mapeamento, execução, relatórios)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Executar exportações de dados (definições, execução, download, presets)",
     "Permission:DataExchange.Exports.Read": "Ver definições e histórico das exportações",
-    "Permission:DataExchange.Exports.Execute": "Executar exportações de dados (definições, execução, download, presets)"
+    "Permission:DataExchange.Imports.Execute": "Executar importações de dados (upload, mapeamento, execução, relatórios)",
+    "Permission:DataExchange.Imports.Read": "Ver histórico e estado das importações",
+    "PermissionGroup:DataExchange": "Troca de dados"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/sv.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/sv.json
@@ -1,10 +1,13 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:DataExchange": "Datautbyte",
-    "Permission:DataExchange.Imports.Read": "Visa importhistorik och status",
-    "Permission:DataExchange.Imports.Execute": "Utför dataimport (uppladdning, mappning, körning, rapporter)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Utför dataexport (definitioner, körning, nedladdning, förinställningar)",
     "Permission:DataExchange.Exports.Read": "Visa exportdefinitioner och historik",
-    "Permission:DataExchange.Exports.Execute": "Utför dataexport (definitioner, körning, nedladdning, förinställningar)"
+    "Permission:DataExchange.Imports.Execute": "Utför dataimport (uppladdning, mappning, körning, rapporter)",
+    "Permission:DataExchange.Imports.Read": "Visa importhistorik och status",
+    "PermissionGroup:DataExchange": "Datautbyte"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/tr.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/tr.json
@@ -1,10 +1,13 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:DataExchange": "Veri Alışverişi",
-    "Permission:DataExchange.Imports.Read": "İçe aktarma geçmişini ve durumunu görüntüle",
-    "Permission:DataExchange.Imports.Execute": "Veri içe aktarmalarını çalıştır (yükleme, eşleme, yürütme, raporlar)",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "Veri dışa aktarmalarını çalıştır (tanımlar, yürütme, indirme, ön ayarlar)",
     "Permission:DataExchange.Exports.Read": "Dışa aktarma tanımlarını ve geçmişini görüntüle",
-    "Permission:DataExchange.Exports.Execute": "Veri dışa aktarmalarını çalıştır (tanımlar, yürütme, indirme, ön ayarlar)"
+    "Permission:DataExchange.Imports.Execute": "Veri içe aktarmalarını çalıştır (yükleme, eşleme, yürütme, raporlar)",
+    "Permission:DataExchange.Imports.Read": "İçe aktarma geçmişini ve durumunu görüntüle",
+    "PermissionGroup:DataExchange": "Veri Alışverişi"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/zh.json
+++ b/src/Granit.DataExchange.Endpoints/Localization/DataExchangeEndpoints/zh.json
@@ -1,10 +1,13 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:DataExchange": "数据交换",
-    "Permission:DataExchange.Imports.Read": "查看导入历史和状态",
-    "Permission:DataExchange.Imports.Execute": "执行数据导入（上传、映射、执行、报告）",
+    "DataExchangeEndpoints:Workspace.Exports": "Exports",
+    "DataExchangeEndpoints:Workspace.Imports": "Imports",
+    "DataExchangeEndpoints:Workspace.Section": "Data exchange",
+    "Permission:DataExchange.Exports.Execute": "执行数据导出（定义、执行、下载、预设）",
     "Permission:DataExchange.Exports.Read": "查看导出定义和历史",
-    "Permission:DataExchange.Exports.Execute": "执行数据导出（定义、执行、下载、预设）"
+    "Permission:DataExchange.Imports.Execute": "执行数据导入（上传、映射、执行、报告）",
+    "Permission:DataExchange.Imports.Read": "查看导入历史和状态",
+    "PermissionGroup:DataExchange": "数据交换"
   }
 }

--- a/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeWorkspaceContribution.cs
+++ b/src/Granit.DataExchange.Endpoints/Workspaces/DataExchangeWorkspaceContribution.cs
@@ -1,0 +1,28 @@
+using Granit.DataExchange.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.DataExchange.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts data-exchange admin entries onto the
+/// <c>Granit.Framework.Data</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class DataExchangeWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Data)
+            .Section("data-exchange", s => s
+                .DisplayKey("DataExchangeEndpoints:Workspace.Section")
+                .Order(10)
+                .Link("/data-exchange/imports", i => i
+                    .DisplayKey("DataExchangeEndpoints:Workspace.Imports")
+                    .Icon("download")
+                    .Order(0)
+                    .RequiresPermission(DataExchangePermissions.Imports.Read))
+                .Link("/data-exchange/exports", i => i
+                    .DisplayKey("DataExchangeEndpoints:Workspace.Exports")
+                    .Icon("upload")
+                    .Order(1)
+                    .RequiresPermission(DataExchangePermissions.Exports.Read)));
+}

--- a/src/Granit.DataExchange.Endpoints/packages.lock.json
+++ b/src/Granit.DataExchange.Endpoints/packages.lock.json
@@ -166,6 +166,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Diagnostics.Endpoints/Granit.Diagnostics.Endpoints.csproj
+++ b/src/Granit.Diagnostics.Endpoints/Granit.Diagnostics.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Diagnostics\Granit.Diagnostics.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
+++ b/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Authorization;
+using Granit.Diagnostics.Endpoints.Workspaces;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Diagnostics.Endpoints;
 
@@ -13,5 +16,11 @@ namespace Granit.Diagnostics.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitDiagnosticsModule),
     typeof(GranitHttpApiDocumentationModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitDiagnosticsEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitDiagnosticsEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<DiagnosticsWorkspaceContribution>();
+}

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/cs.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/cs.json
@@ -1,7 +1,9 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostika",
-    "Permission:Diagnostics.Monitoring.Read": "Zobrazit panel monitorování stavu systému"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Zobrazit panel monitorování stavu systému",
+    "PermissionGroup:Diagnostics": "Diagnostika"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/de.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/de.json
@@ -1,7 +1,9 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnose",
-    "Permission:Diagnostics.Monitoring.Read": "Systemzustands-Dashboard anzeigen"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Systemzustands-Dashboard anzeigen",
+    "PermissionGroup:Diagnostics": "Diagnose"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en-GB.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en-GB.json
@@ -1,4 +1,7 @@
 {
   "culture": "en-GB",
-  "texts": {}
+  "texts": {
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
+  }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/en.json
@@ -1,7 +1,9 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostics",
-    "Permission:Diagnostics.Monitoring.Read": "View system health monitoring dashboard"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "View system health monitoring dashboard",
+    "PermissionGroup:Diagnostics": "Diagnostics"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/es.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/es.json
@@ -1,7 +1,9 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnósticos",
-    "Permission:Diagnostics.Monitoring.Read": "Ver panel de monitorización del sistema"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Ver panel de monitorización del sistema",
+    "PermissionGroup:Diagnostics": "Diagnósticos"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr-CA.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr-CA.json
@@ -1,4 +1,7 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "DiagnosticsEndpoints:Workspace.Item": "Surveillance santé",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
+  }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/fr.json
@@ -1,7 +1,9 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostics",
-    "Permission:Diagnostics.Monitoring.Read": "Consulter le tableau de bord de surveillance"
+    "DiagnosticsEndpoints:Workspace.Item": "Surveillance santé",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Consulter le tableau de bord de surveillance",
+    "PermissionGroup:Diagnostics": "Diagnostics"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/hi.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/hi.json
@@ -1,7 +1,9 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Diagnostics": "डायग्नोस्टिक्स",
-    "Permission:Diagnostics.Monitoring.Read": "सिस्टम स्वास्थ्य मॉनिटरिंग डैशबोर्ड देखें"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "सिस्टम स्वास्थ्य मॉनिटरिंग डैशबोर्ड देखें",
+    "PermissionGroup:Diagnostics": "डायग्नोस्टिक्स"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/it.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/it.json
@@ -1,7 +1,9 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostica",
-    "Permission:Diagnostics.Monitoring.Read": "Visualizzare la dashboard di monitoraggio del sistema"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Visualizzare la dashboard di monitoraggio del sistema",
+    "PermissionGroup:Diagnostics": "Diagnostica"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ja.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ja.json
@@ -1,7 +1,9 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Diagnostics": "診断",
-    "Permission:Diagnostics.Monitoring.Read": "システムヘルスモニタリングダッシュボードを表示"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "システムヘルスモニタリングダッシュボードを表示",
+    "PermissionGroup:Diagnostics": "診断"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ko.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/ko.json
@@ -1,7 +1,9 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Diagnostics": "진단",
-    "Permission:Diagnostics.Monitoring.Read": "시스템 상태 모니터링 대시보드 보기"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "시스템 상태 모니터링 대시보드 보기",
+    "PermissionGroup:Diagnostics": "진단"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/nl.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/nl.json
@@ -1,7 +1,9 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostiek",
-    "Permission:Diagnostics.Monitoring.Read": "Systeemgezondheidsmonitoring bekijken"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Systeemgezondheidsmonitoring bekijken",
+    "PermissionGroup:Diagnostics": "Diagnostiek"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pl.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pl.json
@@ -1,7 +1,9 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostyka",
-    "Permission:Diagnostics.Monitoring.Read": "Przeglądanie panelu monitorowania systemu"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Przeglądanie panelu monitorowania systemu",
+    "PermissionGroup:Diagnostics": "Diagnostyka"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt-BR.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt-BR.json
@@ -1,4 +1,7 @@
 {
   "culture": "pt-BR",
-  "texts": {}
+  "texts": {
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics"
+  }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/pt.json
@@ -1,7 +1,9 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnósticos",
-    "Permission:Diagnostics.Monitoring.Read": "Ver painel de monitorização do sistema"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Ver painel de monitorização do sistema",
+    "PermissionGroup:Diagnostics": "Diagnósticos"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/sv.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/sv.json
@@ -1,7 +1,9 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Diagnostics": "Diagnostik",
-    "Permission:Diagnostics.Monitoring.Read": "Visa systemhälsoövervakningens instrumentpanel"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Visa systemhälsoövervakningens instrumentpanel",
+    "PermissionGroup:Diagnostics": "Diagnostik"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/tr.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/tr.json
@@ -1,7 +1,9 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Diagnostics": "Tanılama",
-    "Permission:Diagnostics.Monitoring.Read": "Sistem sağlık izleme panosunu görüntüle"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "Sistem sağlık izleme panosunu görüntüle",
+    "PermissionGroup:Diagnostics": "Tanılama"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/zh.json
+++ b/src/Granit.Diagnostics.Endpoints/Localization/DiagnosticsEndpoints/zh.json
@@ -1,7 +1,9 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Diagnostics": "诊断",
-    "Permission:Diagnostics.Monitoring.Read": "查看系统健康监控仪表板"
+    "DiagnosticsEndpoints:Workspace.Item": "Health monitoring",
+    "DiagnosticsEndpoints:Workspace.Section": "Diagnostics",
+    "Permission:Diagnostics.Monitoring.Read": "查看系统健康监控仪表板",
+    "PermissionGroup:Diagnostics": "诊断"
   }
 }

--- a/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsWorkspaceContribution.cs
+++ b/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.Diagnostics.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Diagnostics.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts diagnostics admin entries onto the
+/// <c>Granit.Framework.Monitoring</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class DiagnosticsWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Monitoring)
+            .Section("diagnostics", s => s
+                .DisplayKey("DiagnosticsEndpoints:Workspace.Section")
+                .Order(20)
+                .Link("/diagnostics", i => i
+                    .DisplayKey("DiagnosticsEndpoints:Workspace.Item")
+                    .Icon("heart-pulse")
+                    .Order(0)
+                    .RequiresPermission(DiagnosticsPermissions.Monitoring.Read)));
+}

--- a/src/Granit.Diagnostics.Endpoints/packages.lock.json
+++ b/src/Granit.Diagnostics.Endpoints/packages.lock.json
@@ -142,6 +142,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Features.Endpoints/Workspaces/FeaturesWorkspaceContribution.cs
+++ b/src/Granit.Features.Endpoints/Workspaces/FeaturesWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class FeaturesWorkspaceContribution : IWorkspaceContributor
             .Section("features", s => s
                 .DisplayKey("FeaturesEndpoints:Workspace.Section")
                 .Order(10)
-                .Link("/admin/features", i => i
+                .Link("/features", i => i
                     .DisplayKey("FeaturesEndpoints:Workspace.Item")
                     .Icon("flag")
                     .Order(0)

--- a/src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj
+++ b/src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Granit.QueryEngine\Granit.QueryEngine.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
+++ b/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
+using Granit.Identity.Endpoints.Workspaces;
 using Granit.Modularity;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Identity.Endpoints;
 
@@ -25,5 +28,11 @@ namespace Granit.Identity.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitIdentityModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitIdentityEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitIdentityEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<IdentityWorkspaceContribution>();
+}

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/cs.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/cs.json
@@ -1,17 +1,22 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Identity": "Identita",
-    "Permission:Identity.Users.Read": "Zobrazit uživatele (seznam, hledání, dávkově, statistiky)",
-    "Permission:Identity.Users.Sync": "Vynutit synchronizaci uživatelů od poskytovatele identity",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Přidat nebo odebrat uživatele ze skupin",
+    "Permission:Identity.Groups.Read": "Zobrazit skupiny a členství ve skupinách",
+    "Permission:Identity.Passwords.Manage": "Spravovat uživatelská hesla (resetování, dočasné heslo)",
+    "Permission:Identity.Roles.Manage": "Přiřadit nebo odebrat role uživatelům",
+    "Permission:Identity.Roles.Read": "Zobrazit role, přiřazení rolí a členy rolí",
+    "Permission:Identity.Sessions.Manage": "Ukončit uživatelské relace",
+    "Permission:Identity.Sessions.Read": "Zobrazit uživatelské relace a aktivitu zařízení",
     "Permission:Identity.Users.Delete": "Smazat nebo pseudonymizovat uživatele (GDPR)",
     "Permission:Identity.Users.Manage": "Vytvářet, aktualizovat a aktivovat/deaktivovat uživatele u poskytovatele identity",
-    "Permission:Identity.Roles.Read": "Zobrazit role, přiřazení rolí a členy rolí",
-    "Permission:Identity.Roles.Manage": "Přiřadit nebo odebrat role uživatelům",
-    "Permission:Identity.Groups.Read": "Zobrazit skupiny a členství ve skupinách",
-    "Permission:Identity.Groups.Manage": "Přidat nebo odebrat uživatele ze skupin",
-    "Permission:Identity.Sessions.Read": "Zobrazit uživatelské relace a aktivitu zařízení",
-    "Permission:Identity.Sessions.Manage": "Ukončit uživatelské relace",
-    "Permission:Identity.Passwords.Manage": "Spravovat uživatelská hesla (resetování, dočasné heslo)"
+    "Permission:Identity.Users.Read": "Zobrazit uživatele (seznam, hledání, dávkově, statistiky)",
+    "Permission:Identity.Users.Sync": "Vynutit synchronizaci uživatelů od poskytovatele identity",
+    "PermissionGroup:Identity": "Identita"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/de.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/de.json
@@ -1,17 +1,22 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Identity": "Identität",
-    "Permission:Identity.Users.Read": "Benutzer anzeigen (Liste, Suche, Batch, Statistiken)",
-    "Permission:Identity.Users.Sync": "Synchronisierung der Benutzer vom Identitätsanbieter erzwingen",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Benutzer zu Gruppen hinzufügen oder entfernen",
+    "Permission:Identity.Groups.Read": "Gruppen und Gruppenmitgliedschaften anzeigen",
+    "Permission:Identity.Passwords.Manage": "Benutzerpasswörter verwalten (Zurücksetzung, temporäres Passwort)",
+    "Permission:Identity.Roles.Manage": "Rollen an Benutzer zuweisen oder entfernen",
+    "Permission:Identity.Roles.Read": "Rollen, Rollenzuweisungen und Rollenmitglieder anzeigen",
+    "Permission:Identity.Sessions.Manage": "Benutzersitzungen beenden",
+    "Permission:Identity.Sessions.Read": "Benutzersitzungen und Geräteaktivität anzeigen",
     "Permission:Identity.Users.Delete": "Benutzer löschen oder pseudonymisieren (DSGVO)",
     "Permission:Identity.Users.Manage": "Benutzer im Identitätsanbieter erstellen, aktualisieren und aktivieren/deaktivieren",
-    "Permission:Identity.Roles.Read": "Rollen, Rollenzuweisungen und Rollenmitglieder anzeigen",
-    "Permission:Identity.Roles.Manage": "Rollen an Benutzer zuweisen oder entfernen",
-    "Permission:Identity.Groups.Read": "Gruppen und Gruppenmitgliedschaften anzeigen",
-    "Permission:Identity.Groups.Manage": "Benutzer zu Gruppen hinzufügen oder entfernen",
-    "Permission:Identity.Sessions.Read": "Benutzersitzungen und Geräteaktivität anzeigen",
-    "Permission:Identity.Sessions.Manage": "Benutzersitzungen beenden",
-    "Permission:Identity.Passwords.Manage": "Benutzerpasswörter verwalten (Zurücksetzung, temporäres Passwort)"
+    "Permission:Identity.Users.Read": "Benutzer anzeigen (Liste, Suche, Batch, Statistiken)",
+    "Permission:Identity.Users.Sync": "Synchronisierung der Benutzer vom Identitätsanbieter erzwingen",
+    "PermissionGroup:Identity": "Identität"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/en-GB.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/en-GB.json
@@ -1,7 +1,12 @@
 {
   "culture": "en-GB",
   "texts": {
-    "Permission:Identity.Users.Sync": "Force user synchronisation from the identity provider",
-    "Permission:Identity.Users.Delete": "Delete or pseudonymise users (GDPR)"
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Users.Delete": "Delete or pseudonymise users (GDPR)",
+    "Permission:Identity.Users.Sync": "Force user synchronisation from the identity provider"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/en.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/en.json
@@ -1,17 +1,22 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Identity": "Identity",
-    "Permission:Identity.Users.Read": "View users (list, search, batch, stats)",
-    "Permission:Identity.Users.Sync": "Force user synchronization from the identity provider",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Add or remove users from groups",
+    "Permission:Identity.Groups.Read": "View groups and user group memberships",
+    "Permission:Identity.Passwords.Manage": "Manage user passwords (reset email, temporary password)",
+    "Permission:Identity.Roles.Manage": "Assign or remove roles from users",
+    "Permission:Identity.Roles.Read": "View roles, user role assignments, and role members",
+    "Permission:Identity.Sessions.Manage": "Terminate user sessions",
+    "Permission:Identity.Sessions.Read": "View user sessions and device activity",
     "Permission:Identity.Users.Delete": "Delete or pseudonymize users (GDPR)",
     "Permission:Identity.Users.Manage": "Create, update, and enable/disable users in the identity provider",
-    "Permission:Identity.Roles.Read": "View roles, user role assignments, and role members",
-    "Permission:Identity.Roles.Manage": "Assign or remove roles from users",
-    "Permission:Identity.Groups.Read": "View groups and user group memberships",
-    "Permission:Identity.Groups.Manage": "Add or remove users from groups",
-    "Permission:Identity.Sessions.Read": "View user sessions and device activity",
-    "Permission:Identity.Sessions.Manage": "Terminate user sessions",
-    "Permission:Identity.Passwords.Manage": "Manage user passwords (reset email, temporary password)"
+    "Permission:Identity.Users.Read": "View users (list, search, batch, stats)",
+    "Permission:Identity.Users.Sync": "Force user synchronization from the identity provider",
+    "PermissionGroup:Identity": "Identity"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/es.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/es.json
@@ -1,17 +1,22 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Identity": "Identidad",
-    "Permission:Identity.Users.Read": "Consultar usuarios (lista, búsqueda, lote, estadísticas)",
-    "Permission:Identity.Users.Sync": "Forzar la sincronización de usuarios desde el proveedor de identidad",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Agregar o quitar usuarios de grupos",
+    "Permission:Identity.Groups.Read": "Ver grupos y membresías de grupos",
+    "Permission:Identity.Passwords.Manage": "Gestionar contraseñas de usuario (restablecimiento, contraseña temporal)",
+    "Permission:Identity.Roles.Manage": "Asignar o quitar roles de usuarios",
+    "Permission:Identity.Roles.Read": "Ver roles, asignaciones de roles y miembros",
+    "Permission:Identity.Sessions.Manage": "Terminar sesiones de usuario",
+    "Permission:Identity.Sessions.Read": "Ver sesiones de usuario y actividad de dispositivos",
     "Permission:Identity.Users.Delete": "Eliminar o seudonimizar usuarios (RGPD)",
     "Permission:Identity.Users.Manage": "Crear, actualizar y activar/desactivar usuarios en el proveedor de identidad",
-    "Permission:Identity.Roles.Read": "Ver roles, asignaciones de roles y miembros",
-    "Permission:Identity.Roles.Manage": "Asignar o quitar roles de usuarios",
-    "Permission:Identity.Groups.Read": "Ver grupos y membresías de grupos",
-    "Permission:Identity.Groups.Manage": "Agregar o quitar usuarios de grupos",
-    "Permission:Identity.Sessions.Read": "Ver sesiones de usuario y actividad de dispositivos",
-    "Permission:Identity.Sessions.Manage": "Terminar sesiones de usuario",
-    "Permission:Identity.Passwords.Manage": "Gestionar contraseñas de usuario (restablecimiento, contraseña temporal)"
+    "Permission:Identity.Users.Read": "Consultar usuarios (lista, búsqueda, lote, estadísticas)",
+    "Permission:Identity.Users.Sync": "Forzar la sincronización de usuarios desde el proveedor de identidad",
+    "PermissionGroup:Identity": "Identidad"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/fr-CA.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/fr-CA.json
@@ -1,6 +1,11 @@
 {
   "culture": "fr-CA",
   "texts": {
+    "IdentityEndpoints:Workspace.Groups": "Groupes",
+    "IdentityEndpoints:Workspace.Roles": "Rôles",
+    "IdentityEndpoints:Workspace.Section": "Identité",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Utilisateurs",
     "Permission:Identity.Users.Delete": "Supprimer ou pseudonymiser des utilisateurs (LPRPDE)"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/fr.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/fr.json
@@ -1,17 +1,22 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Identity": "Identité",
-    "Permission:Identity.Users.Read": "Consulter les utilisateurs (liste, recherche, batch, stats)",
-    "Permission:Identity.Users.Sync": "Forcer la synchronisation depuis le fournisseur d'identité",
+    "IdentityEndpoints:Workspace.Groups": "Groupes",
+    "IdentityEndpoints:Workspace.Roles": "Rôles",
+    "IdentityEndpoints:Workspace.Section": "Identité",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Utilisateurs",
+    "Permission:Identity.Groups.Manage": "Ajouter ou retirer des utilisateurs de groupes",
+    "Permission:Identity.Groups.Read": "Consulter les groupes et les appartenances",
+    "Permission:Identity.Passwords.Manage": "Gérer les mots de passe (réinitialisation, mot de passe temporaire)",
+    "Permission:Identity.Roles.Manage": "Attribuer ou retirer des rôles aux utilisateurs",
+    "Permission:Identity.Roles.Read": "Consulter les rôles, les attributions et les membres",
+    "Permission:Identity.Sessions.Manage": "Terminer les sessions utilisateurs",
+    "Permission:Identity.Sessions.Read": "Consulter les sessions utilisateurs et l'activité des appareils",
     "Permission:Identity.Users.Delete": "Supprimer ou pseudonymiser des utilisateurs (RGPD)",
     "Permission:Identity.Users.Manage": "Créer, modifier et activer/désactiver les utilisateurs du fournisseur d'identité",
-    "Permission:Identity.Roles.Read": "Consulter les rôles, les attributions et les membres",
-    "Permission:Identity.Roles.Manage": "Attribuer ou retirer des rôles aux utilisateurs",
-    "Permission:Identity.Groups.Read": "Consulter les groupes et les appartenances",
-    "Permission:Identity.Groups.Manage": "Ajouter ou retirer des utilisateurs de groupes",
-    "Permission:Identity.Sessions.Read": "Consulter les sessions utilisateurs et l'activité des appareils",
-    "Permission:Identity.Sessions.Manage": "Terminer les sessions utilisateurs",
-    "Permission:Identity.Passwords.Manage": "Gérer les mots de passe (réinitialisation, mot de passe temporaire)"
+    "Permission:Identity.Users.Read": "Consulter les utilisateurs (liste, recherche, batch, stats)",
+    "Permission:Identity.Users.Sync": "Forcer la synchronisation depuis le fournisseur d'identité",
+    "PermissionGroup:Identity": "Identité"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/hi.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/hi.json
@@ -1,17 +1,22 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Identity": "पहचान",
-    "Permission:Identity.Users.Read": "उपयोगकर्ता देखें (सूची, खोज, बैच, सांख्यिकी)",
-    "Permission:Identity.Users.Sync": "पहचान प्रदाता से उपयोगकर्ता सिंक्रनाइज़ेशन करें",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "समूहों में उपयोगकर्ता जोड़ें या हटाएँ",
+    "Permission:Identity.Groups.Read": "समूह और उपयोगकर्ता समूह सदस्यता देखें",
+    "Permission:Identity.Passwords.Manage": "उपयोगकर्ता पासवर्ड प्रबंधित करें (रीसेट ईमेल, अस्थायी पासवर्ड)",
+    "Permission:Identity.Roles.Manage": "उपयोगकर्ताओं को भूमिकाएँ असाइन करें या हटाएँ",
+    "Permission:Identity.Roles.Read": "भूमिकाएँ, उपयोगकर्ता भूमिका असाइनमेंट और भूमिका सदस्य देखें",
+    "Permission:Identity.Sessions.Manage": "उपयोगकर्ता सत्र समाप्त करें",
+    "Permission:Identity.Sessions.Read": "उपयोगकर्ता सत्र और डिवाइस गतिविधि देखें",
     "Permission:Identity.Users.Delete": "उपयोगकर्ता हटाएँ या छद्मनामीकृत करें (GDPR)",
     "Permission:Identity.Users.Manage": "पहचान प्रदाता में उपयोगकर्ता बनाएँ, अपडेट करें और सक्षम/अक्षम करें",
-    "Permission:Identity.Roles.Read": "भूमिकाएँ, उपयोगकर्ता भूमिका असाइनमेंट और भूमिका सदस्य देखें",
-    "Permission:Identity.Roles.Manage": "उपयोगकर्ताओं को भूमिकाएँ असाइन करें या हटाएँ",
-    "Permission:Identity.Groups.Read": "समूह और उपयोगकर्ता समूह सदस्यता देखें",
-    "Permission:Identity.Groups.Manage": "समूहों में उपयोगकर्ता जोड़ें या हटाएँ",
-    "Permission:Identity.Sessions.Read": "उपयोगकर्ता सत्र और डिवाइस गतिविधि देखें",
-    "Permission:Identity.Sessions.Manage": "उपयोगकर्ता सत्र समाप्त करें",
-    "Permission:Identity.Passwords.Manage": "उपयोगकर्ता पासवर्ड प्रबंधित करें (रीसेट ईमेल, अस्थायी पासवर्ड)"
+    "Permission:Identity.Users.Read": "उपयोगकर्ता देखें (सूची, खोज, बैच, सांख्यिकी)",
+    "Permission:Identity.Users.Sync": "पहचान प्रदाता से उपयोगकर्ता सिंक्रनाइज़ेशन करें",
+    "PermissionGroup:Identity": "पहचान"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/it.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/it.json
@@ -1,17 +1,22 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Identity": "Identità",
-    "Permission:Identity.Users.Read": "Consultare gli utenti (elenco, ricerca, batch, statistiche)",
-    "Permission:Identity.Users.Sync": "Forzare la sincronizzazione degli utenti dal provider di identità",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Aggiungere o rimuovere utenti dai gruppi",
+    "Permission:Identity.Groups.Read": "Visualizzare i gruppi e le appartenenze",
+    "Permission:Identity.Passwords.Manage": "Gestire le password degli utenti (reimpostazione, password temporanea)",
+    "Permission:Identity.Roles.Manage": "Assegnare o rimuovere ruoli dagli utenti",
+    "Permission:Identity.Roles.Read": "Visualizzare i ruoli, le assegnazioni e i membri",
+    "Permission:Identity.Sessions.Manage": "Terminare le sessioni utente",
+    "Permission:Identity.Sessions.Read": "Visualizzare le sessioni utente e l'attività dei dispositivi",
     "Permission:Identity.Users.Delete": "Eliminare o pseudonimizzare gli utenti (GDPR)",
     "Permission:Identity.Users.Manage": "Creare, aggiornare e attivare/disattivare gli utenti nel provider di identità",
-    "Permission:Identity.Roles.Read": "Visualizzare i ruoli, le assegnazioni e i membri",
-    "Permission:Identity.Roles.Manage": "Assegnare o rimuovere ruoli dagli utenti",
-    "Permission:Identity.Groups.Read": "Visualizzare i gruppi e le appartenenze",
-    "Permission:Identity.Groups.Manage": "Aggiungere o rimuovere utenti dai gruppi",
-    "Permission:Identity.Sessions.Read": "Visualizzare le sessioni utente e l'attività dei dispositivi",
-    "Permission:Identity.Sessions.Manage": "Terminare le sessioni utente",
-    "Permission:Identity.Passwords.Manage": "Gestire le password degli utenti (reimpostazione, password temporanea)"
+    "Permission:Identity.Users.Read": "Consultare gli utenti (elenco, ricerca, batch, statistiche)",
+    "Permission:Identity.Users.Sync": "Forzare la sincronizzazione degli utenti dal provider di identità",
+    "PermissionGroup:Identity": "Identità"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/ja.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/ja.json
@@ -1,17 +1,22 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Identity": "アイデンティティ",
-    "Permission:Identity.Users.Read": "ユーザーの表示（一覧、検索、一括、統計）",
-    "Permission:Identity.Users.Sync": "IDプロバイダーからユーザーを強制同期",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "グループにユーザーを追加または削除",
+    "Permission:Identity.Groups.Read": "グループとグループメンバーシップを表示",
+    "Permission:Identity.Passwords.Manage": "ユーザーパスワードの管理（リセット、一時パスワード）",
+    "Permission:Identity.Roles.Manage": "ユーザーにロールを割り当てまたは削除",
+    "Permission:Identity.Roles.Read": "ロール、ロール割り当て、ロールメンバーを表示",
+    "Permission:Identity.Sessions.Manage": "ユーザーセッションを終了",
+    "Permission:Identity.Sessions.Read": "ユーザーセッションとデバイスアクティビティを表示",
     "Permission:Identity.Users.Delete": "ユーザーの削除または仮名化（GDPR）",
     "Permission:Identity.Users.Manage": "IDプロバイダーでユーザーの作成・更新・有効化/無効化",
-    "Permission:Identity.Roles.Read": "ロール、ロール割り当て、ロールメンバーを表示",
-    "Permission:Identity.Roles.Manage": "ユーザーにロールを割り当てまたは削除",
-    "Permission:Identity.Groups.Read": "グループとグループメンバーシップを表示",
-    "Permission:Identity.Groups.Manage": "グループにユーザーを追加または削除",
-    "Permission:Identity.Sessions.Read": "ユーザーセッションとデバイスアクティビティを表示",
-    "Permission:Identity.Sessions.Manage": "ユーザーセッションを終了",
-    "Permission:Identity.Passwords.Manage": "ユーザーパスワードの管理（リセット、一時パスワード）"
+    "Permission:Identity.Users.Read": "ユーザーの表示（一覧、検索、一括、統計）",
+    "Permission:Identity.Users.Sync": "IDプロバイダーからユーザーを強制同期",
+    "PermissionGroup:Identity": "アイデンティティ"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/ko.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/ko.json
@@ -1,17 +1,22 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Identity": "신원",
-    "Permission:Identity.Users.Read": "사용자 보기 (목록, 검색, 일괄, 통계)",
-    "Permission:Identity.Users.Sync": "ID 공급자에서 사용자 강제 동기화",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "그룹에 사용자 추가 또는 제거",
+    "Permission:Identity.Groups.Read": "그룹 및 그룹 구성원 조회",
+    "Permission:Identity.Passwords.Manage": "사용자 비밀번호 관리 (재설정, 임시 비밀번호)",
+    "Permission:Identity.Roles.Manage": "사용자에게 역할 할당 또는 제거",
+    "Permission:Identity.Roles.Read": "역할, 역할 할당 및 역할 구성원 조회",
+    "Permission:Identity.Sessions.Manage": "사용자 세션 종료",
+    "Permission:Identity.Sessions.Read": "사용자 세션 및 장치 활동 조회",
     "Permission:Identity.Users.Delete": "사용자 삭제 또는 가명화 (GDPR)",
     "Permission:Identity.Users.Manage": "ID 공급자에서 사용자 생성, 수정 및 활성화/비활성화",
-    "Permission:Identity.Roles.Read": "역할, 역할 할당 및 역할 구성원 조회",
-    "Permission:Identity.Roles.Manage": "사용자에게 역할 할당 또는 제거",
-    "Permission:Identity.Groups.Read": "그룹 및 그룹 구성원 조회",
-    "Permission:Identity.Groups.Manage": "그룹에 사용자 추가 또는 제거",
-    "Permission:Identity.Sessions.Read": "사용자 세션 및 장치 활동 조회",
-    "Permission:Identity.Sessions.Manage": "사용자 세션 종료",
-    "Permission:Identity.Passwords.Manage": "사용자 비밀번호 관리 (재설정, 임시 비밀번호)"
+    "Permission:Identity.Users.Read": "사용자 보기 (목록, 검색, 일괄, 통계)",
+    "Permission:Identity.Users.Sync": "ID 공급자에서 사용자 강제 동기화",
+    "PermissionGroup:Identity": "신원"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/nl.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/nl.json
@@ -1,17 +1,22 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Identity": "Identiteit",
-    "Permission:Identity.Users.Read": "Gebruikers bekijken (lijst, zoeken, batch, statistieken)",
-    "Permission:Identity.Users.Sync": "Synchronisatie van gebruikers forceren vanuit de identiteitsprovider",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Gebruikers toevoegen aan of verwijderen uit groepen",
+    "Permission:Identity.Groups.Read": "Groepen en groepslidmaatschappen bekijken",
+    "Permission:Identity.Passwords.Manage": "Gebruikerswachtwoorden beheren (reset, tijdelijk wachtwoord)",
+    "Permission:Identity.Roles.Manage": "Rollen toewijzen aan of verwijderen van gebruikers",
+    "Permission:Identity.Roles.Read": "Rollen, roltoewijzingen en rolleden bekijken",
+    "Permission:Identity.Sessions.Manage": "Gebruikerssessies beëindigen",
+    "Permission:Identity.Sessions.Read": "Gebruikerssessies en apparaatactiviteit bekijken",
     "Permission:Identity.Users.Delete": "Gebruikers verwijderen of pseudonimiseren (AVG)",
     "Permission:Identity.Users.Manage": "Gebruikers aanmaken, bijwerken en in-/uitschakelen in de identiteitsprovider",
-    "Permission:Identity.Roles.Read": "Rollen, roltoewijzingen en rolleden bekijken",
-    "Permission:Identity.Roles.Manage": "Rollen toewijzen aan of verwijderen van gebruikers",
-    "Permission:Identity.Groups.Read": "Groepen en groepslidmaatschappen bekijken",
-    "Permission:Identity.Groups.Manage": "Gebruikers toevoegen aan of verwijderen uit groepen",
-    "Permission:Identity.Sessions.Read": "Gebruikerssessies en apparaatactiviteit bekijken",
-    "Permission:Identity.Sessions.Manage": "Gebruikerssessies beëindigen",
-    "Permission:Identity.Passwords.Manage": "Gebruikerswachtwoorden beheren (reset, tijdelijk wachtwoord)"
+    "Permission:Identity.Users.Read": "Gebruikers bekijken (lijst, zoeken, batch, statistieken)",
+    "Permission:Identity.Users.Sync": "Synchronisatie van gebruikers forceren vanuit de identiteitsprovider",
+    "PermissionGroup:Identity": "Identiteit"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pl.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pl.json
@@ -1,17 +1,22 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Identity": "Tożsamość",
-    "Permission:Identity.Users.Read": "Wyświetlanie użytkowników (lista, wyszukiwanie, wsadowe, statystyki)",
-    "Permission:Identity.Users.Sync": "Wymuszenie synchronizacji użytkowników z dostawcy tożsamości",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Dodawanie lub usuwanie użytkowników z grup",
+    "Permission:Identity.Groups.Read": "Przeglądanie grup i przynależności do grup",
+    "Permission:Identity.Passwords.Manage": "Zarządzanie hasłami użytkowników (resetowanie, hasło tymczasowe)",
+    "Permission:Identity.Roles.Manage": "Przypisywanie lub usuwanie ról użytkowników",
+    "Permission:Identity.Roles.Read": "Przeglądanie ról, przypisań ról i członków",
+    "Permission:Identity.Sessions.Manage": "Kończenie sesji użytkowników",
+    "Permission:Identity.Sessions.Read": "Przeglądanie sesji użytkowników i aktywności urządzeń",
     "Permission:Identity.Users.Delete": "Usuwanie lub pseudonimizacja użytkowników (RODO)",
     "Permission:Identity.Users.Manage": "Tworzenie, aktualizowanie i włączanie/wyłączanie użytkowników w dostawcy tożsamości",
-    "Permission:Identity.Roles.Read": "Przeglądanie ról, przypisań ról i członków",
-    "Permission:Identity.Roles.Manage": "Przypisywanie lub usuwanie ról użytkowników",
-    "Permission:Identity.Groups.Read": "Przeglądanie grup i przynależności do grup",
-    "Permission:Identity.Groups.Manage": "Dodawanie lub usuwanie użytkowników z grup",
-    "Permission:Identity.Sessions.Read": "Przeglądanie sesji użytkowników i aktywności urządzeń",
-    "Permission:Identity.Sessions.Manage": "Kończenie sesji użytkowników",
-    "Permission:Identity.Passwords.Manage": "Zarządzanie hasłami użytkowników (resetowanie, hasło tymczasowe)"
+    "Permission:Identity.Users.Read": "Wyświetlanie użytkowników (lista, wyszukiwanie, wsadowe, statystyki)",
+    "Permission:Identity.Users.Sync": "Wymuszenie synchronizacji użytkowników z dostawcy tożsamości",
+    "PermissionGroup:Identity": "Tożsamość"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pt-BR.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pt-BR.json
@@ -1,4 +1,10 @@
 {
   "culture": "pt-BR",
-  "texts": {}
+  "texts": {
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users"
+  }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pt.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/pt.json
@@ -1,17 +1,22 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Identity": "Identidade",
-    "Permission:Identity.Users.Read": "Consultar utilizadores (lista, pesquisa, lote, estatísticas)",
-    "Permission:Identity.Users.Sync": "Forçar a sincronização de utilizadores a partir do fornecedor de identidade",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Adicionar ou remover utilizadores de grupos",
+    "Permission:Identity.Groups.Read": "Ver grupos e participações em grupos",
+    "Permission:Identity.Passwords.Manage": "Gerir palavras-passe de utilizadores (redefinição, palavra-passe temporária)",
+    "Permission:Identity.Roles.Manage": "Atribuir ou remover funções de utilizadores",
+    "Permission:Identity.Roles.Read": "Ver funções, atribuições de funções e membros",
+    "Permission:Identity.Sessions.Manage": "Terminar sessões de utilizador",
+    "Permission:Identity.Sessions.Read": "Ver sessões de utilizador e atividade de dispositivos",
     "Permission:Identity.Users.Delete": "Eliminar ou pseudonimizar utilizadores (RGPD)",
     "Permission:Identity.Users.Manage": "Criar, atualizar e ativar/desativar utilizadores no fornecedor de identidade",
-    "Permission:Identity.Roles.Read": "Ver funções, atribuições de funções e membros",
-    "Permission:Identity.Roles.Manage": "Atribuir ou remover funções de utilizadores",
-    "Permission:Identity.Groups.Read": "Ver grupos e participações em grupos",
-    "Permission:Identity.Groups.Manage": "Adicionar ou remover utilizadores de grupos",
-    "Permission:Identity.Sessions.Read": "Ver sessões de utilizador e atividade de dispositivos",
-    "Permission:Identity.Sessions.Manage": "Terminar sessões de utilizador",
-    "Permission:Identity.Passwords.Manage": "Gerir palavras-passe de utilizadores (redefinição, palavra-passe temporária)"
+    "Permission:Identity.Users.Read": "Consultar utilizadores (lista, pesquisa, lote, estatísticas)",
+    "Permission:Identity.Users.Sync": "Forçar a sincronização de utilizadores a partir do fornecedor de identidade",
+    "PermissionGroup:Identity": "Identidade"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/sv.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/sv.json
@@ -1,17 +1,22 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Identity": "Identitet",
-    "Permission:Identity.Users.Read": "Visa användare (lista, sök, batch, statistik)",
-    "Permission:Identity.Users.Sync": "Tvinga synkronisering av användare från identitetsleverantören",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Lägg till eller ta bort användare från grupper",
+    "Permission:Identity.Groups.Read": "Visa grupper och gruppmedlemskap",
+    "Permission:Identity.Passwords.Manage": "Hantera användarlösenord (återställning, tillfälligt lösenord)",
+    "Permission:Identity.Roles.Manage": "Tilldela eller ta bort roller från användare",
+    "Permission:Identity.Roles.Read": "Visa roller, rolltilldelningar och rollmedlemmar",
+    "Permission:Identity.Sessions.Manage": "Avsluta användarsessioner",
+    "Permission:Identity.Sessions.Read": "Visa användarsessioner och enhetsaktivitet",
     "Permission:Identity.Users.Delete": "Radera eller pseudonymisera användare (GDPR)",
     "Permission:Identity.Users.Manage": "Skapa, uppdatera och aktivera/inaktivera användare i identitetsleverantören",
-    "Permission:Identity.Roles.Read": "Visa roller, rolltilldelningar och rollmedlemmar",
-    "Permission:Identity.Roles.Manage": "Tilldela eller ta bort roller från användare",
-    "Permission:Identity.Groups.Read": "Visa grupper och gruppmedlemskap",
-    "Permission:Identity.Groups.Manage": "Lägg till eller ta bort användare från grupper",
-    "Permission:Identity.Sessions.Read": "Visa användarsessioner och enhetsaktivitet",
-    "Permission:Identity.Sessions.Manage": "Avsluta användarsessioner",
-    "Permission:Identity.Passwords.Manage": "Hantera användarlösenord (återställning, tillfälligt lösenord)"
+    "Permission:Identity.Users.Read": "Visa användare (lista, sök, batch, statistik)",
+    "Permission:Identity.Users.Sync": "Tvinga synkronisering av användare från identitetsleverantören",
+    "PermissionGroup:Identity": "Identitet"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/tr.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/tr.json
@@ -1,17 +1,22 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Identity": "Kimlik",
-    "Permission:Identity.Users.Read": "Kullanıcıları görüntüle (liste, arama, toplu, istatistikler)",
-    "Permission:Identity.Users.Sync": "Kimlik sağlayıcısından kullanıcı eşitlemesini zorla",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "Gruplara kullanıcı ekle veya kaldır",
+    "Permission:Identity.Groups.Read": "Grupları ve grup üyeliklerini görüntüle",
+    "Permission:Identity.Passwords.Manage": "Kullanıcı şifrelerini yönet (sıfırlama, geçici şifre)",
+    "Permission:Identity.Roles.Manage": "Kullanıcılara rol ata veya kaldır",
+    "Permission:Identity.Roles.Read": "Rolleri, rol atamalarını ve rol üyelerini görüntüle",
+    "Permission:Identity.Sessions.Manage": "Kullanıcı oturumlarını sonlandır",
+    "Permission:Identity.Sessions.Read": "Kullanıcı oturumlarını ve cihaz etkinliğini görüntüle",
     "Permission:Identity.Users.Delete": "Kullanıcıları sil veya takma adlandır (KVKK)",
     "Permission:Identity.Users.Manage": "Kimlik sağlayıcısında kullanıcı oluştur, güncelle ve etkinleştir/devre dışı bırak",
-    "Permission:Identity.Roles.Read": "Rolleri, rol atamalarını ve rol üyelerini görüntüle",
-    "Permission:Identity.Roles.Manage": "Kullanıcılara rol ata veya kaldır",
-    "Permission:Identity.Groups.Read": "Grupları ve grup üyeliklerini görüntüle",
-    "Permission:Identity.Groups.Manage": "Gruplara kullanıcı ekle veya kaldır",
-    "Permission:Identity.Sessions.Read": "Kullanıcı oturumlarını ve cihaz etkinliğini görüntüle",
-    "Permission:Identity.Sessions.Manage": "Kullanıcı oturumlarını sonlandır",
-    "Permission:Identity.Passwords.Manage": "Kullanıcı şifrelerini yönet (sıfırlama, geçici şifre)"
+    "Permission:Identity.Users.Read": "Kullanıcıları görüntüle (liste, arama, toplu, istatistikler)",
+    "Permission:Identity.Users.Sync": "Kimlik sağlayıcısından kullanıcı eşitlemesini zorla",
+    "PermissionGroup:Identity": "Kimlik"
   }
 }

--- a/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/zh.json
+++ b/src/Granit.Identity.Endpoints/Localization/IdentityEndpoints/zh.json
@@ -1,17 +1,22 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Identity": "身份",
-    "Permission:Identity.Users.Read": "查看用户（列表、搜索、批量、统计）",
-    "Permission:Identity.Users.Sync": "从身份提供商强制同步用户",
+    "IdentityEndpoints:Workspace.Groups": "Groups",
+    "IdentityEndpoints:Workspace.Roles": "Roles",
+    "IdentityEndpoints:Workspace.Section": "Identity",
+    "IdentityEndpoints:Workspace.Sessions": "Sessions",
+    "IdentityEndpoints:Workspace.Users": "Users",
+    "Permission:Identity.Groups.Manage": "向组中添加或从组中移除用户",
+    "Permission:Identity.Groups.Read": "查看组和组成员资格",
+    "Permission:Identity.Passwords.Manage": "管理用户密码（重置、临时密码）",
+    "Permission:Identity.Roles.Manage": "为用户分配或移除角色",
+    "Permission:Identity.Roles.Read": "查看角色、角色分配和角色成员",
+    "Permission:Identity.Sessions.Manage": "终止用户会话",
+    "Permission:Identity.Sessions.Read": "查看用户会话和设备活动",
     "Permission:Identity.Users.Delete": "删除或假名化用户（GDPR）",
     "Permission:Identity.Users.Manage": "在身份提供者中创建、更新和启用/禁用用户",
-    "Permission:Identity.Roles.Read": "查看角色、角色分配和角色成员",
-    "Permission:Identity.Roles.Manage": "为用户分配或移除角色",
-    "Permission:Identity.Groups.Read": "查看组和组成员资格",
-    "Permission:Identity.Groups.Manage": "向组中添加或从组中移除用户",
-    "Permission:Identity.Sessions.Read": "查看用户会话和设备活动",
-    "Permission:Identity.Sessions.Manage": "终止用户会话",
-    "Permission:Identity.Passwords.Manage": "管理用户密码（重置、临时密码）"
+    "Permission:Identity.Users.Read": "查看用户（列表、搜索、批量、统计）",
+    "Permission:Identity.Users.Sync": "从身份提供商强制同步用户",
+    "PermissionGroup:Identity": "身份"
   }
 }

--- a/src/Granit.Identity.Endpoints/Workspaces/IdentityWorkspaceContribution.cs
+++ b/src/Granit.Identity.Endpoints/Workspaces/IdentityWorkspaceContribution.cs
@@ -1,0 +1,38 @@
+using Granit.Identity.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Identity.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts identity admin entries onto the
+/// <c>Granit.Framework.Users</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class IdentityWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Users)
+            .Section("identity", s => s
+                .DisplayKey("IdentityEndpoints:Workspace.Section")
+                .Order(0)
+                .Link("/identity/users", i => i
+                    .DisplayKey("IdentityEndpoints:Workspace.Users")
+                    .Icon("users-round")
+                    .Order(0)
+                    .RequiresPermission(IdentityPermissions.Users.Read))
+                .Link("/identity/roles", i => i
+                    .DisplayKey("IdentityEndpoints:Workspace.Roles")
+                    .Icon("shield-user")
+                    .Order(1)
+                    .RequiresPermission(IdentityPermissions.Roles.Read))
+                .Link("/identity/groups", i => i
+                    .DisplayKey("IdentityEndpoints:Workspace.Groups")
+                    .Icon("users")
+                    .Order(2)
+                    .RequiresPermission(IdentityPermissions.Groups.Read))
+                .Link("/identity/sessions", i => i
+                    .DisplayKey("IdentityEndpoints:Workspace.Sessions")
+                    .Icon("monitor-smartphone")
+                    .Order(3)
+                    .RequiresPermission(IdentityPermissions.Sessions.Read)));
+}

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -161,6 +161,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
+++ b/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
+++ b/src/Granit.Identity.Local.Endpoints/GranitIdentityLocalEndpointsModule.cs
@@ -3,8 +3,11 @@ using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Identity.Local;
 using Granit.Identity.Local.Endpoints.Endpoints;
+using Granit.Identity.Local.Endpoints.Workspaces;
 using Granit.Modularity;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Identity.Local.Endpoints;
@@ -22,10 +25,14 @@ namespace Granit.Identity.Local.Endpoints;
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitIdentityLocalModule),
-    typeof(GranitValidationModule))]
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
 public sealed class GranitIdentityLocalEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddScoped<IdentityLocalConfigProvider>();
+        context.Services.AddWorkspaceContribution<IdentityLocalWorkspaceContribution>();
+    }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/cs.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/cs.json
@@ -1,17 +1,19 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Místní identita",
-    "Permission:IdentityLocal.Users.Impersonate": "Vydávat se za uživatele",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Vydávat se za uživatele",
+    "PermissionGroup:IdentityLocal": "Místní identita"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/de.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/de.json
@@ -1,17 +1,19 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Lokale Identität",
-    "Permission:IdentityLocal.Users.Impersonate": "Benutzer imitieren",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Benutzer imitieren",
+    "PermissionGroup:IdentityLocal": "Lokale Identität"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en-GB.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en-GB.json
@@ -1,5 +1,7 @@
 {
   "culture": "en-GB",
   "texts": {
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en.json
@@ -1,17 +1,19 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Local Identity",
-    "Permission:IdentityLocal.Users.Impersonate": "Impersonate users",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Impersonate users",
+    "PermissionGroup:IdentityLocal": "Local Identity"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/es.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/es.json
@@ -1,17 +1,19 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Identidad local",
-    "Permission:IdentityLocal.Users.Impersonate": "Suplantar usuarios",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Suplantar usuarios",
+    "PermissionGroup:IdentityLocal": "Identidad local"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr-CA.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr-CA.json
@@ -1,5 +1,7 @@
 {
   "culture": "fr-CA",
   "texts": {
+    "IdentityLocalEndpoints:Workspace.Roles": "Rôles locaux",
+    "IdentityLocalEndpoints:Workspace.Section": "Comptes locaux"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr.json
@@ -1,17 +1,19 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Identité locale",
-    "Permission:IdentityLocal.Users.Impersonate": "Se faire passer pour un utilisateur",
-    "Permission:IdentityLocal.Roles.Read": "Lire les rôles",
-    "Permission:IdentityLocal.Roles.Manage": "Créer et renommer les rôles",
-    "Permission:IdentityLocal.Roles.Delete": "Supprimer les rôles",
-    "Granit:Identity:Role:TenantIdRequired": "Les rôles de tenant requièrent un TenantId non nul.",
-    "Granit:Identity:Role:TenantIdForbidden": "Les rôles Host et Both doivent avoir un TenantId nul.",
     "Granit:Identity:Role:CannotDeleteSystem": "Les rôles système ne peuvent pas être supprimés.",
     "Granit:Identity:Role:CannotRenameSystem": "Les rôles système ne peuvent pas être renommés.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Les administrateurs de tenant ne peuvent gérer que les rôles de leur propre tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "Un rôle portant ce nom existe déjà dans cette portée.",
+    "Granit:Identity:Role:TenantIdForbidden": "Les rôles Host et Both doivent avoir un TenantId nul.",
+    "Granit:Identity:Role:TenantIdRequired": "Les rôles de tenant requièrent un TenantId non nul.",
     "Granit:Identity:Role:TenantRolesDisabled": "La création de rôles de tenant est désactivée dans ce déploiement.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Les administrateurs de tenant ne peuvent gérer que les rôles de leur propre tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Rôles locaux",
+    "IdentityLocalEndpoints:Workspace.Section": "Comptes locaux",
+    "Permission:IdentityLocal.Roles.Delete": "Supprimer les rôles",
+    "Permission:IdentityLocal.Roles.Manage": "Créer et renommer les rôles",
+    "Permission:IdentityLocal.Roles.Read": "Lire les rôles",
+    "Permission:IdentityLocal.Users.Impersonate": "Se faire passer pour un utilisateur",
+    "PermissionGroup:IdentityLocal": "Identité locale"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/hi.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/hi.json
@@ -1,17 +1,19 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:IdentityLocal": "स्थानीय पहचान",
-    "Permission:IdentityLocal.Users.Impersonate": "उपयोगकर्ताओं का प्रतिरूपण करें",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "उपयोगकर्ताओं का प्रतिरूपण करें",
+    "PermissionGroup:IdentityLocal": "स्थानीय पहचान"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/it.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/it.json
@@ -1,17 +1,19 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Identità locale",
-    "Permission:IdentityLocal.Users.Impersonate": "Impersonare utenti",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Impersonare utenti",
+    "PermissionGroup:IdentityLocal": "Identità locale"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ja.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ja.json
@@ -1,17 +1,19 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:IdentityLocal": "ローカル ID",
-    "Permission:IdentityLocal.Users.Impersonate": "ユーザーになりすます",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "ユーザーになりすます",
+    "PermissionGroup:IdentityLocal": "ローカル ID"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ko.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ko.json
@@ -1,17 +1,19 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:IdentityLocal": "로컬 ID",
-    "Permission:IdentityLocal.Users.Impersonate": "사용자 가장",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "사용자 가장",
+    "PermissionGroup:IdentityLocal": "로컬 ID"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/nl.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/nl.json
@@ -1,17 +1,19 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Lokale identiteit",
-    "Permission:IdentityLocal.Users.Impersonate": "Gebruikers nabootsen",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Gebruikers nabootsen",
+    "PermissionGroup:IdentityLocal": "Lokale identiteit"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pl.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pl.json
@@ -1,17 +1,19 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Tożsamość lokalna",
-    "Permission:IdentityLocal.Users.Impersonate": "Podszywanie się pod użytkowników",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Podszywanie się pod użytkowników",
+    "PermissionGroup:IdentityLocal": "Tożsamość lokalna"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt-BR.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt-BR.json
@@ -1,5 +1,7 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt.json
@@ -1,17 +1,19 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Identidade local",
-    "Permission:IdentityLocal.Users.Impersonate": "Personificar utilizadores",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Personificar utilizadores",
+    "PermissionGroup:IdentityLocal": "Identidade local"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/sv.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/sv.json
@@ -1,17 +1,19 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Lokal identitet",
-    "Permission:IdentityLocal.Users.Impersonate": "Imitera användare",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Imitera användare",
+    "PermissionGroup:IdentityLocal": "Lokal identitet"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/tr.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/tr.json
@@ -1,17 +1,19 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Yerel kimlik",
-    "Permission:IdentityLocal.Users.Impersonate": "Kullanıcıların kimliğine bürünme",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "Kullanıcıların kimliğine bürünme",
+    "PermissionGroup:IdentityLocal": "Yerel kimlik"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/zh.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/zh.json
@@ -1,17 +1,19 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:IdentityLocal": "本地身份",
-    "Permission:IdentityLocal.Users.Impersonate": "模拟用户",
-    "Permission:IdentityLocal.Roles.Read": "Read roles",
-    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
-    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
-    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
-    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
     "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
     "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant.",
     "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
     "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
-    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
+    "IdentityLocalEndpoints:Workspace.Roles": "Local roles",
+    "IdentityLocalEndpoints:Workspace.Section": "Local accounts",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Users.Impersonate": "模拟用户",
+    "PermissionGroup:IdentityLocal": "本地身份"
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Workspaces/IdentityLocalWorkspaceContribution.cs
+++ b/src/Granit.Identity.Local.Endpoints/Workspaces/IdentityLocalWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.Identity.Local.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Identity.Local.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts local-identity admin entries onto the
+/// <c>Granit.Framework.Users</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class IdentityLocalWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Users)
+            .Section("identity-local", s => s
+                .DisplayKey("IdentityLocalEndpoints:Workspace.Section")
+                .Order(20)
+                .Link("/identity-local/roles", i => i
+                    .DisplayKey("IdentityLocalEndpoints:Workspace.Roles")
+                    .Icon("shield-check")
+                    .Order(0)
+                    .RequiresPermission(IdentityLocalPermissions.Roles.Read)));
+}

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -197,6 +197,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Localization.Endpoints/Workspaces/LocalizationWorkspaceContribution.cs
+++ b/src/Granit.Localization.Endpoints/Workspaces/LocalizationWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class LocalizationWorkspaceContribution : IWorkspaceContributor
             .Section("localization", s => s
                 .DisplayKey("LocalizationEndpoints:Workspace.Section")
                 .Order(20)
-                .Link("/admin/localization/overrides", i => i
+                .Link("/localization/overrides", i => i
                     .DisplayKey("LocalizationEndpoints:Workspace.Item")
                     .Icon("languages")
                     .Order(0)

--- a/src/Granit.MultiTenancy.Endpoints/Granit.MultiTenancy.Endpoints.csproj
+++ b/src/Granit.MultiTenancy.Endpoints/Granit.MultiTenancy.Endpoints.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
+++ b/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
@@ -2,7 +2,10 @@ using Granit.Authorization;
 using Granit.Guids;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.MultiTenancy.Endpoints.Workspaces;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.MultiTenancy.Endpoints;
 
@@ -19,5 +22,11 @@ namespace Granit.MultiTenancy.Endpoints;
     typeof(GranitGuidsModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitMultiTenancyModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitMultiTenancyEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitMultiTenancyEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<MultiTenancyWorkspaceContribution>();
+}

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/cs.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/cs.json
@@ -1,10 +1,12 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Zobrazit informace o nájemcích",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Vytvořit nové nájemce",
+    "Permission:MultiTenancy.Tenants.Manage": "Spravovat životní cyklus nájemců (aktivovat, deaktivovat)",
+    "Permission:MultiTenancy.Tenants.Read": "Zobrazit informace o nájemcích",
     "Permission:MultiTenancy.Tenants.Update": "Aktualizovat údaje nájemců",
-    "Permission:MultiTenancy.Tenants.Manage": "Spravovat životní cyklus nájemců (aktivovat, deaktivovat)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/de.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/de.json
@@ -1,10 +1,12 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Mandantenfähigkeit",
-    "Permission:MultiTenancy.Tenants.Read": "Mandanteninformationen anzeigen",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Neue Mandanten erstellen",
+    "Permission:MultiTenancy.Tenants.Manage": "Mandantenlebenszyklus verwalten (aktivieren, deaktivieren)",
+    "Permission:MultiTenancy.Tenants.Read": "Mandanteninformationen anzeigen",
     "Permission:MultiTenancy.Tenants.Update": "Mandantendetails aktualisieren",
-    "Permission:MultiTenancy.Tenants.Manage": "Mandantenlebenszyklus verwalten (aktivieren, deaktivieren)"
+    "PermissionGroup:MultiTenancy": "Mandantenfähigkeit"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en-GB.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en-GB.json
@@ -1,4 +1,7 @@
 {
   "culture": "en-GB",
-  "texts": {}
+  "texts": {
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants"
+  }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/en.json
@@ -1,10 +1,12 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "View tenant information",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Create new tenants",
+    "Permission:MultiTenancy.Tenants.Manage": "Manage tenant lifecycle (activate, deactivate)",
+    "Permission:MultiTenancy.Tenants.Read": "View tenant information",
     "Permission:MultiTenancy.Tenants.Update": "Update tenant details",
-    "Permission:MultiTenancy.Tenants.Manage": "Manage tenant lifecycle (activate, deactivate)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/es.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/es.json
@@ -1,10 +1,12 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenencia",
-    "Permission:MultiTenancy.Tenants.Read": "Ver información de inquilinos",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Crear nuevos inquilinos",
+    "Permission:MultiTenancy.Tenants.Manage": "Gestionar ciclo de vida de inquilinos (activar, desactivar)",
+    "Permission:MultiTenancy.Tenants.Read": "Ver información de inquilinos",
     "Permission:MultiTenancy.Tenants.Update": "Actualizar detalles de inquilinos",
-    "Permission:MultiTenancy.Tenants.Manage": "Gestionar ciclo de vida de inquilinos (activar, desactivar)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenencia"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr-CA.json
@@ -1,4 +1,7 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenant",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants"
+  }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/fr.json
@@ -1,10 +1,12 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenant",
-    "Permission:MultiTenancy.Tenants.Read": "Consulter les informations des locataires",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenant",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Créer de nouveaux locataires",
+    "Permission:MultiTenancy.Tenants.Manage": "Gérer le cycle de vie des locataires (activer, désactiver)",
+    "Permission:MultiTenancy.Tenants.Read": "Consulter les informations des locataires",
     "Permission:MultiTenancy.Tenants.Update": "Modifier les détails des locataires",
-    "Permission:MultiTenancy.Tenants.Manage": "Gérer le cycle de vie des locataires (activer, désactiver)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenant"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/hi.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/hi.json
@@ -1,10 +1,12 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:MultiTenancy": "मल्टी-टेनेंसी",
-    "Permission:MultiTenancy.Tenants.Read": "किरायेदार जानकारी देखें",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "नए किरायेदार बनाएँ",
+    "Permission:MultiTenancy.Tenants.Manage": "किरायेदार जीवनचक्र प्रबंधित करें (सक्रिय, निष्क्रिय)",
+    "Permission:MultiTenancy.Tenants.Read": "किरायेदार जानकारी देखें",
     "Permission:MultiTenancy.Tenants.Update": "किरायेदार विवरण अपडेट करें",
-    "Permission:MultiTenancy.Tenants.Manage": "किरायेदार जीवनचक्र प्रबंधित करें (सक्रिय, निष्क्रिय)"
+    "PermissionGroup:MultiTenancy": "मल्टी-टेनेंसी"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/it.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/it.json
@@ -1,10 +1,12 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Visualizzare le informazioni dei tenant",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Creare nuovi tenant",
+    "Permission:MultiTenancy.Tenants.Manage": "Gestire il ciclo di vita dei tenant (attivare, disattivare)",
+    "Permission:MultiTenancy.Tenants.Read": "Visualizzare le informazioni dei tenant",
     "Permission:MultiTenancy.Tenants.Update": "Aggiornare i dettagli dei tenant",
-    "Permission:MultiTenancy.Tenants.Manage": "Gestire il ciclo di vita dei tenant (attivare, disattivare)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ja.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ja.json
@@ -1,10 +1,12 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:MultiTenancy": "マルチテナンシー",
-    "Permission:MultiTenancy.Tenants.Read": "テナント情報の表示",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "新規テナントの作成",
+    "Permission:MultiTenancy.Tenants.Manage": "テナントライフサイクルの管理（有効化、無効化）",
+    "Permission:MultiTenancy.Tenants.Read": "テナント情報の表示",
     "Permission:MultiTenancy.Tenants.Update": "テナント詳細の更新",
-    "Permission:MultiTenancy.Tenants.Manage": "テナントライフサイクルの管理（有効化、無効化）"
+    "PermissionGroup:MultiTenancy": "マルチテナンシー"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ko.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/ko.json
@@ -1,10 +1,12 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:MultiTenancy": "멀티테넌시",
-    "Permission:MultiTenancy.Tenants.Read": "테넌트 정보 조회",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "새 테넌트 생성",
+    "Permission:MultiTenancy.Tenants.Manage": "테넌트 수명 주기 관리 (활성화, 비활성화)",
+    "Permission:MultiTenancy.Tenants.Read": "테넌트 정보 조회",
     "Permission:MultiTenancy.Tenants.Update": "테넌트 세부 정보 수정",
-    "Permission:MultiTenancy.Tenants.Manage": "테넌트 수명 주기 관리 (활성화, 비활성화)"
+    "PermissionGroup:MultiTenancy": "멀티테넌시"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/nl.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/nl.json
@@ -1,10 +1,12 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Tenantinformatie bekijken",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Nieuwe tenants aanmaken",
+    "Permission:MultiTenancy.Tenants.Manage": "Levenscyclus van tenants beheren (activeren, deactiveren)",
+    "Permission:MultiTenancy.Tenants.Read": "Tenantinformatie bekijken",
     "Permission:MultiTenancy.Tenants.Update": "Tenantgegevens bijwerken",
-    "Permission:MultiTenancy.Tenants.Manage": "Levenscyclus van tenants beheren (activeren, deactiveren)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pl.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pl.json
@@ -1,10 +1,12 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Przeglądanie informacji o najemcach",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Tworzenie nowych najemców",
+    "Permission:MultiTenancy.Tenants.Manage": "Zarządzanie cyklem życia najemców (aktywacja, dezaktywacja)",
+    "Permission:MultiTenancy.Tenants.Read": "Przeglądanie informacji o najemcach",
     "Permission:MultiTenancy.Tenants.Update": "Aktualizacja szczegółów najemców",
-    "Permission:MultiTenancy.Tenants.Manage": "Zarządzanie cyklem życia najemców (aktywacja, dezaktywacja)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt-BR.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt-BR.json
@@ -1,10 +1,12 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Criar novos inquilinos",
+    "Permission:MultiTenancy.Tenants.Manage": "Gerenciar ciclo de vida de inquilinos (ativar, desativar)",
+    "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",
     "Permission:MultiTenancy.Tenants.Update": "Atualizar detalhes de inquilinos",
-    "Permission:MultiTenancy.Tenants.Manage": "Gerenciar ciclo de vida de inquilinos (ativar, desativar)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/pt.json
@@ -1,10 +1,12 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Criar novos inquilinos",
+    "Permission:MultiTenancy.Tenants.Manage": "Gerir ciclo de vida de inquilinos (ativar, desativar)",
+    "Permission:MultiTenancy.Tenants.Read": "Ver informações de inquilinos",
     "Permission:MultiTenancy.Tenants.Update": "Atualizar detalhes de inquilinos",
-    "Permission:MultiTenancy.Tenants.Manage": "Gerir ciclo de vida de inquilinos (ativar, desativar)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/sv.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/sv.json
@@ -1,10 +1,12 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Multi-Tenancy",
-    "Permission:MultiTenancy.Tenants.Read": "Visa hyresgästinformation",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Skapa nya hyresgäster",
+    "Permission:MultiTenancy.Tenants.Manage": "Hantera hyresgästlivscykel (aktivera, inaktivera)",
+    "Permission:MultiTenancy.Tenants.Read": "Visa hyresgästinformation",
     "Permission:MultiTenancy.Tenants.Update": "Uppdatera hyresgästdetaljer",
-    "Permission:MultiTenancy.Tenants.Manage": "Hantera hyresgästlivscykel (aktivera, inaktivera)"
+    "PermissionGroup:MultiTenancy": "Multi-Tenancy"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/tr.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/tr.json
@@ -1,10 +1,12 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:MultiTenancy": "Çoklu Kiracılık",
-    "Permission:MultiTenancy.Tenants.Read": "Kiracı bilgilerini görüntüleme",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "Yeni kiracılar oluşturma",
+    "Permission:MultiTenancy.Tenants.Manage": "Kiracı yaşam döngüsünü yönetme (etkinleştirme, devre dışı bırakma)",
+    "Permission:MultiTenancy.Tenants.Read": "Kiracı bilgilerini görüntüleme",
     "Permission:MultiTenancy.Tenants.Update": "Kiracı ayrıntılarını güncelleme",
-    "Permission:MultiTenancy.Tenants.Manage": "Kiracı yaşam döngüsünü yönetme (etkinleştirme, devre dışı bırakma)"
+    "PermissionGroup:MultiTenancy": "Çoklu Kiracılık"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/zh.json
+++ b/src/Granit.MultiTenancy.Endpoints/Localization/MultiTenancyEndpoints/zh.json
@@ -1,10 +1,12 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:MultiTenancy": "多租户",
-    "Permission:MultiTenancy.Tenants.Read": "查看租户信息",
+    "MultiTenancyEndpoints:Workspace.Section": "Multi-tenancy",
+    "MultiTenancyEndpoints:Workspace.Tenants": "Tenants",
     "Permission:MultiTenancy.Tenants.Create": "创建新租户",
+    "Permission:MultiTenancy.Tenants.Manage": "管理租户生命周期（激活、停用）",
+    "Permission:MultiTenancy.Tenants.Read": "查看租户信息",
     "Permission:MultiTenancy.Tenants.Update": "更新租户详情",
-    "Permission:MultiTenancy.Tenants.Manage": "管理租户生命周期（激活、停用）"
+    "PermissionGroup:MultiTenancy": "多租户"
   }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyWorkspaceContribution.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Workspaces/MultiTenancyWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.MultiTenancy.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.MultiTenancy.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts multi-tenancy admin entries onto the
+/// <c>Granit.Framework.System</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class MultiTenancyWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.System)
+            .Section("multi-tenancy", s => s
+                .DisplayKey("MultiTenancyEndpoints:Workspace.Section")
+                .Order(30)
+                .Link("/multi-tenancy/tenants", i => i
+                    .DisplayKey("MultiTenancyEndpoints:Workspace.Tenants")
+                    .Icon("building-2")
+                    .Order(0)
+                    .RequiresPermission(MultiTenancyPermissions.Tenants.Read)));
+}

--- a/src/Granit.MultiTenancy.Endpoints/packages.lock.json
+++ b/src/Granit.MultiTenancy.Endpoints/packages.lock.json
@@ -150,6 +150,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Notifications.Endpoints/Workspaces/NotificationsWorkspaceContribution.cs
+++ b/src/Granit.Notifications.Endpoints/Workspaces/NotificationsWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class NotificationsWorkspaceContribution : IWorkspaceContributor
             .Section("notifications", s => s
                 .DisplayKey("NotificationsEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/notifications", i => i
+                .Link("/notifications", i => i
                     .DisplayKey("NotificationsEndpoints:Workspace.Item")
                     .Icon("bell")
                     .Order(0)

--- a/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
+++ b/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -3,9 +3,12 @@ using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.OpenIddict.Endpoints.Internal;
+using Granit.OpenIddict.Endpoints.Workspaces;
 using Granit.OpenIddict.Server;
 using Granit.QueryEngine;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -30,10 +33,14 @@ namespace Granit.OpenIddict.Endpoints;
     typeof(GranitOpenIddictModule),
     typeof(GranitOpenIddictServerModule),
     typeof(GranitQueryEngineAbstractionsModule),
-    typeof(GranitValidationModule))]
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
 public sealed class GranitOpenIddictEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.TryAddScoped<OidcPrincipalFactory>();
+        context.Services.AddWorkspaceContribution<OpenIddictWorkspaceContribution>();
+    }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/cs.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/cs.json
@@ -1,13 +1,17 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict Identita",
-    "Permission:OpenIddict.Applications.Read": "Zobrazit OIDC aplikace",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Spravovat OIDC aplikace (zobrazit, upravit)",
+    "Permission:OpenIddict.Applications.Read": "Zobrazit OIDC aplikace",
     "Permission:OpenIddict.Applications.Rotate": "Rotovat tajné klíče aplikací",
-    "Permission:OpenIddict.Scopes.Read": "Zobrazit OIDC scopy",
-    "Permission:OpenIddict.Scopes.Manage": "Spravovat OIDC scopy (zobrazit, upravit)",
     "Permission:OpenIddict.Authorizations.Read": "Zobrazit OIDC autorizace",
-    "Permission:OpenIddict.Authorizations.Revoke": "Odvolat OIDC autorizace"
+    "Permission:OpenIddict.Authorizations.Revoke": "Odvolat OIDC autorizace",
+    "Permission:OpenIddict.Scopes.Manage": "Spravovat OIDC scopy (zobrazit, upravit)",
+    "Permission:OpenIddict.Scopes.Read": "Zobrazit OIDC scopy",
+    "PermissionGroup:OpenIddict": "OpenIddict Identita"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/de.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/de.json
@@ -1,13 +1,17 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict Identität",
-    "Permission:OpenIddict.Applications.Read": "OIDC-Anwendungen anzeigen",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDC-Anwendungen verwalten (anzeigen, bearbeiten)",
+    "Permission:OpenIddict.Applications.Read": "OIDC-Anwendungen anzeigen",
     "Permission:OpenIddict.Applications.Rotate": "Anwendungsgeheimnisse rotieren",
-    "Permission:OpenIddict.Scopes.Read": "OIDC-Scopes anzeigen",
-    "Permission:OpenIddict.Scopes.Manage": "OIDC-Scopes verwalten (anzeigen, bearbeiten)",
     "Permission:OpenIddict.Authorizations.Read": "OIDC-Autorisierungen anzeigen",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC-Autorisierungen widerrufen"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC-Autorisierungen widerrufen",
+    "Permission:OpenIddict.Scopes.Manage": "OIDC-Scopes verwalten (anzeigen, bearbeiten)",
+    "Permission:OpenIddict.Scopes.Read": "OIDC-Scopes anzeigen",
+    "PermissionGroup:OpenIddict": "OpenIddict Identität"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/en-GB.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/en-GB.json
@@ -1,7 +1,11 @@
 {
   "culture": "en-GB",
   "texts": {
-    "Permission:OpenIddict.Authorizations.Revoke": "Revoke OIDC authorisations",
-    "Permission:OpenIddict.Authorizations.Read": "Read OIDC authorisations"
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
+    "Permission:OpenIddict.Authorizations.Read": "Read OIDC authorisations",
+    "Permission:OpenIddict.Authorizations.Revoke": "Revoke OIDC authorisations"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/en.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/en.json
@@ -1,13 +1,17 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict OIDC",
-    "Permission:OpenIddict.Applications.Read": "Read OIDC applications",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Manage OIDC applications (read, update)",
+    "Permission:OpenIddict.Applications.Read": "Read OIDC applications",
     "Permission:OpenIddict.Applications.Rotate": "Rotate application secrets",
-    "Permission:OpenIddict.Scopes.Read": "Read OIDC scopes",
-    "Permission:OpenIddict.Scopes.Manage": "Manage OIDC scopes (read, update)",
     "Permission:OpenIddict.Authorizations.Read": "Read OIDC authorizations",
-    "Permission:OpenIddict.Authorizations.Revoke": "Revoke OIDC authorizations"
+    "Permission:OpenIddict.Authorizations.Revoke": "Revoke OIDC authorizations",
+    "Permission:OpenIddict.Scopes.Manage": "Manage OIDC scopes (read, update)",
+    "Permission:OpenIddict.Scopes.Read": "Read OIDC scopes",
+    "PermissionGroup:OpenIddict": "OpenIddict OIDC"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/es.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/es.json
@@ -1,13 +1,17 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:OpenIddict": "Identidad OpenIddict",
-    "Permission:OpenIddict.Applications.Read": "Consultar aplicaciones OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Gestionar aplicaciones OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Applications.Read": "Consultar aplicaciones OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Rotar secretos de aplicación",
-    "Permission:OpenIddict.Scopes.Read": "Consultar scopes OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Gestionar scopes OIDC (consultar, modificar)",
     "Permission:OpenIddict.Authorizations.Read": "Consultar autorizaciones OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Revocar autorizaciones OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Revocar autorizaciones OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Gestionar scopes OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Scopes.Read": "Consultar scopes OIDC",
+    "PermissionGroup:OpenIddict": "Identidad OpenIddict"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/fr-CA.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/fr-CA.json
@@ -1,4 +1,9 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Autorisations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect"
+  }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/fr.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/fr.json
@@ -1,13 +1,17 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:OpenIddict": "OIDC OpenIddict",
-    "Permission:OpenIddict.Applications.Read": "Consulter les applications OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Autorisations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Gérer les applications OIDC (consulter, modifier)",
+    "Permission:OpenIddict.Applications.Read": "Consulter les applications OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Renouveler les secrets d'application",
-    "Permission:OpenIddict.Scopes.Read": "Consulter les scopes OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Gérer les scopes OIDC (consulter, modifier)",
     "Permission:OpenIddict.Authorizations.Read": "Consulter les autorisations OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Révoquer les autorisations OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Révoquer les autorisations OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Gérer les scopes OIDC (consulter, modifier)",
+    "Permission:OpenIddict.Scopes.Read": "Consulter les scopes OIDC",
+    "PermissionGroup:OpenIddict": "OIDC OpenIddict"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/hi.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/hi.json
@@ -1,13 +1,17 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict OIDC",
-    "Permission:OpenIddict.Applications.Read": "OIDC एप्लिकेशन पढ़ें",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDC एप्लिकेशन प्रबंधित करें (पढ़ें, अपडेट करें)",
+    "Permission:OpenIddict.Applications.Read": "OIDC एप्लिकेशन पढ़ें",
     "Permission:OpenIddict.Applications.Rotate": "एप्लिकेशन सीक्रेट रोटेट करें",
-    "Permission:OpenIddict.Scopes.Read": "OIDC स्कोप पढ़ें",
-    "Permission:OpenIddict.Scopes.Manage": "OIDC स्कोप प्रबंधित करें (पढ़ें, अपडेट करें)",
     "Permission:OpenIddict.Authorizations.Read": "OIDC प्राधिकरण पढ़ें",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC प्राधिकरण निरस्त करें"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC प्राधिकरण निरस्त करें",
+    "Permission:OpenIddict.Scopes.Manage": "OIDC स्कोप प्रबंधित करें (पढ़ें, अपडेट करें)",
+    "Permission:OpenIddict.Scopes.Read": "OIDC स्कोप पढ़ें",
+    "PermissionGroup:OpenIddict": "OpenIddict OIDC"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/it.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/it.json
@@ -1,13 +1,17 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:OpenIddict": "Identità OpenIddict",
-    "Permission:OpenIddict.Applications.Read": "Consultare le applicazioni OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Gestire le applicazioni OIDC (consultare, modificare)",
+    "Permission:OpenIddict.Applications.Read": "Consultare le applicazioni OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Ruotare i segreti dell'applicazione",
-    "Permission:OpenIddict.Scopes.Read": "Consultare gli scope OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Gestire gli scope OIDC (consultare, modificare)",
     "Permission:OpenIddict.Authorizations.Read": "Consultare le autorizzazioni OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Revocare le autorizzazioni OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Revocare le autorizzazioni OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Gestire gli scope OIDC (consultare, modificare)",
+    "Permission:OpenIddict.Scopes.Read": "Consultare gli scope OIDC",
+    "PermissionGroup:OpenIddict": "Identità OpenIddict"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/ja.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/ja.json
@@ -1,13 +1,17 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict ID管理",
-    "Permission:OpenIddict.Applications.Read": "OIDCアプリケーションの閲覧",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDCアプリケーションの管理（閲覧、編集）",
+    "Permission:OpenIddict.Applications.Read": "OIDCアプリケーションの閲覧",
     "Permission:OpenIddict.Applications.Rotate": "アプリケーションシークレットのローテーション",
-    "Permission:OpenIddict.Scopes.Read": "OIDCスコープの閲覧",
-    "Permission:OpenIddict.Scopes.Manage": "OIDCスコープの管理（閲覧、編集）",
     "Permission:OpenIddict.Authorizations.Read": "OIDC認可の閲覧",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC認可の取り消し"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC認可の取り消し",
+    "Permission:OpenIddict.Scopes.Manage": "OIDCスコープの管理（閲覧、編集）",
+    "Permission:OpenIddict.Scopes.Read": "OIDCスコープの閲覧",
+    "PermissionGroup:OpenIddict": "OpenIddict ID管理"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/ko.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/ko.json
@@ -1,13 +1,17 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict 인증",
-    "Permission:OpenIddict.Applications.Read": "OIDC 애플리케이션 조회",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDC 애플리케이션 관리 (조회, 수정)",
+    "Permission:OpenIddict.Applications.Read": "OIDC 애플리케이션 조회",
     "Permission:OpenIddict.Applications.Rotate": "애플리케이션 비밀키 순환",
-    "Permission:OpenIddict.Scopes.Read": "OIDC 스코프 조회",
-    "Permission:OpenIddict.Scopes.Manage": "OIDC 스코프 관리 (조회, 수정)",
     "Permission:OpenIddict.Authorizations.Read": "OIDC 인가 조회",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC 인가 취소"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC 인가 취소",
+    "Permission:OpenIddict.Scopes.Manage": "OIDC 스코프 관리 (조회, 수정)",
+    "Permission:OpenIddict.Scopes.Read": "OIDC 스코프 조회",
+    "PermissionGroup:OpenIddict": "OpenIddict 인증"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/nl.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/nl.json
@@ -1,13 +1,17 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict Identiteit",
-    "Permission:OpenIddict.Applications.Read": "OIDC-applicaties raadplegen",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDC-applicaties beheren (raadplegen, wijzigen)",
+    "Permission:OpenIddict.Applications.Read": "OIDC-applicaties raadplegen",
     "Permission:OpenIddict.Applications.Rotate": "Applicatiegeheimen roteren",
-    "Permission:OpenIddict.Scopes.Read": "OIDC-scopes raadplegen",
-    "Permission:OpenIddict.Scopes.Manage": "OIDC-scopes beheren (raadplegen, wijzigen)",
     "Permission:OpenIddict.Authorizations.Read": "OIDC-autorisaties raadplegen",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC-autorisaties intrekken"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC-autorisaties intrekken",
+    "Permission:OpenIddict.Scopes.Manage": "OIDC-scopes beheren (raadplegen, wijzigen)",
+    "Permission:OpenIddict.Scopes.Read": "OIDC-scopes raadplegen",
+    "PermissionGroup:OpenIddict": "OpenIddict Identiteit"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pl.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pl.json
@@ -1,13 +1,17 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:OpenIddict": "Tożsamość OpenIddict",
-    "Permission:OpenIddict.Applications.Read": "Przeglądanie aplikacji OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Zarządzanie aplikacjami OIDC (przeglądanie, edycja)",
+    "Permission:OpenIddict.Applications.Read": "Przeglądanie aplikacji OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Rotacja sekretów aplikacji",
-    "Permission:OpenIddict.Scopes.Read": "Przeglądanie zakresów OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Zarządzanie zakresami OIDC (przeglądanie, edycja)",
     "Permission:OpenIddict.Authorizations.Read": "Przeglądanie autoryzacji OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Cofanie autoryzacji OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Cofanie autoryzacji OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Zarządzanie zakresami OIDC (przeglądanie, edycja)",
+    "Permission:OpenIddict.Scopes.Read": "Przeglądanie zakresów OIDC",
+    "PermissionGroup:OpenIddict": "Tożsamość OpenIddict"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pt-BR.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pt-BR.json
@@ -1,13 +1,17 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict — Provedor de Identidade",
-    "Permission:OpenIddict.Applications.Read": "Consultar aplicações OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Gerenciar aplicações OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Applications.Read": "Consultar aplicações OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Rotacionar segredos de aplicação",
-    "Permission:OpenIddict.Scopes.Read": "Consultar escopos OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Gerenciar escopos OIDC (consultar, modificar)",
     "Permission:OpenIddict.Authorizations.Read": "Consultar autorizações OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Revogar autorizações OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Revogar autorizações OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Gerenciar escopos OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Scopes.Read": "Consultar escopos OIDC",
+    "PermissionGroup:OpenIddict": "OpenIddict — Provedor de Identidade"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pt.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/pt.json
@@ -1,13 +1,17 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:OpenIddict": "Identidade OpenIddict",
-    "Permission:OpenIddict.Applications.Read": "Consultar aplicações OIDC",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Gerir aplicações OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Applications.Read": "Consultar aplicações OIDC",
     "Permission:OpenIddict.Applications.Rotate": "Rodar segredos de aplicação",
-    "Permission:OpenIddict.Scopes.Read": "Consultar scopes OIDC",
-    "Permission:OpenIddict.Scopes.Manage": "Gerir scopes OIDC (consultar, modificar)",
     "Permission:OpenIddict.Authorizations.Read": "Consultar autorizações OIDC",
-    "Permission:OpenIddict.Authorizations.Revoke": "Revogar autorizações OIDC"
+    "Permission:OpenIddict.Authorizations.Revoke": "Revogar autorizações OIDC",
+    "Permission:OpenIddict.Scopes.Manage": "Gerir scopes OIDC (consultar, modificar)",
+    "Permission:OpenIddict.Scopes.Read": "Consultar scopes OIDC",
+    "PermissionGroup:OpenIddict": "Identidade OpenIddict"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/sv.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/sv.json
@@ -1,13 +1,17 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict Identitet",
-    "Permission:OpenIddict.Applications.Read": "Visa OIDC-applikationer",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "Hantera OIDC-applikationer (visa, redigera)",
+    "Permission:OpenIddict.Applications.Read": "Visa OIDC-applikationer",
     "Permission:OpenIddict.Applications.Rotate": "Rotera applikationshemligheter",
-    "Permission:OpenIddict.Scopes.Read": "Visa OIDC-scopes",
-    "Permission:OpenIddict.Scopes.Manage": "Hantera OIDC-scopes (visa, redigera)",
     "Permission:OpenIddict.Authorizations.Read": "Visa OIDC-auktoriseringar",
-    "Permission:OpenIddict.Authorizations.Revoke": "Återkalla OIDC-auktoriseringar"
+    "Permission:OpenIddict.Authorizations.Revoke": "Återkalla OIDC-auktoriseringar",
+    "Permission:OpenIddict.Scopes.Manage": "Hantera OIDC-scopes (visa, redigera)",
+    "Permission:OpenIddict.Scopes.Read": "Visa OIDC-scopes",
+    "PermissionGroup:OpenIddict": "OpenIddict Identitet"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/tr.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/tr.json
@@ -1,13 +1,17 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict Kimlik",
-    "Permission:OpenIddict.Applications.Read": "OIDC uygulamalarını görüntüle",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "OIDC uygulamalarını yönet (görüntüle, düzenle)",
+    "Permission:OpenIddict.Applications.Read": "OIDC uygulamalarını görüntüle",
     "Permission:OpenIddict.Applications.Rotate": "Uygulama gizli anahtarlarını döndür",
-    "Permission:OpenIddict.Scopes.Read": "OIDC kapsamlarını görüntüle",
-    "Permission:OpenIddict.Scopes.Manage": "OIDC kapsamlarını yönet (görüntüle, düzenle)",
     "Permission:OpenIddict.Authorizations.Read": "OIDC yetkilendirmelerini görüntüle",
-    "Permission:OpenIddict.Authorizations.Revoke": "OIDC yetkilendirmelerini iptal et"
+    "Permission:OpenIddict.Authorizations.Revoke": "OIDC yetkilendirmelerini iptal et",
+    "Permission:OpenIddict.Scopes.Manage": "OIDC kapsamlarını yönet (görüntüle, düzenle)",
+    "Permission:OpenIddict.Scopes.Read": "OIDC kapsamlarını görüntüle",
+    "PermissionGroup:OpenIddict": "OpenIddict Kimlik"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/zh.json
+++ b/src/Granit.OpenIddict.Endpoints/Localization/OpenIddictEndpoints/zh.json
@@ -1,13 +1,17 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:OpenIddict": "OpenIddict 身份认证",
-    "Permission:OpenIddict.Applications.Read": "查看 OIDC 应用",
+    "OpenIddictEndpoints:Workspace.Applications": "Applications",
+    "OpenIddictEndpoints:Workspace.Authorizations": "Authorizations",
+    "OpenIddictEndpoints:Workspace.Scopes": "Scopes",
+    "OpenIddictEndpoints:Workspace.Section": "OpenID Connect",
     "Permission:OpenIddict.Applications.Manage": "管理 OIDC 应用（查看、修改）",
+    "Permission:OpenIddict.Applications.Read": "查看 OIDC 应用",
     "Permission:OpenIddict.Applications.Rotate": "轮换应用密钥",
-    "Permission:OpenIddict.Scopes.Read": "查看 OIDC 作用域",
-    "Permission:OpenIddict.Scopes.Manage": "管理 OIDC 作用域（查看、修改）",
     "Permission:OpenIddict.Authorizations.Read": "查看 OIDC 授权",
-    "Permission:OpenIddict.Authorizations.Revoke": "撤销 OIDC 授权"
+    "Permission:OpenIddict.Authorizations.Revoke": "撤销 OIDC 授权",
+    "Permission:OpenIddict.Scopes.Manage": "管理 OIDC 作用域（查看、修改）",
+    "Permission:OpenIddict.Scopes.Read": "查看 OIDC 作用域",
+    "PermissionGroup:OpenIddict": "OpenIddict 身份认证"
   }
 }

--- a/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictWorkspaceContribution.cs
+++ b/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictWorkspaceContribution.cs
@@ -1,0 +1,33 @@
+using Granit.OpenIddict.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.OpenIddict.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts OpenID Connect (OIDC) admin entries onto the
+/// <c>Granit.Framework.Users</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class OpenIddictWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Users)
+            .Section("openiddict", s => s
+                .DisplayKey("OpenIddictEndpoints:Workspace.Section")
+                .Order(30)
+                .Link("/oidc/applications", i => i
+                    .DisplayKey("OpenIddictEndpoints:Workspace.Applications")
+                    .Icon("app-window")
+                    .Order(0)
+                    .RequiresPermission(OpenIddictPermissions.Applications.Read))
+                .Link("/oidc/scopes", i => i
+                    .DisplayKey("OpenIddictEndpoints:Workspace.Scopes")
+                    .Icon("scan")
+                    .Order(1)
+                    .RequiresPermission(OpenIddictPermissions.Scopes.Read))
+                .Link("/oidc/authorizations", i => i
+                    .DisplayKey("OpenIddictEndpoints:Workspace.Authorizations")
+                    .Icon("badge-check")
+                    .Order(2)
+                    .RequiresPermission(OpenIddictPermissions.Authorizations.Read)));
+}

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -487,6 +487,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Privacy.Endpoints/Workspaces/PrivacyWorkspaceContribution.cs
+++ b/src/Granit.Privacy.Endpoints/Workspaces/PrivacyWorkspaceContribution.cs
@@ -15,12 +15,12 @@ internal sealed class PrivacyWorkspaceContribution : IWorkspaceContributor
             .Section("privacy", s => s
                 .DisplayKey("PrivacyEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/privacy/purposes", i => i
+                .Link("/privacy/purposes", i => i
                     .DisplayKey("PrivacyEndpoints:Workspace.Purposes")
                     .Icon("shield-check")
                     .Order(0)
                     .RequiresPermission(PrivacyPermissions.Purposes.Read))
-                .Link("/admin/privacy/agreements", i => i
+                .Link("/privacy/agreements", i => i
                     .DisplayKey("PrivacyEndpoints:Workspace.Agreements")
                     .Icon("file-signature")
                     .Order(1)

--- a/src/Granit.Scheduling.Endpoints/Granit.Scheduling.Endpoints.csproj
+++ b/src/Granit.Scheduling.Endpoints/Granit.Scheduling.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Scheduling\Granit.Scheduling.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
+++ b/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.Scheduling.Endpoints.Workspaces;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Scheduling.Endpoints;
 
@@ -18,5 +21,11 @@ namespace Granit.Scheduling.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitSchedulingModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitSchedulingEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitSchedulingEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<SchedulingWorkspaceContribution>();
+}

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/cs.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/cs.json
@@ -1,8 +1,10 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Scheduling": "Plánování",
+    "Permission:Scheduling.Actions.Manage": "Spravovat naplánované akce (zrušit, přeplánovat)",
     "Permission:Scheduling.Actions.Read": "Zobrazit naplánované akce (seznam, detail)",
-    "Permission:Scheduling.Actions.Manage": "Spravovat naplánované akce (zrušit, přeplánovat)"
+    "PermissionGroup:Scheduling": "Plánování",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/de.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/de.json
@@ -1,8 +1,10 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Scheduling": "Planung",
+    "Permission:Scheduling.Actions.Manage": "Geplante Aktionen verwalten (abbrechen, neu planen)",
     "Permission:Scheduling.Actions.Read": "Geplante Aktionen anzeigen (Liste, Detail)",
-    "Permission:Scheduling.Actions.Manage": "Geplante Aktionen verwalten (abbrechen, neu planen)"
+    "PermissionGroup:Scheduling": "Planung",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/en-GB.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/en-GB.json
@@ -1,4 +1,7 @@
 {
   "culture": "en-GB",
-  "texts": {}
+  "texts": {
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
+  }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/en.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/en.json
@@ -1,8 +1,10 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Scheduling": "Scheduling",
+    "Permission:Scheduling.Actions.Manage": "Manage scheduled actions (cancel, reschedule)",
     "Permission:Scheduling.Actions.Read": "View scheduled actions (list, detail)",
-    "Permission:Scheduling.Actions.Manage": "Manage scheduled actions (cancel, reschedule)"
+    "PermissionGroup:Scheduling": "Scheduling",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/es.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/es.json
@@ -1,8 +1,10 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Scheduling": "Programación",
+    "Permission:Scheduling.Actions.Manage": "Gestionar acciones programadas (cancelar, reprogramar)",
     "Permission:Scheduling.Actions.Read": "Ver acciones programadas (lista, detalle)",
-    "Permission:Scheduling.Actions.Manage": "Gestionar acciones programadas (cancelar, reprogramar)"
+    "PermissionGroup:Scheduling": "Programación",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/fr-CA.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/fr-CA.json
@@ -1,4 +1,7 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "SchedulingEndpoints:Workspace.Item": "Actions planifiées",
+    "SchedulingEndpoints:Workspace.Section": "Planification"
+  }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/fr.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/fr.json
@@ -1,8 +1,10 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Scheduling": "Planification",
+    "Permission:Scheduling.Actions.Manage": "Gérer les actions planifiées (annuler, replanifier)",
     "Permission:Scheduling.Actions.Read": "Consulter les actions planifiées (liste, détail)",
-    "Permission:Scheduling.Actions.Manage": "Gérer les actions planifiées (annuler, replanifier)"
+    "PermissionGroup:Scheduling": "Planification",
+    "SchedulingEndpoints:Workspace.Item": "Actions planifiées",
+    "SchedulingEndpoints:Workspace.Section": "Planification"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/hi.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/hi.json
@@ -1,8 +1,10 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Scheduling": "शेड्यूलिंग",
+    "Permission:Scheduling.Actions.Manage": "निर्धारित कार्य प्रबंधित करें (रद्द करें, पुनर्निर्धारित करें)",
     "Permission:Scheduling.Actions.Read": "निर्धारित कार्य देखें (सूची, विवरण)",
-    "Permission:Scheduling.Actions.Manage": "निर्धारित कार्य प्रबंधित करें (रद्द करें, पुनर्निर्धारित करें)"
+    "PermissionGroup:Scheduling": "शेड्यूलिंग",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/it.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/it.json
@@ -1,8 +1,10 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Scheduling": "Pianificazione",
+    "Permission:Scheduling.Actions.Manage": "Gestire le azioni pianificate (annullare, ripianificare)",
     "Permission:Scheduling.Actions.Read": "Visualizzare le azioni pianificate (elenco, dettaglio)",
-    "Permission:Scheduling.Actions.Manage": "Gestire le azioni pianificate (annullare, ripianificare)"
+    "PermissionGroup:Scheduling": "Pianificazione",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/ja.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/ja.json
@@ -1,8 +1,10 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Scheduling": "スケジュール",
+    "Permission:Scheduling.Actions.Manage": "スケジュール済みアクションの管理（キャンセル、再スケジュール）",
     "Permission:Scheduling.Actions.Read": "スケジュール済みアクションの表示（一覧、詳細）",
-    "Permission:Scheduling.Actions.Manage": "スケジュール済みアクションの管理（キャンセル、再スケジュール）"
+    "PermissionGroup:Scheduling": "スケジュール",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/ko.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/ko.json
@@ -1,8 +1,10 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Scheduling": "스케줄링",
+    "Permission:Scheduling.Actions.Manage": "예약된 작업 관리 (취소, 재예약)",
     "Permission:Scheduling.Actions.Read": "예약된 작업 보기 (목록, 상세)",
-    "Permission:Scheduling.Actions.Manage": "예약된 작업 관리 (취소, 재예약)"
+    "PermissionGroup:Scheduling": "스케줄링",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/nl.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/nl.json
@@ -1,8 +1,10 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Scheduling": "Planning",
+    "Permission:Scheduling.Actions.Manage": "Geplande acties beheren (annuleren, herplannen)",
     "Permission:Scheduling.Actions.Read": "Geplande acties bekijken (lijst, detail)",
-    "Permission:Scheduling.Actions.Manage": "Geplande acties beheren (annuleren, herplannen)"
+    "PermissionGroup:Scheduling": "Planning",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pl.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pl.json
@@ -1,8 +1,10 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Scheduling": "Planowanie",
+    "Permission:Scheduling.Actions.Manage": "Zarządzanie zaplanowanymi akcjami (anulowanie, przeplanowanie)",
     "Permission:Scheduling.Actions.Read": "Wyświetlanie zaplanowanych akcji (lista, szczegóły)",
-    "Permission:Scheduling.Actions.Manage": "Zarządzanie zaplanowanymi akcjami (anulowanie, przeplanowanie)"
+    "PermissionGroup:Scheduling": "Planowanie",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pt-BR.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pt-BR.json
@@ -1,8 +1,10 @@
 {
   "culture": "pt-BR",
   "texts": {
-    "PermissionGroup:Scheduling": "Agendamento",
+    "Permission:Scheduling.Actions.Manage": "Gerenciar ações agendadas (cancelar, reagendar)",
     "Permission:Scheduling.Actions.Read": "Visualizar ações agendadas (lista, detalhe)",
-    "Permission:Scheduling.Actions.Manage": "Gerenciar ações agendadas (cancelar, reagendar)"
+    "PermissionGroup:Scheduling": "Agendamento",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pt.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/pt.json
@@ -1,8 +1,10 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Scheduling": "Agendamento",
+    "Permission:Scheduling.Actions.Manage": "Gerir ações agendadas (cancelar, reagendar)",
     "Permission:Scheduling.Actions.Read": "Ver ações agendadas (lista, detalhe)",
-    "Permission:Scheduling.Actions.Manage": "Gerir ações agendadas (cancelar, reagendar)"
+    "PermissionGroup:Scheduling": "Agendamento",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/sv.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/sv.json
@@ -1,8 +1,10 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Scheduling": "Schemaläggning",
+    "Permission:Scheduling.Actions.Manage": "Hantera schemalagda åtgärder (avbryt, omplanera)",
     "Permission:Scheduling.Actions.Read": "Visa schemalagda åtgärder (lista, detalj)",
-    "Permission:Scheduling.Actions.Manage": "Hantera schemalagda åtgärder (avbryt, omplanera)"
+    "PermissionGroup:Scheduling": "Schemaläggning",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/tr.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/tr.json
@@ -1,8 +1,10 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Scheduling": "Zamanlama",
+    "Permission:Scheduling.Actions.Manage": "Zamanlanmış eylemleri yönet (iptal et, yeniden zamanla)",
     "Permission:Scheduling.Actions.Read": "Zamanlanmış eylemleri görüntüle (liste, detay)",
-    "Permission:Scheduling.Actions.Manage": "Zamanlanmış eylemleri yönet (iptal et, yeniden zamanla)"
+    "PermissionGroup:Scheduling": "Zamanlama",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/zh.json
+++ b/src/Granit.Scheduling.Endpoints/Localization/SchedulingEndpoints/zh.json
@@ -1,8 +1,10 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Scheduling": "计划任务",
+    "Permission:Scheduling.Actions.Manage": "管理计划操作（取消、重新安排）",
     "Permission:Scheduling.Actions.Read": "查看计划操作（列表、详情）",
-    "Permission:Scheduling.Actions.Manage": "管理计划操作（取消、重新安排）"
+    "PermissionGroup:Scheduling": "计划任务",
+    "SchedulingEndpoints:Workspace.Item": "Scheduled actions",
+    "SchedulingEndpoints:Workspace.Section": "Scheduling"
   }
 }

--- a/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingWorkspaceContribution.cs
+++ b/src/Granit.Scheduling.Endpoints/Workspaces/SchedulingWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.Scheduling.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Scheduling.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts scheduling admin entries onto the
+/// <c>Granit.Framework.Automation</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class SchedulingWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Automation)
+            .Section("scheduling", s => s
+                .DisplayKey("SchedulingEndpoints:Workspace.Section")
+                .Order(20)
+                .Link("/scheduling", i => i
+                    .DisplayKey("SchedulingEndpoints:Workspace.Item")
+                    .Icon("calendar-clock")
+                    .Order(0)
+                    .RequiresPermission(SchedulingPermissions.Actions.Read)));
+}

--- a/src/Granit.Scheduling.Endpoints/packages.lock.json
+++ b/src/Granit.Scheduling.Endpoints/packages.lock.json
@@ -169,6 +169,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Settings.Endpoints/Workspaces/SettingsWorkspaceContribution.cs
+++ b/src/Granit.Settings.Endpoints/Workspaces/SettingsWorkspaceContribution.cs
@@ -15,12 +15,12 @@ internal sealed class SettingsWorkspaceContribution : IWorkspaceContributor
             .Section("settings", s => s
                 .DisplayKey("SettingsEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/settings/global", i => i
+                .Link("/settings/global", i => i
                     .DisplayKey("SettingsEndpoints:Workspace.Global")
                     .Icon("settings-2")
                     .Order(0)
                     .RequiresPermission(SettingsPermissions.Global.Read))
-                .Link("/admin/settings/tenant", i => i
+                .Link("/settings/tenant", i => i
                     .DisplayKey("SettingsEndpoints:Workspace.Tenant")
                     .Icon("building")
                     .Order(1)

--- a/src/Granit.Templating.Endpoints/Granit.Templating.Endpoints.csproj
+++ b/src/Granit.Templating.Endpoints/Granit.Templating.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Templating\Granit.Templating.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
+++ b/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
@@ -1,8 +1,11 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.Templating.Endpoints.Workspaces;
 using Granit.Users;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Templating.Endpoints;
 
@@ -23,5 +26,11 @@ namespace Granit.Templating.Endpoints;
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitTemplatingModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitTemplatingEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitTemplatingEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<TemplatingWorkspaceContribution>();
+}

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/cs.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/cs.json
@@ -1,10 +1,13 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Templating": "Šablony",
-    "Permission:Templating.Templates.Read": "Zobrazit šablony (seznam, detail, historie)",
-    "Permission:Templating.Templates.Manage": "Správa šablon (zobrazení, vytvoření, úprava, smazání, publikování)",
+    "Permission:Templating.Categories.Manage": "Spravovat kategorie šablon (vytvořit, upravit, smazat)",
     "Permission:Templating.Categories.Read": "Zobrazit kategorie šablon",
-    "Permission:Templating.Categories.Manage": "Spravovat kategorie šablon (vytvořit, upravit, smazat)"
+    "Permission:Templating.Templates.Manage": "Správa šablon (zobrazení, vytvoření, úprava, smazání, publikování)",
+    "Permission:Templating.Templates.Read": "Zobrazit šablony (seznam, detail, historie)",
+    "PermissionGroup:Templating": "Šablony",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/de.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/de.json
@@ -1,10 +1,13 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Templating": "Vorlagenverwaltung",
-    "Permission:Templating.Templates.Read": "Vorlagen anzeigen (Liste, Detail, Verlauf)",
-    "Permission:Templating.Templates.Manage": "Vorlagen verwalten (anzeigen, erstellen, bearbeiten, löschen, veröffentlichen)",
+    "Permission:Templating.Categories.Manage": "Vorlagenkategorien verwalten (erstellen, bearbeiten, löschen)",
     "Permission:Templating.Categories.Read": "Vorlagenkategorien anzeigen",
-    "Permission:Templating.Categories.Manage": "Vorlagenkategorien verwalten (erstellen, bearbeiten, löschen)"
+    "Permission:Templating.Templates.Manage": "Vorlagen verwalten (anzeigen, erstellen, bearbeiten, löschen, veröffentlichen)",
+    "Permission:Templating.Templates.Read": "Vorlagen anzeigen (Liste, Detail, Verlauf)",
+    "PermissionGroup:Templating": "Vorlagenverwaltung",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/en-GB.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/en-GB.json
@@ -1,7 +1,10 @@
 {
   "culture": "en-GB",
   "texts": {
+    "Permission:Templating.Categories.Manage": "Manage template categories (create, edit, delete)",
     "Permission:Templating.Categories.Read": "View template categories",
-    "Permission:Templating.Categories.Manage": "Manage template categories (create, edit, delete)"
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/en.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/en.json
@@ -1,10 +1,13 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Templating": "Templating",
-    "Permission:Templating.Templates.Read": "View templates (list, detail, history)",
-    "Permission:Templating.Templates.Manage": "Manage templates (view, create, edit, delete, publish)",
+    "Permission:Templating.Categories.Manage": "Manage template categories (create, edit, delete)",
     "Permission:Templating.Categories.Read": "View template categories",
-    "Permission:Templating.Categories.Manage": "Manage template categories (create, edit, delete)"
+    "Permission:Templating.Templates.Manage": "Manage templates (view, create, edit, delete, publish)",
+    "Permission:Templating.Templates.Read": "View templates (list, detail, history)",
+    "PermissionGroup:Templating": "Templating",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/es.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/es.json
@@ -1,10 +1,13 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Templating": "Gestión de plantillas",
-    "Permission:Templating.Templates.Read": "Ver plantillas (lista, detalle, historial)",
-    "Permission:Templating.Templates.Manage": "Gestionar plantillas (ver, crear, editar, eliminar, publicar)",
+    "Permission:Templating.Categories.Manage": "Gestionar categorías de plantillas (crear, editar, eliminar)",
     "Permission:Templating.Categories.Read": "Ver categorías de plantillas",
-    "Permission:Templating.Categories.Manage": "Gestionar categorías de plantillas (crear, editar, eliminar)"
+    "Permission:Templating.Templates.Manage": "Gestionar plantillas (ver, crear, editar, eliminar, publicar)",
+    "Permission:Templating.Templates.Read": "Ver plantillas (lista, detalle, historial)",
+    "PermissionGroup:Templating": "Gestión de plantillas",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/fr-CA.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/fr-CA.json
@@ -1,7 +1,10 @@
 {
   "culture": "fr-CA",
   "texts": {
+    "Permission:Templating.Categories.Manage": "Gérer les catégories de templates (créer, modifier, supprimer)",
     "Permission:Templating.Categories.Read": "Consulter les catégories de templates",
-    "Permission:Templating.Categories.Manage": "Gérer les catégories de templates (créer, modifier, supprimer)"
+    "TemplatingEndpoints:Workspace.Categories": "Catégories",
+    "TemplatingEndpoints:Workspace.Section": "Modèles",
+    "TemplatingEndpoints:Workspace.Templates": "Modèles"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/fr.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/fr.json
@@ -1,10 +1,13 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Templating": "Gestion des templates",
-    "Permission:Templating.Templates.Read": "Consulter les templates (liste, détail, historique)",
-    "Permission:Templating.Templates.Manage": "Gérer les templates (consulter, créer, modifier, supprimer, publier)",
+    "Permission:Templating.Categories.Manage": "Gérer les catégories de templates (créer, modifier, supprimer)",
     "Permission:Templating.Categories.Read": "Consulter les catégories de templates",
-    "Permission:Templating.Categories.Manage": "Gérer les catégories de templates (créer, modifier, supprimer)"
+    "Permission:Templating.Templates.Manage": "Gérer les templates (consulter, créer, modifier, supprimer, publier)",
+    "Permission:Templating.Templates.Read": "Consulter les templates (liste, détail, historique)",
+    "PermissionGroup:Templating": "Gestion des templates",
+    "TemplatingEndpoints:Workspace.Categories": "Catégories",
+    "TemplatingEndpoints:Workspace.Section": "Modèles",
+    "TemplatingEndpoints:Workspace.Templates": "Modèles"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/hi.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/hi.json
@@ -1,10 +1,13 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Templating": "टेम्पलेटिंग",
-    "Permission:Templating.Templates.Read": "टेम्पलेट देखें (सूची, विवरण, इतिहास)",
-    "Permission:Templating.Templates.Manage": "टेम्पलेट प्रबंधित करें (देखें, बनाएँ, संपादित करें, हटाएँ, प्रकाशित करें)",
+    "Permission:Templating.Categories.Manage": "टेम्पलेट श्रेणियाँ प्रबंधित करें (बनाएँ, संपादित करें, हटाएँ)",
     "Permission:Templating.Categories.Read": "टेम्पलेट श्रेणियाँ देखें",
-    "Permission:Templating.Categories.Manage": "टेम्पलेट श्रेणियाँ प्रबंधित करें (बनाएँ, संपादित करें, हटाएँ)"
+    "Permission:Templating.Templates.Manage": "टेम्पलेट प्रबंधित करें (देखें, बनाएँ, संपादित करें, हटाएँ, प्रकाशित करें)",
+    "Permission:Templating.Templates.Read": "टेम्पलेट देखें (सूची, विवरण, इतिहास)",
+    "PermissionGroup:Templating": "टेम्पलेटिंग",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/it.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/it.json
@@ -1,10 +1,13 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Templating": "Gestione modelli",
-    "Permission:Templating.Templates.Read": "Visualizzare i template (elenco, dettaglio, cronologia)",
-    "Permission:Templating.Templates.Manage": "Gestire i modelli (visualizzare, creare, modificare, eliminare, pubblicare)",
+    "Permission:Templating.Categories.Manage": "Gestisci categorie di modelli (crea, modifica, elimina)",
     "Permission:Templating.Categories.Read": "Visualizza categorie di modelli",
-    "Permission:Templating.Categories.Manage": "Gestisci categorie di modelli (crea, modifica, elimina)"
+    "Permission:Templating.Templates.Manage": "Gestire i modelli (visualizzare, creare, modificare, eliminare, pubblicare)",
+    "Permission:Templating.Templates.Read": "Visualizzare i template (elenco, dettaglio, cronologia)",
+    "PermissionGroup:Templating": "Gestione modelli",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/ja.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/ja.json
@@ -1,10 +1,13 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Templating": "テンプレート",
-    "Permission:Templating.Templates.Read": "テンプレートの閲覧（一覧、詳細、履歴）",
-    "Permission:Templating.Templates.Manage": "テンプレートの管理（表示、作成、編集、削除、公開）",
+    "Permission:Templating.Categories.Manage": "テンプレートカテゴリの管理（作成、編集、削除）",
     "Permission:Templating.Categories.Read": "テンプレートカテゴリの表示",
-    "Permission:Templating.Categories.Manage": "テンプレートカテゴリの管理（作成、編集、削除）"
+    "Permission:Templating.Templates.Manage": "テンプレートの管理（表示、作成、編集、削除、公開）",
+    "Permission:Templating.Templates.Read": "テンプレートの閲覧（一覧、詳細、履歴）",
+    "PermissionGroup:Templating": "テンプレート",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/ko.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/ko.json
@@ -1,10 +1,13 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Templating": "템플릿",
-    "Permission:Templating.Templates.Read": "템플릿 조회 (목록, 상세, 이력)",
-    "Permission:Templating.Templates.Manage": "템플릿 관리 (보기, 생성, 편집, 삭제, 게시)",
+    "Permission:Templating.Categories.Manage": "템플릿 카테고리 관리 (생성, 편집, 삭제)",
     "Permission:Templating.Categories.Read": "템플릿 카테고리 보기",
-    "Permission:Templating.Categories.Manage": "템플릿 카테고리 관리 (생성, 편집, 삭제)"
+    "Permission:Templating.Templates.Manage": "템플릿 관리 (보기, 생성, 편집, 삭제, 게시)",
+    "Permission:Templating.Templates.Read": "템플릿 조회 (목록, 상세, 이력)",
+    "PermissionGroup:Templating": "템플릿",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/nl.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/nl.json
@@ -1,10 +1,13 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Templating": "Sjabloonbeheer",
-    "Permission:Templating.Templates.Read": "Templates bekijken (lijst, detail, geschiedenis)",
-    "Permission:Templating.Templates.Manage": "Sjablonen beheren (bekijken, aanmaken, bewerken, verwijderen, publiceren)",
+    "Permission:Templating.Categories.Manage": "Templatecategorieën beheren (aanmaken, bewerken, verwijderen)",
     "Permission:Templating.Categories.Read": "Templatecategorieën bekijken",
-    "Permission:Templating.Categories.Manage": "Templatecategorieën beheren (aanmaken, bewerken, verwijderen)"
+    "Permission:Templating.Templates.Manage": "Sjablonen beheren (bekijken, aanmaken, bewerken, verwijderen, publiceren)",
+    "Permission:Templating.Templates.Read": "Templates bekijken (lijst, detail, geschiedenis)",
+    "PermissionGroup:Templating": "Sjabloonbeheer",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pl.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pl.json
@@ -1,10 +1,13 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Templating": "Szablony",
-    "Permission:Templating.Templates.Read": "Przeglądanie szablonów (lista, szczegóły, historia)",
-    "Permission:Templating.Templates.Manage": "Zarządzanie szablonami (wyświetlanie, tworzenie, edycja, usuwanie, publikowanie)",
+    "Permission:Templating.Categories.Manage": "Zarządzanie kategoriami szablonów (tworzenie, edycja, usuwanie)",
     "Permission:Templating.Categories.Read": "Przeglądanie kategorii szablonów",
-    "Permission:Templating.Categories.Manage": "Zarządzanie kategoriami szablonów (tworzenie, edycja, usuwanie)"
+    "Permission:Templating.Templates.Manage": "Zarządzanie szablonami (wyświetlanie, tworzenie, edycja, usuwanie, publikowanie)",
+    "Permission:Templating.Templates.Read": "Przeglądanie szablonów (lista, szczegóły, historia)",
+    "PermissionGroup:Templating": "Szablony",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pt-BR.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pt-BR.json
@@ -1,7 +1,10 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "Permission:Templating.Categories.Manage": "Gerenciar categorias de modelos (criar, editar, excluir)",
     "Permission:Templating.Categories.Read": "Ver categorias de modelos",
-    "Permission:Templating.Categories.Manage": "Gerenciar categorias de modelos (criar, editar, excluir)"
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pt.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/pt.json
@@ -1,10 +1,13 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Templating": "Gestão de modelos",
-    "Permission:Templating.Templates.Read": "Ver modelos (lista, detalhe, histórico)",
-    "Permission:Templating.Templates.Manage": "Gerir modelos (ver, criar, editar, eliminar, publicar)",
+    "Permission:Templating.Categories.Manage": "Gerir categorias de modelos (criar, editar, eliminar)",
     "Permission:Templating.Categories.Read": "Ver categorias de modelos",
-    "Permission:Templating.Categories.Manage": "Gerir categorias de modelos (criar, editar, eliminar)"
+    "Permission:Templating.Templates.Manage": "Gerir modelos (ver, criar, editar, eliminar, publicar)",
+    "Permission:Templating.Templates.Read": "Ver modelos (lista, detalhe, histórico)",
+    "PermissionGroup:Templating": "Gestão de modelos",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/sv.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/sv.json
@@ -1,10 +1,13 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Templating": "Mallar",
-    "Permission:Templating.Templates.Read": "Visa mallar (lista, detalj, historik)",
-    "Permission:Templating.Templates.Manage": "Hantera mallar (visa, skapa, redigera, radera, publicera)",
+    "Permission:Templating.Categories.Manage": "Hantera mallkategorier (skapa, redigera, ta bort)",
     "Permission:Templating.Categories.Read": "Visa mallkategorier",
-    "Permission:Templating.Categories.Manage": "Hantera mallkategorier (skapa, redigera, ta bort)"
+    "Permission:Templating.Templates.Manage": "Hantera mallar (visa, skapa, redigera, radera, publicera)",
+    "Permission:Templating.Templates.Read": "Visa mallar (lista, detalj, historik)",
+    "PermissionGroup:Templating": "Mallar",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/tr.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/tr.json
@@ -1,10 +1,13 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Templating": "Şablonlar",
-    "Permission:Templating.Templates.Read": "Şablonları görüntüle (liste, detay, geçmiş)",
-    "Permission:Templating.Templates.Manage": "Şablonları yönet (görüntüle, oluştur, düzenle, sil, yayınla)",
+    "Permission:Templating.Categories.Manage": "Şablon kategorilerini yönet (oluştur, düzenle, sil)",
     "Permission:Templating.Categories.Read": "Şablon kategorilerini görüntüle",
-    "Permission:Templating.Categories.Manage": "Şablon kategorilerini yönet (oluştur, düzenle, sil)"
+    "Permission:Templating.Templates.Manage": "Şablonları yönet (görüntüle, oluştur, düzenle, sil, yayınla)",
+    "Permission:Templating.Templates.Read": "Şablonları görüntüle (liste, detay, geçmiş)",
+    "PermissionGroup:Templating": "Şablonlar",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/zh.json
+++ b/src/Granit.Templating.Endpoints/Localization/TemplatingEndpoints/zh.json
@@ -1,10 +1,13 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Templating": "模板",
-    "Permission:Templating.Templates.Read": "查看模板（列表、详情、历史）",
-    "Permission:Templating.Templates.Manage": "管理模板（查看、创建、编辑、删除、发布）",
+    "Permission:Templating.Categories.Manage": "管理模板分类（创建、编辑、删除）",
     "Permission:Templating.Categories.Read": "查看模板分类",
-    "Permission:Templating.Categories.Manage": "管理模板分类（创建、编辑、删除）"
+    "Permission:Templating.Templates.Manage": "管理模板（查看、创建、编辑、删除、发布）",
+    "Permission:Templating.Templates.Read": "查看模板（列表、详情、历史）",
+    "PermissionGroup:Templating": "模板",
+    "TemplatingEndpoints:Workspace.Categories": "Categories",
+    "TemplatingEndpoints:Workspace.Section": "Templating",
+    "TemplatingEndpoints:Workspace.Templates": "Templates"
   }
 }

--- a/src/Granit.Templating.Endpoints/Workspaces/TemplatingWorkspaceContribution.cs
+++ b/src/Granit.Templating.Endpoints/Workspaces/TemplatingWorkspaceContribution.cs
@@ -1,0 +1,28 @@
+using Granit.Templating.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Templating.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts templating admin entries onto the
+/// <c>Granit.Framework.System</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class TemplatingWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.System)
+            .Section("templating", s => s
+                .DisplayKey("TemplatingEndpoints:Workspace.Section")
+                .Order(40)
+                .Link("/templating/templates", i => i
+                    .DisplayKey("TemplatingEndpoints:Workspace.Templates")
+                    .Icon("layout-template")
+                    .Order(0)
+                    .RequiresPermission(TemplatingPermissions.Templates.Read))
+                .Link("/templating/categories", i => i
+                    .DisplayKey("TemplatingEndpoints:Workspace.Categories")
+                    .Icon("folder-tree")
+                    .Order(1)
+                    .RequiresPermission(TemplatingPermissions.Categories.Read)));
+}

--- a/src/Granit.Templating.Endpoints/packages.lock.json
+++ b/src/Granit.Templating.Endpoints/packages.lock.json
@@ -152,6 +152,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Timeline.Endpoints/Granit.Timeline.Endpoints.csproj
+++ b/src/Granit.Timeline.Endpoints/Granit.Timeline.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Timeline\Granit.Timeline.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
+++ b/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Authorization;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.Timeline.Endpoints.Workspaces;
 using Granit.Validation;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Timeline.Endpoints;
 
@@ -20,5 +23,11 @@ namespace Granit.Timeline.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitTimelineModule),
-    typeof(GranitValidationModule))]
-public sealed class GranitTimelineEndpointsModule : GranitModule;
+    typeof(GranitValidationModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
+public sealed class GranitTimelineEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddWorkspaceContribution<TimelineWorkspaceContribution>();
+}

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
@@ -1,19 +1,20 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Timeline": "Časová osa",
-    "Permission:Timeline.Entries.Read": "Zobrazit aktivity a historii auditu",
+    "Granit:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů.",
     "Permission:Timeline.Entries.Create": "Přidávat komentáře a sledovat/přestat sledovat entity",
     "Permission:Timeline.Entries.Manage": "Spravovat (mazat) libovolnou položku časové osy bez ohledu na vlastníka",
-    "Permission:Timeline.InternalNotes.Read": "Zobrazit interní poznámky pouze pro zaměstnance v kanálech aktivity",
+    "Permission:Timeline.Entries.Read": "Zobrazit aktivity a historii auditu",
     "Permission:Timeline.Followers.Manage": "Sledovat a přestat sledovat entity v kanálech aktivity",
+    "Permission:Timeline.InternalNotes.Read": "Zobrazit interní poznámky pouze pro zaměstnance v kanálech aktivity",
     "Permission:Timeline.Reactions.React": "Reagovat na položky časové osy emoji z katalogu",
-    "Granit:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů.",
-
-    "Reaction:thumbs_up": "Palec nahoru",
+    "PermissionGroup:Timeline": "Časová osa",
+    "Reaction:eyes": "Oči",
     "Reaction:heart": "Srdce",
-    "Reaction:tada": "Oslava",
     "Reaction:joy": "Smích",
-    "Reaction:eyes": "Oči"
+    "Reaction:tada": "Oslava",
+    "Reaction:thumbs_up": "Palec nahoru",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
@@ -1,19 +1,20 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Timeline": "Zeitachse",
-    "Permission:Timeline.Entries.Read": "Aktivitätsfeeds und Prüfverlauf anzeigen",
+    "Granit:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden.",
     "Permission:Timeline.Entries.Create": "Kommentare veröffentlichen und Entitäten folgen/entfolgen",
     "Permission:Timeline.Entries.Manage": "Beliebige Zeitachseneinträge verwalten (löschen), unabhängig vom Eigentümer",
-    "Permission:Timeline.InternalNotes.Read": "Interne Notizen (nur für Mitarbeiter) in Aktivitätsfeeds anzeigen",
+    "Permission:Timeline.Entries.Read": "Aktivitätsfeeds und Prüfverlauf anzeigen",
     "Permission:Timeline.Followers.Manage": "Entitäten in Aktivitätsfeeds folgen und entfolgen",
+    "Permission:Timeline.InternalNotes.Read": "Interne Notizen (nur für Mitarbeiter) in Aktivitätsfeeds anzeigen",
     "Permission:Timeline.Reactions.React": "Auf Zeitachseneinträge mit Katalog-Emojis reagieren",
-    "Granit:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden.",
-
-    "Reaction:thumbs_up": "Daumen hoch",
+    "PermissionGroup:Timeline": "Zeitachse",
+    "Reaction:eyes": "Augen",
     "Reaction:heart": "Herz",
-    "Reaction:tada": "Feiern",
     "Reaction:joy": "Lachen",
-    "Reaction:eyes": "Augen"
+    "Reaction:tada": "Feiern",
+    "Reaction:thumbs_up": "Daumen hoch",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
@@ -1,9 +1,11 @@
 {
   "culture": "en-GB",
   "texts": {
+    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
-    "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
     "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
-    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files."
+    "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
@@ -1,19 +1,20 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Timeline": "Timeline",
-    "Permission:Timeline.Entries.Read": "View activity feeds and audit history",
+    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
     "Permission:Timeline.Entries.Create": "Post comments and follow/unfollow entities",
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
-    "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
+    "Permission:Timeline.Entries.Read": "View activity feeds and audit history",
     "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
+    "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
     "Permission:Timeline.Reactions.React": "React to timeline entries with the closed-catalog emojis",
-    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files.",
-
-    "Reaction:thumbs_up": "Thumbs up",
+    "PermissionGroup:Timeline": "Timeline",
+    "Reaction:eyes": "Eyes",
     "Reaction:heart": "Heart",
-    "Reaction:tada": "Celebrate",
     "Reaction:joy": "Laughing",
-    "Reaction:eyes": "Eyes"
+    "Reaction:tada": "Celebrate",
+    "Reaction:thumbs_up": "Thumbs up",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
@@ -1,19 +1,20 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Timeline": "Línea de tiempo",
-    "Permission:Timeline.Entries.Read": "Ver flujos de actividad e historial de auditoría",
+    "Granit:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos.",
     "Permission:Timeline.Entries.Create": "Publicar comentarios y seguir/dejar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gestionar (eliminar) cualquier entrada de línea de tiempo sin importar el propietario",
-    "Permission:Timeline.InternalNotes.Read": "Ver notas internas solo para personal en los feeds de actividad",
+    "Permission:Timeline.Entries.Read": "Ver flujos de actividad e historial de auditoría",
     "Permission:Timeline.Followers.Manage": "Seguir y dejar de seguir entidades en los feeds de actividad",
+    "Permission:Timeline.InternalNotes.Read": "Ver notas internas solo para personal en los feeds de actividad",
     "Permission:Timeline.Reactions.React": "Reaccionar a entradas de la línea de tiempo con los emojis del catálogo",
-    "Granit:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos.",
-
-    "Reaction:thumbs_up": "Pulgar arriba",
+    "PermissionGroup:Timeline": "Línea de tiempo",
+    "Reaction:eyes": "Ojos",
     "Reaction:heart": "Corazón",
-    "Reaction:tada": "Celebración",
     "Reaction:joy": "Risa",
-    "Reaction:eyes": "Ojos"
+    "Reaction:tada": "Celebración",
+    "Reaction:thumbs_up": "Pulgar arriba",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
@@ -1,9 +1,11 @@
 {
   "culture": "fr-CA",
   "texts": {
+    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
-    "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
     "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
-    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers."
+    "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
+    "TimelineEndpoints:Workspace.Item": "Flux d'activité",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
@@ -1,19 +1,20 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Timeline": "Fil d'activité",
-    "Permission:Timeline.Entries.Read": "Consulter les flux d'activité et l'historique d'audit",
+    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
     "Permission:Timeline.Entries.Create": "Poster des commentaires et suivre/ne plus suivre des entités",
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
-    "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
+    "Permission:Timeline.Entries.Read": "Consulter les flux d'activité et l'historique d'audit",
     "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
+    "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
     "Permission:Timeline.Reactions.React": "Réagir aux entrées du fil d'activité avec les emojis du catalogue",
-    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers.",
-
-    "Reaction:thumbs_up": "Pouce levé",
+    "PermissionGroup:Timeline": "Fil d'activité",
+    "Reaction:eyes": "Yeux",
     "Reaction:heart": "Cœur",
-    "Reaction:tada": "Bravo",
     "Reaction:joy": "Rire",
-    "Reaction:eyes": "Yeux"
+    "Reaction:tada": "Bravo",
+    "Reaction:thumbs_up": "Pouce levé",
+    "TimelineEndpoints:Workspace.Item": "Flux d'activité",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/hi.json
@@ -1,19 +1,20 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Timeline": "टाइमलाइन",
-    "Permission:Timeline.Entries.Read": "गतिविधि फ़ीड और ऑडिट इतिहास देखें",
+    "Granit:Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।",
     "Permission:Timeline.Entries.Create": "टिप्पणियाँ पोस्ट करें और इकाइयों को फ़ॉलो/अनफ़ॉलो करें",
     "Permission:Timeline.Entries.Manage": "स्वामित्व की परवाह किए बिना किसी भी टाइमलाइन प्रविष्टि को प्रबंधित (हटाएँ) करें",
-    "Permission:Timeline.InternalNotes.Read": "गतिविधि फ़ीड में केवल-स्टाफ़ आंतरिक नोट देखें",
+    "Permission:Timeline.Entries.Read": "गतिविधि फ़ीड और ऑडिट इतिहास देखें",
     "Permission:Timeline.Followers.Manage": "टाइमलाइन फ़ीड में इकाइयों को फ़ॉलो और अनफ़ॉलो करें",
+    "Permission:Timeline.InternalNotes.Read": "गतिविधि फ़ीड में केवल-स्टाफ़ आंतरिक नोट देखें",
     "Permission:Timeline.Reactions.React": "कैटलॉग इमोजी से टाइमलाइन प्रविष्टियों पर प्रतिक्रिया दें",
-    "Granit:Validation:TooManyAttachments": "20 से अधिक फ़ाइलें संलग्न नहीं की जा सकतीं।",
-
-    "Reaction:thumbs_up": "अंगूठा ऊपर",
+    "PermissionGroup:Timeline": "टाइमलाइन",
+    "Reaction:eyes": "आँखें",
     "Reaction:heart": "दिल",
-    "Reaction:tada": "जश्न",
     "Reaction:joy": "हँसी",
-    "Reaction:eyes": "आँखें"
+    "Reaction:tada": "जश्न",
+    "Reaction:thumbs_up": "अंगूठा ऊपर",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
@@ -1,19 +1,20 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Timeline": "Cronologia",
-    "Permission:Timeline.Entries.Read": "Visualizzare i flussi di attività e la cronologia di audit",
+    "Granit:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file.",
     "Permission:Timeline.Entries.Create": "Pubblicare commenti e seguire/smettere di seguire entità",
     "Permission:Timeline.Entries.Manage": "Gestire (eliminare) qualsiasi voce della timeline indipendentemente dal proprietario",
-    "Permission:Timeline.InternalNotes.Read": "Visualizzare le note interne riservate al personale nei feed di attività",
+    "Permission:Timeline.Entries.Read": "Visualizzare i flussi di attività e la cronologia di audit",
     "Permission:Timeline.Followers.Manage": "Seguire e smettere di seguire entità nei feed di attività",
+    "Permission:Timeline.InternalNotes.Read": "Visualizzare le note interne riservate al personale nei feed di attività",
     "Permission:Timeline.Reactions.React": "Reagire alle voci della timeline con gli emoji del catalogo",
-    "Granit:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file.",
-
-    "Reaction:thumbs_up": "Pollice in su",
+    "PermissionGroup:Timeline": "Cronologia",
+    "Reaction:eyes": "Occhi",
     "Reaction:heart": "Cuore",
-    "Reaction:tada": "Festeggiare",
     "Reaction:joy": "Risata",
-    "Reaction:eyes": "Occhi"
+    "Reaction:tada": "Festeggiare",
+    "Reaction:thumbs_up": "Pollice in su",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
@@ -1,19 +1,20 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Timeline": "タイムライン",
-    "Permission:Timeline.Entries.Read": "アクティビティフィードと監査履歴を表示",
+    "Granit:Validation:TooManyAttachments": "添付ファイルは20個までです。",
     "Permission:Timeline.Entries.Create": "コメントの投稿とエンティティのフォロー/フォロー解除",
     "Permission:Timeline.Entries.Manage": "所有者に関係なくタイムラインエントリを管理（削除）",
-    "Permission:Timeline.InternalNotes.Read": "アクティビティフィードでスタッフ限定の内部メモを表示",
+    "Permission:Timeline.Entries.Read": "アクティビティフィードと監査履歴を表示",
     "Permission:Timeline.Followers.Manage": "アクティビティフィードでエンティティのフォロー・フォロー解除",
+    "Permission:Timeline.InternalNotes.Read": "アクティビティフィードでスタッフ限定の内部メモを表示",
     "Permission:Timeline.Reactions.React": "カタログの絵文字でタイムラインエントリにリアクションを付ける",
-    "Granit:Validation:TooManyAttachments": "添付ファイルは20個までです。",
-
-    "Reaction:thumbs_up": "いいね",
+    "PermissionGroup:Timeline": "タイムライン",
+    "Reaction:eyes": "目",
     "Reaction:heart": "ハート",
-    "Reaction:tada": "お祝い",
     "Reaction:joy": "笑い",
-    "Reaction:eyes": "目"
+    "Reaction:tada": "お祝い",
+    "Reaction:thumbs_up": "いいね",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
@@ -1,19 +1,20 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Timeline": "타임라인",
-    "Permission:Timeline.Entries.Read": "활동 피드 및 감사 이력 보기",
+    "Granit:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다.",
     "Permission:Timeline.Entries.Create": "댓글 작성 및 엔티티 팔로우/언팔로우",
     "Permission:Timeline.Entries.Manage": "소유자에 관계없이 타임라인 항목 관리(삭제)",
-    "Permission:Timeline.InternalNotes.Read": "활동 피드에서 직원 전용 내부 메모 보기",
+    "Permission:Timeline.Entries.Read": "활동 피드 및 감사 이력 보기",
     "Permission:Timeline.Followers.Manage": "활동 피드에서 엔터티 팔로우 및 팔로우 취소",
+    "Permission:Timeline.InternalNotes.Read": "활동 피드에서 직원 전용 내부 메모 보기",
     "Permission:Timeline.Reactions.React": "카탈로그 이모지로 타임라인 항목에 반응하기",
-    "Granit:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다.",
-
-    "Reaction:thumbs_up": "좋아요",
+    "PermissionGroup:Timeline": "타임라인",
+    "Reaction:eyes": "눈",
     "Reaction:heart": "하트",
-    "Reaction:tada": "축하",
     "Reaction:joy": "웃음",
-    "Reaction:eyes": "눈"
+    "Reaction:tada": "축하",
+    "Reaction:thumbs_up": "좋아요",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
@@ -1,19 +1,20 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Timeline": "Tijdlijn",
-    "Permission:Timeline.Entries.Read": "Activiteitsfeeds en auditgeschiedenis bekijken",
+    "Granit:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen.",
     "Permission:Timeline.Entries.Create": "Reacties plaatsen en entiteiten volgen/ontvolgen",
     "Permission:Timeline.Entries.Manage": "Alle tijdlijnvermeldingen beheren (verwijderen) ongeacht eigenaar",
-    "Permission:Timeline.InternalNotes.Read": "Alleen voor personeel bestemde interne notities bekijken",
+    "Permission:Timeline.Entries.Read": "Activiteitsfeeds en auditgeschiedenis bekijken",
     "Permission:Timeline.Followers.Manage": "Entiteiten volgen en ontvolgen in activiteitenfeeds",
+    "Permission:Timeline.InternalNotes.Read": "Alleen voor personeel bestemde interne notities bekijken",
     "Permission:Timeline.Reactions.React": "Reageren op tijdlijnvermeldingen met de catalogus-emoji's",
-    "Granit:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen.",
-
-    "Reaction:thumbs_up": "Duim omhoog",
+    "PermissionGroup:Timeline": "Tijdlijn",
+    "Reaction:eyes": "Ogen",
     "Reaction:heart": "Hart",
-    "Reaction:tada": "Vieren",
     "Reaction:joy": "Lachen",
-    "Reaction:eyes": "Ogen"
+    "Reaction:tada": "Vieren",
+    "Reaction:thumbs_up": "Duim omhoog",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
@@ -1,19 +1,20 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Timeline": "Oś czasu",
-    "Permission:Timeline.Entries.Read": "Wyświetlanie kanałów aktywności i historii audytu",
+    "Granit:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików.",
     "Permission:Timeline.Entries.Create": "Dodawanie komentarzy i śledzenie/zaprzestanie śledzenia encji",
     "Permission:Timeline.Entries.Manage": "Zarządzanie (usuwanie) wpisów osi czasu niezależnie od właściciela",
-    "Permission:Timeline.InternalNotes.Read": "Przeglądanie wewnętrznych notatek dostępnych tylko dla personelu",
+    "Permission:Timeline.Entries.Read": "Wyświetlanie kanałów aktywności i historii audytu",
     "Permission:Timeline.Followers.Manage": "Obserwowanie i rezygnacja z obserwowania podmiotów w kanałach aktywności",
+    "Permission:Timeline.InternalNotes.Read": "Przeglądanie wewnętrznych notatek dostępnych tylko dla personelu",
     "Permission:Timeline.Reactions.React": "Reaguj na wpisy osi czasu emoji z katalogu",
-    "Granit:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików.",
-
-    "Reaction:thumbs_up": "Kciuk w górę",
+    "PermissionGroup:Timeline": "Oś czasu",
+    "Reaction:eyes": "Oczy",
     "Reaction:heart": "Serce",
-    "Reaction:tada": "Świętowanie",
     "Reaction:joy": "Śmiech",
-    "Reaction:eyes": "Oczy"
+    "Reaction:tada": "Świętowanie",
+    "Reaction:thumbs_up": "Kciuk w górę",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
@@ -1,9 +1,11 @@
 {
   "culture": "pt-BR",
   "texts": {
+    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 arquivos.",
     "Permission:Timeline.Entries.Manage": "Gerenciar (excluir) qualquer entrada de linha do tempo independentemente do proprietário",
-    "Permission:Timeline.InternalNotes.Read": "Ver notas internas somente para funcionários nos feeds de atividade",
     "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
-    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 arquivos."
+    "Permission:Timeline.InternalNotes.Read": "Ver notas internas somente para funcionários nos feeds de atividade",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
@@ -1,19 +1,20 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Timeline": "Cronologia",
-    "Permission:Timeline.Entries.Read": "Ver fluxos de atividade e histórico de auditoria",
+    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros.",
     "Permission:Timeline.Entries.Create": "Publicar comentários e seguir/deixar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gerir (eliminar) qualquer entrada de cronologia independentemente do proprietário",
-    "Permission:Timeline.InternalNotes.Read": "Ver notas internas apenas para funcionários nos feeds de atividade",
+    "Permission:Timeline.Entries.Read": "Ver fluxos de atividade e histórico de auditoria",
     "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
+    "Permission:Timeline.InternalNotes.Read": "Ver notas internas apenas para funcionários nos feeds de atividade",
     "Permission:Timeline.Reactions.React": "Reagir às entradas da cronologia com os emojis do catálogo",
-    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros.",
-
-    "Reaction:thumbs_up": "Polegar para cima",
+    "PermissionGroup:Timeline": "Cronologia",
+    "Reaction:eyes": "Olhos",
     "Reaction:heart": "Coração",
-    "Reaction:tada": "Comemorar",
     "Reaction:joy": "Riso",
-    "Reaction:eyes": "Olhos"
+    "Reaction:tada": "Comemorar",
+    "Reaction:thumbs_up": "Polegar para cima",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
@@ -1,19 +1,20 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Timeline": "Tidslinje",
-    "Permission:Timeline.Entries.Read": "Visa aktivitetsflöden och revisionshistorik",
+    "Granit:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer.",
     "Permission:Timeline.Entries.Create": "Publicera kommentarer och följa/sluta följa entiteter",
     "Permission:Timeline.Entries.Manage": "Hantera (ta bort) tidslinjepost oavsett ägare",
-    "Permission:Timeline.InternalNotes.Read": "Visa personalens interna anteckningar i aktivitetsflöden",
+    "Permission:Timeline.Entries.Read": "Visa aktivitetsflöden och revisionshistorik",
     "Permission:Timeline.Followers.Manage": "Följa och sluta följa entiteter i aktivitetsflöden",
+    "Permission:Timeline.InternalNotes.Read": "Visa personalens interna anteckningar i aktivitetsflöden",
     "Permission:Timeline.Reactions.React": "Reagera på tidslinjeposter med katalogens emojier",
-    "Granit:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer.",
-
-    "Reaction:thumbs_up": "Tummen upp",
+    "PermissionGroup:Timeline": "Tidslinje",
+    "Reaction:eyes": "Ögon",
     "Reaction:heart": "Hjärta",
-    "Reaction:tada": "Fira",
     "Reaction:joy": "Skratt",
-    "Reaction:eyes": "Ögon"
+    "Reaction:tada": "Fira",
+    "Reaction:thumbs_up": "Tummen upp",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
@@ -1,19 +1,20 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Timeline": "Zaman Çizelgesi",
-    "Permission:Timeline.Entries.Read": "Etkinlik akışlarını ve denetim geçmişini görüntüle",
+    "Granit:Validation:TooManyAttachments": "20'den fazla dosya eklenemez.",
     "Permission:Timeline.Entries.Create": "Yorum yap ve varlıkları takip et/takipten çık",
     "Permission:Timeline.Entries.Manage": "Sahibinden bağımsız olarak herhangi bir zaman çizelgesi girişini yönetin (silin)",
-    "Permission:Timeline.InternalNotes.Read": "Etkinlik akışlarında yalnızca personele özel dahili notları görüntüleyin",
+    "Permission:Timeline.Entries.Read": "Etkinlik akışlarını ve denetim geçmişini görüntüle",
     "Permission:Timeline.Followers.Manage": "Etkinlik akışlarında varlıkları takip edin ve takipten çıkın",
+    "Permission:Timeline.InternalNotes.Read": "Etkinlik akışlarında yalnızca personele özel dahili notları görüntüleyin",
     "Permission:Timeline.Reactions.React": "Zaman çizelgesi girişlerine katalog emojileriyle tepki verin",
-    "Granit:Validation:TooManyAttachments": "20'den fazla dosya eklenemez.",
-
-    "Reaction:thumbs_up": "Beğeni",
+    "PermissionGroup:Timeline": "Zaman Çizelgesi",
+    "Reaction:eyes": "Gözler",
     "Reaction:heart": "Kalp",
-    "Reaction:tada": "Kutlama",
     "Reaction:joy": "Gülme",
-    "Reaction:eyes": "Gözler"
+    "Reaction:tada": "Kutlama",
+    "Reaction:thumbs_up": "Beğeni",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
@@ -1,19 +1,20 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Timeline": "时间线",
-    "Permission:Timeline.Entries.Read": "查看活动流和审计历史",
+    "Granit:Validation:TooManyAttachments": "不能附加超过20个文件。",
     "Permission:Timeline.Entries.Create": "发表评论和关注/取消关注实体",
     "Permission:Timeline.Entries.Manage": "管理（删除）任何时间轴条目，无论所有者",
-    "Permission:Timeline.InternalNotes.Read": "查看活动源中仅供员工查看的内部笔记",
+    "Permission:Timeline.Entries.Read": "查看活动流和审计历史",
     "Permission:Timeline.Followers.Manage": "在活动源中关注和取消关注实体",
+    "Permission:Timeline.InternalNotes.Read": "查看活动源中仅供员工查看的内部笔记",
     "Permission:Timeline.Reactions.React": "使用目录表情符号对时间线条目作出回应",
-    "Granit:Validation:TooManyAttachments": "不能附加超过20个文件。",
-
-    "Reaction:thumbs_up": "点赞",
+    "PermissionGroup:Timeline": "时间线",
+    "Reaction:eyes": "眼睛",
     "Reaction:heart": "爱心",
-    "Reaction:tada": "庆祝",
     "Reaction:joy": "大笑",
-    "Reaction:eyes": "眼睛"
+    "Reaction:tada": "庆祝",
+    "Reaction:thumbs_up": "点赞",
+    "TimelineEndpoints:Workspace.Item": "Activity feed",
+    "TimelineEndpoints:Workspace.Section": "Timeline"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Workspaces/TimelineWorkspaceContribution.cs
+++ b/src/Granit.Timeline.Endpoints/Workspaces/TimelineWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.Timeline.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Timeline.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts timeline admin entries onto the
+/// <c>Granit.Framework.Monitoring</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class TimelineWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Monitoring)
+            .Section("timeline", s => s
+                .DisplayKey("TimelineEndpoints:Workspace.Section")
+                .Order(10)
+                .Link("/timeline", i => i
+                    .DisplayKey("TimelineEndpoints:Workspace.Item")
+                    .Icon("activity")
+                    .Order(0)
+                    .RequiresPermission(TimelinePermissions.Entries.Read)));
+}

--- a/src/Granit.Timeline.Endpoints/packages.lock.json
+++ b/src/Granit.Timeline.Endpoints/packages.lock.json
@@ -152,6 +152,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksWorkspaceContribution.cs
+++ b/src/Granit.Webhooks.Endpoints/Workspaces/WebhooksWorkspaceContribution.cs
@@ -15,7 +15,7 @@ internal sealed class WebhooksWorkspaceContribution : IWorkspaceContributor
             .Section("webhooks", s => s
                 .DisplayKey("WebhooksEndpoints:Workspace.Section")
                 .Order(0)
-                .Link("/admin/webhooks", i => i
+                .Link("/webhooks", i => i
                     .DisplayKey("WebhooksEndpoints:Workspace.Item")
                     .Icon("webhook")
                     .Order(0)

--- a/src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj
+++ b/src/Granit.Workflow.Endpoints/Granit.Workflow.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
+++ b/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
@@ -3,6 +3,9 @@ using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.Validation;
 using Granit.Workflow.Endpoints.Extensions;
+using Granit.Workflow.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Granit.Workspaces.Extensions;
 
 namespace Granit.Workflow.Endpoints;
 
@@ -29,10 +32,14 @@ namespace Granit.Workflow.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitValidationModule),
-    typeof(GranitWorkflowModule))]
+    typeof(GranitWorkflowModule),
+    typeof(GranitWorkspacesAbstractionsModule))]
 public sealed class GranitWorkflowEndpointsModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddGranitWorkflowEndpoints();
+        context.Services.AddWorkspaceContribution<WorkflowWorkspaceContribution>();
+    }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/cs.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/cs.json
@@ -1,9 +1,11 @@
 {
   "culture": "cs",
   "texts": {
-    "PermissionGroup:Workflow": "Pracovní postup",
     "Permission:Workflow.History.Read": "Zobrazit historii přechodů pracovního postupu (auditní stopa)",
+    "Permission:Workflow.Transitions.Execute": "Provést přechody stavů workflow",
     "Permission:Workflow.Transitions.Read": "Zobrazit dostupné přechody workflow",
-    "Permission:Workflow.Transitions.Execute": "Provést přechody stavů workflow"
+    "PermissionGroup:Workflow": "Pracovní postup",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/de.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/de.json
@@ -1,9 +1,11 @@
 {
   "culture": "de",
   "texts": {
-    "PermissionGroup:Workflow": "Workflow",
     "Permission:Workflow.History.Read": "Workflow-Übergangsverlauf anzeigen (Audit-Prüfpfad)",
+    "Permission:Workflow.Transitions.Execute": "Workflow-Statusübergänge ausführen",
     "Permission:Workflow.Transitions.Read": "Verfügbare Workflow-Übergänge anzeigen",
-    "Permission:Workflow.Transitions.Execute": "Workflow-Statusübergänge ausführen"
+    "PermissionGroup:Workflow": "Workflow",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en-GB.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en-GB.json
@@ -1,4 +1,7 @@
 {
   "culture": "en-GB",
-  "texts": {}
+  "texts": {
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
+  }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/en.json
@@ -1,9 +1,11 @@
 {
   "culture": "en",
   "texts": {
-    "PermissionGroup:Workflow": "Workflow",
     "Permission:Workflow.History.Read": "View workflow transition history (Audit trail)",
+    "Permission:Workflow.Transitions.Execute": "Execute workflow state transitions",
     "Permission:Workflow.Transitions.Read": "View available workflow transitions",
-    "Permission:Workflow.Transitions.Execute": "Execute workflow state transitions"
+    "PermissionGroup:Workflow": "Workflow",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/es.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/es.json
@@ -1,9 +1,11 @@
 {
   "culture": "es",
   "texts": {
-    "PermissionGroup:Workflow": "Flujo de trabajo",
     "Permission:Workflow.History.Read": "Ver el historial de transiciones del flujo de trabajo (Pista de auditoría)",
+    "Permission:Workflow.Transitions.Execute": "Ejecutar transiciones de estado del flujo de trabajo",
     "Permission:Workflow.Transitions.Read": "Ver transiciones de flujo de trabajo disponibles",
-    "Permission:Workflow.Transitions.Execute": "Ejecutar transiciones de estado del flujo de trabajo"
+    "PermissionGroup:Workflow": "Flujo de trabajo",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr-CA.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr-CA.json
@@ -1,4 +1,7 @@
 {
   "culture": "fr-CA",
-  "texts": {}
+  "texts": {
+    "WorkflowEndpoints:Workspace.History": "Historique des transitions",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
+  }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/fr.json
@@ -1,9 +1,11 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:Workflow": "Workflow",
     "Permission:Workflow.History.Read": "Consulter l'historique des transitions workflow (Piste d'audit)",
+    "Permission:Workflow.Transitions.Execute": "Exécuter les transitions d'état workflow",
     "Permission:Workflow.Transitions.Read": "Consulter les transitions workflow disponibles",
-    "Permission:Workflow.Transitions.Execute": "Exécuter les transitions d'état workflow"
+    "PermissionGroup:Workflow": "Workflow",
+    "WorkflowEndpoints:Workspace.History": "Historique des transitions",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/hi.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/hi.json
@@ -1,9 +1,11 @@
 {
   "culture": "hi",
   "texts": {
-    "PermissionGroup:Workflow": "वर्कफ़्लो",
     "Permission:Workflow.History.Read": "वर्कफ़्लो संक्रमण इतिहास देखें (ऑडिट ट्रेल)",
+    "Permission:Workflow.Transitions.Execute": "वर्कफ़्लो स्थिति संक्रमण करें",
     "Permission:Workflow.Transitions.Read": "उपलब्ध वर्कफ़्लो संक्रमण देखें",
-    "Permission:Workflow.Transitions.Execute": "वर्कफ़्लो स्थिति संक्रमण करें"
+    "PermissionGroup:Workflow": "वर्कफ़्लो",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/it.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/it.json
@@ -1,9 +1,11 @@
 {
   "culture": "it",
   "texts": {
-    "PermissionGroup:Workflow": "Flusso di lavoro",
     "Permission:Workflow.History.Read": "Visualizzare la cronologia delle transizioni del flusso di lavoro (Pista di audit)",
+    "Permission:Workflow.Transitions.Execute": "Eseguire le transizioni di stato del workflow",
     "Permission:Workflow.Transitions.Read": "Visualizzare le transizioni workflow disponibili",
-    "Permission:Workflow.Transitions.Execute": "Eseguire le transizioni di stato del workflow"
+    "PermissionGroup:Workflow": "Flusso di lavoro",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ja.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ja.json
@@ -1,9 +1,11 @@
 {
   "culture": "ja",
   "texts": {
-    "PermissionGroup:Workflow": "ワークフロー",
     "Permission:Workflow.History.Read": "ワークフロー遷移履歴を表示（監査証跡）",
+    "Permission:Workflow.Transitions.Execute": "ワークフロー状態遷移を実行",
     "Permission:Workflow.Transitions.Read": "利用可能なワークフロー遷移を表示",
-    "Permission:Workflow.Transitions.Execute": "ワークフロー状態遷移を実行"
+    "PermissionGroup:Workflow": "ワークフロー",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ko.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/ko.json
@@ -1,9 +1,11 @@
 {
   "culture": "ko",
   "texts": {
-    "PermissionGroup:Workflow": "워크플로",
     "Permission:Workflow.History.Read": "워크플로 전환 이력 보기 (감사 추적)",
+    "Permission:Workflow.Transitions.Execute": "워크플로 상태 전환 실행",
     "Permission:Workflow.Transitions.Read": "사용 가능한 워크플로 전환 보기",
-    "Permission:Workflow.Transitions.Execute": "워크플로 상태 전환 실행"
+    "PermissionGroup:Workflow": "워크플로",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/nl.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/nl.json
@@ -1,9 +1,11 @@
 {
   "culture": "nl",
   "texts": {
-    "PermissionGroup:Workflow": "Workflow",
     "Permission:Workflow.History.Read": "Workflow-transitiegeschiedenis bekijken (Auditspoor)",
+    "Permission:Workflow.Transitions.Execute": "Workflowstatustransities uitvoeren",
     "Permission:Workflow.Transitions.Read": "Beschikbare workflowtransities bekijken",
-    "Permission:Workflow.Transitions.Execute": "Workflowstatustransities uitvoeren"
+    "PermissionGroup:Workflow": "Workflow",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pl.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pl.json
@@ -1,9 +1,11 @@
 {
   "culture": "pl",
   "texts": {
-    "PermissionGroup:Workflow": "Przepływ pracy",
     "Permission:Workflow.History.Read": "Wyświetlanie historii przejść przepływu pracy (ścieżka audytu)",
+    "Permission:Workflow.Transitions.Execute": "Wykonaj przejścia stanów workflow",
     "Permission:Workflow.Transitions.Read": "Wyświetl dostępne przejścia workflow",
-    "Permission:Workflow.Transitions.Execute": "Wykonaj przejścia stanów workflow"
+    "PermissionGroup:Workflow": "Przepływ pracy",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt-BR.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt-BR.json
@@ -1,4 +1,7 @@
 {
   "culture": "pt-BR",
-  "texts": {}
+  "texts": {
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
+  }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/pt.json
@@ -1,9 +1,11 @@
 {
   "culture": "pt",
   "texts": {
-    "PermissionGroup:Workflow": "Fluxo de trabalho",
     "Permission:Workflow.History.Read": "Ver o histórico de transições do fluxo de trabalho (Trilha de auditoria)",
+    "Permission:Workflow.Transitions.Execute": "Executar transições de estado do workflow",
     "Permission:Workflow.Transitions.Read": "Ver transições de workflow disponíveis",
-    "Permission:Workflow.Transitions.Execute": "Executar transições de estado do workflow"
+    "PermissionGroup:Workflow": "Fluxo de trabalho",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/sv.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/sv.json
@@ -1,9 +1,11 @@
 {
   "culture": "sv",
   "texts": {
-    "PermissionGroup:Workflow": "Arbetsflöde",
     "Permission:Workflow.History.Read": "Visa arbetsflödets övergångshistorik (revisionsspår)",
+    "Permission:Workflow.Transitions.Execute": "Utför arbetsflödesstatusövergångar",
     "Permission:Workflow.Transitions.Read": "Visa tillgängliga arbetsflödesövergångar",
-    "Permission:Workflow.Transitions.Execute": "Utför arbetsflödesstatusövergångar"
+    "PermissionGroup:Workflow": "Arbetsflöde",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/tr.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/tr.json
@@ -1,9 +1,11 @@
 {
   "culture": "tr",
   "texts": {
-    "PermissionGroup:Workflow": "İş Akışı",
     "Permission:Workflow.History.Read": "İş akışı geçiş geçmişini görüntüle (denetim izi)",
+    "Permission:Workflow.Transitions.Execute": "İş akışı durum geçişlerini yürüt",
     "Permission:Workflow.Transitions.Read": "Mevcut iş akışı geçişlerini görüntüle",
-    "Permission:Workflow.Transitions.Execute": "İş akışı durum geçişlerini yürüt"
+    "PermissionGroup:Workflow": "İş Akışı",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/zh.json
+++ b/src/Granit.Workflow.Endpoints/Localization/WorkflowEndpoints/zh.json
@@ -1,9 +1,11 @@
 {
   "culture": "zh",
   "texts": {
-    "PermissionGroup:Workflow": "工作流",
     "Permission:Workflow.History.Read": "查看工作流转换历史（审计跟踪）",
+    "Permission:Workflow.Transitions.Execute": "执行工作流状态转换",
     "Permission:Workflow.Transitions.Read": "查看可用的工作流转换",
-    "Permission:Workflow.Transitions.Execute": "执行工作流状态转换"
+    "PermissionGroup:Workflow": "工作流",
+    "WorkflowEndpoints:Workspace.History": "Transition history",
+    "WorkflowEndpoints:Workspace.Section": "Workflow"
   }
 }

--- a/src/Granit.Workflow.Endpoints/Workspaces/WorkflowWorkspaceContribution.cs
+++ b/src/Granit.Workflow.Endpoints/Workspaces/WorkflowWorkspaceContribution.cs
@@ -1,0 +1,23 @@
+using Granit.Workflow.Endpoints.Permissions;
+using Granit.Workspaces;
+using Granit.Workspaces.Framework;
+
+namespace Granit.Workflow.Endpoints.Workspaces;
+
+/// <summary>
+/// Grafts workflow admin entries onto the
+/// <c>Granit.Framework.Automation</c> shell (per ADR-040 §IoC).
+/// </summary>
+internal sealed class WorkflowWorkspaceContribution : IWorkspaceContributor
+{
+    public void Contribute(IWorkspaceContributionContext context) =>
+        context.ForWorkspace(FrameworkWorkspaceNames.Automation)
+            .Section("workflow", s => s
+                .DisplayKey("WorkflowEndpoints:Workspace.Section")
+                .Order(10)
+                .Link("/workflow/history", i => i
+                    .DisplayKey("WorkflowEndpoints:Workspace.History")
+                    .Icon("git-branch")
+                    .Order(0)
+                    .RequiresPermission(WorkflowPermissions.History.Read)));
+}

--- a/src/Granit.Workflow.Endpoints/packages.lock.json
+++ b/src/Granit.Workflow.Endpoints/packages.lock.json
@@ -145,6 +145,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -702,7 +702,8 @@
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -758,7 +759,8 @@
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.openiddict.entityframeworkcore": {
@@ -844,6 +846,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.AI.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Endpoints.Tests/packages.lock.json
@@ -327,7 +327,8 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.authorization": {
@@ -461,6 +462,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1469,7 +1469,8 @@
           "Granit.AI": "[0.1.0-dev, )",
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.ai.entityframeworkcore": {
@@ -1994,7 +1995,8 @@
           "Granit.DataExchange": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.entityframeworkcore": {
@@ -2058,7 +2060,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Diagnostics": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.documentgeneration": {
@@ -2290,7 +2293,8 @@
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.identity.entityframeworkcore": {
@@ -2436,7 +2440,8 @@
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.identity.local.notifications": {
@@ -2583,7 +2588,8 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.multitenancy.entityframeworkcore": {
@@ -2896,7 +2902,8 @@
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.openiddict.entityframeworkcore": {
@@ -3121,7 +3128,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.scheduling.entityframeworkcore": {
@@ -3200,7 +3208,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Templating": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.templating.entityframeworkcore": {
@@ -3279,7 +3288,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Timeline": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timeline.entityframeworkcore": {
@@ -3514,7 +3524,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "Granit.Workflow": "[0.1.0-dev, )"
+          "Granit.Workflow": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.workflow.entityframeworkcore": {

--- a/tests/Granit.DataExchange.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Endpoints.Tests/packages.lock.json
@@ -559,7 +559,8 @@
           "Granit.DataExchange": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.datalookup.abstractions": {
@@ -660,6 +661,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/packages.lock.json
@@ -559,7 +559,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Diagnostics": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.entities.abstractions": {
@@ -631,6 +632,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -601,7 +601,8 @@
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -658,6 +659,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -583,7 +583,8 @@
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -649,6 +650,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -647,7 +647,8 @@
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -708,6 +709,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/packages.lock.json
@@ -338,7 +338,8 @@
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -365,6 +366,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -726,7 +726,8 @@
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.openiddict.entityframeworkcore": {
@@ -808,6 +809,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -789,7 +789,8 @@
           "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.localization": {
@@ -833,7 +834,8 @@
           "Granit.OpenIddict": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.openiddict.entityframeworkcore": {
@@ -915,6 +917,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
@@ -498,7 +498,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -520,6 +521,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
@@ -610,7 +610,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Templating": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -642,6 +643,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Timeline.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Timeline.Endpoints.Tests/packages.lock.json
@@ -622,7 +622,8 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Timeline": "[0.1.0-dev, )",
-          "Granit.Validation": "[0.1.0-dev, )"
+          "Granit.Validation": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
@@ -644,6 +645,12 @@
         }
       },
       "granit.workflow.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"

--- a/tests/Granit.Workflow.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Endpoints.Tests/packages.lock.json
@@ -637,7 +637,14 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "Granit.Workflow": "[0.1.0-dev, )"
+          "Granit.Workflow": "[0.1.0-dev, )",
+          "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.workspaces.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "Asp.Versioning.Mvc": {


### PR DESCRIPTION
## Summary

Eleven framework `.Endpoints` packages were not contributing entries to the workspace navigation tree, leaving large gaps in the admin surface (Identity, MultiTenancy, OpenIddict, Workflow, Templating, AI, DataExchange, Scheduling, Timeline, Diagnostics, Identity.Local). This PR closes those gaps and harmonises the `LinkUrl` convention.

## Mapping (which workspace each module grafts onto)

| Shell | Modules added |
|---|---|
| `Users` | Identity, Identity.Local, OpenIddict |
| `System` | MultiTenancy, Templating |
| `Automation` | Workflow, Scheduling |
| `Data` | DataExchange |
| `Integrations` | AI |
| `Monitoring` | Timeline, Diagnostics |

## Out of scope

- `Bff`, `Http.Cookies`, `Validation` — no admin surface
- `DataLookup` — typeahead plumbing (`/lookups`, `/lookups/{name}/resolve`); not a navigable admin feature

## Changes per module

- New `Workspaces/{X}WorkspaceContribution.cs` implementing `IWorkspaceContributor`
- `<ProjectReference>` to `Granit.Workspaces.Abstractions`
- `[DependsOn(typeof(GranitWorkspacesAbstractionsModule))]`
- `services.AddWorkspaceContribution<T>()` in `ConfigureServices`
- Workspace localisation keys added across all 18 cultures (en + fr translated, other cultures seeded with English placeholder — same pattern as the previously merged contributions)

## Convention change — drop `/admin/` prefix (22 files)

`WorkspaceItemDescriptor.LinkUrl` is documented as *"Internal route or absolute URL"*. The workspace tree describes **navigation grouping**, not URL hierarchy. The previous `/admin/...` prefix on all 11 existing contributions hardcoded a routing decision that belongs to the consuming app.

Dropped the prefix everywhere — both the 11 new contributions and the 11 previously-merged ones. Modules keep their own first segment (e.g. `/identity/users`, `/oidc/applications`, `/blob-storage`) to avoid root-level collisions. The host app is now free to mount these paths wherever its router needs them.

## Test plan

- [x] `dotnet build .github/shard-filters/src-only.slnf` — clean (0 warning / 0 error)
- [x] `dotnet build tests/Granit.ArchitectureTests/` — clean
- [x] `dotnet test tests/Granit.ArchitectureTests/` — 178 / 178 passed
- [ ] Full CI shard run green
- [ ] Frontend / Workspace renderer review: confirm dropped `/admin/` is consistent with how the shell consumes `LinkUrl`