### PR TITLE
fix(di): resolve 3 singleton→scoped lifetime violations failing ValidateScopes

### DIFF
--- a/src/Granit.Browsing.Playwright/Internal/PlaywrightHeadlessBrowser.cs
+++ b/src/Granit.Browsing.Playwright/Internal/PlaywrightHeadlessBrowser.cs
@@ -12,6 +12,7 @@ using Granit.Browsing.Sandbox;
 using Granit.Events;
 using Granit.Guids;
 using Granit.Http.Security;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -62,7 +63,7 @@ internal sealed partial class PlaywrightHeadlessBrowser : IHeadlessBrowser, IHea
         IHostEnvironment hostEnvironment,
         IClock clock,
         IGuidGenerator guidGenerator,
-        ILocalEventBus? eventBus = null)
+        IServiceScopeFactory? scopeFactory = null)
     {
         ArgumentNullException.ThrowIfNull(browsingOptions);
         ArgumentNullException.ThrowIfNull(playwrightOptions);
@@ -85,7 +86,9 @@ internal sealed partial class PlaywrightHeadlessBrowser : IHeadlessBrowser, IHea
         _hostEnvironment = hostEnvironment;
         _clock = clock;
         _guidGenerator = guidGenerator;
-        _eventBus = eventBus;
+        // Wrap the scope factory so each event publish creates a fresh DI scope —
+        // ILocalEventBus is scoped and would fail ValidateScopes if captured directly.
+        _eventBus = scopeFactory is null ? null : new ScopedLocalEventBus(scopeFactory);
 
         int permits = _browsingOptions.Value.MaxBrowsers * _browsingOptions.Value.MaxPagesPerBrowser;
         _pageSemaphore = new SemaphoreSlim(permits, permits);

--- a/src/Granit.Browsing.Playwright/Internal/ScopedLocalEventBus.cs
+++ b/src/Granit.Browsing.Playwright/Internal/ScopedLocalEventBus.cs
@@ -1,0 +1,25 @@
+using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Browsing.Playwright.Internal;
+
+/// <summary>
+/// Singleton-safe <see cref="ILocalEventBus"/> wrapper. Creates a fresh DI scope per
+/// publish, resolves the registered (scoped) bus from it, and disposes the scope —
+/// letting <see cref="PlaywrightHeadlessBrowser"/> stay a singleton without capturing
+/// a scoped service. A no-op when no <see cref="ILocalEventBus"/> is registered.
+/// </summary>
+internal sealed class ScopedLocalEventBus(IServiceScopeFactory scopeFactory) : ILocalEventBus
+{
+    public async Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
+        where TEvent : class
+    {
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+        ILocalEventBus? inner = scope.ServiceProvider.GetService<ILocalEventBus>();
+        if (inner is null)
+        {
+            return;
+        }
+        await inner.PublishAsync(localEvent, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs
@@ -34,7 +34,9 @@ public static class ImagingAIHostApplicationBuilderExtensions
             .BindConfiguration(ImagingAIOptions.SectionName);
 
         builder.Services.TryAddSingleton<ImagingAIMetrics>();
-        builder.Services.TryAddSingleton<IAIImageAnalyzer, LlmImageAnalyzer>();
+        // Scoped because LlmImageAnalyzer depends on IAIChatClientFactory (scoped).
+        // The analyzer carries no singleton-justifying state.
+        builder.Services.TryAddScoped<IAIImageAnalyzer, LlmImageAnalyzer>();
 
         return builder;
     }

--- a/src/Granit.Observability.AI/Extensions/ObservabilityAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Observability.AI/Extensions/ObservabilityAIHostApplicationBuilderExtensions.cs
@@ -32,7 +32,9 @@ public static class ObservabilityAIHostApplicationBuilderExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        builder.Services.TryAddSingleton<IAILogAnalyzer, LlmLogAnalyzer>();
+        // Scoped because LlmLogAnalyzer depends on IAIChatClientFactory (scoped).
+        // The analyzer carries no singleton-justifying state.
+        builder.Services.TryAddScoped<IAILogAnalyzer, LlmLogAnalyzer>();
 
         // Diagnostics
         builder.Services.TryAddSingleton<ObservabilityAIMetrics>();

--- a/tests/Granit.Browsing.Playwright.Tests/PlaywrightScopeValidationTests.cs
+++ b/tests/Granit.Browsing.Playwright.Tests/PlaywrightScopeValidationTests.cs
@@ -1,0 +1,69 @@
+using Granit.Browsing.Diagnostics;
+using Granit.Browsing.Playwright.Extensions;
+using Granit.Browsing.Playwright.Options;
+using Granit.Browsing.Sandbox;
+using Granit.Events;
+using Granit.Guids;
+using Granit.Http.Security;
+using Granit.IO.Extensions;
+using Granit.MultiTenancy;
+using Granit.Timing.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using IClock = Granit.Timing.IClock;
+
+namespace Granit.Browsing.Playwright.Tests;
+
+public sealed class PlaywrightScopeValidationTests
+{
+    [Fact]
+    public void AddGranitBrowsingPlaywright_should_pass_scope_validation_with_scoped_local_event_bus()
+    {
+        // Regression: PlaywrightHeadlessBrowser is singleton (owns the browser pool)
+        // and previously captured the scoped ILocalEventBus directly — failing
+        // ValidateScopes (default in Development). The fix routes events through a
+        // singleton-safe wrapper backed by IServiceScopeFactory.
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        services.AddSingleton<BrowsingMetrics>();
+        services.AddSingleton<IBrowserSandboxProfile>(new SandboxProfile());
+        services.AddSingleton(Substitute.For<IUrlSafetyValidator>());
+        services.AddGranitTempFiles();
+        services.AddSingleton<ICurrentTenant>(new NullTenantContext());
+        services.AddSingleton(TimeProvider.System);
+        services.AddGranitTiming();
+        services.AddSingleton<IGuidGenerator, UuidV7GuidGenerator>();
+
+        // The scoped registration that previously broke ValidateScopes.
+        services.TryAddScoped(_ => Substitute.For<ILocalEventBus>());
+
+        services.AddGranitBrowsingPlaywright(
+            configurePlaywright: opts =>
+            {
+                opts.SkipBrowserInstall = true;
+                opts.Engine = BrowserEngine.Chromium;
+            });
+
+        Should.NotThrow(() =>
+        {
+            using ServiceProvider provider = services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
+        });
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "tests";
+        public string ContentRootPath { get; set; } = System.IO.Path.GetTempPath();
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
+++ b/tests/Granit.Imaging.AI.Tests/ImagingAIServiceRegistrationTests.cs
@@ -1,0 +1,43 @@
+using Granit.AI;
+using Granit.Imaging.AI.Extensions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Imaging.AI.Tests;
+
+public sealed class ImagingAIServiceRegistrationTests
+{
+    [Fact]
+    public void AddGranitImagingAI_should_pass_scope_validation_with_scoped_chat_client_factory()
+    {
+        // Regression: LlmImageAnalyzer captures IAIChatClientFactory (scoped). Registering
+        // the analyzer as singleton breaks ValidateScopes (default in Development).
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            DisableDefaults = true,
+        });
+        builder.Configuration.AddInMemoryCollection();
+        builder.Services.AddLogging();
+        builder.Services.AddMetrics();
+
+        // Minimal stand-in for Granit.AI: register the scoped factory contract used by the analyzer.
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIChatClientFactory>());
+
+        builder.AddGranitImagingAI();
+
+        Should.NotThrow(() =>
+        {
+            using ServiceProvider provider = builder.Services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
+
+            using IServiceScope scope = provider.CreateScope();
+            IAIImageAnalyzer analyzer = scope.ServiceProvider.GetRequiredService<IAIImageAnalyzer>();
+            analyzer.ShouldNotBeNull();
+        });
+    }
+}

--- a/tests/Granit.Observability.AI.Tests/ObservabilityAIServiceRegistrationTests.cs
+++ b/tests/Granit.Observability.AI.Tests/ObservabilityAIServiceRegistrationTests.cs
@@ -1,0 +1,43 @@
+using Granit.AI;
+using Granit.MultiTenancy;
+using Granit.Observability.AI.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Observability.AI.Tests;
+
+public sealed class ObservabilityAIServiceRegistrationTests
+{
+    [Fact]
+    public void AddGranitObservabilityAI_should_pass_scope_validation_with_scoped_chat_client_factory()
+    {
+        // Regression: LlmLogAnalyzer captures IAIChatClientFactory (scoped). Registering
+        // the analyzer as singleton breaks ValidateScopes (default in Development).
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            DisableDefaults = true,
+        });
+        builder.Configuration.AddInMemoryCollection();
+        builder.Services.AddLogging();
+        builder.Services.AddMetrics();
+
+        builder.Services.TryAddScoped(_ => Substitute.For<IAIChatClientFactory>());
+        builder.Services.TryAddSingleton<ICurrentTenant>(new NullTenantContext());
+
+        builder.AddGranitObservabilityAI();
+
+        Should.NotThrow(() =>
+        {
+            using ServiceProvider provider = builder.Services.BuildServiceProvider(
+                new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
+
+            using IServiceScope scope = provider.CreateScope();
+            IAILogAnalyzer analyzer = scope.ServiceProvider.GetRequiredService<IAILogAnalyzer>();
+            analyzer.ShouldNotBeNull();
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Three singleton implementations captured scoped dependencies via constructor injection, breaking ASP.NET Core's `ValidateScopes` (default in Development) at host build time.

- **`Granit.Imaging.AI`** — `LlmImageAnalyzer` (singleton) captured `IAIChatClientFactory` (scoped). Registration switched to scoped; the analyzer carries no singleton-justifying state.
- **`Granit.Observability.AI`** — `LlmLogAnalyzer` (singleton) captured `IAIChatClientFactory` (scoped). Same fix.
- **`Granit.Browsing.Playwright`** — `PlaywrightHeadlessBrowser` MUST stay singleton (owns the browser process pool). Constructor now takes `IServiceScopeFactory?` instead of `ILocalEventBus?`, wrapped in a new internal `ScopedLocalEventBus` that creates a fresh DI scope per `PublishAsync`. Collaborators (`RequestRouter`, `PlaywrightBrowserPage`) keep their `ILocalEventBus?` contract unchanged.

Each affected `*.Tests` project gained a regression test asserting `BuildServiceProvider(ValidateScopes = true, ValidateOnBuild = true)` succeeds with the scoped dependency registered.

## Test plan

- [x] `dotnet test tests/Granit.Imaging.AI.Tests` — 12/12 pass
- [x] `dotnet test tests/Granit.Observability.AI.Tests` — 12/12 pass
- [x] `dotnet test tests/Granit.Browsing.Playwright.Tests` — 29/29 pass
- [ ] Verify a hosted app with `Granit.AI` + `Granit.Imaging.AI` + `Granit.Observability.AI` registered boots in Development (ValidateScopes on by default)
- [ ] Verify a hosted app with `Granit.Browsing.Playwright` + `Granit.Events` registered boots in Development