### PR TITLE
fix(browsing): scope IPermissionChecker lookup in advisory service

### DIFF
--- a/src/Granit.Browsing/GranitBrowsingModule.cs
+++ b/src/Granit.Browsing/GranitBrowsingModule.cs
@@ -56,14 +56,16 @@ internal sealed partial class BrowsingPermissionAdvisoryService(
     ILogger<BrowsingPermissionAdvisoryService> logger) : IHostedService
 {
     /// <inheritdoc/>
-    public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)
+    public async System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)
     {
-        var checker = services.GetService(typeof(IPermissionChecker)) as IPermissionChecker;
+        // IPermissionChecker is scoped; resolve it through a transient scope so the
+        // captured root provider doesn't trip ValidateScopes.
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+        var checker = scope.ServiceProvider.GetService(typeof(IPermissionChecker)) as IPermissionChecker;
         if (checker is null)
         {
             LogAdvisory();
         }
-        return System.Threading.Tasks.Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/tests/Granit.Browsing.Tests/BrowsingPermissionAdvisoryServiceTests.cs
+++ b/tests/Granit.Browsing.Tests/BrowsingPermissionAdvisoryServiceTests.cs
@@ -1,0 +1,46 @@
+using Granit.Authorization;
+using Granit.Modularity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Browsing.Tests;
+
+public sealed class BrowsingPermissionAdvisoryServiceTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task GranitBrowsingModule_hosted_services_should_start_under_scope_validation()
+    {
+        // Regression: BrowsingPermissionAdvisoryService is a singleton hosted service
+        // that resolves IPermissionChecker (scoped). Pulling it from the root provider
+        // throws under ValidateScopes — it must create a transient scope per call.
+        ServiceCollection services = new();
+        ConfigurationBuilder cfgBuilder = new();
+        IConfiguration configuration = cfgBuilder.Build();
+        services.AddSingleton(configuration);
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddScoped(_ => Substitute.For<IPermissionChecker>());
+
+        HostApplicationBuilder hostBuilder = Host.CreateEmptyApplicationBuilder(
+            new HostApplicationBuilderSettings { DisableDefaults = true });
+        ServiceConfigurationContext context = new(services, configuration, hostBuilder);
+        new GranitBrowsingModule().ConfigureServices(context);
+
+        using ServiceProvider provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true, ValidateOnBuild = true });
+
+        IEnumerable<IHostedService> hostedServices = provider.GetServices<IHostedService>();
+        hostedServices.ShouldNotBeEmpty();
+
+        foreach (IHostedService hosted in hostedServices)
+        {
+            await Should.NotThrowAsync(() => hosted.StartAsync(CancellationToken.None));
+            await hosted.StopAsync(CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2078 — same family of DI lifetime mismatch.

`BrowsingPermissionAdvisoryService` is registered via `AddHostedService` (singleton) and resolved scoped `IPermissionChecker` from the captured root `IServiceProvider` inside `StartAsync`. On hosts that register `IPermissionChecker` (i.e. anyone wiring `Granit.Authorization`), this throws under `ValidateScopes = true`:

```
System.InvalidOperationException: Cannot resolve scoped service
  'Granit.Authorization.IPermissionChecker' from root provider.
   at Granit.Browsing.BrowsingPermissionAdvisoryService.StartAsync(CancellationToken)
```

Fix: create a transient `AsyncServiceScope` per `StartAsync` and resolve the checker from it.

## Test plan

- [x] New regression test in `Granit.Browsing.Tests`: builds the `ServiceCollection` from `GranitBrowsingModule.ConfigureServices`, registers `IPermissionChecker` scoped, builds the provider with `ValidateScopes = ValidateOnBuild = true`, then invokes `StartAsync` on every `IHostedService` registered by the module. This catches the whole regression class — any future singleton hosted service that captures a scoped dependency will fail this test.
- [x] `dotnet test tests/Granit.Browsing.Tests` — 97/97 pass