### PR TITLE
fix(openiddict): normalize role claim on self-hosted Federation identity

### DIFF
--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -197,15 +197,31 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
         // Normalize OIDC short-name "role" claims emitted by OpenIddict.Validation into
         // ClaimTypes.Role so PermissionChecker.AdminRoles bypass and ICurrentUserService
         // .GetRoles() agree with ClaimsPrincipal.IsInRole(). Mirrors what JwtBearer does
-        // implicitly via TokenValidationParameters.RoleClaimType. Scheme name kept as a
-        // string literal so this package does not depend on
+        // implicitly via TokenValidationParameters.RoleClaimType. Scheme names kept as
+        // string literals so this package does not depend on
         // OpenIddict.Validation.AspNetCore solely to reference its constant.
+        //
+        // Two schemes are registered because UseLocalServer() (self-hosted: server and
+        // validation co-located, the configuration this method always produces) returns
+        // a ClaimsPrincipal whose ClaimsIdentity.AuthenticationType is the default
+        // "AuthenticationTypes.Federation" rather than the validation handler's scheme
+        // name. Without "AuthenticationTypes.Federation" in the scheme list, the
+        // transformation gates out, the short "role" claim is never copied to
+        // ClaimTypes.Role, ICurrentUserService.GetRoles() returns empty, and every
+        // role-gated permission check returns 403.
         builder.Services.AddGranitRoleClaimNormalization(o =>
         {
             const string openIddictValidationScheme = "OpenIddict.Validation.AspNetCore";
+            const string federationScheme = "AuthenticationTypes.Federation";
+
             if (!o.Schemes.Contains(openIddictValidationScheme))
             {
                 o.Schemes.Add(openIddictValidationScheme);
+            }
+
+            if (!o.Schemes.Contains(federationScheme))
+            {
+                o.Schemes.Add(federationScheme);
             }
         });
 

--- a/tests/Granit.OpenIddict.Server.Tests/Extensions/RoleClaimNormalizationRegistrationTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Extensions/RoleClaimNormalizationRegistrationTests.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using Granit.Authentication.Claims;
+using Granit.OpenIddict.Server.Extensions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Server.Tests.Extensions;
+
+/// <summary>
+/// Regression coverage for the self-hosted OpenIddict role-claim normalization bug:
+/// <c>UseLocalServer()</c> co-locates the validation handler with the server and
+/// returns a <see cref="ClaimsIdentity"/> whose <see cref="ClaimsIdentity.AuthenticationType"/>
+/// is the framework default <c>"AuthenticationTypes.Federation"</c> rather than
+/// <c>OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme</c>. Before the
+/// fix, <see cref="RoleClaimNormalizationTransformation"/> gated out, the short
+/// <c>role</c> claim was never promoted to <see cref="ClaimTypes.Role"/>, and every
+/// role-gated permission check returned 403.
+/// </summary>
+public sealed class RoleClaimNormalizationRegistrationTests
+{
+    private const string FederationScheme = "AuthenticationTypes.Federation";
+    private const string OpenIddictValidationScheme = "OpenIddict.Validation.AspNetCore";
+
+    [Fact]
+    public void AddGranitOpenIddictServer_registers_federation_scheme_for_self_hosted_principals()
+    {
+        HostApplicationBuilder builder = BuildMinimalBuilder();
+
+        builder.AddGranitOpenIddictServer();
+
+        using ServiceProvider provider = builder.Services.BuildServiceProvider();
+        RoleClaimNormalizationOptions options = provider
+            .GetRequiredService<IOptions<RoleClaimNormalizationOptions>>().Value;
+
+        options.Schemes.ShouldContain(OpenIddictValidationScheme);
+        options.Schemes.ShouldContain(FederationScheme);
+    }
+
+    [Fact]
+    public async Task Transformation_promotes_short_role_claim_on_self_hosted_federation_identity()
+    {
+        HostApplicationBuilder builder = BuildMinimalBuilder();
+        builder.AddGranitOpenIddictServer();
+
+        using ServiceProvider provider = builder.Services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+
+        RoleClaimNormalizationTransformation transformation = scope.ServiceProvider
+            .GetServices<IClaimsTransformation>()
+            .OfType<RoleClaimNormalizationTransformation>()
+            .Single();
+
+        var identity = new ClaimsIdentity(
+            claims: [new Claim("role", "admin")],
+            authenticationType: FederationScheme);
+        var principal = new ClaimsPrincipal(identity);
+
+        ClaimsPrincipal transformed = await transformation.TransformAsync(principal);
+
+        transformed.FindAll(ClaimTypes.Role).Select(c => c.Value).ShouldContain("admin");
+        transformed.IsInRole("admin").ShouldBeTrue();
+    }
+
+    private static HostApplicationBuilder BuildMinimalBuilder()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Environment.EnvironmentName = Environments.Development;
+        return builder;
+    }
+}


### PR DESCRIPTION
## Summary

- Self-hosted OpenIddict (`UseLocalServer()` — server + validation co-located, which is what `AddGranitOpenIddictServer` always wires up) returns a `ClaimsIdentity` whose `AuthenticationType` is the framework default `"AuthenticationTypes.Federation"`, not `"OpenIddict.Validation.AspNetCore"`.
- `RoleClaimNormalizationTransformation` gates on `AuthenticationType`, so the short `role` claim was never copied to `ClaimTypes.Role` → `ICurrentUserService.GetRoles()` returned `[]` → every role-gated permission check returned **403**.
- Fix: add `"AuthenticationTypes.Federation"` alongside `"OpenIddict.Validation.AspNetCore"` in the normalization scheme list registered by `AddGranitOpenIddictServer`. Smallest surgical fix — keeps `RoleClaimNormalizationOptions`'s "never silently mutates principals" contract intact (option 3 — scheme-independent — would break it).

## Repro (pre-fix)

Self-hosted OIDC + cookie BFF + tenant user → hit any endpoint requiring a role-granted permission → 403.

## Test plan

- [x] New unit tests in `Granit.OpenIddict.Server.Tests`:
  - `AddGranitOpenIddictServer_registers_federation_scheme_for_self_hosted_principals` — asserts both scheme names are in `RoleClaimNormalizationOptions.Schemes`.
  - `Transformation_promotes_short_role_claim_on_self_hosted_federation_identity` — constructs a Federation-typed `ClaimsIdentity` with a `role` claim, runs the resolved transformation, asserts `ClaimTypes.Role` is populated and `IsInRole("admin")` is true. **Fails without the fix.**
- [x] `dotnet build tests/Granit.OpenIddict.Server.Tests` — clean.
- [x] `dotnet test tests/Granit.OpenIddict.Server.Tests --no-build --filter "FullyQualifiedName~RoleClaimNormalizationRegistrationTests"` — 2/2 passed.

## Follow-up (not in this PR)

A full HTTP-level "hit a role-gated endpoint" test belongs in `Granit.OpenIddict.Tests.Integration` (Postgres + TestServer). Happy to wire it in a follow-up if desired — the transformation-level test here locks the regression at the exact gate that was failing.