### PR TITLE
fix(openiddict): clear stale Identity cookie on missing user in /connect/authorize

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -126,9 +126,18 @@ internal static partial class ConnectAuthorizationEndpoints
 
         if (user is null)
         {
+            // Stale Identity cookie referencing a user that no longer exists (deletion,
+            // DB reseed, schema drop). Clear the cookie so the browser can recover —
+            // otherwise every refresh re-presents the same cookie and loops on 403.
             LogUserNotFound(logger);
-            return Results.Forbid(
-                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+            await context.SignOutAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+
+            string returnUrl = context.Request.PathBase + context.Request.Path + context.Request.QueryString;
+            string effectiveLoginPath = request.ClientId is not null
+                && options.ClientLoginPaths.TryGetValue(request.ClientId, out string? clientPath)
+                ? clientPath
+                : options.LoginPath;
+            return Results.Redirect($"{effectiveLoginPath}?returnUrl={Uri.EscapeDataString(returnUrl)}");
         }
 
         // Align the tenant context with the resolved user for the rest of the flow


### PR DESCRIPTION
## Summary

- When `/connect/authorize` resolves the Identity cookie but the referenced user no longer exists (deletion, DB reseed, schema drop), the handler returned `Forbid()` and left the cookie intact — every refresh re-presented the same stale cookie and looped on 403, requiring manual cookie deletion in DevTools.
- Sign out of `IdentityConstants.ApplicationScheme` and redirect to the configured login path (same pattern as the unauthenticated branch) so the browser can self-recover.

## Reproduction

1. Login as a tenant user, get the Identity cookie set.
2. Drop the user (or recreate the DB with new seeded user IDs).
3. Reload any page that triggers `/connect/authorize` → was a permanent 403, now redirects to login.

## Notes

- No integration test included: `Granit.OpenIddict.Endpoints.Tests` has no scaffolding for `/connect/authorize` (would require booting the full OpenIddict server, an EF-backed `UserManager<LocalIdentity>`, signing cert, seeded applications). Follow-up issue recommended.

## Test plan

- [ ] Manual: stale-cookie repro above redirects to `LoginPath` instead of 403
- [ ] Manual: confirm `Set-Cookie` clears `.AspNetCore.Identity.Application`
- [ ] `dotnet build src/Granit.OpenIddict.Endpoints`