### PR TITLE
feat(entities): tag entity list endpoints via EndpointMetadata for discovery

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1712,6 +1712,7 @@
       "deps": [
         "Granit.Http.ApiDocumentation",
         "Granit.Authorization",
+        "Granit.Entities.Abstractions",
         "Granit.QueryEngine",
         "Granit.Validation"
       ],
@@ -15608,6 +15609,24 @@
       ]
     },
     {
+      "name": "EntityEndpointKind",
+      "fqn": "Granit.Entities.EntityEndpointKind",
+      "kind": "enum",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "EntityEndpointMetadata",
+      "fqn": "Granit.Entities.EntityEndpointMetadata",
+      "kind": "record",
+      "project": "Granit.Entities.Abstractions",
+      "file": "src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs",
+      "line": 50,
+      "members": []
+    },
+    {
       "name": "EntityDefinitionServiceCollectionExtensions",
       "fqn": "Granit.Entities.Extensions.EntityDefinitionServiceCollectionExtensions",
       "kind": "class",
@@ -15694,7 +15713,7 @@
       "kind": "class",
       "project": "Granit.Entities.Abstractions",
       "file": "src/Granit.Entities.Abstractions/GranitEntitiesAbstractionsModule.cs",
-      "line": 17,
+      "line": 15,
       "members": []
     },
     {
@@ -35414,7 +35433,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.AspNetCore",
       "file": "src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs",
-      "line": 22,
+      "line": 23,
       "members": []
     },
     {

--- a/src/Granit.AI.Endpoints/packages.lock.json
+++ b/src/Granit.AI.Endpoints/packages.lock.json
@@ -141,6 +141,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/src/Granit.Auditing.Endpoints/packages.lock.json
+++ b/src/Granit.Auditing.Endpoints/packages.lock.json
@@ -141,6 +141,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/src/Granit.BlobStorage.Endpoints/packages.lock.json
+++ b/src/Granit.BlobStorage.Endpoints/packages.lock.json
@@ -160,6 +160,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs
+++ b/src/Granit.Entities.Abstractions/EntityEndpointMetadata.cs
@@ -1,0 +1,50 @@
+namespace Granit.Entities;
+
+/// <summary>
+/// Discriminates the kind of admin endpoint marked by an
+/// <see cref="EntityEndpointMetadata"/>. Values are stable wire-level
+/// identifiers — adding a kind is non-breaking; renaming one is breaking.
+/// </summary>
+public enum EntityEndpointKind
+{
+    /// <summary>
+    /// Paginated query / collection endpoint. By convention the frontend calls
+    /// <c>{path}</c> for the page and <c>{path}/meta</c> for the column metadata.
+    /// </summary>
+    List = 0,
+}
+
+/// <summary>
+/// Endpoint metadata tag that links a route to an entity CLR type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attached at <c>Map*</c> time via the ASP.NET Core
+/// <c>IEndpointConventionBuilder.WithMetadata</c> extension; read by the
+/// entity-discovery surface (<c>Granit.Entities.Endpoints</c>) which walks
+/// <c>EndpointDataSource</c> and exposes the resolved
+/// <c>RouteEndpoint.RoutePattern.RawText</c> on <c>EntityDiscoveryLinks</c>.
+/// </para>
+/// <para>
+/// Endpoint metadata is the same mechanism ASP.NET Core's own OpenAPI generator
+/// uses to associate routes with the data it needs (operation name, tags,
+/// produces, auth). Treating "which entity does this list ?" the same way keeps
+/// a single source of truth — ASP.NET's endpoint table — instead of a parallel
+/// registry that would drift the moment an endpoint is mounted conditionally,
+/// renamed, or removed.
+/// </para>
+/// <para>
+/// Usage from any producer module:
+/// </para>
+/// <code>
+/// group.MapGet("", ...)
+///     .WithMetadata(new EntityEndpointMetadata(typeof(Party), EntityEndpointKind.List))
+///     .WithName(...);
+/// </code>
+/// </remarks>
+/// <param name="EntityType">
+/// CLR type of the entity surfaced by this endpoint — matches
+/// <c>EntityDefinitionDescriptor.EntityType</c>.
+/// </param>
+/// <param name="Kind">Which endpoint kind this route serves.</param>
+public sealed record EntityEndpointMetadata(Type EntityType, EntityEndpointKind Kind);

--- a/src/Granit.Entities.Abstractions/GranitEntitiesAbstractionsModule.cs
+++ b/src/Granit.Entities.Abstractions/GranitEntitiesAbstractionsModule.cs
@@ -8,10 +8,8 @@ namespace Granit.Entities;
 /// <remarks>
 /// This module has no service registrations — it exists so a base module can declare
 /// <c>[DependsOn(typeof(GranitEntitiesAbstractionsModule))]</c> and reference the
-/// <see cref="EntityDefinition{TEntity}"/> hierarchy without taking a runtime
-/// dependency on the <c>Granit.Entities</c> registry, integrity-check runner, or
-/// the <c>Granit.Entities.Endpoints</c> HTTP layer. Same pattern as
-/// <c>GranitQueryEngineAbstractionsModule</c> and
-/// <c>GranitWorkflowAbstractionsModule</c>.
+/// <see cref="EntityDefinition{TEntity}"/> hierarchy (plus <see cref="EntityEndpointMetadata"/>)
+/// without taking a runtime dependency on the <c>Granit.Entities</c> registry,
+/// integrity-check runner, or the <c>Granit.Entities.Endpoints</c> HTTP layer.
 /// </remarks>
 public sealed class GranitEntitiesAbstractionsModule : GranitModule;

--- a/src/Granit.Identity.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Endpoints/packages.lock.json
@@ -134,6 +134,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using Granit.Entities;
 using Granit.QueryEngine.AspNetCore.Dtos;
 using Granit.QueryEngine.AspNetCore.Internal;
 using Granit.QueryEngine.AspNetCore.Options;
@@ -109,18 +110,26 @@ public static class QueryEndpointRouteBuilderExtensions
         Type? projectionType = definitionForProjection?.GetProjectionType();
         LambdaExpression? projectionExpression = definitionForProjection?.GetProjectionExpression();
 
+        IEndpointConventionBuilder listBuilder;
         if (projectionType is not null && projectionExpression is not null)
         {
             MethodInfo dispatch = typeof(QueryEndpointRouteBuilderExtensions)
                 .GetMethod(nameof(MapProjectedGetEndpoint), BindingFlags.NonPublic | BindingFlags.Static)!
                 .MakeGenericMethod(typeof(TEntity), projectionType);
 
-            dispatch.Invoke(null, [group, sourceProvider, projectionExpression, entityName]);
+            listBuilder = (IEndpointConventionBuilder)dispatch.Invoke(
+                null, [group, sourceProvider, projectionExpression, entityName])!;
         }
         else
         {
-            MapNonProjectedGetEndpoint<TEntity>(group, sourceProvider, entityName);
+            listBuilder = MapNonProjectedGetEndpoint<TEntity>(group, sourceProvider, entityName);
         }
+
+        // Tag the endpoint so entity-discovery surfaces (Granit.Entities.Endpoints)
+        // can read RoutePattern.RawText off EndpointDataSource and expose the real
+        // route on EntityDiscoveryLinks.List — same mechanism ASP.NET's own OpenAPI
+        // generator uses for operation/tag/produces lookups.
+        listBuilder.WithMetadata(new EntityEndpointMetadata(typeof(TEntity), EntityEndpointKind.List));
 
         // GET /meta — query metadata
         if (options.IncludeMetaEndpoint)
@@ -137,7 +146,7 @@ public static class QueryEndpointRouteBuilderExtensions
         return group;
     }
 
-    private static void MapNonProjectedGetEndpoint<TEntity>(
+    private static RouteHandlerBuilder MapNonProjectedGetEndpoint<TEntity>(
         RouteGroupBuilder group,
         Func<IServiceProvider, IQueryable<TEntity>> sourceProvider,
         string entityName)
@@ -146,7 +155,7 @@ public static class QueryEndpointRouteBuilderExtensions
         // Lambda returns different typed results (Ok<GroupedResult<T>> / Ok<PagedResult<T>>)
         // depending on the query mode — IResult is the only common type.
 #pragma warning disable GRAPI001 // Results.Ok is needed here for polymorphic return
-        group.MapGet("/", async (
+        return group.MapGet("/", async (
             [FromServices] IQueryEngine<TEntity> engine,
             BindableQueryRequest request,
             HttpContext httpContext,
@@ -178,7 +187,7 @@ public static class QueryEndpointRouteBuilderExtensions
             DescribeQueryEndpointAsync(op, ctx, typeof(PagedResult<TEntity>), typeof(GroupedResult<TEntity>), ct));
     }
 
-    private static void MapProjectedGetEndpoint<TEntity, TDto>(
+    private static RouteHandlerBuilder MapProjectedGetEndpoint<TEntity, TDto>(
         RouteGroupBuilder group,
         Func<IServiceProvider, IQueryable<TEntity>> sourceProvider,
         LambdaExpression projectionLambda,
@@ -192,7 +201,7 @@ public static class QueryEndpointRouteBuilderExtensions
         // ExecuteAsync<TDto>); grouped applies the same projection in-memory after entity
         // materialization so GroupedResult.Items[] surfaces TDto, never the raw entity.
 #pragma warning disable GRAPI001 // Results.Ok is needed here for polymorphic return
-        group.MapGet("/", async (
+        return group.MapGet("/", async (
             [FromServices] IQueryEngine<TEntity> engine,
             BindableQueryRequest request,
             HttpContext httpContext,

--- a/src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj
+++ b/src/Granit.QueryEngine.AspNetCore/Granit.QueryEngine.AspNetCore.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Entities.Abstractions\Granit.Entities.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine\Granit.QueryEngine.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>

--- a/src/Granit.Scheduling.Endpoints/packages.lock.json
+++ b/src/Granit.Scheduling.Endpoints/packages.lock.json
@@ -131,6 +131,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/src/Granit.Webhooks.Endpoints/packages.lock.json
+++ b/src/Granit.Webhooks.Endpoints/packages.lock.json
@@ -240,6 +240,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.AI.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.AI.Endpoints.Tests/packages.lock.json
@@ -438,6 +438,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3103,6 +3103,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Auditing.Endpoints.Tests/packages.lock.json
@@ -362,6 +362,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
@@ -459,6 +459,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -635,6 +635,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/MapGranitQueryRegistersEntityEndpointTests.cs
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/MapGranitQueryRegistersEntityEndpointTests.cs
@@ -1,0 +1,59 @@
+using Granit.Entities;
+using Granit.MultiTenancy;
+using Granit.QueryEngine.AspNetCore.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.QueryEngine.AspNetCore.Tests.Integration;
+
+/// <summary>
+/// Verifies that <c>MapGranitQuery&lt;TEntity&gt;</c> tags its list endpoint with
+/// <see cref="EntityEndpointMetadata"/> so the entity-discovery surface
+/// (<c>Granit.Entities.Endpoints</c>) can walk <see cref="EndpointDataSource"/>
+/// and expose the real URL on <c>EntityDiscoveryLinks.List</c> — same mechanism
+/// ASP.NET's own OpenAPI generator uses for endpoint metadata lookups.
+/// </summary>
+public sealed class MapGranitQueryRegistersEntityEndpointTests
+{
+    [Fact]
+    public async Task Tags_list_endpoint_with_metadata_carrying_resolved_path()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddAuthorization();
+        builder.Services.AddSingleton(Substitute.For<IQueryEngine<TestProduct>>());
+        builder.Services.AddSingleton<QueryDefinition<TestProduct>, TestProductQueryDefinition>();
+        builder.Services.AddSingleton<ICurrentTenant>(Substitute.For<ICurrentTenant>());
+
+        await using WebApplication app = builder.Build();
+
+        app.MapGranitQuery<TestProduct>(
+            _ => Array.Empty<TestProduct>().AsQueryable(),
+            "/api/v1/products",
+            opts => opts.AllowAnonymous = true);
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        EndpointDataSource source = app.Services.GetRequiredService<EndpointDataSource>();
+
+        (RouteEndpoint endpoint, EntityEndpointMetadata meta) =
+            source.Endpoints
+                .OfType<RouteEndpoint>()
+                .Select(e => (Endpoint: e, Meta: e.Metadata.GetMetadata<EntityEndpointMetadata>()))
+                .Where(x => x.Meta is not null
+                    && x.Meta.EntityType == typeof(TestProduct)
+                    && x.Meta.Kind == EntityEndpointKind.List)
+                .Select(x => (x.Endpoint, Meta: x.Meta!))
+                .ShouldHaveSingleItem();
+
+        endpoint.RoutePattern.RawText.ShouldBe("/api/v1/products/");
+        meta.EntityType.ShouldBe(typeof(TestProduct));
+        meta.Kind.ShouldBe(EntityEndpointKind.List);
+    }
+}

--- a/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests.Integration/packages.lock.json
@@ -608,6 +608,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.AspNetCore.Tests/packages.lock.json
@@ -608,6 +608,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Scheduling.Endpoints.Tests/packages.lock.json
@@ -475,6 +475,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Endpoints.Tests/packages.lock.json
@@ -611,6 +611,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

- Add `EntityEndpointMetadata` (POCO record + `EntityEndpointKind` enum) in `Granit.Entities.Abstractions` — no AspNetCore dependency so it stays in the abstractions layer.
- `MapGranitQuery<TEntity>` now attaches the metadata to its list endpoint via `WithMetadata`. The entity-discovery surface (in `granit-business`) walks `EndpointDataSource`, reads each `RouteEndpoint`'s `EntityEndpointMetadata`, and exposes the resolved `RoutePattern.RawText` on `EntityDiscoveryLinks.List` instead of forging an URL from the entity name.

## Why this approach

Same pattern ASP.NET Core's own OpenAPI generator uses for operation/tag/produces lookups: a single source of truth (`EndpointDataSource`), producers tagging with metadata, consumers walking and filtering. No parallel registry to drift when an endpoint is mounted conditionally or moved.

## Impact

- `EntityEndpointMetadata` is additive — zero breaking change for downstream packages.
- `Granit.QueryEngine.AspNetCore` now project-references `Granit.Entities.Abstractions` (small abstractions package, no AspNetCore dep). The dependency captures the semantic coupling (query layer publishes for entity discovery).
- Hosts that don't load entity-discovery still get the metadata tagged — it's just unused.

## Companion change

The discovery handler that consumes this metadata lives in `granit-business` (`Granit.Entities.Endpoints`). The MR there depends on this PR being merged + the new package versions of `Granit.Entities.Abstractions` and `Granit.QueryEngine.AspNetCore` being published.

## Test plan

- [x] `dotnet build src/Granit.Entities.Abstractions` clean
- [x] `dotnet build src/Granit.QueryEngine.AspNetCore` clean
- [x] `dotnet test tests/Granit.Entities.Abstractions.Tests --no-build` — 106 / 106 passing
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests.Integration --no-build` — 11 / 11 passing, including the new `MapGranitQueryRegistersEntityEndpointTests` verifying the metadata is attached with the resolved `RawText`
- [ ] CI green on the relevant shards