### PR TITLE
chore(mergeable): restore IVT for Parties merge integration tests

### DIFF
--- a/src/Granit.Mergeable.EntityFrameworkCore/Granit.Mergeable.EntityFrameworkCore.csproj
+++ b/src/Granit.Mergeable.EntityFrameworkCore/Granit.Mergeable.EntityFrameworkCore.csproj
@@ -10,6 +10,9 @@
     <InternalsVisibleTo Include="Granit.Mergeable.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.Mergeable.BackgroundJobs" />
     <InternalsVisibleTo Include="Granit.Mergeable.BackgroundJobs.Tests" />
+    <!-- granit-business: Parties merge integration tests wire EfMergeService<Party>
+         + MergeableDbContext directly against a Postgres testcontainer. -->
+    <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests.Integration" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- #2082 dropped `InternalsVisibleTo("Granit.Parties.Mergeable.Tests.Integration")` from `Granit.Mergeable.EntityFrameworkCore` along with the truly stale entries, breaking granit-business CI.
- That test is a legitimate cross-repo integration consumer: it constructs `EfMergeService<Party>` + `MergeableDbContext` + `IMergeableSecretProvider` directly against a Postgres testcontainer to assert the orchestrator's ChangeTracker + idempotency contract — there's no public surface that covers that.
- Re-grant the IVT with an inline comment so the next cleanup pass keeps it.

## Test plan
- [ ] CI green on this branch
- [ ] granit-business CI (`develop`) restores the dropped test project once the dev preview package picks up this change