### PR TITLE
chore(mergeable): restore BackgroundJobs IVT for Parties merge integration tests

### DIFF
--- a/src/Granit.Mergeable.BackgroundJobs/Granit.Mergeable.BackgroundJobs.csproj
+++ b/src/Granit.Mergeable.BackgroundJobs/Granit.Mergeable.BackgroundJobs.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Mergeable.BackgroundJobs.Tests" />
+    <!-- granit-business: Parties merge integration tests assert the cleanup
+         service's retention sweep against a real Postgres testcontainer. -->
+    <InternalsVisibleTo Include="Granit.Parties.Mergeable.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Sibling to #2085. `MergeIdempotencyCleanupPostgresTests` in granit-business asserts the cleanup sweeper's retention behaviour directly against a Postgres testcontainer, so it needs the internal `MergeIdempotencyCleanupService`.
- Re-grant `InternalsVisibleTo("Granit.Parties.Mergeable.Tests.Integration")` on `Granit.Mergeable.BackgroundJobs` the same way the EFCore package now does.

## Test plan
- [ ] CI green on this branch
- [ ] granit-business `develop` picks up the new dev preview and the cleanup tests compile again