### PR TITLE
feat(authorization): wire MapGranitQuery for PermissionGrant + RoleMetadata

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -275,6 +275,7 @@
       "deps": [
         "Granit.Authorization",
         "Granit.Http.ApiDocumentation",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Validation",
         "Granit.Workspaces.Abstractions"
       ],
@@ -6801,7 +6802,7 @@
       "kind": "class",
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 17,
       "members": [
         {
           "name": "MapGranitAuthorization",
@@ -6962,7 +6963,7 @@
       "kind": "class",
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.Authorization.Domain;
 using Granit.Authorization.Endpoints.Endpoints;
 using Granit.Authorization.Endpoints.Options;
+using Granit.Authorization.Endpoints.Permissions;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -53,6 +56,19 @@ public static class AuthorizationEndpointRouteBuilderExtensions
         permissionsGroup.MapMyPermissionsEndpoints();
         permissionsGroup.MapPermissionDefinitionsEndpoints();
         group.MapPermissionGrantEndpoints();
+
+        // Admin query surfaces — paginated/filterable lists for the entity discovery.
+        // Routed under their own subgroups so they coexist with the bespoke grant
+        // management endpoints under "/roles/{roleName}" without colliding.
+        group.MapGranitGroup("grants").MapGranitQuery<PermissionGrant>(configure: opts =>
+        {
+            opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Grants.Manage;
+        });
+
+        group.MapGranitGroup("role-metadata").MapGranitQuery<RoleMetadata>(configure: opts =>
+        {
+            opts.AuthorizationPolicy = AuthorizationEndpointsPermissions.Definitions.Read;
+        });
 
         return group;
     }

--- a/src/Granit.Authorization.Endpoints/Granit.Authorization.Endpoints.csproj
+++ b/src/Granit.Authorization.Endpoints/Granit.Authorization.Endpoints.csproj
@@ -19,8 +19,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
-      <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Workspaces.Abstractions\Granit.Workspaces.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Authorization.Endpoints/packages.lock.json
+++ b/src/Granit.Authorization.Endpoints/packages.lock.json
@@ -107,11 +107,28 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using Granit.Authorization;
+using Granit.Authorization.Domain;
 using Granit.Authorization.EntityFrameworkCore.DbContext;
 using Granit.Authorization.EntityFrameworkCore.Internal;
 using Granit.Authorization.EntityFrameworkCore.Stores;
 using Granit.Persistence.EntityFrameworkCore.SharedConnection;
+using Granit.QueryEngine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -41,6 +43,13 @@ public static class AuthorizationEfCoreServiceCollectionExtensions
         // TryAdd so host apps can override with a custom accessor if needed.
         services.TryAddScoped<IAuthorizationHostDbContextAccessor,
             AuthorizationHostDbContextAccessor<TContext>>();
+
+        // Queryable sources for MapGranitQuery (host bypasses tenant filter for
+        // cross-tenant authorization review).
+        services.TryAddScoped<IQueryableSource<PermissionGrant>,
+            EfPermissionGrantQueryableSource<TContext>>();
+        services.TryAddScoped<IQueryableSource<RoleMetadata>,
+            EfRoleMetadataQueryableSource<TContext>>();
 
         return services;
     }

--- a/src/Granit.Authorization.EntityFrameworkCore/Internal/EfPermissionGrantQueryableSource.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Internal/EfPermissionGrantQueryableSource.cs
@@ -1,0 +1,28 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authorization.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="PermissionGrant"/>. When no tenant context is active (host admin)
+/// the multi-tenant query filter is bypassed so all grants are returned cross-tenant
+/// — required for ISO 27001 cross-tenant authorization review.
+/// </summary>
+internal sealed class EfPermissionGrantQueryableSource<TContext>(
+    TContext context,
+    ICurrentTenant currentTenant) : IQueryableSource<PermissionGrant>
+    where TContext : Microsoft.EntityFrameworkCore.DbContext, IPermissionGrantDbContext
+{
+    public IQueryable<PermissionGrant> GetQueryable()
+    {
+        IQueryable<PermissionGrant> query = context.PermissionGrants.AsNoTracking();
+        return currentTenant.IsAvailable
+            ? query
+            : query.IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
+    }
+}

--- a/src/Granit.Authorization.EntityFrameworkCore/Internal/EfRoleMetadataQueryableSource.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Internal/EfRoleMetadataQueryableSource.cs
@@ -1,0 +1,28 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authorization.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for
+/// <see cref="RoleMetadata"/>. Host admins see every row (Host / Both / all tenants);
+/// tenant context applies the standard multi-tenant filter so tenant admins only
+/// see their own tenant + the global Both rows.
+/// </summary>
+internal sealed class EfRoleMetadataQueryableSource<TContext>(
+    TContext context,
+    ICurrentTenant currentTenant) : IQueryableSource<RoleMetadata>
+    where TContext : Microsoft.EntityFrameworkCore.DbContext, IPermissionGrantDbContext
+{
+    public IQueryable<RoleMetadata> GetQueryable()
+    {
+        IQueryable<RoleMetadata> query = context.RoleMetadata.AsNoTracking();
+        return currentTenant.IsAvailable
+            ? query
+            : query.IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1724,6 +1724,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Authorization.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Authorization.Endpoints.Tests/packages.lock.json
@@ -523,6 +523,7 @@
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
           "Granit.Workspaces.Abstractions": "[0.1.0-dev, )"
         }
@@ -599,11 +600,28 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Entities.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {


### PR DESCRIPTION
## Summary

Surfaces \`PermissionGrant\` and \`RoleMetadata\` in the entity-discovery list URLs by mounting \`MapGranitQuery<T>\` under sibling subgroups of the authorization endpoint group. The \`EntityEndpointMetadata\` auto-tag added by \`MapGranitQuery\` (PR #2084) is what \`Granit.Entities.Endpoints\` reads to fill the \`links.list\` field — both entities used to surface as \`list: null\`.

## Changes

- \`EfPermissionGrantQueryableSource<TContext>\` / \`EfRoleMetadataQueryableSource<TContext>\` — read \`AsNoTracking\` from the host's \`IPermissionGrantDbContext\`, bypass the multi-tenant filter when no tenant context is active (host admin). Mirrors the \`EfAuditEntryQueryableSource\` pattern used for cross-tenant ISO 27001 review.
- \`AddGranitAuthorizationEntityFrameworkCore<TContext>\` registers both as scoped services via \`TryAddScoped\`.
- \`MapGranitAuthorization\` now exposes:
  - \`{prefix}/grants\` → \`PermissionGrant\` query, gated by \`Grants.Manage\`
  - \`{prefix}/role-metadata\` → \`RoleMetadata\` query, gated by \`Definitions.Read\`
- New \`ProjectReference\` from \`Granit.Authorization.Endpoints\` → \`Granit.QueryEngine.AspNetCore\`.

## Test plan

- [x] \`dotnet build src/Granit.Authorization.EntityFrameworkCore\` clean
- [x] \`dotnet build src/Granit.Authorization.Endpoints\` clean
- [x] \`dotnet test tests/Granit.ArchitectureTests --no-build\` — 178 / 178 passing
- [ ] CI green
- [ ] Showcase / host with \`AddGranitAuthorizationEntityFrameworkCore<AppDbContext>()\`: \`GET /api/v1/entities\` returns \`links.list\` for \`Granit.Authorization.PermissionGrant\` and \`Granit.Authorization.RoleMetadata\` matching the actual mounted route

## Follow-ups not in this PR

\`GranitUserGroup\` and \`FederatedIdentity\` still surface \`list: null\`:

- \`GranitUserGroup\` lives in the internal \`OpenIddictDbContext\` → its \`IQueryableSource\` belongs in \`Granit.OpenIddict.EntityFrameworkCore\` but the natural \`MapGranitQuery\` mount is \`Granit.Identity.Local.Endpoints\`. Cross-module wiring decision belongs in a dedicated PR.
- \`FederatedIdentity\` has no \`Granit.Identity.Federated.Endpoints\` module today. A new module is heavier than what fits here.