### PR TITLE
fix(blob-storage-s3): preserve http scheme in presigned URLs

### DIFF
--- a/src/Granit.BlobStorage.S3/HealthChecks/S3HealthCheck.cs
+++ b/src/Granit.BlobStorage.S3/HealthChecks/S3HealthCheck.cs
@@ -1,5 +1,6 @@
 using Amazon.S3;
 using Amazon.S3.Model;
+using Granit.BlobStorage.S3.Internal;
 using Granit.BlobStorage.S3.Options;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -58,13 +59,7 @@ internal sealed class S3HealthCheck(
 
     private static AmazonS3Client CreateClient(S3BlobOptions opts)
     {
-        AmazonS3Config config = new()
-        {
-            ServiceURL = opts.ServiceUrl,
-            ForcePathStyle = opts.ForcePathStyle,
-            AuthenticationRegion = opts.Region,
-        };
-
+        AmazonS3Config config = S3ConfigFactory.Create(opts);
         Amazon.Runtime.BasicAWSCredentials credentials = new(opts.AccessKey, opts.SecretKey);
         return new AmazonS3Client(credentials, config);
     }

--- a/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3BlobClient.cs
@@ -26,15 +26,7 @@ internal sealed class S3BlobClient : IBlobStoreProvider, IPresignedUrlProvider, 
     {
         S3BlobOptions opts = options.Value;
 
-        AmazonS3Config config = new()
-        {
-            ServiceURL = opts.ServiceUrl,
-            ForcePathStyle = opts.ForcePathStyle,
-            AuthenticationRegion = opts.Region,
-            // Disable AWS SDK telemetry — we are consuming the S3 protocol, not AWS infrastructure.
-            LogResponse = false,
-            LogMetrics = false,
-        };
+        AmazonS3Config config = S3ConfigFactory.Create(opts);
 
         Amazon.Runtime.BasicAWSCredentials credentials = new(opts.AccessKey, opts.SecretKey);
         _s3 = new AmazonS3Client(credentials, config);

--- a/src/Granit.BlobStorage.S3/Internal/S3ConfigFactory.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3ConfigFactory.cs
@@ -1,0 +1,24 @@
+using Amazon.S3;
+using Granit.BlobStorage.S3.Options;
+
+namespace Granit.BlobStorage.S3.Internal;
+
+/// <summary>
+/// Builds <see cref="AmazonS3Config"/> instances from <see cref="S3BlobOptions"/>.
+/// </summary>
+internal static class S3ConfigFactory
+{
+    // The AWS SDK regenerates the scheme on presigned URLs from AmazonS3Config.UseHttp; ServiceURL
+    // alone is ignored. Without this, http://localhost:9000 (MinIO dev) yields https:// upload URLs.
+    public static AmazonS3Config Create(S3BlobOptions opts) =>
+        new()
+        {
+            ServiceURL = opts.ServiceUrl,
+            ForcePathStyle = opts.ForcePathStyle,
+            AuthenticationRegion = opts.Region,
+            UseHttp = opts.ServiceUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase),
+            // Disable AWS SDK telemetry — we are consuming the S3 protocol, not AWS infrastructure.
+            LogResponse = false,
+            LogMetrics = false,
+        };
+}

--- a/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
+++ b/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
@@ -28,6 +28,11 @@ public sealed class S3BlobOptions : BlobStorageOptions
     /// S3-compatible endpoint URL.
     /// Examples: <c>https://s3.eu-west-1.amazonaws.com</c>, <c>http://localhost:9000</c>.
     /// </summary>
+    /// <remarks>
+    /// The scheme drives <c>AmazonS3Config.UseHttp</c>: an <c>http://</c> value emits presigned URLs
+    /// in cleartext (required for MinIO dev), <c>https://</c> emits TLS presigned URLs. HTTP is only
+    /// accepted for <c>localhost</c> / <c>127.0.0.1</c>; all other hosts must use HTTPS.
+    /// </remarks>
     public string ServiceUrl { get; set; } = string.Empty;
 
     /// <summary>S3 access key. Inject from Granit.Vault; never hardcode.</summary>

--- a/tests/Granit.BlobStorage.S3.Tests/S3ConfigFactoryTests.cs
+++ b/tests/Granit.BlobStorage.S3.Tests/S3ConfigFactoryTests.cs
@@ -1,0 +1,39 @@
+using Amazon.S3;
+using Granit.BlobStorage.S3.Internal;
+using Granit.BlobStorage.S3.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.S3.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="S3ConfigFactory"/>.
+/// Locks in that <c>UseHttp</c> tracks the <see cref="S3BlobOptions.ServiceUrl"/> scheme —
+/// required so AWS SDK presigned URLs preserve <c>http://</c> for MinIO dev endpoints.
+/// </summary>
+public sealed class S3ConfigFactoryTests
+{
+    [Theory]
+    [InlineData("http://localhost:9000", true)]
+    [InlineData("HTTP://LOCALHOST:9000", true)]
+    [InlineData("https://s3.eu-west-1.amazonaws.com", false)]
+    public void Create_SetsUseHttpFromServiceUrlScheme(string serviceUrl, bool expectedUseHttp)
+    {
+        S3BlobOptions opts = new()
+        {
+            ServiceUrl = serviceUrl,
+            AccessKey = "k",
+            SecretKey = "s",
+            Region = "us-east-1",
+            DefaultBucket = "b",
+            ForcePathStyle = true,
+        };
+
+        AmazonS3Config config = S3ConfigFactory.Create(opts);
+
+        config.UseHttp.ShouldBe(expectedUseHttp);
+        config.ServiceURL.ShouldStartWith(serviceUrl);
+        config.ForcePathStyle.ShouldBeTrue();
+        config.AuthenticationRegion.ShouldBe("us-east-1");
+    }
+}


### PR DESCRIPTION
## Summary

- AWS SDK regenerates the scheme on `GetPreSignedURL` from `AmazonS3Config.UseHttp`, ignoring whatever scheme is set on `ServiceURL`. Without `UseHttp=true`, an `http://localhost:9000` endpoint (MinIO dev) returns presigned URLs as `https://`, which fail with `ERR_SSL_PROTOCOL_ERROR` on cleartext MinIO. See [aws/aws-sdk-net#1645](https://github.com/aws/aws-sdk-net/issues/1645).
- Centralized `AmazonS3Config` construction in `S3ConfigFactory` (consumed by both `S3BlobClient` and `S3HealthCheck`) and derive `UseHttp` from the `ServiceUrl` scheme.
- `S3BlobOptionsValidator` already restricts `http://` to localhost; documented the scheme-driven `UseHttp` behavior on `S3BlobOptions.ServiceUrl` xmldoc.

## Test plan

- [x] `dotnet build src/Granit.BlobStorage.S3` clean
- [x] `dotnet test tests/Granit.BlobStorage.S3.Tests` — 38/38 passing (3 new `S3ConfigFactoryTests` covering http/https + case-insensitive scheme)
- [x] `dotnet format` clean
- [ ] End-to-end: showcase admin upload through MinIO via Aspire AppHost — verify ticket `UploadUrl.Scheme == "http"` and PUT succeeds