### PR TITLE
refactor(blob-storage-s3): drop redundant LogResponse/LogMetrics flags

### DIFF
--- a/src/Granit.BlobStorage.S3/Internal/S3ConfigFactory.cs
+++ b/src/Granit.BlobStorage.S3/Internal/S3ConfigFactory.cs
@@ -17,8 +17,5 @@ internal static class S3ConfigFactory
             ForcePathStyle = opts.ForcePathStyle,
             AuthenticationRegion = opts.Region,
             UseHttp = opts.ServiceUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase),
-            // Disable AWS SDK telemetry — we are consuming the S3 protocol, not AWS infrastructure.
-            LogResponse = false,
-            LogMetrics = false,
         };
 }


### PR DESCRIPTION
## Summary

Follow-up to #2089. Drop `LogResponse = false` / `LogMetrics = false` from `S3ConfigFactory`:

- Both already default to `false` on `AmazonS3Config` — the explicit assignments were redundant.
- The companion comment ("Disable AWS SDK telemetry — we are consuming the S3 protocol, not AWS infrastructure") was misleading: these flags control **local SDK logger verbosity** (response bodies, per-request metrics), not anything sent to AWS. They behave identically on AWS S3 and MinIO.

## Test plan

- [x] `dotnet build src/Granit.BlobStorage.S3` clean
- [x] `dotnet test tests/Granit.BlobStorage.S3.Tests` — 38/38 passing