### PR TITLE
fix(tests): drop [Obsolete] hack on InitializeAsync, pass image to MsSqlBuilder

### DIFF
--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/PerTenantRoutingTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/PerTenantRoutingTests.cs
@@ -56,7 +56,6 @@ public sealed class TwoSqlServerContainersFixture : IAsyncLifetime
     public string ConnectionStringA { get; private set; } = string.Empty;
     public string ConnectionStringB { get; private set; } = string.Empty;
 
-    [Obsolete("Required by xUnit IAsyncLifetime")]
     public async ValueTask InitializeAsync()
     {
         string? ciHost = Environment.GetEnvironmentVariable("MSSQL_HOST");
@@ -81,11 +80,11 @@ public sealed class TwoSqlServerContainersFixture : IAsyncLifetime
         else
         {
             // Local mode: use Testcontainers (requires Docker).
-            _containerA = new MsSqlBuilder()
+            _containerA = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
                 .WithPassword("Test_Password1!")
                 .Build();
 
-            _containerB = new MsSqlBuilder()
+            _containerB = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
                 .WithPassword("Test_Password1!")
                 .Build();
 


### PR DESCRIPTION
## Summary

The \`[Obsolete(\"Required by xUnit IAsyncLifetime\")]\` decoration on \`TwoSqlServerContainersFixture.InitializeAsync\` was a hack to silence \`CS0618\` leaking from \`new MsSqlBuilder()\` — Testcontainers .NET deprecated the parameterless ctor in favour of an image-aware one.

Per CLAUDE.md \"no \`[Obsolete]\` graduation while pre-1.0\" — and because the decoration was misleading on a public xUnit lifecycle method anyway — swap the hack for the supported call site:

\`\`\`diff
-new MsSqlBuilder()
+new MsSqlBuilder(\"mcr.microsoft.com/mssql/server:2022-latest\")
\`\`\`

The 2022-latest image is the same default Testcontainers had been resolving silently.

## Test plan

- [x] \`dotnet build tests/Granit.Wolverine.SqlServer.Tests.Integration\` clean
- [ ] CI green