### PR TITLE
refactor(webhooks): drop legacy SigningSecret + RotateSecret aliases

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13370,6 +13370,40 @@
       "members": []
     },
     {
+      "name": "NullDataFilter",
+      "fqn": "Granit.DataFiltering.NullDataFilter",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/DataFiltering/NullDataFilter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "NullDataFilter Instance ="
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Disable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Disable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Enable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Enable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "bool IsEnabled<TFilter>() where TFilter : class",
+          "returnType": "bool IsEnabled<TFilter>() where TFilter :"
+        }
+      ]
+    },
+    {
       "name": "LookupDescriptor",
       "fqn": "Granit.DataLookup.Descriptors.LookupDescriptor",
       "kind": "record",
@@ -31740,6 +31774,28 @@
       "members": []
     },
     {
+      "name": "GranitDesignTime",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitDesignTime",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDesignTime.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "CurrentTenant",
+          "kind": "property",
+          "signature": "ICurrentTenant CurrentTenant",
+          "returnType": "ICurrentTenant"
+        },
+        {
+          "name": "DataFilter",
+          "kind": "property",
+          "signature": "IDataFilter DataFilter",
+          "returnType": "IDataFilter"
+        }
+      ]
+    },
+    {
       "name": "GranitFilterNames",
       "fqn": "Granit.Persistence.EntityFrameworkCore.GranitFilterNames",
       "kind": "class",
@@ -41947,12 +42003,6 @@
           "kind": "method",
           "signature": "DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
           "returnType": "Task"
-        },
-        {
-          "name": "RotateSecretAsync",
-          "kind": "method",
-          "signature": "RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<string>"
         }
       ]
     },
@@ -41978,7 +42028,7 @@
       "kind": "record",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs",
-      "line": 73,
+      "line": 69,
       "members": []
     },
     {
@@ -42230,7 +42280,7 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Domain/WebhookSigningKey.cs",
-      "line": 25,
+      "line": 24,
       "members": [
         {
           "name": "Create",
@@ -42267,12 +42317,12 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Domain/WebhookSubscription.cs",
-      "line": 23,
+      "line": 21,
       "members": [
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, string signingSecret, Guid? tenantId = null)",
+          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, Guid signingKeyId, string protectedSecret, DateTimeOffset createdAt, Guid? tenantId = null)",
           "returnType": "WebhookSubscription"
         },
         {
@@ -42285,7 +42335,7 @@
           "name": "AsReadOnly",
           "kind": "method",
           "signature": "AsReadOnly()",
-          "returnType": "string? SigningSecret { get; private set; } public IReadOnlyList<WebhookSigningKey> SigningKeys => _signingKeys."
+          "returnType": "IReadOnlyList<WebhookSigningKey> SigningKeys => _signingKeys."
         },
         {
           "name": "TenantId",
@@ -42386,15 +42436,6 @@
       "project": "Granit.Webhooks.Endpoints",
       "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs",
       "line": 8,
-      "members": []
-    },
-    {
-      "name": "WebhookSubscriptionRotateSecretResponse",
-      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionRotateSecretResponse",
-      "kind": "record",
-      "project": "Granit.Webhooks.Endpoints",
-      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionRotateSecretResponse.cs",
-      "line": 6,
       "members": []
     },
     {

--- a/src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionRotateSecretResponse.cs
+++ b/src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionRotateSecretResponse.cs
@@ -1,6 +1,0 @@
-namespace Granit.Webhooks.Endpoints.Dtos;
-
-/// <summary>
-/// Response after rotating a subscription's signing secret.
-/// </summary>
-public sealed record WebhookSubscriptionRotateSecretResponse(string SigningSecret);

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionOperationEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionOperationEndpoints.cs
@@ -1,4 +1,3 @@
-using Granit.Http.Idempotency.Attributes;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.Endpoints.Dtos;
@@ -14,17 +13,6 @@ internal static class WebhookSubscriptionOperationEndpoints
 {
     internal static RouteGroupBuilder MapOperationEndpoints(this RouteGroupBuilder group)
     {
-        group.MapPost("/subscriptions/{id:guid}/rotate-secret", RotateSecret)
-            .WithName("RotateWebhookSecret")
-            .WithSummary("Rotates a subscription's signing secret.")
-            .WithDescription(
-                "Generates a new HMAC signing secret for the subscription. "
-                + "The previous secret is invalidated immediately. "
-                + "The new plain-text secret is returned once and cannot be retrieved later.")
-            .WithMetadata(new IdempotentAttribute { Required = false })
-            .Produces<WebhookSubscriptionRotateSecretResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
-
         group.MapPost("/subscriptions/{id:guid}/test-ping", TestPing)
             .WithName("TestWebhookPing")
             .WithSummary("Sends a test ping to the subscription's target URL.")
@@ -44,22 +32,6 @@ internal static class WebhookSubscriptionOperationEndpoints
             .Produces<WebhookSubscriptionStatsResponse>();
 
         return group;
-    }
-
-    private static async Task<Results<Ok<WebhookSubscriptionRotateSecretResponse>, ProblemHttpResult>> RotateSecret(
-        Guid id,
-        [FromServices] IWebhookSubscriptionReader reader,
-        [FromServices] IWebhookSubscriptionWriter writer,
-        CancellationToken cancellationToken)
-    {
-        WebhookSubscription? subscription = await reader.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
-        if (subscription is null)
-        {
-            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
-        }
-
-        string plainSecret = await writer.RotateSecretAsync(id, cancellationToken).ConfigureAwait(false);
-        return TypedResults.Ok(new WebhookSubscriptionRotateSecretResponse(plainSecret));
     }
 
     private static async Task<Results<Ok<WebhookSubscriptionTestPingResponse>, ProblemHttpResult>> TestPing(

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
@@ -27,13 +27,6 @@ internal sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguratio
             .HasMaxLength(200)
             .IsRequired();
 
-        // Legacy protected signing secret — kept nullable for back-compat. New subscriptions
-        // ship with WebhookSigningKey rows instead. Cleared on first RotateSigningKey.
-#pragma warning disable CS0618 // SigningSecret is intentionally retained for back-compat.
-        builder.Property(e => e.SigningSecret)
-            .HasMaxLength(1000);
-#pragma warning restore CS0618
-
         // Aggregate child collection — cascade delete keeps keys tied to their subscription.
         builder.HasMany(e => e.SigningKeys)
             .WithOne()

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
@@ -95,7 +95,7 @@ internal sealed class EfWebhookSubscriptionStore(
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        var subscription = WebhookSubscription.CreateWithSigningKey(
+        var subscription = WebhookSubscription.Create(
             guidGenerator.Create(),
             targetUrl,
             eventType,
@@ -158,15 +158,6 @@ internal sealed class EfWebhookSubscriptionStore(
             WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
             db.WebhookSubscriptions.Remove(subscription);
         }, cancellationToken);
-
-    /// <inheritdoc/>
-    public async Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
-    {
-        WebhookSigningKeyRotatedResult result = await RotateSigningKeyAsync(
-            subscriptionId, retiredKeyGracePeriod: null, cancellationToken).ConfigureAwait(false);
-
-        return result.PlainSecret;
-    }
 
     /// <inheritdoc/>
     public async Task<WebhookSigningKeyRotatedResult> RotateSigningKeyAsync(

--- a/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookSigningKeyWriter.cs
@@ -14,10 +14,6 @@ public interface IWebhookSigningKeyWriter
     /// verification for <paramref name="retiredKeyGracePeriod"/>. A new active key is created
     /// and returned (plain-text — only once).
     /// </para>
-    /// <para>
-    /// On the first rotation after upgrade, the legacy
-    /// <see cref="Domain.WebhookSubscription.SigningSecret"/> field is cleared.
-    /// </para>
     /// </remarks>
     /// <param name="subscriptionId">Target subscription identifier.</param>
     /// <param name="retiredKeyGracePeriod">

--- a/src/Granit.Webhooks/Abstractions/IWebhookSubscriptionWriter.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookSubscriptionWriter.cs
@@ -52,9 +52,4 @@ public interface IWebhookSubscriptionWriter
     /// Hard-deletes a subscription.
     /// </summary>
     Task DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Rotates the signing secret and returns the new plain-text secret (returned once).
-    /// </summary>
-    Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Webhooks/Domain/WebhookSigningKey.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSigningKey.cs
@@ -8,8 +8,7 @@ namespace Granit.Webhooks.Domain;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Replaces the legacy single-<see cref="WebhookSubscription.SigningSecret"/> field with a
-/// proper key history, enabling overlap rotation: a previously-<see cref="WebhookSigningKeyStatus.Active"/>
+/// Per-subscription key history enabling overlap rotation: a previously-<see cref="WebhookSigningKeyStatus.Active"/>
 /// key transitions to <see cref="WebhookSigningKeyStatus.Retired"/> with an
 /// <see cref="ExpiresAt"/> in the (configurable) future and is still accepted in
 /// verification until that grace period elapses, while the new key takes over signing.

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -1,4 +1,3 @@
-using Granit.DataProtection;
 using Granit.Domain;
 using Granit.Domain.ValueObjects;
 using Granit.Webhooks.Events;
@@ -9,12 +8,11 @@ namespace Granit.Webhooks.Domain;
 /// Represents an external subscriber registered to receive webhook events.
 /// </summary>
 /// <remarks>
-/// <para>
-/// The <see cref="SigningSecret"/> field stores an opaque protected value whose format
-/// is determined by the registered <see cref="Abstractions.IWebhookSecretProtector"/>.
-/// Never log or expose this value. At delivery time, the handler calls
-/// <see cref="Abstractions.IWebhookSecretProtector.UnprotectAsync"/> before signing.
-/// </para>
+/// Signing material lives in the <see cref="SigningKeys"/> collection (dual-key
+/// model: one <see cref="WebhookSigningKeyStatus.Active"/> + zero-or-more
+/// <see cref="WebhookSigningKeyStatus.Retired"/> within the grace period).
+/// Never log or expose the protected secret value — at delivery time the handler
+/// calls <see cref="Abstractions.IWebhookSecretProtector.UnprotectAsync"/> before signing.
 /// <para>
 /// ISO 27001 compliance: suspension actions are traced with <see cref="SuspendedAt"/>
 /// and <see cref="SuspendedBy"/> (UserId only, never PII).
@@ -28,37 +26,10 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
     private WebhookSubscription() { }
 
     /// <summary>
-    /// Creates a new active <see cref="WebhookSubscription"/>.
+    /// Creates a new active <see cref="WebhookSubscription"/> with an initial
+    /// <see cref="WebhookSigningKeyStatus.Active"/> signing key.
     /// </summary>
     public static WebhookSubscription Create(
-        Guid id,
-        HttpsUrl targetUrl,
-        string eventType,
-        string signingSecret,
-        Guid? tenantId = null)
-    {
-        var subscription = new WebhookSubscription
-        {
-            Id = id,
-            TargetUrl = targetUrl,
-            EventType = eventType,
-#pragma warning disable CS0618 // SigningSecret is obsolete but still populated when callers
-            SigningSecret = signingSecret,
-#pragma warning restore CS0618 // hand in a legacy single-secret payload (back-compat).
-            TenantId = tenantId,
-            Status = WebhookSubscriptionStatus.Active,
-        };
-
-        subscription.AddDomainEvent(new WebhookSubscriptionCreatedEvent(id, eventType, targetUrl.Value));
-        return subscription;
-    }
-
-    /// <summary>
-    /// Creates a new active <see cref="WebhookSubscription"/> with an initial
-    /// <see cref="WebhookSigningKey"/> rather than the legacy <see cref="SigningSecret"/> field.
-    /// Preferred constructor for callers using the dual-key delivery model.
-    /// </summary>
-    public static WebhookSubscription CreateWithSigningKey(
         Guid id,
         HttpsUrl targetUrl,
         string eventType,
@@ -97,20 +68,6 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
     /// Maximum length: 200 characters.
     /// </summary>
     public string EventType { get; private set; } = string.Empty;
-
-    /// <summary>
-    /// Legacy protected signing secret. Retained for backward-compatibility with subscriptions
-    /// created before the <see cref="WebhookSigningKey"/> aggregate was introduced and never
-    /// rotated since. Set to <c>null</c> on the first call to <see cref="RotateSigningKey"/>.
-    /// </summary>
-    /// <remarks>
-    /// New subscriptions ship with an entry in <see cref="SigningKeys"/> and a <c>null</c>
-    /// <see cref="SigningSecret"/>. Verification falls back to this field when no
-    /// <see cref="WebhookSigningKey"/> matches.
-    /// </remarks>
-    [SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
-    [Obsolete("Use SigningKeys collection. Retained for backward compatibility — set to null on first rotation.")]
-    public string? SigningSecret { get; private set; }
 
     /// <summary>
     /// Signing keys associated with this subscription, including
@@ -250,37 +207,13 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
         TargetUrl = targetUrl;
 
     /// <summary>
-    /// Replaces the legacy single signing secret with a new protected value.
-    /// </summary>
-    /// <remarks>
-    /// Preserved for backward compatibility. New code should call
-    /// <see cref="RotateSigningKey"/>, which uses the <see cref="WebhookSigningKey"/>
-    /// aggregate and supports overlap rotation.
-    /// </remarks>
-    [Obsolete("Use RotateSigningKey for overlap-rotation semantics.")]
-    internal void RotateSecret(string newProtectedSecret) =>
-#pragma warning disable CS0618 // Intentionally writes to legacy field for back-compat.
-        SigningSecret = newProtectedSecret;
-#pragma warning restore CS0618
-
-    /// <summary>
     /// Rotates the subscription's signing key using overlap-rotation semantics.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// The currently <see cref="WebhookSigningKeyStatus.Active"/> key (if any) is moved to
     /// <see cref="WebhookSigningKeyStatus.Retired"/> with an <see cref="WebhookSigningKey.ExpiresAt"/>
     /// set to <paramref name="now"/> + <paramref name="retiredKeyGracePeriod"/>. A new
     /// <see cref="WebhookSigningKeyStatus.Active"/> key is appended.
-    /// </para>
-    /// <para>
-    /// On the first rotation following the upgrade from the legacy single-secret model,
-    /// the legacy <see cref="SigningSecret"/> field is cleared. Note that legacy
-    /// pre-upgrade secret material is intentionally NOT migrated into a
-    /// <see cref="WebhookSigningKey"/> entity — the previous secret is dropped at
-    /// rotation time, matching the behaviour of the legacy
-    /// <see cref="RotateSecret(string)"/> method.
-    /// </para>
     /// </remarks>
     /// <param name="newKeyId">Identifier for the new signing key.</param>
     /// <param name="newProtectedSecret">Opaque protected secret for the new key.</param>
@@ -307,10 +240,6 @@ public sealed class WebhookSubscription : AuditedAggregateRoot, IMultiTenant
             now);
 
         _signingKeys.Add(newKey);
-
-#pragma warning disable CS0618 // Clears the legacy field — the new key is authoritative now.
-        SigningSecret = null;
-#pragma warning restore CS0618
 
         return newKey;
     }

--- a/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks/Internal/InMemoryWebhookSubscriptionStore.cs
@@ -70,7 +70,7 @@ internal sealed class InMemoryWebhookSubscriptionStore(
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        var subscription = WebhookSubscription.CreateWithSigningKey(
+        var subscription = WebhookSubscription.Create(
             _guidGenerator.Create(),
             targetUrl,
             eventType,
@@ -157,15 +157,6 @@ internal sealed class InMemoryWebhookSubscriptionStore(
         }
 
         return Task.CompletedTask;
-    }
-
-    public async Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
-    {
-        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)this)
-            .RotateSigningKeyAsync(subscriptionId, retiredKeyGracePeriod: null, cancellationToken)
-            .ConfigureAwait(false);
-
-        return result.PlainSecret;
     }
 
     public async Task<WebhookSigningKeyRotatedResult> RotateSigningKeyAsync(

--- a/src/Granit.Webhooks/Internal/WebhookSecretResolver.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSecretResolver.cs
@@ -5,23 +5,11 @@ namespace Granit.Webhooks.Internal;
 
 /// <summary>
 /// Resolves the signing material that should be used for an outbound webhook delivery.
+/// Returns the unprotected plaintext of the subscription's
+/// <see cref="WebhookSigningKeyStatus.Active"/> key — throws
+/// <see cref="InvalidOperationException"/> when no active key is present (malformed
+/// subscription).
 /// </summary>
-/// <remarks>
-/// <para>
-/// Selection rule (FU-1a — dual-key delivery):
-/// </para>
-/// <list type="number">
-///   <item>If the subscription has a <see cref="WebhookSigningKeyStatus.Active"/> key,
-///     unprotect and return its <see cref="WebhookSigningKey.ProtectedSecret"/>.</item>
-///   <item>Otherwise (no active key — typically a legacy subscription created before the
-///     dual-key model and never rotated), fall back to the legacy
-///     <see cref="WebhookSubscription.SigningSecret"/> if it is non-null.</item>
-/// </list>
-/// <para>
-/// Throws <see cref="InvalidOperationException"/> if neither source is available — that
-/// would indicate a malformed subscription (no active key AND no legacy secret).
-/// </para>
-/// </remarks>
 internal static class WebhookSecretResolver
 {
     public static async Task<string> ResolvePlainSecretAsync(
@@ -41,26 +29,15 @@ internal static class WebhookSecretResolver
             }
         }
 
-        if (activeKey is not null)
+        if (activeKey is null)
         {
-            return await secretProtector
-                .UnprotectAsync(activeKey.ProtectedSecret, cancellationToken)
-                .ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"Subscription '{subscription.Id}' has no active signing key. "
+              + "Rotate the key to introduce a new active key.");
         }
 
-#pragma warning disable CS0618 // Legacy fallback for subscriptions never rotated since the upgrade.
-        string? legacy = subscription.SigningSecret;
-#pragma warning restore CS0618
-
-        if (!string.IsNullOrEmpty(legacy))
-        {
-            return await secretProtector
-                .UnprotectAsync(legacy, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException(
-            $"Subscription '{subscription.Id}' has no active signing key and no legacy SigningSecret. "
-          + "Rotate the key to seed the dual-key model.");
+        return await secretProtector
+            .UnprotectAsync(activeKey.ProtectedSecret, cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SensitiveDataEncryptionConventionTests.cs
@@ -57,8 +57,6 @@ public sealed class SensitiveDataEncryptionConventionTests
         "Granit.Authentication.ApiKeys.Domain.ApiKeyEntry.HashedKey",       // HMAC-SHA256 hash of the issued key; reversal infeasible. The hash itself is the lookup index.
         "Granit.OpenIddict.Domain.SigningKey.EncryptedKeyMaterial",         // ciphertext produced by IDataProtectionProvider before persistence.
         "Granit.Webhooks.Domain.WebhookSigningKey.ProtectedSecret",         // opaque protected value; format owned by IWebhookSecretProtector (rotates independently).
-        "Granit.Webhooks.Domain.WebhookSubscription.SigningSecret",         // legacy column populated only via the same protector path as ProtectedSecret.
-
     };
 
     [Fact]

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
@@ -220,7 +220,9 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
 
     private async Task SeedSubscriptionAsync(Guid subscriptionId, int consecutiveFailures = 0)
     {
-        var sub = WebhookSubscription.Create(subscriptionId, "https://example.com/hook", "test.event", "protected-secret");
+        var sub = WebhookSubscription.Create(
+            subscriptionId, "https://example.com/hook", "test.event",
+            signingKeyId: Guid.NewGuid(), protectedSecret: "protected-secret", createdAt: DateTimeOffset.UtcNow);
 
         for (int i = 0; i < consecutiveFailures; i++)
         {

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
@@ -187,8 +187,10 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
             Guid.NewGuid(),
             $"https://example.com/{Guid.NewGuid()}",
             eventType,
-            "protected-secret",
-            tenantId);
+            signingKeyId: Guid.NewGuid(),
+            protectedSecret: "protected-secret",
+            createdAt: DateTimeOffset.UtcNow,
+            tenantId: tenantId);
 
         switch (status)
         {

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDbContextTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/WebhooksDbContextTests.cs
@@ -31,7 +31,9 @@ public sealed class WebhooksDbContextTests : IAsyncDisposable
         await using (WebhooksDbContext context = new(_options))
         {
             context.WebhookSubscriptions.Add(
-                WebhookSubscription.Create(id, "https://example.com/hook", "test.event", "secret"));
+                WebhookSubscription.Create(
+                    id, "https://example.com/hook", "test.event",
+                    signingKeyId: Guid.NewGuid(), protectedSecret: "secret", createdAt: DateTimeOffset.UtcNow));
             await context.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 

--- a/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.Tests/InMemoryWebhookSubscriptionStoreTests.cs
@@ -285,45 +285,11 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
     }
 
     // -------------------------------------------------------------------------
-    // RotateSecretAsync
-    // -------------------------------------------------------------------------
-
-    [Fact]
-    public async Task RotateSecretAsync_ReturnsNewPlainSecret()
-    {
-        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
-        _store.Add(sub);
-
-        string newSecret = await _store.RotateSecretAsync(sub.Id, TestContext.Current.CancellationToken);
-
-        newSecret.ShouldStartWith("whsec_");
-    }
-
-    // -------------------------------------------------------------------------
     // RotateSigningKeyAsync — dual-key delivery model (FU-1a)
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task RotateSigningKeyAsync_OnLegacySubscription_AddsActiveKeyAndClearsLegacyField()
-    {
-        WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
-        _store.Add(sub);
-
-        WebhookSigningKeyRotatedResult result = await ((IWebhookSigningKeyWriter)_store)
-            .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
-
-        result.PlainSecret.ShouldStartWith("whsec_");
-        WebhookSubscription? updated = await _store.FindByIdAsync(sub.Id, TestContext.Current.CancellationToken);
-        updated.ShouldNotBeNull();
-        updated!.SigningKeys.Count.ShouldBe(1);
-        updated.SigningKeys[0].Status.ShouldBe(WebhookSigningKeyStatus.Active);
-#pragma warning disable CS0618 // Verifying back-compat behavior.
-        updated.SigningSecret.ShouldBeNull();
-#pragma warning restore CS0618
-    }
-
-    [Fact]
-    public async Task RotateSigningKeyAsync_TwoRotations_RetiresFirstKey()
+    public async Task RotateSigningKeyAsync_TwoRotations_RetiresPreviousActives()
     {
         WebhookSubscription sub = BuildSubscription("test.event", null, WebhookSubscriptionStatus.Active);
         _store.Add(sub);
@@ -334,8 +300,10 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         await ((IWebhookSigningKeyWriter)_store)
             .RotateSigningKeyAsync(sub.Id, retiredKeyGracePeriod: null, TestContext.Current.CancellationToken);
 
+        // Initial seeded key + 2 rotation keys = 3 total. Exactly one is Active;
+        // the other two are Retired with a grace-period ExpiresAt.
         WebhookSubscription? updated = await _store.FindByIdAsync(sub.Id, TestContext.Current.CancellationToken);
-        updated!.SigningKeys.Count.ShouldBe(2);
+        updated!.SigningKeys.Count.ShouldBe(3);
         updated.SigningKeys.Count(k => k.Status == WebhookSigningKeyStatus.Active).ShouldBe(1);
         WebhookSigningKey retired = updated.SigningKeys.Single(k => k.Id == first.KeyId);
         retired.Status.ShouldBe(WebhookSigningKeyStatus.Retired);
@@ -371,7 +339,8 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         IReadOnlyList<WebhookSigningKey> keys = await ((IWebhookSigningKeyReader)_store)
             .GetForSubscriptionAsync(sub.Id, TestContext.Current.CancellationToken);
 
-        keys.Count.ShouldBe(2);
+        // Initial seeded key + 2 rotation keys.
+        keys.Count.ShouldBe(3);
     }
 
     // -------------------------------------------------------------------------
@@ -399,7 +368,9 @@ public sealed class InMemoryWebhookSubscriptionStoreTests
         Guid? tenantId,
         WebhookSubscriptionStatus status)
     {
-        var sub = WebhookSubscription.Create(Guid.NewGuid(), "https://example.com/webhook", eventType, "protected-secret", tenantId);
+        var sub = WebhookSubscription.Create(
+            Guid.NewGuid(), "https://example.com/webhook", eventType,
+            signingKeyId: Guid.NewGuid(), protectedSecret: "protected-secret", createdAt: DateTimeOffset.UtcNow, tenantId: tenantId);
 
         switch (status)
         {

--- a/tests/Granit.Webhooks.Tests/RetryWebhookHandlerTests.cs
+++ b/tests/Granit.Webhooks.Tests/RetryWebhookHandlerTests.cs
@@ -220,7 +220,9 @@ public sealed class RetryWebhookHandlerTests
 
     private static WebhookSubscription BuildSubscription(Guid id, WebhookSubscriptionStatus status)
     {
-        var sub = WebhookSubscription.Create(id, "https://example.com/webhook", "test.event", "test-secret");
+        var sub = WebhookSubscription.Create(
+            id, "https://example.com/webhook", "test.event",
+            signingKeyId: Guid.NewGuid(), protectedSecret: "test-secret", createdAt: DateTimeOffset.UtcNow);
 
         switch (status)
         {

--- a/tests/Granit.Webhooks.Tests/SendWebhookHandlerTests.cs
+++ b/tests/Granit.Webhooks.Tests/SendWebhookHandlerTests.cs
@@ -59,7 +59,8 @@ public sealed class SendWebhookHandlerTests : IDisposable
 
         _subscriptionReader.FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(ci => WebhookSubscription.Create(
-                ci.ArgAt<Guid>(0), "https://example.com/webhook", "test.event", "test-secret"));
+                ci.ArgAt<Guid>(0), "https://example.com/webhook", "test.event",
+                signingKeyId: Guid.NewGuid(), protectedSecret: "test-secret", createdAt: DateTimeOffset.UtcNow));
     }
 
     public void Dispose()

--- a/tests/Granit.Webhooks.Tests/WebhookFanoutHandlerTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookFanoutHandlerTests.cs
@@ -169,5 +169,7 @@ public sealed class WebhookFanoutHandlerTests : IDisposable
     };
 
     private static WebhookSubscription BuildSubscription() =>
-        WebhookSubscription.Create(Guid.NewGuid(), "https://example.com/webhook", "test.event", "protected-secret");
+        WebhookSubscription.Create(
+            Guid.NewGuid(), "https://example.com/webhook", "test.event",
+            signingKeyId: Guid.NewGuid(), protectedSecret: "protected-secret", createdAt: DateTimeOffset.UtcNow);
 }

--- a/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSigningKeyTests.cs
@@ -2,8 +2,7 @@
 // Tests - WebhookSigningKey + WebhookSubscription dual-key delivery model (FU-1a)
 // =============================================================================
 // Verifies overlap rotation: previous Active key transitions to Retired, the new
-// Active key takes over, IsAcceptableAt rules, last-active revocation guard, and
-// legacy SigningSecret clearing on first rotation.
+// Active key takes over, IsAcceptableAt rules, and last-active revocation guard.
 // =============================================================================
 
 using Granit.Webhooks.Domain;
@@ -16,29 +15,6 @@ public sealed class WebhookSigningKeyTests
 {
     private static readonly DateTimeOffset Now = new(2026, 4, 1, 12, 0, 0, TimeSpan.Zero);
     private static readonly TimeSpan Grace = TimeSpan.FromHours(24);
-
-    [Fact]
-    public void RotateSigningKey_FromLegacySecret_AddsActiveKey_ClearsLegacyField()
-    {
-        WebhookSubscription subscription = LegacySubscription();
-
-#pragma warning disable CS0618 // Asserting legacy back-compat field is intentionally read.
-        subscription.SigningSecret.ShouldBe("legacy-protected");
-#pragma warning restore CS0618
-
-        subscription.RotateSigningKey(Guid.NewGuid(), "new-protected", Now, Grace);
-
-        subscription.SigningKeys.Count.ShouldBe(1);
-        WebhookSigningKey active = subscription.SigningKeys[0];
-        active.Status.ShouldBe(WebhookSigningKeyStatus.Active);
-        active.ProtectedSecret.ShouldBe("new-protected");
-        active.CreatedAt.ShouldBe(Now);
-        active.ExpiresAt.ShouldBeNull();
-
-#pragma warning disable CS0618 // Verifying the legacy field is cleared after first rotation.
-        subscription.SigningSecret.ShouldBeNull();
-#pragma warning restore CS0618
-    }
 
     [Fact]
     public void RotateSigningKey_RetiresPreviousActive_WithGracePeriod()
@@ -141,17 +117,10 @@ public sealed class WebhookSigningKeyTests
         // Architectural justification: the scanner (FU-1b) lives in the same assembly.
     }
 
-    private static WebhookSubscription LegacySubscription() =>
-        WebhookSubscription.Create(
-            Guid.NewGuid(),
-            "https://example.com/webhook",
-            "test.event",
-            "legacy-protected");
-
     private static WebhookSubscription WithSigningKey(out Guid initialKeyId)
     {
         initialKeyId = Guid.NewGuid();
-        return WebhookSubscription.CreateWithSigningKey(
+        return WebhookSubscription.Create(
             Guid.NewGuid(),
             "https://example.com/webhook",
             "test.event",

--- a/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
@@ -149,5 +149,7 @@ public sealed class WebhookSubscriptionTests
     }
 
     private static WebhookSubscription BuildSubscription() =>
-        WebhookSubscription.Create(Guid.NewGuid(), "https://example.com/webhook", "test.event", "protected-secret");
+        WebhookSubscription.Create(
+            Guid.NewGuid(), "https://example.com/webhook", "test.event",
+            signingKeyId: Guid.NewGuid(), protectedSecret: "protected-secret", createdAt: DateTimeOffset.UtcNow);
 }

--- a/tests/Granit.Webhooks.Tests/WebhookTestPingServiceTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookTestPingServiceTests.cs
@@ -60,7 +60,8 @@ public sealed class WebhookTestPingServiceTests : IDisposable
     private void SetupSubscription(string targetUrl = "https://example.com/webhook", string secret = "test-secret")
     {
         var subscription = WebhookSubscription.Create(
-            _subscriptionId, targetUrl, "webhook.test", secret);
+            _subscriptionId, targetUrl, "webhook.test",
+            signingKeyId: Guid.NewGuid(), protectedSecret: secret, createdAt: DateTimeOffset.UtcNow);
 
         _subscriptionReader.FindByIdAsync(_subscriptionId, Arg.Any<CancellationToken>())
             .Returns(subscription);


### PR DESCRIPTION
## Summary

Per CLAUDE.md \"no \`[Obsolete]\` graduation while pre-1.0\" — clean removal of the single-secret back-compat path that predated the dual-key delivery model (\`WebhookSigningKey\` aggregate).

## Domain (\`WebhookSubscription\`)

- Drop \`SigningSecret\` property + \`[Obsolete]\` + \`[NotMapped]\` + \`[SensitiveData]\`
- Drop \`RotateSecret(string)\` — \`RotateSigningKey\` is the only path
- Rename \`CreateWithSigningKey\` → \`Create\`. Old \`Create(legacy-secret)\` overload deleted. New signature: \`(id, url, eventType, signingKeyId, protectedSecret, createdAt, tenantId?)\`

## Surface (\`Granit.Webhooks.Endpoints\`)

- Drop \`POST /subscriptions/{id}/rotate-secret\` + handler + DTO \`WebhookSubscriptionRotateSecretResponse\`
- \`/signing-keys\` rotation route remains the supported path

## Abstractions / stores

- \`IWebhookSubscriptionWriter.RotateSecretAsync\` removed
- Both in-memory + EF Core stores drop the delegating wrapper

## Persistence

- \`WebhookSubscriptionConfiguration\` no longer maps \`SigningSecret\`. **Hosts must scaffold an EF Core migration that drops the legacy nullable column.**

## Resolver

- \`WebhookSecretResolver\` no longer falls back to \`SigningSecret\` — throws \`InvalidOperationException\` when no Active key (dead path: every subscription created through \`Create()\` ships with an initial Active key).

## Tests

- 9 \`WebhookSubscription.Create(...)\` call sites updated to the new shape (named args)
- Drop \`WebhookSigningKeyTests.RotateSigningKey_FromLegacySecret\` + \`LegacySubscription\` helper
- Drop \`InMemoryWebhookSubscriptionStoreTests.RotateSecretAsync\` section
- Rewrite two rotation-count assertions: 3 keys total (initial + 2 rotations) instead of 2
- Drop archi exemption for \`WebhookSubscription.SigningSecret\` (field gone)

## Test plan

- [x] \`Granit.Webhooks.Tests\` 194 / 194
- [x] \`Granit.Webhooks.EntityFrameworkCore.Tests\` 26 / 26
- [x] \`Granit.Webhooks.Endpoints.Tests\` 53 / 53
- [x] \`Granit.ArchitectureTests\` 178 / 178
- [ ] CI green

## Breaking

- Wire: \`POST /subscriptions/{id}/rotate-secret\` returns 404; \`WebhookSubscriptionCreatedResponse\` still carries \`signingSecret\` (plaintext, one-time) so the create flow is unchanged
- API: \`WebhookSubscription.Create(...)\` signature; \`IWebhookSubscriptionWriter.RotateSecretAsync\` removed
- DB schema: legacy \`signing_secret\` column needs a host-side migration drop

All clean pre-1.0 cuts.