### PR TITLE
feat(workspaces): feature catalog primitives (ADR-057 phase 1.a)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -44453,6 +44453,24 @@
       "members": []
     },
     {
+      "name": "FeatureBuilder",
+      "fqn": "Granit.Workspaces.FeatureBuilder",
+      "kind": "class",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/FeatureBuilder.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "FeatureDescriptor",
+      "fqn": "Granit.Workspaces.FeatureDescriptor",
+      "kind": "record",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/FeatureDescriptor.cs",
+      "line": 36,
+      "members": []
+    },
+    {
       "name": "FrameworkWorkspaceNames",
       "fqn": "Granit.Workspaces.Framework.FrameworkWorkspaceNames",
       "kind": "class",
@@ -44469,6 +44487,54 @@
       "file": "src/Granit.Workspaces.Abstractions/GranitWorkspacesAbstractionsModule.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "IFeatureCatalog",
+      "fqn": "Granit.Workspaces.IFeatureCatalog",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/IFeatureCatalog.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "IReadOnlyList<FeatureDescriptor> All { get; } FeatureDescriptor?"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureCatalogBuilder",
+      "fqn": "Granit.Workspaces.IFeatureCatalogBuilder",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/IFeatureCatalog.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(string name, Action<FeatureBuilder> configure)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureProvider",
+      "fqn": "Granit.Workspaces.IFeatureProvider",
+      "kind": "interface",
+      "project": "Granit.Workspaces.Abstractions",
+      "file": "src/Granit.Workspaces.Abstractions/IFeatureProvider.cs",
+      "line": 38,
+      "members": [
+        {
+          "name": "DefineFeatures",
+          "kind": "method",
+          "signature": "DefineFeatures(IFeatureCatalogBuilder catalog)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IWorkspaceContributionBuilder",
@@ -44576,7 +44642,7 @@
       "kind": "record",
       "project": "Granit.Workspaces.Abstractions",
       "file": "src/Granit.Workspaces.Abstractions/WorkspaceItemDescriptor.cs",
-      "line": 35,
+      "line": 44,
       "members": []
     },
     {

--- a/src/Granit.Workspaces.Abstractions/FeatureBuilder.cs
+++ b/src/Granit.Workspaces.Abstractions/FeatureBuilder.cs
@@ -1,0 +1,86 @@
+namespace Granit.Workspaces;
+
+/// <summary>
+/// Fluent builder used by <see cref="IFeatureProvider"/> implementations to
+/// describe a feature (per ADR-057). The builder collects the catalog entry
+/// fields and produces an immutable <see cref="FeatureDescriptor"/> at boot.
+/// </summary>
+public sealed class FeatureBuilder
+{
+    private readonly string _name;
+    private string? _permission;
+    private string? _routeName;
+    private string? _defaultIcon;
+    private string? _displayKey;
+
+    internal FeatureBuilder(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _name = name;
+    }
+
+    /// <summary>
+    /// Permission gate that controls feature visibility. The composer drops the
+    /// feature from the tree for users who don't hold it (ADR-040 §6).
+    /// </summary>
+    public FeatureBuilder Permission(string permission)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+        _permission = permission;
+        return this;
+    }
+
+    /// <summary>
+    /// Logical frontend route identifier (per ADR-057 §5). When omitted the
+    /// route name falls back to the feature name — the convention covers ~95 %
+    /// of cases.
+    /// </summary>
+    public FeatureBuilder RouteName(string routeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(routeName);
+        _routeName = routeName;
+        return this;
+    }
+
+    /// <summary>Default Lucide icon. Per-placement overrides win.</summary>
+    public FeatureBuilder DefaultIcon(string icon)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(icon);
+        _defaultIcon = icon;
+        return this;
+    }
+
+    /// <summary>
+    /// Localisation key for the feature label (e.g.
+    /// <c>"InvoicingEndpoints:Invoices.List"</c>). Mandatory in all 18 cultures.
+    /// </summary>
+    public FeatureBuilder DisplayKey(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        _displayKey = key;
+        return this;
+    }
+
+    internal FeatureDescriptor Build()
+    {
+        if (string.IsNullOrWhiteSpace(_permission))
+        {
+            throw new InvalidOperationException(
+                $"Feature '{_name}' must declare a permission via .Permission(...). " +
+                "Features without permissions are not supported (see ADR-057).");
+        }
+        if (string.IsNullOrWhiteSpace(_displayKey))
+        {
+            throw new InvalidOperationException(
+                $"Feature '{_name}' must declare a display key via .DisplayKey(...). " +
+                "Features without a label are not renderable.");
+        }
+
+        return new FeatureDescriptor(
+            _name,
+            _permission,
+            _routeName ?? _name,
+            _defaultIcon,
+            _displayKey);
+    }
+}

--- a/src/Granit.Workspaces.Abstractions/FeatureDescriptor.cs
+++ b/src/Granit.Workspaces.Abstractions/FeatureDescriptor.cs
@@ -1,0 +1,41 @@
+namespace Granit.Workspaces;
+
+/// <summary>
+/// Immutable description of a navigable feature exposed by a module
+/// (per ADR-057). A feature is a *capability* — a thing a user can do,
+/// gated by one permission, rendered behind one logical frontend route.
+/// Modules declare features via <see cref="IFeatureProvider"/>; hosts
+/// compose workspaces by referencing features through
+/// <c>WorkspaceSectionBuilder.Feature(name)</c>.
+/// </summary>
+/// <param name="Name">
+/// Globally unique wire identifier. Convention:
+/// <c>{module}.{entity-plural}.{view}</c> (kebab-case segments, dot-separated)
+/// e.g. <c>"invoicing.invoices.list"</c>, <c>"identity.users.detail"</c>.
+/// The composer rejects duplicates at boot.
+/// </param>
+/// <param name="Permission">
+/// Permission gate — the feature is filtered out of the workspace tree for
+/// users who don't hold it (defense in depth, ADR-040 §6). Must be a
+/// permission declared by some <c>IPermissionDefinitionProvider</c>.
+/// </param>
+/// <param name="RouteName">
+/// Logical frontend route identifier (per ADR-057 §5). The host's React
+/// route table maps this to an actual SPA path. Defaults to
+/// <see cref="Name"/> when convention holds; explicit override permits
+/// reusing the same feature on multiple paths (e.g. tenant vs. host shell).
+/// </param>
+/// <param name="DefaultIcon">
+/// Lucide icon name. Per-placement overrides on the workspace item win.
+/// </param>
+/// <param name="DisplayKey">
+/// Localisation key for the feature label (e.g.
+/// <c>"InvoicingEndpoints:Invoices.List"</c>). Mandatory in all 18 cultures
+/// (CLAUDE.md localisation rules).
+/// </param>
+public sealed record FeatureDescriptor(
+    string Name,
+    string Permission,
+    string RouteName,
+    string? DefaultIcon,
+    string DisplayKey);

--- a/src/Granit.Workspaces.Abstractions/IFeatureCatalog.cs
+++ b/src/Granit.Workspaces.Abstractions/IFeatureCatalog.cs
@@ -1,0 +1,41 @@
+namespace Granit.Workspaces;
+
+/// <summary>
+/// Registration-time builder passed to <see cref="IFeatureProvider"/> instances
+/// to declare features (per ADR-057). Modules add features via
+/// <see cref="Add(string, Action{FeatureBuilder})"/>; the host's composer
+/// freezes the collected entries into an immutable
+/// <see cref="IFeatureCatalog"/> after every provider has run.
+/// </summary>
+public interface IFeatureCatalogBuilder
+{
+    /// <summary>
+    /// Adds a feature to the catalog under the supplied wire name.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown at boot if another provider already declared a feature with the
+    /// same name — the framework requires globally unique feature names.
+    /// </exception>
+    void Add(string name, Action<FeatureBuilder> configure);
+}
+
+/// <summary>
+/// Immutable read-only view of the feature catalog (per ADR-057). The host's
+/// composer queries this after every <see cref="IFeatureProvider"/> has run,
+/// and resolves <see cref="WorkspaceItemKind.Feature"/> items against it.
+/// </summary>
+public interface IFeatureCatalog
+{
+    /// <summary>
+    /// All declared features, ordered by <see cref="FeatureDescriptor.Name"/>.
+    /// </summary>
+    IReadOnlyList<FeatureDescriptor> All { get; }
+
+    /// <summary>
+    /// Returns the feature with the supplied name, or <see langword="null"/>
+    /// when no provider declared it. Workspace composition that references a
+    /// missing feature fails fast at startup — runtime callers can rely on the
+    /// catalog being complete.
+    /// </summary>
+    FeatureDescriptor? Find(string name);
+}

--- a/src/Granit.Workspaces.Abstractions/IFeatureProvider.cs
+++ b/src/Granit.Workspaces.Abstractions/IFeatureProvider.cs
@@ -1,0 +1,44 @@
+namespace Granit.Workspaces;
+
+/// <summary>
+/// Module-supplied feature catalog contributor (per ADR-057). A
+/// <see cref="IWorkspaceContributor"/> declares *where* something appears in
+/// the UI; an <see cref="IFeatureProvider"/> declares *what exists* and
+/// nothing else (capability + permission + route name + display hints).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Provider implementations are registered in DI by the module's
+/// <c>GranitModule</c> via the <c>AddFeatureProvider&lt;T&gt;()</c> extension
+/// (see <c>Granit.Workspaces</c> runtime). The composer collects every
+/// registered provider once at boot, runs each <see cref="DefineFeatures"/>
+/// against a shared builder, and freezes the result into an immutable
+/// <see cref="IFeatureCatalog"/>.
+/// </para>
+/// <para>
+/// Provider order is irrelevant: feature names are required to be globally
+/// unique, and the catalog rejects duplicates regardless of order.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// internal sealed class InvoicingFeatureProvider : IFeatureProvider
+/// {
+///     public void DefineFeatures(IFeatureCatalogBuilder catalog)
+///     {
+///         catalog.Add("invoicing.invoices.list", f => f
+///             .Permission(InvoicingPermissions.Invoices.Read)
+///             .RouteName("invoicing.invoices.list")
+///             .DefaultIcon("receipt")
+///             .DisplayKey("InvoicingEndpoints:Invoices.List"));
+///     }
+/// }
+/// </code>
+/// </example>
+public interface IFeatureProvider
+{
+    /// <summary>
+    /// Declares every feature this module exposes. Called once at boot.
+    /// </summary>
+    void DefineFeatures(IFeatureCatalogBuilder catalog);
+}

--- a/src/Granit.Workspaces.Abstractions/WorkspaceItemBuilder.cs
+++ b/src/Granit.Workspaces.Abstractions/WorkspaceItemBuilder.cs
@@ -10,12 +10,14 @@ public sealed class WorkspaceItemBuilder
     private readonly string? _dashboardName;
     private readonly string? _linkUrl;
     private readonly string? _subWorkspaceName;
+    private readonly string? _featureName;
 
     private string? _entityViewName;
     private IReadOnlyDictionary<string, object?>? _entityPresetOverlay;
     private string? _displayKey;
     private string? _icon;
     private int _order;
+    private string? _routeName;
     private string? _requiresPermission;
 
     internal WorkspaceItemBuilder(
@@ -23,13 +25,15 @@ public sealed class WorkspaceItemBuilder
         string? entityName = null,
         string? dashboardName = null,
         string? linkUrl = null,
-        string? subWorkspaceName = null)
+        string? subWorkspaceName = null,
+        string? featureName = null)
     {
         _kind = kind;
         _entityName = entityName;
         _dashboardName = dashboardName;
         _linkUrl = linkUrl;
         _subWorkspaceName = subWorkspaceName;
+        _featureName = featureName;
     }
 
     /// <summary>i18n key for the item label.</summary>
@@ -90,6 +94,19 @@ public sealed class WorkspaceItemBuilder
         return this;
     }
 
+    /// <summary>
+    /// Overrides the route name resolved against the host's React route table
+    /// for a <see cref="WorkspaceItemKind.Feature"/> item (per ADR-057 §5).
+    /// When unset, the composer falls back to the feature's catalog-declared route name.
+    /// </summary>
+    public WorkspaceItemBuilder RouteName(string routeName)
+    {
+        EnsureKind(WorkspaceItemKind.Feature);
+        ArgumentException.ThrowIfNullOrWhiteSpace(routeName);
+        _routeName = routeName;
+        return this;
+    }
+
     internal WorkspaceItemDescriptor Build() =>
         new(
             _kind,
@@ -102,6 +119,8 @@ public sealed class WorkspaceItemBuilder
             _dashboardName,
             _linkUrl,
             _subWorkspaceName,
+            _featureName,
+            _routeName,
             _requiresPermission);
 
     private void EnsureKind(WorkspaceItemKind expected)

--- a/src/Granit.Workspaces.Abstractions/WorkspaceItemDescriptor.cs
+++ b/src/Granit.Workspaces.Abstractions/WorkspaceItemDescriptor.cs
@@ -16,6 +16,13 @@ public enum WorkspaceItemKind
 
     /// <summary>Sub-workspace — recurses into a child <see cref="WorkspaceDescriptor"/>.</summary>
     SubWorkspace,
+
+    /// <summary>
+    /// Reference to a feature declared in the <see cref="IFeatureCatalog"/> (per ADR-057).
+    /// The composer resolves the feature at filter time and emits a payload carrying the
+    /// feature's route name + display key + default icon, with optional per-placement overrides.
+    /// </summary>
+    Feature,
 }
 
 /// <summary>
@@ -31,7 +38,9 @@ public enum WorkspaceItemKind
 /// <param name="DashboardName">Wire identifier of the referenced <c>DashboardDefinition</c> when <see cref="Kind"/> is <see cref="WorkspaceItemKind.Dashboard"/>.</param>
 /// <param name="LinkUrl">Internal route or absolute URL when <see cref="Kind"/> is <see cref="WorkspaceItemKind.Link"/>.</param>
 /// <param name="SubWorkspaceName">Wire identifier of the referenced <see cref="WorkspaceDescriptor"/> when <see cref="Kind"/> is <see cref="WorkspaceItemKind.SubWorkspace"/>.</param>
-/// <param name="RequiresPermission">Optional permission gate — drops the item from the manifest payload when the user does not hold the permission. Defense-in-depth (ADR-040).</param>
+/// <param name="FeatureName">Wire identifier of the referenced feature (catalog entry) when <see cref="Kind"/> is <see cref="WorkspaceItemKind.Feature"/>. Composer resolves it at filter time and lifts the feature's metadata into the payload (per ADR-057).</param>
+/// <param name="RouteName">Logical frontend route identifier resolved against the host's React route table (per ADR-057 §5). Populated by the composer for <see cref="WorkspaceItemKind.Feature"/> items; <see langword="null"/> otherwise.</param>
+/// <param name="RequiresPermission">Optional permission gate — drops the item from the manifest payload when the user does not hold the permission. Defense in depth (ADR-040).</param>
 public sealed record WorkspaceItemDescriptor(
     WorkspaceItemKind Kind,
     int Order,
@@ -43,4 +52,6 @@ public sealed record WorkspaceItemDescriptor(
     string? DashboardName,
     string? LinkUrl,
     string? SubWorkspaceName,
+    string? FeatureName,
+    string? RouteName,
     string? RequiresPermission);

--- a/src/Granit.Workspaces.Abstractions/WorkspaceSectionBuilder.cs
+++ b/src/Granit.Workspaces.Abstractions/WorkspaceSectionBuilder.cs
@@ -94,6 +94,25 @@ public sealed class WorkspaceSectionBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a feature reference by catalog name (per ADR-057). The composer
+    /// resolves the feature at filter time, lifting the feature's permission,
+    /// route name, display key, and default icon into the payload. The optional
+    /// <paramref name="configure"/> callback applies per-placement overrides
+    /// (icon, order, route name, displayed-as label) without mutating the
+    /// catalog entry. The feature must be declared by an
+    /// <see cref="IFeatureProvider"/> registered at boot time; missing features
+    /// cause startup to fail fast (no silent drop).
+    /// </summary>
+    public WorkspaceSectionBuilder Feature(string featureName, Action<WorkspaceItemBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(featureName);
+        WorkspaceItemBuilder builder = new(WorkspaceItemKind.Feature, featureName: featureName);
+        configure?.Invoke(builder);
+        _itemFactories.Add(builder.Build);
+        return this;
+    }
+
     internal WorkspaceSectionDescriptor Build()
     {
         IReadOnlyList<WorkspaceItemDescriptor> items =

--- a/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
+++ b/tests/Granit.Workspaces.Abstractions.Tests/WorkspaceBuilderTests.cs
@@ -50,6 +50,25 @@ public sealed class WorkspaceBuilderTests
         Should.Throw<InvalidOperationException>(() => new InvalidViewOnLink().Descriptor);
     }
 
+    [Fact]
+    public void Feature_item_carries_feature_name_and_optional_route_override()
+    {
+        FeatureDefinition def = new();
+        WorkspaceItemDescriptor item = def.Descriptor.Sections.Single().Items.Single();
+
+        item.Kind.ShouldBe(WorkspaceItemKind.Feature);
+        item.FeatureName.ShouldBe("invoicing.invoices.list");
+        item.RouteName.ShouldBe("invoicing.invoices.list.tenant-view");
+        item.DisplayKey.ShouldBe("Showcase:Workspace.Erp.InvoiceList");
+        item.Icon.ShouldBe("chart-bar");
+    }
+
+    [Fact]
+    public void RouteName_can_only_be_called_on_feature_items()
+    {
+        Should.Throw<InvalidOperationException>(() => new InvalidRouteNameOnLink().Descriptor);
+    }
+
     private sealed class SampleDefinition : WorkspaceDefinition
     {
         public override string Name => "Sample";
@@ -87,5 +106,77 @@ public sealed class WorkspaceBuilderTests
 
         protected override void Configure(WorkspaceBuilder b) =>
             b.Section("s", s => s.Link("/x", i => i.View("any")));
+    }
+
+    private sealed class FeatureDefinition : WorkspaceDefinition
+    {
+        public override string Name => "Showcase.Erp";
+
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("billing", s => s
+                .Feature("invoicing.invoices.list", i => i
+                    .DisplayKey("Showcase:Workspace.Erp.InvoiceList")
+                    .Icon("chart-bar")
+                    .RouteName("invoicing.invoices.list.tenant-view")));
+    }
+
+    private sealed class InvalidRouteNameOnLink : WorkspaceDefinition
+    {
+        public override string Name => "Invalid";
+
+        protected override void Configure(WorkspaceBuilder b) =>
+            b.Section("s", s => s.Link("/x", i => i.RouteName("any.route")));
+    }
+}
+
+public sealed class FeatureBuilderTests
+{
+    [Fact]
+    public void Build_assembles_a_descriptor()
+    {
+        FeatureBuilder builder = new("invoicing.invoices.list");
+        builder
+            .Permission("Invoicing.Invoices.Read")
+            .RouteName("invoicing.invoices.list")
+            .DefaultIcon("receipt")
+            .DisplayKey("InvoicingEndpoints:Invoices.List");
+
+        FeatureDescriptor descriptor = builder.Build();
+
+        descriptor.Name.ShouldBe("invoicing.invoices.list");
+        descriptor.Permission.ShouldBe("Invoicing.Invoices.Read");
+        descriptor.RouteName.ShouldBe("invoicing.invoices.list");
+        descriptor.DefaultIcon.ShouldBe("receipt");
+        descriptor.DisplayKey.ShouldBe("InvoicingEndpoints:Invoices.List");
+    }
+
+    [Fact]
+    public void RouteName_defaults_to_feature_name_when_omitted()
+    {
+        FeatureBuilder builder = new("identity.users.list");
+        builder
+            .Permission("Identity.Users.Read")
+            .DisplayKey("IdentityEndpoints:Users.List");
+
+        FeatureDescriptor descriptor = builder.Build();
+        descriptor.RouteName.ShouldBe("identity.users.list");
+    }
+
+    [Fact]
+    public void Build_throws_when_permission_missing()
+    {
+        FeatureBuilder builder = new("x.y.z");
+        builder.DisplayKey("X:Y.Z");
+        Should.Throw<InvalidOperationException>(() => builder.Build())
+            .Message.ShouldContain("permission");
+    }
+
+    [Fact]
+    public void Build_throws_when_display_key_missing()
+    {
+        FeatureBuilder builder = new("x.y.z");
+        builder.Permission("X.Y.Read");
+        Should.Throw<InvalidOperationException>(() => builder.Build())
+            .Message.ShouldContain("display key");
     }
 }


### PR DESCRIPTION
## Summary

First MR of [ADR-057](https://github.com/granit-fx/granit-docs/pull/37) phase 1: **contracts only**. Introduces the type surface that lets:

- modules expose **features** (capability + permission + route name + display hints, **zero placement**)
- host applications **reference** features when composing workspaces

Pure additive. `IWorkspaceContributor`, `Link()`, `Entity()`, `Dashboard()`, `SubWorkspace()` keep working unchanged.

## What ships

New types in `Granit.Workspaces.Abstractions`:

| Type | Role |
|---|---|
| `FeatureDescriptor` | Immutable catalog entry: name, permission, route name, default icon, display key |
| `FeatureBuilder` | Fluent registration-time builder. Validates permission + display key, defaults route name to feature name |
| `IFeatureCatalogBuilder` | Registration surface passed to `IFeatureProvider` implementations |
| `IFeatureCatalog` | Frozen read-only runtime view |
| `IFeatureProvider` | Module-supplied catalog contributor, sibling of `IPermissionDefinitionProvider` |

Extensions to existing types:

- `WorkspaceItemKind.Feature` enum value
- `WorkspaceItemDescriptor` gains `FeatureName` + `RouteName` fields
- `WorkspaceSectionBuilder.Feature(name, configure?)` for host-side composition
- `WorkspaceItemBuilder.RouteName(...)` per-placement override (rare; reuse the same feature on different paths between e.g. tenant and host shells)

## What does NOT ship in this MR

- Runtime catalog implementation (collects providers at boot, freezes catalog) — granit-business, phase 1.b
- Composer resolution of `Feature` items at filter time — granit-business, phase 1.b
- `IncludeWorkspacesMatching(predicate)` dynamic SubWorkspace expansion — granit-business, phase 1.b
- Frontend `Feature` kind support — granit-front, phase 4

## Why ship contracts alone

Module authors who want to start drafting their `*FeatureProvider` can do so as soon as this lands, in parallel with the runtime work landing in granit-business. The contracts also unblock typing and tooling on the route-names side (granit-front).

## Test plan

- [x] `Granit.Workspaces.Abstractions.Tests` — 10/10 green (4 new tests + 6 existing)
- [x] Sample downstream consumer builds clean (`Granit.Identity.Endpoints`)
- [ ] CI shards green

## Refs

- ADR-057 (proposed): granit-docs PR #37
- Supersedes (partial): ADR-044 §3, ADR-045 §2 (workspace contributor specialisation only)