### PR TITLE
feat(diagnostics): pilot FeatureProvider migration (ADR-057 phase 3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13915,6 +13915,15 @@
       "members": []
     },
     {
+      "name": "DiagnosticsFeatures",
+      "fqn": "Granit.Diagnostics.Endpoints.Workspaces.DiagnosticsFeatures",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsFeatures.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "DiagnosticsEndpointRouteBuilderExtensions",
       "fqn": "Granit.Diagnostics.Extensions.DiagnosticsEndpointRouteBuilderExtensions",
       "kind": "class",

--- a/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
+++ b/src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs
@@ -21,6 +21,9 @@ namespace Granit.Diagnostics.Endpoints;
 public sealed class GranitDiagnosticsEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<DiagnosticsWorkspaceContribution>();
+        context.Services.AddFeatureProvider<DiagnosticsFeatureProvider>();
+    }
 }

--- a/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsFeatureProvider.cs
+++ b/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsFeatureProvider.cs
@@ -1,0 +1,29 @@
+using Granit.Diagnostics.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Diagnostics.Endpoints.Workspaces;
+
+/// <summary>
+/// Declares the diagnostics module's features for the host's workspace
+/// composition (per ADR-057). One feature today — the aggregated health
+/// dashboard reachable at <c>/diagnostics</c> — gated by
+/// <see cref="DiagnosticsPermissions.Monitoring"/>. A host that wants the
+/// dashboard in its admin UI references this feature by name when
+/// composing its workspace tree (e.g. <c>section.Feature(DiagnosticsFeatures.Monitoring)</c>).
+/// </summary>
+/// <remarks>
+/// Ships alongside the legacy <see cref="DiagnosticsWorkspaceContribution"/>
+/// during the phase 3 migration window — both surfaces work, both produce
+/// the same UI entry. Defaults bundles (phase 2) consume the feature; the
+/// legacy contribution is removed in phase 5.
+/// </remarks>
+internal sealed class DiagnosticsFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(DiagnosticsFeatures.Monitoring, f => f
+            .Permission(DiagnosticsPermissions.Monitoring.Read)
+            .RouteName(DiagnosticsFeatures.Monitoring)
+            .DefaultIcon("heart-pulse")
+            .DisplayKey("DiagnosticsEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsFeatures.cs
+++ b/src/Granit.Diagnostics.Endpoints/Workspaces/DiagnosticsFeatures.cs
@@ -1,0 +1,14 @@
+namespace Granit.Diagnostics.Endpoints.Workspaces;
+
+/// <summary>
+/// Feature name constants for the diagnostics module (per ADR-057).
+/// Mirrors the <c>XxxPermissions</c> pattern: hosts compose workspaces
+/// with <c>section.Feature(DiagnosticsFeatures.Monitoring)</c> rather
+/// than typing the string by hand, so a rename is a compile-time fix
+/// instead of a silent drop at boot.
+/// </summary>
+public static class DiagnosticsFeatures
+{
+    /// <summary>Aggregated health dashboard — pairs with <c>/diagnostics</c> on the React shell.</summary>
+    public const string Monitoring = "diagnostics.monitoring";
+}

--- a/src/Granit.Workspaces.Abstractions/Extensions/WorkspaceServiceCollectionExtensions.cs
+++ b/src/Granit.Workspaces.Abstractions/Extensions/WorkspaceServiceCollectionExtensions.cs
@@ -36,4 +36,18 @@ public static class WorkspaceServiceCollectionExtensions
         services.AddSingleton<IWorkspaceContributor, TContributor>();
         return services;
     }
+
+    /// <summary>
+    /// Registers <typeparamref name="TProvider"/> as a singleton implementing
+    /// <see cref="IFeatureProvider"/> (per ADR-057). Every registered provider
+    /// is invoked once when the <see cref="IFeatureCatalog"/> is first
+    /// resolved; the result is frozen for the lifetime of the host.
+    /// </summary>
+    public static IServiceCollection AddFeatureProvider<TProvider>(this IServiceCollection services)
+        where TProvider : class, IFeatureProvider
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<IFeatureProvider, TProvider>();
+        return services;
+    }
 }

--- a/src/Granit.Workspaces.Abstractions/FeatureBuilder.cs
+++ b/src/Granit.Workspaces.Abstractions/FeatureBuilder.cs
@@ -13,7 +13,13 @@ public sealed class FeatureBuilder
     private string? _defaultIcon;
     private string? _displayKey;
 
-    internal FeatureBuilder(string name)
+    /// <summary>
+    /// Constructs a new builder for the supplied feature name. Public so
+    /// tests and tooling can capture provider invocations without going
+    /// through <see cref="IFeatureCatalogBuilder"/>; production code rarely
+    /// needs to instantiate one directly.
+    /// </summary>
+    public FeatureBuilder(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         _name = name;
@@ -61,7 +67,12 @@ public sealed class FeatureBuilder
         return this;
     }
 
-    internal FeatureDescriptor Build()
+    /// <summary>
+    /// Materialises the configured fields into an immutable
+    /// <see cref="FeatureDescriptor"/>. Throws when permission or display key
+    /// are missing — those two are non-optional per the framework convention.
+    /// </summary>
+    public FeatureDescriptor Build()
     {
         if (string.IsNullOrWhiteSpace(_permission))
         {

--- a/tests/Granit.Diagnostics.Endpoints.Tests/DiagnosticsFeatureProviderTests.cs
+++ b/tests/Granit.Diagnostics.Endpoints.Tests/DiagnosticsFeatureProviderTests.cs
@@ -1,0 +1,40 @@
+using Granit.Diagnostics.Endpoints.Permissions;
+using Granit.Diagnostics.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Diagnostics.Endpoints.Tests;
+
+public sealed class DiagnosticsFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_monitoring_feature_with_expected_metadata()
+    {
+        FakeFeatureCatalogBuilder catalog = new();
+        DiagnosticsFeatureProvider provider = new();
+
+        provider.DefineFeatures(catalog);
+
+        FeatureDescriptor feature = catalog.Single(DiagnosticsFeatures.Monitoring);
+        feature.Name.ShouldBe(DiagnosticsFeatures.Monitoring);
+        feature.Permission.ShouldBe(DiagnosticsPermissions.Monitoring.Read);
+        feature.RouteName.ShouldBe(DiagnosticsFeatures.Monitoring);
+        feature.DefaultIcon.ShouldBe("heart-pulse");
+        feature.DisplayKey.ShouldBe("DiagnosticsEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeFeatureCatalogBuilder : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder builder = new(name);
+            configure(builder);
+            _byName.Add(name, builder.Build());
+        }
+
+        public FeatureDescriptor Single(string name) => _byName[name];
+    }
+}


### PR DESCRIPTION
## Summary

First module to migrate to the feature-catalog pattern (per [ADR-057](https://github.com/granit-fx/granit-docs/pull/37)). **`Granit.Diagnostics.Endpoints`** is the simplest `*.Endpoints` module — a single endpoint, a single permission, a single workspace entry — making it the natural pilot for the migration recipe.

## What ships

- **`DiagnosticsFeatures`** — public string constants (mirrors the `DiagnosticsPermissions` pattern). Hosts compose with `section.Feature(DiagnosticsFeatures.Monitoring)` so renames are compile-time fixes.
- **`DiagnosticsFeatureProvider`** (internal `IFeatureProvider`) — declares the monitoring feature: permission, route name, default icon, display key.
- Module wires **both** the legacy `AddWorkspaceContribution<>` and the new `AddFeatureProvider<>` — additive, no behaviour change.

`WorkspaceServiceCollectionExtensions` gains `AddFeatureProvider<T>()` — sync with the granit-business runtime extension that already shipped via the abstraction sync.

`FeatureBuilder` ctor + `Build()` widened from internal → public so module test projects can capture provider invocations without `InternalsVisibleTo` leaks. Production code still prefers `IFeatureCatalogBuilder.Add(name, configure)` as the entry point.

## Migration recipe for the remaining ~20 modules

This MR establishes the pattern:

1. **`<Module>Features.cs`** — public string constants
2. **`<Module>FeatureProvider : IFeatureProvider`** — one `.Add` per feature, mapping to existing permissions
3. **Register both** legacy contribution + new provider in `ConfigureServices` (additive)
4. **Test** the provider with a fake `IFeatureCatalogBuilder`

Module-by-module migration can now parallelise across owners.

## Tests

- 10/10 green (1 new + 9 existing). New test verifies the provider populates the catalog with the expected metadata.

## What this does NOT do

- Remove the legacy `DiagnosticsWorkspaceContribution` — kept for now, will be deleted in phase 5 when all consumers have migrated
- Wire the feature into a workspace — that needs a `*.Defaults` bundle from phase 2 (or a host that opts in explicitly). The feature catalog will contain the entry; no workspace will reference it yet, so no UI changes until phase 2 lands

## Refs

- ADR-057 §1, phase 3 — granit-docs PR #37
- Builds on phase 1 contracts (#2096, merged)