### PR TITLE
feat(workspaces): migrate IdentityAccess modules to FeatureProvider (ADR-057 phase 3)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -5212,6 +5212,15 @@
       "members": []
     },
     {
+      "name": "ApiKeysFeatures",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Workspaces.ApiKeysFeatures",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysFeatures.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
       "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions.ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
       "kind": "class",
@@ -6875,6 +6884,15 @@
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
       "line": 19,
+      "members": []
+    },
+    {
+      "name": "AuthorizationFeatures",
+      "fqn": "Granit.Authorization.Endpoints.Workspaces.AuthorizationFeatures",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Workspaces/AuthorizationFeatures.cs",
+      "line": 6,
       "members": []
     },
     {
@@ -20058,6 +20076,15 @@
       "members": []
     },
     {
+      "name": "IdentityFeatures",
+      "fqn": "Granit.Identity.Endpoints.Workspaces.IdentityFeatures",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Workspaces/IdentityFeatures.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "UserEntityDefinition",
       "fqn": "Granit.Identity.Entities.UserEntityDefinition",
       "kind": "class",
@@ -30823,6 +30850,15 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "OpenIddictFeatures",
+      "fqn": "Granit.OpenIddict.Endpoints.Workspaces.OpenIddictFeatures",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictFeatures.cs",
+      "line": 6,
+      "members": []
     },
     {
       "name": "GranitOpenIddictApplicationEntityDefinition",

--- a/src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs
@@ -21,6 +21,9 @@ namespace Granit.Authentication.ApiKeys.Endpoints;
 public sealed class GranitAuthenticationApiKeysEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<ApiKeysWorkspaceContribution>();
+        context.Services.AddFeatureProvider<ApiKeysFeatureProvider>();
+    }
 }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysFeatureProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysFeatureProvider.cs
@@ -1,0 +1,20 @@
+using Granit.Authentication.ApiKeys.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Authentication.ApiKeys.Endpoints.Workspaces;
+
+/// <summary>
+/// Declares the API-keys module's features for the host's workspace
+/// composition (per ADR-057). One feature: the API-keys management
+/// dashboard, gated by <see cref="ApiKeyPermissions.Keys.Read"/>.
+/// </summary>
+internal sealed class ApiKeysFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(ApiKeysFeatures.Keys, f => f
+            .Permission(ApiKeyPermissions.Keys.Read)
+            .RouteName(ApiKeysFeatures.Keys)
+            .DefaultIcon("key-round")
+            .DisplayKey("AuthenticationApiKeysEndpoints:Workspace.Item"));
+}

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysFeatures.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Workspaces/ApiKeysFeatures.cs
@@ -1,0 +1,10 @@
+namespace Granit.Authentication.ApiKeys.Endpoints.Workspaces;
+
+/// <summary>
+/// Feature name constants for the API-keys module (per ADR-057).
+/// </summary>
+public static class ApiKeysFeatures
+{
+    /// <summary>API-keys list — paired with <c>/api-keys</c> on the React shell.</summary>
+    public const string Keys = "authentication.api-keys";
+}

--- a/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
+++ b/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
@@ -28,6 +28,9 @@ namespace Granit.Authorization.Endpoints;
 public sealed class GranitAuthorizationEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<AuthorizationWorkspaceContribution>();
+        context.Services.AddFeatureProvider<AuthorizationFeatureProvider>();
+    }
 }

--- a/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationFeatureProvider.cs
+++ b/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationFeatureProvider.cs
@@ -1,0 +1,20 @@
+using Granit.Authorization.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Authorization.Endpoints.Workspaces;
+
+/// <summary>
+/// Declares the authorization module's features (per ADR-057). One feature
+/// today — the permission definitions browser, gated by
+/// <see cref="AuthorizationEndpointsPermissions.Definitions.Read"/>.
+/// </summary>
+internal sealed class AuthorizationFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog) =>
+        catalog.Add(AuthorizationFeatures.Permissions, f => f
+            .Permission(AuthorizationEndpointsPermissions.Definitions.Read)
+            .RouteName(AuthorizationFeatures.Permissions)
+            .DefaultIcon("key")
+            .DisplayKey("AuthorizationEndpoints:Workspace.Definitions"));
+}

--- a/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationFeatures.cs
+++ b/src/Granit.Authorization.Endpoints/Workspaces/AuthorizationFeatures.cs
@@ -1,0 +1,10 @@
+namespace Granit.Authorization.Endpoints.Workspaces;
+
+/// <summary>
+/// Feature name constants for the authorization module (per ADR-057).
+/// </summary>
+public static class AuthorizationFeatures
+{
+    /// <summary>Permission definitions browser — paired with <c>/authorization/permissions</c>.</summary>
+    public const string Permissions = "authorization.permissions";
+}

--- a/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
+++ b/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
@@ -33,6 +33,9 @@ namespace Granit.Identity.Endpoints;
 public sealed class GranitIdentityEndpointsModule : GranitModule
 {
     /// <inheritdoc />
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.AddWorkspaceContribution<IdentityWorkspaceContribution>();
+        context.Services.AddFeatureProvider<IdentityFeatureProvider>();
+    }
 }

--- a/src/Granit.Identity.Endpoints/Workspaces/IdentityFeatureProvider.cs
+++ b/src/Granit.Identity.Endpoints/Workspaces/IdentityFeatureProvider.cs
@@ -1,0 +1,47 @@
+using Granit.Identity.Endpoints.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.Identity.Endpoints.Workspaces;
+
+/// <summary>
+/// Declares the identity module's features for the host's workspace
+/// composition (per ADR-057). Four features: users, roles, groups, sessions —
+/// each gated by its existing <see cref="IdentityPermissions"/> entry.
+/// </summary>
+/// <remarks>
+/// Ships alongside the legacy <see cref="IdentityWorkspaceContribution"/>
+/// during the phase 3 migration window. Default placement on the
+/// <c>Granit.Framework.IdentityAccess</c> shell is provided by the
+/// framework Defaults bundle (phase 2); the legacy contribution is
+/// removed in phase 5.
+/// </remarks>
+internal sealed class IdentityFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(IdentityFeatures.Users, f => f
+            .Permission(IdentityPermissions.Users.Read)
+            .RouteName(IdentityFeatures.Users)
+            .DefaultIcon("users-round")
+            .DisplayKey("IdentityEndpoints:Workspace.Users"));
+
+        catalog.Add(IdentityFeatures.Roles, f => f
+            .Permission(IdentityPermissions.Roles.Read)
+            .RouteName(IdentityFeatures.Roles)
+            .DefaultIcon("shield-user")
+            .DisplayKey("IdentityEndpoints:Workspace.Roles"));
+
+        catalog.Add(IdentityFeatures.Groups, f => f
+            .Permission(IdentityPermissions.Groups.Read)
+            .RouteName(IdentityFeatures.Groups)
+            .DefaultIcon("users")
+            .DisplayKey("IdentityEndpoints:Workspace.Groups"));
+
+        catalog.Add(IdentityFeatures.Sessions, f => f
+            .Permission(IdentityPermissions.Sessions.Read)
+            .RouteName(IdentityFeatures.Sessions)
+            .DefaultIcon("monitor-smartphone")
+            .DisplayKey("IdentityEndpoints:Workspace.Sessions"));
+    }
+}

--- a/src/Granit.Identity.Endpoints/Workspaces/IdentityFeatures.cs
+++ b/src/Granit.Identity.Endpoints/Workspaces/IdentityFeatures.cs
@@ -1,0 +1,22 @@
+namespace Granit.Identity.Endpoints.Workspaces;
+
+/// <summary>
+/// Feature name constants for the identity module (per ADR-057).
+/// Mirrors the <see cref="Permissions.IdentityPermissions"/> pattern so
+/// hosts compose with <c>section.Feature(IdentityFeatures.Users)</c>
+/// instead of typing the string by hand.
+/// </summary>
+public static class IdentityFeatures
+{
+    /// <summary>Users list — paired with <c>/identity/users</c> on the React shell.</summary>
+    public const string Users = "identity.users";
+
+    /// <summary>Roles list — paired with <c>/identity/roles</c>.</summary>
+    public const string Roles = "identity.roles";
+
+    /// <summary>Groups list — paired with <c>/identity/groups</c>.</summary>
+    public const string Groups = "identity.groups";
+
+    /// <summary>Sessions list — paired with <c>/identity/sessions</c>.</summary>
+    public const string Sessions = "identity.sessions";
+}

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -42,5 +42,6 @@ public sealed class GranitOpenIddictEndpointsModule : GranitModule
     {
         context.Services.TryAddScoped<OidcPrincipalFactory>();
         context.Services.AddWorkspaceContribution<OpenIddictWorkspaceContribution>();
+        context.Services.AddFeatureProvider<OpenIddictFeatureProvider>();
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictFeatureProvider.cs
+++ b/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictFeatureProvider.cs
@@ -1,0 +1,34 @@
+using Granit.OpenIddict.Permissions;
+using Granit.Workspaces;
+
+namespace Granit.OpenIddict.Endpoints.Workspaces;
+
+/// <summary>
+/// Declares the OpenIddict (OIDC) module's features (per ADR-057). Three
+/// features — applications, scopes, authorizations — each gated by its
+/// existing <see cref="OpenIddictPermissions"/> entry.
+/// </summary>
+internal sealed class OpenIddictFeatureProvider : IFeatureProvider
+{
+    /// <inheritdoc />
+    public void DefineFeatures(IFeatureCatalogBuilder catalog)
+    {
+        catalog.Add(OpenIddictFeatures.Applications, f => f
+            .Permission(OpenIddictPermissions.Applications.Read)
+            .RouteName(OpenIddictFeatures.Applications)
+            .DefaultIcon("app-window")
+            .DisplayKey("OpenIddictEndpoints:Workspace.Applications"));
+
+        catalog.Add(OpenIddictFeatures.Scopes, f => f
+            .Permission(OpenIddictPermissions.Scopes.Read)
+            .RouteName(OpenIddictFeatures.Scopes)
+            .DefaultIcon("scan")
+            .DisplayKey("OpenIddictEndpoints:Workspace.Scopes"));
+
+        catalog.Add(OpenIddictFeatures.Authorizations, f => f
+            .Permission(OpenIddictPermissions.Authorizations.Read)
+            .RouteName(OpenIddictFeatures.Authorizations)
+            .DefaultIcon("badge-check")
+            .DisplayKey("OpenIddictEndpoints:Workspace.Authorizations"));
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictFeatures.cs
+++ b/src/Granit.OpenIddict.Endpoints/Workspaces/OpenIddictFeatures.cs
@@ -1,0 +1,16 @@
+namespace Granit.OpenIddict.Endpoints.Workspaces;
+
+/// <summary>
+/// Feature name constants for the OpenIddict (OIDC) module (per ADR-057).
+/// </summary>
+public static class OpenIddictFeatures
+{
+    /// <summary>OIDC applications list — paired with <c>/oidc/applications</c>.</summary>
+    public const string Applications = "openiddict.applications";
+
+    /// <summary>OIDC scopes list — paired with <c>/oidc/scopes</c>.</summary>
+    public const string Scopes = "openiddict.scopes";
+
+    /// <summary>OIDC authorizations list — paired with <c>/oidc/authorizations</c>.</summary>
+    public const string Authorizations = "openiddict.authorizations";
+}

--- a/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/ApiKeysFeatureProviderTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/ApiKeysFeatureProviderTests.cs
@@ -1,0 +1,35 @@
+using Granit.Authentication.ApiKeys.Endpoints.Permissions;
+using Granit.Authentication.ApiKeys.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.ApiKeys.Endpoints.Tests;
+
+public sealed class ApiKeysFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_keys_feature()
+    {
+        FakeCatalog catalog = new();
+        new ApiKeysFeatureProvider().DefineFeatures(catalog);
+
+        FeatureDescriptor keys = catalog.Get(ApiKeysFeatures.Keys);
+        keys.Permission.ShouldBe(ApiKeyPermissions.Keys.Read);
+        keys.RouteName.ShouldBe(ApiKeysFeatures.Keys);
+        keys.DefaultIcon.ShouldBe("key-round");
+        keys.DisplayKey.ShouldBe("AuthenticationApiKeysEndpoints:Workspace.Item");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Authorization.Endpoints.Tests/AuthorizationFeatureProviderTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/AuthorizationFeatureProviderTests.cs
@@ -1,0 +1,35 @@
+using Granit.Authorization.Endpoints.Permissions;
+using Granit.Authorization.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Endpoints.Tests;
+
+public sealed class AuthorizationFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_permissions_feature()
+    {
+        FakeCatalog catalog = new();
+        new AuthorizationFeatureProvider().DefineFeatures(catalog);
+
+        FeatureDescriptor permissions = catalog.Get(AuthorizationFeatures.Permissions);
+        permissions.Permission.ShouldBe(AuthorizationEndpointsPermissions.Definitions.Read);
+        permissions.RouteName.ShouldBe(AuthorizationFeatures.Permissions);
+        permissions.DefaultIcon.ShouldBe("key");
+        permissions.DisplayKey.ShouldBe("AuthorizationEndpoints:Workspace.Definitions");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityFeatureProviderTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityFeatureProviderTests.cs
@@ -1,0 +1,38 @@
+using Granit.Identity.Endpoints.Permissions;
+using Granit.Identity.Endpoints.Workspaces;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Endpoints.Tests;
+
+public sealed class IdentityFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_users_roles_groups_sessions()
+    {
+        FakeCatalog catalog = new();
+        new IdentityFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(IdentityFeatures.Users).Permission.ShouldBe(IdentityPermissions.Users.Read);
+        catalog.Get(IdentityFeatures.Roles).Permission.ShouldBe(IdentityPermissions.Roles.Read);
+        catalog.Get(IdentityFeatures.Groups).Permission.ShouldBe(IdentityPermissions.Groups.Read);
+        catalog.Get(IdentityFeatures.Sessions).Permission.ShouldBe(IdentityPermissions.Sessions.Read);
+
+        catalog.Get(IdentityFeatures.Users).RouteName.ShouldBe(IdentityFeatures.Users);
+        catalog.Get(IdentityFeatures.Users).DefaultIcon.ShouldBe("users-round");
+        catalog.Get(IdentityFeatures.Users).DisplayKey.ShouldBe("IdentityEndpoints:Workspace.Users");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/OpenIddictFeatureProviderTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/OpenIddictFeatureProviderTests.cs
@@ -1,0 +1,37 @@
+using Granit.OpenIddict.Endpoints.Workspaces;
+using Granit.OpenIddict.Permissions;
+using Granit.Workspaces;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests;
+
+public sealed class OpenIddictFeatureProviderTests
+{
+    [Fact]
+    public void DefineFeatures_registers_applications_scopes_authorizations()
+    {
+        FakeCatalog catalog = new();
+        new OpenIddictFeatureProvider().DefineFeatures(catalog);
+
+        catalog.Get(OpenIddictFeatures.Applications).Permission.ShouldBe(OpenIddictPermissions.Applications.Read);
+        catalog.Get(OpenIddictFeatures.Scopes).Permission.ShouldBe(OpenIddictPermissions.Scopes.Read);
+        catalog.Get(OpenIddictFeatures.Authorizations).Permission.ShouldBe(OpenIddictPermissions.Authorizations.Read);
+
+        catalog.Get(OpenIddictFeatures.Applications).DefaultIcon.ShouldBe("app-window");
+        catalog.Get(OpenIddictFeatures.Scopes).DefaultIcon.ShouldBe("scan");
+        catalog.Get(OpenIddictFeatures.Authorizations).DefaultIcon.ShouldBe("badge-check");
+    }
+
+    private sealed class FakeCatalog : IFeatureCatalogBuilder
+    {
+        private readonly Dictionary<string, FeatureDescriptor> _byName = new(StringComparer.Ordinal);
+        public void Add(string name, Action<FeatureBuilder> configure)
+        {
+            FeatureBuilder b = new(name);
+            configure(b);
+            _byName.Add(name, b.Build());
+        }
+        public FeatureDescriptor Get(string name) => _byName[name];
+    }
+}


### PR DESCRIPTION
## Summary

**Batch migration** of the four IdentityAccess modules to the feature-catalog pattern (per [ADR-057](https://github.com/granit-fx/granit-docs/pull/37) phase 3), following the [Diagnostics pilot](https://github.com/granit-fx/granit-dotnet/pull/2097). Additive — each module continues to ship its legacy \`WorkspaceContribution\` alongside the new \`FeatureProvider\`; the contribution is removed in phase 5.

## Features migrated (9 total)

| Module | Feature | Permission | Icon |
|---|---|---|---|
| Granit.Identity.Endpoints | \`identity.users\` | \`Identity.Users.Read\` | \`users-round\` |
| Granit.Identity.Endpoints | \`identity.roles\` | \`Identity.Roles.Read\` | \`shield-user\` |
| Granit.Identity.Endpoints | \`identity.groups\` | \`Identity.Groups.Read\` | \`users\` |
| Granit.Identity.Endpoints | \`identity.sessions\` | \`Identity.Sessions.Read\` | \`monitor-smartphone\` |
| Granit.Authentication.ApiKeys.Endpoints | \`authentication.api-keys\` | \`Authentication.ApiKeys.Keys.Read\` | \`key-round\` |
| Granit.Authorization.Endpoints | \`authorization.permissions\` | \`Authorization.Definitions.Read\` | \`key\` |
| Granit.OpenIddict.Endpoints | \`openiddict.applications\` | \`OpenIddict.Applications.Read\` | \`app-window\` |
| Granit.OpenIddict.Endpoints | \`openiddict.scopes\` | \`OpenIddict.Scopes.Read\` | \`scan\` |
| Granit.OpenIddict.Endpoints | \`openiddict.authorizations\` | \`OpenIddict.Authorizations.Read\` | \`badge-check\` |

## Per-module shape (matches Diagnostics pilot)

For each migrated module:

1. **\`<Module>Features.cs\`** — public string constants. Hosts use \`section.Feature(IdentityFeatures.Users)\` so renames are compile-time fixes.
2. **\`<Module>FeatureProvider.cs\`** — internal \`IFeatureProvider\` with one \`.Add\` per feature.
3. **Module class** registers both legacy contribution + new provider.
4. **One unit test** per module verifying catalog metadata.

Display keys reused verbatim from the legacy contributions — no localisation file changes needed. Route names follow \`{module}.{entity-plural}.{view?}\` (ADR-057 convention). React route table mapping is phase 4.

## Tests

| Project | Tests | Status |
|---|---|---|
| Granit.Identity.Endpoints.Tests | 175 (1 new) | ✅ |
| Granit.Authentication.ApiKeys.Endpoints.Tests | 75 (1 new) | ✅ |
| Granit.Authorization.Endpoints.Tests | 56 (1 new) | ✅ |
| Granit.OpenIddict.Endpoints.Tests | 67 (1 new) | ✅ |

## What this does NOT do

- Remove the legacy \`*WorkspaceContribution\` — kept for now, deleted in phase 5
- Wire features into a workspace — that needs the framework Defaults bundle (phase 2). The catalog is populated; no UI changes until phase 2 lands.

## Refs

- ADR-057 §1, phase 3 — granit-docs PR #37
- Builds on phase 1 contracts (#2096, merged) and Diagnostics pilot (#2097, merged)